### PR TITLE
fix(config): switch OG image routes from edge to nodejs runtime

### DIFF
--- a/apps/web/src/app/(main)/players/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/players/[slug]/opengraph-image.tsx
@@ -14,7 +14,7 @@ import { Effect } from "effect";
 import { runPromise } from "@/lib/effect/runtime";
 import { SanityService } from "@/lib/effect/services/SanityService";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export const size = {
   width: 1200,

--- a/apps/web/src/app/(main)/team/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/team/[slug]/opengraph-image.tsx
@@ -15,7 +15,7 @@ import { runPromise } from "@/lib/effect/runtime";
 import { SanityService } from "@/lib/effect/services/SanityService";
 import { getSanityAgeGroup, getSanityTeamTagline } from "./utils";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export const size = {
   width: 1200,


### PR DESCRIPTION
## Summary
- Switch `runtime` from `"edge"` to `"nodejs"` in both player and team OG image routes
- Effect + SanityService bundle exceeds Vercel's 1 MB edge function limit (1.04 MB)
- Node.js serverless functions support up to 250 MB and are fine for OG images which are cached by social crawlers anyway

Unblocks #894

## Test plan
- [ ] Verify Vercel build succeeds without edge function size error
- [ ] Check player OG image renders correctly (e.g. `/players/[slug]`)
- [ ] Check team OG image renders correctly (e.g. `/team/[slug]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)