### PR TITLE
fix(api): reduce player sync concurrency to avoid Sanity upload rate limit

### DIFF
--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -235,7 +235,7 @@ export const runSync = Effect.gen(function* () {
             ),
           );
       }),
-    { concurrency: 5 },
+    { concurrency: 2 }, // low to avoid Sanity asset upload rate limit
   );
 
   yield* Effect.forEach(


### PR DESCRIPTION
## Summary

Running player upsert + image upload at `concurrency: 5` triggers Sanity asset API 429s (confirmed in logs). Reduces to `concurrency: 2` — still parallelises PSD download + Sanity upload across two players at a time without flooding the endpoint.

Observed in logs:
```
Sanity upload failed: 429 {"statusCode":500,"error":"Internal Server Error","message":"An internal server error occurred"}
```

## Test plan

- [ ] Merge and deploy
- [ ] Trigger sync and confirm no 429s in logs — all players show `patch committed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)