### PR TITLE
refactor(api): migrate ranking handler to FootbalistoService (#857)

### DIFF
--- a/apps/api/src/footbalisto/service.test.ts
+++ b/apps/api/src/footbalisto/service.test.ts
@@ -374,6 +374,146 @@ describe("FootbalistoService.getMatchById", () => {
   });
 });
 
+const rawRankingCompetitions = [
+  {
+    name: "Beker van Brabant",
+    type: "CUP",
+    teams: [
+      {
+        id: 1,
+        rank: 1,
+        matchesPlayed: 3,
+        wins: 2,
+        draws: 1,
+        losses: 0,
+        goalsScored: 5,
+        goalsConceded: 2,
+        points: 7,
+        team: {
+          id: 10,
+          club: { id: 100, localName: "Cup Team", name: "Cup Team" },
+        },
+      },
+    ],
+  },
+  {
+    name: "3de Nationale",
+    type: "LEAGUE",
+    teams: [
+      {
+        id: 2,
+        rank: 1,
+        matchesPlayed: 20,
+        wins: 15,
+        draws: 3,
+        losses: 2,
+        goalsScored: 45,
+        goalsConceded: 12,
+        points: 48,
+        team: {
+          id: 20,
+          club: { id: 200, localName: "KCVV Elewijt", name: "KCVV" },
+        },
+      },
+      {
+        id: 3,
+        rank: 2,
+        matchesPlayed: 20,
+        wins: 12,
+        draws: 4,
+        losses: 4,
+        goalsScored: 38,
+        goalsConceded: 18,
+        points: 40,
+        team: {
+          id: 30,
+          club: { id: 300, localName: "Rival FC", name: "Rival" },
+        },
+      },
+    ],
+  },
+];
+
+describe("FootbalistoService.getRanking", () => {
+  it("prefers non-CUP, non-FRIENDLY competition and returns transformed RankingEntry[]", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => rawRankingCompetitions,
+    });
+
+    const result = await runService((svc) =>
+      svc.getRanking(1, "https://cdn.example.com"),
+    );
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right).toHaveLength(2);
+      expect(result.right[0]?.team_name).toBe("KCVV Elewijt");
+      expect(result.right[0]?.position).toBe(1);
+      expect(result.right[0]?.points).toBe(48);
+      expect(result.right[0]?.team_logo).toBe(
+        "https://cdn.example.com/extra_groot/200.png",
+      );
+    }
+  });
+  it("falls back to CUP competition when no LEAGUE/other exists", async () => {
+    const cupOnly = [
+      {
+        name: "Beker van Brabant",
+        type: "CUP",
+        teams: [
+          {
+            id: 1,
+            rank: 1,
+            matchesPlayed: 3,
+            wins: 2,
+            draws: 1,
+            losses: 0,
+            goalsScored: 5,
+            goalsConceded: 2,
+            points: 7,
+            team: {
+              id: 10,
+              club: { id: 100, localName: "Cup Team", name: "Cup Team" },
+            },
+          },
+        ],
+      },
+    ];
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => cupOnly,
+    });
+
+    const result = await runService((svc) =>
+      svc.getRanking(1, "https://cdn.example.com"),
+    );
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right).toHaveLength(1);
+      expect(result.right[0]?.team_name).toBe("Cup Team");
+    }
+  });
+
+  it("returns empty array when no competitions have teams", async () => {
+    const noTeams = [{ name: "Empty League", type: "LEAGUE", teams: [] }];
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => noTeams,
+    });
+
+    const result = await runService((svc) =>
+      svc.getRanking(1, "https://cdn.example.com"),
+    );
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right).toHaveLength(0);
+    }
+  });
+});
+
 describe("FootbalistoService.getMatchDetail", () => {
   it("returns normalized MatchDetail from mocked HTTP response", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({

--- a/apps/api/src/footbalisto/service.ts
+++ b/apps/api/src/footbalisto/service.ts
@@ -6,6 +6,7 @@ import {
   type TeamStats as TeamStatsType,
   type Match,
   type MatchDetail,
+  type RankingEntry,
   PsdTeamsArray,
 } from "@kcvv/api-contract";
 import {
@@ -14,6 +15,7 @@ import {
   PsdTeamStatsResponse,
   PsdMatchListSchema,
   FootbalistoMatchDetailResponse,
+  FootbalistoRankingArray,
   type PsdGame,
 } from "./schemas";
 import {
@@ -21,6 +23,7 @@ import {
   transformPsdGame,
   transformFootbalistoMatchDetail,
   matchDetailToMatch,
+  transformFootbalistoRankingEntry,
 } from "./transforms";
 
 export class FootbalistoServiceError extends Error {
@@ -52,6 +55,10 @@ export interface FootbalistoServiceInterface {
   readonly getMatchDetail: (
     matchId: number,
   ) => Effect.Effect<MatchDetail, FootbalistoServiceError>;
+  readonly getRanking: (
+    teamId: number,
+    logoCdnUrl: string,
+  ) => Effect.Effect<readonly RankingEntry[], FootbalistoServiceError>;
 }
 
 export class FootbalistoService extends Context.Tag("FootbalistoService")<
@@ -256,6 +263,30 @@ export const FootbalistoServiceLive = Layer.effect(
         fetchRawMatchDetail(matchId).pipe(
           Effect.map(transformFootbalistoMatchDetail),
         ),
+
+      getRanking: (teamId: number, logoCdnUrl: string) =>
+        Effect.gen(function* () {
+          const competitions = yield* countedFetch(
+            `${base}/teams/${teamId}/ranking`,
+            FootbalistoRankingArray,
+          );
+
+          const competition =
+            competitions.find(
+              (c) =>
+                c.teams.length > 0 &&
+                c.type.toUpperCase() !== "CUP" &&
+                c.type.toUpperCase() !== "FRIENDLY",
+            ) ?? competitions.find((c) => c.teams.length > 0);
+
+          if (!competition || competition.teams.length === 0) {
+            return [] as readonly RankingEntry[];
+          }
+
+          return competition.teams.map((e) =>
+            transformFootbalistoRankingEntry(e, logoCdnUrl),
+          );
+        }),
     };
   }),
 );

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -54,6 +54,7 @@ function makeServiceMock(): FootbalistoServiceInterface {
     getNextMatches: () => Effect.succeed([baseMatch]),
     getMatchById: (_matchId) => Effect.succeed({ ...baseMatch, id: 99 }),
     getMatchDetail: (_matchId) => Effect.succeed(baseDetail),
+    getRanking: () => Effect.die("not needed"),
   };
 }
 

--- a/apps/api/src/handlers/ranking.test.ts
+++ b/apps/api/src/handlers/ranking.test.ts
@@ -2,48 +2,40 @@ import { describe, it, expect } from "vitest";
 import { Effect, Layer } from "effect";
 import { getRankingHandler } from "./ranking";
 import {
-  FootbalistoClient,
-  type FootbalistoClientInterface,
-} from "../footbalisto/client";
+  FootbalistoService,
+  type FootbalistoServiceInterface,
+} from "../footbalisto/service";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
+import type { RankingEntry } from "@kcvv/api-contract";
 
-const rawCompetitions = [
+const rankingEntries: readonly RankingEntry[] = [
   {
-    name: "3de Nationale A",
-    type: "LEAGUE",
-    teams: [
-      {
-        id: 1,
-        rank: 1,
-        matchesPlayed: 20,
-        wins: 15,
-        draws: 3,
-        losses: 2,
-        goalsScored: 45,
-        goalsConceded: 20,
-        points: 48,
-        team: {
-          id: 101,
-          club: { id: 123, localName: "KCVV Elewijt", name: "KCVV Elewijt" },
-        },
-      },
-    ],
+    position: 1,
+    team_id: 101,
+    team_name: "KCVV Elewijt",
+    team_logo: "https://cdn.example.com/extra_groot/123.png",
+    played: 20,
+    won: 15,
+    drawn: 3,
+    lost: 2,
+    goals_for: 45,
+    goals_against: 20,
+    goal_difference: 25,
+    points: 48,
+    form: undefined,
   },
-  { name: "Beker", type: "CUP", teams: [] }, // should be skipped
 ];
 
-function makeClientMock(
-  overrides: Partial<FootbalistoClientInterface> = {},
-): FootbalistoClientInterface {
+function makeServiceMock(
+  overrides: Partial<FootbalistoServiceInterface> = {},
+): FootbalistoServiceInterface {
   return {
-    getRawMatches: () => Effect.succeed([]),
-    getRawNextMatches: () => Effect.succeed([]),
-    getRawMatchDetail: () => Effect.fail(new Error("not needed") as never),
-    getRawRanking: () => Effect.succeed(rawCompetitions),
-    getRawTeamStats: () => Effect.fail(new Error("not needed") as never),
-    getRawTeams: () => Effect.succeed([]),
-    getRawMembers: () => Effect.succeed([]),
-    getRawStaff: () => Effect.succeed([]),
+    getTeamStats: () => Effect.fail(new Error("not needed") as never),
+    getTeamMatches: () => Effect.fail(new Error("not needed") as never),
+    getNextMatches: () => Effect.fail(new Error("not needed") as never),
+    getMatchById: () => Effect.fail(new Error("not needed") as never),
+    getMatchDetail: () => Effect.fail(new Error("not needed") as never),
+    getRanking: () => Effect.succeed(rankingEntries),
     ...overrides,
   };
 }
@@ -55,10 +47,10 @@ const cacheMock: KvCacheInterface = {
 };
 
 describe("getRankingHandler", () => {
-  it("returns ranking from first non-CUP/FRIENDLY competition", async () => {
+  it("yields FootbalistoService and returns ranking entries", async () => {
     const result = await Effect.runPromise(
       getRankingHandler(1, "https://cdn.example.com").pipe(
-        Effect.provide(Layer.succeed(FootbalistoClient, makeClientMock())),
+        Effect.provide(Layer.succeed(FootbalistoService, makeServiceMock())),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
       ),
     );
@@ -67,15 +59,14 @@ describe("getRankingHandler", () => {
     expect(result[0]?.points).toBe(48);
   });
 
-  it("returns empty array when no competition has teams", async () => {
+  it("returns empty array when service returns empty", async () => {
     const result = await Effect.runPromise(
       getRankingHandler(1, "https://cdn.example.com").pipe(
         Effect.provide(
           Layer.succeed(
-            FootbalistoClient,
-            makeClientMock({
-              getRawRanking: () =>
-                Effect.succeed([{ name: "Cup", type: "CUP", teams: [] }]),
+            FootbalistoService,
+            makeServiceMock({
+              getRanking: () => Effect.succeed([]),
             }),
           ),
         ),

--- a/apps/api/src/handlers/ranking.ts
+++ b/apps/api/src/handlers/ranking.ts
@@ -2,12 +2,11 @@ import { Effect } from "effect";
 import { HttpApiBuilder } from "@effect/platform";
 import { PsdApi, RankingArray, type RankingEntry } from "@kcvv/api-contract";
 import {
-  FootbalistoClient,
-  type FootbalistoClientError,
-} from "../footbalisto/client";
+  FootbalistoService,
+  type FootbalistoServiceError,
+} from "../footbalisto/service";
 import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
-import { transformFootbalistoRankingEntry } from "../footbalisto/transforms";
 
 const rankingCache = TypedKvCache(RankingArray);
 
@@ -16,29 +15,13 @@ export const getRankingHandler = (
   logoCdnUrl: string,
 ): Effect.Effect<
   readonly RankingEntry[],
-  FootbalistoClientError,
-  FootbalistoClient | KvCacheService
+  FootbalistoServiceError,
+  FootbalistoService | KvCacheService
 > => {
   const cacheKey = `ranking:team:${teamId}`;
   const fetchRanking = Effect.gen(function* () {
-    const client = yield* FootbalistoClient;
-    const competitions = yield* client.getRawRanking(teamId);
-
-    const competition =
-      competitions.find(
-        (c) =>
-          c.teams.length > 0 &&
-          c.type.toUpperCase() !== "CUP" &&
-          c.type.toUpperCase() !== "FRIENDLY",
-      ) ?? competitions.find((c) => c.teams.length > 0);
-
-    if (!competition || competition.teams.length === 0) {
-      return [] as readonly RankingEntry[];
-    }
-
-    return competition.teams.map((e) =>
-      transformFootbalistoRankingEntry(e, logoCdnUrl),
-    );
+    const service = yield* FootbalistoService;
+    return yield* service.getRanking(teamId, logoCdnUrl);
   });
 
   return rankingCache.getOrFetch(cacheKey, fetchRanking, TTL.RANKING);

--- a/apps/api/src/handlers/stats.test.ts
+++ b/apps/api/src/handlers/stats.test.ts
@@ -25,6 +25,7 @@ const mockServiceImpl: FootbalistoServiceInterface = {
   getNextMatches: () => Effect.die("not needed"),
   getMatchById: () => Effect.die("not needed"),
   getMatchDetail: () => Effect.die("not needed"),
+  getRanking: () => Effect.die("not needed"),
 };
 
 const cacheMock: KvCacheInterface = {


### PR DESCRIPTION
Closes #857

## What changed
- Added `getRanking(teamId, logoCdnUrl)` to `FootbalistoService` — absorbs HTTP fetch, schema decode, competition selection logic, and ranking transform
- Competition selection logic (prefer non-CUP/non-FRIENDLY; fallback to any with teams) moved from handler into service
- `ranking.ts` handler now yields only `FootbalistoService` + `KvCacheService`

## Testing
- 3 new boundary tests in `service.test.ts`: prefer league, fallback to CUP, empty when no teams
- Handler tests updated to mock `FootbalistoService` instead of `FootbalistoClient`
- All 85 tests pass, type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)