### PR TITLE
feat(api): resilient match list decoding with Effect.partition (#940)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -92,7 +92,7 @@ pnpm --filter @kcvv/api cache:clear:staging:key "ranking:team:23"
 
 ## Rules
 
-- No `S.Unknown` in PSD schemas — only declare fields actively used in transforms
+- No `S.Unknown` in PSD schemas — only declare fields actively used in transforms. Exception: wrapper schemas for resilient per-item decoding (e.g., `PsdMatchListSchema`) use `S.Array(S.Unknown)` so items can be decoded individually via `Effect.partition`
 - Secrets via `wrangler secret put`, never in `wrangler.toml`
 - `Effect.orDie` in HttpApiGroup handlers — errors become 500s; keep errors typed at handler level
 - After changing `@kcvv/api-contract`, run `pnpm turbo build --filter=@kcvv/api-contract` first

--- a/apps/api/src/footbalisto/schemas.ts
+++ b/apps/api/src/footbalisto/schemas.ts
@@ -183,7 +183,7 @@ export class PsdGame extends S.Class<PsdGame>("PsdGame")({
 }) {}
 
 export const PsdMatchListSchema = S.Struct({
-  content: S.Array(PsdRawGame),
+  content: S.Array(S.Unknown),
 });
 
 export class PsdTeamStatsResponse extends S.Class<PsdTeamStatsResponse>(

--- a/apps/api/src/footbalisto/service.test.ts
+++ b/apps/api/src/footbalisto/service.test.ts
@@ -272,6 +272,36 @@ describe("FootbalistoService.getTeamMatches", () => {
     }
   });
 
+  it("filters invalid games and returns only valid ones", async () => {
+    const ghostGame = {
+      id: 999,
+      status: 0,
+      date: "2025-01-20 00:00",
+      time: "15:00",
+      homeClub: null, // ghost match — null club data
+      awayClub: null,
+      goalsHomeTeam: null,
+      goalsAwayTeam: null,
+      competitionType: null,
+    };
+    const mixedMatchList = {
+      content: [rawMatchList.content[0], ghostGame],
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: async () => seasons })
+      .mockResolvedValueOnce({ ok: true, json: async () => mixedMatchList });
+
+    const result = await runService((svc) => svc.getTeamMatches(1));
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      // Should return only the valid game, ghost game filtered out
+      expect(result.right).toHaveLength(1);
+      expect(result.right[0]?.id).toBe(101);
+    }
+  });
+
   it("fails when season fetch fails", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: false,
@@ -318,6 +348,46 @@ describe("FootbalistoService.getNextMatches", () => {
       expect(result.right[0]?.kcvv_team_id).toBe(1);
       // kcvv_team_label derived from team name/age
       expect(result.right[0]?.kcvv_team_label).toBe("A-Ploeg");
+    }
+  });
+
+  it("filters invalid games from team match lists", async () => {
+    const ghostGame = {
+      id: 888,
+      status: 0,
+      date: "2099-12-31 00:00",
+      time: "15:00",
+      homeClub: null,
+      awayClub: null,
+      goalsHomeTeam: null,
+      goalsAwayTeam: null,
+      competitionType: null,
+    };
+    const mixedFutureMatchList = {
+      content: [rawFutureGame, ghostGame],
+    };
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => mixedFutureMatchList,
+        });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => seasons });
+      }
+      return Promise.resolve({ ok: true, json: async () => [rawTeams[0]] });
+    });
+
+    const result = await runService((svc) => svc.getNextMatches());
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      // Ghost game should be filtered, valid future game returned
+      expect(result.right).toHaveLength(1);
+      expect(result.right[0]?.id).toBe(102);
     }
   });
 

--- a/apps/api/src/footbalisto/service.ts
+++ b/apps/api/src/footbalisto/service.ts
@@ -18,8 +18,7 @@ import {
   PsdMatchListSchema,
   FootbalistoMatchDetailResponse,
   FootbalistoRankingArray,
-  type PsdRawGame,
-  type PsdGame,
+  PsdGame,
   type FootbalistoLineupPlayer,
   type FootbalistoMatchEvent,
   type FootbalistoMatchDetailResponse as RawDetailResponse,
@@ -91,14 +90,6 @@ function parseDateString(dateStr: string): { date: Date; time: string } {
     date: new Date(Date.UTC(year!, month! - 1, day!, hour, minute)),
     time: timePart,
   };
-}
-
-/**
- * Type guard: narrows a PsdRawGame (external) to PsdGame (internal).
- * Rejects "ghost" matches where a club is null (opponent forfeited/removed from league).
- */
-function isValidGame(game: PsdRawGame): game is PsdGame {
-  return game.homeClub !== null && game.awayClub !== null;
 }
 
 function transformPsdGame(game: PsdGame): Match {
@@ -364,6 +355,15 @@ function transformFootbalistoRankingEntry(
   };
 }
 
