### PR TITLE
test(api): contract boundary schema assertion in transformPsdGame (#859)

### DIFF
--- a/apps/api/src/footbalisto/service.test.ts
+++ b/apps/api/src/footbalisto/service.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Effect, Layer, Logger } from "effect";
+import { Effect, Layer, Logger, Schema as S } from "effect";
 import {
   FootbalistoService,
   FootbalistoServiceLive,
   mapGameStatus,
 } from "./service";
+import { Match } from "@kcvv/api-contract";
 import { UpstreamUnavailableError, type BffError } from "./errors";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
@@ -270,6 +271,8 @@ describe("FootbalistoService.getTeamMatches", () => {
       expect(result.right[0]?.id).toBe(101);
       expect(result.right[0]?.status).toBe("finished");
       expect(result.right[0]?.home_team.name).toBe("KCVV Elewijt");
+      // Contract boundary: validate transform output against api-contract schema
+      expect(() => S.decodeUnknownSync(Match)(result.right[0])).not.toThrow();
     }
   });
 


### PR DESCRIPTION
Closes #859

## What changed
- Added `S.decodeUnknownSync(Match)` assertion to the existing `getTeamMatches` test that exercises `transformPsdGame`
- Imports `Match` from `@kcvv/api-contract` and `Schema` from `effect` in `service.test.ts`
- Confirms no circular dependency issues (turbo build passes)

## Testing
- All 136 tests pass: `pnpm --filter @kcvv/api test`
- Type-check passes: `pnpm --filter @kcvv/api type-check`
- No circular deps: `pnpm turbo build --filter=@kcvv/api` succeeds