### PR TITLE
feat(config): API-based unblocking in ralph.sh (#1049)

### DIFF
--- a/docs/prd/github-issue-relationships.md
+++ b/docs/prd/github-issue-relationships.md
@@ -36,7 +36,7 @@ Manually set a blocking relationship between two test issues via `gh api`, then 
 ```bash
 # Create relationship
 gh api /repos/{owner}/{repo}/issues/{child}/sub_issues \
-  --method POST -f sub_issue_id={parent_issue_node_id}
+  --method POST -F sub_issue_id={parent_issue_id}
 
 # Query blockers for an issue
 gh api /repos/{owner}/{repo}/issues/{number}/sub_issues

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -269,17 +269,20 @@ while [ $i -lt $MAX ]; do
   if [ -n "$BLOCKED_ISSUES" ]; then
     for CANDIDATE_NUM in $BLOCKED_ISSUES; do
       # Query sub-issues (blockers) for this candidate via GitHub Sub-issues API
+      SUB_ISSUES_ERR=$(mktemp)
       SUB_ISSUES_JSON=$(gh api "/repos/{owner}/{repo}/issues/${CANDIDATE_NUM}/sub_issues" \
-        --jq '[.[] | {number, state}]' 2>&1)
+        --jq '[.[] | {number, state}]' 2>"$SUB_ISSUES_ERR")
       API_EXIT=$?
 
       if [ $API_EXIT -ne 0 ]; then
-        echo "  ⚠️  Sub-issues API failed for #${CANDIDATE_NUM} — skipping (fallback)"
+        echo "  ⚠️  Sub-issues API failed for #${CANDIDATE_NUM} — skipping ($(cat "$SUB_ISSUES_ERR"))"
+        rm -f "$SUB_ISSUES_ERR"
         continue
       fi
+      rm -f "$SUB_ISSUES_ERR"
 
-      if [ -z "$SUB_ISSUES_JSON" ] || [ "$SUB_ISSUES_JSON" = "null" ] || [ "$SUB_ISSUES_JSON" = "[]" ]; then
-        # No sub-issues set on this issue
+      if ! echo "$SUB_ISSUES_JSON" | jq -e 'type=="array" and length>0' >/dev/null 2>&1; then
+        # No sub-issues or invalid response
         continue
       fi
 


### PR DESCRIPTION
Closes #1049

## What changed
- Replaced sed-based body-text parsing for blocker extraction with GitHub's Sub-issues API (`/issues/{n}/sub_issues`)
- Model: blocked issue = parent, blockers = sub-issues. When all sub-issues are closed, the parent is unblocked
- Added explicit fallback: API errors log a warning and skip (don't crash the loop)
- Updated PRD with answered open questions and discovered unknowns (jq `!=` zsh issue, `sub_issue_id` requires integer `id` not `node_id`)

## Testing
- Verified Sub-issues API round-trip: created sub-issue relationship (#1049 → #1050), confirmed API returns correct data
- Tested single-blocker scenario: completing only blocker correctly unblocks
- Tested multi-blocker scenario: completing one of two blockers does NOT unblock
- Tested API error fallback: non-existent issue returns non-zero exit, warning logged, loop continues
- Tested "not a blocker" case: issues without the completed issue as sub-issue are skipped
- `bash -n scripts/ralph.sh` — syntax OK