### PR TITLE
fix(api): use full profilePictureURL with auth key for image download

### DIFF
--- a/apps/api/src/sanity/client.ts
+++ b/apps/api/src/sanity/client.ts
@@ -226,7 +226,8 @@ export const SanityWriteClientLive = Layer.effect(
                   _type: "image",
                   asset: { _type: "reference", _ref: asset._id },
                 },
-                psdImageUrl: imageUrl,
+                // Store stable URL (no query param) for dedup comparison on future syncs.
+                psdImageUrl: imageUrl.split("?")[0],
               })
               .commit();
           },

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -20,7 +20,10 @@ import { WorkerEnvTag } from "../env";
 export function transformMember(
   psd: PsdMember,
   baseUrl: string,
-): SanityPlayerDoc & { _psdImageUrl: string | null } {
+): SanityPlayerDoc & {
+  _psdImageUrl: string | null;
+  _psdImageFetchUrl: string | null;
+} {
   return {
     psdId: String(psd.id),
     firstName: psd.firstName,
@@ -34,10 +37,14 @@ export function transformMember(
         : psd.bestPosition !== null
           ? psd.bestPosition.type.name
           : null,
-    // Strip the rotating ?profileAccessKey query param so the stored URL stays
-    // stable across syncs — the path alone uniquely identifies the player photo.
+    // Stable URL (no query param) used for dedup comparison across syncs.
+    // The path alone uniquely identifies the player photo.
     _psdImageUrl: psd.profilePictureURL
       ? `${baseUrl}${psd.profilePictureURL.split("?")[0]}`
+      : null,
+    // Full URL including ?profileAccessKey — required to actually fetch the image.
+    _psdImageFetchUrl: psd.profilePictureURL
+      ? `${baseUrl}${psd.profilePictureURL}`
       : null,
   };
 }
@@ -187,15 +194,16 @@ export const runSync = Effect.gen(function* () {
         const doc = transformMember(m, baseUrl);
         yield* sanity.upsertPlayer(doc);
 
-        const newImageUrl = doc._psdImageUrl;
-        if (newImageUrl) {
+        const stableImageUrl = doc._psdImageUrl;
+        const fetchImageUrl = doc._psdImageFetchUrl;
+        if (stableImageUrl && fetchImageUrl) {
           const existing = imageState.get(doc.psdId);
           const needsUpload =
-            !existing?.hasPsdImage || existing.psdImageUrl !== newImageUrl;
+            !existing?.hasPsdImage || existing.psdImageUrl !== stableImageUrl;
           if (needsUpload) {
             yield* Effect.log(`uploading image for player ${doc.psdId}`);
             yield* sanity
-              .uploadPlayerImage(doc.psdId, newImageUrl)
+              .uploadPlayerImage(doc.psdId, fetchImageUrl)
               .pipe(
                 Effect.catchAll((e) =>
                   Effect.log(


### PR DESCRIPTION
## Summary

- PSD's `profilePictureURL` requires `?profileAccessKey=...` to fetch the image — without it PSD returns 404 (silently skipped in the sync)
- The sync logged "uploading image for player X" but immediately hit a silent 404, so no player images were ever uploaded to Sanity
- Root cause: `transformMember` stripped the query param before passing the URL to `uploadPlayerImage`

## Fix

- `transformMember` now returns both `_psdImageUrl` (stable path, no query param — used for dedup comparison) and `_psdImageFetchUrl` (full URL with key — used for the actual HTTP download)
- `uploadPlayerImage` stores the stable URL in `psdImageUrl` so future dedup works correctly without triggering re-uploads when `profileAccessKey` rotates

## Test plan
- [ ] Merge, deploy, trigger sync for team 1
- [ ] Verify `hasPsdImage: true` in Sanity for players like Gregory Boudart (id 1674)

🤖 Generated with [Claude Code](https://claude.com/claude-code)