+/** Safely extract an `id` field from an unknown item for logging. */
+function extractId(item: unknown): string | number {
+  if (typeof item === "object" && item !== null && "id" in item) {
+    const id = (item as Record<string, unknown>).id;
+    if (typeof id === "number" || typeof id === "string") return id;
+  }
+  return "unknown";
+}
+
 // ─── Service definition ────────────────────────────────────────────────────────
 
 export class FootbalistoServiceError extends Error {
@@ -551,21 +551,26 @@ export const FootbalistoServiceLive = Layer.effect(
             `${base}/games/team/${teamId}/seasons/${season.id}`,
             PsdMatchListSchema,
           );
-          const ghostIds: number[] = [];
-          const matches: Array<ReturnType<typeof transformPsdGame>> = [];
-          for (const game of data.content) {
-            if (isValidGame(game)) {
-              matches.push(transformPsdGame(game));
-            } else {
-              ghostIds.push(game.id);
-            }
-          }
-          if (ghostIds.length > 0) {
+
+          const [errors, games] = yield* Effect.partition(
+            data.content,
+            (item) =>
+              S.decodeUnknown(PsdGame)(item).pipe(
+                Effect.mapError((parseError) => ({
+                  id: extractId(item),
+                  parseError,
+                })),
+              ),
+          );
+
+          if (errors.length > 0) {
+            const ids = errors.map((e) => e.id).join(", ");
             yield* Effect.log(
-              `[matches] Skipping ${ghostIds.length} ghost game(s) for team ${teamId}: ${ghostIds.map((id) => `id=${id}`).join(", ")}`,
+              `getTeamMatches(${teamId}): filtered ${errors.length} invalid game(s) — IDs: [${ids}]`,
             );
           }
-          return matches;
+
+          return games.map(transformPsdGame);
         }),
 
       getNextMatches: () =>
@@ -582,15 +587,34 @@ export const FootbalistoServiceLive = Layer.effect(
                   `${base}/games/team/${team.id}/seasons/${season.id}`,
                   PsdMatchListSchema,
                 ).pipe(
-                  Effect.map((data) => {
-                    const next = [...data.content]
-                      .filter(isValidGame)
-                      .filter((m) => toMs(m) >= now)
-                      .sort((a, b) => toMs(a) - toMs(b))[0];
-                    return next
-                      ? ({ ...next, teamId: team.id } as PsdGame)
-                      : null;
-                  }),
+                  Effect.flatMap((data) =>
+                    Effect.gen(function* () {
+                      const [errors, games] = yield* Effect.partition(
+                        data.content,
+                        (item) =>
+                          S.decodeUnknown(PsdGame)(item).pipe(
+                            Effect.mapError((parseError) => ({
+                              id: extractId(item),
+                              parseError,
+                            })),
+                          ),
+                      );
+
+                      if (errors.length > 0) {
+                        const ids = errors.map((e) => e.id).join(", ");
+                        yield* Effect.log(
+                          `getNextMatches(${team.id}): filtered ${errors.length} invalid game(s) — IDs: [${ids}]`,
+                        );
+                      }
+
+                      const next = [...games]
+                        .filter((m) => toMs(m) >= now)
+                        .sort((a, b) => toMs(a) - toMs(b))[0];
+                      return next
+                        ? transformPsdGame({ ...next, teamId: team.id })
+                        : null;
+                    }),
+                  ),
                   Effect.catchAll((e) =>
                     Effect.log(
                       `getNextMatches: team ${team.id} failed: ${String(e)}`,
@@ -609,7 +633,7 @@ export const FootbalistoServiceLive = Layer.effect(
             if (game) {
               const team = filteredTeams[i]!;
               matches.push({
-                ...transformPsdGame(game),
+                ...game,
                 kcvv_team_label: derivePsdTeamLabel(team.name, team.age),
               });
             }


### PR DESCRIPTION
Closes #940

## What changed
- Changed `PsdMatchListSchema` to decode wrapper only (`S.Array(S.Unknown)`) — item validation moves to service layer
- `getTeamMatches` and `getNextMatches` now use `Effect.partition` + `S.decodeUnknown(PsdGame)` to filter invalid games (e.g. ghost matches with null club data) instead of failing the entire endpoint
- Invalid items are logged with count and extractable IDs via `Effect.log`

## Testing
- All checks pass: `pnpm --filter @kcvv/api type-check && pnpm --filter @kcvv/api test && pnpm --filter @kcvv/api lint`
- 2 new tests: ghost game filtering for both `getTeamMatches` and `getNextMatches`
- Manual test: `curl /matches/18` should return 200 with ghost matches filtered (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)