### PR TITLE
feat(ui): RelatedContentCard + RelatedContentSlider components (#931)

### DIFF
--- a/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.stories.tsx
+++ b/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { RelatedContentCard } from "./RelatedContentCard";
+import type {
+  RelatedArticleItem,
+  RelatedPageItem,
+  RelatedPlayerItem,
+  RelatedTeamItem,
+  RelatedStaffItem,
+} from "../types";
+
+const articleItem: RelatedArticleItem = {
+  type: "article",
+  id: "art-1",
+  title: "Interview met de kapitein over het seizoen",
+  slug: "interview-kapitein",
+  imageUrl: "https://picsum.photos/seed/article/512/288",
+  date: "2026-03-20T10:00:00Z",
+  excerpt: "Een exclusief interview met onze kapitein over de ambities.",
+};
+
+const pageItem: RelatedPageItem = {
+  type: "page",
+  id: "page-1",
+  title: "Over de club",
+  slug: "over-de-club",
+  imageUrl: "https://picsum.photos/seed/page/512/288",
+  excerpt: "Alles wat je moet weten over KCVV Elewijt.",
+};
+
+const playerItem: RelatedPlayerItem = {
+  type: "player",
+  id: "player-1",
+  firstName: "Jan",
+  lastName: "Janssens",
+  position: "Aanvaller",
+  imageUrl: "https://picsum.photos/seed/player/512/288",
+  psdId: "12345",
+};
+
+const teamItem: RelatedTeamItem = {
+  type: "team",
+  id: "team-1",
+  name: "A-ploeg",
+  slug: "a-ploeg",
+  imageUrl: "https://picsum.photos/seed/team/512/288",
+  tagline: "Eerste ploeg van KCVV Elewijt",
+};
+
+const staffItem: RelatedStaffItem = {
+  type: "staff",
+  id: "staff-1",
+  firstName: "Piet",
+  lastName: "Pieters",
+  role: "Hoofdtrainer",
+  imageUrl: "https://picsum.photos/seed/staff/512/288",
+};
+
+const meta = {
+  title: "Features/Related/RelatedContentCard",
+  component: RelatedContentCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Unified card for rendering related content across all content types. " +
+          "Five variants: article, page, player, team, staff — all with consistent dimensions.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RelatedContentCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Article variant with image, title, date, and excerpt */
+export const Article: Story = {
+  args: { item: articleItem },
+};
+
+/** Page variant with title and excerpt */
+export const Page: Story = {
+  args: { item: pageItem },
+};
+
+/** Player variant with photo, name, and position */
+export const Player: Story = {
+  args: { item: playerItem },
+};
+
+/** Team variant with photo, name, and tagline */
+export const Team: Story = {
+  args: { item: teamItem },
+};
+
+/** Staff variant with photo, name, and role (no link) */
+export const Staff: Story = {
+  args: { item: staffItem },
+};
+
+/** All variants side-by-side to verify consistent dimensions */
+export const AllVariants: Story = {
+  args: { item: articleItem },
+  decorators: [
+    () => (
+      <div className="flex gap-4 items-start">
+        <RelatedContentCard item={articleItem} />
+        <RelatedContentCard item={pageItem} />
+        <RelatedContentCard item={playerItem} />
+        <RelatedContentCard item={teamItem} />
+        <RelatedContentCard item={staffItem} />
+      </div>
+    ),
+  ],
+};
+
+/** Card without an image */
+export const NoImage: Story = {
+  args: {
+    item: { ...articleItem, imageUrl: null },
+  },
+};

--- a/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.test.tsx
+++ b/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RelatedContentCard } from "./RelatedContentCard";
+import type {
+  RelatedArticleItem,
+  RelatedPageItem,
+  RelatedPlayerItem,
+  RelatedTeamItem,
+  RelatedStaffItem,
+} from "../types";
+
+const articleItem: RelatedArticleItem = {
+  type: "article",
+  id: "art-1",
+  title: "Interview met de kapitein",
+  slug: "interview-kapitein",
+  imageUrl: "https://cdn.sanity.io/images/article.jpg",
+  date: "2026-03-20T10:00:00Z",
+  excerpt: "Een exclusief interview met onze kapitein.",
+};
+
+const pageItem: RelatedPageItem = {
+  type: "page",
+  id: "page-1",
+  title: "Over de club",
+  slug: "over-de-club",
+  imageUrl: null,
+  excerpt: "Alles over KCVV Elewijt.",
+};
+
+const playerItem: RelatedPlayerItem = {
+  type: "player",
+  id: "player-1",
+  firstName: "Jan",
+  lastName: "Janssens",
+  position: "Aanvaller",
+  imageUrl: "https://cdn.sanity.io/images/player.jpg",
+  psdId: "12345",
+};
+
+const teamItem: RelatedTeamItem = {
+  type: "team",
+  id: "team-1",
+  name: "A-ploeg",
+  slug: "a-ploeg",
+  imageUrl: "https://cdn.sanity.io/images/team.jpg",
+  tagline: "Eerste ploeg van KCVV Elewijt",
+};
+
+const staffItem: RelatedStaffItem = {
+  type: "staff",
+  id: "staff-1",
+  firstName: "Piet",
+  lastName: "Pieters",
+  role: "Hoofdtrainer",
+  imageUrl: "https://cdn.sanity.io/images/staff.jpg",
+};
+
+describe("RelatedContentCard", () => {
+  describe("article variant", () => {
+    it("renders title, date, and excerpt", () => {
+      render(<RelatedContentCard item={articleItem} />);
+
+      expect(screen.getByText("Interview met de kapitein")).toBeInTheDocument();
+      expect(
+        screen.getByText("Een exclusief interview met onze kapitein."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("20 maart 2026")).toBeInTheDocument();
+    });
+
+    it("links to /news/[slug]", () => {
+      render(<RelatedContentCard item={articleItem} />);
+
+      const link = screen.getByText("Interview met de kapitein").closest("a");
+      expect(link).toHaveAttribute("href", "/news/interview-kapitein");
+    });
+
+    it("renders cover image when available", () => {
+      render(<RelatedContentCard item={articleItem} />);
+
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("alt", "Interview met de kapitein");
+    });
+  });
+
+  describe("page variant", () => {
+    it("renders title and excerpt", () => {
+      render(<RelatedContentCard item={pageItem} />);
+
+      expect(screen.getByText("Over de club")).toBeInTheDocument();
+      expect(screen.getByText("Alles over KCVV Elewijt.")).toBeInTheDocument();
+    });
+
+    it("links to /[slug]", () => {
+      render(<RelatedContentCard item={pageItem} />);
+
+      const link = screen.getByText("Over de club").closest("a");
+      expect(link).toHaveAttribute("href", "/over-de-club");
+    });
+  });
+
+  describe("player variant", () => {
+    it("renders name and position", () => {
+      render(<RelatedContentCard item={playerItem} />);
+
+      expect(screen.getByText("Jan Janssens")).toBeInTheDocument();
+      expect(screen.getByText("Aanvaller")).toBeInTheDocument();
+    });
+
+    it("links to /players/[psdId]", () => {
+      render(<RelatedContentCard item={playerItem} />);
+
+      const link = screen.getByText("Jan Janssens").closest("a");
+      expect(link).toHaveAttribute("href", "/players/12345");
+    });
+
+    it("renders player photo when available", () => {
+      render(<RelatedContentCard item={playerItem} />);
+
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("alt", "Jan Janssens");
+    });
+  });
+
+  describe("team variant", () => {
+    it("renders name and tagline", () => {
+      render(<RelatedContentCard item={teamItem} />);
+
+      expect(screen.getByText("A-ploeg")).toBeInTheDocument();
+      expect(
+        screen.getByText("Eerste ploeg van KCVV Elewijt"),
+      ).toBeInTheDocument();
+    });
+
+    it("links to /team/[slug]", () => {
+      render(<RelatedContentCard item={teamItem} />);
+
+      const link = screen.getByText("A-ploeg").closest("a");
+      expect(link).toHaveAttribute("href", "/team/a-ploeg");
+    });
+  });
+
+  describe("staff variant", () => {
+    it("renders name and role", () => {
+      render(<RelatedContentCard item={staffItem} />);
+
+      expect(screen.getByText("Piet Pieters")).toBeInTheDocument();
+      expect(screen.getByText("Hoofdtrainer")).toBeInTheDocument();
+    });
+
+    it("does not render a link (staff has no detail page)", () => {
+      const { container } = render(<RelatedContentCard item={staffItem} />);
+
+      expect(container.querySelector("a")).toBeNull();
+    });
+
+    it("renders staff photo when available", () => {
+      render(<RelatedContentCard item={staffItem} />);
+
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("alt", "Piet Pieters");
+    });
+  });
+
+  describe("consistent dimensions", () => {
+    it("all variants have the same fixed width class", () => {
+      const { container: c1 } = render(
+        <RelatedContentCard item={articleItem} />,
+      );
+      const { container: c2 } = render(
+        <RelatedContentCard item={playerItem} />,
+      );
+      const { container: c3 } = render(<RelatedContentCard item={teamItem} />);
+
+      const card1 = c1.firstChild as HTMLElement;
+      const card2 = c2.firstChild as HTMLElement;
+      const card3 = c3.firstChild as HTMLElement;
+
+      expect(card1.className).toContain("w-64");
+      expect(card2.className).toContain("w-64");
+      expect(card3.className).toContain("w-64");
+    });
+  });
+});

--- a/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.tsx
+++ b/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.tsx
@@ -1,0 +1,171 @@
+import Link from "next/link";
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+import type { RelatedContentItem } from "../types";
+
+export interface RelatedContentCardProps {
+  /** The related content item to display */
+  item: RelatedContentItem;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+function getHref(item: RelatedContentItem): string | null {
+  switch (item.type) {
+    case "article":
+      return `/news/${item.slug}`;
+    case "page":
+      return `/${item.slug}`;
+    case "player":
+      return `/players/${item.psdId}`;
+    case "team":
+      return `/team/${item.slug}`;
+    case "staff":
+      return null;
+  }
+}
+
+function getImageAlt(item: RelatedContentItem): string {
+  switch (item.type) {
+    case "article":
+    case "page":
+      return item.title;
+    case "player":
+      return [item.firstName, item.lastName].filter(Boolean).join(" ");
+    case "team":
+      return item.name;
+    case "staff":
+      return [item.firstName, item.lastName].filter(Boolean).join(" ");
+  }
+}
+
+function getImageUrl(item: RelatedContentItem): string | null {
+  return item.imageUrl;
+}
+
+function CardContent({ item }: { item: RelatedContentItem }) {
+  switch (item.type) {
+    case "article":
+      return (
+        <div className="p-3 flex flex-col flex-1">
+          <h4 className="font-semibold text-sm line-clamp-2 group-hover:text-kcvv-green-dark transition-colors">
+            {item.title}
+          </h4>
+          {item.date && (
+            <time
+              className="text-xs text-gray-500 mt-1 block"
+              dateTime={item.date}
+            >
+              {new Date(item.date).toLocaleDateString("nl-BE", {
+                day: "numeric",
+                month: "long",
+                year: "numeric",
+              })}
+            </time>
+          )}
+          {item.excerpt && (
+            <p className="text-xs text-gray-600 mt-1 line-clamp-2">
+              {item.excerpt}
+            </p>
+          )}
+        </div>
+      );
+
+    case "page":
+      return (
+        <div className="p-3 flex flex-col flex-1">
+          <h4 className="font-semibold text-sm line-clamp-2 group-hover:text-kcvv-green-dark transition-colors">
+            {item.title}
+          </h4>
+          {item.excerpt && (
+            <p className="text-xs text-gray-600 mt-1 line-clamp-2">
+              {item.excerpt}
+            </p>
+          )}
+        </div>
+      );
+
+    case "player":
+      return (
+        <div className="p-3 flex flex-col flex-1">
+          <h4 className="font-semibold text-sm line-clamp-1 group-hover:text-kcvv-green-dark transition-colors">
+            {[item.firstName, item.lastName].filter(Boolean).join(" ")}
+          </h4>
+          {item.position && (
+            <p className="text-xs text-gray-500 mt-1">{item.position}</p>
+          )}
+        </div>
+      );
+
+    case "team":
+      return (
+        <div className="p-3 flex flex-col flex-1">
+          <h4 className="font-semibold text-sm line-clamp-1 group-hover:text-kcvv-green-dark transition-colors">
+            {item.name}
+          </h4>
+          {item.tagline && (
+            <p className="text-xs text-gray-500 mt-1 line-clamp-2">
+              {item.tagline}
+            </p>
+          )}
+        </div>
+      );
+
+    case "staff":
+      return (
+        <div className="p-3 flex flex-col flex-1">
+          <h4 className="font-semibold text-sm line-clamp-1">
+            {[item.firstName, item.lastName].filter(Boolean).join(" ")}
+          </h4>
+          {item.role && (
+            <p className="text-xs text-gray-500 mt-1">{item.role}</p>
+          )}
+        </div>
+      );
+  }
+}
+
+export const RelatedContentCard = ({
+  item,
+  className,
+}: RelatedContentCardProps) => {
+  const href = getHref(item);
+  const imageUrl = getImageUrl(item);
+  const imageAlt = getImageAlt(item);
+
+  const cardClasses = cn(
+    "w-64 flex-shrink-0 overflow-hidden rounded-lg border border-gray-200 flex flex-col",
+    href && "group hover:border-kcvv-green-bright transition-colors",
+    className,
+  );
+
+  const imageBlock = imageUrl ? (
+    <div className="relative aspect-video overflow-hidden">
+      <Image
+        src={imageUrl}
+        alt={imageAlt}
+        fill
+        className="object-cover group-hover:scale-105 transition-transform duration-300"
+        sizes="256px"
+      />
+    </div>
+  ) : (
+    <div className="aspect-video bg-gray-100" />
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={cardClasses} data-related-card={item.type}>
+        {imageBlock}
+        <CardContent item={item} />
+      </Link>
+    );
+  }
+
+  return (
+    <div className={cardClasses} data-related-card={item.type}>
+      {imageBlock}
+      <CardContent item={item} />
+    </div>
+  );
+};

--- a/apps/web/src/components/related/RelatedContentCard/index.ts
+++ b/apps/web/src/components/related/RelatedContentCard/index.ts
@@ -1,0 +1,2 @@
+export { RelatedContentCard } from "./RelatedContentCard";
+export type { RelatedContentCardProps } from "./RelatedContentCard";

--- a/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.stories.tsx
+++ b/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { RelatedContentSlider } from "./RelatedContentSlider";
+import type {
+  RelatedArticleItem,
+  RelatedPageItem,
+  RelatedPlayerItem,
+  RelatedTeamItem,
+  RelatedStaffItem,
+  RelatedContentItem,
+} from "../types";
+
+const articles: RelatedArticleItem[] = [
+  {
+    type: "article",
+    id: "art-1",
+    title: "Interview met de kapitein",
+    slug: "interview-kapitein",
+    imageUrl: "https://picsum.photos/seed/art1/512/288",
+    date: "2026-03-20T10:00:00Z",
+    excerpt: "Een exclusief interview.",
+  },
+  {
+    type: "article",
+    id: "art-2",
+    title: "Wedstrijdverslag: overwinning in de derby",
+    slug: "wedstrijdverslag-derby",
+    imageUrl: "https://picsum.photos/seed/art2/512/288",
+    date: "2026-03-18T10:00:00Z",
+    excerpt: "Het verslag van de gewonnen derby.",
+  },
+];
+
+const page: RelatedPageItem = {
+  type: "page",
+  id: "page-1",
+  title: "Over de club",
+  slug: "over-de-club",
+  imageUrl: "https://picsum.photos/seed/page1/512/288",
+  excerpt: "Alles over KCVV Elewijt.",
+};
+
+const players: RelatedPlayerItem[] = [
+  {
+    type: "player",
+    id: "player-1",
+    firstName: "Jan",
+    lastName: "Janssens",
+    position: "Aanvaller",
+    imageUrl: "https://picsum.photos/seed/player1/512/288",
+    psdId: "12345",
+  },
+  {
+    type: "player",
+    id: "player-2",
+    firstName: "Pieter",
+    lastName: "De Smet",
+    position: "Middenvelder",
+    imageUrl: "https://picsum.photos/seed/player2/512/288",
+    psdId: "67890",
+  },
+];
+
+const team: RelatedTeamItem = {
+  type: "team",
+  id: "team-1",
+  name: "A-ploeg",
+  slug: "a-ploeg",
+  imageUrl: "https://picsum.photos/seed/team1/512/288",
+  tagline: "Eerste ploeg van KCVV Elewijt",
+};
+
+const staff: RelatedStaffItem = {
+  type: "staff",
+  id: "staff-1",
+  firstName: "Piet",
+  lastName: "Pieters",
+  role: "Hoofdtrainer",
+  imageUrl: "https://picsum.photos/seed/staff1/512/288",
+};
+
+const mixedItems: RelatedContentItem[] = [
+  ...articles,
+  page,
+  ...players,
+  team,
+  staff,
+];
+
+const meta = {
+  title: "Features/Related/RelatedContentSlider",
+  component: RelatedContentSlider,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Horizontal slider for related content. Composes HorizontalSlider + RelatedContentCard. " +
+          'Renders a "Gerelateerd" section heading. Automatically sorts items by type: ' +
+          "articles/pages → players → staff → teams.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="max-w-4xl mx-auto">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RelatedContentSlider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Mixed content from multiple types, automatically sorted */
+export const MixedContent: Story = {
+  args: { items: mixedItems },
+};
+
+/** Single type — articles only */
+export const ArticlesOnly: Story = {
+  args: { items: articles },
+};
+
+/** Single type — players only */
+export const PlayersOnly: Story = {
+  args: { items: players },
+};
+
+/** Empty state — renders nothing */
+export const Empty: Story = {
+  args: { items: [] },
+};

--- a/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.test.tsx
+++ b/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RelatedContentSlider } from "./RelatedContentSlider";
+import type {
+  RelatedArticleItem,
+  RelatedPageItem,
+  RelatedPlayerItem,
+  RelatedTeamItem,
+  RelatedStaffItem,
+} from "../types";
+
+const article: RelatedArticleItem = {
+  type: "article",
+  id: "art-1",
+  title: "Wedstrijdverslag",
+  slug: "wedstrijdverslag",
+  imageUrl: null,
+  date: "2026-03-20T10:00:00Z",
+  excerpt: "Het verslag van de wedstrijd.",
+};
+
+const page: RelatedPageItem = {
+  type: "page",
+  id: "page-1",
+  title: "Clubinfo",
+  slug: "clubinfo",
+  imageUrl: null,
+  excerpt: "Info over de club.",
+};
+
+const player: RelatedPlayerItem = {
+  type: "player",
+  id: "player-1",
+  firstName: "Jan",
+  lastName: "Janssens",
+  position: "Aanvaller",
+  imageUrl: null,
+  psdId: "12345",
+};
+
+const team: RelatedTeamItem = {
+  type: "team",
+  id: "team-1",
+  name: "A-ploeg",
+  slug: "a-ploeg",
+  imageUrl: null,
+  tagline: null,
+};
+
+const staff: RelatedStaffItem = {
+  type: "staff",
+  id: "staff-1",
+  firstName: "Piet",
+  lastName: "Pieters",
+  role: "Trainer",
+  imageUrl: null,
+};
+
+describe("RelatedContentSlider", () => {
+  it("renders section heading 'Gerelateerd'", () => {
+    render(<RelatedContentSlider items={[article]} />);
+
+    expect(screen.getByText("Gerelateerd")).toBeInTheDocument();
+  });
+
+  it("returns null when items array is empty", () => {
+    const { container } = render(<RelatedContentSlider items={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders correct card variant per item type", () => {
+    render(<RelatedContentSlider items={[article, player, team]} />);
+
+    expect(screen.getByText("Wedstrijdverslag")).toBeInTheDocument();
+    expect(screen.getByText("Jan Janssens")).toBeInTheDocument();
+    expect(screen.getByText("A-ploeg")).toBeInTheDocument();
+  });
+
+  it("orders items: articles/pages → players → staff → teams", () => {
+    // Pass in reverse order — component should reorder
+    const items = [team, staff, player, page, article];
+    const { container } = render(<RelatedContentSlider items={items} />);
+
+    const cards = container.querySelectorAll("[data-related-card]");
+    const types = Array.from(cards).map((c) =>
+      c.getAttribute("data-related-card"),
+    );
+
+    expect(types).toEqual(["article", "page", "player", "staff", "team"]);
+  });
+
+  it("renders all 5 variant types in a mixed array", () => {
+    render(
+      <RelatedContentSlider items={[article, page, player, team, staff]} />,
+    );
+
+    expect(screen.getByText("Wedstrijdverslag")).toBeInTheDocument();
+    expect(screen.getByText("Clubinfo")).toBeInTheDocument();
+    expect(screen.getByText("Jan Janssens")).toBeInTheDocument();
+    expect(screen.getByText("A-ploeg")).toBeInTheDocument();
+    expect(screen.getByText("Piet Pieters")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.tsx
+++ b/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.tsx
@@ -1,0 +1,41 @@
+import { HorizontalSlider } from "@/components/design-system/HorizontalSlider/HorizontalSlider";
+import { RelatedContentCard } from "../RelatedContentCard";
+import type { RelatedContentItem } from "../types";
+
+export interface RelatedContentSliderProps {
+  /** Mixed array of related content items */
+  items: RelatedContentItem[];
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const TYPE_ORDER: Record<RelatedContentItem["type"], number> = {
+  article: 0,
+  page: 1,
+  player: 2,
+  staff: 3,
+  team: 4,
+};
+
+function sortItems(items: RelatedContentItem[]): RelatedContentItem[] {
+  return [...items].sort((a, b) => TYPE_ORDER[a.type] - TYPE_ORDER[b.type]);
+}
+
+export const RelatedContentSlider = ({
+  items,
+  className,
+}: RelatedContentSliderProps) => {
+  if (items.length === 0) return null;
+
+  const sorted = sortItems(items);
+
+  return (
+    <section className={className}>
+      <HorizontalSlider title="Gerelateerd">
+        {sorted.map((item) => (
+          <RelatedContentCard key={item.id} item={item} />
+        ))}
+      </HorizontalSlider>
+    </section>
+  );
+};

--- a/apps/web/src/components/related/RelatedContentSlider/index.ts
+++ b/apps/web/src/components/related/RelatedContentSlider/index.ts
@@ -1,0 +1,2 @@
+export { RelatedContentSlider } from "./RelatedContentSlider";
+export type { RelatedContentSliderProps } from "./RelatedContentSlider";

--- a/apps/web/src/components/related/types.ts
+++ b/apps/web/src/components/related/types.ts
@@ -1,0 +1,55 @@
+/** Discriminated union for all related content item types */
+
+export interface RelatedArticleItem {
+  type: "article";
+  id: string;
+  title: string;
+  slug: string;
+  imageUrl: string | null;
+  date: string | null;
+  excerpt: string | null;
+}
+
+export interface RelatedPageItem {
+  type: "page";
+  id: string;
+  title: string;
+  slug: string;
+  imageUrl: string | null;
+  excerpt: string | null;
+}
+
+export interface RelatedPlayerItem {
+  type: "player";
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  position: string | null;
+  imageUrl: string | null;
+  psdId: string;
+}
+
+export interface RelatedTeamItem {
+  type: "team";
+  id: string;
+  name: string;
+  slug: string;
+  imageUrl: string | null;
+  tagline: string | null;
+}
+
+export interface RelatedStaffItem {
+  type: "staff";
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  role: string | null;
+  imageUrl: string | null;
+}
+
+export type RelatedContentItem =
+  | RelatedArticleItem
+  | RelatedPageItem
+  | RelatedPlayerItem
+  | RelatedTeamItem
+  | RelatedStaffItem;


### PR DESCRIPTION
Closes #931

## What changed
- Added `RelatedContentCard` component with five variants: article, page, player, team, staff — all with consistent `w-64` dimensions for mixed slider layout
- Added `RelatedContentSlider` composing `HorizontalSlider` + `RelatedContentCard` with "Gerelateerd" heading and automatic type-based ordering (articles/pages → players → staff → teams)
- Added shared discriminated union types in `src/components/related/types.ts`

## Testing
- 19 new unit tests across both components (all passing)
- Lint, type-check pass: `pnpm --filter @kcvv/web lint && pnpm --filter @kcvv/web type-check`
- Full test suite: 1630 tests passing
- Storybook stories for both components with all variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)