### PR TITLE
test(api): schema-level tests for Match, MatchDetail, RankingEntry, TeamStats (#860)

### DIFF
--- a/packages/api-contract/src/schemas/match.test.ts
+++ b/packages/api-contract/src/schemas/match.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { Schema as S } from "effect";
+import { Match, MatchDetail, MatchesArray, MatchStatus } from "./match";
+
+const validMatchTeam = { id: 1, name: "KCVV Elewijt", logo: "/logo.png", score: 2 };
+const validAwayTeam = { id: 2, name: "FC Opponent", score: 1 };
+
+const validMatch = {
+  id: 123,
+  date: "2026-03-15T15:00:00.000Z",
+  time: "15:00",
+  venue: "Koninklijk Stadion",
+  home_team: validMatchTeam,
+  away_team: validAwayTeam,
+  status: "finished",
+  round: "15",
+  competition: "2de Nationale",
+  kcvv_team_id: 1,
+  kcvv_team_label: "A-Ploeg",
+};
+
+describe("Match schema", () => {
+  it("decodes a valid Match", () => {
+    const result = S.decodeUnknownSync(Match)(validMatch);
+    expect(result.id).toBe(123);
+    expect(result.home_team.name).toBe("KCVV Elewijt");
+    expect(result.away_team.score).toBe(1);
+    expect(result.status).toBe("finished");
+  });
+
+  it("decodes a minimal Match (only required fields)", () => {
+    const minimal = {
+      id: 1,
+      date: "2026-01-01T00:00:00.000Z",
+      home_team: { id: 1, name: "Home" },
+      away_team: { id: 2, name: "Away" },
+      status: "scheduled",
+    };
+    const result = S.decodeUnknownSync(Match)(minimal);
+    expect(result.id).toBe(1);
+    expect(result.home_team.logo).toBeUndefined();
+    expect(result.time).toBeUndefined();
+  });
+
+  it("coerces ISO string to Date in Match.date", () => {
+    const result = S.decodeUnknownSync(Match)(validMatch);
+    expect(result.date).toBeInstanceOf(Date);
+    expect(result.date.toISOString()).toBe("2026-03-15T15:00:00.000Z");
+  });
+
+  it("accepts a Date object for Match.date", () => {
+    const withDate = { ...validMatch, date: new Date("2026-03-15T15:00:00.000Z") };
+    const result = S.decodeUnknownSync(Match)(withDate);
+    expect(result.date).toBeInstanceOf(Date);
+  });
+
+  it("throws on invalid MatchStatus value", () => {
+    const invalid = { ...validMatch, status: "unknown" };
+    expect(() => S.decodeUnknownSync(Match)(invalid)).toThrow();
+  });
+
+  it("throws on missing required field", () => {
+    const { id: _, ...noId } = validMatch;
+    expect(() => S.decodeUnknownSync(Match)(noId)).toThrow();
+  });
+
+  it("decodes MatchesArray", () => {
+    const result = S.decodeUnknownSync(MatchesArray)([validMatch]);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("MatchStatus schema", () => {
+  it.each(["scheduled", "finished", "forfeited", "postponed", "stopped"] as const)(
+    "accepts '%s'",
+    (status) => {
+      expect(() => S.decodeUnknownSync(MatchStatus)(status)).not.toThrow();
+    },
+  );
+
+  it("rejects invalid status", () => {
+    expect(() => S.decodeUnknownSync(MatchStatus)("invalid")).toThrow();
+  });
+});
+
+describe("MatchDetail schema", () => {
+  const validDetail = {
+    ...validMatch,
+    hasReport: true,
+  };
+
+  it("decodes a valid MatchDetail without lineup", () => {
+    const result = S.decodeUnknownSync(MatchDetail)(validDetail);
+    expect(result.id).toBe(123);
+    expect(result.hasReport).toBe(true);
+    expect(result.lineup).toBeUndefined();
+  });
+
+  it("decodes a valid MatchDetail with lineup", () => {
+    const withLineup = {
+      ...validDetail,
+      lineup: {
+        home: [
+          {
+            name: "Jan Janssens",
+            number: 1,
+            isCaptain: true,
+            isKeeper: true,
+            status: "starter",
+            minutesPlayed: 90,
+          },
+        ],
+        away: [
+          {
+            name: "Piet Pieters",
+            isCaptain: false,
+            status: "substitute",
+            card: "yellow",
+          },
+        ],
+      },
+    };
+    const result = S.decodeUnknownSync(MatchDetail)(withLineup);
+    expect(result.lineup?.home).toHaveLength(1);
+    expect(result.lineup?.home[0].isCaptain).toBe(true);
+    expect(result.lineup?.away[0].card).toBe("yellow");
+  });
+
+  it("throws on missing hasReport", () => {
+    expect(() => S.decodeUnknownSync(MatchDetail)(validMatch)).toThrow();
+  });
+});

--- a/packages/api-contract/src/schemas/ranking.test.ts
+++ b/packages/api-contract/src/schemas/ranking.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { Schema as S } from "effect";
+import { RankingEntry, RankingArray } from "./ranking";
+
+const validEntry = {
+  position: 1,
+  team_id: 42,
+  team_name: "KCVV Elewijt",
+  team_logo: "/logo.png",
+  played: 20,
+  won: 14,
+  drawn: 3,
+  lost: 3,
+  goals_for: 45,
+  goals_against: 18,
+  goal_difference: 27,
+  points: 45,
+  form: "WWDLW",
+};
+
+describe("RankingEntry schema", () => {
+  it("decodes a valid RankingEntry", () => {
+    const result = S.decodeUnknownSync(RankingEntry)(validEntry);
+    expect(result.position).toBe(1);
+    expect(result.team_name).toBe("KCVV Elewijt");
+    expect(result.points).toBe(45);
+  });
+
+  it("decodes without optional fields", () => {
+    const { team_logo: _, form: __, ...minimal } = validEntry;
+    const result = S.decodeUnknownSync(RankingEntry)(minimal);
+    expect(result.team_logo).toBeUndefined();
+    expect(result.form).toBeUndefined();
+  });
+
+  it("throws on missing required field", () => {
+    const { points: _, ...noPoints } = validEntry;
+    expect(() => S.decodeUnknownSync(RankingEntry)(noPoints)).toThrow();
+  });
+});
+
+describe("RankingArray schema", () => {
+  it("decodes a valid RankingArray", () => {
+    const result = S.decodeUnknownSync(RankingArray)([validEntry]);
+    expect(result).toHaveLength(1);
+    expect(result[0].position).toBe(1);
+  });
+
+  it("decodes an empty array", () => {
+    const result = S.decodeUnknownSync(RankingArray)([]);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/packages/api-contract/src/schemas/stats.test.ts
+++ b/packages/api-contract/src/schemas/stats.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { Schema as S } from "effect";
+import { PlayerStats, TeamStats } from "./stats";
+
+const validPlayerStats = {
+  player_id: 101,
+  player_name: "Jan Janssens",
+  team_id: 1,
+  matches_played: 18,
+  goals: 12,
+  assists: 5,
+  yellow_cards: 2,
+  red_cards: 0,
+  minutes_played: 1440,
+};
+
+const validTeamStats = {
+  team_id: 1,
+  team_name: "KCVV Elewijt",
+  total_matches: 20,
+  wins: 14,
+  draws: 3,
+  losses: 3,
+  goals_scored: 45,
+  goals_conceded: 18,
+  clean_sheets: 8,
+  top_scorers: [validPlayerStats],
+};
+
+describe("PlayerStats schema", () => {
+  it("decodes valid PlayerStats", () => {
+    const result = S.decodeUnknownSync(PlayerStats)(validPlayerStats);
+    expect(result.player_id).toBe(101);
+    expect(result.goals).toBe(12);
+    expect(result.assists).toBe(5);
+  });
+
+  it("decodes without optional fields", () => {
+    const minimal = {
+      player_id: 1,
+      player_name: "Test",
+      team_id: 1,
+      matches_played: 0,
+      goals: 0,
+    };
+    const result = S.decodeUnknownSync(PlayerStats)(minimal);
+    expect(result.assists).toBeUndefined();
+    expect(result.minutes_played).toBeUndefined();
+  });
+
+  it("throws on numeric field type violation", () => {
+    const invalid = { ...validPlayerStats, goals: "twelve" };
+    expect(() => S.decodeUnknownSync(PlayerStats)(invalid)).toThrow();
+  });
+});
+
+describe("TeamStats schema", () => {
+  it("decodes valid TeamStats", () => {
+    const result = S.decodeUnknownSync(TeamStats)(validTeamStats);
+    expect(result.team_id).toBe(1);
+    expect(result.wins).toBe(14);
+    expect(result.top_scorers).toHaveLength(1);
+    expect(result.top_scorers![0].goals).toBe(12);
+  });
+
+  it("decodes without optional fields", () => {
+    const { clean_sheets: _, top_scorers: __, ...minimal } = validTeamStats;
+    const result = S.decodeUnknownSync(TeamStats)(minimal);
+    expect(result.clean_sheets).toBeUndefined();
+    expect(result.top_scorers).toBeUndefined();
+  });
+
+  it("throws on numeric field type violation", () => {
+    const invalid = { ...validTeamStats, wins: "fourteen" };
+    expect(() => S.decodeUnknownSync(TeamStats)(invalid)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #860

## What changed
- Added `match.test.ts` — tests Match, MatchDetail, MatchStatus decode (valid/invalid), DateFromStringOrDate coercion, lineup with/without
- Added `ranking.test.ts` — tests RankingEntry and RankingArray decode, missing required field rejection
- Added `stats.test.ts` — tests TeamStats and PlayerStats decode, numeric field type violations

## Testing
- All 50 tests pass: `pnpm --filter @kcvv/api-contract test`
- Type-check passes: `pnpm --filter @kcvv/api-contract type-check`
- Pre-commit hooks pass (full monorepo type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)