### PR TITLE
fix(config): remove invalid pnpm manager from Renovate enabledManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "group:nextjsMonorepo",
     "security:openssf-scorecard"
   ],
-  "enabledManagers": ["npm", "pnpm", "nvm", "github-actions", "dockerfile"],
+  "enabledManagers": ["npm", "nvm", "github-actions", "dockerfile"],
   "packageRules": [
     {
       "description": "Security/vulnerability fixes with 🔒",
@@ -173,6 +173,7 @@
   "commitMessageAction": "{{semanticCommitType}}({{semanticCommitScope}}): update",
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+  "postUpdateOptions": ["pnpmDedupe"],
   "prCreation": "immediate",
   "prConcurrentLimit": 3,
   "rebaseWhen": "behind-base-branch"


### PR DESCRIPTION
## Summary

- Removes `pnpm` from `enabledManagers` — not a valid Renovate manager name, causes runtime `config-validation` error
- Adds `postUpdateOptions: ["pnpmDedupe"]` — runs `pnpm dedupe` after lockfile updates, keeping `pnpm-lock.yaml` clean across workspaces
- The `npm` manager handles pnpm lockfiles natively

Validated with `renovate-config-validator --strict` ✅

This is the actual root cause of #728 / #793.

Fixes #793. Closes #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)