### PR TITLE
perf(api): increase MATCHES_TEAM, RANKING, STATS TTLs to 24h + fix MATCH_DETAIL logic (#878)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -59,15 +59,15 @@ wrangler secret put PSD_API_CLUB --env staging
 
 All cache keys use `KvCacheService`. TTLs are defined in `cache/kv-cache.ts`:
 
-| Key pattern             | TTL                             |
-| ----------------------- | ------------------------------- |
-| `psd:current-season-id` | 24 h                            |
-| `matches:team:{id}`     | 6 h                             |
-| `matches:next`          | 4 h                             |
-| `match:detail:{id}`     | 60 s (live) / 7 days (finished) |
-| `ranking:team:{id}`     | 4 h                             |
-| `stats:team:{id}`       | 12 h                            |
-| `psd:calls:YYYY-MM-DD`  | 48 h (daily PSD call counter)   |
+| Key pattern             | TTL                                                 |
+| ----------------------- | --------------------------------------------------- |
+| `psd:current-season-id` | 24 h                                                |
+| `matches:team:{id}`     | 24 h                                                |
+| `matches:next`          | 4 h                                                 |
+| `match:detail:{id}`     | 7 days (finished ≥48h ago) / 24 h (all other cases) |
+| `ranking:team:{id}`     | 24 h                                                |
+| `stats:team:{id}`       | 24 h                                                |
+| `psd:calls:YYYY-MM-DD`  | 48 h (daily PSD call counter)                       |
 
 ## Rules
 

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -37,6 +37,30 @@ describe("TTL constants", () => {
   it("NEXT_MATCHES is 4 hours", () => {
     expect(TTL.NEXT_MATCHES).toBe(60 * 60 * 4);
   });
+
+  it("MATCHES_TEAM is 24 hours", () => {
+    expect(TTL.MATCHES_TEAM).toBe(60 * 60 * 24);
+  });
+
+  it("RANKING is 24 hours", () => {
+    expect(TTL.RANKING).toBe(60 * 60 * 24);
+  });
+
+  it("STATS is 24 hours", () => {
+    expect(TTL.STATS).toBe(60 * 60 * 24);
+  });
+
+  it("MATCH_DETAIL_LIVE does not exist", () => {
+    expect("MATCH_DETAIL_LIVE" in TTL).toBe(false);
+  });
+
+  it("MATCH_DETAIL_DEFAULT is 24 hours", () => {
+    expect(TTL.MATCH_DETAIL_DEFAULT).toBe(60 * 60 * 24);
+  });
+
+  it("MATCH_DETAIL_PAST is 7 days (unchanged)", () => {
+    expect(TTL.MATCH_DETAIL_PAST).toBe(60 * 60 * 24 * 7);
+  });
 });
 
 describe("TypedKvCache", () => {

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -3,12 +3,12 @@ import { WorkerEnvTag } from "../env";
 
 /** Per-endpoint TTLs in seconds */
 export const TTL = {
-  MATCHES_TEAM: 60 * 60 * 6, // 6 hours — season schedule rarely changes mid-week
+  MATCHES_TEAM: 60 * 60 * 24, // 24 hours — season schedule rarely changes mid-week
   NEXT_MATCHES: 60 * 60 * 4, // 4 hours — no live scores, schedule is stable for hours
   MATCH_DETAIL_PAST: 60 * 60 * 24 * 7, // 7 days — historical, never changes
-  MATCH_DETAIL_LIVE: 60, // 60 seconds — live match updates
-  RANKING: 60 * 60 * 4, // 4 hours — updates only after a match day
-  STATS: 60 * 60 * 12, // 12 hours — season stats updated weekly at most
+  MATCH_DETAIL_DEFAULT: 60 * 60 * 24, // 24 hours — upcoming/recent matches
+  RANKING: 60 * 60 * 24, // 24 hours — updates only after a match day
+  STATS: 60 * 60 * 24, // 24 hours — season stats updated weekly at most
 } as const;
 
 export interface KvCacheInterface {

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -104,12 +104,19 @@ describe("getMatchDetailHandler", () => {
     expect(result.hasReport).toBe(true);
   });
 
-  it("uses MATCH_DETAIL_PAST TTL for finished matches", async () => {
+  it("uses MATCH_DETAIL_PAST TTL for finished matches ≥48h ago", async () => {
     const setCalls: Array<[string, string, number]> = [];
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
 
     await Effect.runPromise(
       getMatchDetailHandler(99).pipe(
-        Effect.provide(Layer.succeed(FootbalistoService, makeServiceMock())),
+        Effect.provide(
+          Layer.succeed(FootbalistoService, {
+            ...makeServiceMock(),
+            getMatchDetail: () =>
+              Effect.succeed({ ...baseDetail, date: threeDaysAgo }),
+          }),
+        ),
         Effect.provide(
           Layer.succeed(KvCacheService, {
             get: () => Effect.succeed(null),
@@ -130,7 +137,40 @@ describe("getMatchDetailHandler", () => {
     expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_PAST);
   });
 
-  it("uses MATCH_DETAIL_LIVE TTL for scheduled matches", async () => {
+  it("uses MATCH_DETAIL_DEFAULT TTL for finished matches <48h ago", async () => {
+    const setCalls: Array<[string, string, number]> = [];
+    const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
+
+    await Effect.runPromise(
+      getMatchDetailHandler(99).pipe(
+        Effect.provide(
+          Layer.succeed(FootbalistoService, {
+            ...makeServiceMock(),
+            getMatchDetail: () =>
+              Effect.succeed({ ...baseDetail, date: oneDayAgo }),
+          }),
+        ),
+        Effect.provide(
+          Layer.succeed(KvCacheService, {
+            get: () => Effect.succeed(null),
+            increment: () => Effect.succeed(undefined),
+            set: vi.fn((key, value, ttl) => {
+              setCalls.push([key, value, ttl]);
+              return Effect.succeed(undefined);
+            }),
+          }),
+        ),
+        Effect.orDie,
+      ),
+    );
+
+    const detailCall = setCalls.find(([key]) =>
+      key.startsWith("match:detail:"),
+    );
+    expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_DEFAULT);
+  });
+
+  it("uses MATCH_DETAIL_DEFAULT TTL for scheduled matches", async () => {
     const setCalls: Array<[string, string, number]> = [];
 
     await Effect.runPromise(
@@ -158,7 +198,7 @@ describe("getMatchDetailHandler", () => {
     const detailCall = setCalls.find(([key]) =>
       key.startsWith("match:detail:"),
     );
-    expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_LIVE);
+    expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_DEFAULT);
   });
 });
 

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -66,13 +66,17 @@ export const getMatchDetailHandler = (
     return yield* service.getMatchDetail(matchId);
   });
 
-  // Finished and forfeited matches are immutable — cache 7 days.
-  // Postponed/stopped may be rescheduled; scheduled = upcoming. Cache 60s.
-  return matchDetailCache.getOrFetch(cacheKey, fetchDetail, (detail) =>
-    detail.status === "finished" || detail.status === "forfeited"
+  // Finished ≥48h ago → 7 days (immutable). All other cases → 24h.
+  const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
+  return matchDetailCache.getOrFetch(cacheKey, fetchDetail, (detail) => {
+    const isFinished =
+      detail.status === "finished" || detail.status === "forfeited";
+    const isOldEnough =
+      Date.now() - new Date(detail.date).getTime() >= FORTY_EIGHT_HOURS_MS;
+    return isFinished && isOldEnough
       ? TTL.MATCH_DETAIL_PAST
-      : TTL.MATCH_DETAIL_LIVE,
-  );
+      : TTL.MATCH_DETAIL_DEFAULT;
+  });
 };
 
 export const MatchesApiLive = HttpApiBuilder.group(


### PR DESCRIPTION
Closes #878

## What changed
- `TTL.MATCHES_TEAM` 6h → 24h, `TTL.RANKING` 4h → 24h, `TTL.STATS` 12h → 24h
- Removed `TTL.MATCH_DETAIL_LIVE` (60s) — no live scores exist
- Added `TTL.MATCH_DETAIL_DEFAULT` (24h) and time-based rule: finished ≥48h ago → 7 days; else → 24h
- Updated TTL table in `apps/api/CLAUDE.md`

## Testing
- All checks pass: `pnpm --filter @kcvv/api type-check` + `pnpm --filter @kcvv/api test` (73/73)
- New tests: TTL constant assertions, match detail TTL for finished ≥48h, finished <48h, and scheduled

🤖 Generated with [Claude Code](https://claude.com/claude-code)