### PR TITLE
chore(config): add lint script and underscore convention to studio ESLint

### DIFF
--- a/apps/studio/eslint.config.mjs
+++ b/apps/studio/eslint.config.mjs
@@ -1,3 +1,18 @@
-import studio from '@sanity/eslint-config-studio'
+import studio from "@sanity/eslint-config-studio";
 
-export default [...studio]
+export default [
+  ...studio,
+  {
+    files: ["**/*.ts?(x)"],
+    rules: {
+      "typescript/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+];

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -9,7 +9,8 @@
     "start": "sanity start",
     "build": "sanity build",
     "deploy": "sanity deploy",
-    "deploy-graphql": "sanity graphql deploy"
+    "deploy-graphql": "sanity graphql deploy",
+    "lint": "eslint ."
   },
   "keywords": [
     "sanity"


### PR DESCRIPTION
## Summary
- Adds `lint` script to `apps/studio/package.json` (was missing despite having `eslint` + `@sanity/eslint-config-studio` as deps)
- Extends the existing `eslint.config.mjs` with the underscore convention for unused vars (`argsIgnorePattern: "^_"`, etc.) to match the web and api apps

## Test plan
- [x] `pnpm --filter @kcvv/studio lint` passes cleanly
- [x] Pre-commit hooks pass (type-check, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)