### PR TITLE
feat(ui): /club storybook stories for all components (#1032)

### DIFF
--- a/apps/web/src/components/club/ClubContactCta/ClubContactCta.stories.tsx
+++ b/apps/web/src/components/club/ClubContactCta/ClubContactCta.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ClubContactCta } from "./ClubContactCta";
+
+const meta = {
+  title: "Features/Club/ClubContactCta",
+  component: ClubContactCta,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: { default: "dark" },
+    docs: {
+      description: {
+        component:
+          "Contact call-to-action bar for the /club landing page. Two-column layout with heading and body text on the left, CTA button on the right. Collapses to centered single-column on mobile.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ClubContactCta>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default desktop layout — text left, CTA button right.
+ */
+export const Default: Story = {};
+
+/**
+ * Mobile viewport — stacked and centered layout.
+ */
+export const MobileViewport: Story = {
+  globals: {
+    viewport: { value: "kcvvMobile" },
+  },
+};

--- a/apps/web/src/components/club/ClubEditorialGrid/ClubEditorialGrid.stories.tsx
+++ b/apps/web/src/components/club/ClubEditorialGrid/ClubEditorialGrid.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ClubEditorialGrid } from "./ClubEditorialGrid";
+
+const meta = {
+  title: "Features/Club/ClubEditorialGrid",
+  component: ClubEditorialGrid,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: { default: "light" },
+    docs: {
+      description: {
+        component:
+          "Asymmetric 12-column editorial card grid for the /club landing page. Shows all 6 club sub-section cards (geschiedenis, bestuur, organigram, ultras, angels, aansluiten) with responsive breakpoints at 960px and 640px.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ClubEditorialGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Full grid with all 6 editorial cards in the asymmetric desktop layout.
+ */
+export const Default: Story = {};

--- a/apps/web/src/components/club/ClubHero/ClubHero.stories.tsx
+++ b/apps/web/src/components/club/ClubHero/ClubHero.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ClubHero } from "./ClubHero";
+
+const meta = {
+  title: "Features/Club/ClubHero",
+  component: ClubHero,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Hero section for the /club landing page. Full-bleed background image with gradient overlays, title with green accent, and a built-in diagonal transition to the next section.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof ClubHero>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default hero with placeholder background image, title, subtitle,
+ * and built-in diagonal SVG transition.
+ */
+export const Default: Story = {};

--- a/apps/web/src/components/club/MissionBanner/MissionBanner.stories.tsx
+++ b/apps/web/src/components/club/MissionBanner/MissionBanner.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { MissionBanner } from "./MissionBanner";
+
+const meta = {
+  title: "Features/Club/MissionBanner",
+  component: MissionBanner,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: { default: "dark" },
+    docs: {
+      description: {
+        component:
+          "Centered mission statement banner for the /club landing page. Displays a decorative opening quote, the club mission text, and attribution line on a dark green background.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof MissionBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default mission banner with quote, mission statement, and attribution.
+ */
+export const Default: Story = {};


### PR DESCRIPTION
Closes #1032

## What changed
- Added `ClubHero.stories.tsx` under `Features/Club/ClubHero`
- Added `ClubEditorialGrid.stories.tsx` under `Features/Club/ClubEditorialGrid`
- Added `MissionBanner.stories.tsx` under `Features/Club/MissionBanner`
- Added `ClubContactCta.stories.tsx` under `Features/Club/ClubContactCta` (with mobile viewport variant)

## Testing
- All stories use `StoryObj<typeof meta>` pattern with `fn()` handlers convention
- All stories include `tags: ["autodocs"]`
- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, tests, build)