### PR TITLE
refactor(matches): extract UpcomingMatch type to shared match-domain module

### DIFF
--- a/src/components/home/UpcomingMatches/UpcomingMatches.tsx
+++ b/src/components/home/UpcomingMatches/UpcomingMatches.tsx
@@ -12,55 +12,9 @@ import Link from "next/link";
 import Image from "next/image";
 import { cn } from "@/lib/utils/cn";
 import { formatMatchDate } from "@/lib/utils/dates";
+import type { UpcomingMatch } from "@/components/match/types";
 
-export interface UpcomingMatch {
-  /**
-   * Match ID
-   */
-  id: number;
-  /**
-   * Match date
-   */
-  date: Date;
-  /**
-   * Match time (optional)
-   */
-  time?: string;
-  /**
-   * Venue/location (optional)
-   */
-  venue?: string;
-  /**
-   * Home team
-   */
-  homeTeam: {
-    id: number;
-    name: string;
-    logo?: string;
-    score?: number;
-  };
-  /**
-   * Away team
-   */
-  awayTeam: {
-    id: number;
-    name: string;
-    logo?: string;
-    score?: number;
-  };
-  /**
-   * Match status
-   */
-  status: "scheduled" | "live" | "finished" | "postponed" | "cancelled";
-  /**
-   * Round/matchday (optional)
-   */
-  round?: string;
-  /**
-   * Competition name (optional)
-   */
-  competition?: string;
-}
+export type { UpcomingMatch };
 
 export interface UpcomingMatchesProps {
   /**

--- a/src/components/match/MatchList/MatchList.tsx
+++ b/src/components/match/MatchList/MatchList.tsx
@@ -7,7 +7,7 @@
 
 import { cn } from "@/lib/utils/cn";
 import { MatchTeaser } from "../MatchTeaser/MatchTeaser";
-import type { UpcomingMatch } from "@/components/home/UpcomingMatches/UpcomingMatches";
+import type { UpcomingMatch } from "@/components/match/types";
 
 export interface MatchListProps {
   /** Matches to display */

--- a/src/components/match/MatchesOverview/MatchesOverview.stories.tsx
+++ b/src/components/match/MatchesOverview/MatchesOverview.stories.tsx
@@ -4,7 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { MatchesOverview } from "./MatchesOverview";
-import type { UpcomingMatch } from "@/components/home/UpcomingMatches/UpcomingMatches";
+import type { UpcomingMatch } from "@/components/match/types";
 import {
   mockScheduledMatches,
   mockFinishedMatch,

--- a/src/components/match/MatchesOverview/MatchesOverview.tsx
+++ b/src/components/match/MatchesOverview/MatchesOverview.tsx
@@ -7,7 +7,7 @@
 
 import { cn } from "@/lib/utils/cn";
 import { MatchList } from "../MatchList/MatchList";
-import type { UpcomingMatch } from "@/components/home/UpcomingMatches/UpcomingMatches";
+import type { UpcomingMatch } from "@/components/match/types";
 
 export interface MatchesOverviewProps {
   /** Upcoming / scheduled matches */

--- a/src/components/match/MatchesSlider/MatchesSlider.tsx
+++ b/src/components/match/MatchesSlider/MatchesSlider.tsx
@@ -10,7 +10,7 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils/cn";
 import { MatchTeaser } from "../MatchTeaser/MatchTeaser";
-import type { UpcomingMatch } from "@/components/home/UpcomingMatches/UpcomingMatches";
+import type { UpcomingMatch } from "@/components/match/types";
 
 export interface MatchesSliderProps {
   /** Matches to display */

--- a/src/components/match/MatchesTabs/MatchesTabs.tsx
+++ b/src/components/match/MatchesTabs/MatchesTabs.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils/cn";
 import { FilterTabs } from "@/components/design-system/FilterTabs/FilterTabs";
 import { MatchList } from "../MatchList/MatchList";
-import type { UpcomingMatch } from "@/components/home/UpcomingMatches/UpcomingMatches";
+import type { UpcomingMatch } from "@/components/match/types";
 
 export interface MatchesTabsProps {
   /** All matches — component splits them by status */

--- a/src/components/match/index.ts
+++ b/src/components/match/index.ts
@@ -19,3 +19,5 @@ export type { MatchesSliderProps } from "./MatchesSlider/MatchesSlider";
 
 export { MatchesTabs } from "./MatchesTabs/MatchesTabs";
 export type { MatchesTabsProps } from "./MatchesTabs/MatchesTabs";
+
+export type { UpcomingMatch } from "./types";

--- a/src/components/match/types.ts
+++ b/src/components/match/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared match domain types.
+ * Imported by all match-domain components — keep this file free of
+ * React / component dependencies so it can be used anywhere in the app.
+ */
+
+export interface UpcomingMatch {
+  /**
+   * Match ID
+   */
+  id: number;
+  /**
+   * Match date
+   */
+  date: Date;
+  /**
+   * Match time (optional)
+   */
+  time?: string;
+  /**
+   * Venue/location (optional)
+   */
+  venue?: string;
+  /**
+   * Home team
+   */
+  homeTeam: {
+    id: number;
+    name: string;
+    logo?: string;
+    score?: number;
+  };
+  /**
+   * Away team
+   */
+  awayTeam: {
+    id: number;
+    name: string;
+    logo?: string;
+    score?: number;
+  };
+  /**
+   * Match status
+   */
+  status: "scheduled" | "live" | "finished" | "postponed" | "cancelled";
+  /**
+   * Round/matchday (optional)
+   */
+  round?: string;
+  /**
+   * Competition name (optional)
+   */
+  competition?: string;
+}

--- a/src/lib/mappers/match.mapper.ts
+++ b/src/lib/mappers/match.mapper.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Match } from "@/lib/effect/schemas/match.schema";
-import type { UpcomingMatch } from "@/components/home/UpcomingMatches/UpcomingMatches";
+import type { UpcomingMatch } from "@/components/match/types";
 
 /**
  * Fix team name capitalization


### PR DESCRIPTION
## Summary

- Creates `src/components/match/types.ts` with the `UpcomingMatch` interface
- Removes the definition from `home/UpcomingMatches/UpcomingMatches.tsx` — it now imports and re-exports the type for backwards compatibility (no breaking change)
- Updates all 6 cross-domain importers (`match.mapper.ts`, `MatchList`, `MatchesOverview`, `MatchesTabs`, `MatchesSlider`, `MatchesOverview.stories`) to import from `@/components/match/types`
- Exports `UpcomingMatch` from the match barrel (`src/components/match/index.ts`)

Closes #699

## Test plan

- [ ] `npm run type-check` passes (zero errors)
- [ ] `npm run lint:fix` passes (zero warnings)
- [ ] No behaviour change — type-only refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)