### PR TITLE
feat(ui): show role-filtered suggestions on role selection

### DIFF
--- a/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
+++ b/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
@@ -127,7 +127,7 @@ export function ResponsibilityFinder({
     semanticSearch(questionText);
   }, [questionText, semanticSearch]);
 
-  const suggestions: AutocompleteSuggestion[] = questionText
+  const suggestions: AutocompleteSuggestion[] = questionText?.trim()
     ? semanticResults
         .map((r) => {
           const path = paths.find((p) => p.id === r.slug);
@@ -147,6 +147,7 @@ export function ResponsibilityFinder({
     setSelectedResult(null);
     setShowRoleDropdown(false);
     setShowSuggestions(true);
+    setQuestionText("");
 
     // Clear any existing timeout
     if (focusTimeoutRef.current) {


### PR DESCRIPTION
## Summary

- When a role is selected in the ResponsibilityFinder dropdown, immediately show up to 5 responsibility paths matching that role (from the local `paths` prop) as suggestions
- Once the user starts typing, Vectorize semantic search takes over as before
- Fixes the empty dropdown state after role selection

## Also fixed (infra, no code change)

- Created a Vectorize metadata index on the `type` field (`wrangler vectorize create-metadata-index kcvv-search --property-name=type --type=string`)
- Re-ran the sanity-index-sync cron to re-upsert vectors with the metadata index active — filtered search (`type=responsibility`) now returns results

Closes #767

## Test plan

- [ ] Select "Speler" from the role dropdown → suggestions appear immediately without typing
- [ ] Start typing a query → suggestions switch to Vectorize semantic results
- [ ] Clear the input → role-based suggestions return
- [ ] Search on `/hulp` with a term like "ongeval" → results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)