### PR TITLE
refactor(matches): wire MatchStatusBadge to getStatusColor + add tests (#866)

### DIFF
--- a/apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.test.tsx
+++ b/apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.test.tsx
@@ -32,6 +32,11 @@ describe("MatchStatusBadge", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("renders nothing for unknown string status", () => {
+    const { container } = render(<MatchStatusBadge status="toString" />);
+    expect(container.innerHTML).toBe("");
+  });
+
   it("uses getStatusColor to determine badge variant", () => {
     // postponed → orange → warning variant
     const { container } = render(<MatchStatusBadge status="postponed" />);

--- a/apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.tsx
+++ b/apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.tsx
@@ -31,7 +31,7 @@ const darkClasses: Record<string, string> = {
 };
 
 function isBadgeStatus(status: string): status is BadgeStatus {
-  return status in statusLabels;
+  return Object.hasOwn(statusLabels, status);
 }
 
 export function MatchStatusBadge({


### PR DESCRIPTION
Closes #866

## What changed
- Refactored `MatchStatusBadge` to derive Badge variants from `getStatusColor()` in `match-display.ts` instead of a parallel `statusConfig` mapping
- Added `className` prop to `MatchStatusBadge` for custom styling
- Added 7 unit tests covering all status rendering, null returns, and className passthrough

## Testing
- All 1710 tests pass (`pnpm test`)
- Lint + type-check pass (verified by pre-commit hook)
- `check-all` build step fails due to pre-existing Sanity `projectId` env issue (unrelated)