### PR TITLE
feat(teams): add TeamStandings, TeamSchedule, CoachProfile components

### DIFF
--- a/src/components/team/CoachProfile/CoachProfile.stories.tsx
+++ b/src/components/team/CoachProfile/CoachProfile.stories.tsx
@@ -1,0 +1,188 @@
+/**
+ * CoachProfile Component Stories
+ *
+ * Coach/staff profile card with photo, role, and contact info.
+ *
+ * Stories created BEFORE implementation (Storybook-first workflow).
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CoachProfile } from "./CoachProfile";
+
+const meta = {
+  title: "Components/Team/CoachProfile",
+  component: CoachProfile,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `
+Coach/staff profile card component.
+
+**Features:**
+- Photo with fallback placeholder
+- Name and role display
+- Optional contact info (email, phone)
+- Optional biography text
+- Card and inline variants
+
+**Usage:**
+Used in team detail pages to display coaching staff and team officials.
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    name: { control: "text", description: "Coach name" },
+    role: { control: "text", description: "Role/position" },
+    imageUrl: { control: "text", description: "Photo URL" },
+    email: { control: "text", description: "Contact email" },
+    phone: { control: "text", description: "Contact phone" },
+    biography: { control: "text", description: "Biography text" },
+    variant: {
+      control: "select",
+      options: ["card", "inline"],
+      description: "Display variant",
+    },
+    className: { control: "text", description: "Additional CSS classes" },
+  },
+} satisfies Meta<typeof CoachProfile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SAMPLE_PHOTO =
+  "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=300&h=300&fit=crop&crop=face";
+
+/**
+ * Default - Coach card with photo
+ */
+export const Default: Story = {
+  args: {
+    name: "Jan Peeters",
+    role: "Hoofdtrainer",
+    imageUrl: SAMPLE_PHOTO,
+  },
+};
+
+/**
+ * Without photo - Shows placeholder
+ */
+export const WithoutPhoto: Story = {
+  args: {
+    name: "Marc Janssen",
+    role: "Assistent-trainer",
+  },
+};
+
+/**
+ * With contact info
+ */
+export const WithContact: Story = {
+  args: {
+    name: "Jan Peeters",
+    role: "Hoofdtrainer",
+    imageUrl: SAMPLE_PHOTO,
+    email: "jan.peeters@kcvvelewijt.be",
+    phone: "+32 479 12 34 56",
+  },
+};
+
+/**
+ * With biography
+ */
+export const WithBiography: Story = {
+  args: {
+    name: "Jan Peeters",
+    role: "Hoofdtrainer",
+    imageUrl: SAMPLE_PHOTO,
+    biography:
+      "Jan heeft meer dan 15 jaar ervaring als trainer bij verschillende clubs in de regio. Hij behaalde zijn UEFA B-diploma in 2018 en is gepassioneerd door jeugdopleiding.",
+  },
+};
+
+/**
+ * Full profile - All info
+ */
+export const FullProfile: Story = {
+  args: {
+    name: "Jan Peeters",
+    role: "Hoofdtrainer A-ploeg",
+    imageUrl: SAMPLE_PHOTO,
+    email: "jan.peeters@kcvvelewijt.be",
+    phone: "+32 479 12 34 56",
+    biography:
+      "Jan heeft meer dan 15 jaar ervaring als trainer bij verschillende clubs in de regio. Hij behaalde zijn UEFA B-diploma in 2018 en is gepassioneerd door jeugdopleiding en technische ontwikkeling.",
+  },
+};
+
+/**
+ * Inline variant - Compact display
+ */
+export const Inline: Story = {
+  args: {
+    name: "Marc Janssen",
+    role: "Assistent-trainer",
+    imageUrl: SAMPLE_PHOTO,
+    variant: "inline",
+  },
+};
+
+/**
+ * Inline without photo
+ */
+export const InlineWithoutPhoto: Story = {
+  args: {
+    name: "Kris De Vos",
+    role: "Keepertrainer",
+    variant: "inline",
+  },
+};
+
+/**
+ * Staff member (non-coach)
+ */
+export const StaffMember: Story = {
+  args: {
+    name: "Peter Willems",
+    role: "Materiaalmeester",
+    email: "materiaal@kcvvelewijt.be",
+  },
+};
+
+/**
+ * Youth team coach
+ */
+export const YouthCoach: Story = {
+  args: {
+    name: "Tom Hermans",
+    role: "Trainer U15",
+    imageUrl: SAMPLE_PHOTO,
+    phone: "+32 476 98 76 54",
+  },
+};
+
+/**
+ * Multiple coaches display (using decorator)
+ */
+export const MultipleCoaches: Story = {
+  args: {
+    name: "Jan Peeters",
+    role: "Hoofdtrainer",
+    imageUrl: SAMPLE_PHOTO,
+  },
+  decorators: [
+    () => (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <CoachProfile
+          name="Jan Peeters"
+          role="Hoofdtrainer"
+          imageUrl={SAMPLE_PHOTO}
+        />
+        <CoachProfile name="Marc Janssen" role="Assistent-trainer" />
+        <CoachProfile name="Kris De Vos" role="Keepertrainer" />
+      </div>
+    ),
+  ],
+};

