### PR TITLE
fix: Make news page title dynamic based on category filter

### DIFF
--- a/src/app/(main)/news/page.tsx
+++ b/src/app/(main)/news/page.tsx
@@ -96,12 +96,14 @@ export default async function NewsPage({ searchParams }: NewsPageProps) {
   )
 
   // Extract slug from path and find matching category
-  const categoryId = categorySlug
+  const activeCategory = categorySlug
     ? tags.find((tag) => {
         const slug = tag.attributes.path?.alias?.split('/').pop()
         return slug === categorySlug
-      })?.attributes.drupal_internal__tid
+      })
     : undefined
+
+  const categoryId = activeCategory?.attributes.drupal_internal__tid
 
   // Fetch articles with category filter
   const { articles, links } = await runPromise(
@@ -116,9 +118,14 @@ export default async function NewsPage({ searchParams }: NewsPageProps) {
     })
   )
 
+  // Generate dynamic page title
+  const pageTitle = activeCategory
+    ? `${activeCategory.attributes.name} - Nieuwsarchief KCVV Elewijt`
+    : 'Nieuwsarchief KCVV Elewijt'
+
   return (
     <>
-      <PageTitle title="Nieuwsarchief KCVV Elewijt" />
+      <PageTitle title={pageTitle} />
 
       <div className="w-full max-w-inner-lg mx-auto px-3 lg:px-0 py-6">
         {/* Category filters */}


### PR DESCRIPTION
## Summary
Fixed issue where category page titles didn't change when filtering by category. The page title now dynamically updates to show the selected category name.

## Changes
- Extract active category from tags lookup
- Generate dynamic `pageTitle` based on active category
- Pass dynamic title to `PageTitle` component

## Before
- Page title was always "Nieuwsarchief KCVV Elewijt" regardless of category filter
- Metadata was dynamic but visible title was static

## After
- Page title shows "Jeugd - Nieuwsarchief KCVV Elewijt" when filtering by Jeugd
- Page title shows "Ploeg - Nieuwsarchief KCVV Elewijt" when filtering by Ploeg
- Matches the dynamic metadata generation

## Testing
- ✅ All 463 tests passing
- ✅ Build successful
- ✅ Category filtering works correctly
- ✅ Title changes dynamically based on active category

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)