### PR TITLE
refactor(api): migrate remaining 4 handlers to TypedKvCache (#851)

### DIFF
--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -27,7 +27,7 @@ export class KvCacheService extends Context.Tag("KvCacheService")<
   KvCacheInterface
 >() {}
 
-export const TypedKvCache = <A>(schema: S.Schema<A>) => ({
+export const TypedKvCache = <A>(schema: S.Schema<A, any>) => ({
   getOrFetch: <E, R>(
     key: string,
     fetch: Effect.Effect<A, E, R>,

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -1,4 +1,4 @@
-import { Effect, Option, Schema as S } from "effect";
+import { Effect } from "effect";
 import { HttpApiBuilder } from "@effect/platform";
 import {
   PsdApi,
@@ -10,12 +10,15 @@ import {
   FootbalistoClient,
   type FootbalistoClientError,
 } from "../footbalisto/client";
-import { KvCacheService, TTL } from "../cache/kv-cache";
+import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import {
   transformPsdGame,
   transformFootbalistoMatchDetail,
   matchDetailToMatch,
 } from "../footbalisto/transforms";
+
+const matchesCache = TypedKvCache(MatchesArray);
+const matchDetailCache = TypedKvCache(MatchDetail);
 
 export const getMatchesByTeamHandler = (
   teamId: number,
@@ -23,54 +26,32 @@ export const getMatchesByTeamHandler = (
   readonly Match[],
   FootbalistoClientError,
   FootbalistoClient | KvCacheService
-> =>
-  Effect.gen(function* () {
+> => {
+  const cacheKey = `matches:team:${teamId}`;
+  const fetchMatches = Effect.gen(function* () {
     const client = yield* FootbalistoClient;
-    const cache = yield* KvCacheService;
-    const cacheKey = `matches:team:${teamId}`;
-
-    const cached = yield* cache.get(cacheKey);
-    if (cached) {
-      const decoded = yield* Effect.try({
-        try: () => JSON.parse(cached),
-        catch: () => null,
-      }).pipe(Effect.flatMap(S.decodeUnknown(MatchesArray)), Effect.option);
-      if (Option.isSome(decoded)) return decoded.value;
-    }
-
     const rawMatches = yield* client.getRawMatches(teamId);
-    const matches = rawMatches.map(transformPsdGame);
-    yield* cache.set(cacheKey, JSON.stringify(matches), TTL.MATCHES_TEAM);
-    return matches;
+    return rawMatches.map(transformPsdGame);
   });
+
+  return matchesCache.getOrFetch(cacheKey, fetchMatches, TTL.MATCHES_TEAM);
+};
 
 export const getNextMatchesHandler = (): Effect.Effect<
   readonly Match[],
   FootbalistoClientError,
   FootbalistoClient | KvCacheService
-> =>
-  Effect.gen(function* () {
+> => {
+  const cacheKey = "matches:next";
+  const fetchMatches = Effect.gen(function* () {
     const client = yield* FootbalistoClient;
-    const cache = yield* KvCacheService;
-    const cacheKey = "matches:next";
-
-    const cached = yield* cache.get(cacheKey);
-    if (cached) {
-      const decoded = yield* Effect.try({
-        try: () => JSON.parse(cached),
-        catch: () => null,
-      }).pipe(Effect.flatMap(S.decodeUnknown(MatchesArray)), Effect.option);
-      if (Option.isSome(decoded)) return decoded.value;
-    }
-
     const rawMatches = yield* client.getRawNextMatches();
     // Filter out Weitse Gans (teamId 23) — not KCVV but plays on KCVV pitch
-    const matches = rawMatches
-      .filter((m) => m.teamId !== 23)
-      .map(transformPsdGame);
-    yield* cache.set(cacheKey, JSON.stringify(matches), TTL.NEXT_MATCHES);
-    return matches;
+    return rawMatches.filter((m) => m.teamId !== 23).map(transformPsdGame);
   });
+
+  return matchesCache.getOrFetch(cacheKey, fetchMatches, TTL.NEXT_MATCHES);
+};
 
 export const getMatchByIdHandler = (
   matchId: number,
@@ -87,32 +68,22 @@ export const getMatchDetailHandler = (
   MatchDetail,
   FootbalistoClientError,
   FootbalistoClient | KvCacheService
-> =>
-  Effect.gen(function* () {
+> => {
+  const cacheKey = `match:detail:${matchId}`;
+  const fetchDetail = Effect.gen(function* () {
     const client = yield* FootbalistoClient;
-    const cache = yield* KvCacheService;
-    const cacheKey = `match:detail:${matchId}`;
-
-    const cached = yield* cache.get(cacheKey);
-    if (cached) {
-      const decoded = yield* Effect.try({
-        try: () => JSON.parse(cached),
-        catch: () => null,
-      }).pipe(Effect.flatMap(S.decodeUnknown(MatchDetail)), Effect.option);
-      if (Option.isSome(decoded)) return decoded.value;
-    }
-
     const rawDetail = yield* client.getRawMatchDetail(matchId);
-    const detail = transformFootbalistoMatchDetail(rawDetail);
-    // Finished and forfeited matches are immutable — cache 7 days.
-    // Postponed/stopped may be rescheduled; scheduled = upcoming. Cache 60s.
-    const ttl =
-      detail.status === "finished" || detail.status === "forfeited"
-        ? TTL.MATCH_DETAIL_PAST
-        : TTL.MATCH_DETAIL_LIVE;
-    yield* cache.set(cacheKey, JSON.stringify(detail), ttl);
-    return detail;
+    return transformFootbalistoMatchDetail(rawDetail);
   });
+
+  // Finished and forfeited matches are immutable — cache 7 days.
+  // Postponed/stopped may be rescheduled; scheduled = upcoming. Cache 60s.
+  return matchDetailCache.getOrFetch(cacheKey, fetchDetail, (detail) =>
+    detail.status === "finished" || detail.status === "forfeited"
+      ? TTL.MATCH_DETAIL_PAST
+      : TTL.MATCH_DETAIL_LIVE,
+  );
+};
 
 export const MatchesApiLive = HttpApiBuilder.group(
   PsdApi,

--- a/apps/api/src/handlers/ranking.ts
+++ b/apps/api/src/handlers/ranking.ts
@@ -1,13 +1,15 @@
-import { Effect, Option, Schema as S } from "effect";
+import { Effect } from "effect";
 import { HttpApiBuilder } from "@effect/platform";
 import { PsdApi, RankingArray, type RankingEntry } from "@kcvv/api-contract";
 import {
   FootbalistoClient,
   type FootbalistoClientError,
 } from "../footbalisto/client";
-import { KvCacheService, TTL } from "../cache/kv-cache";
+import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
 import { transformFootbalistoRankingEntry } from "../footbalisto/transforms";
+
+const rankingCache = TypedKvCache(RankingArray);
 
 export const getRankingHandler = (
   teamId: number,
@@ -16,21 +18,10 @@ export const getRankingHandler = (
   readonly RankingEntry[],
   FootbalistoClientError,
   FootbalistoClient | KvCacheService
-> =>
-  Effect.gen(function* () {
+> => {
+  const cacheKey = `ranking:team:${teamId}`;
+  const fetchRanking = Effect.gen(function* () {
     const client = yield* FootbalistoClient;
-    const cache = yield* KvCacheService;
-    const cacheKey = `ranking:team:${teamId}`;
-
-    const cached = yield* cache.get(cacheKey);
-    if (cached) {
-      const decoded = yield* Effect.try({
-        try: () => JSON.parse(cached),
-        catch: () => null,
-      }).pipe(Effect.flatMap(S.decodeUnknown(RankingArray)), Effect.option);
-      if (Option.isSome(decoded)) return decoded.value;
-    }
-
     const competitions = yield* client.getRawRanking(teamId);
 
     const competition =
@@ -45,12 +36,13 @@ export const getRankingHandler = (
       return [] as readonly RankingEntry[];
     }
 
-    const ranking = competition.teams.map((e) =>
+    return competition.teams.map((e) =>
       transformFootbalistoRankingEntry(e, logoCdnUrl),
     );
-    yield* cache.set(cacheKey, JSON.stringify(ranking), TTL.RANKING);
-    return ranking;
   });
+
+  return rankingCache.getOrFetch(cacheKey, fetchRanking, TTL.RANKING);
+};
 
 export const RankingApiLive = HttpApiBuilder.group(
   PsdApi,


### PR DESCRIPTION
Closes #851

## What changed

- Migrated `getMatchesByTeamHandler`, `getNextMatchesHandler`, `getMatchDetailHandler`, and `getRankingHandler` to use `typedCache.getOrFetch` — removing all inline `JSON.parse` / `S.decodeUnknown` / `Effect.option` patterns from handler files
- `getMatchDetailHandler` uses the conditional TTL callback: `(detail) => detail.status === "finished" || detail.status === "forfeited" ? TTL.MATCH_DETAIL_PAST : TTL.MATCH_DETAIL_LIVE`
- Fixed `TypedKvCache` signature from `S.Schema<A>` to `S.Schema<A, any>` so TypeScript correctly infers `A` as the decoded Type when schemas have transformation fields (e.g. `DateFromStringOrDate` where Type=`Date`, Encoded=`string|Date`)

## Testing

- All 73 tests pass: `pnpm --filter @kcvv/api test`
- Type-check passes: `pnpm --filter @kcvv/api type-check`
- All existing handler tests pass unchanged