### PR TITLE
refactor(ui): storybook navigation & naming consistency (#982)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,7 +11,7 @@ import type { SanityEvent } from "@/lib/effect/services/SanityService";
 import { BffService } from "@/lib/effect/services/BffService";
 import {
   FeaturedArticles,
-  LatestNews,
+  NewsGrid,
   MatchWidget,
   BannerSlot,
   MatchesSliderSection,
@@ -42,7 +42,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 /**
- * Builds the featured event stub for the LatestNews section.
+ * Builds the featured event stub for the NewsGrid section.
  * Same-day event: shows date + time range.
  * Multi-day event: shows "d MMM HH:mm – d MMM HH:mm" as single date string.
  */
@@ -141,7 +141,7 @@ export default async function HomePage() {
     articles.slice(0, 3),
     true,
   );
-  const latestNewsArticles = mapSanityArticlesToHomepageArticles(
+  const newsGridArticles = mapSanityArticlesToHomepageArticles(
     articles.slice(3, 9),
     false,
   );
@@ -220,13 +220,13 @@ export default async function HomePage() {
     : null;
 
   const latestNewsSection: SectionConfig | null =
-    latestNewsArticles.length > 0 || featuredEvent
+    newsGridArticles.length > 0 || featuredEvent
       ? {
           key: "latest-news",
           bg: "gray-100",
           content: (
-            <LatestNews
-              articles={latestNewsArticles}
+            <NewsGrid
+              articles={newsGridArticles}
               featuredEvent={featuredEvent}
               title="Laatste nieuws"
               showViewAll

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { FeaturedArticles } from "./FeaturedArticles";
 
 const meta = {
-  title: "Features/Home/FeaturedArticles",
+  title: "Features/Homepage/FeaturedArticles",
   component: FeaturedArticles,
   tags: ["autodocs"],
   parameters: {

--- a/apps/web/src/components/home/Homepage.stories.tsx
+++ b/apps/web/src/components/home/Homepage.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { FeaturedArticles } from "./FeaturedArticles";
-import { LatestNews } from "./LatestNews";
-import type { FeaturedEventStub } from "./LatestNews";
+import { NewsGrid } from "./NewsGrid";
+import type { FeaturedEventStub } from "./NewsGrid";
 import { MatchWidget } from "./MatchWidget";
 import { BannerSlot } from "./BannerSlot";
 import { MatchesSliderSection } from "./MatchesSliderSection";
@@ -183,7 +183,7 @@ function buildSections(
       key: "latest-news",
       bg: "gray-100",
       content: (
-        <LatestNews
+        <NewsGrid
           articles={featuredEvent ? mockLatestNews.slice(0, 2) : mockLatestNews}
           featuredEvent={featuredEvent}
           title="Laatste nieuws"

--- a/apps/web/src/components/home/LatestNews/index.ts
+++ b/apps/web/src/components/home/LatestNews/index.ts
@@ -1,6 +1,0 @@
-export { LatestNews } from "./LatestNews";
-export type {
-  LatestNewsProps,
-  LatestNewsArticle,
-  FeaturedEventStub,
-} from "./LatestNews";

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.stories.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "./MatchWidget.mocks";
 
 const meta = {
-  title: "Features/Home/MatchWidget",
+  title: "Features/Homepage/MatchWidget",
   component: MatchWidget,
   parameters: {
     layout: "fullscreen",

--- a/apps/web/src/components/home/NewsGrid/NewsGrid.stories.tsx
+++ b/apps/web/src/components/home/NewsGrid/NewsGrid.stories.tsx
@@ -1,10 +1,10 @@
-// apps/web/src/components/home/LatestNews/LatestNews.stories.tsx
+// apps/web/src/components/home/NewsGrid/NewsGrid.stories.tsx
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { LatestNews } from "./LatestNews";
+import { NewsGrid } from "./NewsGrid";
 
 const meta = {
-  title: "Features/News/NewsGrid",
-  component: LatestNews,
+  title: "Features/Homepage/NewsGrid",
+  component: NewsGrid,
   tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
@@ -17,7 +17,7 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof LatestNews>;
+} satisfies Meta<typeof NewsGrid>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/web/src/components/home/NewsGrid/NewsGrid.test.tsx
+++ b/apps/web/src/components/home/NewsGrid/NewsGrid.test.tsx
@@ -1,8 +1,8 @@
-// apps/web/src/components/home/LatestNews/LatestNews.test.tsx
+// apps/web/src/components/home/NewsGrid/NewsGrid.test.tsx
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ImageProps } from "next/image";
-import { LatestNews, type LatestNewsArticle } from "./LatestNews";
+import { NewsGrid, type NewsGridArticle } from "./NewsGrid";
 
 vi.mock("next/image", () => ({
   default: ({ alt, src, ...props }: ImageProps) => {
@@ -11,8 +11,8 @@ vi.mock("next/image", () => ({
   },
 }));
 
-describe("LatestNews", () => {
-  const mockArticles: LatestNewsArticle[] = [
+describe("NewsGrid", () => {
+  const mockArticles: NewsGridArticle[] = [
     {
       href: "/news/article-1",
       title: "First News Article",
@@ -40,23 +40,23 @@ describe("LatestNews", () => {
 
   describe("Section structure", () => {
     it("renders a section element", () => {
-      const { container } = render(<LatestNews articles={mockArticles} />);
+      const { container } = render(<NewsGrid articles={mockArticles} />);
       expect(container.querySelector("section")).toBeInTheDocument();
     });
 
     it("renders default title", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       expect(screen.getByText("Laatste nieuws")).toBeInTheDocument();
     });
 
     it("renders custom title", () => {
-      render(<LatestNews articles={mockArticles} title="Nieuwsoverzicht" />);
+      render(<NewsGrid articles={mockArticles} title="Nieuwsoverzicht" />);
       expect(screen.getByText("Nieuwsoverzicht")).toBeInTheDocument();
     });
 
     it("accepts custom className", () => {
       const { container } = render(
-        <LatestNews articles={mockArticles} className="custom-class" />,
+        <NewsGrid articles={mockArticles} className="custom-class" />,
       );
       expect(container.firstChild).toHaveClass("custom-class");
     });
@@ -64,21 +64,21 @@ describe("LatestNews", () => {
 
   describe("View All link", () => {
     it("renders view all link by default", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       const link = screen.getByRole("link", { name: /Alle berichten/i });
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute("href", "/news");
     });
 
     it("hides view all link when showViewAll is false", () => {
-      render(<LatestNews articles={mockArticles} showViewAll={false} />);
+      render(<NewsGrid articles={mockArticles} showViewAll={false} />);
       expect(
         screen.queryByRole("link", { name: /Alle berichten/i }),
       ).not.toBeInTheDocument();
     });
 
     it("uses custom viewAllHref", () => {
-      render(<LatestNews articles={mockArticles} viewAllHref="/nieuws" />);
+      render(<NewsGrid articles={mockArticles} viewAllHref="/nieuws" />);
       expect(
         screen.getByRole("link", { name: /Alle berichten/i }),
       ).toHaveAttribute("href", "/nieuws");
@@ -87,12 +87,12 @@ describe("LatestNews", () => {
 
   describe("Grid layout", () => {
     it("renders the grid container", () => {
-      const { container } = render(<LatestNews articles={mockArticles} />);
+      const { container } = render(<NewsGrid articles={mockArticles} />);
       expect(container.querySelector(".grid")).toBeInTheDocument();
     });
 
     it("uses 2-column responsive grid", () => {
-      const { container } = render(<LatestNews articles={mockArticles} />);
+      const { container } = render(<NewsGrid articles={mockArticles} />);
       // outer grid is 2-col on md+
       const outerGrid = container.querySelector(".grid");
       expect(outerGrid).toHaveClass("grid-cols-1");
@@ -102,28 +102,28 @@ describe("LatestNews", () => {
 
   describe("Article rendering", () => {
     it("renders all article titles", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       expect(screen.getByText("First News Article")).toBeInTheDocument();
       expect(screen.getByText("Second News Article")).toBeInTheDocument();
       expect(screen.getByText("Third News Article")).toBeInTheDocument();
     });
 
     it("renders article dates", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       expect(screen.getByText("20 januari 2025")).toBeInTheDocument();
       expect(screen.getByText("19 januari 2025")).toBeInTheDocument();
       expect(screen.getByText("18 januari 2025")).toBeInTheDocument();
     });
 
     it("renders first article with featured variant (text-2xl heading)", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       // First article heading is h3 with text-2xl!
       const headings = screen.getAllByRole("heading", { level: 3 });
       expect(headings[0]).toHaveClass("text-2xl!");
     });
 
     it("renders subsequent articles with standard variant (text-base heading)", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       const headings = screen.getAllByRole("heading", { level: 3 });
       // headings[1] and [2] are standard
       expect(headings[1]).toHaveClass("text-base!");
@@ -131,7 +131,7 @@ describe("LatestNews", () => {
     });
 
     it("renders article tags as badge", () => {
-      render(<LatestNews articles={mockArticles} />);
+      render(<NewsGrid articles={mockArticles} />);
       // Tags rendered as badge text (no # prefix in NewsCard)
       expect(screen.getAllByText("Ploeg").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Jeugd").length).toBeGreaterThanOrEqual(1);
@@ -150,14 +150,14 @@ describe("LatestNews", () => {
 
     it("renders event title in featured slot when featuredEvent provided", () => {
       render(
-        <LatestNews articles={mockArticles} featuredEvent={featuredEvent} />,
+        <NewsGrid articles={mockArticles} featuredEvent={featuredEvent} />,
       );
       expect(screen.getByText("Jeugdtoernooi 2026")).toBeInTheDocument();
     });
 
     it("renders first article as standard (not featured) when event fills featured slot", () => {
       render(
-        <LatestNews articles={mockArticles} featuredEvent={featuredEvent} />,
+        <NewsGrid articles={mockArticles} featuredEvent={featuredEvent} />,
       );
       const headings = screen.getAllByRole("heading", { level: 3 });
       // Event is featured (text-2xl), articles are standard (text-base)
@@ -175,7 +175,7 @@ describe("LatestNews", () => {
 
   describe("Empty state", () => {
     it("returns null when no articles and no featuredEvent", () => {
-      const { container } = render(<LatestNews articles={[]} />);
+      const { container } = render(<NewsGrid articles={[]} />);
       expect(container.firstChild).toBeNull();
     });
 
@@ -185,7 +185,7 @@ describe("LatestNews", () => {
         href: "/evenementen/test",
         badge: "Evenement",
       };
-      render(<LatestNews articles={[]} featuredEvent={featuredEvent} />);
+      render(<NewsGrid articles={[]} featuredEvent={featuredEvent} />);
       expect(
         screen.getByText("Evenement zonder artikelen"),
       ).toBeInTheDocument();

--- a/apps/web/src/components/home/NewsGrid/NewsGrid.tsx
+++ b/apps/web/src/components/home/NewsGrid/NewsGrid.tsx
@@ -1,8 +1,8 @@
-// apps/web/src/components/home/LatestNews/LatestNews.tsx
+// apps/web/src/components/home/NewsGrid/NewsGrid.tsx
 import { SectionHeader } from "@/components/design-system";
 import { NewsCard } from "@/components/article/NewsCard";
 
-export interface LatestNewsArticle {
+export interface NewsGridArticle {
   href: string;
   title: string;
   imageUrl?: string;
@@ -24,9 +24,9 @@ export interface FeaturedEventStub {
   isExternal?: boolean;
 }
 
-export interface LatestNewsProps {
+export interface NewsGridProps {
   /** 2–3 articles; first becomes featured when no featuredEvent */
-  articles: LatestNewsArticle[];
+  articles: NewsGridArticle[];
   /** When provided, fills the featured slot instead of articles[0]. #802 */
   featuredEvent?: FeaturedEventStub;
   title?: string;
@@ -35,14 +35,14 @@ export interface LatestNewsProps {
   className?: string;
 }
 
-export const LatestNews = ({
+export const NewsGrid = ({
   articles,
   featuredEvent,
   title = "Laatste nieuws",
   showViewAll = true,
   viewAllHref = "/news",
   className,
-}: LatestNewsProps) => {
+}: NewsGridProps) => {
   if (articles.length === 0 && !featuredEvent) {
     return null;
   }

--- a/apps/web/src/components/home/NewsGrid/index.ts
+++ b/apps/web/src/components/home/NewsGrid/index.ts
@@ -1,0 +1,6 @@
+export { NewsGrid } from "./NewsGrid";
+export type {
+  NewsGridProps,
+  NewsGridArticle,
+  FeaturedEventStub,
+} from "./NewsGrid";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -4,12 +4,12 @@ export type {
   FeaturedArticle,
 } from "./FeaturedArticles";
 
-export { LatestNews } from "./LatestNews";
+export { NewsGrid } from "./NewsGrid";
 export type {
-  LatestNewsProps,
-  LatestNewsArticle,
+  NewsGridProps,
+  NewsGridArticle,
   FeaturedEventStub,
-} from "./LatestNews";
+} from "./NewsGrid";
 
 export { NewsCard } from "@/components/article/NewsCard";
 export type { NewsCardProps } from "@/components/article/NewsCard";

--- a/apps/web/src/components/sponsors/SponsorCallToAction.stories.tsx
+++ b/apps/web/src/components/sponsors/SponsorCallToAction.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { SponsorsCallToAction } from "./SponsorsCallToAction";
+import { SponsorCallToAction } from "./SponsorCallToAction";
 
 const meta = {
-  title: "Features/Sponsors/SponsorsCallToAction",
-  component: SponsorsCallToAction,
+  title: "Features/Sponsors/SponsorCallToAction",
+  component: SponsorCallToAction,
   parameters: {
     layout: "padded",
   },
   tags: ["autodocs"],
-} satisfies Meta<typeof SponsorsCallToAction>;
+} satisfies Meta<typeof SponsorCallToAction>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/web/src/components/sponsors/SponsorCallToAction.tsx
+++ b/apps/web/src/components/sponsors/SponsorCallToAction.tsx
@@ -1,21 +1,21 @@
 /**
- * SponsorsCallToAction Component
+ * SponsorCallToAction Component
  * Encourages businesses to become sponsors with contact information
  */
 
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
 
-export interface SponsorsCallToActionProps {
+export interface SponsorCallToActionProps {
   /**
    * Additional CSS classes
    */
   className?: string;
 }
 
-export const SponsorsCallToAction = ({
+export const SponsorCallToAction = ({
   className,
-}: SponsorsCallToActionProps) => {
+}: SponsorCallToActionProps) => {
   return (
     <div
       className={cn(

--- a/apps/web/src/components/sponsors/SponsorEmptyState.stories.tsx
+++ b/apps/web/src/components/sponsors/SponsorEmptyState.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { SponsorsEmptyState } from "./SponsorsEmptyState";
+import { SponsorEmptyState } from "./SponsorEmptyState";
 
 const meta = {
-  title: "Features/Sponsors/SponsorsEmptyState",
-  component: SponsorsEmptyState,
+  title: "Features/Sponsors/SponsorEmptyState",
+  component: SponsorEmptyState,
   parameters: {
     layout: "padded",
   },
   tags: ["autodocs"],
-} satisfies Meta<typeof SponsorsEmptyState>;
+} satisfies Meta<typeof SponsorEmptyState>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/web/src/components/sponsors/SponsorEmptyState.tsx
+++ b/apps/web/src/components/sponsors/SponsorEmptyState.tsx
@@ -1,19 +1,19 @@
 /**
- * SponsorsEmptyState Component
+ * SponsorEmptyState Component
  * Displayed when no sponsors are available
  */
 
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
 
-export interface SponsorsEmptyStateProps {
+export interface SponsorEmptyStateProps {
   /**
    * Additional CSS classes
    */
   className?: string;
 }
 
-export const SponsorsEmptyState = ({ className }: SponsorsEmptyStateProps) => {
+export const SponsorEmptyState = ({ className }: SponsorEmptyStateProps) => {
   return (
     <div className={cn("text-center py-16 px-6", className)}>
       {/* Illustration */}

--- a/apps/web/src/components/sponsors/SponsorsPage/SponsorsPage.tsx
+++ b/apps/web/src/components/sponsors/SponsorsPage/SponsorsPage.tsx
@@ -7,10 +7,10 @@ import { PageTitle } from "@/components/layout";
 import {
   SponsorsStats,
   SponsorsSpotlight,
-  SponsorsCallToAction,
+  SponsorCallToAction,
   SponsorsTier,
   TierDivider,
-  SponsorsEmptyState,
+  SponsorEmptyState,
 } from "@/components/sponsors";
 import type { Sponsor } from "../Sponsors";
 
@@ -81,9 +81,9 @@ export function SponsorsPage({
             sponsors={bronzeSponsors}
           />
 
-          {totalSponsors === 0 && <SponsorsEmptyState />}
+          {totalSponsors === 0 && <SponsorEmptyState />}
 
-          <SponsorsCallToAction />
+          <SponsorCallToAction />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/sponsors/SponsorsWithFilters.stories.tsx
+++ b/apps/web/src/components/sponsors/SponsorsWithFilters.stories.tsx
@@ -32,7 +32,7 @@ export const GoldOnly: Story = {
   },
 };
 
-/** No sponsors at all — renders SponsorsEmptyState. */
+/** No sponsors at all — renders SponsorEmptyState. */
 export const Empty: Story = {
   args: {
     goldSponsors: [],

--- a/apps/web/src/components/sponsors/SponsorsWithFilters.tsx
+++ b/apps/web/src/components/sponsors/SponsorsWithFilters.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils/cn";
 import { SponsorsFilters, type FilterState } from "./SponsorsFilters";
 import { SponsorsTier, type SponsorTier } from "./SponsorsTier";
 import { TierDivider } from "./TierDivider";
-import { SponsorsEmptyState } from "./SponsorsEmptyState";
+import { SponsorEmptyState } from "./SponsorEmptyState";
 import type { Sponsor } from "./Sponsors";
 
 export interface SponsorsWithFiltersProps {
@@ -97,7 +97,7 @@ export const SponsorsWithFilters = ({
   const hasSponsors = totalCount > 0;
 
   if (!hasSponsors) {
-    return <SponsorsEmptyState />;
+    return <SponsorEmptyState />;
   }
 
   return (

--- a/apps/web/src/components/sponsors/index.ts
+++ b/apps/web/src/components/sponsors/index.ts
@@ -17,10 +17,10 @@ export type {
 } from "./SponsorsSpotlight";
 export { TierDivider } from "./TierDivider";
 export type { TierDividerProps } from "./TierDivider";
-export { SponsorsCallToAction } from "./SponsorsCallToAction";
-export type { SponsorsCallToActionProps } from "./SponsorsCallToAction";
-export { SponsorsEmptyState } from "./SponsorsEmptyState";
-export type { SponsorsEmptyStateProps } from "./SponsorsEmptyState";
+export { SponsorCallToAction } from "./SponsorCallToAction";
+export type { SponsorCallToActionProps } from "./SponsorCallToAction";
+export { SponsorEmptyState } from "./SponsorEmptyState";
+export type { SponsorEmptyStateProps } from "./SponsorEmptyState";
 export { SponsorsFilters } from "./SponsorsFilters";
 export type { SponsorsFiltersProps, FilterState } from "./SponsorsFilters";
 export { SponsorsWithFilters } from "./SponsorsWithFilters";


### PR DESCRIPTION
Closes #982

## What changed
- Moved all `Features/Home/*` story titles to `Features/Homepage/*` (MatchWidget, FeaturedArticles)
- Renamed `LatestNews` component to `NewsGrid` (component, story, test, barrel export) and moved story to `Features/Homepage/NewsGrid`
- Renamed `SponsorsCallToAction` to `SponsorCallToAction` and `SponsorsEmptyState` to `SponsorEmptyState` (component, story, barrel export)

## Testing
- All checks pass: `pnpm --filter @kcvv/web run lint && pnpm --filter @kcvv/web run type-check && pnpm --filter @kcvv/web run test` (86 test files, 1577 tests)
- `pnpm --filter @kcvv/web build-storybook` passes — no duplicate or orphaned nav entries