### PR TITLE
fix(teams): mark staff as sync-owned and use psdTeamId for rankings

### DIFF
--- a/apps/api/src/sanity/client.ts
+++ b/apps/api/src/sanity/client.ts
@@ -85,7 +85,8 @@ export class SanityWriteClient extends Context.Tag("SanityWriteClient")<
 /**
  * Upsert strategy: createIfNotExists sets the document skeleton on first run.
  * patch().set() overwrites only PSD-sourced fields — never touches editorial
- * fields (transparentImage, celebrationImage, position, bio, trainingSchedule, staff).
+ * fields (transparentImage, celebrationImage, position, bio, trainingSchedule).
+ * Both `players` and `staff` on team documents are sync-owned (readOnly in Studio).
  */
 export const SanityWriteClientLive = Layer.effect(
   SanityWriteClient,

--- a/apps/studio/schemaTypes/team.ts
+++ b/apps/studio/schemaTypes/team.ts
@@ -138,6 +138,7 @@ export const team = defineType({
       title: 'Staff',
       type: 'array',
       of: [{type: 'reference', to: [{type: 'staffMember'}]}],
+      readOnly: true,
     }),
   ],
   preview: {

--- a/apps/web/src/app/(main)/team/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/team/[slug]/page.tsx
@@ -96,17 +96,10 @@ interface BffData {
 /**
  * Fetches matches and standings from the BFF for a given team.
  *
- * @param psdTeamId - The team's PSD internal ID (used for matches and as ranking fallback).
- * @param leagueId - Optional league identifier used to select the ranking; if provided,
- *   standings are fetched for this league instead of the PSD team ID.
+ * @param psdTeamId - The team's PSD internal ID (used for both matches and standings).
  * @returns An object with `matches`, `standings`, and `teamId` when successful; `null` on error.
  */
-async function fetchBffData(
-  psdTeamId: number,
-  leagueId: number | null,
-): Promise<BffData | null> {
-  const rankingId = leagueId ?? psdTeamId;
-
+async function fetchBffData(psdTeamId: number): Promise<BffData | null> {
   try {
     const [matches, standings] = await runPromise(
       Effect.gen(function* () {
@@ -119,7 +112,7 @@ async function fetchBffData(
                 Effect.catchAll(() => Effect.succeed([] as readonly Match[])),
               ),
             bff
-              .getRanking(rankingId)
+              .getRanking(psdTeamId)
               .pipe(
                 Effect.catchAll(() =>
                   Effect.succeed([] as readonly RankingEntry[]),
@@ -157,7 +150,7 @@ export default async function TeamPage({ params }: TeamPageProps) {
 
   if (!team) notFound();
 
-  const bffData = await fetchBffData(Number(team.psdId), team.leagueId);
+  const bffData = await fetchBffData(Number(team.psdId));
 
   return (
     <TeamDetail


### PR DESCRIPTION
- Add readOnly:true to team.staff in Sanity Studio schema — staff refs are PSD-managed (like players) and must not be overwritten by editors
- Update client.ts contract comment to explicitly state players and staff are both sync-owned fields
- fetchBffData: remove leagueId parameter and always pass psdTeamId to getRanking; leagueId is readOnly/never synced so it was always null and the fallback was already psdTeamId — simplifies the signature