### PR TITLE
fix(config): restore npm manager in Renovate enabledManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "group:nextjsMonorepo",
     "security:openssf-scorecard"
   ],
-  "enabledManagers": ["pnpm", "nvm", "github-actions", "dockerfile"],
+  "enabledManagers": ["npm", "pnpm", "nvm", "github-actions", "dockerfile"],
   "packageRules": [
     {
       "description": "Security/vulnerability fixes with 🔒",


### PR DESCRIPTION
## Summary

Reverts the incorrect part of #789. Removing `npm` from `enabledManagers` broke Renovate's ability to update `package.json` dependencies — the `npm` manager handles all `package.json` updates regardless of lockfile type. The `pnpm` manager only covers `pnpm-workspace.yaml`.

The actual fix for the original issue (#728) was deleting `package-lock.json` (done in #789). The `npm` manager entry was never the problem.

Fixes #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)