### PR TITLE
feat(api): stale-on-error — serve expired cache data on PSD 429/500 (#879)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -57,17 +57,22 @@ wrangler secret put PSD_API_CLUB --env staging
 
 ## Cache
 
-All cache keys use `KvCacheService`. TTLs are defined in `cache/kv-cache.ts`:
+`TypedKvCache` uses a two-TTL pattern (stale-on-error):
 
-| Key pattern             | TTL                                                 |
-| ----------------------- | --------------------------------------------------- |
-| `psd:current-season-id` | 24 h                                                |
-| `matches:team:{id}`     | 24 h                                                |
-| `matches:next`          | 4 h                                                 |
-| `match:detail:{id}`     | 7 days (finished ≥48h ago) / 24 h (all other cases) |
-| `ranking:team:{id}`     | 24 h                                                |
-| `stats:team:{id}`       | 24 h                                                |
-| `psd:calls:YYYY-MM-DD`  | 48 h (daily PSD call counter)                       |
+- **softTtl** — freshness threshold. If cached data is younger than softTtl, return it immediately.
+- **hardTtl** — KV storage TTL (default 7 days). If cached data is older than softTtl but younger than hardTtl, attempt refresh; on failure, serve stale data with a warning log.
+
+Values are stored as `{ value, fetchedAt }` wrappers. On deploy, existing cache entries without the wrapper trigger a one-time cold start.
+
+| Key pattern             | softTtl                                             | hardTtl |
+| ----------------------- | --------------------------------------------------- | ------- |
+| `psd:current-season-id` | 24 h                                                | 7 days  |
+| `matches:team:{id}`     | 24 h                                                | 7 days  |
+| `matches:next`          | 4 h                                                 | 7 days  |
+| `match:detail:{id}`     | 7 days (finished ≥48h ago) / 24 h (all other cases) | 7 days  |
+| `ranking:team:{id}`     | 24 h                                                | 7 days  |
+| `stats:team:{id}`       | 24 h                                                | 7 days  |
+| `psd:calls:YYYY-MM-DD`  | 48 h (daily PSD call counter, not via TypedKvCache) | —       |
 
 ## Rules
 

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { Effect, Layer, Schema as S } from "effect";
-import { KvCacheService, KvCacheLive, TypedKvCache, TTL } from "./kv-cache";
+import {
+  KvCacheService,
+  KvCacheLive,
+  TypedKvCache,
+  TTL,
+  HARD_TTL_DEFAULT,
+} from "./kv-cache";
 import { WorkerEnvTag } from "../env";
 
 function makeMockKv() {
@@ -33,6 +39,11 @@ function makeEnvLayer(mockKv: ReturnType<typeof makeMockKv>) {
 
 const TestSchema = S.Struct({ name: S.String, value: S.Number });
 
+/** Helper to create a cached wrapper entry */
+function makeWrapper(value: unknown, ageMs: number) {
+  return JSON.stringify({ value, fetchedAt: Date.now() - ageMs });
+}
+
 describe("TTL constants", () => {
   it("NEXT_MATCHES is 4 hours", () => {
     expect(TTL.NEXT_MATCHES).toBe(60 * 60 * 4);
@@ -61,10 +72,39 @@ describe("TTL constants", () => {
   it("MATCH_DETAIL_PAST is 7 days (unchanged)", () => {
     expect(TTL.MATCH_DETAIL_PAST).toBe(60 * 60 * 24 * 7);
   });
+
+  it("HARD_TTL_DEFAULT is 7 days", () => {
+    expect(HARD_TTL_DEFAULT).toBe(60 * 60 * 24 * 7);
+  });
 });
 
 describe("TypedKvCache", () => {
-  it("cache miss: calls fetch, caches result, returns value", async () => {
+  it("fresh path: cached value within softTtl returns without fetch", async () => {
+    const mockKv = makeMockKv();
+    // Cached 10 seconds ago, softTtl is 60 seconds → fresh
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "cached", value: 99 }, 10_000),
+    );
+
+    const fetchEffect = Effect.fail(
+      new Error("fetch should not be called") as never,
+    );
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "cached", value: 99 });
+  });
+
+  it("cache miss: calls fetch, stores wrapper with hardTtl, returns value", async () => {
     const mockKv = makeMockKv();
     let fetchCalled = false;
     const fetchEffect = Effect.sync(() => {
@@ -84,20 +124,27 @@ describe("TypedKvCache", () => {
 
     expect(result).toEqual({ name: "test", value: 42 });
     expect(fetchCalled).toBe(true);
+    // Stored with hardTtl (default 7 days), not softTtl
     expect(mockKv.put).toHaveBeenCalledWith(
       "test-key",
-      JSON.stringify({ name: "test", value: 42 }),
-      { expirationTtl: 60 },
+      expect.stringContaining('"value":{"name":"test","value":42}'),
+      { expirationTtl: HARD_TTL_DEFAULT },
     );
+    // Verify wrapper contains fetchedAt
+    const stored = JSON.parse(mockKv.put.mock.calls[0]![1]);
+    expect(stored).toHaveProperty("fetchedAt");
+    expect(stored.value).toEqual({ name: "test", value: 42 });
   });
 
-  it("cache hit with valid data: returns decoded value, fetch not called", async () => {
+  it("stale + successful refresh: updates cache with fresh value", async () => {
     const mockKv = makeMockKv();
-    mockKv.store.set("test-key", JSON.stringify({ name: "cached", value: 99 }));
-
-    const fetchEffect = Effect.fail(
-      new Error("fetch should not be called") as never,
+    // Cached 2 hours ago, softTtl is 60 seconds → stale
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "old", value: 1 }, 2 * 60 * 60 * 1000),
     );
+
+    const fetchEffect = Effect.succeed({ name: "fresh", value: 42 });
 
     const typedCache = TypedKvCache(TestSchema);
     const result = await Effect.runPromise(
@@ -109,7 +156,35 @@ describe("TypedKvCache", () => {
         ),
     );
 
-    expect(result).toEqual({ name: "cached", value: 99 });
+    expect(result).toEqual({ name: "fresh", value: 42 });
+    // Cache should be updated with new wrapper
+    const stored = JSON.parse(mockKv.put.mock.calls[0]![1]);
+    expect(stored.value).toEqual({ name: "fresh", value: 42 });
+  });
+
+  it("stale-on-error: fetch fails, returns stale value", async () => {
+    const mockKv = makeMockKv();
+    // Cached 2 hours ago, softTtl is 60 seconds → stale
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 99 }, 2 * 60 * 60 * 1000),
+    );
+
+    const fetchEffect = Effect.fail(new Error("PSD 429") as never);
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "stale", value: 99 });
+    // Should NOT update cache on error
+    expect(mockKv.put).not.toHaveBeenCalled();
   });
 
   it("cache hit with corrupted JSON: logs warning, falls through to fetch", async () => {
@@ -136,10 +211,13 @@ describe("TypedKvCache", () => {
     expect(fetchCalled).toBe(true);
   });
 
-  it("cache hit with stale schema: logs warning, falls through to fetch", async () => {
+  it("cache hit with old format (no wrapper): logs warning, falls through to fetch", async () => {
     const mockKv = makeMockKv();
-    // Valid JSON but missing required 'value' field
-    mockKv.store.set("test-key", JSON.stringify({ name: "stale" }));
+    // Pre-Phase 3 format: raw value without wrapper
+    mockKv.store.set(
+      "test-key",
+      JSON.stringify({ name: "old-format", value: 5 }),
+    );
 
     let fetchCalled = false;
     const fetchEffect = Effect.sync(() => {
@@ -161,7 +239,7 @@ describe("TypedKvCache", () => {
     expect(fetchCalled).toBe(true);
   });
 
-  it("supports dynamic TTL function based on the fetched value", async () => {
+  it("supports dynamic softTtl function based on the fetched value", async () => {
     const mockKv = makeMockKv();
     const fetchEffect = Effect.succeed({ name: "test", value: 10 });
 
@@ -175,11 +253,32 @@ describe("TypedKvCache", () => {
         ),
     );
 
+    // Stored with hardTtl (default 7 days)
     expect(mockKv.put).toHaveBeenCalledWith(
       "test-key",
-      JSON.stringify({ name: "test", value: 10 }),
-      { expirationTtl: 600 },
+      expect.stringContaining('"value":{"name":"test","value":10}'),
+      { expirationTtl: HARD_TTL_DEFAULT },
     );
+  });
+
+  it("uses custom hardTtl when provided", async () => {
+    const mockKv = makeMockKv();
+    const fetchEffect = Effect.succeed({ name: "test", value: 10 });
+    const customHardTtl = 60 * 60 * 24 * 30; // 30 days
+
+    const typedCache = TypedKvCache(TestSchema);
+    await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60, customHardTtl)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(mockKv.put).toHaveBeenCalledWith("test-key", expect.any(String), {
+      expirationTtl: customHardTtl,
+    });
   });
 });
 

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -27,39 +27,81 @@ export class KvCacheService extends Context.Tag("KvCacheService")<
   KvCacheInterface
 >() {}
 
-export const TypedKvCache = <A>(schema: S.Schema<A, any>) => ({
-  getOrFetch: <E, R>(
-    key: string,
-    fetch: Effect.Effect<A, E, R>,
-    ttl: number | ((value: A) => number),
-  ): Effect.Effect<A, E, R | KvCacheService> =>
-    Effect.gen(function* () {
-      const cache = yield* KvCacheService;
-      const cached = yield* cache.get(key);
+/** Default hard TTL: 7 days — safety net for stale-on-error */
+export const HARD_TTL_DEFAULT = 60 * 60 * 24 * 7;
 
-      if (cached !== null) {
-        const decoded = yield* Effect.try({
-          try: () => JSON.parse(cached),
-          catch: (e) => new Error(String(e)),
-        }).pipe(
-          Effect.flatMap(S.decodeUnknown(schema)),
-          Effect.tapError((e) =>
-            Effect.logWarning(
-              `TypedKvCache: cache decode failed for key "${key}": ${String(e)}`,
+export const TypedKvCache = <A>(schema: S.Schema<A, any>) => {
+  const WrapperSchema = S.Struct({
+    value: schema,
+    fetchedAt: S.Number,
+  });
+
+  return {
+    getOrFetch: <E, R>(
+      key: string,
+      fetch: Effect.Effect<A, E, R>,
+      softTtl: number | ((value: A) => number),
+      hardTtl: number = HARD_TTL_DEFAULT,
+    ): Effect.Effect<A, E, R | KvCacheService> =>
+      Effect.gen(function* () {
+        const cache = yield* KvCacheService;
+        const cached = yield* cache.get(key);
+
+        if (cached !== null) {
+          const decoded = yield* Effect.try({
+            try: () => JSON.parse(cached),
+            catch: (e) => new Error(String(e)),
+          }).pipe(
+            Effect.flatMap(S.decodeUnknown(WrapperSchema)),
+            Effect.tapError((e) =>
+              Effect.logWarning(
+                `TypedKvCache: cache decode failed for key "${key}": ${String(e)}`,
+              ),
             ),
-          ),
-          Effect.option,
-        );
+            Effect.option,
+          );
 
-        if (Option.isSome(decoded)) return decoded.value;
-      }
+          if (Option.isSome(decoded)) {
+            const { value, fetchedAt } = decoded.value;
+            const resolvedSoftTtl =
+              typeof softTtl === "function" ? softTtl(value) : softTtl;
+            const isFresh = (Date.now() - fetchedAt) / 1000 <= resolvedSoftTtl;
 
-      const value = yield* fetch;
-      const resolvedTtl = typeof ttl === "function" ? ttl(value) : ttl;
-      yield* cache.set(key, JSON.stringify(value), resolvedTtl);
-      return value;
-    }),
-});
+            if (isFresh) return value;
+
+            // Stale: attempt refresh, fall back to stale on error
+            const refreshed = yield* fetch.pipe(
+              Effect.map((freshValue) => ({ freshValue, ok: true as const })),
+              Effect.catchAll(() =>
+                Effect.gen(function* () {
+                  yield* Effect.logWarning(
+                    `TypedKvCache: refresh failed for key "${key}", serving stale data (age: ${Math.round((Date.now() - fetchedAt) / 1000)}s)`,
+                  );
+                  return { freshValue: value, ok: false as const };
+                }),
+              ),
+            );
+
+            if (refreshed.ok) {
+              const wrapper = JSON.stringify({
+                value: refreshed.freshValue,
+                fetchedAt: Date.now(),
+              });
+              yield* cache.set(key, wrapper, hardTtl);
+            }
+
+            return refreshed.freshValue;
+          }
+        }
+
+        // Cache miss: fetch, wrap, store
+        const value = yield* fetch;
+        const wrapper = JSON.stringify({ value, fetchedAt: Date.now() });
+        yield* cache.set(key, wrapper, hardTtl);
+        return value;
+      }),
+  };
+};
 
 export const KvCacheLive = Layer.effect(
   KvCacheService,

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -6,7 +6,7 @@ import {
   getMatchByIdHandler,
   getMatchDetailHandler,
 } from "./matches";
-import { TTL } from "../cache/kv-cache";
+import { HARD_TTL_DEFAULT } from "../cache/kv-cache";
 import {
   FootbalistoService,
   FootbalistoServiceError,
@@ -34,17 +34,6 @@ const baseDetail: MatchDetail = {
   status: "finished",
   competition: "3de Nationale",
   hasReport: true,
-};
-
-const scheduledDetail: MatchDetail = {
-  id: 100,
-  date: new Date("2025-06-01T15:00:00.000Z"),
-  time: "15:00",
-  home_team: { id: 123, name: "KCVV Elewijt" },
-  away_team: { id: 456, name: "Opponent FC" },
-  status: "scheduled",
-  competition: "3de Nationale",
-  hasReport: false,
 };
 
 function makeServiceMock(): FootbalistoServiceInterface {
@@ -104,7 +93,7 @@ describe("getMatchDetailHandler", () => {
     expect(result.hasReport).toBe(true);
   });
 
-  it("uses MATCH_DETAIL_PAST TTL for finished matches ≥48h ago", async () => {
+  it("stores match detail with hardTtl (7 days)", async () => {
     const setCalls: Array<[string, string, number]> = [];
     const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
 
@@ -134,71 +123,7 @@ describe("getMatchDetailHandler", () => {
     const detailCall = setCalls.find(([key]) =>
       key.startsWith("match:detail:"),
     );
-    expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_PAST);
-  });
-
-  it("uses MATCH_DETAIL_DEFAULT TTL for finished matches <48h ago", async () => {
-    const setCalls: Array<[string, string, number]> = [];
-    const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
-
-    await Effect.runPromise(
-      getMatchDetailHandler(99).pipe(
-        Effect.provide(
-          Layer.succeed(FootbalistoService, {
-            ...makeServiceMock(),
-            getMatchDetail: () =>
-              Effect.succeed({ ...baseDetail, date: oneDayAgo }),
-          }),
-        ),
-        Effect.provide(
-          Layer.succeed(KvCacheService, {
-            get: () => Effect.succeed(null),
-            increment: () => Effect.succeed(undefined),
-            set: vi.fn((key, value, ttl) => {
-              setCalls.push([key, value, ttl]);
-              return Effect.succeed(undefined);
-            }),
-          }),
-        ),
-        Effect.orDie,
-      ),
-    );
-
-    const detailCall = setCalls.find(([key]) =>
-      key.startsWith("match:detail:"),
-    );
-    expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_DEFAULT);
-  });
-
-  it("uses MATCH_DETAIL_DEFAULT TTL for scheduled matches", async () => {
-    const setCalls: Array<[string, string, number]> = [];
-
-    await Effect.runPromise(
-      getMatchDetailHandler(100).pipe(
-        Effect.provide(
-          Layer.succeed(FootbalistoService, {
-            ...makeServiceMock(),
-            getMatchDetail: () => Effect.succeed(scheduledDetail),
-          }),
-        ),
-        Effect.provide(
-          Layer.succeed(KvCacheService, {
-            get: () => Effect.succeed(null),
-            increment: () => Effect.succeed(undefined),
-            set: vi.fn((key, value, ttl) => {
-              setCalls.push([key, value, ttl]);
-              return Effect.succeed(undefined);
-            }),
-          }),
-        ),
-        Effect.orDie,
-      ),
-    );
-
-    const detailCall = setCalls.find(([key]) =>
-      key.startsWith("match:detail:"),
-    );
-    expect(detailCall?.[2]).toBe(TTL.MATCH_DETAIL_DEFAULT);
+    expect(detailCall?.[2]).toBe(HARD_TTL_DEFAULT);
   });
 });
 


### PR DESCRIPTION
Closes #879

## What changed
- Extended `TypedKvCache.getOrFetch` with a two-TTL pattern: `softTtl` (freshness threshold) and `hardTtl` (KV storage TTL, default 7 days)
- Values are now stored as `{ value, fetchedAt }` wrappers — causes a one-time cold start on deploy (deploy outside Saturday afternoon)
- When cached data is stale and a refresh fails (429/500/any error), stale data is served with `Effect.logWarning` instead of propagating the error

## Testing
- All checks pass: `pnpm --filter @kcvv/api type-check` + `pnpm --filter @kcvv/api test` (75/75 tests)
- New tests cover: fresh path, cache miss, stale+refresh success, stale-on-error, old format migration, custom hardTtl
- Pre-commit hooks pass (prettier, type-check across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)