### PR TITLE
feat(api): typed KV cache factory + migrate stats handler (#850)

### DIFF
--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { Effect, Layer } from "effect";
-import { KvCacheService, KvCacheLive } from "./kv-cache";
+import { Effect, Layer, Schema as S } from "effect";
+import { KvCacheService, KvCacheLive, TypedKvCache } from "./kv-cache";
 import { WorkerEnvTag } from "../env";
 
 function makeMockKv() {
@@ -30,6 +30,128 @@ function makeEnvLayer(mockKv: ReturnType<typeof makeMockKv>) {
     SEARCH_INDEX: {} as VectorizeIndex,
   });
 }
+
+const TestSchema = S.Struct({ name: S.String, value: S.Number });
+
+describe("TypedKvCache", () => {
+  it("cache miss: calls fetch, caches result, returns value", async () => {
+    const mockKv = makeMockKv();
+    let fetchCalled = false;
+    const fetchEffect = Effect.sync(() => {
+      fetchCalled = true;
+      return { name: "test", value: 42 };
+    });
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "test", value: 42 });
+    expect(fetchCalled).toBe(true);
+    expect(mockKv.put).toHaveBeenCalledWith(
+      "test-key",
+      JSON.stringify({ name: "test", value: 42 }),
+      { expirationTtl: 60 },
+    );
+  });
+
+  it("cache hit with valid data: returns decoded value, fetch not called", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", JSON.stringify({ name: "cached", value: 99 }));
+
+    const fetchEffect = Effect.fail(
+      new Error("fetch should not be called") as never,
+    );
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "cached", value: 99 });
+  });
+
+  it("cache hit with corrupted JSON: logs warning, falls through to fetch", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", "not-valid-json{{{");
+
+    let fetchCalled = false;
+    const fetchEffect = Effect.sync(() => {
+      fetchCalled = true;
+      return { name: "fallback", value: 1 };
+    });
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "fallback", value: 1 });
+    expect(fetchCalled).toBe(true);
+  });
+
+  it("cache hit with stale schema: logs warning, falls through to fetch", async () => {
+    const mockKv = makeMockKv();
+    // Valid JSON but missing required 'value' field
+    mockKv.store.set("test-key", JSON.stringify({ name: "stale" }));
+
+    let fetchCalled = false;
+    const fetchEffect = Effect.sync(() => {
+      fetchCalled = true;
+      return { name: "fresh", value: 42 };
+    });
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "fresh", value: 42 });
+    expect(fetchCalled).toBe(true);
+  });
+
+  it("supports dynamic TTL function based on the fetched value", async () => {
+    const mockKv = makeMockKv();
+    const fetchEffect = Effect.succeed({ name: "test", value: 10 });
+
+    const typedCache = TypedKvCache(TestSchema);
+    await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, (v) => v.value * 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(mockKv.put).toHaveBeenCalledWith(
+      "test-key",
+      JSON.stringify({ name: "test", value: 10 }),
+      { expirationTtl: 600 },
+    );
+  });
+});
 
 describe("KvCacheService", () => {
   it("returns null on a cache miss", async () => {

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, Option, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
 
 /** Per-endpoint TTLs in seconds */
@@ -26,6 +26,40 @@ export class KvCacheService extends Context.Tag("KvCacheService")<
   KvCacheService,
   KvCacheInterface
 >() {}
+
+export const TypedKvCache = <A>(schema: S.Schema<A>) => ({
+  getOrFetch: <E, R>(
+    key: string,
+    fetch: Effect.Effect<A, E, R>,
+    ttl: number | ((value: A) => number),
+  ): Effect.Effect<A, E, R | KvCacheService> =>
+    Effect.gen(function* () {
+      const cache = yield* KvCacheService;
+      const cached = yield* cache.get(key);
+
+      if (cached !== null) {
+        const decoded = yield* Effect.try({
+          try: () => JSON.parse(cached),
+          catch: (e) => new Error(String(e)),
+        }).pipe(
+          Effect.flatMap(S.decodeUnknown(schema)),
+          Effect.tapError((e) =>
+            Effect.logWarning(
+              `TypedKvCache: cache decode failed for key "${key}": ${String(e)}`,
+            ),
+          ),
+          Effect.option,
+        );
+
+        if (Option.isSome(decoded)) return decoded.value;
+      }
+
+      const value = yield* fetch;
+      const resolvedTtl = typeof ttl === "function" ? ttl(value) : ttl;
+      yield* cache.set(key, JSON.stringify(value), resolvedTtl);
+      return value;
+    }),
+});
 
 export const KvCacheLive = Layer.effect(
   KvCacheService,

--- a/apps/api/src/handlers/stats.ts
+++ b/apps/api/src/handlers/stats.ts
@@ -1,4 +1,4 @@
-import { Effect, Option, Schema as S } from "effect";
+import { Effect } from "effect";
 import { HttpApiBuilder } from "@effect/platform";
 import {
   PsdApi,
@@ -9,8 +9,10 @@ import {
   FootbalistoClient,
   type FootbalistoClientError,
 } from "../footbalisto/client";
-import { KvCacheService, TTL } from "../cache/kv-cache";
+import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { transformPsdTeamStats } from "../footbalisto/transforms";
+
+const teamStatsCache = TypedKvCache(TeamStats);
 
 export const getTeamStatsHandler = (
   teamId: number,
@@ -18,26 +20,16 @@ export const getTeamStatsHandler = (
   TeamStatsType,
   FootbalistoClientError,
   FootbalistoClient | KvCacheService
-> =>
-  Effect.gen(function* () {
+> => {
+  const cacheKey = `stats:team:${teamId}`;
+  const fetchStats = Effect.gen(function* () {
     const client = yield* FootbalistoClient;
-    const cache = yield* KvCacheService;
-    const cacheKey = `stats:team:${teamId}`;
-
-    const cached = yield* cache.get(cacheKey);
-    if (cached) {
-      const decoded = yield* Effect.try({
-        try: () => JSON.parse(cached),
-        catch: () => null,
-      }).pipe(Effect.flatMap(S.decodeUnknown(TeamStats)), Effect.option);
-      if (Option.isSome(decoded)) return decoded.value;
-    }
-
     const rawStats = yield* client.getRawTeamStats(teamId);
-    const stats = transformPsdTeamStats(teamId, rawStats);
-    yield* cache.set(cacheKey, JSON.stringify(stats), TTL.STATS);
-    return stats;
+    return transformPsdTeamStats(teamId, rawStats);
   });
+
+  return teamStatsCache.getOrFetch(cacheKey, fetchStats, TTL.STATS);
+};
 
 export const StatsApiLive = HttpApiBuilder.group(PsdApi, "stats", (handlers) =>
   handlers.handle("getTeamStats", ({ path: { teamId } }) =>


### PR DESCRIPTION
Closes #850

## What changed
- Added `TypedKvCache<A>` factory to `apps/api/src/cache/kv-cache.ts` — owns the full cache read/write contract (JSON.parse → schema decode → fallthrough to fetch)
- Stale/corrupt cache hits log a warning via `Effect.logWarning` (observable, not silent)
- Migrated `getTeamStatsHandler` in `stats.ts` as the tracer bullet — inline 7-line decode pattern removed
- 5 new boundary tests in `kv-cache.test.ts` covering: cache miss, valid hit, corrupted JSON, stale schema, dynamic TTL

## Testing
- `pnpm --filter @kcvv/api test` — 73 tests pass (68 existing + 5 new)
- `pnpm --filter @kcvv/api type-check` — passes
- Pre-commit hooks pass (prettier + turbo type-check)