### PR TITLE
refactor(api): extract image upload decision logic as pure tested functions (#871)

### DIFF
--- a/apps/api/src/sync/image-upload-utils.test.ts
+++ b/apps/api/src/sync/image-upload-utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { extractStableImageUrl, needsUpload } from "./image-upload-utils";
+
+const BASE_URL = "https://kcvv.prosoccerdata.com";
+
+describe("extractStableImageUrl", () => {
+  it("strips profileAccessKey but retains ?v=N", () => {
+    const result = extractStableImageUrl(
+      "/api/v2/members/profilepicture/6453?profileAccessKey=abc123&v=1",
+      BASE_URL,
+    );
+    expect(result).toBe(
+      "https://kcvv.prosoccerdata.com/api/v2/members/profilepicture/6453?v=1",
+    );
+  });
+
+  it("returns null for null URL", () => {
+    expect(extractStableImageUrl(null, BASE_URL)).toBeNull();
+  });
+
+  it("returns URL without ?v= when v param is absent", () => {
+    const result = extractStableImageUrl(
+      "/api/v2/members/profilepicture/6453?profileAccessKey=newkey999",
+      BASE_URL,
+    );
+    expect(result).toBe(
+      "https://kcvv.prosoccerdata.com/api/v2/members/profilepicture/6453",
+    );
+  });
+
+  it("handles URL with no query params at all", () => {
+    const result = extractStableImageUrl(
+      "/api/v2/members/profilepicture/6453",
+      BASE_URL,
+    );
+    expect(result).toBe(
+      "https://kcvv.prosoccerdata.com/api/v2/members/profilepicture/6453",
+    );
+  });
+
+  it("retains v=0", () => {
+    const result = extractStableImageUrl(
+      "/api/v2/members/profilepicture/6453?profileAccessKey=key&v=0",
+      BASE_URL,
+    );
+    expect(result).toBe(
+      "https://kcvv.prosoccerdata.com/api/v2/members/profilepicture/6453?v=0",
+    );
+  });
+});
+
+describe("needsUpload", () => {
+  it("returns true when no existing image (existingPsdImageUrl is null)", () => {
+    expect(needsUpload("https://example.com/img?v=1", null)).toBe(true);
+  });
+
+  it("returns true when no existing image (existingPsdImageUrl is undefined)", () => {
+    expect(needsUpload("https://example.com/img?v=1", undefined)).toBe(true);
+  });
+
+  it("returns true when stableUrl differs from existing (version change)", () => {
+    expect(
+      needsUpload("https://example.com/img?v=2", "https://example.com/img?v=1"),
+    ).toBe(true);
+  });
+
+  it("returns false when stableUrl matches existing", () => {
+    expect(
+      needsUpload("https://example.com/img?v=1", "https://example.com/img?v=1"),
+    ).toBe(false);
+  });
+
+  it("returns false when stableUrl is null (no profile picture)", () => {
+    expect(needsUpload(null, null)).toBe(false);
+  });
+
+  it("returns false when stableUrl is null even if existing has image", () => {
+    expect(needsUpload(null, "https://example.com/img?v=1")).toBe(false);
+  });
+});

--- a/apps/api/src/sync/image-upload-utils.ts
+++ b/apps/api/src/sync/image-upload-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Extract a stable image URL from a PSD profilePictureURL.
+ *
+ * Strips ephemeral auth params (profileAccessKey) that change on every API call,
+ * but retains the photo version param (?v=N) so that version changes trigger
+ * re-uploads.
+ *
+ * @param profilePictureURL - Relative path from PSD (e.g. "/api/v2/members/profilepicture/6453?profileAccessKey=abc&v=1")
+ * @param baseUrl - Base URL to prepend (e.g. "https://kcvv.prosoccerdata.com")
+ * @returns Absolute stable URL, or null if profilePictureURL is falsy
+ */
+export function extractStableImageUrl(
+  profilePictureURL: string | null,
+  baseUrl: string,
+): string | null {
+  if (!profilePictureURL) return null;
+
+  const path = profilePictureURL.split("?")[0];
+  const v = new URLSearchParams(profilePictureURL.split("?")[1] ?? "").get("v");
+  return v !== null ? `${baseUrl}${path}?v=${v}` : `${baseUrl}${path}`;
+}
+
+/**
+ * Determine whether a player image needs to be uploaded to Sanity.
+ *
+ * Upload is needed when:
+ * - There is a new image from PSD (stableUrl is non-null) AND
+ * - Either no existing image in Sanity, or the stored URL differs (version change)
+ *
+ * @param stableUrl - Stable image URL from PSD (output of extractStableImageUrl), or null if no profile picture
+ * @param existingPsdImageUrl - Currently stored psdImageUrl in Sanity, or null/undefined if none
+ */
+export function needsUpload(
+  stableUrl: string | null,
+  existingPsdImageUrl: string | null | undefined,
+): boolean {
+  if (!stableUrl) return false;
+  return !existingPsdImageUrl || existingPsdImageUrl !== stableUrl;
+}

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -8,6 +8,7 @@ import type {
 import { SanityWriteClient } from "../sanity/client";
 import { PsdTeamClient } from "./psd-team-client";
 import { WorkerEnvTag } from "../env";
+import { extractStableImageUrl, needsUpload } from "./image-upload-utils";
 
 /**
  * Convert a PSD member record into a Sanity-compatible player document and include the PSD image URL when present.
@@ -37,19 +38,7 @@ export function transformMember(
         : psd.bestPosition !== null
           ? psd.bestPosition.type.name
           : null,
-    // Stable URL used for dedup comparison across syncs.
-    // Includes ?v=N (PSD photo version) so that a player uploading a new photo
-    // to PSD (v increments) triggers a fresh upload on the next sync cycle.
-    // profileAccessKey is stripped — it is ephemeral and changes each sync.
-    _psdImageUrl: psd.profilePictureURL
-      ? (() => {
-          const path = psd.profilePictureURL!.split("?")[0];
-          const v = new URLSearchParams(
-            psd.profilePictureURL!.split("?")[1] ?? "",
-          ).get("v");
-          return v !== null ? `${baseUrl}${path}?v=${v}` : `${baseUrl}${path}`;
-        })()
-      : null,
+    _psdImageUrl: extractStableImageUrl(psd.profilePictureURL, baseUrl),
     // Full URL including ?profileAccessKey — required to actually fetch the image.
     _psdImageFetchUrl: psd.profilePictureURL
       ? `${baseUrl}${psd.profilePictureURL}`
@@ -219,10 +208,12 @@ export const runSync = Effect.gen(function* () {
         }
 
         const existing = imageState.get(doc.psdId);
-        const needsUpload =
-          !existing?.hasPsdImage || existing.psdImageUrl !== stableImageUrl;
+        const shouldUpload = needsUpload(
+          stableImageUrl,
+          existing?.hasPsdImage ? existing.psdImageUrl : null,
+        );
 
-        if (!needsUpload) {
+        if (!shouldUpload) {
           yield* Effect.log(
             `player ${doc.psdId}: image up-to-date (hasPsdImage=${existing?.hasPsdImage}, storedUrl=${existing?.psdImageUrl ?? "null"})`,
           );


### PR DESCRIPTION
Closes #871

## What changed
- Extracted `extractStableImageUrl` and `needsUpload` from inline code in `transformMember` and `runSync` into `apps/api/src/sync/image-upload-utils.ts`
- Added 11 dedicated unit tests covering: null URL, URL with auth params, URL with `?v=N`, version change detection, no existing image
- Updated both call sites (`transformMember`, `runSync`) to use the extracted functions

## Testing
- All checks pass: `tsc --noEmit`, `eslint`, `vitest run` (156 tests, 18 files)
- No behavior change — pure refactor with identical logic


🤖 Generated with [Claude Code](https://claude.com/claude-code)