### PR TITLE
feat(ui): homepage v3 — all new blocks + section transitions

### DIFF
--- a/apps/studio/schemaTypes/banner.ts
+++ b/apps/studio/schemaTypes/banner.ts
@@ -1,0 +1,32 @@
+import {defineField, defineType} from 'sanity'
+
+export const banner = defineType({
+  name: 'banner',
+  title: 'Banner',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Banner image',
+      type: 'image',
+      options: {hotspot: true},
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: 'alt',
+      title: 'Alt text',
+      type: 'string',
+      validation: (r) => r.required(),
+      description: 'Required for accessibility. Describe the banner content.',
+    }),
+    defineField({
+      name: 'href',
+      title: 'Click-through URL',
+      type: 'url',
+      description: 'Optional. Wraps the banner in a link.',
+    }),
+  ],
+  preview: {
+    select: {title: 'alt', media: 'image'},
+  },
+})

--- a/apps/studio/schemaTypes/event.ts
+++ b/apps/studio/schemaTypes/event.ts
@@ -33,6 +33,13 @@ export const event = defineType({
         defineField({name: 'label', title: 'Label', type: 'string'}),
       ],
     }),
+    defineField({
+      name: 'featuredOnHome',
+      title: 'Featured on homepage',
+      type: 'boolean',
+      description: 'When enabled, this event fills the featured slot in the news section on the homepage.',
+      initialValue: false,
+    }),
   ],
   preview: {
     select: {title: 'title', media: 'coverImage', dateStart: 'dateStart'},

--- a/apps/studio/schemaTypes/homePage.ts
+++ b/apps/studio/schemaTypes/homePage.ts
@@ -1,0 +1,33 @@
+import {defineField, defineType} from 'sanity'
+
+export const homePage = defineType({
+  name: 'homePage',
+  title: 'Homepage',
+  type: 'document',
+  __experimental_actions: ['update', 'publish'],
+  fields: [
+    defineField({
+      name: 'bannerSlotA',
+      title: 'Banner slot A (below Match Widget)',
+      type: 'reference',
+      to: [{type: 'banner'}],
+    }),
+    defineField({
+      name: 'bannerSlotB',
+      title: 'Banner slot B (below News section)',
+      type: 'reference',
+      to: [{type: 'banner'}],
+    }),
+    defineField({
+      name: 'bannerSlotC',
+      title: 'Banner slot C (below Youth section)',
+      type: 'reference',
+      to: [{type: 'banner'}],
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {title: 'Homepage configuration'}
+    },
+  },
+})

--- a/apps/studio/schemaTypes/index.ts
+++ b/apps/studio/schemaTypes/index.ts
@@ -8,5 +8,11 @@ import {event} from './event'
 import {page} from './page'
 import {fileAttachment} from './fileAttachment'
 import {htmlTable} from './htmlTable'
+import {banner} from './banner'
+import {homePage} from './homePage'
 
-export const schemaTypes = [player, team, trainingDay, staffMember, responsibilityPath, article, sponsor, event, page, fileAttachment, htmlTable]
+export const schemaTypes = [
+  player, team, trainingDay, staffMember, responsibilityPath,
+  article, sponsor, event, page, fileAttachment, htmlTable,
+  banner, homePage,
+]

--- a/apps/studio/structure.ts
+++ b/apps/studio/structure.ts
@@ -86,6 +86,18 @@ export const structure: StructureResolver = (S) =>
         .child(S.documentTypeList('page').title('Pages')),
       S.divider(),
       S.listItem()
+        .title('Banners')
+        .child(S.documentTypeList('banner').title('Banners')),
+      S.listItem()
+        .title('Homepage')
+        .child(
+          S.document()
+            .schemaType('homePage')
+            .documentId('homePage')
+            .title('Homepage configuratie'),
+        ),
+      S.divider(),
+      S.listItem()
         .title('Hulp & Contact')
         .child(
           S.documentTypeList('responsibilityPath')

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,10 +4,21 @@
  */
 
 import { Effect } from "effect";
+import { DateTime } from "luxon";
 import { runPromise } from "@/lib/effect/runtime";
 import { SanityService } from "@/lib/effect/services/SanityService";
+import type { SanityEvent } from "@/lib/effect/services/SanityService";
 import { BffService } from "@/lib/effect/services/BffService";
-import { FeaturedArticles, LatestNews, MatchWidget } from "@/components/home";
+import {
+  FeaturedArticles,
+  LatestNews,
+  MatchWidget,
+  BannerSlot,
+  MatchesSliderSection,
+  YouthSection,
+  SponsorsSection,
+} from "@/components/home";
+import type { FeaturedEventStub } from "@/components/home";
 import {
   mapSanityArticlesToHomepageArticles,
   mapMatchesToUpcomingMatches,
@@ -29,41 +40,106 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 /**
- * Render the homepage with a featured articles carousel, the next match widget, and a latest-news section.
- *
- * Fetches recent articles and upcoming matches, shows the first three articles as featured items and the next six as latest news, and renders a centered fallback message if both article and match data are unavailable.
- *
- * @returns The homepage React element containing the featured articles carousel, the next match widget (if available), and the latest news section, or a centered fallback message when no content is available.
+ * Builds the featured event stub for the LatestNews section.
+ * Same-day event: shows date + time range.
+ * Multi-day event: shows "d MMM HH:mm – d MMM HH:mm" as single date string.
  */
+function buildFeaturedEventStub(event: SanityEvent): FeaturedEventStub {
+  const start = DateTime.fromISO(event.dateStart).setLocale("nl");
+  const end = event.dateEnd
+    ? DateTime.fromISO(event.dateEnd).setLocale("nl")
+    : null;
+
+  const now = DateTime.now();
+  const diffDays = Math.ceil(start.diff(now, "days").days);
+  const countdown =
+    diffDays > 0
+      ? `over ${diffDays} ${diffDays === 1 ? "dag" : "dagen"}`
+      : undefined;
+
+  let eventDate: string;
+  let eventTime: string | undefined;
+
+  if (end && end.startOf("day").valueOf() !== start.startOf("day").valueOf()) {
+    // Multi-day: "26 apr 10:00 – 28 apr 12:00"
+    eventDate = `${start.toFormat("d MMM HH:mm")} – ${end.toFormat("d MMM HH:mm")}`;
+    eventTime = undefined;
+  } else {
+    // Same-day: date + optional time range
+    eventDate = start.toFormat("d MMM");
+    const startTime = start.toFormat("HH:mm");
+    eventTime =
+      end && end.valueOf() !== start.valueOf()
+        ? `${startTime}–${end.toFormat("HH:mm")}`
+        : startTime !== "00:00"
+          ? startTime
+          : undefined;
+  }
+
+  return {
+    title: event.title,
+    href: event.externalLink?.url,
+    imageUrl: event.coverImageUrl ?? undefined,
+    badge: "EVENEMENT",
+    date: eventDate,
+    time: eventTime,
+    countdown,
+    isExternal: !!event.externalLink?.url,
+  };
+}
+
+// TODO: load team label map from Sanity teams to avoid hardcoding team IDs
+const TEAM_LABELS: Record<number, string> = {
+  1235: "A-Ploeg",
+};
+
 export default async function HomePage() {
-  // Fetch latest articles and upcoming matches in parallel with error handling
-  const [articlesResult, matchesResult] = await Promise.all([
-    runPromise(
-      Effect.gen(function* () {
-        const sanity = yield* SanityService;
-        const all = yield* sanity.getArticles();
-        // Return 9 most-recent articles (already sorted by publishAt desc in GROQ)
-        return all.slice(0, 9);
-      }).pipe(Effect.catchAll(() => Effect.succeed([]))),
-    ),
-    runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* bff.getNextMatches();
-      }).pipe(
-        // Graceful fallback: return empty array on error
-        Effect.catchAll((error) => {
-          console.error("[HomePage] Failed to fetch matches:", error);
-          return Effect.succeed([]);
-        }),
+  const [articlesResult, matchesResult, eventResult, bannersResult] =
+    await Promise.all([
+      runPromise(
+        Effect.gen(function* () {
+          const sanity = yield* SanityService;
+          const all = yield* sanity.getArticles();
+          return all.slice(0, 9);
+        }).pipe(Effect.catchAll(() => Effect.succeed([]))),
       ),
-    ),
-  ]);
+      runPromise(
+        Effect.gen(function* () {
+          const bff = yield* BffService;
+          return yield* bff.getNextMatches();
+        }).pipe(
+          Effect.catchAll((error) => {
+            console.error("[HomePage] Failed to fetch matches:", error);
+            return Effect.succeed([]);
+          }),
+        ),
+      ),
+      runPromise(
+        Effect.gen(function* () {
+          const sanity = yield* SanityService;
+          return yield* sanity.getNextFeaturedEvent();
+        }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+      ),
+      runPromise(
+        Effect.gen(function* () {
+          const sanity = yield* SanityService;
+          return yield* sanity.getHomepageBanners();
+        }).pipe(
+          Effect.catchAll(() =>
+            Effect.succeed({
+              bannerSlotA: null,
+              bannerSlotB: null,
+              bannerSlotC: null,
+            }),
+          ),
+        ),
+      ),
+    ]);
 
   const articles = articlesResult;
   const matches = matchesResult;
+  const banners = bannersResult;
 
-  // Split articles: first 3 for featured carousel, remaining 6 for latest news
   const featuredArticles = mapSanityArticlesToHomepageArticles(
     articles.slice(0, 3),
     true,
@@ -73,11 +149,21 @@ export default async function HomePage() {
     false,
   );
 
-  // Map matches to component format (Weitse Gans already filtered at service level)
   const upcomingMatches = mapMatchesToUpcomingMatches(matches);
   const nextMatch = upcomingMatches[0];
 
-  // Show fallback message if no content could be loaded at all
+  const featuredEvent = eventResult
+    ? buildFeaturedEventStub(eventResult)
+    : undefined;
+
+  const sliderMatches = upcomingMatches.map((m) => ({
+    ...m,
+    teamLabel:
+      TEAM_LABELS[m.homeTeam.id as number] ??
+      TEAM_LABELS[m.awayTeam.id as number] ??
+      undefined,
+  }));
+
   if (articles.length === 0 && matches.length === 0) {
     return (
       <div className="max-w-inner-lg mx-auto px-3 lg:px-0 py-16 text-center">
@@ -93,7 +179,7 @@ export default async function HomePage() {
 
   return (
     <>
-      {/* Featured Articles Hero Carousel */}
+      {/* Hero */}
       {featuredArticles.length > 0 && (
         <FeaturedArticles
           articles={featuredArticles}
@@ -102,22 +188,55 @@ export default async function HomePage() {
         />
       )}
 
-      {/* Match Widget — next A-team match */}
+      {/* Match Widget — A-team next match */}
       {nextMatch && <MatchWidget match={nextMatch} teamLabel="A-Ploeg" />}
 
-      {/* Latest News Section */}
-      {latestNewsArticles.length > 0 && (
+      {/* Banner slot A — below match widget */}
+      {banners.bannerSlotA && (
+        <BannerSlot
+          image={banners.bannerSlotA.imageUrl}
+          alt={banners.bannerSlotA.alt}
+          href={banners.bannerSlotA.href ?? undefined}
+        />
+      )}
+
+      {/* News + featured event */}
+      {(latestNewsArticles.length > 0 || featuredEvent) && (
         <LatestNews
           articles={latestNewsArticles}
+          featuredEvent={featuredEvent}
           title="Laatste nieuws"
-          showViewAll={true}
+          showViewAll
           viewAllHref="/news"
         />
       )}
 
-      {/* TODO: Future enhancements:
-       * - KCVVTV video section (on hold - no cameraman available)
-       */}
+      {/* Banner slot B — below news */}
+      {banners.bannerSlotB && (
+        <BannerSlot
+          image={banners.bannerSlotB.imageUrl}
+          alt={banners.bannerSlotB.alt}
+          href={banners.bannerSlotB.href ?? undefined}
+        />
+      )}
+
+      {/* Match slider */}
+      <MatchesSliderSection matches={sliderMatches} highlightTeamId={1235} />
+
+      {/* Youth section */}
+      <YouthSection />
+
+      {/* Banner slot C — below youth */}
+      {banners.bannerSlotC && (
+        <BannerSlot
+          image={banners.bannerSlotC.imageUrl}
+          alt={banners.bannerSlotC.alt}
+          href={banners.bannerSlotC.href ?? undefined}
+        />
+      )}
+
+      {/* Sponsors */}
+      <SponsorsSection />
     </>
   );
 }

--- a/apps/web/src/components/design-system/SectionDivider/SectionDivider.tsx
+++ b/apps/web/src/components/design-system/SectionDivider/SectionDivider.tsx
@@ -79,7 +79,11 @@ export function SectionDivider({
         colorClass[color],
         className,
       )}
-      style={{ clipPath, height: "clamp(2rem, 6vw, 5rem)" }}
+      style={{
+        clipPath,
+        height: "clamp(2rem, 6vw, 5rem)",
+        transform: "translateZ(0)",
+      }}
     />
   );
 }

--- a/apps/web/src/components/home/BannerSlot/BannerSlot.stories.tsx
+++ b/apps/web/src/components/home/BannerSlot/BannerSlot.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { BannerSlot } from "./BannerSlot";
+
+const meta = {
+  title: "Features/Homepage/BannerSlot",
+  component: BannerSlot,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof BannerSlot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLink: Story = {
+  args: {
+    image: "/images/header-pattern.png",
+    alt: "Anti-racism campaign",
+    href: "https://example.com",
+  },
+};
+
+export const NoLink: Story = {
+  args: {
+    image: "/images/header-pattern.png",
+    alt: "Summer camp 2026",
+  },
+};

--- a/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
+++ b/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
@@ -48,14 +48,12 @@ export const BannerSlot = ({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="block max-w-[1280px] mx-auto px-4 md:px-8 py-8"
+        className="block max-w-7xl mx-auto px-4 md:px-8 py-8"
       >
         {inner}
       </a>
     );
   }
 
-  return (
-    <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-8">{inner}</div>
-  );
+  return <div className="max-w-7xl mx-auto px-4 md:px-8 py-8">{inner}</div>;
 };

--- a/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
+++ b/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
@@ -1,0 +1,61 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+
+export interface BannerSlotProps {
+  /** Banner image URL */
+  image: string;
+  /** Alt text for accessibility */
+  alt: string;
+  /** Optional click-through URL — wraps in <a> when set */
+  href?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Optional editorial/campaign banner.
+ * Contained (not full-bleed), rounded corners, subtle shadow.
+ * Hidden when no banner is configured (call site handles conditional rendering).
+ */
+export const BannerSlot = ({
+  image,
+  alt,
+  href,
+  className,
+}: BannerSlotProps) => {
+  const inner = (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded shadow-sm",
+        "aspect-[6/1] min-h-[60px]",
+        className,
+      )}
+    >
+      <Image
+        src={image}
+        alt={alt}
+        fill
+        className="object-cover"
+        sizes="(max-width: 768px) 100vw, 1280px"
+        priority={false}
+      />
+    </div>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block max-w-[1280px] mx-auto px-4 md:px-8 py-8"
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-8">{inner}</div>
+  );
+};

--- a/apps/web/src/components/home/BannerSlot/index.ts
+++ b/apps/web/src/components/home/BannerSlot/index.ts
@@ -1,0 +1,2 @@
+export { BannerSlot } from "./BannerSlot";
+export type { BannerSlotProps } from "./BannerSlot";

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
@@ -185,7 +185,7 @@ export const FeaturedArticles = ({
         {activeArticle.title}
       </div>
 
-      <div className="relative w-full h-[400px] lg:h-[600px]">
+      <div className="relative w-full h-[400px] md:h-[500px] lg:h-[600px]">
         {/* Background Image with Overlay */}
         <div className="absolute inset-0">
           {activeArticle.imageUrl && (
@@ -203,7 +203,7 @@ export const FeaturedArticles = ({
         </div>
 
         {/* Content Overlay — padded away from sidebar on desktop */}
-        <div className="relative z-10 h-full flex items-center px-4 lg:px-10">
+        <div className="relative z-10 h-full flex items-start pt-10 md:pt-14 lg:items-center lg:pt-0 px-4 lg:px-10">
           <Link
             href={activeArticle.href}
             className="group flex flex-col justify-center max-w-lg lg:max-w-xl"

--- a/apps/web/src/components/home/Homepage.stories.tsx
+++ b/apps/web/src/components/home/Homepage.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { FeaturedArticles } from "./FeaturedArticles";
 import { LatestNews } from "./LatestNews";
 import { MatchWidget } from "./MatchWidget";
+import { BannerSlot } from "./BannerSlot";
 import { MatchesSliderSection } from "./MatchesSliderSection";
 import { YouthSection } from "./YouthSection";
 import { PageFooter } from "@/components/layout/PageFooter";
@@ -110,6 +111,12 @@ const mockSliderMatches = mockMatches.mixed.map((m, i) => ({
   teamLabel: i < 3 ? "A-Ploeg" : "U17",
 }));
 
+const mockBanner = {
+  image: "https://placehold.co/1280x213/1e2024/4acf52?text=Banner+Slot",
+  alt: "Mock banner",
+  href: "https://example.com",
+};
+
 /** SponsorsSection is an async server component — inline here with mock data */
 const SponsorsSectionMock = () => (
   <section className="-mt-0.5 bg-gray-100 py-20">
@@ -133,8 +140,8 @@ const SponsorsSectionMock = () => (
 );
 
 /**
- * Complete v3 homepage: hero → match widget → news → match slider →
- * youth section → sponsors → footer
+ * Complete v3 homepage: hero → match widget → banner A → news → banner B →
+ * match slider → youth section → banner C → sponsors → footer
  */
 export const Default: Story = {
   render: () => (
@@ -145,17 +152,20 @@ export const Default: Story = {
         autoRotateInterval={5000}
       />
       <MatchWidget match={mockUpcomingMatch} teamLabel="A-Ploeg" />
+      <BannerSlot {...mockBanner} />
       <LatestNews
         articles={mockLatestNews}
         title="Laatste nieuws"
         showViewAll={true}
         viewAllHref="/news"
       />
+      <BannerSlot {...mockBanner} />
       <MatchesSliderSection
         matches={mockSliderMatches}
         highlightTeamId={1235}
       />
       <YouthSection />
+      <BannerSlot {...mockBanner} />
       <SponsorsSectionMock />
       <PageFooter />
     </>
@@ -174,6 +184,7 @@ export const WithFeaturedEvent: Story = {
         autoRotateInterval={5000}
       />
       <MatchWidget match={mockUpcomingMatch} teamLabel="A-Ploeg" />
+      <BannerSlot {...mockBanner} />
       <LatestNews
         articles={mockLatestNews.slice(0, 2)}
         featuredEvent={{
@@ -190,11 +201,13 @@ export const WithFeaturedEvent: Story = {
         showViewAll={true}
         viewAllHref="/news"
       />
+      <BannerSlot {...mockBanner} />
       <MatchesSliderSection
         matches={mockSliderMatches}
         highlightTeamId={1235}
       />
       <YouthSection />
+      <BannerSlot {...mockBanner} />
       <SponsorsSectionMock />
       <PageFooter />
     </>
@@ -219,17 +232,20 @@ export const NoAutoRotation: Story = {
     <>
       <FeaturedArticles articles={mockFeaturedArticles} autoRotate={false} />
       <MatchWidget match={mockUpcomingMatch} teamLabel="A-Ploeg" />
+      <BannerSlot {...mockBanner} />
       <LatestNews
         articles={mockLatestNews}
         title="Laatste nieuws"
         showViewAll={true}
         viewAllHref="/news"
       />
+      <BannerSlot {...mockBanner} />
       <MatchesSliderSection
         matches={mockSliderMatches}
         highlightTeamId={1235}
       />
       <YouthSection />
+      <BannerSlot {...mockBanner} />
       <SponsorsSectionMock />
       <PageFooter />
     </>

--- a/apps/web/src/components/home/Homepage.stories.tsx
+++ b/apps/web/src/components/home/Homepage.stories.tsx
@@ -1,6 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { FeaturedArticles } from "./FeaturedArticles";
 import { LatestNews } from "./LatestNews";
+import { MatchWidget } from "./MatchWidget";
+import { MatchesSliderSection } from "./MatchesSliderSection";
+import { YouthSection } from "./YouthSection";
+import { PageFooter } from "@/components/layout/PageFooter";
+import { Sponsors } from "@/components/sponsors/Sponsors";
+import { mockSponsors } from "@/components/sponsors/Sponsors.mocks";
+import { SectionHeader } from "@/components/design-system";
+import { mockUpcomingMatch } from "./MatchWidget/MatchWidget.mocks";
+import { mockMatches } from "./UpcomingMatches/UpcomingMatches.mocks";
 
 const meta: Meta = {
   title: "Pages/Homepage",
@@ -96,8 +105,36 @@ const mockLatestNews = [
   },
 ];
 
+const mockSliderMatches = mockMatches.mixed.map((m, i) => ({
+  ...m,
+  teamLabel: i < 3 ? "A-Ploeg" : "U17",
+}));
+
+/** SponsorsSection is an async server component — inline here with mock data */
+const SponsorsSectionMock = () => (
+  <section className="-mt-0.5 bg-gray-100 py-20">
+    <div className="max-w-7xl mx-auto px-4 md:px-8">
+      <SectionHeader
+        title="Sponsors"
+        linkText="Word sponsor"
+        linkHref="/sponsors"
+      />
+      <Sponsors
+        sponsors={mockSponsors}
+        title=""
+        description=""
+        showViewAll={false}
+        variant="light"
+        columns={5}
+        className="py-0"
+      />
+    </div>
+  </section>
+);
+
 /**
- * Complete homepage layout with hero carousel and latest news
+ * Complete v3 homepage: hero → match widget → news → match slider →
+ * youth section → sponsors → footer
  */
 export const Default: Story = {
   render: () => (
@@ -107,58 +144,28 @@ export const Default: Story = {
         autoRotate={true}
         autoRotateInterval={5000}
       />
+      <MatchWidget match={mockUpcomingMatch} teamLabel="A-Ploeg" />
       <LatestNews
         articles={mockLatestNews}
         title="Laatste nieuws"
         showViewAll={true}
         viewAllHref="/news"
       />
+      <MatchesSliderSection
+        matches={mockSliderMatches}
+        highlightTeamId={1235}
+      />
+      <YouthSection />
+      <SponsorsSectionMock />
+      <PageFooter />
     </>
   ),
 };
 
 /**
- * Homepage with slow carousel rotation
+ * v3 homepage with featured event in the news section
  */
-export const SlowRotation: Story = {
-  render: () => (
-    <>
-      <FeaturedArticles
-        articles={mockFeaturedArticles}
-        autoRotate={true}
-        autoRotateInterval={8000}
-      />
-      <LatestNews
-        articles={mockLatestNews}
-        title="Laatste nieuws"
-        showViewAll={true}
-        viewAllHref="/news"
-      />
-    </>
-  ),
-};
-
-/**
- * Homepage without auto-rotation
- */
-export const NoAutoRotation: Story = {
-  render: () => (
-    <>
-      <FeaturedArticles articles={mockFeaturedArticles} autoRotate={false} />
-      <LatestNews
-        articles={mockLatestNews}
-        title="Laatste nieuws"
-        showViewAll={true}
-        viewAllHref="/news"
-      />
-    </>
-  ),
-};
-
-/**
- * Homepage with custom section title
- */
-export const CustomTitle: Story = {
+export const WithFeaturedEvent: Story = {
   render: () => (
     <>
       <FeaturedArticles
@@ -166,32 +173,30 @@ export const CustomTitle: Story = {
         autoRotate={true}
         autoRotateInterval={5000}
       />
+      <MatchWidget match={mockUpcomingMatch} teamLabel="A-Ploeg" />
       <LatestNews
-        articles={mockLatestNews}
-        title="Recente berichten"
-        showViewAll={true}
-        viewAllHref="/news"
-      />
-    </>
-  ),
-};
-
-/**
- * Minimal homepage (fewer articles)
- */
-export const Minimal: Story = {
-  render: () => (
-    <>
-      <FeaturedArticles
-        articles={mockFeaturedArticles.slice(0, 1)}
-        autoRotate={false}
-      />
-      <LatestNews
-        articles={mockLatestNews.slice(0, 3)}
+        articles={mockLatestNews.slice(0, 2)}
+        featuredEvent={{
+          title: "Jeugdtoernooi 2026 — schrijf je nu in!",
+          imageUrl: "https://placehold.co/800x600/008755/fff?text=Toernooi",
+          imageAlt: "Jeugdtoernooi KCVV",
+          badge: "EVENEMENT",
+          date: "26 apr",
+          time: "10:00–17:00",
+          countdown: "over 40 dagen",
+          isExternal: false,
+        }}
         title="Laatste nieuws"
         showViewAll={true}
         viewAllHref="/news"
       />
+      <MatchesSliderSection
+        matches={mockSliderMatches}
+        highlightTeamId={1235}
+      />
+      <YouthSection />
+      <SponsorsSectionMock />
+      <PageFooter />
     </>
   ),
 };
@@ -204,4 +209,29 @@ export const MobileViewport: Story = {
   globals: {
     viewport: { value: "kcvvMobile" },
   },
+};
+
+/**
+ * Homepage without auto-rotation
+ */
+export const NoAutoRotation: Story = {
+  render: () => (
+    <>
+      <FeaturedArticles articles={mockFeaturedArticles} autoRotate={false} />
+      <MatchWidget match={mockUpcomingMatch} teamLabel="A-Ploeg" />
+      <LatestNews
+        articles={mockLatestNews}
+        title="Laatste nieuws"
+        showViewAll={true}
+        viewAllHref="/news"
+      />
+      <MatchesSliderSection
+        matches={mockSliderMatches}
+        highlightTeamId={1235}
+      />
+      <YouthSection />
+      <SponsorsSectionMock />
+      <PageFooter />
+    </>
+  ),
 };

--- a/apps/web/src/components/home/Homepage.stories.tsx
+++ b/apps/web/src/components/home/Homepage.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta = {
 };
 
 export default meta;
-type Story = StoryObj;
+type Story = StoryObj<typeof meta>;
 
 const mockFeaturedArticles = [
   {

--- a/apps/web/src/components/home/LatestNews/LatestNews.tsx
+++ b/apps/web/src/components/home/LatestNews/LatestNews.tsx
@@ -1,6 +1,6 @@
 // apps/web/src/components/home/LatestNews/LatestNews.tsx
 import { cn } from "@/lib/utils/cn";
-import { SectionHeader } from "@/components/design-system";
+import { SectionDivider, SectionHeader } from "@/components/design-system";
 import { NewsCard } from "./NewsCard";
 
 export interface LatestNewsArticle {
@@ -55,8 +55,10 @@ export const LatestNews = ({
     : articles.slice(1, 3);
 
   return (
-    <section className={cn("bg-gray-100 py-20", className)}>
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8">
+    <section
+      className={cn("relative bg-gray-100 py-20 overflow-hidden", className)}
+    >
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
         <SectionHeader
           title={title}
           linkText={showViewAll ? "Alle berichten" : undefined}
@@ -111,6 +113,8 @@ export const LatestNews = ({
           )}
         </div>
       </div>
+      {/* Diagonal bottom cut: gray-100 → kcvv-black (flip: diagonal reaches left edge) */}
+      <SectionDivider color="kcvv-black" position="bottom" flip />
     </section>
   );
 };

--- a/apps/web/src/components/home/LatestNews/LatestNews.tsx
+++ b/apps/web/src/components/home/LatestNews/LatestNews.tsx
@@ -15,11 +15,14 @@ export interface LatestNewsArticle {
 /** Stub for upcoming featured event — wired in #802 */
 export interface FeaturedEventStub {
   title: string;
-  href: string;
+  href?: string;
   imageUrl?: string;
   imageAlt?: string;
   badge?: string;
   date?: string;
+  time?: string;
+  countdown?: string;
+  isExternal?: boolean;
 }
 
 export interface LatestNewsProps {
@@ -70,8 +73,11 @@ export const LatestNews = ({
               href={featuredEvent.href}
               imageUrl={featuredEvent.imageUrl}
               imageAlt={featuredEvent.imageAlt}
-              badge={featuredEvent.badge}
-              date={featuredEvent.date}
+              badge={featuredEvent.badge ?? "EVENEMENT"}
+              eventDate={featuredEvent.date}
+              eventTime={featuredEvent.time}
+              countdown={featuredEvent.countdown}
+              isExternal={featuredEvent.isExternal}
             />
           ) : articles[0] ? (
             <NewsCard

--- a/apps/web/src/components/home/LatestNews/NewsCard.stories.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.stories.tsx
@@ -99,6 +99,31 @@ export const NoBadge: Story = {
   },
 };
 
+export const FeaturedEvent: Story = {
+  args: {
+    variant: "featured",
+    title: "Sponsorfeest KCVV Elewijt 2026",
+    href: "https://facebook.com/event",
+    badge: "EVENEMENT",
+    eventDate: "26 apr",
+    eventTime: "19:00",
+    countdown: "over 33 dagen",
+    isExternal: true,
+    imageUrl: "https://picsum.photos/1200/500?random=6",
+  },
+};
+
+export const FeaturedEventNoImage: Story = {
+  args: {
+    variant: "featured",
+    title: "Sponsorfeest KCVV Elewijt 2026",
+    badge: "EVENEMENT",
+    eventDate: "26 apr",
+    eventTime: "19:00",
+    countdown: "over 33 dagen",
+  },
+};
+
 export const MobileView: Story = {
   args: { ...Default.args },
   globals: { viewport: { value: "mobile1" } },

--- a/apps/web/src/components/home/LatestNews/NewsCard.test.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.test.tsx
@@ -124,6 +124,53 @@ describe("NewsCard", () => {
     });
   });
 
+  describe("event card features", () => {
+    it("renders eventTime with Calendar and Clock icons when time provided", () => {
+      render(
+        <NewsCard
+          title="Sponsorfeest"
+          href="/event/1"
+          variant="featured"
+          eventDate="15 apr"
+          eventTime="19:00"
+        />,
+      );
+      expect(screen.getByText("15 apr")).toBeInTheDocument();
+      expect(screen.getByText("19:00")).toBeInTheDocument();
+    });
+
+    it("renders countdown chip when countdown provided", () => {
+      render(
+        <NewsCard
+          title="Sponsorfeest"
+          href="/event/1"
+          variant="featured"
+          countdown="over 33 dagen"
+        />,
+      );
+      expect(screen.getByText("over 33 dagen")).toBeInTheDocument();
+    });
+
+    it("renders ExternalLink indicator when isExternal=true and href is set", () => {
+      render(
+        <NewsCard
+          title="Sponsorfeest"
+          href="https://facebook.com/event"
+          variant="featured"
+          isExternal
+        />,
+      );
+      // ExternalLink icon is aria-hidden, verify the link has target="_blank"
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+
+    it("renders as non-interactive div when no href", () => {
+      render(<NewsCard title="Sponsorfeest" variant="featured" />);
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Custom className", () => {
     it("accepts custom className on the article", () => {
       const { container } = render(

--- a/apps/web/src/components/home/LatestNews/NewsCard.test.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.test.tsx
@@ -68,10 +68,7 @@ describe("NewsCard", () => {
   describe("Badge and date", () => {
     it("renders badge above title", () => {
       render(<NewsCard {...defaultProps} badge="Clubnieuws" />);
-      // badge appears above title AND in footer — getAllByText
-      expect(screen.getAllByText("Clubnieuws").length).toBeGreaterThanOrEqual(
-        1,
-      );
+      expect(screen.getByText("Clubnieuws")).toBeInTheDocument();
     });
 
     it("renders date in footer", () => {
@@ -79,7 +76,7 @@ describe("NewsCard", () => {
       expect(screen.getByText("5 mei 2025")).toBeInTheDocument();
     });
 
-    it("does not render footer when no date and no badge", () => {
+    it("does not render footer when no date", () => {
       const { container } = render(<NewsCard {...defaultProps} />);
       expect(
         container.querySelector(".border-t.border-white\\/20"),

--- a/apps/web/src/components/home/LatestNews/NewsCard.test.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.test.tsx
@@ -151,6 +151,22 @@ describe("NewsCard", () => {
       expect(screen.getByText("over 33 dagen")).toBeInTheDocument();
     });
 
+    it("renders eventDate alongside countdown when both provided", () => {
+      render(
+        <NewsCard
+          title="Sponsorfeest"
+          href="/event/1"
+          variant="featured"
+          eventDate="26 apr"
+          eventTime="19:00"
+          countdown="over 33 dagen"
+        />,
+      );
+      expect(screen.getByText("26 apr")).toBeInTheDocument();
+      expect(screen.getByText("19:00")).toBeInTheDocument();
+      expect(screen.getByText("over 33 dagen")).toBeInTheDocument();
+    });
+
     it("renders ExternalLink indicator when isExternal=true and href is set", () => {
       render(
         <NewsCard

--- a/apps/web/src/components/home/LatestNews/NewsCard.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.tsx
@@ -2,15 +2,24 @@
 import Link from "next/link";
 import Image from "next/image";
 import { cn } from "@/lib/utils/cn";
+import { Calendar, Clock, ExternalLink } from "@/lib/icons";
 
 export interface NewsCardProps {
   title: string;
-  href: string;
+  href?: string; // now optional — cards without href are non-interactive
   imageUrl?: string;
   imageAlt?: string;
   /** Single category label — shown above title and in footer */
   badge?: string;
   date?: string;
+  /** ISO datetime or formatted string for event date (shown with Calendar icon) */
+  eventDate?: string;
+  /** HH:MM time string for events (shown with Clock icon) */
+  eventTime?: string;
+  /** Countdown label shown in footer chip (e.g. "over 33 dagen") */
+  countdown?: string;
+  /** When true, full-card link opens in new tab with ExternalLink indicator */
+  isExternal?: boolean;
   variant?: "standard" | "featured";
   as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   className?: string;
@@ -23,6 +32,10 @@ export const NewsCard = ({
   imageAlt,
   badge,
   date,
+  eventDate,
+  eventTime,
+  countdown,
+  isExternal,
   variant = "standard",
   as: Heading = "h3",
   className,
@@ -33,19 +46,31 @@ export const NewsCard = ({
     <article
       className={cn(
         "relative group overflow-hidden rounded bg-kcvv-black",
-        "transition-all duration-300 hover:-translate-y-1 hover:shadow-xl",
+        href &&
+          "transition-all duration-300 hover:-translate-y-1 hover:shadow-xl",
         "aspect-[3/2]",
         className,
       )}
     >
       {/* Green top-border: hidden by default, expands from center on hover */}
-      <div
-        className="absolute top-0 inset-x-0 h-[3px] bg-kcvv-green-bright z-20 pointer-events-none [clip-path:inset(0_50%)] group-hover:[clip-path:inset(0_0%)] transition-[clip-path] duration-300 ease-out"
-        aria-hidden="true"
-      />
+      {href && (
+        <div
+          className="absolute top-0 inset-x-0 h-[3px] bg-kcvv-green-bright z-20 pointer-events-none [clip-path:inset(0_50%)] group-hover:[clip-path:inset(0_0%)] transition-[clip-path] duration-300 ease-out"
+          aria-hidden="true"
+        />
+      )}
 
       {/* Full-card link — click target only, text sits outside */}
-      <Link href={href} className="absolute inset-0 z-10" aria-label={title} />
+      {href && (
+        <Link
+          href={href}
+          className="absolute inset-0 z-10"
+          aria-label={title}
+          {...(isExternal
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+        />
+      )}
 
       {/* Background image */}
       {imageUrl ? (
@@ -92,10 +117,36 @@ export const NewsCard = ({
           {title}
         </Heading>
 
-        {(date ?? badge) && (
-          <div className="border-t border-white/20 mt-3 pt-3 text-white/60 text-xs flex justify-between">
-            {date && <time>{date}</time>}
-            {badge && <span>{badge}</span>}
+        {/* Footer bar: countdown chip OR date+badge */}
+        {(countdown ?? date ?? badge ?? eventDate ?? eventTime) && (
+          <div className="border-t border-white/20 mt-3 pt-3 text-white/60 text-xs flex justify-between items-center">
+            <div className="flex items-center gap-3">
+              {eventDate && !countdown && (
+                <time className="flex items-center gap-1">
+                  <Calendar className="w-3 h-3 flex-shrink-0" aria-hidden />
+                  {eventDate}
+                </time>
+              )}
+              {eventTime && (
+                <span className="flex items-center gap-1">
+                  <Clock className="w-3 h-3 flex-shrink-0" aria-hidden />
+                  {eventTime}
+                </span>
+              )}
+              {!eventDate && !eventTime && date && <time>{date}</time>}
+              {badge && !eventDate && !eventTime && <span>{badge}</span>}
+            </div>
+            {countdown && (
+              <span className="text-xs uppercase tracking-wider bg-white/10 px-2 py-0.5 rounded-sm font-medium text-white/70">
+                {countdown}
+              </span>
+            )}
+            {isExternal && !countdown && (
+              <ExternalLink
+                className="w-3 h-3 flex-shrink-0 text-white/40"
+                aria-hidden
+              />
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/components/home/LatestNews/NewsCard.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.tsx
@@ -118,7 +118,7 @@ export const NewsCard = ({
         </Heading>
 
         {/* Footer bar: date+time on left, countdown chip on right */}
-        {(countdown ?? date ?? badge ?? eventDate ?? eventTime) && (
+        {(countdown ?? date ?? eventDate ?? eventTime) && (
           <div className="border-t border-white/20 mt-3 pt-3 text-white/60 text-xs flex justify-between items-center">
             <div className="flex items-center gap-3">
               {eventDate && (
@@ -134,7 +134,6 @@ export const NewsCard = ({
                 </span>
               )}
               {!eventDate && !eventTime && date && <time>{date}</time>}
-              {badge && !eventDate && !eventTime && <span>{badge}</span>}
             </div>
             {countdown && (
               <span className="text-xs uppercase tracking-wider bg-white/10 px-2 py-0.5 rounded-sm font-medium text-white/70">

--- a/apps/web/src/components/home/LatestNews/NewsCard.tsx
+++ b/apps/web/src/components/home/LatestNews/NewsCard.tsx
@@ -117,11 +117,11 @@ export const NewsCard = ({
           {title}
         </Heading>
 
-        {/* Footer bar: countdown chip OR date+badge */}
+        {/* Footer bar: date+time on left, countdown chip on right */}
         {(countdown ?? date ?? badge ?? eventDate ?? eventTime) && (
           <div className="border-t border-white/20 mt-3 pt-3 text-white/60 text-xs flex justify-between items-center">
             <div className="flex items-center gap-3">
-              {eventDate && !countdown && (
+              {eventDate && (
                 <time className="flex items-center gap-1">
                   <Calendar className="w-3 h-3 flex-shrink-0" aria-hidden />
                   {eventDate}

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
@@ -50,7 +50,7 @@ export function MatchWidget({
       {/* Bottom diagonal — reveals gray-100 from LatestNews */}
       <SectionDivider color="gray-100" position="bottom" />
 
-      <div className="relative z-20 py-24 px-4 md:px-8 max-w-[1280px] mx-auto">
+      <div className="relative z-20 py-24 px-4 md:px-8 max-w-7xl mx-auto">
         {/* Overline — left-aligned, single leading rule */}
         <p className="flex items-center gap-2 mb-6 text-[11px] font-bold uppercase tracking-[0.14em] text-white/50">
           <span aria-hidden="true" className="block w-5 h-0.5 bg-white/30" />

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
@@ -50,7 +50,7 @@ export function MatchWidget({
       {/* Bottom diagonal — reveals gray-100 from LatestNews */}
       <SectionDivider color="gray-100" position="bottom" />
 
-      <div className="relative z-20 py-24 px-4 md:px-8 max-w-7xl mx-auto">
+      <div className="relative z-20 py-20 px-4 md:px-8 max-w-7xl mx-auto">
         {/* Overline — left-aligned, single leading rule */}
         <p className="flex items-center gap-2 mb-6 text-[11px] font-bold uppercase tracking-[0.14em] text-white/50">
           <span aria-hidden="true" className="block w-5 h-0.5 bg-white/30" />

--- a/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.stories.tsx
+++ b/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { MatchesSliderSection } from "./MatchesSliderSection";
+import { mockMatches } from "@/components/home/UpcomingMatches/UpcomingMatches.mocks";
+
+const meta = {
+  title: "Features/Homepage/MatchesSliderSection",
+  component: MatchesSliderSection,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof MatchesSliderSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    matches: mockMatches.mixed.map((m, i) => ({
+      ...m,
+      teamLabel: i < 3 ? "A-Ploeg" : "U17",
+    })),
+    highlightTeamId: 1235,
+  },
+  parameters: { backgrounds: { default: "dark" } },
+};

--- a/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
+++ b/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
@@ -1,5 +1,5 @@
 import { MatchesSlider } from "@/components/match/MatchesSlider/MatchesSlider";
-import { SectionDivider, SectionHeader } from "@/components/design-system";
+import { SectionHeader } from "@/components/design-system";
 import type { UpcomingMatch } from "@/components/match/types";
 import { cn } from "@/lib/utils/cn";
 
@@ -18,12 +18,12 @@ export const MatchesSliderSection = ({
 
   return (
     <section
-      className={cn("relative bg-kcvv-black overflow-hidden py-20", className)}
+      className={cn(
+        "relative bg-kcvv-black overflow-hidden py-20 -mt-px",
+        className,
+      )}
     >
-      {/* Diagonal top cut: gray-100 → kcvv-black */}
-      <SectionDivider color="gray-100" position="top" />
-
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-4">
+      <div className="relative z-20 max-w-7xl mx-auto px-4 md:px-8 pt-4">
         <SectionHeader
           title="Wedstrijden"
           linkText="Alle wedstrijden"

--- a/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
+++ b/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { MatchesSlider } from "@/components/match/MatchesSlider/MatchesSlider";
+import { SectionDivider } from "@/components/design-system";
+import type { UpcomingMatch } from "@/components/match/types";
+import { cn } from "@/lib/utils/cn";
+
+export interface MatchesSliderSectionProps {
+  matches: UpcomingMatch[];
+  highlightTeamId?: number;
+  className?: string;
+}
+
+export const MatchesSliderSection = ({
+  matches,
+  highlightTeamId,
+  className,
+}: MatchesSliderSectionProps) => {
+  if (matches.length === 0) return null;
+
+  return (
+    <section
+      className={cn("relative bg-kcvv-black overflow-hidden py-20", className)}
+    >
+      {/* Diagonal top cut: gray-100 → kcvv-black */}
+      <SectionDivider color="gray-100" position="top" />
+
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-4">
+        {/* Section header */}
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-bold text-white border-l-4 border-kcvv-green pl-3">
+            Wedstrijden
+          </h2>
+          <Link
+            href="/calendar"
+            className="text-sm text-kcvv-green hover:text-white transition-colors font-medium"
+          >
+            Alle wedstrijden →
+          </Link>
+        </div>
+
+        <MatchesSlider
+          matches={matches}
+          highlightTeamId={highlightTeamId}
+          theme="dark"
+        />
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
+++ b/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
@@ -1,6 +1,5 @@
-import Link from "next/link";
 import { MatchesSlider } from "@/components/match/MatchesSlider/MatchesSlider";
-import { SectionDivider } from "@/components/design-system";
+import { SectionDivider, SectionHeader } from "@/components/design-system";
 import type { UpcomingMatch } from "@/components/match/types";
 import { cn } from "@/lib/utils/cn";
 
@@ -25,18 +24,12 @@ export const MatchesSliderSection = ({
       <SectionDivider color="gray-100" position="top" />
 
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-4">
-        {/* Section header */}
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-xl font-bold text-white border-l-4 border-kcvv-green pl-3">
-            Wedstrijden
-          </h2>
-          <Link
-            href="/calendar"
-            className="text-sm text-kcvv-green hover:text-white transition-colors font-medium"
-          >
-            Alle wedstrijden →
-          </Link>
-        </div>
+        <SectionHeader
+          title="Wedstrijden"
+          linkText="Alle wedstrijden"
+          linkHref="/calendar"
+          variant="dark"
+        />
 
         <MatchesSlider
           matches={matches}

--- a/apps/web/src/components/home/MatchesSliderSection/index.ts
+++ b/apps/web/src/components/home/MatchesSliderSection/index.ts
@@ -1,0 +1,2 @@
+export { MatchesSliderSection } from "./MatchesSliderSection";
+export type { MatchesSliderSectionProps } from "./MatchesSliderSection";

--- a/apps/web/src/components/home/SponsorsSection/SponsorsSection.stories.tsx
+++ b/apps/web/src/components/home/SponsorsSection/SponsorsSection.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   parameters: { layout: "fullscreen" },
   render: () => (
     <section className="bg-gray-100 py-20">
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8">
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
         <SectionHeader
           title="Sponsors"
           linkText="Word sponsor"

--- a/apps/web/src/components/home/SponsorsSection/SponsorsSection.stories.tsx
+++ b/apps/web/src/components/home/SponsorsSection/SponsorsSection.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SectionHeader } from "@/components/design-system";
+import { Sponsors } from "@/components/sponsors/Sponsors";
+import { mockSponsors } from "@/components/sponsors/Sponsors.mocks";
+
+/**
+ * SponsorsSection is an async server component (fetches from Sanity).
+ * This story renders the visual composition using mock data.
+ */
+const meta = {
+  title: "Features/Homepage/SponsorsSection",
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+  render: () => (
+    <section className="bg-gray-100 py-20">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8">
+        <SectionHeader
+          title="Sponsors"
+          linkText="Word sponsor"
+          linkHref="/sponsors"
+        />
+        <Sponsors
+          sponsors={mockSponsors}
+          title=""
+          description=""
+          showViewAll={false}
+          variant="light"
+          columns={5}
+          className="py-0"
+        />
+      </div>
+    </section>
+  ),
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/web/src/components/home/SponsorsSection/SponsorsSection.tsx
+++ b/apps/web/src/components/home/SponsorsSection/SponsorsSection.tsx
@@ -8,8 +8,8 @@ export interface SponsorsSectionProps {
 
 export async function SponsorsSection({ className }: SponsorsSectionProps) {
   return (
-    <section className={cn("bg-gray-100 py-20", className)}>
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8">
+    <section className={cn("bg-gray-100 py-20 -mt-0.5", className)}>
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
         <SectionHeader
           title="Sponsors"
           linkText="Word sponsor"

--- a/apps/web/src/components/home/SponsorsSection/SponsorsSection.tsx
+++ b/apps/web/src/components/home/SponsorsSection/SponsorsSection.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils/cn";
+import { SectionHeader } from "@/components/design-system";
+import { SponsorsBlock } from "@/components/sponsors";
+
+export interface SponsorsSectionProps {
+  className?: string;
+}
+
+export async function SponsorsSection({ className }: SponsorsSectionProps) {
+  return (
+    <section className={cn("bg-gray-100 py-20", className)}>
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8">
+        <SectionHeader
+          title="Sponsors"
+          linkText="Word sponsor"
+          linkHref="/sponsors"
+        />
+        <SponsorsBlock
+          title=""
+          description=""
+          showViewAll={false}
+          variant="light"
+          columns={5}
+          className="py-0"
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/home/SponsorsSection/index.ts
+++ b/apps/web/src/components/home/SponsorsSection/index.ts
@@ -1,0 +1,2 @@
+export { SponsorsSection } from "./SponsorsSection";
+export type { SponsorsSectionProps } from "./SponsorsSection";

--- a/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { YouthSection } from "./YouthSection";
+
+const meta = {
+  title: "Features/Homepage/YouthSection",
+  component: YouthSection,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof YouthSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -11,7 +11,7 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
   return (
     <section
       className={cn(
-        "relative bg-kcvv-green-dark overflow-hidden py-20 text-center",
+        "relative bg-kcvv-green-dark overflow-hidden py-20 text-center -mt-0.5",
         className,
       )}
     >
@@ -20,17 +20,20 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
       {/* Diagonal bottom cut: kcvv-green-dark → gray-100 */}
       <SectionDivider color="gray-100" position="bottom" flip />
 
-      <div className="relative max-w-3xl mx-auto px-4 md:px-8">
-        {/* Section label */}
-        <p className="text-xs font-bold uppercase tracking-[0.25em] text-white/50 mb-6">
-          Jeugd
+      {/* Section label — aligned to the full-width 1280px grid */}
+      <div className="relative max-w-7xl mx-auto px-4 md:px-8 mb-6">
+        <p className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.14em] text-white/50">
+          <span aria-hidden="true" className="block w-5 h-0.5 bg-white/30" />
+          Jeugdwerking
         </p>
+      </div>
 
+      <div className="relative max-w-3xl mx-auto px-4 md:px-8">
         {/* Stat row */}
         <div className="flex items-center justify-center gap-8 md:gap-16 mb-10">
           <div>
             <div
-              className="font-bold text-kcvv-green leading-none"
+              className="font-title font-black text-kcvv-green leading-none"
               style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
             >
               220+
@@ -42,7 +45,7 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
           <div className="w-px h-16 bg-white/15" aria-hidden="true" />
           <div>
             <div
-              className="font-bold text-kcvv-green leading-none"
+              className="font-title font-black text-kcvv-green leading-none"
               style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
             >
               16
@@ -69,9 +72,15 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
         <div>
           <Link
             href="/jeugd"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-kcvv-green text-kcvv-black font-bold text-sm uppercase tracking-wider rounded-sm hover:bg-kcvv-green/90 transition-colors"
+            className="group inline-flex items-center gap-2 px-6 py-3 bg-white text-kcvv-black font-bold text-sm uppercase tracking-wider rounded-sm hover:bg-kcvv-green transition-colors"
           >
             Ontdek onze jeugd
+            <span
+              className="inline-block transition-transform group-hover:translate-x-1"
+              aria-hidden="true"
+            >
+              →
+            </span>
           </Link>
         </div>
       </div>

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -1,0 +1,80 @@
+import Image from "next/image";
+import Link from "next/link";
+import { SectionDivider } from "@/components/design-system";
+import { cn } from "@/lib/utils/cn";
+
+export interface YouthSectionProps {
+  className?: string;
+}
+
+export const YouthSection = ({ className }: YouthSectionProps) => {
+  return (
+    <section
+      className={cn(
+        "relative bg-kcvv-green-dark overflow-hidden py-20 text-center",
+        className,
+      )}
+    >
+      {/* Diagonal top cut: kcvv-black → kcvv-green-dark */}
+      <SectionDivider color="kcvv-black" position="top" />
+      {/* Diagonal bottom cut: kcvv-green-dark → gray-100 */}
+      <SectionDivider color="gray-100" position="bottom" flip />
+
+      <div className="relative max-w-3xl mx-auto px-4 md:px-8">
+        {/* Section label */}
+        <p className="text-xs font-bold uppercase tracking-[0.25em] text-white/50 mb-6">
+          Jeugd
+        </p>
+
+        {/* Stat row */}
+        <div className="flex items-center justify-center gap-8 md:gap-16 mb-10">
+          <div>
+            <div
+              className="font-bold text-kcvv-green leading-none"
+              style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
+            >
+              220+
+            </div>
+            <div className="text-xs tracking-widest uppercase text-white/50 mt-1">
+              Spelers
+            </div>
+          </div>
+          <div className="w-px h-16 bg-white/15" aria-hidden="true" />
+          <div>
+            <div
+              className="font-bold text-kcvv-green leading-none"
+              style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
+            >
+              16
+            </div>
+            <div className="text-xs tracking-widest uppercase text-white/50 mt-1">
+              Ploegen
+            </div>
+          </div>
+        </div>
+
+        {/* Jersey photo — TODO: add youth-jerseys.png to public/images/ */}
+        <div className="relative inline-block mb-10">
+          <Image
+            src="/images/youth-jerseys.png"
+            alt="KCVV jeugd tenues"
+            width={480}
+            height={360}
+            className="max-w-sm w-full mx-auto object-contain drop-shadow-xl"
+            style={{ rotate: "1deg" }}
+          />
+        </div>
+
+        {/* CTA */}
+        <div>
+          <Link
+            href="/jeugd"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-kcvv-green text-kcvv-black font-bold text-sm uppercase tracking-wider rounded-sm hover:bg-kcvv-green/90 transition-colors"
+          >
+            Ontdek onze jeugd
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/components/home/YouthSection/index.ts
+++ b/apps/web/src/components/home/YouthSection/index.ts
@@ -1,0 +1,2 @@
+export { YouthSection } from "./YouthSection";
+export type { YouthSectionProps } from "./YouthSection";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -25,3 +25,6 @@ export type { BannerSlotProps } from "./BannerSlot";
 
 export { MatchesSliderSection } from "./MatchesSliderSection";
 export type { MatchesSliderSectionProps } from "./MatchesSliderSection";
+
+export { YouthSection } from "./YouthSection";
+export type { YouthSectionProps } from "./YouthSection";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -22,3 +22,6 @@ export type { MatchWidgetProps } from "./MatchWidget";
 
 export { BannerSlot } from "./BannerSlot";
 export type { BannerSlotProps } from "./BannerSlot";
+
+export { MatchesSliderSection } from "./MatchesSliderSection";
+export type { MatchesSliderSectionProps } from "./MatchesSliderSection";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -28,3 +28,6 @@ export type { MatchesSliderSectionProps } from "./MatchesSliderSection";
 
 export { YouthSection } from "./YouthSection";
 export type { YouthSectionProps } from "./YouthSection";
+
+export { SponsorsSection } from "./SponsorsSection";
+export type { SponsorsSectionProps } from "./SponsorsSection";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -19,3 +19,6 @@ export type { UpcomingMatchesProps, UpcomingMatch } from "./UpcomingMatches";
 
 export { MatchWidget } from "./MatchWidget";
 export type { MatchWidgetProps } from "./MatchWidget";
+
+export { BannerSlot } from "./BannerSlot";
+export type { BannerSlotProps } from "./BannerSlot";

--- a/apps/web/src/components/layout/Navigation/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation/Navigation.tsx
@@ -201,8 +201,8 @@ export const Navigation = ({
         }}
       />
 
-      <nav className={cn("flex flex-grow max-w-[90%]", className)}>
-        <ul className="flex items-center justify-between flex-grow flex-nowrap list-none m-0 p-0">
+      <nav className={cn("flex grow max-w-[90%]", className)}>
+        <ul className="flex items-center justify-between grow flex-nowrap list-none m-0 p-0">
           {menuItems.map((item, index) => {
             const active = isActive(item.href) || hasActiveChild(item);
             const hasDropdown = item.children && item.children.length > 0;

--- a/apps/web/src/components/layout/PageFooter/PageFooter.stories.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.stories.tsx
@@ -1,269 +1,29 @@
-/**
- * PageFooter Component Stories
- * Showcases the site footer with black background and wavy SVG top
- */
-
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import Link from "next/link";
-import Image from "next/image";
-import { SocialLinks } from "@/components/design-system";
-import { Sponsors, mockSponsors } from "@/components/sponsors";
-import { cn } from "@/lib/utils/cn";
-
-// Contact rows configuration (same as PageFooter)
-const contactRows = [
-  { label: "KCVV Elewijt", value: "Driesstraat 30, 1982 Elewijt" },
-  { label: "Voorzitter", value: "Rudy Bautmans" },
-  {
-    label: "GC",
-    value: (
-      <a
-        href="mailto:gc@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        John De Ron
-      </a>
-    ),
-  },
-  {
-    label: "Algemeen contact",
-    value: (
-      <a
-        href="mailto:info@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        info@kcvvelewijt.be
-      </a>
-    ),
-  },
-  {
-    label: "Jeugdwerking",
-    value: (
-      <a
-        href="mailto:jeugd@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        jeugd@kcvvelewijt.be
-      </a>
-    ),
-  },
-  {
-    label: "Verhuur kantine",
-    value: (
-      <a
-        href="mailto:verhuur@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        Ann Walgraef
-      </a>
-    ),
-  },
-  {
-    label: "Website",
-    value: (
-      <a
-        href="mailto:kevin@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        Kevin Van Ransbeeck
-      </a>
-    ),
-  },
-  {
-    label: "Privacy & cookies",
-    value: (
-      <a href="/privacy" className="text-kcvv-green-bright hover:underline">
-        Privacyverklaring
-      </a>
-    ),
-  },
-];
-
-// PageFooter component for Storybook (with inline sponsors instead of server component)
-const PageFooterStorybook = ({ className }: { className?: string }) => {
-  return (
-    <footer
-      className={cn("relative z-10 mt-[50px] text-white", className)}
-      style={{
-        background:
-          "linear-gradient(to bottom, transparent 0%, transparent 50px, #1E2024 50px 100%), url(/images/footer-top.svg) top center no-repeat",
-        backgroundSize: "100%",
-        padding: "75px 2rem 2rem",
-      }}
-    >
-      <div className="container mx-auto">
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-          {/* Contact Section - 5 columns */}
-          <div className="lg:col-span-5">
-            <div className="flex flex-row items-center mb-8">
-              <div className="mr-6">
-                <Link href="/">
-                  <Image
-                    src="/images/logo-flat.png"
-                    alt="KCVV ELEWIJT"
-                    width={150}
-                    height={60}
-                    className="h-auto w-auto"
-                  />
-                </Link>
-              </div>
-              <SocialLinks variant="circle" />
-            </div>
-
-            <table className="w-full text-[0.875rem]">
-              <tbody>
-                {contactRows.map((row, index) => (
-                  <tr
-                    key={index}
-                    className="lg:table-row flex flex-col lg:flex-row mb-2 lg:mb-0"
-                  >
-                    <th className="text-left font-normal uppercase p-0 lg:pr-4 lg:pb-1 lg:align-top lg:w-[180px] underline lg:no-underline">
-                      {row.label}
-                    </th>
-                    <td className="p-0 lg:pb-1 lg:align-top text-white">
-                      {row.value}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Vertical Divider - 1 column */}
-          <div className="hidden lg:block lg:col-span-1 relative">
-            <div
-              className="absolute h-full w-px top-0 left-1/2"
-              style={{
-                background:
-                  "linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 100%)",
-              }}
-            />
-          </div>
-
-          {/* Sponsors Section - 6 columns */}
-          <div className="lg:col-span-6">
-            <Sponsors
-              sponsors={mockSponsors}
-              title="Onze sponsors"
-              description="KCVV Elewijt wordt mede mogelijk gemaakt door onze trouwe sponsors."
-              columns={4}
-              variant="dark"
-              showViewAll={true}
-              viewAllHref="/sponsors"
-              className="py-0"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Bottom Motto - Desktop only */}
-      <div
-        className="hidden lg:block relative pt-12 -mb-8 -mx-8"
-        style={{
-          width: "100vw",
-          marginLeft: "-2rem",
-        }}
-      >
-        <div
-          className="absolute top-4 left-0 w-full h-px"
-          style={{
-            background:
-              "linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 33%, rgba(255, 255, 255, 0.2) 66%, rgba(255, 255, 255, 0) 100%)",
-          }}
-        />
-
-        <p className="text-center text-white/60 text-sm italic py-4">
-          Er is maar één plezante compagnie
-        </p>
-      </div>
-    </footer>
-  );
-};
+import { PageFooter } from "./PageFooter";
 
 const meta = {
   title: "Layout/PageFooter",
-  component: PageFooterStorybook,
+  component: PageFooter,
   parameters: {
     layout: "fullscreen",
-    docs: {
-      description: {
-        component:
-          "Site footer with contact info, social links, and sponsors. Black background (#1E2024) with wavy SVG top edge. Note: This Storybook version uses mock data instead of fetching from Drupal CMS.",
-      },
-    },
   },
   tags: ["autodocs"],
-} satisfies Meta<typeof PageFooterStorybook>;
+} satisfies Meta<typeof PageFooter>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/**
- * Default footer with all sections
- * Shows black background with SVG wavy top, contact table, social links, and sponsors grid
- */
 export const Default: Story = {
   render: () => (
-    <div className="min-h-screen bg-gray-50">
-      <div className="h-[400px] flex items-center justify-center bg-white">
+    <div className="min-h-screen flex flex-col bg-gray-100">
+      <div className="flex-1 flex items-center justify-center">
         <p className="text-gray-600">Page content above footer</p>
       </div>
-      <PageFooterStorybook />
+      <PageFooter />
     </div>
   ),
 };
 
-/**
- * Footer with full page context
- */
-export const WithPageContent: Story = {
-  render: () => (
-    <div className="min-h-screen flex flex-col bg-gray-50">
-      <main className="flex-1">
-        <div className="container mx-auto px-4 py-12">
-          <h1 className="text-3xl font-bold text-kcvv-gray-blue mb-4">
-            Page Content
-          </h1>
-          <p className="text-gray-600 mb-6">
-            This shows how the footer looks at the bottom of a page with the
-            wavy SVG transition.
-          </p>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="bg-white border border-gray-200 rounded p-6"
-              >
-                <h3 className="font-bold text-lg mb-2">
-                  Content Block {i + 1}
-                </h3>
-                <p className="text-gray-600 text-sm">
-                  Sample content above the footer.
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </main>
-      <PageFooterStorybook />
-    </div>
-  ),
-};
-
-/**
- * Mobile view
- */
-export const MobileView: Story = {
-  render: () => (
-    <div className="min-h-screen bg-gray-50">
-      <div className="h-[300px] flex items-center justify-center bg-white">
-        <p className="text-gray-600 text-sm">Page content</p>
-      </div>
-      <PageFooterStorybook />
-    </div>
-  ),
-  globals: {
-    viewport: { value: "mobile1" },
-  },
+export const Standalone: Story = {
+  args: {},
 };

--- a/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
@@ -8,51 +8,49 @@ vi.mock("./CookiePreferencesButton", () => ({
   ),
 }));
 
-// Mock the SponsorsBlock server component
-vi.mock("@/components/sponsors", () => ({
-  SponsorsBlock: ({
-    title,
-    description,
-  }: {
-    title?: string;
-    description?: string;
-  }) => (
-    <div data-testid="sponsors-block">
-      <h3>{title || "Onze sponsors"}</h3>
-      <p>
-        {description ||
-          "KCVV Elewijt wordt mede mogelijk gemaakt door onze trouwe sponsors."}
-      </p>
-      <a href="/sponsors">Alle sponsors &raquo;</a>
-    </div>
-  ),
-}));
-
 describe("PageFooter", () => {
   it("renders the footer", () => {
     const { container } = render(<PageFooter />);
     expect(container.querySelector("footer")).toBeInTheDocument();
   });
 
-  it("renders the KCVV logo", () => {
+  it("renders KCVV logo", () => {
     render(<PageFooter />);
-    const logo = screen.getByRole("img", { name: /kcvv elewijt/i });
+    const logo = screen.getByAltText(/KCVV/i);
     expect(logo).toBeInTheDocument();
   });
 
-  it("renders all 9 contact rows", () => {
+  it("renders club address", () => {
     render(<PageFooter />);
-    expect(screen.getByText("KCVV Elewijt")).toBeInTheDocument();
-    expect(screen.getByText("Voorzitter")).toBeInTheDocument();
-    expect(screen.getByText("GC")).toBeInTheDocument();
-    expect(screen.getByText("Algemeen contact")).toBeInTheDocument();
-    expect(screen.getByText("Jeugdwerking")).toBeInTheDocument();
-    expect(screen.getByText("Verhuur kantine")).toBeInTheDocument();
-    expect(screen.getByText("Website")).toBeInTheDocument();
-    expect(screen.getByText("Privacy & cookies")).toBeInTheDocument();
-    expect(screen.getAllByText("Cookie-instellingen").length).toBeGreaterThan(
-      0,
-    );
+    expect(screen.getByText(/Driesstraat 32/)).toBeInTheDocument();
+  });
+
+  it("renders club email", () => {
+    render(<PageFooter />);
+    expect(screen.getByText("info@kcvvelewijt.be")).toBeInTheDocument();
+  });
+
+  it("renders Facebook link", () => {
+    render(<PageFooter />);
+    const fbLink = screen.getByRole("link", { name: /facebook/i });
+    expect(fbLink).toBeInTheDocument();
+  });
+
+  it("renders Instagram link", () => {
+    render(<PageFooter />);
+    const igLink = screen.getByRole("link", { name: /instagram/i });
+    expect(igLink).toBeInTheDocument();
+  });
+
+  it("renders copyright text", () => {
+    render(<PageFooter />);
+    expect(screen.getByText(/©.*Elewijt/)).toBeInTheDocument();
+  });
+
+  it("renders privacy policy link", () => {
+    render(<PageFooter />);
+    const privacyLink = screen.getByRole("link", { name: "Privacyverklaring" });
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
   });
 
   it("renders cookie preferences button", () => {
@@ -61,96 +59,15 @@ describe("PageFooter", () => {
     expect(btn).toBeInTheDocument();
   });
 
-  it("renders contact email links", () => {
-    render(<PageFooter />);
-    expect(screen.getByText("info@kcvvelewijt.be")).toHaveAttribute(
-      "href",
-      "mailto:info@kcvvelewijt.be",
-    );
-    expect(screen.getByText("jeugd@kcvvelewijt.be")).toHaveAttribute(
-      "href",
-      "mailto:jeugd@kcvvelewijt.be",
-    );
-  });
-
-  it("renders social links via SocialLinks component", () => {
-    render(<PageFooter />);
-    expect(screen.getByLabelText("Facebook")).toBeInTheDocument();
-    expect(screen.getByLabelText("Twitter")).toBeInTheDocument();
-    expect(screen.getByLabelText("Instagram")).toBeInTheDocument();
-  });
-
-  it("renders sponsors section heading", () => {
-    render(<PageFooter />);
-    expect(screen.getByText("Onze sponsors")).toBeInTheDocument();
-  });
-
-  it("renders sponsors description", () => {
-    render(<PageFooter />);
-    expect(
-      screen.getByText(
-        "KCVV Elewijt wordt mede mogelijk gemaakt door onze trouwe sponsors.",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("renders link to all sponsors page", () => {
-    render(<PageFooter />);
-    const link = screen.getByText(/Alle sponsors/i);
-    expect(link).toHaveAttribute("href", "/sponsors");
-  });
-
-  it("renders bottom motto on desktop", () => {
-    render(<PageFooter />);
-    expect(
-      screen.getByText("Er is maar één plezante compagnie"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders privacy link", () => {
-    render(<PageFooter />);
-    const privacyLink = screen.getByText("Privacyverklaring");
-    expect(privacyLink).toHaveAttribute("href", "/privacy");
-  });
-
   it("applies custom className", () => {
     const { container } = render(<PageFooter className="custom-footer" />);
     expect(container.querySelector("footer")).toHaveClass("custom-footer");
   });
 
-  it("has correct background styling with SVG wave", () => {
-    const { container } = render(<PageFooter />);
-    const footer = container.querySelector("footer") as HTMLElement;
-    // happy-dom v20.6+ parses background shorthand into longhands
-    // Verify the style properties that survive parsing
-    expect(footer.style.backgroundSize).toBe("100%");
-    expect(footer.style.padding).toBe("75px 2rem 2rem");
-  });
-
-  it("renders address", () => {
+  it("renders navigation links", () => {
     render(<PageFooter />);
-    expect(
-      screen.getByText("Driesstraat 30, 1982 Elewijt"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders voorzitter name", () => {
-    render(<PageFooter />);
-    expect(screen.getByText("Rudy Bautmans")).toBeInTheDocument();
-  });
-
-  it("renders GC contact", () => {
-    render(<PageFooter />);
-    expect(screen.getByText("John De Ron")).toBeInTheDocument();
-  });
-
-  it("renders website contact", () => {
-    render(<PageFooter />);
-    expect(screen.getByText("Kevin Van Ransbeeck")).toBeInTheDocument();
-  });
-
-  it("renders verhuur contact", () => {
-    render(<PageFooter />);
-    expect(screen.getByText("Ann Walgraef")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Nieuws" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Kalender" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sponsors" })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
@@ -33,13 +33,13 @@ describe("PageFooter", () => {
   it("renders Facebook link", () => {
     render(<PageFooter />);
     const fbLink = screen.getByRole("link", { name: /facebook/i });
-    expect(fbLink).toBeInTheDocument();
+    expect(fbLink).toHaveAttribute("href", "https://facebook.com/KCVVElewijt/");
   });
 
   it("renders Instagram link", () => {
     render(<PageFooter />);
     const igLink = screen.getByRole("link", { name: /instagram/i });
-    expect(igLink).toBeInTheDocument();
+    expect(igLink).toHaveAttribute("href", "https://www.instagram.com/kcvve");
   });
 
   it("renders copyright text", () => {

--- a/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
@@ -47,9 +47,8 @@ describe("PageFooter", () => {
 
   it("renders copyright text", () => {
     render(<PageFooter />);
-    expect(
-      screen.getByText(/© \d{4} K\.C\.V\.V\. Elewijt/),
-    ).toBeInTheDocument();
+    const year = new Date().getFullYear();
+    expect(screen.getByText(`© ${year} K.C.V.V. Elewijt`)).toBeInTheDocument();
   });
 
   it("renders privacy policy link", () => {
@@ -71,8 +70,17 @@ describe("PageFooter", () => {
 
   it("renders navigation links", () => {
     render(<PageFooter />);
-    expect(screen.getByRole("link", { name: "Nieuws" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Kalender" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Sponsors" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Nieuws" })).toHaveAttribute(
+      "href",
+      "/news",
+    );
+    expect(screen.getByRole("link", { name: "Kalender" })).toHaveAttribute(
+      "href",
+      "/calendar",
+    );
+    expect(screen.getByRole("link", { name: "Sponsors" })).toHaveAttribute(
+      "href",
+      "/sponsors",
+    );
   });
 });

--- a/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
@@ -27,7 +27,10 @@ describe("PageFooter", () => {
 
   it("renders club email", () => {
     render(<PageFooter />);
-    expect(screen.getByText("info@kcvvelewijt.be")).toBeInTheDocument();
+    const emailLink = screen.getByRole("link", {
+      name: /info@kcvvelewijt\.be/i,
+    });
+    expect(emailLink).toHaveAttribute("href", "mailto:info@kcvvelewijt.be");
   });
 
   it("renders Facebook link", () => {
@@ -44,7 +47,9 @@ describe("PageFooter", () => {
 
   it("renders copyright text", () => {
     render(<PageFooter />);
-    expect(screen.getByText(/©.*Elewijt/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/© \d{4} K\.C\.V\.V\. Elewijt/),
+    ).toBeInTheDocument();
   });
 
   it("renders privacy policy link", () => {

--- a/apps/web/src/components/layout/PageFooter/PageFooter.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.tsx
@@ -18,7 +18,7 @@ export const PageFooter = ({ className }: PageFooterProps) => {
         className,
       )}
     >
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-16">
+      <div className="max-w-7xl mx-auto px-4 md:px-8 py-16">
         <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr] gap-12">
           {/* Brand column */}
           <div>
@@ -124,7 +124,7 @@ export const PageFooter = ({ className }: PageFooterProps) => {
 
       {/* Bottom bar */}
       <div className="border-t border-white/6">
-        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-4 flex flex-col sm:flex-row items-center justify-between gap-2">
+        <div className="max-w-7xl mx-auto px-4 md:px-8 py-4 flex flex-col sm:flex-row items-center justify-between gap-2">
           <p className="text-white/25 text-xs">
             © {currentYear} K.C.V.V. Elewijt
           </p>

--- a/apps/web/src/components/layout/PageFooter/PageFooter.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.tsx
@@ -1,209 +1,143 @@
-/**
- * PageFooter Component
- * Site footer with contact info, social links, and sponsors
- * Matches Gatsby visual: black background with SVG wavy top edge
- */
-
 import Link from "next/link";
-import { CookiePreferencesButton } from "./CookiePreferencesButton";
 import Image from "next/image";
-import { SocialLinks } from "@/components/design-system";
-import { SponsorsBlock } from "@/components/sponsors";
+import { Mail, MapPin, Facebook, Instagram } from "@/lib/icons";
+import { CookiePreferencesButton } from "./CookiePreferencesButton";
 import { cn } from "@/lib/utils/cn";
 
 export interface PageFooterProps {
-  /**
-   * Additional CSS classes
-   */
   className?: string;
 }
 
-interface ContactRow {
-  label: string;
-  value: string | React.ReactNode;
-}
-
-const contactRows: ContactRow[] = [
-  {
-    label: "KCVV Elewijt",
-    value: "Driesstraat 30, 1982 Elewijt",
-  },
-  {
-    label: "Voorzitter",
-    value: "Rudy Bautmans",
-  },
-  {
-    label: "GC",
-    value: (
-      <a
-        href="mailto:gc@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        John De Ron
-      </a>
-    ),
-  },
-  {
-    label: "Algemeen contact",
-    value: (
-      <a
-        href="mailto:info@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        info@kcvvelewijt.be
-      </a>
-    ),
-  },
-  {
-    label: "Jeugdwerking",
-    value: (
-      <a
-        href="mailto:jeugd@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        jeugd@kcvvelewijt.be
-      </a>
-    ),
-  },
-  {
-    label: "Verhuur kantine",
-    value: (
-      <a
-        href="mailto:verhuur@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        Ann Walgraef
-      </a>
-    ),
-  },
-  {
-    label: "Website",
-    value: (
-      <a
-        href="mailto:kevin@kcvvelewijt.be"
-        className="text-kcvv-green-bright hover:underline"
-      >
-        Kevin Van Ransbeeck
-      </a>
-    ),
-  },
-  {
-    label: "Privacy & cookies",
-    value: (
-      <a href="/privacy" className="text-kcvv-green-bright hover:underline">
-        Privacyverklaring
-      </a>
-    ),
-  },
-  {
-    label: "Cookie-instellingen",
-    value: <CookiePreferencesButton />,
-  },
-];
-
-/**
- * Site footer component
- *
- * Visual specifications (matching Gatsby):
- * - Background: Black (#1E2024) with SVG wavy top edge
- * - Text: White
- * - Contact table: 0.875rem (14px), uppercase labels
- * - Social links: Circle variant with gray borders
- * - Sponsors: 4-column grid, inverted logos, opacity 0.5→1
- * - Bottom motto: "Er is maar één plezante compagnie" with gradient line
- * - Padding: 75px top (to accommodate SVG wave), 2em sides
- * - Margin-top: 50px
- */
 export const PageFooter = ({ className }: PageFooterProps) => {
+  const currentYear = new Date().getFullYear();
+
   return (
     <footer
-      className={cn("relative z-10 mt-[50px] text-white", className)}
-      style={{
-        background:
-          "linear-gradient(to bottom, transparent 0%, transparent 50px, #1E2024 50px 100%), url(/images/footer-top.svg) top center no-repeat",
-        backgroundSize: "100%",
-        padding: "75px 2rem 2rem",
-      }}
+      className={cn(
+        "bg-kcvv-black border-t border-white/6 text-white",
+        className,
+      )}
     >
-      <div className="container mx-auto">
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-          {/* Contact Section - 5 columns */}
-          <div className="lg:col-span-5">
-            {/* Logo and Social */}
-            <div className="flex flex-row items-center mb-8">
-              <div className="mr-6">
-                <Link href="/">
-                  <Image
-                    src="/images/logo-flat.png"
-                    alt="KCVV ELEWIJT"
-                    width={150}
-                    height={60}
-                    className="h-auto w-auto"
-                  />
-                </Link>
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr] gap-12">
+          {/* Brand column */}
+          <div>
+            <Link href="/" className="inline-block mb-4">
+              <Image
+                src="/images/logo-flat.png"
+                alt="KCVV Elewijt"
+                width={120}
+                height={48}
+                className="h-14 w-auto"
+              />
+            </Link>
+            <p className="font-bold text-white text-sm mb-0.5">
+              K.C.V.V. Elewijt
+            </p>
+            <p className="text-white/30 text-xs mb-6">Opgericht in 1964</p>
+
+            <div className="space-y-2 mb-6">
+              <div className="flex items-center gap-2 text-white/50 text-sm">
+                <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden />
+                <span>Driesstraat 32, 1982 Elewijt</span>
               </div>
-              <SocialLinks variant="circle" />
+              <a
+                href="mailto:info@kcvvelewijt.be"
+                className="flex items-center gap-2 text-white/50 text-sm hover:text-white transition-colors"
+              >
+                <Mail className="w-4 h-4 flex-shrink-0" aria-hidden />
+                <span>info@kcvvelewijt.be</span>
+              </a>
             </div>
 
-            {/* Contact Details Table */}
-            <table className="w-full text-[0.875rem]">
-              <tbody>
-                {contactRows.map((row, index) => (
-                  <tr
-                    key={index}
-                    className="lg:table-row flex flex-col lg:flex-row mb-2 lg:mb-0"
+            {/* Social icons */}
+            <div className="flex items-center gap-3">
+              <a
+                href="https://facebook.com/KCVVElewijt/"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="KCVV Elewijt op Facebook"
+                className="text-white/30 hover:text-kcvv-green transition-colors"
+              >
+                <Facebook className="w-5 h-5" />
+              </a>
+              <a
+                href="https://www.instagram.com/kcvve"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="KCVV Elewijt op Instagram"
+                className="text-white/30 hover:text-kcvv-green transition-colors"
+              >
+                <Instagram className="w-5 h-5" />
+              </a>
+            </div>
+          </div>
+
+          {/* Link column 1 — Club */}
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-widest text-white/40 mb-4">
+              Club
+            </h3>
+            <ul className="space-y-2">
+              {[
+                { href: "/club/organigram", label: "Bestuur" },
+                { href: "/sponsors", label: "Sponsors" },
+                { href: "/privacy", label: "Privacy" },
+              ].map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="text-sm text-white/50 hover:text-white transition-colors"
                   >
-                    <th className="text-left font-normal uppercase p-0 lg:pr-4 lg:pb-1 lg:align-top lg:w-[180px] underline lg:no-underline">
-                      {row.label}
-                    </th>
-                    <td className="p-0 lg:pb-1 lg:align-top text-white">
-                      {row.value}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
           </div>
 
-          {/* Vertical Divider - 1 column */}
-          <div className="hidden lg:block lg:col-span-1 relative">
-            <div
-              className="absolute h-full w-px top-0 left-1/2"
-              style={{
-                background:
-                  "linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 100%)",
-              }}
-            />
-          </div>
-
-          {/* Sponsors Section - 6 columns */}
-          <div className="lg:col-span-6">
-            <SponsorsBlock variant="dark" columns={4} className="py-0" />
+          {/* Link column 2 — Website */}
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-widest text-white/40 mb-4">
+              Website
+            </h3>
+            <ul className="space-y-2">
+              {[
+                { href: "/news", label: "Nieuws" },
+                { href: "/calendar", label: "Kalender" },
+                { href: "/jeugd", label: "Jeugd" },
+                { href: "/hulp", label: "Hulp" },
+              ].map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="text-sm text-white/50 hover:text-white transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
       </div>
 
-      {/* Bottom Motto - Desktop only */}
-      <div
-        className="hidden lg:block relative pt-12 -mb-8 -mx-8"
-        style={{
-          width: "100vw",
-          marginLeft: "-2rem",
-        }}
-      >
-        {/* Gradient top border */}
-        <div
-          className="absolute top-4 left-0 w-full h-px"
-          style={{
-            background:
-              "linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.2) 33%, rgba(255, 255, 255, 0.2) 66%, rgba(255, 255, 255, 0) 100%)",
-          }}
-        />
-
-        {/* Motto Text */}
-        <p className="text-center text-white/60 text-sm italic py-4">
-          Er is maar één plezante compagnie
-        </p>
+      {/* Bottom bar */}
+      <div className="border-t border-white/6">
+        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-4 flex flex-col sm:flex-row items-center justify-between gap-2">
+          <p className="text-white/25 text-xs">
+            © {currentYear} K.C.V.V. Elewijt
+          </p>
+          <div className="flex items-center gap-4 text-xs text-white/25">
+            <Link
+              href="/privacy"
+              className="hover:text-white/50 transition-colors"
+            >
+              Privacyverklaring
+            </Link>
+            <CookiePreferencesButton />
+          </div>
+        </div>
       </div>
     </footer>
   );

--- a/apps/web/src/components/layout/PageHeader/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader/PageHeader.tsx
@@ -103,7 +103,7 @@ export const PageHeader = ({
             </Link>
 
             {/* Desktop Navigation - Suspense boundary for useSearchParams */}
-            <Suspense fallback={<div className="flex-grow" />}>
+            <Suspense fallback={<div className="grow" />}>
               <Navigation youthTeams={youthTeams} seniorTeams={seniorTeams} />
             </Suspense>
 

--- a/apps/web/src/components/match/MatchTeaser/MatchTeaser.stories.tsx
+++ b/apps/web/src/components/match/MatchTeaser/MatchTeaser.stories.tsx
@@ -186,6 +186,35 @@ export const Compact: Story = {
   },
 };
 
+export const WithTeamLabel: Story = {
+  args: {
+    ...Upcoming.args,
+    teamLabel: "A-Ploeg",
+  },
+};
+
+export const DarkTheme: Story = {
+  args: {
+    ...Upcoming.args,
+    theme: "dark",
+    teamLabel: "U21",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+
+export const DarkThemeWithScore: Story = {
+  args: {
+    ...Finished.args,
+    theme: "dark",
+    teamLabel: "A-Ploeg",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+
 /**
  * Loading state with skeleton
  */

--- a/apps/web/src/components/match/MatchTeaser/MatchTeaser.test.tsx
+++ b/apps/web/src/components/match/MatchTeaser/MatchTeaser.test.tsx
@@ -174,10 +174,10 @@ describe("MatchTeaser", () => {
       const { container } = render(
         <MatchTeaser {...defaultProps} variant="compact" />,
       );
-      expect(container.firstChild).toHaveClass("p-3");
+      expect(container.firstChild).toHaveClass("p-5");
     });
 
-    it("does not show venue in compact variant", () => {
+    it("shows venue in compact variant footer", () => {
       render(
         <MatchTeaser
           {...defaultProps}
@@ -185,8 +185,7 @@ describe("MatchTeaser", () => {
           venue="Sportpark Elewijt"
         />,
       );
-      // Venue is not shown in compact mode
-      expect(screen.queryByText("Sportpark Elewijt")).not.toBeInTheDocument();
+      expect(screen.getByText("Sportpark Elewijt")).toBeInTheDocument();
     });
   });
 
@@ -281,7 +280,7 @@ describe("MatchTeaser", () => {
       const { container } = render(
         <MatchTeaser {...defaultProps} theme="dark" />,
       );
-      expect(container.firstChild).toHaveClass("bg-kcvv-black");
+      expect(container.firstChild).toHaveClass("bg-white/8");
       expect(container.firstChild).not.toHaveClass("bg-white");
     });
 

--- a/apps/web/src/components/match/MatchTeaser/MatchTeaser.test.tsx
+++ b/apps/web/src/components/match/MatchTeaser/MatchTeaser.test.tsx
@@ -263,6 +263,34 @@ describe("MatchTeaser", () => {
     });
   });
 
+  describe("teamLabel", () => {
+    it("renders teamLabel badge above date row", () => {
+      render(<MatchTeaser {...defaultProps} teamLabel="A-Ploeg" />);
+      expect(screen.getByText("A-Ploeg")).toBeInTheDocument();
+    });
+
+    it("does not render teamLabel badge when absent", () => {
+      const { container } = render(<MatchTeaser {...defaultProps} />);
+      // No empty badge element — verify no data-testid="team-label"
+      expect(container.querySelector("[data-testid='team-label']")).toBeNull();
+    });
+  });
+
+  describe("dark theme", () => {
+    it("renders dark container classes when theme=dark", () => {
+      const { container } = render(
+        <MatchTeaser {...defaultProps} theme="dark" />,
+      );
+      expect(container.firstChild).toHaveClass("bg-kcvv-black");
+      expect(container.firstChild).not.toHaveClass("bg-white");
+    });
+
+    it("renders light container classes by default", () => {
+      const { container } = render(<MatchTeaser {...defaultProps} />);
+      expect(container.firstChild).toHaveClass("bg-white");
+    });
+  });
+
   describe("date formatting edge cases", () => {
     it("handles invalid date gracefully", () => {
       render(<MatchTeaser {...defaultProps} date="invalid-date" />);

--- a/apps/web/src/components/match/MatchTeaser/MatchTeaser.tsx
+++ b/apps/web/src/components/match/MatchTeaser/MatchTeaser.tsx
@@ -76,21 +76,6 @@ function formatDate(dateStr: string): string {
 
 /**
  * Render a compact match preview showing teams, date, score, and status.
- *
- * @param homeTeam - Home team info (name and optional logo)
- * @param awayTeam - Away team info (name and optional logo)
- * @param date - Match date in ISO or YYYY-MM-DD format
- * @param time - Optional match time in HH:MM format
- * @param venue - Optional venue name
- * @param score - Optional score object for live/finished matches
- * @param status - Match status: "upcoming" (scheduled, not yet played), "finished" (played with score),
- *   "forfeited" (FF result, may have score), "postponed" (Uitgesteld), "stopped" (Gestopt, ended prematurely)
- * @param href - Optional link to match detail page
- * @param highlightTeamId - Optional team ID to highlight
- * @param variant - Display variant (default or compact)
- * @param isLoading - Show loading skeleton
- * @param className - Additional CSS classes
- * @returns The rendered match teaser element
  */
 export function MatchTeaser({
   homeTeam,
@@ -127,8 +112,9 @@ export function MatchTeaser({
     return (
       <div
         className={cn(
-          "bg-white border border-gray-200 rounded-lg",
-          isCompact ? "p-3" : "p-4",
+          "border rounded",
+          isDark ? "bg-white/8 border-white/8" : "bg-white border-gray-200",
+          isCompact ? "p-5" : "p-4",
           className,
         )}
       >
@@ -153,24 +139,138 @@ export function MatchTeaser({
     );
   }
 
-  const content = (
+  const containerClasses = cn(
+    "block border rounded transition-shadow",
+    isDark
+      ? "bg-white/8 border-white/8 hover:border-white/20"
+      : "bg-white border-gray-200 hover:shadow-md",
+    isCompact ? "p-5" : "p-4",
+    className,
+  );
+
+  const content = isCompact ? (
+    // COMPACT VARIANT — vertical team stack
+    <>
+      {/* Header: team label left + date right */}
+      <div className="flex items-start justify-between mb-4">
+        {teamLabel ? (
+          <span
+            data-testid="team-label"
+            className="text-xs font-bold uppercase tracking-[0.14em] text-kcvv-green-bright"
+          >
+            {teamLabel}
+          </span>
+        ) : (
+          <span />
+        )}
+        <span
+          className={cn(
+            "text-[11px] font-semibold",
+            isDark ? "text-white/30" : "text-gray-500",
+          )}
+        >
+          {formatDate(date)}
+        </span>
+      </div>
+
+      {/* Home team */}
+      <div className="flex items-center gap-3 h-10">
+        <CompactLogo
+          team={homeTeam}
+          isHighlighted={isHomeHighlighted}
+          isDark={isDark}
+        />
+        <span
+          className={cn(
+            "text-[13px] font-semibold truncate",
+            isDark
+              ? isHomeHighlighted
+                ? "text-white"
+                : "text-white/60"
+              : isHomeHighlighted
+                ? "text-gray-900"
+                : "text-gray-500",
+          )}
+        >
+          {homeTeam.name}
+        </span>
+      </div>
+
+      {/* "vs" separator — indented past logo */}
+      <div className="pl-11 flex items-center">
+        <span
+          className={cn(
+            "text-sm font-bold",
+            isDark ? "text-white/30" : "text-gray-300",
+          )}
+        >
+          vs
+        </span>
+      </div>
+
+      {/* Away team */}
+      <div className="flex items-center gap-3 h-10 mb-5">
+        <CompactLogo
+          team={awayTeam}
+          isHighlighted={isAwayHighlighted}
+          isDark={isDark}
+        />
+        <span
+          className={cn(
+            "text-[13px] font-semibold truncate",
+            isDark
+              ? isAwayHighlighted
+                ? "text-white"
+                : "text-white/60"
+              : isAwayHighlighted
+                ? "text-gray-900"
+                : "text-gray-500",
+          )}
+        >
+          {awayTeam.name}
+        </span>
+      </div>
+
+      {/* Divider */}
+      <div
+        className={cn(
+          "border-t mb-3",
+          isDark ? "border-white/10" : "border-gray-100",
+        )}
+      />
+
+      {/* Footer: time · venue (upcoming) or time · status badge */}
+      <div
+        className={cn(
+          "flex items-center gap-1.5 text-[11px] font-semibold",
+          isDark ? "text-white/30" : "text-gray-500",
+        )}
+      >
+        {time && <span>{time}</span>}
+        {time && status !== "upcoming" && status !== "finished" && (
+          <span aria-hidden="true">·</span>
+        )}
+        <StatusBadge status={status} isDark={isDark} />
+        {venue && status === "upcoming" && time && (
+          <span aria-hidden="true">·</span>
+        )}
+        {venue && status === "upcoming" && <span>{venue}</span>}
+      </div>
+    </>
+  ) : (
+    // DEFAULT VARIANT — horizontal layout
     <>
       {teamLabel && (
         <div
           data-testid="team-label"
-          className="mb-1 text-xs font-bold uppercase tracking-widest text-kcvv-green"
+          className="mb-1 text-xs font-bold uppercase tracking-widest text-kcvv-green-bright"
         >
           {teamLabel}
         </div>
       )}
 
       {/* Header: Date, time, status */}
-      <div
-        className={cn(
-          "flex items-center justify-between text-sm",
-          isCompact ? "mb-2" : "mb-3",
-        )}
-      >
+      <div className="flex items-center justify-between text-sm mb-3">
         <div className="flex items-center gap-2">
           <span
             className={cn(
@@ -187,35 +287,28 @@ export function MatchTeaser({
           )}
           <StatusBadge status={status} isDark={isDark} />
         </div>
-        {venue && !isCompact && (
+        {venue && (
           <span className="text-gray-500 text-xs hidden sm:block">{venue}</span>
         )}
       </div>
 
       {/* Teams and score */}
       <div className="flex items-center justify-between">
-        {/* Home team */}
         <TeamDisplay
           team={homeTeam}
           side="home"
           isHighlighted={isHomeHighlighted}
-          compact={isCompact}
+          compact={false}
           isDark={isDark}
         />
 
-        {/* Score or VS */}
-        <div className="flex-shrink-0 px-3">
+        <div className="shrink-0 px-3">
           {hasScore ? (
-            <div
-              className={cn(
-                "flex items-center gap-2 font-mono font-bold",
-                isCompact ? "text-base" : "text-lg",
-              )}
-            >
+            <div className="flex items-center gap-2 font-mono font-bold text-lg">
               <span
                 className={cn(
                   isHomeHighlighted && score.home > score.away
-                    ? "text-kcvv-green"
+                    ? "text-kcvv-green-bright"
                     : isDark
                       ? "text-white"
                       : "text-gray-900",
@@ -229,7 +322,7 @@ export function MatchTeaser({
               <span
                 className={cn(
                   isAwayHighlighted && score.away > score.home
-                    ? "text-kcvv-green"
+                    ? "text-kcvv-green-bright"
                     : isDark
                       ? "text-white"
                       : "text-gray-900",
@@ -250,30 +343,19 @@ export function MatchTeaser({
           )}
         </div>
 
-        {/* Away team */}
         <TeamDisplay
           team={awayTeam}
           side="away"
           isHighlighted={isAwayHighlighted}
-          compact={isCompact}
+          compact={false}
           isDark={isDark}
         />
       </div>
 
-      {/* Venue on mobile */}
-      {venue && !isCompact && (
+      {venue && (
         <div className="mt-2 text-xs text-gray-500 sm:hidden">{venue}</div>
       )}
     </>
-  );
-
-  const containerClasses = cn(
-    "block border rounded transition-shadow",
-    isDark
-      ? "bg-kcvv-black border-white/8 hover:border-white/20"
-      : "bg-white border-gray-200 hover:shadow-md",
-    isCompact ? "p-3" : "p-4",
-    className,
   );
 
   if (href) {
@@ -285,6 +367,47 @@ export function MatchTeaser({
   }
 
   return <div className={containerClasses}>{content}</div>;
+}
+
+/**
+ * Logo for compact variant — bare image (no container), circle letter fallback
+ */
+function CompactLogo({
+  team,
+  isHighlighted,
+  isDark,
+}: {
+  team: MatchTeaserTeam;
+  isHighlighted?: boolean;
+  isDark?: boolean;
+}) {
+  if (team.logo) {
+    return (
+      <Image
+        src={team.logo}
+        alt=""
+        width={32}
+        height={32}
+        className="w-8 h-8 shrink-0 object-contain"
+      />
+    );
+  }
+  return (
+    <div
+      className={cn(
+        "w-8 h-8 shrink-0 flex items-center justify-center text-sm font-bold rounded-full",
+        isHighlighted
+          ? isDark
+            ? "bg-kcvv-green/20 text-kcvv-green-bright"
+            : "bg-kcvv-green/15 text-kcvv-green-dark"
+          : isDark
+            ? "bg-white/10 text-white/40"
+            : "bg-gray-200 text-gray-500",
+      )}
+    >
+      {team.name.charAt(0).toUpperCase()}
+    </div>
+  );
 }
 
 /**
@@ -341,7 +464,7 @@ function StatusBadge({
 }
 
 /**
- * Renders team logo and name
+ * Renders team logo and name (default variant)
  */
 function TeamDisplay({
   team,
@@ -371,12 +494,12 @@ function TeamDisplay({
           alt={`${team.name} logo`}
           width={logoSize}
           height={logoSize}
-          className="object-contain flex-shrink-0"
+          className="object-contain shrink-0"
         />
       ) : (
         <div
           className={cn(
-            "rounded-full flex items-center justify-center flex-shrink-0",
+            "rounded-full flex items-center justify-center shrink-0",
             compact ? "w-6 h-6" : "w-8 h-8",
             isDark ? "bg-white/15" : "bg-gray-200",
           )}

--- a/apps/web/src/components/match/MatchTeaser/MatchTeaser.tsx
+++ b/apps/web/src/components/match/MatchTeaser/MatchTeaser.tsx
@@ -47,6 +47,10 @@ export interface MatchTeaserProps {
   highlightTeamId?: string | number;
   /** Display variant */
   variant?: "default" | "compact";
+  /** Optional team label shown as a small green badge above the date row (e.g. "A-Ploeg") */
+  teamLabel?: string;
+  /** Theme variant — "dark" for dark-background sections */
+  theme?: "light" | "dark";
   /** Loading state */
   isLoading?: boolean;
   /** Additional CSS classes */
@@ -98,11 +102,14 @@ export function MatchTeaser({
   status,
   href,
   highlightTeamId,
+  teamLabel,
+  theme,
   variant = "default",
   isLoading = false,
   className,
 }: MatchTeaserProps) {
   const isCompact = variant === "compact";
+  const isDark = theme === "dark";
   const hasScore = !!score;
 
   // Check if either team should be highlighted (strict ID equality)
@@ -148,6 +155,15 @@ export function MatchTeaser({
 
   const content = (
     <>
+      {teamLabel && (
+        <div
+          data-testid="team-label"
+          className="mb-1 text-xs font-bold uppercase tracking-widest text-kcvv-green"
+        >
+          {teamLabel}
+        </div>
+      )}
+
       {/* Header: Date, time, status */}
       <div
         className={cn(
@@ -156,9 +172,20 @@ export function MatchTeaser({
         )}
       >
         <div className="flex items-center gap-2">
-          <span className="font-medium text-gray-900">{formatDate(date)}</span>
-          {time && <span className="text-gray-500">{time}</span>}
-          <StatusBadge status={status} />
+          <span
+            className={cn(
+              "font-medium",
+              isDark ? "text-white/70" : "text-gray-900",
+            )}
+          >
+            {formatDate(date)}
+          </span>
+          {time && (
+            <span className={cn(isDark ? "text-white/50" : "text-gray-500")}>
+              {time}
+            </span>
+          )}
+          <StatusBadge status={status} isDark={isDark} />
         </div>
         {venue && !isCompact && (
           <span className="text-gray-500 text-xs hidden sm:block">{venue}</span>
@@ -173,6 +200,7 @@ export function MatchTeaser({
           side="home"
           isHighlighted={isHomeHighlighted}
           compact={isCompact}
+          isDark={isDark}
         />
 
         {/* Score or VS */}
@@ -186,26 +214,39 @@ export function MatchTeaser({
             >
               <span
                 className={cn(
-                  isHomeHighlighted &&
-                    score.home > score.away &&
-                    "text-kcvv-green-bright",
+                  isHomeHighlighted && score.home > score.away
+                    ? "text-kcvv-green"
+                    : isDark
+                      ? "text-white"
+                      : "text-gray-900",
                 )}
               >
                 {score.home}
               </span>
-              <span className="text-gray-400">-</span>
+              <span className={cn(isDark ? "text-white/30" : "text-gray-400")}>
+                -
+              </span>
               <span
                 className={cn(
-                  isAwayHighlighted &&
-                    score.away > score.home &&
-                    "text-kcvv-green-bright",
+                  isAwayHighlighted && score.away > score.home
+                    ? "text-kcvv-green"
+                    : isDark
+                      ? "text-white"
+                      : "text-gray-900",
                 )}
               >
                 {score.away}
               </span>
             </div>
           ) : (
-            <span className="text-gray-400 font-medium">VS</span>
+            <span
+              className={cn(
+                "font-medium",
+                isDark ? "text-white/30" : "text-gray-400",
+              )}
+            >
+              VS
+            </span>
           )}
         </div>
 
@@ -215,6 +256,7 @@ export function MatchTeaser({
           side="away"
           isHighlighted={isAwayHighlighted}
           compact={isCompact}
+          isDark={isDark}
         />
       </div>
 
@@ -226,7 +268,10 @@ export function MatchTeaser({
   );
 
   const containerClasses = cn(
-    "block bg-white border rounded-lg transition-shadow border-gray-200 hover:shadow-md",
+    "block border rounded transition-shadow",
+    isDark
+      ? "bg-kcvv-black border-white/8 hover:border-white/20"
+      : "bg-white border-gray-200 hover:shadow-md",
     isCompact ? "p-3" : "p-4",
     className,
   );
@@ -245,24 +290,49 @@ export function MatchTeaser({
 /**
  * Renders status badge for match
  */
-function StatusBadge({ status }: { status: MatchTeaserProps["status"] }) {
+function StatusBadge({
+  status,
+  isDark,
+}: {
+  status: MatchTeaserProps["status"];
+  isDark?: boolean;
+}) {
   if (status === "postponed") {
     return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
+      <span
+        className={cn(
+          "inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium",
+          isDark
+            ? "bg-orange-900/40 text-orange-300"
+            : "bg-orange-100 text-orange-800",
+        )}
+      >
         Uitgesteld
       </span>
     );
   }
   if (status === "stopped") {
     return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-800">
+      <span
+        className={cn(
+          "inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium",
+          isDark
+            ? "bg-orange-900/40 text-orange-300"
+            : "bg-orange-100 text-orange-800",
+        )}
+      >
         Gestopt
       </span>
     );
   }
   if (status === "forfeited") {
     return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">
+      <span
+        className={cn(
+          "inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium",
+          isDark ? "bg-white/10 text-white/60" : "bg-gray-100 text-gray-700",
+        )}
+      >
         FF
       </span>
     );
@@ -278,11 +348,13 @@ function TeamDisplay({
   side,
   isHighlighted,
   compact,
+  isDark,
 }: {
   team: MatchTeaserTeam;
   side: "home" | "away";
   isHighlighted?: boolean;
   compact?: boolean;
+  isDark?: boolean;
 }) {
   const logoSize = compact ? 24 : 32;
 
@@ -304,12 +376,16 @@ function TeamDisplay({
       ) : (
         <div
           className={cn(
-            "rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0",
+            "rounded-full flex items-center justify-center flex-shrink-0",
             compact ? "w-6 h-6" : "w-8 h-8",
+            isDark ? "bg-white/15" : "bg-gray-200",
           )}
         >
           <span
-            className={cn("text-gray-500", compact ? "text-xs" : "text-sm")}
+            className={cn(
+              compact ? "text-xs" : "text-sm",
+              isDark ? "text-white/60" : "text-gray-500",
+            )}
           >
             {team.name.charAt(0)}
           </span>
@@ -321,7 +397,13 @@ function TeamDisplay({
           "truncate",
           compact ? "text-sm" : "text-base",
           side === "away" && "text-right",
-          isHighlighted ? "font-semibold text-gray-900" : "text-gray-700",
+          isDark
+            ? isHighlighted
+              ? "font-bold text-white"
+              : "text-white/85"
+            : isHighlighted
+              ? "font-semibold text-gray-900"
+              : "text-gray-700",
         )}
       >
         {team.name}

--- a/apps/web/src/components/match/MatchesSlider/MatchesSlider.stories.tsx
+++ b/apps/web/src/components/match/MatchesSlider/MatchesSlider.stories.tsx
@@ -70,6 +70,19 @@ export const Mixed: Story = {
   },
 };
 
+export const DarkTheme: Story = {
+  args: {
+    matches: mockMatches.mixed.map((m, i) => ({
+      ...m,
+      teamLabel: i % 2 === 0 ? "A-Ploeg" : "U17",
+    })),
+    theme: "dark",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+
 /** Empty matches array — component renders nothing (null). */
 export const Empty: Story = {
   args: {

--- a/apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx
+++ b/apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx
@@ -9,6 +9,7 @@
 
 import { useRef, useState, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils/cn";
+import { ChevronLeft, ChevronRight } from "@/lib/icons";
 import { MatchTeaser } from "../MatchTeaser/MatchTeaser";
 import type { UpcomingMatch } from "@/components/match/types";
 
@@ -19,6 +20,8 @@ export interface MatchesSliderProps {
   highlightTeamId?: number;
   /** Section heading */
   title?: string;
+  /** Theme variant — "dark" for kcvv-black sections */
+  theme?: "light" | "dark";
   /** Additional CSS classes */
   className?: string;
 }
@@ -33,6 +36,7 @@ export const MatchesSlider = ({
   matches,
   highlightTeamId,
   title,
+  theme,
   className,
 }: MatchesSliderProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -80,22 +84,21 @@ export const MatchesSlider = ({
           <button
             type="button"
             onClick={() => scroll("left")}
-            className="hidden lg:flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-5 z-10 w-10 h-10 items-center justify-center bg-white rounded-full shadow-md hover:bg-gray-50 transition-colors"
+            className={cn(
+              "hidden lg:flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-5 z-10",
+              "w-10 h-10 items-center justify-center transition-colors",
+              theme === "dark"
+                ? "bg-kcvv-black border border-kcvv-green rounded-sm hover:bg-kcvv-green/10"
+                : "bg-white rounded-full shadow-md hover:bg-gray-50",
+            )}
             aria-label="Scroll naar links"
           >
-            <svg
-              className="w-5 h-5 text-kcvv-green-dark"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
+            <ChevronLeft
+              className={cn(
+                "w-5 h-5",
+                theme === "dark" ? "text-kcvv-green" : "text-kcvv-green-dark",
+              )}
+            />
           </button>
         )}
 
@@ -132,6 +135,8 @@ export const MatchesSlider = ({
                   }
                   status={mapStatus(match.status)}
                   highlightTeamId={highlightTeamId}
+                  teamLabel={match.teamLabel}
+                  theme={theme}
                   variant="compact"
                 />
               </div>
@@ -144,22 +149,21 @@ export const MatchesSlider = ({
           <button
             type="button"
             onClick={() => scroll("right")}
-            className="hidden lg:flex absolute right-0 top-1/2 -translate-y-1/2 translate-x-5 z-10 w-10 h-10 items-center justify-center bg-white rounded-full shadow-md hover:bg-gray-50 transition-colors"
+            className={cn(
+              "hidden lg:flex absolute right-0 top-1/2 -translate-y-1/2 translate-x-5 z-10",
+              "w-10 h-10 items-center justify-center transition-colors",
+              theme === "dark"
+                ? "bg-kcvv-black border border-kcvv-green rounded-sm hover:bg-kcvv-green/10"
+                : "bg-white rounded-full shadow-md hover:bg-gray-50",
+            )}
             aria-label="Scroll naar rechts"
           >
-            <svg
-              className="w-5 h-5 text-kcvv-green-dark"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 5l7 7-7 7"
-              />
-            </svg>
+            <ChevronRight
+              className={cn(
+                "w-5 h-5",
+                theme === "dark" ? "text-kcvv-green" : "text-kcvv-green-dark",
+              )}
+            />
           </button>
         )}
       </div>

--- a/apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx
+++ b/apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx
@@ -85,10 +85,10 @@ export const MatchesSlider = ({
             type="button"
             onClick={() => scroll("left")}
             className={cn(
-              "hidden lg:flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-5 z-10",
+              "flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-5 z-10",
               "w-10 h-10 items-center justify-center transition-colors",
               theme === "dark"
-                ? "bg-kcvv-black border border-kcvv-green rounded-sm hover:bg-kcvv-green/10"
+                ? "bg-kcvv-black border border-kcvv-green-bright/50 rounded-sm hover:bg-kcvv-green-bright/10 hover:border-kcvv-green-bright"
                 : "bg-white rounded-full shadow-md hover:bg-gray-50",
             )}
             aria-label="Scroll naar links"
@@ -96,7 +96,9 @@ export const MatchesSlider = ({
             <ChevronLeft
               className={cn(
                 "w-5 h-5",
-                theme === "dark" ? "text-kcvv-green" : "text-kcvv-green-dark",
+                theme === "dark"
+                  ? "text-kcvv-green-bright"
+                  : "text-kcvv-green-dark",
               )}
             />
           </button>
@@ -125,6 +127,16 @@ export const MatchesSlider = ({
                   }}
                   date={match.date.toISOString()}
                   time={match.time}
+                  venue={
+                    match.venue ??
+                    (highlightTeamId !== undefined
+                      ? match.homeTeam.id === highlightTeamId
+                        ? "Thuis"
+                        : match.awayTeam.id === highlightTeamId
+                          ? "Uit"
+                          : undefined
+                      : undefined)
+                  }
                   score={
                     match.homeTeam.score != null && match.awayTeam.score != null
                       ? {
@@ -150,10 +162,10 @@ export const MatchesSlider = ({
             type="button"
             onClick={() => scroll("right")}
             className={cn(
-              "hidden lg:flex absolute right-0 top-1/2 -translate-y-1/2 translate-x-5 z-10",
+              "flex absolute right-0 top-1/2 -translate-y-1/2 translate-x-5 z-10",
               "w-10 h-10 items-center justify-center transition-colors",
               theme === "dark"
-                ? "bg-kcvv-black border border-kcvv-green rounded-sm hover:bg-kcvv-green/10"
+                ? "bg-kcvv-black border border-kcvv-green-bright/50 rounded-sm hover:bg-kcvv-green-bright/10 hover:border-kcvv-green-bright"
                 : "bg-white rounded-full shadow-md hover:bg-gray-50",
             )}
             aria-label="Scroll naar rechts"
@@ -161,7 +173,9 @@ export const MatchesSlider = ({
             <ChevronRight
               className={cn(
                 "w-5 h-5",
-                theme === "dark" ? "text-kcvv-green" : "text-kcvv-green-dark",
+                theme === "dark"
+                  ? "text-kcvv-green-bright"
+                  : "text-kcvv-green-dark",
               )}
             />
           </button>

--- a/apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx
+++ b/apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx
@@ -75,7 +75,7 @@ export const MatchesSlider = ({
   return (
     <div className={cn("", className)}>
       {title && (
-        <h3 className="text-lg font-bold text-[#31404b] mb-3">{title}</h3>
+        <h3 className="text-lg font-bold text-kcvv-black mb-3">{title}</h3>
       )}
 
       <div className="relative">

--- a/apps/web/src/components/match/types.ts
+++ b/apps/web/src/components/match/types.ts
@@ -51,4 +51,6 @@ export interface UpcomingMatch {
    * Competition name (optional)
    */
   competition?: string;
+  /** Optional team label for display (e.g. "A-Ploeg", "U21") — set by calling page */
+  teamLabel?: string;
 }

--- a/apps/web/src/lib/effect/services/SanityService.test.ts
+++ b/apps/web/src/lib/effect/services/SanityService.test.ts
@@ -221,3 +221,75 @@ describe("SanityService.getPage", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("SanityService.getNextFeaturedEvent", () => {
+  it("returns the next event with featuredOnHome=true when present", async () => {
+    const mockEvent = {
+      _id: "event-1",
+      title: "Sponsorfeest",
+      dateStart: "2026-04-26T19:00:00.000Z",
+      dateEnd: null,
+      externalLink: { url: "https://fb.com", label: "Facebook" },
+      coverImageUrl: "https://cdn.sanity.io/img.jpg",
+      featuredOnHome: true,
+    };
+    mockFetch(mockEvent);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* SanityService;
+        return yield* svc.getNextFeaturedEvent();
+      }).pipe(Effect.provide(SanityServiceLive)),
+    );
+    expect(result).not.toBeNull();
+    expect(result?._id).toBe("event-1");
+  });
+
+  it("returns null when no upcoming events exist", async () => {
+    mockFetch(null);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* SanityService;
+        return yield* svc.getNextFeaturedEvent();
+      }).pipe(Effect.provide(SanityServiceLive)),
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("SanityService.getHomepageBanners", () => {
+  it("returns resolved banner data from homepage singleton", async () => {
+    mockFetch({
+      bannerSlotA: {
+        _id: "b1",
+        imageUrl: "/img.jpg",
+        alt: "Anti-racism",
+        href: null,
+      },
+      bannerSlotB: null,
+      bannerSlotC: null,
+    });
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* SanityService;
+        return yield* svc.getHomepageBanners();
+      }).pipe(Effect.provide(SanityServiceLive)),
+    );
+    expect(result.bannerSlotA).not.toBeNull();
+    expect(result.bannerSlotB).toBeNull();
+  });
+
+  it("returns all-null banners when homepage doc is missing", async () => {
+    mockFetch(null);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* SanityService;
+        return yield* svc.getHomepageBanners();
+      }).pipe(Effect.provide(SanityServiceLive)),
+    );
+    expect(result).toEqual({
+      bannerSlotA: null,
+      bannerSlotB: null,
+      bannerSlotC: null,
+    });
+  });
+});

--- a/apps/web/src/lib/effect/services/SanityService.ts
+++ b/apps/web/src/lib/effect/services/SanityService.ts
@@ -10,7 +10,11 @@ import {
   ARTICLE_BY_SLUG_QUERY,
 } from "../../sanity/queries/articles";
 import { SPONSORS_QUERY } from "../../sanity/queries/sponsors";
-import { EVENTS_QUERY } from "../../sanity/queries/events";
+import {
+  EVENTS_QUERY,
+  NEXT_FEATURED_EVENT_QUERY,
+} from "../../sanity/queries/events";
+import { HOMEPAGE_BANNERS_QUERY } from "../../sanity/queries/homePage";
 import { RESPONSIBILITY_PATHS_QUERY } from "../../sanity/queries/responsibilityPaths";
 import { STAFF_MEMBERS_QUERY } from "../../sanity/queries/staffMembers";
 import { PAGE_BY_SLUG_QUERY } from "../../sanity/queries/pages";
@@ -106,6 +110,20 @@ export interface SanityEvent {
   dateEnd: string | null;
   externalLink: { url: string; label: string } | null;
   coverImageUrl: string | null;
+  featuredOnHome?: boolean;
+}
+
+export interface SanityBannerSlot {
+  _id: string;
+  imageUrl: string;
+  alt: string;
+  href: string | null;
+}
+
+export interface SanityHomepageBanners {
+  bannerSlotA: SanityBannerSlot | null;
+  bannerSlotB: SanityBannerSlot | null;
+  bannerSlotC: SanityBannerSlot | null;
 }
 
 export interface SanityResponsibilityContact {
@@ -172,6 +190,8 @@ export interface SanityServiceInterface {
   ) => Effect.Effect<SanityArticle | null>;
   readonly getSponsors: () => Effect.Effect<SanitySponsor[]>;
   readonly getEvents: () => Effect.Effect<SanityEvent[]>;
+  readonly getNextFeaturedEvent: () => Effect.Effect<SanityEvent | null>;
+  readonly getHomepageBanners: () => Effect.Effect<SanityHomepageBanners>;
   readonly getResponsibilityPaths: () => Effect.Effect<ResponsibilityPath[]>;
   readonly getStaffMembers: () => Effect.Effect<OrgChartNode[]>;
   readonly getPage: (slug: string) => Effect.Effect<SanityPage | null>;
@@ -271,6 +291,17 @@ export const SanityServiceLive = Layer.succeed(SanityService, {
     fetchGroq<SanityArticle | null>(ARTICLE_BY_SLUG_QUERY, { slug }),
   getSponsors: () => fetchGroq<SanitySponsor[]>(SPONSORS_QUERY),
   getEvents: () => fetchGroq<SanityEvent[]>(EVENTS_QUERY),
+  getNextFeaturedEvent: () =>
+    fetchGroq<SanityEvent | null>(NEXT_FEATURED_EVENT_QUERY, {
+      now: new Date().toISOString(),
+    }),
+  getHomepageBanners: () =>
+    fetchGroq<SanityHomepageBanners | null>(HOMEPAGE_BANNERS_QUERY).pipe(
+      Effect.map(
+        (data) =>
+          data ?? { bannerSlotA: null, bannerSlotB: null, bannerSlotC: null },
+      ),
+    ),
   getResponsibilityPaths: () =>
     fetchGroq<SanityResponsibilityPath[]>(RESPONSIBILITY_PATHS_QUERY).pipe(
       Effect.map((paths) => paths.map(mapResponsibilityPath)),

--- a/apps/web/src/lib/sanity/queries/events.ts
+++ b/apps/web/src/lib/sanity/queries/events.ts
@@ -2,3 +2,18 @@ export const EVENTS_QUERY = `*[_type == "event"] | order(dateStart asc) {
   _id, title, dateStart, dateEnd, externalLink,
   "coverImageUrl": coverImage.asset->url
 }`;
+
+// Returns the next event with featuredOnHome=true, or the earliest upcoming event,
+// or null if none exist. $now must be current ISO datetime.
+export const NEXT_FEATURED_EVENT_QUERY = `
+  coalesce(
+    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {
+      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,
+      "coverImageUrl": coverImage.asset->url
+    },
+    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {
+      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,
+      "coverImageUrl": coverImage.asset->url
+    }
+  )
+`;

--- a/apps/web/src/lib/sanity/queries/homePage.ts
+++ b/apps/web/src/lib/sanity/queries/homePage.ts
@@ -1,0 +1,22 @@
+export const HOMEPAGE_BANNERS_QUERY = `
+  *[_type == "homePage"][0] {
+    "bannerSlotA": bannerSlotA-> {
+      _id,
+      "imageUrl": image.asset->url,
+      alt,
+      href
+    },
+    "bannerSlotB": bannerSlotB-> {
+      _id,
+      "imageUrl": image.asset->url,
+      alt,
+      href
+    },
+    "bannerSlotC": bannerSlotC-> {
+      _id,
+      "imageUrl": image.asset->url,
+      alt,
+      href
+    }
+  }
+`;

--- a/docs/mockups/homepage-v3.html
+++ b/docs/mockups/homepage-v3.html
@@ -831,11 +831,11 @@ img { max-width: 100%; display: block; }
 }
 
 /* ============================================================
-   SPONSORS SECTION  (kcvv-black)
+   SPONSORS SECTION  (gray-100)
    ============================================================ */
 .section-sponsors {
-  background: var(--black);
-  padding: 80px 0;
+  background: var(--gray-100);
+  padding: 72px 0;
   position: relative;
 }
 .sponsor-grid {
@@ -843,12 +843,12 @@ img { max-width: 100%; display: block; }
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 40px 60px;
-  margin-top: 48px;
+  gap: 32px 52px;
+  margin-top: 44px;
 }
 .sponsor-item {
   display: block;
-  opacity: 0.4;
+  opacity: 0.35;
   filter: grayscale(100%);
   transition: opacity 0.3s ease, filter 0.3s ease;
   cursor: pointer;
@@ -859,11 +859,11 @@ img { max-width: 100%; display: block; }
 }
 .sponsor-ph {
   display: flex; align-items: center; justify-content: center;
-  background: rgba(255,255,255,0.08);
+  background: rgba(0,0,0,0.08);
   border-radius: 3px;
   font-size: 11px; font-weight: 800;
   text-transform: uppercase; letter-spacing: 0.1em;
-  color: var(--white);
+  color: var(--black);
 }
 
 /* ============================================================
@@ -871,78 +871,78 @@ img { max-width: 100%; display: block; }
    ============================================================ */
 .footer {
   background: var(--black);
-  padding: 64px 0 32px;
+  padding: 44px 0 20px;
   border-top: 1px solid rgba(255,255,255,0.07);
 }
 .footer__grid {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;
-  gap: 56px;
-  padding-bottom: 48px;
+  gap: 40px;
+  padding-bottom: 32px;
   border-bottom: 1px solid rgba(255,255,255,0.07);
-  margin-bottom: 24px;
+  margin-bottom: 18px;
 }
 .footer__logo-row {
-  display: flex; align-items: center; gap: 14px;
-  margin-bottom: 16px;
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 14px;
 }
-.footer__logo-row img { height: 52px; width: auto; }
+.footer__logo-row img { height: 44px; width: auto; }
 .footer__logo-name { line-height: 1.2; }
 .footer__logo-name strong {
   display: block;
-  font-size: 13px; font-weight: 800;
+  font-size: 12px; font-weight: 800;
   color: var(--white);
   text-transform: uppercase; letter-spacing: 0.08em;
 }
 .footer__logo-name span {
-  font-size: 11px; color: rgba(255,255,255,0.3);
+  font-size: 11px; color: rgba(255,255,255,0.28);
   letter-spacing: 0.04em;
 }
 .footer__contact {
-  display: flex; flex-direction: column; gap: 11px;
-  margin-top: 20px;
+  display: flex; flex-direction: column; gap: 8px;
+  margin-top: 14px;
 }
 .footer__contact-item {
-  display: flex; align-items: center; gap: 10px;
-  font-size: 13px; color: rgba(255,255,255,0.45);
+  display: flex; align-items: center; gap: 9px;
+  font-size: 12px; color: rgba(255,255,255,0.4);
   transition: color 0.15s;
 }
-.footer__contact-item:hover { color: rgba(255,255,255,0.7); }
+.footer__contact-item:hover { color: rgba(255,255,255,0.65); }
 .footer__contact-item svg {
-  width: 13px; height: 13px;
+  width: 12px; height: 12px;
   flex-shrink: 0; color: rgba(255,255,255,0.2);
 }
 .footer__social {
   display: flex; gap: 6px;
-  margin-top: 22px;
+  margin-top: 16px;
 }
 .footer__social-link {
   display: flex; align-items: center; justify-content: center;
-  width: 34px; height: 34px;
+  width: 30px; height: 30px;
   border: 1px solid rgba(255,255,255,0.1);
   border-radius: 2px;
-  color: rgba(255,255,255,0.3);
+  color: rgba(255,255,255,0.28);
   transition: border-color 0.15s, color 0.15s;
 }
 .footer__social-link:hover { border-color: var(--green); color: var(--green); }
-.footer__social-link svg { width: 14px; height: 14px; }
+.footer__social-link svg { width: 13px; height: 13px; }
 .footer__heading {
   font-size: 10px; font-weight: 800;
   text-transform: uppercase; letter-spacing: 0.16em;
-  color: rgba(255,255,255,0.22);
-  margin-bottom: 18px;
+  color: rgba(255,255,255,0.2);
+  margin-bottom: 14px;
 }
-.footer__links { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+.footer__links { list-style: none; display: flex; flex-direction: column; gap: 8px; }
 .footer__links a {
-  font-size: 14px; color: rgba(255,255,255,0.45);
+  font-size: 13px; color: rgba(255,255,255,0.4);
   transition: color 0.15s;
 }
 .footer__links a:hover { color: var(--green); }
 .footer__bottom {
   display: flex; align-items: center; justify-content: space-between;
-  font-size: 11px; color: rgba(255,255,255,0.18);
+  font-size: 11px; color: rgba(255,255,255,0.16);
 }
-.footer__bottom a { color: rgba(255,255,255,0.28); transition: color 0.15s; }
+.footer__bottom a { color: rgba(255,255,255,0.24); transition: color 0.15s; }
 .footer__bottom a:hover { color: var(--green); }
 
 /* ============================================================
@@ -1434,8 +1434,8 @@ img { max-width: 100%; display: block; }
 <section class="section-sponsors">
   <div class="container">
     <div class="section-header">
-      <h2 class="section-title section-title--dark">Sponsors</h2>
-      <a href="#" class="section-link section-link--dark">Word sponsor</a>
+      <h2 class="section-title section-title--light">Sponsors</h2>
+      <a href="#" class="section-link">Word sponsor</a>
     </div>
     <div class="sponsor-grid">
       <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:180px;height:72px;font-size:12px;">Hoofdsponsor A</div></a>

--- a/docs/mockups/homepage-v3.html
+++ b/docs/mockups/homepage-v3.html
@@ -1,0 +1,1528 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>KCVV Elewijt — Redesign Mockup v3</title>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    corePlugins: { preflight: false },
+    theme: {
+      extend: {
+        colors: {
+          'kcvv-green': '#4acf52',
+          'kcvv-green-dark': '#008755',
+          'kcvv-black': '#1E2024',
+        },
+      }
+    }
+  }
+</script>
+<style>
+/* ============================================================
+   DESIGN TOKENS
+   ============================================================ */
+:root {
+  --green:          #4acf52;
+  --green-dark:     #008755;
+  --black:          #1E2024;
+  --black-soft:     #25282a;
+  --white:          #ffffff;
+  --gray-100:       #f4f5f7;
+  --gray-200:       #e8eaed;
+  --gray-400:       #9ca3af;
+  --gray-700:       #374151;
+
+  --font-display:   'quasimoda', 'Montserrat', sans-serif;
+  --font-body:      'Montserrat', sans-serif;
+  --font-accent:    'stenciletta', 'Montserrat', sans-serif;
+  --font-mono:      'SF Mono', 'Fira Code', monospace;
+
+  --max-w:    1280px;
+  --gutter:   clamp(1rem, 4vw, 2rem);
+
+  --pattern-chevron: url('file:///Users/kevinvanransbeeck/Downloads/Redesign/Asset 4.svg');
+  --pattern-dark:    url('file:///Users/kevinvanransbeeck/Downloads/Redesign/Layer 1.svg');
+}
+
+/* ============================================================
+   RESET & BASE
+   ============================================================ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  font-family: var(--font-body);
+  background: var(--white);
+  color: var(--black);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; text-decoration: none; }
+img { max-width: 100%; display: block; }
+
+.container {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+
+/* ============================================================
+   SHARED SECTION PRIMITIVES
+   ============================================================ */
+.section-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 40px;
+}
+
+.section-title {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  padding-left: 16px;
+  border-left: 4px solid var(--green);
+  font-family: var(--font-display);
+}
+.section-title--light { color: var(--black); }
+.section-title--dark  { color: var(--white); }
+
+.section-link {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--green-dark);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: gap 0.2s;
+}
+.section-link::after { content: '→'; }
+.section-link:hover { gap: 10px; }
+.section-link--dark { color: var(--green); }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 32px;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border-radius: 2px;
+  transition: all 0.15s;
+  cursor: pointer;
+  border: none;
+}
+.btn--primary {
+  background: var(--green);
+  color: var(--black);
+}
+.btn--primary:hover { background: #3dba45; transform: translateY(-1px); }
+.btn--outline-dark {
+  border: 2px solid var(--black);
+  color: var(--black);
+  background: transparent;
+}
+.btn--outline-dark:hover { background: var(--black); color: var(--white); }
+
+/* ============================================================
+   NAV
+   ============================================================ */
+.nav {
+  position: sticky;
+  top: 3px; /* below accent strip */
+  z-index: 100;
+  background: var(--black);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.nav__inner {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+}
+.nav__logo { display: flex; align-items: center; gap: 12px; }
+.nav__logo img { height: 40px; width: auto; display: block; }
+.nav__menu { display: flex; align-items: center; gap: 2px; list-style: none; }
+.nav__menu a {
+  display: block;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 700;
+  color: rgba(255,255,255,0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: color 0.15s;
+  position: relative;
+}
+.nav__menu a:hover,
+.nav__menu a.active { color: var(--white); }
+.nav__menu a.active::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 14px; right: 14px;
+  height: 2px;
+  background: var(--green);
+}
+.nav__utils { display: flex; align-items: center; gap: 8px; }
+.nav__search {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px; height: 36px;
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 2px;
+  color: rgba(255,255,255,0.5);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+  background: transparent;
+}
+.nav__search:hover { border-color: var(--green); color: var(--green); }
+.nav__cta {
+  padding: 9px 20px;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--green);
+  color: var(--black);
+  border-radius: 2px;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+.nav__cta:hover { background: #3dba45; }
+
+/* ============================================================
+   HERO — FeaturedArticles carousel
+   ============================================================ */
+.hero {
+  position: relative;
+  height: 600px;
+  background: var(--black);
+  overflow: hidden;
+}
+.hero__photo {
+  position: absolute; inset: 0; z-index: 0;
+  background-size: cover;
+  background-position: center;
+}
+.hero__gradient {
+  position: absolute; inset: 0; z-index: 1;
+  background: linear-gradient(to right,
+    rgba(0,0,0,0.88) 0%,
+    rgba(0,0,0,0.55) 55%,
+    rgba(0,0,0,0.15) 100%);
+}
+.hero__bignumber {
+  position: absolute;
+  right: 320px; bottom: 40px;
+  font-size: clamp(12rem, 22vw, 20rem);
+  font-weight: 900;
+  color: rgba(255,255,255,0.035);
+  line-height: 1;
+  pointer-events: none;
+  letter-spacing: -0.05em;
+  font-family: var(--font-accent);
+  z-index: 2;
+  user-select: none;
+}
+/* Diagonal bottom cut → white */
+.hero::after {
+  content: '';
+  position: absolute;
+  bottom: -1px; left: 0; right: 0;
+  height: 100px;
+  background: var(--white);
+  clip-path: polygon(0 100%, 100% 100%, 100% 100%, 0 55%);
+  z-index: 10;
+}
+.hero__content {
+  position: absolute; inset: 0; z-index: 5;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 32px;
+  padding: 0 clamp(1.5rem, 4vw, 3rem);
+  max-width: var(--max-w);
+  width: 100%;
+  margin: 0 auto;
+  left: 50%; transform: translateX(-50%);
+}
+.hero__article-link {
+  display: flex; flex-direction: column; justify-content: center;
+  max-width: 540px; flex: 1; min-width: 0;
+}
+.hero__tag {
+  display: inline-block;
+  padding: 3px 10px;
+  background: var(--green);
+  color: var(--black);
+  font-size: 10px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  margin-bottom: 18px;
+  border-radius: 2px; width: fit-content;
+}
+.hero__title {
+  font-size: clamp(2.5rem, 5.5vw, 5rem);
+  font-weight: 900;
+  color: var(--white);
+  line-height: 1.02;
+  margin-bottom: 20px;
+  letter-spacing: -0.03em;
+  font-family: var(--font-display);
+  transition: color 0.15s;
+}
+.hero__article-link:hover .hero__title { color: var(--green); }
+.hero__subtitle {
+  font-size: 1.05rem;
+  color: rgba(255,255,255,0.7);
+  margin-bottom: 20px;
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.hero__meta {
+  display: flex; align-items: center; gap: 16px;
+  font-size: 12px; color: rgba(255,255,255,0.5);
+  font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
+}
+.hero__meta-dot { width: 3px; height: 3px; border-radius: 50%; background: rgba(255,255,255,0.3); }
+.hero__controls { display: flex; align-items: center; gap: 10px; margin-top: 28px; }
+.hero__pause {
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.7);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; transition: background 0.15s;
+}
+.hero__pause:hover { background: rgba(255,255,255,0.2); }
+.hero__dots { display: flex; gap: 6px; align-items: center; }
+.hero__dot {
+  height: 3px; border-radius: 2px;
+  border: none; cursor: pointer; padding: 0;
+  transition: background 0.2s, width 0.3s;
+  width: 20px; background: rgba(255,255,255,0.3);
+}
+.hero__dot--active { background: var(--green); width: 40px; }
+.hero__panel {
+  flex-shrink: 0; width: 290px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.hero__panel-item {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: background 0.15s, border-color 0.15s;
+  text-align: left;
+}
+.hero__panel-item--active {
+  background: rgba(30,32,36,0.9);
+  border-color: var(--green);
+}
+.hero__panel-item:hover:not(.hero__panel-item--active) {
+  background: rgba(0,0,0,0.75);
+  border-color: rgba(255,255,255,0.2);
+}
+.hero__panel-thumb {
+  width: 52px; height: 52px;
+  border-radius: 3px; flex-shrink: 0;
+  object-fit: cover;
+  background: var(--black-soft);
+}
+.hero__panel-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.hero__panel-title {
+  font-size: 12px; font-weight: 600;
+  color: var(--white); line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.hero__panel-date { font-size: 11px; color: rgba(255,255,255,0.35); font-weight: 500; }
+
+/* ============================================================
+   BANNER SLOT
+   ============================================================ */
+.banner-slot {
+  padding: 28px 0;
+}
+.banner-slot--on-white  { background: var(--white); }
+.banner-slot--on-gray   { background: var(--gray-100); }
+
+.banner-slot__link {
+  display: block;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 4px 32px rgba(0,0,0,0.12);
+  transition: box-shadow 0.25s, transform 0.25s;
+}
+.banner-slot__link:hover {
+  box-shadow: 0 10px 48px rgba(0,0,0,0.18);
+  transform: translateY(-2px);
+}
+.banner-slot__static {
+  display: block;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 4px 32px rgba(0,0,0,0.12);
+}
+.banner-slot__img { width: 100%; height: auto; display: block; }
+
+/* ============================================================
+   MATCH WIDGET  (kcvv-green-dark, diagonal cuts)
+   ============================================================ */
+.match-widget {
+  background: var(--green-dark);
+  position: relative; overflow: hidden;
+}
+.match-widget::before {
+  content: '';
+  position: absolute; top: -1px; left: 0; right: 0;
+  height: 80px; background: var(--white);
+  clip-path: polygon(0 0, 100% 0, 100% 0, 0 100%);
+  z-index: 1;
+}
+.match-widget::after {
+  content: '';
+  position: absolute; bottom: -1px; left: 0; right: 0;
+  height: 80px; background: var(--gray-100);
+  clip-path: polygon(0 100%, 100% 100%, 100% 0, 0 100%);
+  z-index: 1;
+}
+.match-widget__inner {
+  position: relative; z-index: 2;
+  padding: 100px var(--gutter);
+  max-width: var(--max-w); margin: 0 auto;
+}
+.match-widget__label {
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.18em;
+  color: rgba(255,255,255,0.45);
+  margin-bottom: 28px;
+  display: flex; align-items: center; gap: 10px;
+}
+.match-widget__label::before {
+  content: ''; display: block;
+  width: 24px; height: 2px;
+  background: rgba(255,255,255,0.25);
+}
+.match-widget__grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center; gap: 32px;
+}
+.match-widget__team {
+  display: flex; flex-direction: column;
+  align-items: center; gap: 14px;
+}
+.match-widget__team--home { align-items: flex-end; text-align: right; }
+.match-widget__team--away { align-items: flex-start; text-align: left; }
+.match-widget__logo {
+  width: 76px; height: 76px;
+  background: rgba(255,255,255,0.1);
+  border-radius: 4px;
+  border: 2px solid rgba(255,255,255,0.15);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 26px; font-weight: 900; color: var(--green);
+  font-family: var(--font-accent);
+}
+.match-widget__teamname {
+  font-size: clamp(1.1rem, 2.5vw, 1.6rem);
+  font-weight: 900; color: var(--white);
+  text-transform: uppercase; letter-spacing: -0.02em;
+  font-family: var(--font-display);
+}
+.match-widget__center {
+  display: flex; flex-direction: column;
+  align-items: center; gap: 10px;
+}
+.match-widget__vs {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 900; color: var(--green);
+  letter-spacing: -0.04em; line-height: 1;
+  font-family: var(--font-accent);
+}
+.match-widget__meta {
+  display: flex; flex-direction: column;
+  align-items: center; gap: 6px;
+}
+.match-widget__date {
+  font-size: 13px; font-weight: 700;
+  color: rgba(255,255,255,0.75);
+}
+.match-widget__competition {
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: rgba(255,255,255,0.4);
+  background: rgba(255,255,255,0.08);
+  padding: 3px 12px; border-radius: 2px;
+}
+
+/* ============================================================
+   NEWS SECTION  (gray-100)
+   ============================================================ */
+.section-news {
+  background: var(--gray-100);
+  padding: 80px 0;
+}
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.card {
+  background: var(--black);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.card::before {
+  content: '';
+  position: absolute; top: 0; left: 0; right: 0;
+  height: 3px; background: var(--green);
+  transform: scaleX(0); transition: transform 0.2s;
+  z-index: 5;
+}
+.card:hover { transform: translateY(-4px); box-shadow: 0 16px 40px rgba(0,0,0,0.2); }
+.card:hover::before { transform: scaleX(1); }
+.card--featured { grid-column: span 2; }
+
+.card__img {
+  aspect-ratio: 3/2;
+  background: var(--black-soft);
+  overflow: hidden; position: relative;
+}
+.card--featured .card__img { aspect-ratio: 16/7; }
+.card__img::after {
+  content: '';
+  position: absolute; inset: 0;
+  background: linear-gradient(to top,
+    rgba(20,22,26,0.96) 0%,
+    rgba(20,22,26,0.4) 50%,
+    transparent 100%);
+}
+.card__img-inner {
+  width: 100%; height: 100%;
+  background-size: cover; background-position: center;
+}
+.card__overlay {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  padding: 18px 22px 22px; z-index: 1;
+}
+.card--featured .card__overlay { padding: 24px 30px 30px; }
+
+.card__category {
+  display: inline-block;
+  font-size: 9px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.14em;
+  color: var(--green);
+  margin-bottom: 8px;
+  border-left: 3px solid var(--green);
+  padding-left: 7px;
+}
+.card__title {
+  font-size: 0.95rem; font-weight: 700;
+  color: var(--white); line-height: 1.3;
+  margin-bottom: 6px;
+  font-family: var(--font-display);
+}
+.card--featured .card__title {
+  font-size: 1.5rem; line-height: 1.15; margin-bottom: 10px;
+}
+.card__excerpt {
+  font-size: 13px; color: rgba(255,255,255,0.6);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.card__footer {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 9px 22px;
+  border-top: 1px solid rgba(255,255,255,0.07);
+  font-size: 11px; color: rgba(255,255,255,0.3);
+  font-weight: 600;
+}
+
+/* Event card variant */
+.card--event .card__event-badge {
+  display: inline-flex;
+  align-items: center; gap: 5px;
+  padding: 4px 10px;
+  background: var(--green); color: var(--black);
+  font-size: 9px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.14em;
+  border-radius: 2px;
+  margin-bottom: 12px;
+}
+.card--event .card__event-badge svg { width: 10px; height: 10px; }
+.card--event .card__event-meta {
+  display: flex; align-items: center; gap: 14px;
+  margin-top: 10px;
+}
+.card--event .card__event-meta-item {
+  display: flex; align-items: center; gap: 5px;
+  font-size: 12px; color: rgba(255,255,255,0.55);
+}
+.card--event .card__event-meta-item svg {
+  width: 11px; height: 11px; color: var(--green); flex-shrink: 0;
+}
+.card--event .card__countdown {
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.4);
+  background: rgba(255,255,255,0.07);
+  padding: 3px 10px; border-radius: 2px;
+}
+.card--event .card__ext-link {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--green);
+}
+.card--event .card__ext-link svg { width: 10px; height: 10px; }
+.card--event:not([href]) { cursor: default; }
+.card--event:not([href]):hover { transform: none; box-shadow: none; }
+.card--event:not([href])::before { display: none; }
+
+/* ============================================================
+   MATCH SLIDER SECTION  (kcvv-black)
+   ============================================================ */
+.section-slider {
+  background: var(--black);
+  padding: 80px 0;
+  position: relative; overflow: hidden;
+}
+/* diagonal top cut from gray-100 */
+.section-slider::before {
+  content: '';
+  position: absolute; top: -1px; left: 0; right: 0;
+  height: 80px; background: var(--gray-100);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 0);
+}
+.section-slider__inner { position: relative; z-index: 1; }
+
+.slider-controls {
+  display: flex; align-items: center; gap: 6px;
+}
+.slider-arrow {
+  display: flex; align-items: center; justify-content: center;
+  width: 36px; height: 36px;
+  background: transparent;
+  border: 1.5px solid var(--green);
+  border-radius: 2px; color: var(--green);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.slider-arrow:hover { background: rgba(74,207,82,0.12); }
+.slider-arrow:disabled { border-color: rgba(255,255,255,0.12); color: rgba(255,255,255,0.2); cursor: default; }
+.slider-arrow:disabled:hover { background: transparent; }
+.slider-arrow svg { width: 16px; height: 16px; }
+
+.slider-track {
+  overflow-x: auto;
+  scrollbar-width: none; -ms-overflow-style: none;
+  padding-bottom: 4px;
+}
+.slider-track::-webkit-scrollbar { display: none; }
+.slider-cards { display: flex; gap: 10px; min-width: max-content; }
+
+/* MatchTeaser dark card */
+.match-teaser {
+  width: 256px; flex-shrink: 0;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 4px;
+  padding: 14px 16px;
+  transition: border-color 0.15s, background 0.15s;
+  cursor: pointer;
+}
+.match-teaser:hover {
+  background: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.16);
+}
+.match-teaser--next {
+  border-color: rgba(74,207,82,0.5);
+  background: rgba(74,207,82,0.05);
+}
+.match-teaser--next:hover { background: rgba(74,207,82,0.08); }
+
+.match-teaser__team-label {
+  font-size: 9px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.16em;
+  color: var(--green);
+  margin-bottom: 10px;
+  display: block;
+}
+.match-teaser__header {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.match-teaser__datetime {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px; font-weight: 600; color: rgba(255,255,255,0.55);
+}
+.match-teaser__time-sep { color: rgba(255,255,255,0.2); }
+.match-teaser__badge {
+  font-size: 9px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 2px 7px; border-radius: 2px;
+}
+.match-teaser__badge--next { background: var(--green); color: var(--black); }
+.match-teaser__badge--win  { background: rgba(74,207,82,0.18); color: var(--green); }
+.match-teaser__badge--loss { background: rgba(239,68,68,0.18); color: #ef4444; }
+.match-teaser__badge--draw { background: rgba(234,179,8,0.18); color: #eab308; }
+
+.match-teaser__teams {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center; gap: 8px;
+}
+.match-teaser__team {
+  display: flex; align-items: center; gap: 7px; min-width: 0;
+}
+.match-teaser__team--away { flex-direction: row-reverse; text-align: right; }
+.match-teaser__logo {
+  width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0;
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.1);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 9px; font-weight: 800; color: rgba(255,255,255,0.4);
+}
+.match-teaser__logo--kcvv {
+  background: rgba(74,207,82,0.15);
+  border-color: rgba(74,207,82,0.35);
+  color: var(--green);
+}
+.match-teaser__teamname {
+  font-size: 11px; font-weight: 600;
+  color: rgba(255,255,255,0.7);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.match-teaser__teamname--kcvv { color: var(--white); font-weight: 800; }
+.match-teaser__score {
+  font-size: 15px; font-weight: 800;
+  color: var(--white);
+  font-family: var(--font-mono);
+  text-align: center; white-space: nowrap;
+  letter-spacing: 0.08em;
+}
+.match-teaser__score--win  { color: var(--green); }
+.match-teaser__vs {
+  font-size: 10px; font-weight: 700;
+  color: rgba(255,255,255,0.2);
+  text-align: center;
+  text-transform: uppercase; letter-spacing: 0.1em;
+}
+
+/* ============================================================
+   YOUTH SECTION  (kcvv-green-dark)
+   ============================================================ */
+.section-youth {
+  background: var(--green-dark);
+  padding: 120px 0;
+  position: relative; overflow: hidden;
+  text-align: center;
+}
+/* diagonal top cut from black */
+.section-youth::before {
+  content: '';
+  position: absolute; top: -1px; left: 0; right: 0;
+  height: 80px; background: var(--black);
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 0);
+  z-index: 1;
+}
+/* diagonal bottom cut to white */
+.section-youth::after {
+  content: '';
+  position: absolute; bottom: -1px; left: 0; right: 0;
+  height: 80px; background: var(--white);
+  clip-path: polygon(0 100%, 100% 100%, 100% 0, 0 100%);
+  z-index: 1;
+}
+.section-youth__pattern {
+  position: absolute; inset: 0;
+  background-image: var(--pattern-chevron);
+  background-size: cover; background-position: center;
+  opacity: 0.04; pointer-events: none; z-index: 0;
+}
+.section-youth__inner {
+  position: relative; z-index: 2;
+  max-width: 840px; margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+.section-youth__eyebrow {
+  font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.35);
+  margin-bottom: 20px;
+  display: flex; align-items: center; justify-content: center; gap: 14px;
+}
+.section-youth__eyebrow::before,
+.section-youth__eyebrow::after {
+  content: ''; display: block;
+  height: 1px; width: 36px;
+  background: rgba(255,255,255,0.2);
+}
+.section-youth__title {
+  font-size: clamp(2.8rem, 7vw, 5.5rem);
+  font-weight: 900; color: var(--white);
+  text-transform: uppercase;
+  letter-spacing: -0.04em; line-height: 0.95;
+  margin-bottom: 56px;
+  font-family: var(--font-display);
+}
+.section-youth__stats {
+  display: flex; align-items: center;
+  justify-content: center; gap: 0;
+  margin-bottom: 60px;
+}
+.section-youth__stat { padding: 0 52px; }
+.section-youth__stat-number {
+  display: block;
+  font-size: clamp(4.5rem, 12vw, 9rem);
+  font-weight: 900; color: var(--green);
+  line-height: 1; letter-spacing: -0.05em;
+  font-family: var(--font-accent);
+}
+.section-youth__stat-label {
+  display: block;
+  font-size: 10px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.22em;
+  color: rgba(255,255,255,0.35);
+  margin-top: 10px;
+}
+.section-youth__divider {
+  width: 1px; height: 100px;
+  background: rgba(255,255,255,0.12);
+  flex-shrink: 0;
+}
+.section-youth__photo {
+  display: flex; justify-content: center;
+  margin-bottom: 44px;
+}
+.section-youth__photo img {
+  max-width: 460px; width: 100%;
+  border-radius: 4px;
+  box-shadow: 0 28px 80px rgba(0,0,0,0.55);
+  transform: rotate(1deg);
+}
+/* Placeholder for jersey photo */
+.section-youth__photo-ph {
+  max-width: 460px; width: 100%; height: 220px;
+  background: linear-gradient(160deg,
+    rgba(74,207,82,0.2) 0%,
+    rgba(0,135,85,0.5) 50%,
+    rgba(10,12,16,0.7) 100%);
+  border-radius: 4px;
+  box-shadow: 0 28px 80px rgba(0,0,0,0.55);
+  transform: rotate(1deg);
+  display: flex; align-items: center; justify-content: center;
+  border: 1px dashed rgba(255,255,255,0.15);
+  font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.14em;
+  color: rgba(255,255,255,0.25);
+}
+
+/* ============================================================
+   SPONSORS SECTION  (kcvv-black)
+   ============================================================ */
+.section-sponsors {
+  background: var(--black);
+  padding: 80px 0;
+  position: relative;
+}
+.sponsor-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 40px 60px;
+  margin-top: 48px;
+}
+.sponsor-item {
+  display: block;
+  opacity: 0.4;
+  filter: grayscale(100%);
+  transition: opacity 0.3s ease, filter 0.3s ease;
+  cursor: pointer;
+}
+.sponsor-item:hover {
+  opacity: 1;
+  filter: grayscale(0%);
+}
+.sponsor-ph {
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(255,255,255,0.08);
+  border-radius: 3px;
+  font-size: 11px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  color: var(--white);
+}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.footer {
+  background: var(--black);
+  padding: 64px 0 32px;
+  border-top: 1px solid rgba(255,255,255,0.07);
+}
+.footer__grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 56px;
+  padding-bottom: 48px;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  margin-bottom: 24px;
+}
+.footer__logo-row {
+  display: flex; align-items: center; gap: 14px;
+  margin-bottom: 16px;
+}
+.footer__logo-row img { height: 52px; width: auto; }
+.footer__logo-name { line-height: 1.2; }
+.footer__logo-name strong {
+  display: block;
+  font-size: 13px; font-weight: 800;
+  color: var(--white);
+  text-transform: uppercase; letter-spacing: 0.08em;
+}
+.footer__logo-name span {
+  font-size: 11px; color: rgba(255,255,255,0.3);
+  letter-spacing: 0.04em;
+}
+.footer__contact {
+  display: flex; flex-direction: column; gap: 11px;
+  margin-top: 20px;
+}
+.footer__contact-item {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 13px; color: rgba(255,255,255,0.45);
+  transition: color 0.15s;
+}
+.footer__contact-item:hover { color: rgba(255,255,255,0.7); }
+.footer__contact-item svg {
+  width: 13px; height: 13px;
+  flex-shrink: 0; color: rgba(255,255,255,0.2);
+}
+.footer__social {
+  display: flex; gap: 6px;
+  margin-top: 22px;
+}
+.footer__social-link {
+  display: flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 2px;
+  color: rgba(255,255,255,0.3);
+  transition: border-color 0.15s, color 0.15s;
+}
+.footer__social-link:hover { border-color: var(--green); color: var(--green); }
+.footer__social-link svg { width: 14px; height: 14px; }
+.footer__heading {
+  font-size: 10px; font-weight: 800;
+  text-transform: uppercase; letter-spacing: 0.16em;
+  color: rgba(255,255,255,0.22);
+  margin-bottom: 18px;
+}
+.footer__links { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+.footer__links a {
+  font-size: 14px; color: rgba(255,255,255,0.45);
+  transition: color 0.15s;
+}
+.footer__links a:hover { color: var(--green); }
+.footer__bottom {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; color: rgba(255,255,255,0.18);
+}
+.footer__bottom a { color: rgba(255,255,255,0.28); transition: color 0.15s; }
+.footer__bottom a:hover { color: var(--green); }
+
+/* ============================================================
+   NOTE BAR
+   ============================================================ */
+.note-bar {
+  background: #fef08a;
+  padding: 10px 20px;
+  font-size: 12px; color: #713f12;
+  text-align: center; font-weight: 600;
+}
+</style>
+</head>
+<body>
+
+<!-- Note bar -->
+<div class="note-bar">
+  <strong>KCVV Redesign Mockup v3</strong> &nbsp;·&nbsp;
+  Jersey photo: replace placeholder with actual image &nbsp;·&nbsp;
+  Patterns load from <code>/Downloads/Redesign/*.svg</code> &nbsp;·&nbsp;
+  Fonts: Montserrat (loaded) · quasimoda + stenciletta require local install
+</div>
+
+<!-- Accent strip -->
+<div style="height:3px; background:var(--green); position:sticky; top:0; z-index:101;"></div>
+
+<!-- ============================================================
+     NAV
+     ============================================================ -->
+<nav class="nav">
+  <div class="nav__inner">
+    <a href="#" class="nav__logo">
+      <img src="file:///Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/apps/web/public/images/logos/kcvv-logo.png" alt="KCVV Elewijt">
+    </a>
+    <ul class="nav__menu">
+      <li><a href="#" class="active">Club</a></li>
+      <li><a href="#">Ploegen</a></li>
+      <li><a href="#">Kalender</a></li>
+      <li><a href="#">Nieuws</a></li>
+      <li><a href="#">Sponsors</a></li>
+    </ul>
+    <div class="nav__utils">
+      <button class="nav__search" aria-label="Zoeken">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      </button>
+      <a href="#" class="nav__cta">Word lid</a>
+    </div>
+  </div>
+</nav>
+
+<!-- ============================================================
+     HERO
+     ============================================================ -->
+<section class="hero" role="region" aria-label="Uitgelichte artikelen">
+  <div class="hero__photo" style="background-image:url('file:///Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/apps/web/public/images/ultras/header-ultras.jpg'); background-position: center top;"></div>
+  <div class="hero__gradient"></div>
+  <span class="hero__bignumber" aria-hidden="true">55</span>
+
+  <div class="hero__content">
+    <a href="#" class="hero__article-link">
+      <span class="hero__tag">Clubnieuws</span>
+      <h1 class="hero__title">Kampioen! 58 punten en titel in eerste provinciale</h1>
+      <p class="hero__subtitle">Na een ijzersterk seizoen met 17 zeges pakt KCVV Elewijt de titel met acht punten voorsprong op de nummer twee.</p>
+      <div class="hero__meta">
+        <time>5 mei 2025</time>
+        <span class="hero__meta-dot"></span>
+        <span>A-Ploeg</span>
+      </div>
+      <div class="hero__controls">
+        <button class="hero__pause" aria-label="Pauzeren">&#9646;&#9646;</button>
+        <div class="hero__dots">
+          <button class="hero__dot hero__dot--active" aria-label="Artikel 1"></button>
+          <button class="hero__dot" aria-label="Artikel 2"></button>
+          <button class="hero__dot" aria-label="Artikel 3"></button>
+        </div>
+      </div>
+    </a>
+
+    <aside class="hero__panel" aria-label="Andere uitgelichte artikelen">
+      <div class="hero__panel-item hero__panel-item--active">
+        <div class="hero__panel-thumb" style="background:linear-gradient(135deg,#4acf52,#1E2024);"></div>
+        <div class="hero__panel-info">
+          <span class="hero__panel-title">Kampioen! 58 punten en titel in eerste provinciale</span>
+          <time class="hero__panel-date">5 mei 2025</time>
+        </div>
+      </div>
+      <div class="hero__panel-item">
+        <div class="hero__panel-thumb" style="background:linear-gradient(135deg,#008755,#1a2030);"></div>
+        <div class="hero__panel-info">
+          <span class="hero__panel-title">Spelersvoorstelling: versterkingen voor nationaal debuut</span>
+          <time class="hero__panel-date">14 maart 2026</time>
+        </div>
+      </div>
+      <div class="hero__panel-item">
+        <div class="hero__panel-thumb" style="background:linear-gradient(135deg,#374151,#008755);"></div>
+        <div class="hero__panel-info">
+          <span class="hero__panel-title">Jeugdtoernooi 2026: inschrijvingen open voor U9 t/m U15</span>
+          <time class="hero__panel-date">10 maart 2026</time>
+        </div>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<!-- ============================================================
+     BANNER SLOT A  (optional — between hero and match widget)
+     ============================================================ -->
+<div class="banner-slot banner-slot--on-white">
+  <div class="container">
+    <!-- Mockup: anti-racism campaign banner (Voetbal Vlaanderen) -->
+    <a href="#" class="banner-slot__link" aria-label="Voetbal Vlaanderen — Together tegen racisme">
+      <div style="background:linear-gradient(120deg,#3d6fa8 0%,#5b8fc7 45%,#4a7db5 100%);height:180px;display:flex;align-items:center;padding:0 48px;gap:48px;position:relative;overflow:hidden;">
+        <!-- subtle texture overlay -->
+        <div style="position:absolute;inset:0;background:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2260%22 height=%2260%22><rect fill=%22none%22 stroke=%22rgba(255,255,255,0.03)%22 stroke-width=%221%22 width=%2260%22 height=%2260%22/></svg>');"></div>
+        <div style="flex:1;max-width:640px;position:relative;">
+          <p style="font-family:var(--font-display);font-size:clamp(1rem,2.4vw,1.55rem);font-weight:800;color:white;line-height:1.25;margin-bottom:10px;">'Niemand is geboren als racist. Onwetendheid en een gebrek aan opvoeding duwen iemand in dat straatje.'</p>
+          <p style="font-style:italic;color:rgba(255,255,255,0.65);font-size:13px;font-weight:500;">Romelu Lukaku, Belgian Red Devil</p>
+        </div>
+        <div style="display:flex;gap:16px;align-items:center;flex-shrink:0;position:relative;">
+          <div style="width:56px;height:56px;background:rgba(255,255,255,0.18);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white;text-align:center;letter-spacing:0.05em;text-transform:uppercase;line-height:1.2;">TO<br>GE<br>THER</div>
+          <div style="width:48px;height:48px;background:rgba(255,255,255,0.18);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:800;color:white;letter-spacing:0.04em;text-transform:uppercase;">KBVB</div>
+          <div style="width:80px;height:48px;background:rgba(255,255,255,0.18);border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white;text-align:center;letter-spacing:0.06em;text-transform:uppercase;line-height:1.4;">VOETBAL<br>VLAANDEREN</div>
+        </div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- ============================================================
+     MATCH WIDGET
+     ============================================================ -->
+<section class="match-widget">
+  <div class="match-widget__inner container">
+    <p class="match-widget__label">Volgende wedstrijd · A-Ploeg</p>
+    <div class="match-widget__grid">
+      <div class="match-widget__team match-widget__team--home">
+        <div class="match-widget__logo">K</div>
+        <span class="match-widget__teamname">KCVV Elewijt</span>
+      </div>
+      <div class="match-widget__center">
+        <span class="match-widget__vs">VS</span>
+        <div class="match-widget__meta">
+          <span class="match-widget__date">Za 22 maart · 15:00</span>
+          <span class="match-widget__competition">3e Afdeling VV · Thuis</span>
+        </div>
+      </div>
+      <div class="match-widget__team match-widget__team--away">
+        <div class="match-widget__logo">W</div>
+        <span class="match-widget__teamname">KVC Wilrijk</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     NEWS  (gray-100) — featured slot = event card
+     ============================================================ -->
+<section class="section-news">
+  <div class="container">
+    <div class="section-header">
+      <h2 class="section-title section-title--light">Nieuws</h2>
+      <a href="#" class="section-link">Alle berichten</a>
+    </div>
+    <div class="cards">
+
+      <!-- FEATURED EVENT CARD (replaces featured article when event upcoming) -->
+      <article class="card card--featured card--event">
+        <a href="#" style="display:contents;">
+          <div class="card__img">
+            <!-- Event: jersey chevron pattern on black as fallback bg -->
+            <div class="card__img-inner" style="background:linear-gradient(160deg,#0a3020 0%,#1E2024 60%,#0a0c0e 100%);background-image:var(--pattern-chevron);background-size:cover;background-position:center;background-blend-mode:overlay;"></div>
+            <div class="card__overlay">
+              <span class="card__event-badge">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+                Evenement
+              </span>
+              <h3 class="card__title" style="font-size:1.45rem;line-height:1.15;margin-bottom:12px;">Jeugdtoernooi 2026 — U9 t/m U15 op Sportpark Elewijt</h3>
+              <p class="card__excerpt">Op zaterdag 18 april organiseert KCVV Elewijt haar jaarlijks jeugdtoernooi. Inschrijvingen zijn open voor clubs uit de regio.</p>
+              <div class="card__event-meta">
+                <span class="card__event-meta-item">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+                  za 18 april 2026
+                </span>
+                <span class="card__event-meta-item">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                  09:00
+                </span>
+              </div>
+            </div>
+          </div>
+          <div class="card__footer">
+            <span class="card__countdown">over 33 dagen</span>
+            <span class="card__ext-link">
+              Meer info
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+            </span>
+          </div>
+        </a>
+      </article>
+
+      <!-- Regular article card 1 -->
+      <article class="card">
+        <div class="card__img">
+          <div class="card__img-inner" style="background:linear-gradient(160deg,#1a2a1a 0%,#4acf52 40%,#1E2024 100%);"></div>
+          <div class="card__overlay">
+            <span class="card__category">Clubnieuws</span>
+            <h3 class="card__title">Kampioen! 58 punten en titel in eerste provinciale</h3>
+            <p class="card__excerpt">Na een ijzersterk seizoen met 17 zeges pakt KCVV Elewijt de titel.</p>
+          </div>
+        </div>
+        <div class="card__footer"><span>5 mei 2025</span><span>A-Ploeg</span></div>
+      </article>
+
+      <!-- Regular article card 2 -->
+      <article class="card">
+        <div class="card__img">
+          <div class="card__img-inner" style="background:linear-gradient(160deg,#1a1e2e 0%,#374151 50%,#008755 100%);"></div>
+          <div class="card__overlay">
+            <span class="card__category">Selectie</span>
+            <h3 class="card__title">Spelersvoorstelling: vijf versterkingen voor het nationale seizoen</h3>
+            <p class="card__excerpt">Met het oog op het nationale debuut verwelkomt KCVV vijf nieuwe gezichten.</p>
+          </div>
+        </div>
+        <div class="card__footer"><span>14 maart 2026</span><span>A-Ploeg</span></div>
+      </article>
+
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     BANNER SLOT B  (optional — between news and match slider)
+     ============================================================ -->
+<div class="banner-slot banner-slot--on-gray">
+  <div class="container">
+    <!-- Mockup: sponsor CTA banner -->
+    <div class="banner-slot__static">
+      <div style="background:linear-gradient(105deg,#1E2024 0%,#25282a 50%,#1a1c20 100%);height:140px;display:flex;align-items:center;justify-content:space-between;padding:0 48px;gap:32px;">
+        <div>
+          <p style="font-size:10px;font-weight:800;text-transform:uppercase;letter-spacing:0.18em;color:var(--green);margin-bottom:10px;">Partnerschappen</p>
+          <p style="font-family:var(--font-display);font-size:clamp(1.1rem,2.5vw,1.6rem);font-weight:900;color:var(--white);letter-spacing:-0.02em;line-height:1.1;">Word sponsor van KCVV Elewijt</p>
+        </div>
+        <a href="#" class="btn btn--primary" style="white-space:nowrap;flex-shrink:0;">Meer info</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     MATCH SLIDER  (kcvv-black)
+     ============================================================ -->
+<section class="section-slider">
+  <div class="section-slider__inner container">
+    <div class="section-header" style="margin-bottom:28px;">
+      <h2 class="section-title section-title--dark">Wedstrijden</h2>
+      <div style="display:flex;align-items:center;gap:20px;">
+        <a href="#" class="section-link section-link--dark">Volledige kalender</a>
+        <div class="slider-controls">
+          <button class="slider-arrow" aria-label="Scroll links" disabled>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+          </button>
+          <button class="slider-arrow" aria-label="Scroll rechts">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="slider-track">
+      <div class="slider-cards">
+
+        <!-- A-Ploeg: next match -->
+        <div class="match-teaser match-teaser--next">
+          <span class="match-teaser__team-label">A-Ploeg</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime">
+              <span>za 22 mrt</span>
+              <span class="match-teaser__time-sep">·</span>
+              <span>15:00</span>
+            </div>
+            <span class="match-teaser__badge match-teaser__badge--next">Volgende</span>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV Elewijt</span>
+            </div>
+            <span class="match-teaser__vs">vs</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo">W</div>
+              <span class="match-teaser__teamname">KVC Wilrijk</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- A-Ploeg: past match (win) -->
+        <div class="match-teaser">
+          <span class="match-teaser__team-label">A-Ploeg</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime"><span>za 8 mrt</span></div>
+            <span class="match-teaser__badge match-teaser__badge--win">W</span>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV Elewijt</span>
+            </div>
+            <span class="match-teaser__score">3 – 1</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo">F</div>
+              <span class="match-teaser__teamname">FC Wezel Sport</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- B-Ploeg: upcoming -->
+        <div class="match-teaser">
+          <span class="match-teaser__team-label">B-Ploeg</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime">
+              <span>za 22 mrt</span>
+              <span class="match-teaser__time-sep">·</span>
+              <span>11:00</span>
+            </div>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV Elewijt B</span>
+            </div>
+            <span class="match-teaser__vs">vs</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo">M</div>
+              <span class="match-teaser__teamname">KFC Mechelen</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- U21: past match (loss) -->
+        <div class="match-teaser">
+          <span class="match-teaser__team-label">U21</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime"><span>za 15 mrt</span></div>
+            <span class="match-teaser__badge match-teaser__badge--loss">V</span>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo">R</div>
+              <span class="match-teaser__teamname">Racing Genk B</span>
+            </div>
+            <span class="match-teaser__score match-teaser__score--win">4 – 1</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U21</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- U17: upcoming -->
+        <div class="match-teaser">
+          <span class="match-teaser__team-label">U17</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime">
+              <span>zo 23 mrt</span>
+              <span class="match-teaser__time-sep">·</span>
+              <span>10:30</span>
+            </div>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U17</span>
+            </div>
+            <span class="match-teaser__vs">vs</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo">V</div>
+              <span class="match-teaser__teamname">Verbroedering Geel</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- U15: draw -->
+        <div class="match-teaser">
+          <span class="match-teaser__team-label">U15 A</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime"><span>za 15 mrt</span></div>
+            <span class="match-teaser__badge match-teaser__badge--draw">G</span>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U15 A</span>
+            </div>
+            <span class="match-teaser__score">2 – 2</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo">H</div>
+              <span class="match-teaser__teamname">KSK Heist</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- U13: win -->
+        <div class="match-teaser">
+          <span class="match-teaser__team-label">U13 A</span>
+          <div class="match-teaser__header">
+            <div class="match-teaser__datetime"><span>za 15 mrt</span></div>
+            <span class="match-teaser__badge match-teaser__badge--win">W</span>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo">S</div>
+              <span class="match-teaser__teamname">Sporting Hasselt</span>
+            </div>
+            <span class="match-teaser__score">1 – 3</span>
+            <div class="match-teaser__team match-teaser__team--away">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U13 A</span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     YOUTH SECTION  (kcvv-green-dark)
+     ============================================================ -->
+<section class="section-youth">
+  <div class="section-youth__pattern" aria-hidden="true"></div>
+  <div class="section-youth__inner">
+    <p class="section-youth__eyebrow">K.C.V.V. Elewijt</p>
+    <h2 class="section-youth__title">Jeugd</h2>
+
+    <div class="section-youth__stats">
+      <div class="section-youth__stat">
+        <span class="section-youth__stat-number">220+</span>
+        <span class="section-youth__stat-label">Spelers</span>
+      </div>
+      <div class="section-youth__divider"></div>
+      <div class="section-youth__stat">
+        <span class="section-youth__stat-number">16</span>
+        <span class="section-youth__stat-label">Ploegen</span>
+      </div>
+    </div>
+
+    <div class="section-youth__photo">
+      <!-- Replace with: <img src="/images/youth-jerseys.jpg" alt="KCVV jeugdshirts" /> -->
+      <div class="section-youth__photo-ph">Jeugdshirts foto — vervang door echt beeld</div>
+    </div>
+
+    <a href="#" class="btn btn--primary">Ontdek onze jeugd</a>
+  </div>
+</section>
+
+<!-- ============================================================
+     BANNER SLOT C  (optional — between youth and sponsors)
+     ============================================================ -->
+<div class="banner-slot banner-slot--on-white">
+  <div class="container">
+    <!-- This slot is empty in this mockup — shown as dashed placeholder -->
+    <div style="border:2px dashed rgba(0,0,0,0.08);border-radius:4px;height:80px;display:flex;align-items:center;justify-content:center;">
+      <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.12em;color:rgba(0,0,0,0.2);">Banner slot C — optioneel · verborgen als leeg in Sanity</span>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     SPONSORS  (kcvv-black)
+     ============================================================ -->
+<section class="section-sponsors">
+  <div class="container">
+    <div class="section-header">
+      <h2 class="section-title section-title--dark">Sponsors</h2>
+      <a href="#" class="section-link section-link--dark">Word sponsor</a>
+    </div>
+    <div class="sponsor-grid">
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:180px;height:72px;font-size:12px;">Hoofdsponsor A</div></a>
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:180px;height:72px;font-size:12px;">Hoofdsponsor B</div></a>
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:130px;height:56px;">Sponsor C</div></a>
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:130px;height:56px;">Sponsor D</div></a>
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:130px;height:56px;">Sponsor E</div></a>
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:130px;height:56px;">Sponsor F</div></a>
+      <div class="sponsor-item"><div class="sponsor-ph" style="width:110px;height:48px;font-size:10px;">Sponsor G</div></div>
+      <div class="sponsor-item"><div class="sponsor-ph" style="width:110px;height:48px;font-size:10px;">Sponsor H</div></div>
+      <a href="#" class="sponsor-item"><div class="sponsor-ph" style="width:110px;height:48px;font-size:10px;">Sponsor I</div></a>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="footer">
+  <div class="container">
+    <div class="footer__grid">
+
+      <!-- Brand column -->
+      <div>
+        <div class="footer__logo-row">
+          <img src="file:///Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/apps/web/public/images/logos/kcvv-logo.png" alt="KCVV Elewijt" style="height:52px;width:auto;">
+          <div class="footer__logo-name">
+            <strong>K.C.V.V. Elewijt</strong>
+            <span>Opgericht in 1964</span>
+          </div>
+        </div>
+
+        <div class="footer__contact">
+          <span class="footer__contact-item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 13-8 13s-8-7-8-13a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+            Driesstraat 32, 1982 Elewijt
+          </span>
+          <a href="mailto:info@kcvvelewijt.be" class="footer__contact-item">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+            info@kcvvelewijt.be
+          </a>
+        </div>
+
+        <div class="footer__social">
+          <a href="#" class="footer__social-link" aria-label="Facebook">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/></svg>
+          </a>
+          <a href="#" class="footer__social-link" aria-label="Instagram">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="20" x="2" y="2" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" x2="17.51" y1="6.5" y2="6.5"/></svg>
+          </a>
+        </div>
+      </div>
+
+      <!-- Club links -->
+      <div>
+        <p class="footer__heading">Club</p>
+        <ul class="footer__links">
+          <li><a href="#">Over ons</a></li>
+          <li><a href="#">Bestuur</a></li>
+          <li><a href="#">Geschiedenis</a></li>
+          <li><a href="#">Contact</a></li>
+          <li><a href="#">Angels</a></li>
+          <li><a href="#">Ultras</a></li>
+        </ul>
+      </div>
+
+      <!-- Voetbal links -->
+      <div>
+        <p class="footer__heading">Voetbal</p>
+        <ul class="footer__links">
+          <li><a href="#">Ploegen</a></li>
+          <li><a href="#">Kalender</a></li>
+          <li><a href="#">Nieuws</a></li>
+          <li><a href="#">Sponsors</a></li>
+          <li><a href="#">Word lid</a></li>
+          <li><a href="#">Privacy</a></li>
+        </ul>
+      </div>
+
+    </div>
+
+    <div class="footer__bottom">
+      <span>© 2026 K.C.V.V. Elewijt · Stamnummer 55</span>
+      <a href="#">Privacybeleid</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/mockups/homepage-v3.html
+++ b/docs/mockups/homepage-v3.html
@@ -649,13 +649,13 @@ img { max-width: 100%; display: block; }
 .slider-track::-webkit-scrollbar { display: none; }
 .slider-cards { display: flex; gap: 10px; min-width: max-content; }
 
-/* MatchTeaser dark card */
+/* MatchTeaser dark card — vertical layout */
 .match-teaser {
-  width: 256px; flex-shrink: 0;
+  width: 272px; flex-shrink: 0;
   background: rgba(255,255,255,0.04);
   border: 1px solid rgba(255,255,255,0.08);
   border-radius: 4px;
-  padding: 14px 16px;
+  padding: 16px;
   transition: border-color 0.15s, background 0.15s;
   cursor: pointer;
 }
@@ -663,50 +663,30 @@ img { max-width: 100%; display: block; }
   background: rgba(255,255,255,0.07);
   border-color: rgba(255,255,255,0.16);
 }
-.match-teaser--next {
-  border-color: rgba(74,207,82,0.5);
-  background: rgba(74,207,82,0.05);
+.match-teaser__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
 }
-.match-teaser--next:hover { background: rgba(74,207,82,0.08); }
-
 .match-teaser__team-label {
   font-size: 9px; font-weight: 800;
   text-transform: uppercase; letter-spacing: 0.16em;
   color: var(--green);
-  margin-bottom: 10px;
-  display: block;
 }
-.match-teaser__header {
-  display: flex; align-items: center;
-  justify-content: space-between;
-  margin-bottom: 12px;
+.match-teaser__date {
+  font-size: 11px; font-weight: 600;
+  color: rgba(255,255,255,0.35);
 }
-.match-teaser__datetime {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 11px; font-weight: 600; color: rgba(255,255,255,0.55);
-}
-.match-teaser__time-sep { color: rgba(255,255,255,0.2); }
-.match-teaser__badge {
-  font-size: 9px; font-weight: 800;
-  text-transform: uppercase; letter-spacing: 0.08em;
-  padding: 2px 7px; border-radius: 2px;
-}
-.match-teaser__badge--next { background: var(--green); color: var(--black); }
-.match-teaser__badge--win  { background: rgba(74,207,82,0.18); color: var(--green); }
-.match-teaser__badge--loss { background: rgba(239,68,68,0.18); color: #ef4444; }
-.match-teaser__badge--draw { background: rgba(234,179,8,0.18); color: #eab308; }
-
 .match-teaser__teams {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center; gap: 8px;
+  display: flex; flex-direction: column; gap: 7px;
+  margin-bottom: 14px;
 }
 .match-teaser__team {
-  display: flex; align-items: center; gap: 7px; min-width: 0;
+  display: flex; align-items: center; gap: 9px;
 }
-.match-teaser__team--away { flex-direction: row-reverse; text-align: right; }
 .match-teaser__logo {
-  width: 26px; height: 26px; border-radius: 50%; flex-shrink: 0;
+  width: 24px; height: 24px; border-radius: 50%; flex-shrink: 0;
   background: rgba(255,255,255,0.07);
   border: 1px solid rgba(255,255,255,0.1);
   display: flex; align-items: center; justify-content: center;
@@ -714,28 +694,31 @@ img { max-width: 100%; display: block; }
 }
 .match-teaser__logo--kcvv {
   background: rgba(74,207,82,0.15);
-  border-color: rgba(74,207,82,0.35);
+  border-color: rgba(74,207,82,0.3);
   color: var(--green);
 }
 .match-teaser__teamname {
-  font-size: 11px; font-weight: 600;
-  color: rgba(255,255,255,0.7);
+  font-size: 13px; font-weight: 600;
+  color: rgba(255,255,255,0.6);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.match-teaser__teamname--kcvv { color: var(--white); font-weight: 800; }
-.match-teaser__score {
-  font-size: 15px; font-weight: 800;
-  color: var(--white);
-  font-family: var(--font-mono);
-  text-align: center; white-space: nowrap;
-  letter-spacing: 0.08em;
-}
-.match-teaser__score--win  { color: var(--green); }
+.match-teaser__teamname--kcvv { color: var(--white); font-weight: 700; }
 .match-teaser__vs {
   font-size: 10px; font-weight: 700;
-  color: rgba(255,255,255,0.2);
-  text-align: center;
+  color: rgba(255,255,255,0.18);
   text-transform: uppercase; letter-spacing: 0.1em;
+  padding-left: 33px;
+}
+.match-teaser__footer {
+  display: flex; align-items: center; gap: 7px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255,255,255,0.07);
+  font-size: 11px; font-weight: 600;
+  color: rgba(255,255,255,0.28);
+}
+.match-teaser__footer-dot {
+  width: 2px; height: 2px; border-radius: 50%;
+  background: rgba(255,255,255,0.2); flex-shrink: 0;
 }
 
 /* ============================================================
@@ -743,7 +726,7 @@ img { max-width: 100%; display: block; }
    ============================================================ */
 .section-youth {
   background: var(--green-dark);
-  padding: 120px 0;
+  padding: 80px 0;
   position: relative; overflow: hidden;
   text-align: center;
 }
@@ -788,22 +771,22 @@ img { max-width: 100%; display: block; }
   background: rgba(255,255,255,0.2);
 }
 .section-youth__title {
-  font-size: clamp(2.8rem, 7vw, 5.5rem);
+  font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 900; color: var(--white);
   text-transform: uppercase;
   letter-spacing: -0.04em; line-height: 0.95;
-  margin-bottom: 56px;
+  margin-bottom: 32px;
   font-family: var(--font-display);
 }
 .section-youth__stats {
   display: flex; align-items: center;
   justify-content: center; gap: 0;
-  margin-bottom: 60px;
+  margin-bottom: 40px;
 }
-.section-youth__stat { padding: 0 52px; }
+.section-youth__stat { padding: 0 36px; }
 .section-youth__stat-number {
   display: block;
-  font-size: clamp(4.5rem, 12vw, 9rem);
+  font-size: clamp(3rem, 8vw, 5.5rem);
   font-weight: 900; color: var(--green);
   line-height: 1; letter-spacing: -0.05em;
   font-family: var(--font-accent);
@@ -813,26 +796,26 @@ img { max-width: 100%; display: block; }
   font-size: 10px; font-weight: 800;
   text-transform: uppercase; letter-spacing: 0.22em;
   color: rgba(255,255,255,0.35);
-  margin-top: 10px;
+  margin-top: 8px;
 }
 .section-youth__divider {
-  width: 1px; height: 100px;
+  width: 1px; height: 72px;
   background: rgba(255,255,255,0.12);
   flex-shrink: 0;
 }
 .section-youth__photo {
   display: flex; justify-content: center;
-  margin-bottom: 44px;
+  margin-bottom: 32px;
 }
 .section-youth__photo img {
-  max-width: 460px; width: 100%;
+  max-width: 380px; width: 100%;
   border-radius: 4px;
-  box-shadow: 0 28px 80px rgba(0,0,0,0.55);
+  box-shadow: 0 16px 48px rgba(0,0,0,0.5);
   transform: rotate(1deg);
 }
 /* Placeholder for jersey photo */
 .section-youth__photo-ph {
-  max-width: 460px; width: 100%; height: 220px;
+  max-width: 380px; width: 100%; height: 180px;
   background: linear-gradient(160deg,
     rgba(74,207,82,0.2) 0%,
     rgba(0,135,85,0.5) 50%,
@@ -1065,30 +1048,6 @@ img { max-width: 100%; display: block; }
 </section>
 
 <!-- ============================================================
-     BANNER SLOT A  (optional — between hero and match widget)
-     ============================================================ -->
-<div class="banner-slot banner-slot--on-white">
-  <div class="container">
-    <!-- Mockup: anti-racism campaign banner (Voetbal Vlaanderen) -->
-    <a href="#" class="banner-slot__link" aria-label="Voetbal Vlaanderen — Together tegen racisme">
-      <div style="background:linear-gradient(120deg,#3d6fa8 0%,#5b8fc7 45%,#4a7db5 100%);height:180px;display:flex;align-items:center;padding:0 48px;gap:48px;position:relative;overflow:hidden;">
-        <!-- subtle texture overlay -->
-        <div style="position:absolute;inset:0;background:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2260%22 height=%2260%22><rect fill=%22none%22 stroke=%22rgba(255,255,255,0.03)%22 stroke-width=%221%22 width=%2260%22 height=%2260%22/></svg>');"></div>
-        <div style="flex:1;max-width:640px;position:relative;">
-          <p style="font-family:var(--font-display);font-size:clamp(1rem,2.4vw,1.55rem);font-weight:800;color:white;line-height:1.25;margin-bottom:10px;">'Niemand is geboren als racist. Onwetendheid en een gebrek aan opvoeding duwen iemand in dat straatje.'</p>
-          <p style="font-style:italic;color:rgba(255,255,255,0.65);font-size:13px;font-weight:500;">Romelu Lukaku, Belgian Red Devil</p>
-        </div>
-        <div style="display:flex;gap:16px;align-items:center;flex-shrink:0;position:relative;">
-          <div style="width:56px;height:56px;background:rgba(255,255,255,0.18);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white;text-align:center;letter-spacing:0.05em;text-transform:uppercase;line-height:1.2;">TO<br>GE<br>THER</div>
-          <div style="width:48px;height:48px;background:rgba(255,255,255,0.18);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:800;color:white;letter-spacing:0.04em;text-transform:uppercase;">KBVB</div>
-          <div style="width:80px;height:48px;background:rgba(255,255,255,0.18);border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white;text-align:center;letter-spacing:0.06em;text-transform:uppercase;line-height:1.4;">VOETBAL<br>VLAANDEREN</div>
-        </div>
-      </div>
-    </a>
-  </div>
-</div>
-
-<!-- ============================================================
      MATCH WIDGET
      ============================================================ -->
 <section class="match-widget">
@@ -1113,6 +1072,29 @@ img { max-width: 100%; display: block; }
     </div>
   </div>
 </section>
+
+<!-- ============================================================
+     BANNER SLOT A  (optional — between match widget and news)
+     ============================================================ -->
+<div class="banner-slot banner-slot--on-gray">
+  <div class="container">
+    <!-- Mockup: anti-racism campaign banner (Voetbal Vlaanderen) -->
+    <a href="#" class="banner-slot__link" aria-label="Voetbal Vlaanderen — Together tegen racisme">
+      <div style="background:linear-gradient(120deg,#3d6fa8 0%,#5b8fc7 45%,#4a7db5 100%);height:180px;display:flex;align-items:center;padding:0 48px;gap:48px;position:relative;overflow:hidden;">
+        <div style="position:absolute;inset:0;background:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2260%22 height=%2260%22><rect fill=%22none%22 stroke=%22rgba(255,255,255,0.03)%22 stroke-width=%221%22 width=%2260%22 height=%2260%22/></svg>');"></div>
+        <div style="flex:1;max-width:640px;position:relative;">
+          <p style="font-family:var(--font-display);font-size:clamp(1rem,2.4vw,1.55rem);font-weight:800;color:white;line-height:1.25;margin-bottom:10px;">'Niemand is geboren als racist. Onwetendheid en een gebrek aan opvoeding duwen iemand in dat straatje.'</p>
+          <p style="font-style:italic;color:rgba(255,255,255,0.65);font-size:13px;font-weight:500;">Romelu Lukaku, Belgian Red Devil</p>
+        </div>
+        <div style="display:flex;gap:16px;align-items:center;flex-shrink:0;position:relative;">
+          <div style="width:56px;height:56px;background:rgba(255,255,255,0.18);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white;text-align:center;letter-spacing:0.05em;text-transform:uppercase;line-height:1.2;">TO<br>GE<br>THER</div>
+          <div style="width:48px;height:48px;background:rgba(255,255,255,0.18);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:800;color:white;letter-spacing:0.04em;text-transform:uppercase;">KBVB</div>
+          <div style="width:80px;height:48px;background:rgba(255,255,255,0.18);border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:800;color:white;text-align:center;letter-spacing:0.06em;text-transform:uppercase;line-height:1.4;">VOETBAL<br>VLAANDEREN</div>
+        </div>
+      </div>
+    </a>
+  </div>
+</div>
 
 <!-- ============================================================
      NEWS  (gray-100) — featured slot = event card
@@ -1231,16 +1213,11 @@ img { max-width: 100%; display: block; }
     <div class="slider-track">
       <div class="slider-cards">
 
-        <!-- A-Ploeg: next match -->
-        <div class="match-teaser match-teaser--next">
-          <span class="match-teaser__team-label">A-Ploeg</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime">
-              <span>za 22 mrt</span>
-              <span class="match-teaser__time-sep">·</span>
-              <span>15:00</span>
-            </div>
-            <span class="match-teaser__badge match-teaser__badge--next">Volgende</span>
+        <!-- A-Ploeg -->
+        <div class="match-teaser">
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">A-Ploeg</span>
+            <span class="match-teaser__date">za 22 mrt</span>
           </div>
           <div class="match-teaser__teams">
             <div class="match-teaser__team">
@@ -1248,42 +1225,23 @@ img { max-width: 100%; display: block; }
               <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV Elewijt</span>
             </div>
             <span class="match-teaser__vs">vs</span>
-            <div class="match-teaser__team match-teaser__team--away">
+            <div class="match-teaser__team">
               <div class="match-teaser__logo">W</div>
               <span class="match-teaser__teamname">KVC Wilrijk</span>
             </div>
           </div>
-        </div>
-
-        <!-- A-Ploeg: past match (win) -->
-        <div class="match-teaser">
-          <span class="match-teaser__team-label">A-Ploeg</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime"><span>za 8 mrt</span></div>
-            <span class="match-teaser__badge match-teaser__badge--win">W</span>
-          </div>
-          <div class="match-teaser__teams">
-            <div class="match-teaser__team">
-              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
-              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV Elewijt</span>
-            </div>
-            <span class="match-teaser__score">3 – 1</span>
-            <div class="match-teaser__team match-teaser__team--away">
-              <div class="match-teaser__logo">F</div>
-              <span class="match-teaser__teamname">FC Wezel Sport</span>
-            </div>
+          <div class="match-teaser__footer">
+            <span>15:00</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Thuis</span>
           </div>
         </div>
 
-        <!-- B-Ploeg: upcoming -->
+        <!-- B-Ploeg -->
         <div class="match-teaser">
-          <span class="match-teaser__team-label">B-Ploeg</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime">
-              <span>za 22 mrt</span>
-              <span class="match-teaser__time-sep">·</span>
-              <span>11:00</span>
-            </div>
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">B-Ploeg</span>
+            <span class="match-teaser__date">za 22 mrt</span>
           </div>
           <div class="match-teaser__teams">
             <div class="match-teaser__team">
@@ -1291,42 +1249,47 @@ img { max-width: 100%; display: block; }
               <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV Elewijt B</span>
             </div>
             <span class="match-teaser__vs">vs</span>
-            <div class="match-teaser__team match-teaser__team--away">
+            <div class="match-teaser__team">
               <div class="match-teaser__logo">M</div>
-              <span class="match-teaser__teamname">KFC Mechelen</span>
+              <span class="match-teaser__teamname">KFC Mechelen B</span>
             </div>
+          </div>
+          <div class="match-teaser__footer">
+            <span>11:00</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Thuis</span>
           </div>
         </div>
 
-        <!-- U21: past match (loss) -->
+        <!-- U21 -->
         <div class="match-teaser">
-          <span class="match-teaser__team-label">U21</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime"><span>za 15 mrt</span></div>
-            <span class="match-teaser__badge match-teaser__badge--loss">V</span>
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">U21</span>
+            <span class="match-teaser__date">zo 23 mrt</span>
           </div>
           <div class="match-teaser__teams">
             <div class="match-teaser__team">
-              <div class="match-teaser__logo">R</div>
-              <span class="match-teaser__teamname">Racing Genk B</span>
+              <div class="match-teaser__logo">A</div>
+              <span class="match-teaser__teamname">Antwerp FC B</span>
             </div>
-            <span class="match-teaser__score match-teaser__score--win">4 – 1</span>
-            <div class="match-teaser__team match-teaser__team--away">
+            <span class="match-teaser__vs">vs</span>
+            <div class="match-teaser__team">
               <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
               <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U21</span>
             </div>
           </div>
+          <div class="match-teaser__footer">
+            <span>10:00</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Uit</span>
+          </div>
         </div>
 
-        <!-- U17: upcoming -->
+        <!-- U17 -->
         <div class="match-teaser">
-          <span class="match-teaser__team-label">U17</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime">
-              <span>zo 23 mrt</span>
-              <span class="match-teaser__time-sep">·</span>
-              <span>10:30</span>
-            </div>
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">U17</span>
+            <span class="match-teaser__date">zo 23 mrt</span>
           </div>
           <div class="match-teaser__teams">
             <div class="match-teaser__team">
@@ -1334,50 +1297,87 @@ img { max-width: 100%; display: block; }
               <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U17</span>
             </div>
             <span class="match-teaser__vs">vs</span>
-            <div class="match-teaser__team match-teaser__team--away">
+            <div class="match-teaser__team">
               <div class="match-teaser__logo">V</div>
               <span class="match-teaser__teamname">Verbroedering Geel</span>
             </div>
           </div>
+          <div class="match-teaser__footer">
+            <span>10:30</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Thuis</span>
+          </div>
         </div>
 
-        <!-- U15: draw -->
+        <!-- U15 A -->
         <div class="match-teaser">
-          <span class="match-teaser__team-label">U15 A</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime"><span>za 15 mrt</span></div>
-            <span class="match-teaser__badge match-teaser__badge--draw">G</span>
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">U15 A</span>
+            <span class="match-teaser__date">za 29 mrt</span>
           </div>
           <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo">H</div>
+              <span class="match-teaser__teamname">KSK Heist</span>
+            </div>
+            <span class="match-teaser__vs">vs</span>
             <div class="match-teaser__team">
               <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
               <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U15 A</span>
             </div>
-            <span class="match-teaser__score">2 – 2</span>
-            <div class="match-teaser__team match-teaser__team--away">
-              <div class="match-teaser__logo">H</div>
-              <span class="match-teaser__teamname">KSK Heist</span>
-            </div>
+          </div>
+          <div class="match-teaser__footer">
+            <span>09:30</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Uit</span>
           </div>
         </div>
 
-        <!-- U13: win -->
+        <!-- U13 A -->
         <div class="match-teaser">
-          <span class="match-teaser__team-label">U13 A</span>
-          <div class="match-teaser__header">
-            <div class="match-teaser__datetime"><span>za 15 mrt</span></div>
-            <span class="match-teaser__badge match-teaser__badge--win">W</span>
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">U13 A</span>
+            <span class="match-teaser__date">za 29 mrt</span>
           </div>
           <div class="match-teaser__teams">
             <div class="match-teaser__team">
-              <div class="match-teaser__logo">S</div>
-              <span class="match-teaser__teamname">Sporting Hasselt</span>
-            </div>
-            <span class="match-teaser__score">1 – 3</span>
-            <div class="match-teaser__team match-teaser__team--away">
               <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
               <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U13 A</span>
             </div>
+            <span class="match-teaser__vs">vs</span>
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo">L</div>
+              <span class="match-teaser__teamname">Lyra-Lierse SK</span>
+            </div>
+          </div>
+          <div class="match-teaser__footer">
+            <span>09:30</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Thuis</span>
+          </div>
+        </div>
+
+        <!-- U11 -->
+        <div class="match-teaser">
+          <div class="match-teaser__top">
+            <span class="match-teaser__team-label">U11</span>
+            <span class="match-teaser__date">za 5 apr</span>
+          </div>
+          <div class="match-teaser__teams">
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo match-teaser__logo--kcvv">K</div>
+              <span class="match-teaser__teamname match-teaser__teamname--kcvv">KCVV U11</span>
+            </div>
+            <span class="match-teaser__vs">vs</span>
+            <div class="match-teaser__team">
+              <div class="match-teaser__logo">S</div>
+              <span class="match-teaser__teamname">KRC Genk B</span>
+            </div>
+          </div>
+          <div class="match-teaser__footer">
+            <span>10:00</span>
+            <span class="match-teaser__footer-dot"></span>
+            <span>Thuis</span>
           </div>
         </div>
 

--- a/docs/plans/2026-03-15-match-widget-812-plan.md
+++ b/docs/plans/2026-03-15-match-widget-812-plan.md
@@ -715,7 +715,7 @@ export function MatchWidget({
       {/* Bottom diagonal — reveals gray-100 from LatestNews */}
       <SectionDivider color="gray-100" position="bottom" />
 
-      <div className="relative z-20 py-24 px-4 md:px-8 max-w-[1280px] mx-auto">
+      <div className="relative z-20 py-24 px-4 md:px-8 max-w-7xl mx-auto">
         {/* Overline label */}
         <p className="flex items-center justify-center gap-2 mb-6 text-[10px] sm:text-[11px] font-bold uppercase tracking-[0.14em] text-white/50">
           <span aria-hidden="true" className="block w-5 h-px bg-white/30" />

--- a/docs/plans/2026-03-15-pageheader-nav-restructure-810.md
+++ b/docs/plans/2026-03-15-pageheader-nav-restructure-810.md
@@ -264,7 +264,7 @@ The desktop `<div>` currently ends with `<Navigation ... />`. Add a utility grou
 {
   /* Desktop Navigation - Suspense boundary for useSearchParams */
 }
-<Suspense fallback={<div className="flex-grow" />}>
+<Suspense fallback={<div className="grow" />}>
   <Navigation youthTeams={youthTeams} seniorTeams={seniorTeams} />
 </Suspense>;
 

--- a/docs/plans/2026-03-16-homepage-v3-design.md
+++ b/docs/plans/2026-03-16-homepage-v3-design.md
@@ -1,0 +1,207 @@
+# Homepage v3 — Design
+
+**Date:** 2026-03-16
+**Status:** Approved
+**Scope:** Complete homepage redesign — all blocks finalised, ready for mockup (v3 HTML) and implementation
+
+---
+
+## 1. Process
+
+- Build `docs/mockups/homepage-v3.html` to lock in the full design
+- Once approved, implement block-by-block in Next.js
+- Other pages: brainstorm with Claude per page before implementing — homepage establishes the visual contract
+
+---
+
+## 2. Section Structure
+
+```
+Accent strip (3px kcvv-green)           sticky
+Nav (kcvv-black)                         sticky
+─────────────────────────────────────────────────
+Hero — FeaturedArticles carousel         dark / kcvv-black
+  └─ diagonal bottom cut ▿
+─────────────────────────────────────────────────
+[BANNER SLOT A — optional]               flat, contained
+─────────────────────────────────────────────────
+Match Widget — next A-team match         kcvv-green-dark, diagonals top+bottom
+─────────────────────────────────────────────────
+News — image overlay cards               gray-100
+  └─ featured slot: article OR event
+─────────────────────────────────────────────────
+[BANNER SLOT B — optional]               flat, contained
+─────────────────────────────────────────────────
+Match Slider — all teams → /calendar     kcvv-black, diagonal top
+─────────────────────────────────────────────────
+Youth — stat block + jersey photo        kcvv-green-dark, diagonals top+bottom
+─────────────────────────────────────────────────
+[BANNER SLOT C — optional]               flat, contained
+─────────────────────────────────────────────────
+Sponsors — logo grid                     kcvv-black
+─────────────────────────────────────────────────
+Footer                                   kcvv-black
+```
+
+### Diagonal cut strategy
+
+Each section owns its own diagonal pseudo-elements (`::before` / `::after`). Banner slots are flat rectangles — they sit between sections with `py-8` breathing room on the surrounding section's background. When a banner is absent, adjacent sections compose their diagonals normally. Banner slots never carry diagonal cuts themselves.
+
+---
+
+## 3. Block Designs
+
+### 3.1 Accent strip + Nav
+
+No changes from v2. Keep as-is.
+
+### 3.2 Hero — FeaturedArticles carousel
+
+No changes from v2. Keep as-is.
+
+### 3.3 Banner Slots (A, B, C)
+
+- Wide image provided by editor (campaign/sponsor supplies the image with all text and branding baked in)
+- Contained within `max-width` container — not full bleed
+- `rounded` (4px) corners, subtle `box-shadow`
+- Optional `<a>` wrapper when link configured, plain `<div>` when not
+- Sits on surrounding section's background — no dedicated bg color
+- `py-8` vertical spacing
+- **Hidden entirely when no banner configured in Sanity**
+
+**Sanity schema fields:** `image` (required), `href` (optional), `alt` (required for a11y)
+
+### 3.4 Match Widget
+
+No changes from v2. Keep as-is. Data source: BFF `/matches` (A-team next match).
+
+### 3.5 News section — image overlay cards
+
+Keep v2 styling. One change: the featured card slot (`card--featured`, spanning 2 columns) can render as either an **article card** or an **event card** depending on whether an upcoming event exists.
+
+**Featured event card variant:**
+
+- Same `card--featured` dimensions and image overlay structure as article card
+- Background: event image if available; fallback to jersey chevron pattern on `kcvv-black` (no blank gray)
+- Top-left badge: "EVENEMENT" pill in `kcvv-green` — visually distinct from article category badge
+- Content overlay (bottom):
+  - Event title in same large bold type as article card
+  - Date/time strip using Lucide `Calendar` + `Clock` SVG icons — no emojis
+  - Optional 2-line excerpt (same `-webkit-line-clamp: 2` as article cards)
+- Footer bar: right-aligned countdown chip ("over 33 dagen") — uppercase, muted bg, small text; same style as competition badge on match widget
+- External link indicator: Lucide `ExternalLink` icon shown when `href` present; card is non-interactive when absent
+- Hover: same green top-border slide-in as article cards (only when link present)
+
+**Logic:** query Sanity events ordered by date — show next upcoming event if `featuredOnHome: true` is set on any event, else fall back to next upcoming event by date, else fall back to featured article card.
+
+### 3.6 Match Slider section
+
+Replaces the v2 match schedule list (which is **preserved separately** for reuse on other pages).
+
+**Section wrapper:**
+
+- Background: `kcvv-black`, diagonal top cut from gray-100
+- Section header: "Wedstrijden" with green left-border title, white text — `/calendar` link right-aligned as `section-link--dark`
+- Prev/next arrow buttons: `rounded-sm` (2px), `kcvv-black` bg with `kcvv-green` border + green Lucide chevron icon
+
+**`MatchTeaser` — dark-theme reskin:**
+
+- `kcvv-black` bg, `border border-white/8`, `rounded` (4px)
+- Date/time: `white/70`
+- Team names: `white/85`; highlighted KCVV team name in full `white` bold
+- Team logos rendered; fallback initial letter adapted for dark bg
+- Score: `white` bold monospace; winning side's score in `kcvv-green`
+- VS separator: `white/30`
+- Status badges (postponed/stopped): adapted for dark bg
+- W/L/D result chips: green/15 + green, red/15 + red, yellow/15 + yellow
+
+**New `teamLabel` prop on `MatchTeaser`:**
+
+- `teamLabel?: string` — e.g. `"A-Ploeg"`, `"U21"`
+- Rendered as small `kcvv-green` uppercase badge, top-left of card, above date row
+- No space reserved when absent
+
+**Data:** reuses match data already fetched on the homepage (same fetch as Match Widget — no second request). Sorted chronologically across all teams. Calling page responsible for mapping team ID → label string.
+
+### 3.7 Youth section — stat block + jersey photo
+
+- Background: `kcvv-green-dark`, diagonal top+bottom cuts
+- Optional jersey chevron pattern at ~4% opacity as full-bleed texture
+
+**Layout (single centered column, `max-w-3xl`, `text-center`):**
+
+1. Section label: "Jeugd" — centered, white, section-title style
+2. Stat row:
+   - `220+` / "SPELERS" and `16` / "PLOEGEN" side by side
+   - Numbers: `clamp(4rem, 10vw, 8rem)`, `font-weight: 900`, `kcvv-green`, display/stencil font
+   - Labels: `text-xs tracking-widest uppercase white/50`
+   - Separated by thin vertical `white/15` divider
+3. Jersey photo: high-def youth jerseys image, centered, `max-w-lg`, clean with subtle drop shadow — no gradient overlay. Optional very slight `rotate-1` for editorial energy.
+4. CTA: `btn--primary` "Ontdek onze jeugd" → `/jeugd`, centered below photo
+
+### 3.8 Sponsors section
+
+- Background: `kcvv-black`
+- Section header: "Sponsors" with green left-border title, white text; "Word sponsor →" link right-aligned in `kcvv-green`
+- Layout: single centered flex row, `flex-wrap`, generous gap
+- Logos: transparent bg, `grayscale(100%) opacity-50` default → `grayscale(0) opacity-100` on hover, smooth transition
+- Each logo: `<a href={sponsor.url}>` when URL present, plain `<div>` when not — no visual difference
+
+### 3.9 Footer
+
+- Background: `kcvv-black`, `border-top: 1px solid white/6`
+- Grid: brand column (2fr) + 2–3 link columns (TBD at implementation)
+- Bottom bar: copyright left, privacy policy link right — `white/25`
+
+**Brand column:**
+
+- KCVV logo (`kcvv-logo.png`, ~56px tall)
+- Club name "K.C.V.V. Elewijt" white, "Opgericht in 1964" `white/30`
+- Contact block (Lucide icons, `white/50` text):
+  - `MapPin` — Driesstraat 32, 1982 Elewijt
+  - `Mail` — info@kcvvelewijt.be
+- Social icon links (`white/30` → `kcvv-green` on hover):
+  - `Facebook` (Lucide)
+  - `Instagram` (Lucide)
+
+---
+
+## 4. Components to Create / Modify
+
+| Component           | Change                                                          |
+| ------------------- | --------------------------------------------------------------- |
+| `MatchTeaser`       | Add `teamLabel?: string` prop; add dark-theme variant styling   |
+| `MatchesSlider`     | Restyle arrows for dark theme; pass `teamLabel` from match data |
+| `FeaturedEventCard` | New — variant of news featured card                             |
+| `BannerSlot`        | New — image + optional link, contained                          |
+| `YouthSection`      | New homepage block component                                    |
+| `SponsorsSection`   | Restyle — grayscale/hover treatment                             |
+| `PageFooter`        | Add contact info, social icons, logo                            |
+
+---
+
+## 5. Sanity Schema Changes
+
+| Document             | Change                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `event`              | Add optional `featuredOnHome: boolean` (defaults false; falls back to next upcoming event) |
+| `banner`             | New document: `image` (required), `href` (optional), `alt` (required)                      |
+| `homePage` singleton | Add `bannerSlotA`, `bannerSlotB`, `bannerSlotC` references to `banner`                     |
+
+---
+
+## 6. Data / Fetch Strategy
+
+- **Match Widget + Match Slider** share a single fetch — homepage fetches all upcoming matches once, passes data to both components as props. No duplicate requests.
+- **Featured event** — Sanity query: next event where `featuredOnHome == true`, fallback to earliest upcoming event by date.
+- **Banner slots** — Sanity query on homepage singleton, resolve references.
+- **Sponsors** — existing Sanity sponsors query, unchanged.
+
+---
+
+## 7. Implementation Notes
+
+- The v2 match schedule list (`.section-schedule` / `.match-list` / `.match-row`) is **preserved** — not deleted. Will be reused on team/calendar pages.
+- `MatchTeaser` dark-theme: determine at implementation whether to use a `theme` prop (`"light" | "dark"`) or Tailwind `dark:` variant scoped to the section wrapper.
+- Jersey photo for youth section: confirm filename in `public/images/` before implementation.
+- Banner slot diagonal handling: sections adjacent to banner slots keep their own diagonal pseudo-elements unchanged. The banner's `py-8` provides visual separation.

--- a/docs/plans/2026-03-16-homepage-v3-implementation.md
+++ b/docs/plans/2026-03-16-homepage-v3-implementation.md
@@ -1,0 +1,1905 @@
+# Homepage v3 — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement all homepage v3 blocks in Next.js as defined in `docs/plans/2026-03-16-homepage-v3-design.md`.
+
+**Architecture:** Build new components bottom-up (primitives first, sections last), keep existing components as baseline, wire everything together on the homepage page.tsx in the final task.
+
+**Tech Stack:** Next.js 15, TypeScript strict, Tailwind CSS v4, Vitest + React Testing Library, Storybook 10, Lucide React, Sanity, Effect.
+
+**Important:** The mockup (`docs/mockups/homepage-v3.html`) is for style direction only. The current live component code is the baseline. Each modified component must feel native to the existing codebase.
+
+---
+
+## Branch
+
+```bash
+git checkout -b feat/homepage-v3
+```
+
+---
+
+### Task 1: MatchTeaser — `teamLabel` prop + dark-theme variant
+
+**Files:**
+
+- Modify: `apps/web/src/components/match/MatchTeaser/MatchTeaser.tsx`
+- Modify: `apps/web/src/components/match/MatchTeaser/MatchTeaser.test.tsx`
+- Modify: `apps/web/src/components/match/MatchTeaser/MatchTeaser.stories.tsx`
+
+**Step 1: Write failing tests**
+
+Add to `MatchTeaser.test.tsx` under a new `describe("teamLabel")` block:
+
+```typescript
+describe("teamLabel", () => {
+  it("renders teamLabel badge above date row", () => {
+    render(<MatchTeaser {...defaultProps} teamLabel="A-Ploeg" />);
+    expect(screen.getByText("A-Ploeg")).toBeInTheDocument();
+  });
+
+  it("does not render teamLabel badge when absent", () => {
+    const { container } = render(<MatchTeaser {...defaultProps} />);
+    // No empty badge element — verify no data-testid="team-label"
+    expect(container.querySelector("[data-testid='team-label']")).toBeNull();
+  });
+});
+
+describe("dark theme", () => {
+  it("renders dark container classes when theme=dark", () => {
+    const { container } = render(
+      <MatchTeaser {...defaultProps} theme="dark" />,
+    );
+    expect(container.firstChild).toHaveClass("bg-kcvv-black");
+    expect(container.firstChild).not.toHaveClass("bg-white");
+  });
+
+  it("renders light container classes by default", () => {
+    const { container } = render(<MatchTeaser {...defaultProps} />);
+    expect(container.firstChild).toHaveClass("bg-white");
+  });
+});
+```
+
+**Step 2: Run test to confirm failure**
+
+```bash
+pnpm --filter @kcvv/web test src/components/match/MatchTeaser/MatchTeaser.test.tsx
+```
+
+Expected: FAIL — `teamLabel`, `theme` props don't exist yet.
+
+**Step 3: Implement changes in `MatchTeaser.tsx`**
+
+Add to `MatchTeaserProps`:
+
+```typescript
+/** Optional team label shown as a small green badge above the date row (e.g. "A-Ploeg") */
+teamLabel?: string;
+/** Theme variant — "dark" for dark-background sections */
+theme?: "light" | "dark";
+```
+
+In the component body, derive `isDark = theme === "dark"`.
+
+Update `containerClasses`:
+
+```typescript
+const containerClasses = cn(
+  "block border rounded transition-shadow",
+  isDark
+    ? "bg-kcvv-black border-white/8 hover:border-white/20"
+    : "bg-white border-gray-200 hover:shadow-md",
+  isCompact ? "p-3" : "p-4",
+  className,
+);
+```
+
+Render `teamLabel` before the header row:
+
+```tsx
+{
+  teamLabel && (
+    <div
+      data-testid="team-label"
+      className="mb-1 text-xs font-bold uppercase tracking-widest text-kcvv-green"
+    >
+      {teamLabel}
+    </div>
+  );
+}
+```
+
+Update date/time text colours in the header row, passing `isDark` into the header section:
+
+```tsx
+<span className={cn("font-medium", isDark ? "text-white/70" : "text-gray-900")}>
+  {formatDate(date)}
+</span>;
+{
+  time && (
+    <span className={cn(isDark ? "text-white/50" : "text-gray-500")}>
+      {time}
+    </span>
+  );
+}
+```
+
+Update `VS` separator:
+
+```tsx
+<span className={cn("font-medium", isDark ? "text-white/30" : "text-gray-400")}>
+  VS
+</span>
+```
+
+Update `StatusBadge` — add `isDark` prop and swap bg when dark:
+
+```typescript
+function StatusBadge({
+  status,
+  isDark,
+}: {
+  status: MatchTeaserProps["status"];
+  isDark?: boolean;
+}) {
+  if (status === "postponed") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium",
+          isDark
+            ? "bg-orange-900/40 text-orange-300"
+            : "bg-orange-100 text-orange-800",
+        )}
+      >
+        Uitgesteld
+      </span>
+    );
+  }
+  if (status === "stopped") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium",
+          isDark
+            ? "bg-orange-900/40 text-orange-300"
+            : "bg-orange-100 text-orange-800",
+        )}
+      >
+        Gestopt
+      </span>
+    );
+  }
+  if (status === "forfeited") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium",
+          isDark
+            ? "bg-white/10 text-white/60"
+            : "bg-gray-100 text-gray-700",
+        )}
+      >
+        FF
+      </span>
+    );
+  }
+  return null;
+}
+```
+
+Update `TeamDisplay` — add `isDark` prop:
+
+```typescript
+function TeamDisplay({
+  team,
+  side,
+  isHighlighted,
+  compact,
+  isDark,
+}: { ...; isDark?: boolean }) {
+```
+
+Team name span:
+
+```tsx
+<span
+  className={cn(
+    "truncate",
+    compact ? "text-sm" : "text-base",
+    side === "away" && "text-right",
+    isDark
+      ? isHighlighted
+        ? "font-bold text-white"
+        : "text-white/85"
+      : isHighlighted
+        ? "font-semibold text-gray-900"
+        : "text-gray-700",
+  )}
+>
+```
+
+Fallback initial letter for dark theme:
+
+```tsx
+<div
+  className={cn(
+    "rounded-full flex items-center justify-center flex-shrink-0",
+    compact ? "w-6 h-6" : "w-8 h-8",
+    isDark ? "bg-white/15" : "bg-gray-200",
+  )}
+>
+  <span
+    className={cn(
+      compact ? "text-xs" : "text-sm",
+      isDark ? "text-white/60" : "text-gray-500",
+    )}
+  >
+    {team.name.charAt(0)}
+  </span>
+</div>
+```
+
+Score display — winning team in `kcvv-green` (same in both themes):
+
+```tsx
+<span
+  className={cn(
+    isHomeHighlighted && score.home > score.away && "text-kcvv-green",
+    !(isHomeHighlighted && score.home > score.away) &&
+      (isDark ? "text-white" : "text-gray-900"),
+  )}
+>
+  {score.home}
+</span>
+```
+
+Pass `isDark` to both `StatusBadge` and `TeamDisplay` callsites.
+
+**Step 4: Run tests to confirm pass**
+
+```bash
+pnpm --filter @kcvv/web test src/components/match/MatchTeaser/MatchTeaser.test.tsx
+```
+
+Expected: all PASS.
+
+**Step 5: Update Storybook stories**
+
+Add to `MatchTeaser.stories.tsx`:
+
+```typescript
+export const WithTeamLabel: Story = {
+  args: {
+    ...Default.args,
+    teamLabel: "A-Ploeg",
+  },
+};
+
+export const DarkTheme: Story = {
+  args: {
+    ...Default.args,
+    theme: "dark",
+    teamLabel: "U21",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+
+export const DarkThemeWithScore: Story = {
+  args: {
+    ...WithScore.args,
+    theme: "dark",
+    teamLabel: "A-Ploeg",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+```
+
+**Step 6: Commit**
+
+```bash
+git add apps/web/src/components/match/MatchTeaser/
+git commit -m "feat(ui): MatchTeaser — teamLabel badge + dark theme variant"
+```
+
+---
+
+### Task 2: MatchTeaser — add `teamLabel` to shared `UpcomingMatch` type
+
+**Files:**
+
+- Modify: `apps/web/src/components/match/types.ts`
+
+**Step 1: Add optional `teamLabel` field**
+
+In `UpcomingMatch`, add:
+
+```typescript
+/** Optional team label for display (e.g. "A-Ploeg", "U21") — set by calling page */
+teamLabel?: string;
+```
+
+This is the cleanest data-flow: calling page sets `teamLabel` during mapping; components pass it through without knowing about team IDs.
+
+No tests needed — this is a type change only.
+
+**Step 2: Commit**
+
+```bash
+git add apps/web/src/components/match/types.ts
+git commit -m "feat(ui): add teamLabel to UpcomingMatch type"
+```
+
+---
+
+### Task 3: MatchesSlider — dark-theme reskin + `teamLabel` passthrough
+
+**Files:**
+
+- Modify: `apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx`
+- Modify: `apps/web/src/components/match/MatchesSlider/MatchesSlider.stories.tsx`
+
+No test file exists for MatchesSlider. Do not create one — this component has no testable logic beyond the scroll state which requires a real browser.
+
+**Step 1: Add `theme` prop to `MatchesSliderProps`**
+
+```typescript
+/** Theme variant — "dark" for kcvv-black sections */
+theme?: "light" | "dark";
+```
+
+**Step 2: Reskin arrows for dark theme**
+
+Replace the arrow button `className` with theme-aware classes. For dark theme:
+
+- `kcvv-black` bg, `border border-kcvv-green rounded-sm`, green icon
+- Remove `rounded-full` and `shadow-md`
+
+Import `ChevronLeft` and `ChevronRight` from `@/lib/icons` (already exported there). Replace inline SVG paths.
+
+```tsx
+import { ChevronLeft, ChevronRight } from "@/lib/icons";
+
+// Left arrow:
+className={cn(
+  "hidden lg:flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-5 z-10",
+  "w-10 h-10 items-center justify-center transition-colors",
+  theme === "dark"
+    ? "bg-kcvv-black border border-kcvv-green rounded-sm hover:bg-kcvv-green/10"
+    : "bg-white rounded-full shadow-md hover:bg-gray-50",
+)}
+
+// Icon inside:
+<ChevronLeft
+  className={cn("w-5 h-5", theme === "dark" ? "text-kcvv-green" : "text-kcvv-green-dark")}
+/>
+```
+
+Same for right arrow with `ChevronRight`.
+
+**Step 3: Pass `teamLabel` and `theme` to MatchTeaser**
+
+In the map loop:
+
+```tsx
+<MatchTeaser
+  ...existing props...
+  teamLabel={match.teamLabel}
+  theme={theme}
+/>
+```
+
+**Step 4: Update stories**
+
+Add a dark-theme story:
+
+```typescript
+export const DarkTheme: Story = {
+  args: {
+    matches: mockMatches.mixed.map((m, i) => ({
+      ...m,
+      teamLabel: i % 2 === 0 ? "A-Ploeg" : "U17",
+    })),
+    theme: "dark",
+  },
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+```
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/components/match/MatchesSlider/
+git commit -m "feat(ui): MatchesSlider — dark-theme arrows + teamLabel passthrough"
+```
+
+---
+
+### Task 4: NewsCard — event card enhancements (Calendar/Clock icons, countdown, external link)
+
+**Goal:** When the featured slot is an event, the card shows date/time with Lucide icons and a countdown chip in the footer. This is done by extending `NewsCard` props and the `LatestNews` → `NewsCard` data flow.
+
+**Files:**
+
+- Modify: `apps/web/src/components/home/LatestNews/NewsCard.tsx`
+- Modify: `apps/web/src/components/home/LatestNews/LatestNews.tsx`
+- Modify: `apps/web/src/components/home/LatestNews/NewsCard.test.tsx`
+- Modify: `apps/web/src/components/home/LatestNews/NewsCard.stories.tsx`
+
+**Step 1: Write failing tests**
+
+Add to `NewsCard.test.tsx`:
+
+```typescript
+import { Calendar, Clock, ExternalLink } from "@/lib/icons";
+
+describe("event card features", () => {
+  it("renders eventTime with Calendar and Clock icons when time provided", () => {
+    render(
+      <NewsCard
+        title="Sponsorfeest"
+        href="/event/1"
+        variant="featured"
+        eventDate="15 apr"
+        eventTime="19:00"
+      />,
+    );
+    expect(screen.getByText("15 apr")).toBeInTheDocument();
+    expect(screen.getByText("19:00")).toBeInTheDocument();
+  });
+
+  it("renders countdown chip when countdown provided", () => {
+    render(
+      <NewsCard
+        title="Sponsorfeest"
+        href="/event/1"
+        variant="featured"
+        countdown="over 33 dagen"
+      />,
+    );
+    expect(screen.getByText("over 33 dagen")).toBeInTheDocument();
+  });
+
+  it("renders ExternalLink indicator when isExternal=true and href is set", () => {
+    render(
+      <NewsCard
+        title="Sponsorfeest"
+        href="https://facebook.com/event"
+        variant="featured"
+        isExternal
+      />,
+    );
+    // ExternalLink icon is aria-hidden, verify the link has target="_blank"
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders as non-interactive div when no href", () => {
+    render(<NewsCard title="Sponsorfeest" variant="featured" />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});
+```
+
+Note: `NewsCard` currently always has `href: string` (required). The last test requires making `href` optional. Update the prop type first (Step 3).
+
+**Step 2: Run tests to confirm failure**
+
+```bash
+pnpm --filter @kcvv/web test src/components/home/LatestNews/NewsCard.test.tsx
+```
+
+**Step 3: Update `NewsCard` props**
+
+```typescript
+export interface NewsCardProps {
+  title: string;
+  href?: string; // now optional — cards without href are non-interactive
+  imageUrl?: string;
+  imageAlt?: string;
+  badge?: string;
+  date?: string;
+  /** ISO datetime or formatted string for event date (shown with Calendar icon) */
+  eventDate?: string;
+  /** HH:MM time string for events (shown with Clock icon) */
+  eventTime?: string;
+  /** Countdown label shown in footer chip (e.g. "over 33 dagen") */
+  countdown?: string;
+  /** When true, full-card link opens in new tab with ExternalLink indicator */
+  isExternal?: boolean;
+  variant?: "standard" | "featured";
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  className?: string;
+}
+```
+
+**Step 4: Update rendering in `NewsCard`**
+
+Import icons:
+
+```typescript
+import { Calendar, Clock, ExternalLink } from "@/lib/icons";
+```
+
+Update the full-card link to support external:
+
+```tsx
+{
+  href && (
+    <Link
+      href={href}
+      className="absolute inset-0 z-10"
+      aria-label={title}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    />
+  );
+}
+```
+
+Remove hover effect when no href:
+
+```typescript
+"transition-all duration-300 hover:-translate-y-1 hover:shadow-xl",
+```
+
+becomes:
+
+```typescript
+href && "transition-all duration-300 hover:-translate-y-1 hover:shadow-xl",
+```
+
+Similarly, the green top-border animation should be conditional:
+
+```tsx
+{
+  href && (
+    <div
+      className="absolute top-0 inset-x-0 h-[3px] bg-kcvv-green-bright z-20 pointer-events-none [clip-path:inset(0_50%)] group-hover:[clip-path:inset(0_0%)] transition-[clip-path] duration-300 ease-out"
+      aria-hidden="true"
+    />
+  );
+}
+```
+
+Replace the bottom content overlay's date/badge footer with event-aware rendering:
+
+```tsx
+{
+  /* Footer bar: countdown chip OR date+badge */
+}
+{
+  (countdown ?? date ?? badge) && (
+    <div className="border-t border-white/20 mt-3 pt-3 text-white/60 text-xs flex justify-between items-center">
+      <div className="flex items-center gap-3">
+        {(eventDate ?? date) && !countdown && (
+          <time className="flex items-center gap-1">
+            <Calendar className="w-3 h-3 flex-shrink-0" aria-hidden />
+            {eventDate ?? date}
+          </time>
+        )}
+        {eventTime && (
+          <span className="flex items-center gap-1">
+            <Clock className="w-3 h-3 flex-shrink-0" aria-hidden />
+            {eventTime}
+          </span>
+        )}
+        {!eventDate && !eventTime && date && <time>{date}</time>}
+        {badge && !eventDate && !eventTime && <span>{badge}</span>}
+      </div>
+      {countdown && (
+        <span className="text-xs uppercase tracking-wider bg-white/10 px-2 py-0.5 rounded-sm font-medium text-white/70">
+          {countdown}
+        </span>
+      )}
+      {isExternal && !countdown && (
+        <ExternalLink
+          className="w-3 h-3 flex-shrink-0 text-white/40"
+          aria-hidden
+        />
+      )}
+    </div>
+  );
+}
+```
+
+**Step 5: Update `FeaturedEventStub` in `LatestNews.tsx`**
+
+Add `time?: string`, `countdown?: string`, `isExternal?: boolean` to `FeaturedEventStub` and pass them through to `NewsCard`:
+
+```typescript
+export interface FeaturedEventStub {
+  title: string;
+  href?: string;
+  imageUrl?: string;
+  imageAlt?: string;
+  badge?: string;
+  date?: string;
+  time?: string;
+  countdown?: string;
+  isExternal?: boolean;
+}
+```
+
+In `LatestNews` JSX:
+
+```tsx
+<NewsCard
+  variant="featured"
+  title={featuredEvent.title}
+  href={featuredEvent.href}
+  imageUrl={featuredEvent.imageUrl}
+  imageAlt={featuredEvent.imageAlt}
+  badge={featuredEvent.badge ?? "EVENEMENT"}
+  eventDate={featuredEvent.date}
+  eventTime={featuredEvent.time}
+  countdown={featuredEvent.countdown}
+  isExternal={featuredEvent.isExternal}
+/>
+```
+
+**Step 6: Run tests**
+
+```bash
+pnpm --filter @kcvv/web test src/components/home/LatestNews/
+```
+
+Expected: all PASS.
+
+**Step 7: Update Storybook stories**
+
+Add to `NewsCard.stories.tsx`:
+
+```typescript
+export const FeaturedEvent: Story = {
+  args: {
+    variant: "featured",
+    title: "Sponsorfeest KCVV Elewijt 2026",
+    href: "https://facebook.com/event",
+    badge: "EVENEMENT",
+    eventDate: "26 apr",
+    eventTime: "19:00",
+    countdown: "over 33 dagen",
+    isExternal: true,
+    imageUrl: "...",
+  },
+};
+
+export const FeaturedEventNoImage: Story = {
+  args: {
+    variant: "featured",
+    title: "Sponsorfeest KCVV Elewijt 2026",
+    badge: "EVENEMENT",
+    eventDate: "26 apr",
+    eventTime: "19:00",
+    countdown: "over 33 dagen",
+  },
+};
+```
+
+**Step 8: Commit**
+
+```bash
+git add apps/web/src/components/home/LatestNews/
+git commit -m "feat(ui): NewsCard — event card enhancements (icons, countdown, external link)"
+```
+
+---
+
+### Task 5: BannerSlot component
+
+**Files:**
+
+- Create: `apps/web/src/components/home/BannerSlot/BannerSlot.tsx`
+- Create: `apps/web/src/components/home/BannerSlot/index.ts`
+- Create: `apps/web/src/components/home/BannerSlot/BannerSlot.stories.tsx`
+- Modify: `apps/web/src/components/home/index.ts`
+
+No unit tests needed — purely presentational, no logic.
+
+**Step 1: Create `BannerSlot.tsx`**
+
+```typescript
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+
+export interface BannerSlotProps {
+  /** Banner image URL */
+  image: string;
+  /** Alt text for accessibility */
+  alt: string;
+  /** Optional click-through URL — wraps in <a> when set */
+  href?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Optional editorial/campaign banner.
+ * Contained (not full-bleed), rounded corners, subtle shadow.
+ * Hidden when no banner is configured (call site handles conditional rendering).
+ */
+export const BannerSlot = ({ image, alt, href, className }: BannerSlotProps) => {
+  const inner = (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded shadow-sm",
+        "aspect-[6/1] min-h-[60px]",
+        className,
+      )}
+    >
+      <Image
+        src={image}
+        alt={alt}
+        fill
+        className="object-cover"
+        sizes="(max-width: 768px) 100vw, 1280px"
+        priority={false}
+      />
+    </div>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block max-w-7xl mx-auto px-4 md:px-8 py-8"
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 md:px-8 py-8">{inner}</div>
+  );
+};
+```
+
+**Step 2: Create `index.ts`**
+
+```typescript
+export { BannerSlot } from "./BannerSlot";
+export type { BannerSlotProps } from "./BannerSlot";
+```
+
+**Step 3: Add export to `apps/web/src/components/home/index.ts`**
+
+```typescript
+export { BannerSlot } from "./BannerSlot";
+export type { BannerSlotProps } from "./BannerSlot";
+```
+
+**Step 4: Create stories**
+
+```typescript
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { BannerSlot } from "./BannerSlot";
+
+const meta = {
+  title: "Features/Homepage/BannerSlot",
+  component: BannerSlot,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof BannerSlot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLink: Story = {
+  args: {
+    image: "/images/placeholder-banner.jpg",
+    alt: "Anti-racism campaign",
+    href: "https://example.com",
+  },
+};
+
+export const NoLink: Story = {
+  args: {
+    image: "/images/placeholder-banner.jpg",
+    alt: "Summer camp 2026",
+  },
+};
+```
+
+Note: placeholder image must exist. Use any existing image in `public/images/` for stories.
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/components/home/BannerSlot/
+git add apps/web/src/components/home/index.ts
+git commit -m "feat(ui): add BannerSlot component"
+```
+
+---
+
+### Task 6: Sanity schema — `event.featuredOnHome`, `banner` document, `homePage` singleton
+
+**Files:**
+
+- Modify: `apps/studio/schemaTypes/event.ts`
+- Create: `apps/studio/schemaTypes/banner.ts`
+- Create: `apps/studio/schemaTypes/homePage.ts`
+- Modify: `apps/studio/schemaTypes/index.ts`
+
+**Step 1: Add `featuredOnHome` to event schema**
+
+In `event.ts`, add inside `fields`:
+
+```typescript
+defineField({
+  name: 'featuredOnHome',
+  title: 'Featured on homepage',
+  type: 'boolean',
+  description: 'When enabled, this event fills the featured slot in the news section on the homepage.',
+  initialValue: false,
+}),
+```
+
+**Step 2: Create `banner.ts`**
+
+```typescript
+import { defineField, defineType } from "sanity";
+
+export const banner = defineType({
+  name: "banner",
+  title: "Banner",
+  type: "document",
+  fields: [
+    defineField({
+      name: "image",
+      title: "Banner image",
+      type: "image",
+      options: { hotspot: true },
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: "alt",
+      title: "Alt text",
+      type: "string",
+      validation: (r) => r.required(),
+      description: "Required for accessibility. Describe the banner content.",
+    }),
+    defineField({
+      name: "href",
+      title: "Click-through URL",
+      type: "url",
+      description: "Optional. Wraps the banner in a link.",
+    }),
+  ],
+  preview: {
+    select: { title: "alt", media: "image" },
+  },
+});
+```
+
+**Step 3: Create `homePage.ts`**
+
+```typescript
+import { defineField, defineType } from "sanity";
+
+export const homePage = defineType({
+  name: "homePage",
+  title: "Homepage",
+  type: "document",
+  __experimental_actions: ["update", "publish"],
+  fields: [
+    defineField({
+      name: "bannerSlotA",
+      title: "Banner slot A (below Match Widget)",
+      type: "reference",
+      to: [{ type: "banner" }],
+    }),
+    defineField({
+      name: "bannerSlotB",
+      title: "Banner slot B (below News section)",
+      type: "reference",
+      to: [{ type: "banner" }],
+    }),
+    defineField({
+      name: "bannerSlotC",
+      title: "Banner slot C (below Youth section)",
+      type: "reference",
+      to: [{ type: "banner" }],
+    }),
+  ],
+  preview: {
+    prepare() {
+      return { title: "Homepage configuration" };
+    },
+  },
+});
+```
+
+**Step 4: Register schemas**
+
+In `apps/studio/schemaTypes/index.ts`:
+
+```typescript
+import { banner } from "./banner";
+import { homePage } from "./homePage";
+
+export const schemaTypes = [
+  player,
+  team,
+  trainingDay,
+  staffMember,
+  responsibilityPath,
+  article,
+  sponsor,
+  event,
+  page,
+  fileAttachment,
+  htmlTable,
+  banner,
+  homePage,
+];
+```
+
+**Step 5: Commit**
+
+```bash
+git add apps/studio/schemaTypes/
+git commit -m "feat(schema): add banner document, homePage singleton, event.featuredOnHome"
+```
+
+---
+
+### Task 7: SanityService — `getNextFeaturedEvent` + `getHomepageBanners`
+
+**Files:**
+
+- Modify: `apps/web/src/lib/sanity/queries/events.ts`
+- Create: `apps/web/src/lib/sanity/queries/homePage.ts`
+- Modify: `apps/web/src/lib/effect/services/SanityService.ts`
+- Modify: `apps/web/src/lib/effect/services/SanityService.test.ts`
+
+**Step 1: Write failing service tests**
+
+In `SanityService.test.ts`, look at the existing test pattern (mocking `sanityClient.fetch`) and add:
+
+```typescript
+describe("getNextFeaturedEvent", () => {
+  it("returns the next event with featuredOnHome=true when present", async () => {
+    const mockEvent = {
+      _id: "event-1",
+      title: "Sponsorfeest",
+      dateStart: "2026-04-26T19:00:00.000Z",
+      dateEnd: null,
+      externalLink: { url: "https://fb.com", label: "Facebook" },
+      coverImageUrl: "https://cdn.sanity.io/img.jpg",
+      featuredOnHome: true,
+    };
+    vi.mocked(sanityClient.fetch).mockResolvedValueOnce(mockEvent);
+    const result = await runPromise(
+      Effect.flatMap(SanityService, (s) => s.getNextFeaturedEvent()),
+    );
+    expect(result).not.toBeNull();
+    expect(result?._id).toBe("event-1");
+  });
+
+  it("returns null when no upcoming events exist", async () => {
+    vi.mocked(sanityClient.fetch).mockResolvedValueOnce(null);
+    const result = await runPromise(
+      Effect.flatMap(SanityService, (s) => s.getNextFeaturedEvent()),
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("getHomepageBanners", () => {
+  it("returns resolved banner data from homepage singleton", async () => {
+    vi.mocked(sanityClient.fetch).mockResolvedValueOnce({
+      bannerSlotA: {
+        _id: "b1",
+        imageUrl: "/img.jpg",
+        alt: "Anti-racism",
+        href: null,
+      },
+      bannerSlotB: null,
+      bannerSlotC: null,
+    });
+    const result = await runPromise(
+      Effect.flatMap(SanityService, (s) => s.getHomepageBanners()),
+    );
+    expect(result.bannerSlotA).not.toBeNull();
+    expect(result.bannerSlotB).toBeNull();
+  });
+});
+```
+
+**Step 2: Run to confirm failure**
+
+```bash
+pnpm --filter @kcvv/web test src/lib/effect/services/SanityService.test.ts
+```
+
+**Step 3: Add query to `events.ts`**
+
+```typescript
+// Returns the next event with featuredOnHome=true, or the earliest upcoming event,
+// or null if none exist. $now must be current ISO datetime.
+export const NEXT_FEATURED_EVENT_QUERY = `
+  coalesce(
+    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {
+      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,
+      "coverImageUrl": coverImage.asset->url
+    },
+    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {
+      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,
+      "coverImageUrl": coverImage.asset->url
+    }
+  )
+`;
+```
+
+**Step 4: Create `homePage.ts` query file**
+
+```typescript
+export const HOMEPAGE_BANNERS_QUERY = `
+  *[_type == "homePage"][0] {
+    "bannerSlotA": bannerSlotA-> {
+      _id,
+      "imageUrl": image.asset->url,
+      alt,
+      href
+    },
+    "bannerSlotB": bannerSlotB-> {
+      _id,
+      "imageUrl": image.asset->url,
+      alt,
+      href
+    },
+    "bannerSlotC": bannerSlotC-> {
+      _id,
+      "imageUrl": image.asset->url,
+      alt,
+      href
+    }
+  }
+`;
+```
+
+**Step 5: Add types and methods to `SanityService.ts`**
+
+Add new types:
+
+```typescript
+export interface SanityBannerSlot {
+  _id: string;
+  imageUrl: string;
+  alt: string;
+  href: string | null;
+}
+
+export interface SanityHomepageBanners {
+  bannerSlotA: SanityBannerSlot | null;
+  bannerSlotB: SanityBannerSlot | null;
+  bannerSlotC: SanityBannerSlot | null;
+}
+
+// Update SanityEvent to include featuredOnHome:
+export interface SanityEvent {
+  _id: string;
+  title: string;
+  dateStart: string;
+  dateEnd: string | null;
+  externalLink: { url: string; label: string } | null;
+  coverImageUrl: string | null;
+  featuredOnHome?: boolean;
+}
+```
+
+Add to `SanityServiceInterface`:
+
+```typescript
+readonly getNextFeaturedEvent: () => Effect.Effect<SanityEvent | null>;
+readonly getHomepageBanners: () => Effect.Effect<SanityHomepageBanners>;
+```
+
+Add to `SanityServiceLive`:
+
+```typescript
+getNextFeaturedEvent: () =>
+  fetchGroq<SanityEvent | null>(NEXT_FEATURED_EVENT_QUERY, {
+    now: new Date().toISOString(),
+  }),
+getHomepageBanners: () =>
+  fetchGroq<SanityHomepageBanners | null>(HOMEPAGE_BANNERS_QUERY).pipe(
+    Effect.map((data) => data ?? { bannerSlotA: null, bannerSlotB: null, bannerSlotC: null }),
+  ),
+```
+
+Import the new queries at the top of `SanityService.ts`.
+
+**Step 6: Run tests**
+
+```bash
+pnpm --filter @kcvv/web test src/lib/effect/services/SanityService.test.ts
+```
+
+Expected: all PASS.
+
+**Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/sanity/queries/ apps/web/src/lib/effect/services/SanityService.ts apps/web/src/lib/effect/services/SanityService.test.ts
+git commit -m "feat(schema): SanityService — getNextFeaturedEvent + getHomepageBanners"
+```
+
+---
+
+### Task 8: MatchesSlider section wrapper — homepage dark section
+
+The `MatchesSlider` component itself is a flat row. The homepage needs it wrapped in a `py-20` dark section with `SectionHeader`, diagonal top cut, and a "Wedstrijden" title + `/calendar` link. Create a thin wrapper component.
+
+**Files:**
+
+- Create: `apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx`
+- Create: `apps/web/src/components/home/MatchesSliderSection/index.ts`
+- Create: `apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.stories.tsx`
+- Modify: `apps/web/src/components/home/index.ts`
+
+No unit tests — presentational wrapper with no logic.
+
+**Step 1: Create `MatchesSliderSection.tsx`**
+
+```typescript
+import Link from "next/link";
+import { MatchesSlider } from "@/components/match/MatchesSlider/MatchesSlider";
+import type { UpcomingMatch } from "@/components/match/types";
+import { cn } from "@/lib/utils/cn";
+
+export interface MatchesSliderSectionProps {
+  matches: UpcomingMatch[];
+  highlightTeamId?: number;
+  className?: string;
+}
+
+export const MatchesSliderSection = ({
+  matches,
+  highlightTeamId,
+  className,
+}: MatchesSliderSectionProps) => {
+  if (matches.length === 0) return null;
+
+  return (
+    <section
+      className={cn(
+        "relative bg-kcvv-black py-20",
+        // Diagonal top cut: gray-100 → kcvv-black
+        "before:content-[''] before:absolute before:top-0 before:left-0 before:right-0",
+        "before:h-8 before:bg-gray-100 before:[clip-path:polygon(0_0,100%_0,100%_100%,0_0)]",
+        className,
+      )}
+    >
+      <div className="max-w-7xl mx-auto px-4 md:px-8 pt-4">
+        {/* Section header */}
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-bold text-white border-l-4 border-kcvv-green pl-3">
+            Wedstrijden
+          </h2>
+          <Link
+            href="/calendar"
+            className="text-sm text-kcvv-green hover:text-white transition-colors font-medium"
+          >
+            Alle wedstrijden →
+          </Link>
+        </div>
+
+        <MatchesSlider
+          matches={matches}
+          highlightTeamId={highlightTeamId}
+          theme="dark"
+        />
+      </div>
+    </section>
+  );
+};
+```
+
+Note on diagonal implementation: the CSS `clip-path` approach for diagonals should match the existing pattern in the codebase. Check how `MatchWidget` or `FeaturedArticles` implement diagonal cuts — replicate the exact same technique. If they use a different method (e.g. `skewY`, SVG, `polygon()`), use that method here for visual consistency.
+
+**Step 2: Create barrel + export**
+
+`index.ts`:
+
+```typescript
+export { MatchesSliderSection } from "./MatchesSliderSection";
+export type { MatchesSliderSectionProps } from "./MatchesSliderSection";
+```
+
+Add to `apps/web/src/components/home/index.ts`.
+
+**Step 3: Stories**
+
+```typescript
+export const Default: Story = {
+  args: {
+    matches: mockMatches.mixed.map((m, i) => ({
+      ...m,
+      teamLabel: i < 3 ? "A-Ploeg" : "U17",
+    })),
+  },
+  parameters: { layout: "fullscreen", backgrounds: { default: "dark" } },
+};
+```
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/components/home/MatchesSliderSection/
+git add apps/web/src/components/home/index.ts
+git commit -m "feat(ui): add MatchesSliderSection homepage block"
+```
+
+---
+
+### Task 9: YouthSection homepage block
+
+**Files:**
+
+- Create: `apps/web/src/components/home/YouthSection/YouthSection.tsx`
+- Create: `apps/web/src/components/home/YouthSection/index.ts`
+- Create: `apps/web/src/components/home/YouthSection/YouthSection.stories.tsx`
+- Modify: `apps/web/src/components/home/index.ts`
+
+Before implementing, run:
+
+```bash
+ls apps/web/public/images/ | grep -i jersey
+ls apps/web/public/images/ | grep -i youth
+```
+
+Confirm the jersey/youth image filename. The design doc says "confirm filename in `public/images/`". Use whatever file exists. If none exists yet, use a placeholder path and note it with a `TODO:` comment.
+
+**Step 1: Create `YouthSection.tsx`**
+
+```typescript
+import Image from "next/image";
+import Link from "next/link";
+import { cn } from "@/lib/utils/cn";
+
+export interface YouthSectionProps {
+  className?: string;
+}
+
+export const YouthSection = ({ className }: YouthSectionProps) => {
+  return (
+    <section
+      className={cn(
+        "relative bg-kcvv-green-dark py-20 text-center overflow-hidden",
+        // Diagonal top cut from kcvv-black
+        "before:content-[''] before:absolute before:top-0 before:left-0 before:right-0",
+        "before:h-8 before:bg-kcvv-black before:[clip-path:polygon(0_0,100%_0,100%_100%,0_0)]",
+        // Diagonal bottom cut to gray-100
+        "after:content-[''] after:absolute after:bottom-0 after:left-0 after:right-0",
+        "after:h-8 after:bg-gray-100 after:[clip-path:polygon(0_100%,100%_0,100%_100%,0_100%)]",
+        className,
+      )}
+    >
+      <div className="relative max-w-3xl mx-auto px-4 md:px-8">
+        {/* Section label */}
+        <p className="text-xs font-bold uppercase tracking-[0.25em] text-white/50 mb-6">
+          Jeugd
+        </p>
+
+        {/* Stat row */}
+        <div className="flex items-center justify-center gap-8 md:gap-16 mb-10">
+          <div>
+            <div
+              className="font-display font-black text-kcvv-green leading-none"
+              style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
+            >
+              220+
+            </div>
+            <div className="text-xs tracking-widest uppercase text-white/50 mt-1">
+              Spelers
+            </div>
+          </div>
+          <div className="w-px h-16 bg-white/15" aria-hidden="true" />
+          <div>
+            <div
+              className="font-display font-black text-kcvv-green leading-none"
+              style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
+            >
+              16
+            </div>
+            <div className="text-xs tracking-widest uppercase text-white/50 mt-1">
+              Ploegen
+            </div>
+          </div>
+        </div>
+
+        {/* Jersey photo */}
+        {/* TODO: confirm jersey image path in public/images/ */}
+        <div className="relative inline-block mb-10">
+          <Image
+            src="/images/youth-jerseys.png"
+            alt="KCVV jeugd tenues"
+            width={480}
+            height={360}
+            className="max-w-sm w-full mx-auto object-contain drop-shadow-xl"
+            style={{ rotate: "1deg" }}
+          />
+        </div>
+
+        {/* CTA */}
+        <div>
+          <Link
+            href="/jeugd"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-kcvv-green text-kcvv-black font-bold text-sm uppercase tracking-wider rounded-sm hover:bg-kcvv-green/90 transition-colors"
+          >
+            Ontdek onze jeugd
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+```
+
+Check the `font-display` class — verify it maps to the stenciletta/quasimoda font in `globals.css`. If not, use `font-bold` with Tailwind's default.
+
+**Step 2: Barrel + export + stories — same pattern as BannerSlot task.**
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/components/home/YouthSection/
+git add apps/web/src/components/home/index.ts
+git commit -m "feat(ui): add YouthSection homepage block"
+```
+
+---
+
+### Task 10: SponsorsSection — homepage light-section wrapper
+
+**Goal:** Wrap `SponsorsBlock` in a `py-20 bg-gray-100` section with a v3-style `SectionHeader` (green left border, "Word sponsor →" link).
+
+The existing `Sponsors` component uses its own internal header. For the homepage, we need the standard `SectionHeader` component. Create a thin section wrapper.
+
+**Files:**
+
+- Create: `apps/web/src/components/home/SponsorsSection/SponsorsSection.tsx`
+- Create: `apps/web/src/components/home/SponsorsSection/index.ts`
+- Create: `apps/web/src/components/home/SponsorsSection/SponsorsSection.stories.tsx`
+- Modify: `apps/web/src/components/home/index.ts`
+
+**Step 1: Create `SponsorsSection.tsx`**
+
+This is a server component (async) because it fetches sponsors.
+
+```typescript
+import { cn } from "@/lib/utils/cn";
+import { SectionHeader } from "@/components/design-system";
+import { SponsorsBlock } from "@/components/sponsors";
+
+export interface SponsorsSectionProps {
+  className?: string;
+}
+
+export async function SponsorsSection({ className }: SponsorsSectionProps) {
+  return (
+    <section className={cn("bg-gray-100 py-20", className)}>
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
+        <SectionHeader
+          title="Sponsors"
+          linkText="Word sponsor"
+          linkHref="/sponsors"
+        />
+        <SponsorsBlock
+          title=""
+          description=""
+          showViewAll={false}
+          variant="light"
+          columns={5}
+          className="py-0"
+        />
+      </div>
+    </section>
+  );
+}
+```
+
+Note: the `Sponsors` component already has `grayscale` + opacity hover on logos in light variant. Verify the hover treatment matches the design (opacity-50 default → opacity-100 hover). If it doesn't, update `Sponsors.tsx` at this step.
+
+**Step 2: Barrel + exports + stories (use `Sponsors.mocks.ts` for story data).**
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/components/home/SponsorsSection/
+git add apps/web/src/components/home/index.ts
+git commit -m "feat(ui): add SponsorsSection homepage block"
+```
+
+---
+
+### Task 11: PageFooter redesign
+
+**Goal:** Replace the current footer (SVG wavy, contact table, sponsors) with the v3 design: simplified 3-column grid, brand column, 2 link columns, copyright bar.
+
+**Files:**
+
+- Modify: `apps/web/src/components/layout/PageFooter/PageFooter.tsx`
+- Modify: `apps/web/src/components/layout/PageFooter/PageFooter.test.tsx`
+- Modify: `apps/web/src/components/layout/PageFooter/PageFooter.stories.tsx`
+
+**Step 1: Read and understand existing footer tests before changing**
+
+```bash
+cat apps/web/src/components/layout/PageFooter/PageFooter.test.tsx
+```
+
+Update tests to match new structure before implementing (TDD).
+
+**Step 2: Write updated failing tests**
+
+Replace tests with expectations matching the new design:
+
+```typescript
+it("renders KCVV logo", () => {
+  render(<PageFooter />);
+  const logo = screen.getByAltText(/KCVV/i);
+  expect(logo).toBeInTheDocument();
+});
+
+it("renders club address", () => {
+  render(<PageFooter />);
+  expect(screen.getByText(/Driesstraat 32/)).toBeInTheDocument();
+});
+
+it("renders club email", () => {
+  render(<PageFooter />);
+  expect(screen.getByText("info@kcvvelewijt.be")).toBeInTheDocument();
+});
+
+it("renders Facebook link", () => {
+  render(<PageFooter />);
+  const fbLink = screen.getByRole("link", { name: /facebook/i });
+  expect(fbLink).toBeInTheDocument();
+});
+
+it("renders Instagram link", () => {
+  render(<PageFooter />);
+  const igLink = screen.getByRole("link", { name: /instagram/i });
+  expect(igLink).toBeInTheDocument();
+});
+
+it("renders copyright text", () => {
+  render(<PageFooter />);
+  expect(screen.getByText(/KCVV Elewijt/)).toBeInTheDocument();
+});
+
+it("renders privacy policy link", () => {
+  render(<PageFooter />);
+  const privacyLink = screen.getByRole("link", { name: /privacy/i });
+  expect(privacyLink).toHaveAttribute("href", "/privacy");
+});
+```
+
+**Step 3: Run tests to confirm failure**
+
+```bash
+pnpm --filter @kcvv/web test src/components/layout/PageFooter/PageFooter.test.tsx
+```
+
+**Step 4: Rewrite `PageFooter.tsx`**
+
+Remove the SVG wavy bg, the contact table rows, the SocialLinks component import, the SponsorsBlock import. Replace with:
+
+```tsx
+import Link from "next/link";
+import Image from "next/image";
+import { Mail, MapPin, Facebook, Instagram } from "@/lib/icons";
+import { CookiePreferencesButton } from "./CookiePreferencesButton";
+import { cn } from "@/lib/utils/cn";
+
+export const PageFooter = ({ className }: PageFooterProps) => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer
+      className={cn(
+        "bg-kcvv-black border-t border-white/6 text-white",
+        className,
+      )}
+    >
+      <div className="max-w-7xl mx-auto px-4 md:px-8 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr] gap-12">
+          {/* Brand column */}
+          <div>
+            <Link href="/" className="inline-block mb-4">
+              <Image
+                src="/images/logo-flat.png"
+                alt="KCVV Elewijt"
+                width={120}
+                height={48}
+                className="h-14 w-auto"
+              />
+            </Link>
+            <p className="font-bold text-white text-sm mb-0.5">
+              K.C.V.V. Elewijt
+            </p>
+            <p className="text-white/30 text-xs mb-6">Opgericht in 1964</p>
+
+            <div className="space-y-2 mb-6">
+              <div className="flex items-center gap-2 text-white/50 text-sm">
+                <MapPin className="w-4 h-4 flex-shrink-0" aria-hidden />
+                <span>Driesstraat 32, 1982 Elewijt</span>
+              </div>
+              <a
+                href="mailto:info@kcvvelewijt.be"
+                className="flex items-center gap-2 text-white/50 text-sm hover:text-white transition-colors"
+              >
+                <Mail className="w-4 h-4 flex-shrink-0" aria-hidden />
+                <span>info@kcvvelewijt.be</span>
+              </a>
+            </div>
+
+            {/* Social icons */}
+            <div className="flex items-center gap-3">
+              <a
+                href="https://www.facebook.com/KCVVElewijt"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="KCVV Elewijt op Facebook"
+                className="text-white/30 hover:text-kcvv-green transition-colors"
+              >
+                <Facebook className="w-5 h-5" />
+              </a>
+              <a
+                href="https://www.instagram.com/kcvv_elewijt"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="KCVV Elewijt op Instagram"
+                className="text-white/30 hover:text-kcvv-green transition-colors"
+              >
+                <Instagram className="w-5 h-5" />
+              </a>
+            </div>
+          </div>
+
+          {/* Link column 1 — Club */}
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-widest text-white/40 mb-4">
+              Club
+            </h3>
+            <ul className="space-y-2">
+              {[
+                { href: "/club/organigram", label: "Bestuur" },
+                { href: "/sponsors", label: "Sponsors" },
+                { href: "/privacy", label: "Privacy" },
+              ].map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="text-sm text-white/50 hover:text-white transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Link column 2 — Website */}
+          <div>
+            <h3 className="text-xs font-bold uppercase tracking-widest text-white/40 mb-4">
+              Website
+            </h3>
+            <ul className="space-y-2">
+              {[
+                { href: "/news", label: "Nieuws" },
+                { href: "/calendar", label: "Kalender" },
+                { href: "/jeugd", label: "Jeugd" },
+                { href: "/hulp", label: "Hulp" },
+              ].map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    className="text-sm text-white/50 hover:text-white transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom bar */}
+      <div className="border-t border-white/6">
+        <div className="max-w-7xl mx-auto px-4 md:px-8 py-4 flex flex-col sm:flex-row items-center justify-between gap-2">
+          <p className="text-white/25 text-xs">
+            © {currentYear} K.C.V.V. Elewijt
+          </p>
+          <div className="flex items-center gap-4 text-xs text-white/25">
+            <Link
+              href="/privacy"
+              className="hover:text-white/50 transition-colors"
+            >
+              Privacyverklaring
+            </Link>
+            <CookiePreferencesButton />
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+```
+
+Note: Facebook and Instagram URLs above are guesses. Verify the correct URLs from the existing `SocialLinks` component or Gatsby source before committing.
+
+**Step 5: Run tests**
+
+```bash
+pnpm --filter @kcvv/web test src/components/layout/PageFooter/PageFooter.test.tsx
+```
+
+**Step 6: Update stories in `PageFooter.stories.tsx`**
+
+**Step 7: Commit**
+
+```bash
+git add apps/web/src/components/layout/PageFooter/
+git commit -m "feat(ui): redesign PageFooter — simplified grid, brand column, copyright bar"
+```
+
+---
+
+### Task 12: Wire homepage `page.tsx`
+
+**Goal:** Update the homepage to fetch all new data and render all new blocks in the correct order with diagonal cuts composing correctly when banner slots are absent.
+
+**Files:**
+
+- Modify: `apps/web/src/app/page.tsx`
+
+**Step 1: Read the current `page.tsx` and understand the existing data flow**
+
+Already done. Current fetches: articles + next matches.
+
+**Step 2: Update `page.tsx`**
+
+Add parallel fetches for `nextFeaturedEvent` and `banners`. Add `teamLabel` mapping to matches. Render all new sections.
+
+```typescript
+import {
+  FeaturedArticles,
+  LatestNews,
+  MatchWidget,
+  BannerSlot,
+  MatchesSliderSection,
+  YouthSection,
+  SponsorsSection,
+} from "@/components/home";
+import { PageFooter } from "@/components/layout/PageFooter";
+import { DateTime } from "luxon";
+
+// Inside the component, add to Promise.all:
+const [articlesResult, matchesResult, eventResult, bannersResult] =
+  await Promise.all([
+    // ... existing article fetch
+    // ... existing match fetch
+    runPromise(
+      Effect.gen(function* () {
+        const sanity = yield* SanityService;
+        return yield* sanity.getNextFeaturedEvent();
+      }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+    ),
+    runPromise(
+      Effect.gen(function* () {
+        const sanity = yield* SanityService;
+        return yield* sanity.getHomepageBanners();
+      }).pipe(
+        Effect.catchAll(() =>
+          Effect.succeed({
+            bannerSlotA: null,
+            bannerSlotB: null,
+            bannerSlotC: null,
+          }),
+        ),
+      ),
+    ),
+  ]);
+```
+
+Build the featured event stub when event data is available:
+
+```typescript
+const featuredEvent = eventResult
+  ? buildFeaturedEventStub(eventResult)
+  : undefined;
+```
+
+Add a helper `buildFeaturedEventStub`:
+
+```typescript
+function buildFeaturedEventStub(event: SanityEvent): FeaturedEventStub {
+  const dt = DateTime.fromISO(event.dateStart).setLocale("nl");
+  const now = DateTime.now();
+  const diffDays = Math.ceil(dt.diff(now, "days").days);
+  const countdown =
+    diffDays > 0
+      ? `over ${diffDays} ${diffDays === 1 ? "dag" : "dagen"}`
+      : undefined;
+
+  return {
+    title: event.title,
+    href: event.externalLink?.url,
+    imageUrl: event.coverImageUrl ?? undefined,
+    badge: "EVENEMENT",
+    date: dt.toFormat("d MMM"),
+    time: dt.toFormat("HH:mm"),
+    countdown,
+    isExternal: !!event.externalLink?.url,
+  };
+}
+```
+
+Add `teamLabel` to matches for the slider. A-team ID is `1235` (from existing usage), B-team mapping TBD (check Sanity teams or BFF — use `TODO:` comment for now):
+
+```typescript
+// Build slider matches with team labels
+// TODO: load team label map from Sanity teams to avoid hardcoding team IDs
+const TEAM_LABELS: Record<number, string> = {
+  1235: "A-Ploeg",
+  // Add B-ploeg ID once confirmed
+};
+
+const sliderMatches = upcomingMatches.map((m) => ({
+  ...m,
+  teamLabel:
+    TEAM_LABELS[m.homeTeam.id] ?? TEAM_LABELS[m.awayTeam.id] ?? undefined,
+}));
+```
+
+Render the full section stack:
+
+```tsx
+return (
+  <>
+    {/* Hero */}
+    {featuredArticles.length > 0 && <FeaturedArticles ... />}
+
+    {/* Match Widget — A-team next match */}
+    {nextMatch && <MatchWidget match={nextMatch} teamLabel="A-Ploeg" />}
+
+    {/* Banner slot A — below match widget */}
+    {banners.bannerSlotA && (
+      <BannerSlot
+        image={banners.bannerSlotA.imageUrl}
+        alt={banners.bannerSlotA.alt}
+        href={banners.bannerSlotA.href ?? undefined}
+      />
+    )}
+
+    {/* News section */}
+    {(latestNewsArticles.length > 0 || featuredEvent) && (
+      <LatestNews
+        articles={latestNewsArticles}
+        featuredEvent={featuredEvent}
+        title="Laatste nieuws"
+        showViewAll
+        viewAllHref="/news"
+      />
+    )}
+
+    {/* Banner slot B — below news */}
+    {banners.bannerSlotB && (
+      <BannerSlot
+        image={banners.bannerSlotB.imageUrl}
+        alt={banners.bannerSlotB.alt}
+        href={banners.bannerSlotB.href ?? undefined}
+      />
+    )}
+
+    {/* Match slider */}
+    <MatchesSliderSection
+      matches={sliderMatches}
+      highlightTeamId={1235}
+    />
+
+    {/* Youth section */}
+    <YouthSection />
+
+    {/* Banner slot C — below youth */}
+    {banners.bannerSlotC && (
+      <BannerSlot
+        image={banners.bannerSlotC.imageUrl}
+        alt={banners.bannerSlotC.alt}
+        href={banners.bannerSlotC.href ?? undefined}
+      />
+    )}
+
+    {/* Sponsors */}
+    <SponsorsSection />
+  </>
+);
+```
+
+**Step 3: Run type-check and lint**
+
+```bash
+pnpm --filter @kcvv/web lint:fix
+pnpm --filter @kcvv/web type-check
+```
+
+Fix all errors before committing.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/app/page.tsx
+git commit -m "feat(ui): wire homepage v3 — all new blocks, shared match fetch, event stub"
+```
+
+---
+
+### Task 13: Full check + type-check before PR
+
+**Step 1: Run full check**
+
+```bash
+pnpm --filter @kcvv/web check-all
+```
+
+Fix any remaining lint/type/test failures.
+
+**Step 2: Run build to catch Turbopack issues**
+
+```bash
+pnpm turbo build --filter=@kcvv/web
+```
+
+**Step 3: Visual smoke test**
+
+Start dev server and verify each homepage section visually:
+
+```bash
+pnpm --filter @kcvv/web dev
+```
+
+Check:
+
+- Hero carousel loads
+- Match widget shows A-team next match
+- Banner slot A: hidden when no Sanity data (expected in local dev)
+- News section: event card variant if upcoming event exists in Sanity, else first article is featured
+- Banner slot B: hidden
+- Match slider: dark theme, team labels, scrollable
+- Youth section: stats + CTA visible, jersey photo (verify file exists)
+- Banner slot C: hidden
+- Sponsors section: gray-100 bg, logo grid
+- Footer: new layout, contact info, social icons, copyright bar
+
+**Step 4: Final commit if any fixes**
+
+```bash
+git add -p  # stage specific changes only
+git commit -m "fix(ui): homepage v3 smoke test fixes"
+```
+
+---
+
+### Task 14: Push + PR
+
+```bash
+git push -u origin feat/homepage-v3
+```
+
+Then ask the user whether to open a PR.

--- a/docs/plans/2026-03-16-news-cards-image-overlay.md
+++ b/docs/plans/2026-03-16-news-cards-image-overlay.md
@@ -701,7 +701,7 @@ export const LatestNews = ({
 
   return (
     <section className={cn("bg-gray-100 py-20", className)}>
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8">
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
         {/* Section header */}
         <header className="flex items-end justify-between mb-10">
           <h2 className="text-[clamp(1.8rem,4vw,2.8rem)] font-black uppercase tracking-tight leading-none pl-4 border-l-4 border-kcvv-green text-kcvv-black">

--- a/docs/plans/redesign-inspiration.md
+++ b/docs/plans/redesign-inspiration.md
@@ -11,8 +11,11 @@ Living document. Add links, exports, and notes as you collect them.
 
 ## Reference Sites
 
-<!-- Football club sites worth studying -->
-<!-- Format: [Club name](URL) — what's interesting about it -->
+- [Sporting Hasselt](https://www.sportinghasselt.be) — Belgian football club at similar scale. Belgian football UX patterns, regional club identity.
+- [Real Madrid](https://www.realmadrid.com) — Benchmark for football UX, dark/dramatic aesthetic, match widget design.
+- [Inter Miami CF](https://www.intermiamicf.com) — Modern MLS club. Bold graphic identity, diagonal cuts, strong brand color use.
+
+**Key constraint:** KCVV has no professional photographer. Study these sites specifically for how they handle sections without strong photography — graphic/typographic design, solid color sections, pattern overlays, diagonal cuts.
 
 ## Pattern / Motif Notes
 


### PR DESCRIPTION
Closes #802

## Summary

- **MatchTeaser**: optional `teamLabel` badge + dark-theme variant
- **MatchesSlider**: dark-theme reskin, arrows always visible (was `hidden lg:flex`), `teamLabel` passthrough
- **NewsCard**: event card enhancements — Lucide Calendar/Clock icons, countdown chip, external link support
- **BannerSlot**: new presentational component with `next/image` optimisation
- **MatchesSliderSection**: homepage dark-section wrapper with `SectionHeader` + diagonal cuts
- **YouthSection**: homepage block with stats, jersey image, CTA
- **SponsorsSection**: light-section wrapper
- **PageFooter**: redesigned — 3-column grid, brand column, copyright bar
- **Homepage `page.tsx`**: wired with real data (matches, featured event, banners, `teamLabel` mapping)
- **SectionDivider**: added `transform: translateZ(0)` to force GPU rasterisation, eliminating clip-path anti-aliasing hairlines
- **Section transitions**: single-sided divider pattern (no complementary pairs) to prevent double-wedge artifacts; `LatestNews` bottom flipped so diagonal reaches left viewport edge

## Test plan

- [ ] Storybook: `Pages/Homepage` — Default, WithFeaturedEvent, MobileViewport, NoAutoRotation
- [ ] All slider arrows visible on mobile, tablet, desktop
- [ ] No visible hairlines or double-wedge between sections
- [ ] Diagonal reaches both left and right edges at each section boundary
- [ ] 1635 tests passing, build clean (398 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)