### PR TITLE
perf(api): increase NEXT_MATCHES TTL from 30min to 4h (#877)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -63,7 +63,7 @@ All cache keys use `KvCacheService`. TTLs are defined in `cache/kv-cache.ts`:
 | ----------------------- | ------------------------------- |
 | `psd:current-season-id` | 24 h                            |
 | `matches:team:{id}`     | 6 h                             |
-| `matches:next`          | 30 min                          |
+| `matches:next`          | 4 h                             |
 | `match:detail:{id}`     | 60 s (live) / 7 days (finished) |
 | `ranking:team:{id}`     | 4 h                             |
 | `stats:team:{id}`       | 12 h                            |

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { Effect, Layer, Schema as S } from "effect";
-import { KvCacheService, KvCacheLive, TypedKvCache } from "./kv-cache";
+import { KvCacheService, KvCacheLive, TypedKvCache, TTL } from "./kv-cache";
 import { WorkerEnvTag } from "../env";
 
 function makeMockKv() {
@@ -32,6 +32,12 @@ function makeEnvLayer(mockKv: ReturnType<typeof makeMockKv>) {
 }
 
 const TestSchema = S.Struct({ name: S.String, value: S.Number });
+
+describe("TTL constants", () => {
+  it("NEXT_MATCHES is 4 hours", () => {
+    expect(TTL.NEXT_MATCHES).toBe(60 * 60 * 4);
+  });
+});
 
 describe("TypedKvCache", () => {
   it("cache miss: calls fetch, caches result, returns value", async () => {

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -4,7 +4,7 @@ import { WorkerEnvTag } from "../env";
 /** Per-endpoint TTLs in seconds */
 export const TTL = {
   MATCHES_TEAM: 60 * 60 * 6, // 6 hours — season schedule rarely changes mid-week
-  NEXT_MATCHES: 60 * 30, // 30 minutes — home page widget; was 5 min (too aggressive)
+  NEXT_MATCHES: 60 * 60 * 4, // 4 hours — no live scores, schedule is stable for hours
   MATCH_DETAIL_PAST: 60 * 60 * 24 * 7, // 7 days — historical, never changes
   MATCH_DETAIL_LIVE: 60, // 60 seconds — live match updates
   RANKING: 60 * 60 * 4, // 4 hours — updates only after a match day


### PR DESCRIPTION
Closes #877

## What changed
- `TTL.NEXT_MATCHES` changed from `60 * 30` (30 min) to `60 * 60 * 4` (4 h) in `cache/kv-cache.ts`
- Added test asserting the new TTL value
- Updated cache TTL table in `apps/api/CLAUDE.md`

## Testing
- All checks pass: `pnpm --filter @kcvv/api test` (66 tests), `pnpm --filter @kcvv/api type-check`
- After deploy: verify KV key `matches:next` stored with 4h TTL via Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)