### PR TITLE
test(api): runSync tracer bullet — mocked SanityWriteClient (#869)

### DIFF
--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -115,6 +115,7 @@ describe("runSync", () => {
       upsertPlayer,
       upsertTeam,
       upsertStaff,
+      uploadPlayerImage,
       mock: sanityMock,
     } = makeSanityWriteClientMock();
     const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER]);
@@ -141,5 +142,8 @@ describe("runSync", () => {
 
     // upsertStaff not called (no staff members)
     expect(upsertStaff).not.toHaveBeenCalled();
+
+    // uploadPlayerImage not called (profilePictureURL is null)
+    expect(uploadPlayerImage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #869

## What changed
- Created `SanityWriteClientMock` with vitest spy functions for `upsertPlayer`, `upsertTeam`, `upsertStaff`, `uploadPlayerImage`, and `getPlayersImageState`
- Created `PsdTeamClientMock` factory and in-memory KV stub for cursor tracking
- Added one `runSync` integration test: 1 team, 1 player (no image) → verifies `upsertPlayer` called once, `upsertTeam` called once, `upsertStaff` not called

## Testing
- All checks pass: `pnpm --filter @kcvv/api run type-check && pnpm --filter @kcvv/api run lint && pnpm --filter @kcvv/api run test` (139 tests, all green)
- New test file: `apps/api/src/sync/run-sync.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)