### PR TITLE
test(api): schema-validate handler return values + fix fresh-data validation gap (#862)

### DIFF
--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -387,6 +387,55 @@ describe("TypedKvCache", () => {
 
     expect(result).toEqual({ name: "stale", value: 99 });
   });
+
+  it("cache miss: dies when fetch returns schema-invalid data", async () => {
+    const mockKv = makeMockKv();
+    // Fetch returns data that doesn't match TestSchema (value should be number, not string)
+    const fetchEffect = Effect.succeed({
+      name: "test",
+      value: "not-a-number",
+    } as never);
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromiseExit(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result._tag).toBe("Failure");
+    // Should NOT cache invalid data
+    expect(mockKv.put).not.toHaveBeenCalled();
+  });
+
+  it("stale + refresh: dies when refresh returns schema-invalid data", async () => {
+    const mockKv = makeMockKv();
+    // Cached 2 hours ago → stale
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "old", value: 1 }, 2 * 60 * 60 * 1000),
+    );
+
+    // Refresh returns schema-invalid data
+    const fetchEffect = Effect.succeed({ name: 123, value: "bad" } as never);
+
+    const typedCache = TypedKvCache(TestSchema);
+    const result = await Effect.runPromiseExit(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result._tag).toBe("Failure");
+    // Should NOT cache invalid data
+    expect(mockKv.put).not.toHaveBeenCalled();
+  });
 });
 
 describe("KvCacheService", () => {

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -111,6 +111,9 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             );
 
             if (refreshed.ok) {
+              yield* S.decodeUnknown(schema)(refreshed.freshValue).pipe(
+                Effect.orDie,
+              );
               const wrapper = JSON.stringify({
                 value: refreshed.freshValue,
                 fetchedAt: Date.now(),
@@ -122,8 +125,9 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
           }
         }
 
-        // Cache miss: fetch, wrap, store
+        // Cache miss: fetch, validate, wrap, store
         const value = yield* fetch;
+        yield* S.decodeUnknown(schema)(value).pipe(Effect.orDie);
         const wrapper = JSON.stringify({ value, fetchedAt: Date.now() });
         yield* cache.set(key, wrapper, effectiveHardTtl);
         return value;

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schema as S } from "effect";
 import {
   getMatchesByTeamHandler,
   getNextMatchesHandler,
@@ -19,9 +19,15 @@ import {
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
 import { testEnvLayer } from "../test-helpers/env-layer";
-import type { Match, MatchDetail } from "@kcvv/api-contract";
+import {
+  Match,
+  MatchesArray,
+  MatchDetail,
+  type Match as MatchType,
+  type MatchDetail as MatchDetailType,
+} from "@kcvv/api-contract";
 
-const baseMatch: Match = {
+const baseMatch: MatchType = {
   id: 1,
   date: new Date("2025-01-15T15:00:00.000Z"),
   time: "15:00",
@@ -31,7 +37,7 @@ const baseMatch: Match = {
   competition: "LEAGUE",
 };
 
-const baseDetail: MatchDetail = {
+const baseDetail: MatchDetailType = {
   id: 99,
   date: new Date("2025-01-15T15:00:00.000Z"),
   time: "15:00",
@@ -87,6 +93,7 @@ describe("getMatchesByTeamHandler", () => {
     expect(result[0]?.id).toBe(1);
     expect(result[0]?.status).toBe("finished");
     expect(result[0]?.home_team.name).toBe("KCVV Elewijt");
+    expect(() => S.decodeUnknownSync(MatchesArray)(result)).not.toThrow();
   });
 
   it("propagates UpstreamUnavailableError from service", async () => {
@@ -115,6 +122,7 @@ describe("getNextMatchesHandler", () => {
     const result = await Effect.runPromise(provide(getNextMatchesHandler()));
     expect(result).toHaveLength(1);
     expect(result[0]?.id).toBe(1);
+    expect(() => S.decodeUnknownSync(MatchesArray)(result)).not.toThrow();
   });
 
   it("propagates UpstreamUnavailableError from service", async () => {
@@ -143,6 +151,7 @@ describe("getMatchDetailHandler", () => {
     const result = await Effect.runPromise(provide(getMatchDetailHandler(99)));
     expect(result.id).toBe(99);
     expect(result.hasReport).toBe(true);
+    expect(() => S.decodeUnknownSync(MatchDetail)(result)).not.toThrow();
   });
 
   it("stores match detail with hardTtl (7 days)", async () => {
@@ -230,5 +239,6 @@ describe("getMatchByIdHandler", () => {
     );
     expect(result.id).toBe(99);
     expect("lineup" in result).toBe(false);
+    expect(() => S.decodeUnknownSync(Match)(result)).not.toThrow();
   });
 });

--- a/apps/api/src/handlers/ranking.test.ts
+++ b/apps/api/src/handlers/ranking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schema as S } from "effect";
 import { getRankingHandler } from "./ranking";
 import {
   FootbalistoService,
@@ -7,7 +7,7 @@ import {
 } from "../footbalisto/service";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { testEnvLayer } from "../test-helpers/env-layer";
-import type { RankingEntry } from "@kcvv/api-contract";
+import { RankingArray, type RankingEntry } from "@kcvv/api-contract";
 import { UpstreamUnavailableError } from "../footbalisto/errors";
 
 const rankingEntries: readonly RankingEntry[] = [
@@ -60,6 +60,7 @@ describe("getRankingHandler", () => {
     expect(result[0]?.position).toBe(1);
     expect(result[0]?.team_name).toBe("KCVV Elewijt");
     expect(result[0]?.points).toBe(48);
+    expect(() => S.decodeUnknownSync(RankingArray)(result)).not.toThrow();
   });
 
   it("fails with ResourceNotFoundError when service returns empty ranking", async () => {

--- a/apps/api/src/handlers/stats.test.ts
+++ b/apps/api/src/handlers/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Schema as S } from "effect";
 import { getTeamStatsHandler } from "./stats";
 import {
   FootbalistoService,
@@ -11,6 +11,7 @@ import {
   UpstreamUnavailableError,
   ResourceNotFoundError,
 } from "../footbalisto/errors";
+import { TeamStats } from "@kcvv/api-contract";
 
 const mockServiceImpl: FootbalistoServiceInterface = {
   getTeamStats: (_teamId) =>
@@ -66,6 +67,7 @@ describe("getTeamStatsHandler", () => {
       expect(result.right.team_id).toBe(1);
       expect(result.right.team_name).toBe("KCVV Elewijt A");
       expect(result.right.wins).toBe(18);
+      expect(() => S.decodeUnknownSync(TeamStats)(result.right)).not.toThrow();
     }
   });
 


### PR DESCRIPTION
Closes #862

## What changed
- Handler tests (`matches.test.ts`, `ranking.test.ts`, `stats.test.ts`) now schema-validate return values with `S.decodeUnknownSync` against api-contract schemas (`MatchesArray`, `Match`, `MatchDetail`, `RankingArray`, `TeamStats`)
- `TypedKvCache.getOrFetch` now validates fresh transform output against the schema before caching — both on cache miss and stale refresh paths. Validation failure triggers `Effect.orDie` (500) instead of silently caching invalid data
- Two new tests in `kv-cache.test.ts` verify that schema-invalid fresh data is rejected and not cached

## Testing
- All checks pass: `pnpm --filter @kcvv/api lint && pnpm --filter @kcvv/api type-check && pnpm --filter @kcvv/api test` (138 tests, 16 files)
- Pre-commit hooks pass (prettier, type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)