### PR TITLE
fix(config): prevent shell injection in summary workflow

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Comment with AI summary
         run: |
-          gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
+          gh issue comment $ISSUE_NUMBER --body "$RESPONSE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

- Replaces inline `${{ steps.inference.outputs.response }}` expression in shell command with `"$RESPONSE"` env var reference
- The `RESPONSE` env var was already declared but unused — now actually used
- Eliminates the command injection vector where LLM output containing single quotes could break out of the shell string

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)