### PR TITLE
feat(config): prd-to-issues sets blocking relationships via API (#1050)

### DIFF
--- a/.claude/commands/prd-to-issues.md
+++ b/.claude/commands/prd-to-issues.md
@@ -72,13 +72,28 @@ gh issue create \
 
 For blocked issues use `--label "blocked"` instead of `--label "ready"`.
 
-## Step 4 — Wire dependencies
+## Step 4 — Wire dependencies via Sub-issues API
 
-Add `blocked-by` comments to dependent issues:
+For each issue that has a `## Blocked by` section listing other issues, create a Sub-issues relationship via the GitHub API. This makes dependencies machine-readable and visible in the GitHub UI.
+
+The relationship model: the **blocked** issue is the parent, and each **blocker** is added as a sub-issue. This matches how `ralph.sh` queries blockers.
 
 ```bash
-gh issue comment <blocked-issue> --body "Blocked by #<dependency>"
+# For each blocked issue, set up Sub-issues relationships:
+
+# 1. Get the integer id of the blocker issue (required by the API — not node_id)
+BLOCKER_ID=$(gh api /repos/{owner}/{repo}/issues/<blocker-number> --jq '.id')
+
+# 2. Add the blocker as a sub-issue of the blocked issue
+gh api /repos/{owner}/{repo}/issues/<blocked-number>/sub_issues \
+  --method POST -F sub_issue_id="$BLOCKER_ID"
 ```
+
+Repeat for every blocker listed in the `## Blocked by` section.
+
+If the API call fails, log a warning and continue — the `## Blocked by` markdown in the body still serves as a fallback.
+
+**Note:** The `## Blocked by` markdown is still written in issue bodies for human readability (transitional). Both the API relationship and the markdown must be present.
 
 ## Step 5 — Update the PRD with issue numbers
 

--- a/docs/prd/github-issue-relationships.md
+++ b/docs/prd/github-issue-relationships.md
@@ -19,7 +19,7 @@ GitHub's native Sub-issues API (`/repos/{owner}/{repo}/issues/{number}/sub_issue
 
 - `scripts/ralph.sh` — replace sed-based blocker extraction with API calls
 - `.claude/commands/ralph.md` — update guidance for setting/checking blocked status
-- `.claude/skills/prd-to-issues/` — set relationships via API when creating issues from a PRD
+- `.claude/commands/prd-to-issues.md` — set relationships via API when creating issues from a PRD
 - `docs/prd/` — update PRD template to remove `## Blocked by` markdown convention
 
 **Out of scope:**
@@ -96,7 +96,7 @@ None. This is entirely tooling and workflow.
 
 - [x] Does the Sub-issues API support "blocked by" as a relationship type, or only parent/child? — **Parent/child only.** No native "blocked by" semantics. We model blocking as: blocked issue = parent, blockers = sub-issues (children). When all sub-issues are closed, the parent is unblocked. Confirmed 2026-03-25.
 - [x] Is the Sub-issues API available on our GitHub plan? — **Yes**, confirmed 2026-03-25. Both read (`/issues/{n}/sub_issues`) and `sub_issues_summary` field work. Write requires integer `id` (not `node_id` or issue number) for the `sub_issue_id` param.
-- [ ] Should Phase 2 write both API relationships AND markdown (transitional), or API-only from the start? — decision needed before Phase 2
+- [x] Should Phase 2 write both API relationships AND markdown (transitional), or API-only from the start? — **Both (transitional).** API relationships for machine-readable dependencies, `## Blocked by` markdown retained for human readability. Markdown will be removed in Phase 4. Decided 2026-03-25.
 - [x] Do GitHub Actions or third-party bots interact with these relationships in ways we should be aware of? — No interactions observed. Sub-issues are a native GitHub feature; no third-party bot interference detected during tracer bullet testing. Confirmed 2026-03-25.
 
 ## 8. Discovered Unknowns


### PR DESCRIPTION
Closes #1050

## What changed
- Updated `/prd-to-issues` Step 4 to create Sub-issues API relationships (blocked issue = parent, blocker = sub-issue) instead of just posting comments
- Resolved PRD open question: both API relationships AND `## Blocked by` markdown are written (transitional)
- Fixed PRD path reference from `.claude/skills/prd-to-issues/` to `.claude/commands/prd-to-issues.md`

## Testing
- Tooling-only change (command documentation) — no runtime code to test
- API pattern matches the proven approach from #1049 (`ralph.sh` Sub-issues integration)
- Uses integer `id` (not `node_id`) per discovered unknown from Phase 1