--- a/src/components/team/CoachProfile/CoachProfile.test.tsx
+++ b/src/components/team/CoachProfile/CoachProfile.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * CoachProfile Component Tests
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CoachProfile } from "./CoachProfile";
+
+// Mock next/image
+vi.mock("next/image", () => ({
+  default: ({
+    src,
+    alt,
+    fill: _fill,
+    ...props
+  }: {
+    src: string;
+    alt: string;
+    fill?: boolean;
+  }) => <img src={src} alt={alt} {...props} />,
+}));
+
+describe("CoachProfile", () => {
+  const defaultProps = {
+    name: "Jan Peeters",
+    role: "Hoofdtrainer",
+  };
+
+  describe("rendering", () => {
+    it("renders name and role", () => {
+      render(<CoachProfile {...defaultProps} />);
+      expect(screen.getByText("Jan Peeters")).toBeInTheDocument();
+      expect(screen.getByText("Hoofdtrainer")).toBeInTheDocument();
+    });
+
+    it("renders photo when imageUrl is provided", () => {
+      render(<CoachProfile {...defaultProps} imageUrl="/photo.jpg" />);
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("src", "/photo.jpg");
+      expect(img).toHaveAttribute("alt", "Jan Peeters foto");
+    });
+
+    it("renders placeholder when no imageUrl", () => {
+      const { container } = render(<CoachProfile {...defaultProps} />);
+      // Should have User icon placeholder (SVG)
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+    });
+
+    it("renders biography when provided", () => {
+      render(
+        <CoachProfile
+          {...defaultProps}
+          biography="Een ervaren trainer met veel passie."
+        />,
+      );
+      expect(
+        screen.getByText("Een ervaren trainer met veel passie."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("contact info", () => {
+    it("renders email link when provided", () => {
+      render(<CoachProfile {...defaultProps} email="jan@example.com" />);
+      const emailLink = screen.getByRole("link", { name: /jan@example.com/i });
+      expect(emailLink).toHaveAttribute("href", "mailto:jan@example.com");
+    });
+
+    it("renders phone link when provided", () => {
+      render(<CoachProfile {...defaultProps} phone="+32 479 12 34 56" />);
+      const phoneLink = screen.getByRole("link", {
+        name: /\+32 479 12 34 56/i,
+      });
+      expect(phoneLink).toHaveAttribute("href", "tel:+32479123456");
+    });
+
+    it("renders both email and phone", () => {
+      render(
+        <CoachProfile
+          {...defaultProps}
+          email="jan@example.com"
+          phone="+32 479 12 34 56"
+        />,
+      );
+      expect(
+        screen.getByRole("link", { name: /jan@example.com/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /\+32 479 12 34 56/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render contact section when no email or phone", () => {
+      render(<CoachProfile {...defaultProps} />);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("variants", () => {
+    it("renders card variant by default", () => {
+      const { container } = render(<CoachProfile {...defaultProps} />);
+      // Card variant has aspect-square for photo
+      expect(container.querySelector(".aspect-square")).toBeInTheDocument();
+    });
+
+    it("renders inline variant", () => {
+      const { container } = render(
+        <CoachProfile {...defaultProps} variant="inline" />,
+      );
+      // Inline variant should not have aspect-square
+      expect(container.querySelector(".aspect-square")).not.toBeInTheDocument();
+      // Should have flex layout
+      expect(container.firstChild).toHaveClass("flex");
+    });
+
+    it("renders photo in inline variant", () => {
+      render(
+        <CoachProfile
+          {...defaultProps}
+          variant="inline"
+          imageUrl="/photo.jpg"
+        />,
+      );
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("src", "/photo.jpg");
+    });
+
+    it("renders placeholder in inline variant without photo", () => {
+      const { container } = render(
+        <CoachProfile {...defaultProps} variant="inline" />,
+      );
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+    });
+  });
+
+  describe("className prop", () => {
+    it("applies custom className to card variant", () => {
+      const { container } = render(
+        <CoachProfile {...defaultProps} className="custom-class" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+
+    it("applies custom className to inline variant", () => {
+      const { container } = render(
+        <CoachProfile
+          {...defaultProps}
+          variant="inline"
+          className="custom-class"
+        />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("has proper alt text for photo", () => {
+      render(<CoachProfile {...defaultProps} imageUrl="/photo.jpg" />);
+      expect(screen.getByAltText("Jan Peeters foto")).toBeInTheDocument();
+    });
+
+    it("icons are hidden from screen readers", () => {
+      const { container } = render(
+        <CoachProfile {...defaultProps} email="test@example.com" />,
+      );
+      const icons = container.querySelectorAll('svg[aria-hidden="true"]');
+      expect(icons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles long biography with truncation", () => {
+      const longBio =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(10);
+      const { container } = render(
+        <CoachProfile {...defaultProps} biography={longBio} />,
+      );
+      // Should have line-clamp class for truncation
+      expect(container.querySelector(".line-clamp-3")).toBeInTheDocument();
+    });
+
+    it("handles long email with truncation", () => {
+      const { container } = render(
+        <CoachProfile
+          {...defaultProps}
+          email="very.long.email.address@example.domain.com"
+        />,
+      );
+      expect(container.querySelector(".truncate")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/team/CoachProfile/CoachProfile.tsx
+++ b/src/components/team/CoachProfile/CoachProfile.tsx
@@ -1,0 +1,174 @@
+/**
+ * CoachProfile Component
+ *
+ * Coach/staff profile card with photo, role, and contact info.
+ *
+ * Features:
+ * - Photo with fallback placeholder
+ * - Name and role display
+ * - Optional contact info (email, phone)
+ * - Optional biography text
+ * - Card and inline variants
+ */
+
+import Image from "next/image";
+import { Mail, Phone, User } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+export interface CoachProfileProps {
+  /** Coach name */
+  name: string;
+  /** Role/position (e.g., "Hoofdtrainer", "Assistent-trainer") */
+  role: string;
+  /** Photo URL */
+  imageUrl?: string;
+  /** Contact email */
+  email?: string;
+  /** Contact phone */
+  phone?: string;
+  /** Biography text */
+  biography?: string;
+  /** Display variant */
+  variant?: "card" | "inline";
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Render a coach/staff profile card or inline display.
+ *
+ * The card variant shows a larger photo with name, role, optional biography, and contact icons.
+ * The inline variant shows a compact horizontal layout with smaller photo.
+ *
+ * @param name - Coach or staff member name
+ * @param role - Role or position title
+ * @param imageUrl - Optional profile photo URL
+ * @param email - Optional contact email
+ * @param phone - Optional contact phone number
+ * @param biography - Optional biography text
+ * @param variant - Display style: "card" (default) or "inline"
+ * @param className - Optional additional CSS classes
+ * @returns The rendered profile element
+ */
+export function CoachProfile({
+  name,
+  role,
+  imageUrl,
+  email,
+  phone,
+  biography,
+  variant = "card",
+  className,
+}: CoachProfileProps) {
+  // Inline variant - compact horizontal layout
+  if (variant === "inline") {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-3 p-3 bg-white border border-gray-200 rounded-lg",
+          className,
+        )}
+      >
+        {/* Photo */}
+        <div className="flex-shrink-0">
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt={`${name} foto`}
+              width={48}
+              height={48}
+              className="w-12 h-12 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center">
+              <User
+                className="w-6 h-6 text-gray-400"
+                aria-hidden="true"
+                focusable={false}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold text-gray-900 truncate">{name}</h3>
+          <p className="text-sm text-gray-500 truncate">{role}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Card variant - full profile card
+  return (
+    <div
+      className={cn(
+        "bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm",
+        className,
+      )}
+    >
+      {/* Photo section */}
+      <div className="aspect-square relative bg-gray-100">
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={`${name} foto`}
+            fill
+            className="object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <User
+              className="w-20 h-20 text-gray-300"
+              aria-hidden="true"
+              focusable={false}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Content section */}
+      <div className="p-4">
+        <h3 className="font-semibold text-lg text-gray-900">{name}</h3>
+        <p className="text-sm text-kcvv-green-bright font-medium">{role}</p>
+
+        {/* Biography */}
+        {biography && (
+          <p className="mt-3 text-sm text-gray-600 line-clamp-3">{biography}</p>
+        )}
+
+        {/* Contact info */}
+        {(email || phone) && (
+          <div className="mt-4 space-y-2">
+            {email && (
+              <a
+                href={`mailto:${email}`}
+                className="flex items-center gap-2 text-sm text-gray-600 hover:text-kcvv-green-bright transition-colors"
+              >
+                <Mail
+                  className="w-4 h-4 flex-shrink-0"
+                  aria-hidden="true"
+                  focusable={false}
+                />
+                <span className="truncate">{email}</span>
+              </a>
+            )}
+            {phone && (
+              <a
+                href={`tel:${phone.replace(/\s/g, "")}`}
+                className="flex items-center gap-2 text-sm text-gray-600 hover:text-kcvv-green-bright transition-colors"
+              >
+                <Phone
+                  className="w-4 h-4 flex-shrink-0"
+                  aria-hidden="true"
+                  focusable={false}
+                />
+                <span>{phone}</span>
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/team/CoachProfile/index.ts
+++ b/src/components/team/CoachProfile/index.ts
@@ -1,0 +1,1 @@
+export { CoachProfile, type CoachProfileProps } from "./CoachProfile";

--- a/src/components/team/TeamSchedule/TeamSchedule.stories.tsx
+++ b/src/components/team/TeamSchedule/TeamSchedule.stories.tsx
@@ -1,0 +1,303 @@
+/**
+ * TeamSchedule Component Stories
+ *
+ * Team match schedule with upcoming and past matches.
+ *
+ * Stories created BEFORE implementation (Storybook-first workflow).
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TeamSchedule, type ScheduleMatch } from "./TeamSchedule";
+
+const meta = {
+  title: "Components/Team/TeamSchedule",
+  component: TeamSchedule,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Team match schedule component.
+
+**Features:**
+- Upcoming matches highlighted
+- Past results with scores
+- Next match emphasized
+- Competition type labels
+- Home/Away indicators
+- Responsive design
+
+**Usage:**
+Used in team detail pages "Wedstrijden" tab.
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    matches: { control: "object", description: "Array of matches" },
+    teamId: { control: "number", description: "Team ID for home/away display" },
+    showPast: { control: "boolean", description: "Show past results" },
+    highlightNext: { control: "boolean", description: "Highlight next match" },
+    limit: { control: "number", description: "Limit number of matches shown" },
+    isLoading: { control: "boolean", description: "Loading state" },
+    className: { control: "text", description: "Additional CSS classes" },
+  },
+} satisfies Meta<typeof TeamSchedule>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Create dates relative to now for realistic stories
+const now = new Date();
+const pastDate = (daysAgo: number) => {
+  const d = new Date(now);
+  d.setDate(d.getDate() - daysAgo);
+  return d;
+};
+const futureDate = (daysAhead: number) => {
+  const d = new Date(now);
+  d.setDate(d.getDate() + daysAhead);
+  return d;
+};
+
+const KCVV_LOGO =
+  "https://dfaozfi7c7f3s.cloudfront.net/logos/extra_groot/1235.png?v=1";
+const OPPONENT_LOGO =
+  "https://dfaozfi7c7f3s.cloudfront.net/logos/extra_groot/59.png?v=1";
+
+// Mock matches data
+const mockMatches: ScheduleMatch[] = [
+  {
+    id: 1001,
+    date: pastDate(21),
+    time: "15:00",
+    homeTeam: {
+      id: 1235,
+      name: "KCVV Elewijt",
+      logo: KCVV_LOGO,
+    },
+    awayTeam: {
+      id: 59,
+      name: "KFC Turnhout",
+      logo: OPPONENT_LOGO,
+    },
+    homeScore: 3,
+    awayScore: 1,
+    status: "finished",
+    competition: "3de Nationale",
+  },
+  {
+    id: 1002,
+    date: pastDate(14),
+    time: "14:30",
+    homeTeam: {
+      id: 789,
+      name: "SK Londerzeel",
+    },
+    awayTeam: {
+      id: 1235,
+      name: "KCVV Elewijt",
+      logo: KCVV_LOGO,
+    },
+    homeScore: 0,
+    awayScore: 2,
+    status: "finished",
+    competition: "3de Nationale",
+  },
+  {
+    id: 1003,
+    date: pastDate(7),
+    time: "15:00",
+    homeTeam: {
+      id: 1235,
+      name: "KCVV Elewijt",
+      logo: KCVV_LOGO,
+    },
+    awayTeam: {
+      id: 456,
+      name: "FC Diest",
+    },
+    homeScore: 2,
+    awayScore: 2,
+    status: "finished",
+    competition: "3de Nationale",
+  },
+  {
+    id: 1004,
+    date: futureDate(3),
+    time: "15:00",
+    homeTeam: {
+      id: 123,
+      name: "Union Mechelen",
+    },
+    awayTeam: {
+      id: 1235,
+      name: "KCVV Elewijt",
+      logo: KCVV_LOGO,
+    },
+    status: "scheduled",
+    competition: "3de Nationale",
+  },
+  {
+    id: 1005,
+    date: futureDate(10),
+    time: "15:00",
+    homeTeam: {
+      id: 1235,
+      name: "KCVV Elewijt",
+      logo: KCVV_LOGO,
+    },
+    awayTeam: {
+      id: 222,
+      name: "KVK Tienen",
+    },
+    status: "scheduled",
+    competition: "3de Nationale",
+  },
+  {
+    id: 1006,
+    date: futureDate(17),
+    time: "14:00",
+    homeTeam: {
+      id: 333,
+      name: "VK Linden",
+    },
+    awayTeam: {
+      id: 1235,
+      name: "KCVV Elewijt",
+      logo: KCVV_LOGO,
+    },
+    status: "scheduled",
+    competition: "Beker van Brabant",
+  },
+];
+
+/**
+ * Default - Full schedule with past and future matches
+ */
+export const Default: Story = {
+  args: {
+    matches: mockMatches,
+    teamId: 1235,
+    showPast: true,
+    highlightNext: true,
+  },
+};
+
+/**
+ * Upcoming only - Only future matches
+ */
+export const UpcomingOnly: Story = {
+  args: {
+    matches: mockMatches.filter((m) => m.status === "scheduled"),
+    teamId: 1235,
+    showPast: false,
+    highlightNext: true,
+  },
+};
+
+/**
+ * Results only - Only past matches with scores
+ */
+export const ResultsOnly: Story = {
+  args: {
+    matches: mockMatches.filter((m) => m.status === "finished"),
+    teamId: 1235,
+    showPast: true,
+    highlightNext: false,
+  },
+};
+
+/**
+ * Next match highlighted
+ */
+export const NextMatchHighlighted: Story = {
+  args: {
+    matches: mockMatches,
+    teamId: 1235,
+    showPast: true,
+    highlightNext: true,
+  },
+};
+
+/**
+ * Compact view - Limited matches
+ */
+export const Compact: Story = {
+  args: {
+    matches: mockMatches,
+    teamId: 1235,
+    showPast: true,
+    highlightNext: true,
+    limit: 3,
+  },
+};
+
+/**
+ * With postponed match
+ */
+export const WithPostponed: Story = {
+  args: {
+    matches: [
+      ...mockMatches.slice(0, 3),
+      {
+        id: 1007,
+        date: futureDate(5),
+        time: "15:00",
+        homeTeam: {
+          id: 1235,
+          name: "KCVV Elewijt",
+          logo: KCVV_LOGO,
+        },
+        awayTeam: {
+          id: 444,
+          name: "SC Grimbergen",
+        },
+        status: "postponed",
+        competition: "3de Nationale",
+      },
+      ...mockMatches.slice(3),
+    ],
+    teamId: 1235,
+    showPast: true,
+    highlightNext: true,
+  },
+};
+
+/**
+ * Loading skeleton
+ */
+export const Loading: Story = {
+  args: {
+    matches: [],
+    teamId: 1235,
+    isLoading: true,
+  },
+};
+
+/**
+ * Empty state - No scheduled matches
+ */
+export const Empty: Story = {
+  args: {
+    matches: [],
+    teamId: 1235,
+  },
+};
+
+/**
+ * Without team logos
+ */
+export const WithoutLogos: Story = {
+  args: {
+    matches: mockMatches.map((m) => ({
+      ...m,
+      homeTeam: { ...m.homeTeam, logo: undefined },
+      awayTeam: { ...m.awayTeam, logo: undefined },
+    })),
+    teamId: 1235,
+    showPast: true,
+    highlightNext: true,
+  },
+};

--- a/src/components/team/TeamSchedule/TeamSchedule.test.tsx
+++ b/src/components/team/TeamSchedule/TeamSchedule.test.tsx
@@ -1,0 +1,330 @@
+/**
+ * TeamSchedule Component Tests
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TeamSchedule, type ScheduleMatch } from "./TeamSchedule";
+
+// Mock next/image
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} {...props} />
+  ),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("TeamSchedule", () => {
+  const now = new Date();
+  const pastDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const futureDate = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const mockMatches: ScheduleMatch[] = [
+    {
+      id: 1001,
+      date: pastDate,
+      time: "15:00",
+      homeTeam: {
+        id: 1235,
+        name: "KCVV Elewijt",
+        logo: "/logo1.png",
+      },
+      awayTeam: {
+        id: 59,
+        name: "KFC Turnhout",
+        logo: "/logo2.png",
+      },
+      homeScore: 3,
+      awayScore: 1,
+      status: "finished",
+      competition: "3de Nationale",
+    },
+    {
+      id: 1002,
+      date: futureDate,
+      time: "14:30",
+      homeTeam: {
+        id: 789,
+        name: "SK Londerzeel",
+      },
+      awayTeam: {
+        id: 1235,
+        name: "KCVV Elewijt",
+        logo: "/logo1.png",
+      },
+      status: "scheduled",
+      competition: "3de Nationale",
+    },
+  ];
+
+  describe("rendering", () => {
+    it("renders match list", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      // KCVV Elewijt appears in both matches
+      const kcvvElements = screen.getAllByText("KCVV Elewijt");
+      expect(kcvvElements.length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText("KFC Turnhout")).toBeInTheDocument();
+      expect(screen.getByText("SK Londerzeel")).toBeInTheDocument();
+    });
+
+    it("renders match times", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      expect(screen.getByText("15:00")).toBeInTheDocument();
+      expect(screen.getByText("14:30")).toBeInTheDocument();
+    });
+
+    it("renders scores for finished matches", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      expect(screen.getByText("3")).toBeInTheDocument();
+      // "1" appears in date formatting too, use getAllByText
+      const onesElements = screen.getAllByText("1");
+      expect(onesElements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders VS for scheduled matches", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      expect(screen.getByText("VS")).toBeInTheDocument();
+    });
+
+    it("renders competition names", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      const competitions = screen.getAllByText("3de Nationale");
+      expect(competitions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders team logos", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      const images = screen.getAllByRole("img");
+      expect(images.length).toBeGreaterThan(0);
+    });
+
+    it("links to match detail page", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      const links = screen.getAllByRole("link");
+      expect(links[0]).toHaveAttribute("href", "/game/1001");
+    });
+  });
+
+  describe("filtering", () => {
+    it("shows all matches when showPast is true", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} showPast />);
+      expect(screen.getByText("KFC Turnhout")).toBeInTheDocument();
+      expect(screen.getByText("SK Londerzeel")).toBeInTheDocument();
+    });
+
+    it("hides finished matches when showPast is false", () => {
+      render(
+        <TeamSchedule matches={mockMatches} teamId={1235} showPast={false} />,
+      );
+      expect(screen.queryByText("KFC Turnhout")).not.toBeInTheDocument();
+      expect(screen.getByText("SK Londerzeel")).toBeInTheDocument();
+    });
+  });
+
+  describe("limit prop", () => {
+    it("shows all matches by default", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} />);
+      const links = screen.getAllByRole("link");
+      expect(links).toHaveLength(2);
+    });
+
+    it("limits matches when limit is set", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} limit={1} />);
+      const links = screen.getAllByRole("link");
+      expect(links).toHaveLength(1);
+    });
+  });
+
+  describe("next match highlighting", () => {
+    it("shows 'Volgende' badge for next match", () => {
+      render(
+        <TeamSchedule matches={mockMatches} teamId={1235} highlightNext />,
+      );
+      expect(screen.getByText("Volgende")).toBeInTheDocument();
+    });
+
+    it("does not show 'Volgende' badge when highlightNext is false", () => {
+      render(
+        <TeamSchedule
+          matches={mockMatches}
+          teamId={1235}
+          highlightNext={false}
+        />,
+      );
+      expect(screen.queryByText("Volgende")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("match status badges", () => {
+    it("shows postponed badge", () => {
+      const postponedMatch: ScheduleMatch = {
+        id: 2001,
+        date: futureDate,
+        time: "15:00",
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "KFC Turnhout" },
+        status: "postponed",
+      };
+      render(<TeamSchedule matches={[postponedMatch]} teamId={1235} />);
+      expect(screen.getByText("Uitgesteld")).toBeInTheDocument();
+    });
+
+    it("shows cancelled badge", () => {
+      const cancelledMatch: ScheduleMatch = {
+        id: 2002,
+        date: futureDate,
+        time: "15:00",
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "KFC Turnhout" },
+        status: "cancelled",
+      };
+      render(<TeamSchedule matches={[cancelledMatch]} teamId={1235} />);
+      expect(screen.getByText("Afgelast")).toBeInTheDocument();
+    });
+
+    it("shows live badge", () => {
+      const liveMatch: ScheduleMatch = {
+        id: 2003,
+        date: now,
+        time: "15:00",
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "KFC Turnhout" },
+        homeScore: 1,
+        awayScore: 0,
+        status: "live",
+      };
+      render(<TeamSchedule matches={[liveMatch]} teamId={1235} />);
+      expect(screen.getByText("Live")).toBeInTheDocument();
+    });
+  });
+
+  describe("result highlighting", () => {
+    it("applies green border for wins", () => {
+      const winMatch: ScheduleMatch = {
+        id: 3001,
+        date: pastDate,
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "Opponent" },
+        homeScore: 3,
+        awayScore: 1,
+        status: "finished",
+      };
+      render(<TeamSchedule matches={[winMatch]} teamId={1235} />);
+      const link = screen.getByRole("link");
+      expect(link.className).toContain("border-l-green-500");
+    });
+
+    it("applies red border for losses", () => {
+      const lossMatch: ScheduleMatch = {
+        id: 3002,
+        date: pastDate,
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "Opponent" },
+        homeScore: 0,
+        awayScore: 2,
+        status: "finished",
+      };
+      render(<TeamSchedule matches={[lossMatch]} teamId={1235} />);
+      const link = screen.getByRole("link");
+      expect(link.className).toContain("border-l-red-500");
+    });
+
+    it("applies yellow border for draws", () => {
+      const drawMatch: ScheduleMatch = {
+        id: 3003,
+        date: pastDate,
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "Opponent" },
+        homeScore: 2,
+        awayScore: 2,
+        status: "finished",
+      };
+      render(<TeamSchedule matches={[drawMatch]} teamId={1235} />);
+      const link = screen.getByRole("link");
+      expect(link.className).toContain("border-l-yellow-500");
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders skeleton when loading", () => {
+      const { container } = render(
+        <TeamSchedule matches={[]} teamId={1235} isLoading />,
+      );
+      expect(
+        container.querySelectorAll(".animate-pulse").length,
+      ).toBeGreaterThan(0);
+    });
+
+    it("does not render matches when loading", () => {
+      render(<TeamSchedule matches={mockMatches} teamId={1235} isLoading />);
+      expect(screen.queryByText("KCVV Elewijt")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty message when no matches", () => {
+      render(<TeamSchedule matches={[]} teamId={1235} />);
+      expect(screen.getByText("Geen wedstrijden gepland.")).toBeInTheDocument();
+    });
+  });
+
+  describe("home/away indication", () => {
+    it("highlights home team name when playing at home", () => {
+      const homeMatch: ScheduleMatch = {
+        id: 4001,
+        date: futureDate,
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "Opponent" },
+        status: "scheduled",
+      };
+      render(<TeamSchedule matches={[homeMatch]} teamId={1235} />);
+      const kcvvText = screen.getByText("KCVV Elewijt");
+      expect(kcvvText).toHaveClass("font-semibold");
+    });
+  });
+
+  describe("className prop", () => {
+    it("applies custom className", () => {
+      const { container } = render(
+        <TeamSchedule
+          matches={mockMatches}
+          teamId={1235}
+          className="custom-class"
+        />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  describe("teams without logos", () => {
+    it("renders placeholder for teams without logos", () => {
+      const noLogoMatch: ScheduleMatch = {
+        id: 5001,
+        date: futureDate,
+        homeTeam: { id: 1235, name: "KCVV Elewijt" },
+        awayTeam: { id: 59, name: "Opponent FC" },
+        status: "scheduled",
+      };
+      render(<TeamSchedule matches={[noLogoMatch]} teamId={1235} />);
+      // First letters should appear as placeholders
+      expect(screen.getByText("K")).toBeInTheDocument(); // KCVV
+      expect(screen.getByText("O")).toBeInTheDocument(); // Opponent
+    });
+  });
+});

--- a/src/components/team/TeamSchedule/TeamSchedule.tsx
+++ b/src/components/team/TeamSchedule/TeamSchedule.tsx
@@ -1,0 +1,352 @@
+/**
+ * TeamSchedule Component
+ *
+ * Team match schedule with upcoming and past matches.
+ *
+ * Features:
+ * - Upcoming matches highlighted
+ * - Past results with scores
+ * - Next match emphasized
+ * - Competition type labels
+ * - Home/Away indicators
+ * - Responsive design
+ */
+
+import Image from "next/image";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+export interface ScheduleTeam {
+  /** Team ID */
+  id: number;
+  /** Team name */
+  name: string;
+  /** Team logo URL */
+  logo?: string;
+}
+
+export interface ScheduleMatch {
+  /** Match ID */
+  id: number;
+  /** Match date */
+  date: Date;
+  /** Match time (HH:MM) */
+  time?: string;
+  /** Home team */
+  homeTeam: ScheduleTeam;
+  /** Away team */
+  awayTeam: ScheduleTeam;
+  /** Home team score (for finished matches) */
+  homeScore?: number;
+  /** Away team score (for finished matches) */
+  awayScore?: number;
+  /** Match status */
+  status: "scheduled" | "live" | "finished" | "postponed" | "cancelled";
+  /** Competition name */
+  competition?: string;
+}
+
+export interface TeamScheduleProps {
+  /** Array of matches */
+  matches: ScheduleMatch[];
+  /** Team ID for home/away display */
+  teamId: number;
+  /** Show past results */
+  showPast?: boolean;
+  /** Highlight next match */
+  highlightNext?: boolean;
+  /** Limit number of matches shown */
+  limit?: number;
+  /** Loading state */
+  isLoading?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Format date in Dutch locale
+ */
+function formatDate(date: Date): string {
+  return date.toLocaleDateString("nl-BE", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+}
+
+/**
+ * Get status badge for match
+ */
+function StatusBadge({ status }: { status: ScheduleMatch["status"] }) {
+  if (status === "postponed") {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
+        Uitgesteld
+      </span>
+    );
+  }
+  if (status === "cancelled") {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">
+        Afgelast
+      </span>
+    );
+  }
+  if (status === "live") {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-500 text-white animate-pulse">
+        Live
+      </span>
+    );
+  }
+  return null;
+}
+
+/**
+ * Render the team's match schedule with optional past results, next match highlighting, and limit.
+ *
+ * @param matches - Array of matches to display
+ * @param teamId - Current team's ID (for home/away determination)
+ * @param showPast - If true, includes finished matches
+ * @param highlightNext - If true, highlights the next upcoming match
+ * @param limit - Optional limit on number of matches shown
+ * @param isLoading - If true, renders skeleton loader
+ * @param className - Optional additional CSS classes for the root element
+ * @returns The rendered schedule element
+ */
+export function TeamSchedule({
+  matches,
+  teamId,
+  showPast = true,
+  highlightNext = true,
+  limit,
+  isLoading = false,
+  className,
+}: TeamScheduleProps) {
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <div className={cn("space-y-3", className)}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-white border border-gray-200 rounded-lg p-4"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="h-4 w-20 bg-gray-200 rounded animate-pulse" />
+                <div className="h-4 w-12 bg-gray-200 rounded animate-pulse" />
+              </div>
+              <div className="h-4 w-24 bg-gray-200 rounded animate-pulse" />
+            </div>
+            <div className="mt-3 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="h-8 w-8 bg-gray-200 rounded-full animate-pulse" />
+                <div className="h-4 w-28 bg-gray-200 rounded animate-pulse" />
+              </div>
+              <div className="h-6 w-16 bg-gray-200 rounded animate-pulse" />
+              <div className="flex items-center gap-2">
+                <div className="h-4 w-28 bg-gray-200 rounded animate-pulse" />
+                <div className="h-8 w-8 bg-gray-200 rounded-full animate-pulse" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // Filter matches based on showPast
+  let filteredMatches = showPast
+    ? matches
+    : matches.filter((m) => m.status !== "finished");
+
+  // Sort by date
+  filteredMatches = [...filteredMatches].sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
+
+  // Apply limit if specified
+  if (limit) {
+    filteredMatches = filteredMatches.slice(0, limit);
+  }
+
+  // Find next match for highlighting
+  const now = new Date();
+  const nextMatchIndex = highlightNext
+    ? filteredMatches.findIndex((m) => m.date > now && m.status === "scheduled")
+    : -1;
+
+  // Empty state
+  if (filteredMatches.length === 0) {
+    return (
+      <div
+        className={cn(
+          "text-center py-8 text-gray-500 bg-gray-50 rounded-lg",
+          className,
+        )}
+      >
+        <p>Geen wedstrijden gepland.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {filteredMatches.map((match, index) => {
+        const isHome = match.homeTeam.id === teamId;
+        const isNext = index === nextMatchIndex;
+        const hasScore =
+          match.status === "finished" &&
+          typeof match.homeScore === "number" &&
+          typeof match.awayScore === "number";
+
+        // Determine result for KCVV
+        let resultClass = "";
+        if (hasScore) {
+          const kcvvScore = isHome ? match.homeScore! : match.awayScore!;
+          const oppScore = isHome ? match.awayScore! : match.homeScore!;
+          if (kcvvScore > oppScore) {
+            resultClass = "border-l-4 border-l-green-500";
+          } else if (kcvvScore < oppScore) {
+            resultClass = "border-l-4 border-l-red-500";
+          } else {
+            resultClass = "border-l-4 border-l-yellow-500";
+          }
+        }
+
+        return (
+          <Link
+            key={match.id}
+            href={`/game/${match.id}`}
+            className={cn(
+              "block bg-white border rounded-lg p-4 transition-shadow hover:shadow-md",
+              isNext
+                ? "border-kcvv-green-bright ring-2 ring-kcvv-green-bright/20"
+                : "border-gray-200",
+              resultClass,
+            )}
+          >
+            {/* Header row: date, time, competition */}
+            <div className="flex items-center justify-between text-sm mb-3">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-gray-900">
+                  {formatDate(match.date)}
+                </span>
+                {match.time && (
+                  <span className="text-gray-500">{match.time}</span>
+                )}
+                <StatusBadge status={match.status} />
+                {isNext && (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-kcvv-green-bright text-white">
+                    Volgende
+                  </span>
+                )}
+              </div>
+              {match.competition && (
+                <span className="text-gray-500 text-xs hidden sm:block">
+                  {match.competition}
+                </span>
+              )}
+            </div>
+
+            {/* Match row: teams and score */}
+            <div className="flex items-center justify-between">
+              {/* Home team */}
+              <div className="flex items-center gap-2 flex-1 min-w-0">
+                {match.homeTeam.logo ? (
+                  <Image
+                    src={match.homeTeam.logo}
+                    alt={`${match.homeTeam.name} logo`}
+                    width={32}
+                    height={32}
+                    className="object-contain flex-shrink-0"
+                  />
+                ) : (
+                  <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
+                    <span className="text-xs text-gray-500">
+                      {match.homeTeam.name.charAt(0)}
+                    </span>
+                  </div>
+                )}
+                <span
+                  className={cn(
+                    "truncate text-sm",
+                    match.homeTeam.id === teamId
+                      ? "font-semibold"
+                      : "text-gray-700",
+                  )}
+                >
+                  {match.homeTeam.name}
+                </span>
+              </div>
+
+              {/* Score or VS */}
+              <div className="flex-shrink-0 px-4">
+                {hasScore ? (
+                  <div className="flex items-center gap-2 font-mono font-bold text-lg">
+                    <span
+                      className={cn(
+                        match.homeTeam.id === teamId &&
+                          match.homeScore! > match.awayScore! &&
+                          "text-kcvv-green-bright",
+                      )}
+                    >
+                      {match.homeScore}
+                    </span>
+                    <span className="text-gray-400">-</span>
+                    <span
+                      className={cn(
+                        match.awayTeam.id === teamId &&
+                          match.awayScore! > match.homeScore! &&
+                          "text-kcvv-green-bright",
+                      )}
+                    >
+                      {match.awayScore}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-gray-400 font-medium">VS</span>
+                )}
+              </div>
+
+              {/* Away team */}
+              <div className="flex items-center gap-2 flex-1 min-w-0 justify-end">
+                <span
+                  className={cn(
+                    "truncate text-sm text-right",
+                    match.awayTeam.id === teamId
+                      ? "font-semibold"
+                      : "text-gray-700",
+                  )}
+                >
+                  {match.awayTeam.name}
+                </span>
+                {match.awayTeam.logo ? (
+                  <Image
+                    src={match.awayTeam.logo}
+                    alt={`${match.awayTeam.name} logo`}
+                    width={32}
+                    height={32}
+                    className="object-contain flex-shrink-0"
+                  />
+                ) : (
+                  <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
+                    <span className="text-xs text-gray-500">
+                      {match.awayTeam.name.charAt(0)}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Home/Away indicator for mobile */}
+            <div className="mt-2 text-xs text-gray-500 sm:hidden">
+              {isHome ? "Thuis" : "Uit"} • {match.competition || "Competitie"}
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/team/TeamSchedule/index.ts
+++ b/src/components/team/TeamSchedule/index.ts
@@ -1,0 +1,6 @@
+export {
+  TeamSchedule,
+  type TeamScheduleProps,
+  type ScheduleMatch,
+  type ScheduleTeam,
+} from "./TeamSchedule";

--- a/src/components/team/TeamStandings/TeamStandings.stories.tsx
+++ b/src/components/team/TeamStandings/TeamStandings.stories.tsx
@@ -1,0 +1,312 @@
+/**
+ * TeamStandings Component Stories
+ *
+ * League standings table with team highlighting and form display.
+ *
+ * Stories created BEFORE implementation (Storybook-first workflow).
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { TeamStandings, type StandingsEntry } from "./TeamStandings";
+
+const meta = {
+  title: "Components/Team/TeamStandings",
+  component: TeamStandings,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+League standings table component.
+
+**Features:**
+- Full standings with all columns (P, W, D, L, G+, G-, +/-, Pts)
+- Team highlighting for KCVV teams
+- Form display (recent results as WWLDW)
+- Compact variant showing top N teams
+- Responsive design for mobile
+
+**Usage:**
+Used in team detail pages "Stand" tab and on homepage.
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    standings: { control: "object", description: "Array of standings entries" },
+    highlightTeamId: {
+      control: "number",
+      description: "Team ID to highlight (KCVV)",
+    },
+    showForm: { control: "boolean", description: "Show recent form column" },
+    limit: { control: "number", description: "Limit number of rows shown" },
+    isLoading: { control: "boolean", description: "Loading state" },
+    className: { control: "text", description: "Additional CSS classes" },
+  },
+} satisfies Meta<typeof TeamStandings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Mock data based on actual Footbalisto API structure
+const mockStandings: StandingsEntry[] = [
+  {
+    position: 1,
+    teamId: 1235,
+    teamName: "KCVV ELEWIJT",
+    teamLogo:
+      "https://dfaozfi7c7f3s.cloudfront.net/logos/extra_groot/1235.png?v=1",
+    played: 15,
+    won: 12,
+    drawn: 2,
+    lost: 1,
+    goalsFor: 38,
+    goalsAgainst: 12,
+    goalDifference: 26,
+    points: 38,
+    form: "WWWDW",
+  },
+  {
+    position: 2,
+    teamId: 59,
+    teamName: "KFC TURNHOUT",
+    teamLogo:
+      "https://dfaozfi7c7f3s.cloudfront.net/logos/extra_groot/59.png?v=1",
+    played: 15,
+    won: 11,
+    drawn: 2,
+    lost: 2,
+    goalsFor: 35,
+    goalsAgainst: 15,
+    goalDifference: 20,
+    points: 35,
+    form: "WWDWL",
+  },
+  {
+    position: 3,
+    teamId: 123,
+    teamName: "FC DIEST",
+    played: 15,
+    won: 10,
+    drawn: 3,
+    lost: 2,
+    goalsFor: 28,
+    goalsAgainst: 14,
+    goalDifference: 14,
+    points: 33,
+    form: "DWWWW",
+  },
+  {
+    position: 4,
+    teamId: 456,
+    teamName: "UNION MECHELEN",
+    played: 15,
+    won: 9,
+    drawn: 4,
+    lost: 2,
+    goalsFor: 30,
+    goalsAgainst: 18,
+    goalDifference: 12,
+    points: 31,
+    form: "WDWDW",
+  },
+  {
+    position: 5,
+    teamId: 789,
+    teamName: "KVK TIENEN",
+    played: 15,
+    won: 8,
+    drawn: 4,
+    lost: 3,
+    goalsFor: 25,
+    goalsAgainst: 16,
+    goalDifference: 9,
+    points: 28,
+    form: "LWWWW",
+  },
+  {
+    position: 6,
+    teamId: 111,
+    teamName: "SK LONDERZEEL",
+    played: 15,
+    won: 7,
+    drawn: 5,
+    lost: 3,
+    goalsFor: 22,
+    goalsAgainst: 15,
+    goalDifference: 7,
+    points: 26,
+    form: "DWDWL",
+  },
+  {
+    position: 7,
+    teamId: 222,
+    teamName: "VK LINDEN",
+    played: 15,
+    won: 6,
+    drawn: 5,
+    lost: 4,
+    goalsFor: 20,
+    goalsAgainst: 18,
+    goalDifference: 2,
+    points: 23,
+    form: "DDWLW",
+  },
+  {
+    position: 8,
+    teamId: 333,
+    teamName: "KFC NIJLEN",
+    played: 15,
+    won: 5,
+    drawn: 6,
+    lost: 4,
+    goalsFor: 18,
+    goalsAgainst: 17,
+    goalDifference: 1,
+    points: 21,
+    form: "DDDWL",
+  },
+  {
+    position: 9,
+    teamId: 444,
+    teamName: "VC WESTERLO B",
+    played: 15,
+    won: 5,
+    drawn: 4,
+    lost: 6,
+    goalsFor: 19,
+    goalsAgainst: 22,
+    goalDifference: -3,
+    points: 19,
+    form: "LWDWL",
+  },
+  {
+    position: 10,
+    teamId: 555,
+    teamName: "KSK HEIST",
+    played: 15,
+    won: 4,
+    drawn: 5,
+    lost: 6,
+    goalsFor: 16,
+    goalsAgainst: 20,
+    goalDifference: -4,
+    points: 17,
+    form: "LLDWD",
+  },
+  {
+    position: 11,
+    teamId: 666,
+    teamName: "SC GRIMBERGEN",
+    played: 15,
+    won: 3,
+    drawn: 5,
+    lost: 7,
+    goalsFor: 14,
+    goalsAgainst: 24,
+    goalDifference: -10,
+    points: 14,
+    form: "LDLLD",
+  },
+  {
+    position: 12,
+    teamId: 777,
+    teamName: "RFC HOEI",
+    played: 15,
+    won: 2,
+    drawn: 4,
+    lost: 9,
+    goalsFor: 12,
+    goalsAgainst: 28,
+    goalDifference: -16,
+    points: 10,
+    form: "LLLLD",
+  },
+];
+
+/**
+ * Default - Full standings table
+ */
+export const Default: Story = {
+  args: {
+    standings: mockStandings,
+    highlightTeamId: 1235,
+  },
+};
+
+/**
+ * Highlighted team - KCVV row emphasized
+ */
+export const Highlighted: Story = {
+  args: {
+    standings: mockStandings,
+    highlightTeamId: 1235,
+  },
+};
+
+/**
+ * Compact view - Top 5 only
+ */
+export const Compact: Story = {
+  args: {
+    standings: mockStandings,
+    highlightTeamId: 1235,
+    limit: 5,
+  },
+};
+
+/**
+ * With form column - Recent results shown
+ */
+export const WithForm: Story = {
+  args: {
+    standings: mockStandings,
+    highlightTeamId: 1235,
+    showForm: true,
+  },
+};
+
+/**
+ * Without logos - Teams without logos render correctly
+ */
+export const WithoutLogos: Story = {
+  args: {
+    standings: mockStandings.map((s) => ({ ...s, teamLogo: undefined })),
+    highlightTeamId: 1235,
+  },
+};
+
+/**
+ * Loading skeleton
+ */
+export const Loading: Story = {
+  args: {
+    standings: [],
+    isLoading: true,
+  },
+};
+
+/**
+ * Empty state - No standings available
+ */
+export const Empty: Story = {
+  args: {
+    standings: [],
+  },
+};
+
+/**
+ * KCVV not in top 5 - Ensures highlight works when scrolled
+ */
+export const HighlightedLower: Story = {
+  args: {
+    standings: [
+      ...mockStandings.slice(1, 5),
+      { ...mockStandings[0], position: 6 },
+      ...mockStandings.slice(5),
+    ].map((s, i) => ({ ...s, position: i + 1 })),
+    highlightTeamId: 1235,
+    showForm: true,
+  },
+};

--- a/src/components/team/TeamStandings/TeamStandings.test.tsx
+++ b/src/components/team/TeamStandings/TeamStandings.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * TeamStandings Component Tests
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TeamStandings, type StandingsEntry } from "./TeamStandings";
+
+// Mock next/image
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} {...props} />
+  ),
+}));
+
+describe("TeamStandings", () => {
+  const mockStandings: StandingsEntry[] = [
+    {
+      position: 1,
+      teamId: 1235,
+      teamName: "KCVV ELEWIJT",
+      teamLogo: "/logo1.png",
+      played: 15,
+      won: 12,
+      drawn: 2,
+      lost: 1,
+      goalsFor: 38,
+      goalsAgainst: 12,
+      goalDifference: 26,
+      points: 38,
+      form: "WWWDW",
+    },
+    {
+      position: 2,
+      teamId: 59,
+      teamName: "KFC TURNHOUT",
+      teamLogo: "/logo2.png",
+      played: 15,
+      won: 11,
+      drawn: 2,
+      lost: 2,
+      goalsFor: 35,
+      goalsAgainst: 15,
+      goalDifference: 20,
+      points: 35,
+      form: "WWDWL",
+    },
+    {
+      position: 3,
+      teamId: 123,
+      teamName: "FC DIEST",
+      played: 15,
+      won: 10,
+      drawn: 3,
+      lost: 2,
+      goalsFor: 28,
+      goalsAgainst: 14,
+      goalDifference: 14,
+      points: 33,
+      form: "DWWWW",
+    },
+  ];
+
+  describe("rendering", () => {
+    it("renders table with standings", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      expect(screen.getByText("KCVV ELEWIJT")).toBeInTheDocument();
+      expect(screen.getByText("KFC TURNHOUT")).toBeInTheDocument();
+      expect(screen.getByText("FC DIEST")).toBeInTheDocument();
+    });
+
+    it("renders table headers", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      expect(screen.getByText("#")).toBeInTheDocument();
+      expect(screen.getByText("Team")).toBeInTheDocument();
+      expect(screen.getByText("P")).toBeInTheDocument();
+      expect(screen.getByText("Pts")).toBeInTheDocument();
+    });
+
+    it("renders position numbers", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      // Position numbers may appear in other columns too (losses, draws)
+      const ones = screen.getAllByText("1");
+      expect(ones.length).toBeGreaterThanOrEqual(1);
+      const twos = screen.getAllByText("2");
+      expect(twos.length).toBeGreaterThanOrEqual(1);
+      const threes = screen.getAllByText("3");
+      expect(threes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders points correctly", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      // Points appear in multiple places (goalsFor too), use getAllByText
+      const thirtyEights = screen.getAllByText("38");
+      expect(thirtyEights.length).toBeGreaterThanOrEqual(1);
+      const thirtyFives = screen.getAllByText("35");
+      expect(thirtyFives.length).toBeGreaterThanOrEqual(1);
+      const thirtyThrees = screen.getAllByText("33");
+      expect(thirtyThrees.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("renders goal difference with + sign for positive", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      expect(screen.getByText("+26")).toBeInTheDocument();
+      expect(screen.getByText("+20")).toBeInTheDocument();
+      expect(screen.getByText("+14")).toBeInTheDocument();
+    });
+
+    it("renders team logos", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      const images = screen.getAllByRole("img");
+      expect(images).toHaveLength(2); // Only teams with logos
+      expect(images[0]).toHaveAttribute("alt", "KCVV ELEWIJT logo");
+      expect(images[1]).toHaveAttribute("alt", "KFC TURNHOUT logo");
+    });
+  });
+
+  describe("highlighting", () => {
+    it("highlights team when highlightTeamId matches", () => {
+      const { container } = render(
+        <TeamStandings standings={mockStandings} highlightTeamId={1235} />,
+      );
+      const highlightedRow = container.querySelector(".bg-kcvv-green-bright");
+      expect(highlightedRow).toBeInTheDocument();
+      expect(highlightedRow).toHaveTextContent("KCVV ELEWIJT");
+    });
+
+    it("does not highlight when highlightTeamId does not match", () => {
+      const { container } = render(
+        <TeamStandings standings={mockStandings} highlightTeamId={9999} />,
+      );
+      const highlightedRow = container.querySelector(".bg-kcvv-green-bright");
+      expect(highlightedRow).not.toBeInTheDocument();
+    });
+  });
+
+  describe("form display", () => {
+    it("does not show form column by default", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      expect(screen.queryByText("Vorm")).not.toBeInTheDocument();
+    });
+
+    it("shows form column when showForm is true", () => {
+      render(<TeamStandings standings={mockStandings} showForm />);
+      expect(screen.getByText("Vorm")).toBeInTheDocument();
+    });
+
+    it("renders form badges with correct colors", () => {
+      const { container } = render(
+        <TeamStandings standings={mockStandings} showForm />,
+      );
+      // Check for W badges (green)
+      const greenBadges = container.querySelectorAll(".bg-green-500");
+      expect(greenBadges.length).toBeGreaterThan(0);
+      // Check for D badges (yellow)
+      const yellowBadges = container.querySelectorAll(".bg-yellow-500");
+      expect(yellowBadges.length).toBeGreaterThan(0);
+      // Check for L badges (red)
+      const redBadges = container.querySelectorAll(".bg-red-500");
+      expect(redBadges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("limit prop", () => {
+    it("shows all entries by default", () => {
+      render(<TeamStandings standings={mockStandings} />);
+      expect(screen.getByText("KCVV ELEWIJT")).toBeInTheDocument();
+      expect(screen.getByText("KFC TURNHOUT")).toBeInTheDocument();
+      expect(screen.getByText("FC DIEST")).toBeInTheDocument();
+    });
+
+    it("limits entries when limit is set", () => {
+      render(<TeamStandings standings={mockStandings} limit={2} />);
+      expect(screen.getByText("KCVV ELEWIJT")).toBeInTheDocument();
+      expect(screen.getByText("KFC TURNHOUT")).toBeInTheDocument();
+      expect(screen.queryByText("FC DIEST")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders skeleton when loading", () => {
+      const { container } = render(<TeamStandings standings={[]} isLoading />);
+      expect(
+        container.querySelectorAll(".animate-pulse").length,
+      ).toBeGreaterThan(0);
+    });
+
+    it("does not render team names when loading", () => {
+      render(<TeamStandings standings={mockStandings} isLoading />);
+      expect(screen.queryByText("KCVV ELEWIJT")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty message when no standings", () => {
+      render(<TeamStandings standings={[]} />);
+      expect(
+        screen.getByText("Geen klassement beschikbaar."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("teams without logos", () => {
+    it("renders placeholder for teams without logos", () => {
+      const standingsWithoutLogos: StandingsEntry[] = [
+        {
+          position: 1,
+          teamId: 1,
+          teamName: "Team A",
+          played: 10,
+          won: 5,
+          drawn: 3,
+          lost: 2,
+          goalsFor: 20,
+          goalsAgainst: 15,
+          goalDifference: 5,
+          points: 18,
+        },
+      ];
+      render(<TeamStandings standings={standingsWithoutLogos} />);
+      expect(screen.getByText("T")).toBeInTheDocument(); // First letter placeholder
+      expect(screen.getByText("Team A")).toBeInTheDocument();
+    });
+  });
+
+  describe("negative goal difference", () => {
+    it("renders negative goal difference without + sign", () => {
+      const standingsWithNegative: StandingsEntry[] = [
+        {
+          position: 1,
+          teamId: 1,
+          teamName: "Team A",
+          played: 10,
+          won: 2,
+          drawn: 3,
+          lost: 5,
+          goalsFor: 10,
+          goalsAgainst: 20,
+          goalDifference: -10,
+          points: 9,
+        },
+      ];
+      render(<TeamStandings standings={standingsWithNegative} />);
+      expect(screen.getByText("-10")).toBeInTheDocument();
+    });
+  });
+
+  describe("className prop", () => {
+    it("applies custom className", () => {
+      const { container } = render(
+        <TeamStandings standings={mockStandings} className="custom-class" />,
+      );
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+});

--- a/src/components/team/TeamStandings/TeamStandings.tsx
+++ b/src/components/team/TeamStandings/TeamStandings.tsx
@@ -1,0 +1,311 @@
+/**
+ * TeamStandings Component
+ *
+ * League standings table with team highlighting and form display.
+ *
+ * Features:
+ * - Full standings with all columns (P, W, D, L, G+, G-, +/-, Pts)
+ * - Team highlighting for KCVV teams
+ * - Form display (recent results as WWLDW)
+ * - Compact variant showing top N teams
+ * - Responsive design for mobile
+ */
+
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+
+export interface StandingsEntry {
+  /** Position in the league table */
+  position: number;
+  /** Team ID for highlighting */
+  teamId: number;
+  /** Team name */
+  teamName: string;
+  /** Team logo URL */
+  teamLogo?: string;
+  /** Matches played */
+  played: number;
+  /** Matches won */
+  won: number;
+  /** Matches drawn */
+  drawn: number;
+  /** Matches lost */
+  lost: number;
+  /** Goals scored */
+  goalsFor: number;
+  /** Goals conceded */
+  goalsAgainst: number;
+  /** Goal difference */
+  goalDifference: number;
+  /** Total points */
+  points: number;
+  /** Recent form string (e.g., "WWDLW") */
+  form?: string;
+}
+
+export interface TeamStandingsProps {
+  /** Array of standings entries */
+  standings: StandingsEntry[];
+  /** Team ID to highlight (e.g., KCVV) */
+  highlightTeamId?: number;
+  /** Show recent form column */
+  showForm?: boolean;
+  /** Limit number of rows shown */
+  limit?: number;
+  /** Loading state */
+  isLoading?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Render a form result badge (W/D/L)
+ */
+function FormBadge({ result }: { result: string }) {
+  const colors: Record<string, string> = {
+    W: "bg-green-500 text-white",
+    D: "bg-yellow-500 text-gray-900",
+    L: "bg-red-500 text-white",
+  };
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center w-5 h-5 text-xs font-bold rounded",
+        colors[result] || "bg-gray-300 text-gray-700",
+      )}
+    >
+      {result}
+    </span>
+  );
+}
+
+/**
+ * Render the standings table for a league, optionally highlighting a specific team.
+ *
+ * Displays position, team name (with optional logo), matches played, wins, draws, losses,
+ * goals for/against, goal difference, and points. Optionally shows recent form if enabled.
+ * Supports compact view via `limit` and loading/empty states.
+ *
+ * @param standings - Array of standings entries to display
+ * @param highlightTeamId - Optional team ID to highlight (e.g., KCVV)
+ * @param showForm - If true, displays recent form column
+ * @param limit - Limits the number of rows displayed
+ * @param isLoading - If true, renders a skeleton loader instead of data
+ * @param className - Optional additional CSS classes applied to the root element
+ * @returns The rendered standings table element
+ */
+export function TeamStandings({
+  standings,
+  highlightTeamId,
+  showForm = false,
+  limit,
+  isLoading = false,
+  className,
+}: TeamStandingsProps) {
+  // Loading skeleton
+  if (isLoading) {
+    return (
+      <div className={cn("overflow-x-auto", className)}>
+        <table className="w-full text-sm">
+          <thead className="bg-kcvv-green-dark text-white">
+            <tr>
+              <th className="px-2 py-3 text-left w-10">#</th>
+              <th className="px-2 py-3 text-left">Team</th>
+              <th className="px-2 py-3 text-center w-10">P</th>
+              <th className="px-2 py-3 text-center w-10 hidden md:table-cell">
+                W
+              </th>
+              <th className="px-2 py-3 text-center w-10 hidden md:table-cell">
+                D
+              </th>
+              <th className="px-2 py-3 text-center w-10 hidden md:table-cell">
+                L
+              </th>
+              <th className="px-2 py-3 text-center w-12 hidden lg:table-cell">
+                G+
+              </th>
+              <th className="px-2 py-3 text-center w-12 hidden lg:table-cell">
+                G-
+              </th>
+              <th className="px-2 py-3 text-center w-12">+/-</th>
+              <th className="px-2 py-3 text-center w-12 font-bold">Pts</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <tr key={i} className="border-b border-gray-200">
+                <td className="px-2 py-3">
+                  <div className="h-4 w-6 bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3">
+                  <div className="flex items-center gap-2">
+                    <div className="h-6 w-6 bg-gray-200 rounded-full animate-pulse" />
+                    <div className="h-4 w-32 bg-gray-200 rounded animate-pulse" />
+                  </div>
+                </td>
+                <td className="px-2 py-3 text-center">
+                  <div className="h-4 w-6 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center hidden md:table-cell">
+                  <div className="h-4 w-6 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center hidden md:table-cell">
+                  <div className="h-4 w-6 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center hidden md:table-cell">
+                  <div className="h-4 w-6 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center hidden lg:table-cell">
+                  <div className="h-4 w-6 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center hidden lg:table-cell">
+                  <div className="h-4 w-6 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center">
+                  <div className="h-4 w-8 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+                <td className="px-2 py-3 text-center">
+                  <div className="h-4 w-8 mx-auto bg-gray-200 rounded animate-pulse" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (standings.length === 0) {
+    return (
+      <div
+        className={cn(
+          "text-center py-8 text-gray-500 bg-gray-50 rounded-lg",
+          className,
+        )}
+      >
+        <p>Geen klassement beschikbaar.</p>
+      </div>
+    );
+  }
+
+  // Apply limit if specified
+  const displayedStandings = limit ? standings.slice(0, limit) : standings;
+
+  return (
+    <div className={cn("overflow-x-auto", className)}>
+      <table className="w-full text-sm">
+        <thead className="bg-kcvv-green-dark text-white">
+          <tr>
+            <th className="px-2 py-3 text-left w-10">#</th>
+            <th className="px-2 py-3 text-left">Team</th>
+            <th className="px-2 py-3 text-center w-10">P</th>
+            <th className="px-2 py-3 text-center w-10 hidden md:table-cell">
+              W
+            </th>
+            <th className="px-2 py-3 text-center w-10 hidden md:table-cell">
+              D
+            </th>
+            <th className="px-2 py-3 text-center w-10 hidden md:table-cell">
+              L
+            </th>
+            <th className="px-2 py-3 text-center w-12 hidden lg:table-cell">
+              G+
+            </th>
+            <th className="px-2 py-3 text-center w-12 hidden lg:table-cell">
+              G-
+            </th>
+            <th className="px-2 py-3 text-center w-12">+/-</th>
+            <th className="px-2 py-3 text-center w-12 font-bold">Pts</th>
+            {showForm && (
+              <th className="px-2 py-3 text-center w-28 hidden sm:table-cell">
+                Vorm
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {displayedStandings.map((entry) => {
+            const isHighlighted = entry.teamId === highlightTeamId;
+            return (
+              <tr
+                key={entry.teamId}
+                className={cn(
+                  "border-b border-gray-200 transition-colors",
+                  isHighlighted
+                    ? "bg-kcvv-green-bright text-white font-semibold"
+                    : "hover:bg-gray-50",
+                )}
+              >
+                <td className="px-2 py-3 text-center font-medium">
+                  {entry.position}
+                </td>
+                <td className="px-2 py-3">
+                  <div className="flex items-center gap-2">
+                    {entry.teamLogo ? (
+                      <Image
+                        src={entry.teamLogo}
+                        alt={`${entry.teamName} logo`}
+                        width={24}
+                        height={24}
+                        className="object-contain"
+                      />
+                    ) : (
+                      <div
+                        className={cn(
+                          "w-6 h-6 rounded-full flex items-center justify-center",
+                          isHighlighted ? "bg-white/20" : "bg-gray-200",
+                        )}
+                      >
+                        <span className="text-xs">
+                          {entry.teamName.charAt(0)}
+                        </span>
+                      </div>
+                    )}
+                    <span className="truncate max-w-[120px] sm:max-w-none">
+                      {entry.teamName}
+                    </span>
+                  </div>
+                </td>
+                <td className="px-2 py-3 text-center">{entry.played}</td>
+                <td className="px-2 py-3 text-center hidden md:table-cell">
+                  {entry.won}
+                </td>
+                <td className="px-2 py-3 text-center hidden md:table-cell">
+                  {entry.drawn}
+                </td>
+                <td className="px-2 py-3 text-center hidden md:table-cell">
+                  {entry.lost}
+                </td>
+                <td className="px-2 py-3 text-center hidden lg:table-cell">
+                  {entry.goalsFor}
+                </td>
+                <td className="px-2 py-3 text-center hidden lg:table-cell">
+                  {entry.goalsAgainst}
+                </td>
+                <td className="px-2 py-3 text-center">
+                  {entry.goalDifference > 0
+                    ? `+${entry.goalDifference}`
+                    : entry.goalDifference}
+                </td>
+                <td className="px-2 py-3 text-center font-bold">
+                  {entry.points}
+                </td>
+                {showForm && (
+                  <td className="px-2 py-3 hidden sm:table-cell">
+                    <div className="flex items-center justify-center gap-1">
+                      {entry.form?.split("").map((result, i) => (
+                        <FormBadge key={i} result={result} />
+                      ))}
+                    </div>
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/team/TeamStandings/index.ts
+++ b/src/components/team/TeamStandings/index.ts
@@ -1,0 +1,5 @@
+export {
+  TeamStandings,
+  type TeamStandingsProps,
+  type StandingsEntry,
+} from "./TeamStandings";


### PR DESCRIPTION
## Summary
- Adds `TeamStandings` component for league standings tables
- Adds `TeamSchedule` component for team match schedules
- Adds `CoachProfile` component for coach/staff profiles

Closes #524

## Components

### TeamStandings
- Full standings table with all columns (P, W, D, L, G+, G-, +/-, Pts)
- Team highlighting for KCVV teams
- Form display (recent results as WWLDW badges)
- Compact variant showing top N teams
- Responsive design for mobile

### TeamSchedule
- Upcoming and past matches display
- Next match highlighting
- Result color coding (green/red/yellow borders)
- Status badges (Live, Postponed, Cancelled)
- Links to match detail pages

### CoachProfile
- Card and inline variants
- Photo with fallback placeholder
- Contact info (email, phone) links
- Optional biography text
- Accessible icons

## Test plan
- [x] TeamStandings: 19 tests passing
- [x] TeamSchedule: 25 tests passing
- [x] CoachProfile: 18 tests passing
- [x] TypeScript check passes
- [x] ESLint passes with no warnings
- [x] Full test suite (1271 tests) passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)