### PR TITLE
feat(config): update /ralph command for API-based blocking (#1051)

### DIFF
--- a/.claude/commands/ralph.md
+++ b/.claude/commands/ralph.md
@@ -34,6 +34,15 @@ gh issue list --label ready --state open --json number,title,labels,body \
   --jq '.[] | "\(.number): \(.title)"' | head -10
 ```
 
+Check for blocking relationships before ranking. An issue with unresolved sub-issues (blockers) should not be picked up:
+
+```bash
+# For each candidate, check if it has open sub-issues (blockers)
+gh api "/repos/{owner}/{repo}/issues/${CANDIDATE}/sub_issues" \
+  --jq '[.[] | select(.state != "closed")] | length'
+# 0 = no open blockers → safe to pick up
+```
+
 Present the top candidates ranked by: dependencies resolved → smallest scope → label priority.
 
 **Wait for human approval before proceeding.**
@@ -114,6 +123,37 @@ git worktree remove "../kcvv-issue-${ISSUE_NUM}" --force
 git branch -d "$BRANCH"
 ```
 
+## If Blocked
+
+When an issue is blocked by another issue, set the relationship via the Sub-issues API so `ralph.sh` can automatically unblock it later:
+
+```bash
+# 1. Get the node_id of the blocking issue
+BLOCKER_NUM=<blocking-issue-number>
+BLOCKER_NODE_ID=$(gh api "/repos/{owner}/{repo}/issues/${BLOCKER_NUM}" --jq '.node_id')
+
+# 2. Add the blocking issue as a sub-issue of the blocked issue
+gh api "/repos/{owner}/{repo}/issues/${ISSUE_NUM}/sub_issues" \
+  --method POST \
+  -f sub_issue_id="$BLOCKER_NODE_ID"
+
+# 3. Label the blocked issue
+gh issue edit $ISSUE_NUM --add-label "blocked" --remove-label "ready"
+
+# 4. Comment with context
+gh issue comment $ISSUE_NUM --body "Blocked by #${BLOCKER_NUM}. Sub-issue relationship set via API."
+```
+
+When checking if an issue is still blocked, query its sub-issues:
+
+```bash
+# List sub-issues (blockers) and their state
+gh api "/repos/{owner}/{repo}/issues/${ISSUE_NUM}/sub_issues" \
+  --jq '.[] | "\(.number) \(.state)"'
+```
+
+An issue is unblocked when all its sub-issues are in `closed` state. The automated `ralph.sh` script handles unblocking automatically after each PR merge.
+
 ## Labels Convention
 
 | Label              | Meaning                           |
@@ -128,4 +168,4 @@ git branch -d "$BRANCH"
 - Never start a second issue before the current PR is open
 - Never commit directly to main
 - Never skip the quality gate
-- If blocked, comment on the issue with the blocker and propose the next one
+- If blocked, set the sub-issue relationship via API (see "If Blocked" above) and propose the next issue

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -159,11 +159,18 @@ Output the PR URL as the last line of your response.
 
 ## If blocked mid-implementation
   gh issue edit ${issue} --add-label "blocked" --remove-label "in-progress"
-  gh issue create \
+  BLOCKER_ISSUE=\$(gh issue create \
     --title "[type](scope): [blocker]" \
     --label "ready" \
-    --body "Discovered during #${issue}.\n\n[description]"
-  gh issue comment ${issue} --body "Blocked by [reason]. Created #[N] to resolve."
+    --body "Discovered during #${issue}.\n\n[description]")
+  BLOCKER_NUM=\$(echo "\$BLOCKER_ISSUE" | grep -o '[0-9]*$')
+
+  # Set sub-issue relationship so ralph.sh can auto-unblock later
+  BLOCKER_NODE_ID=\$(gh api "/repos/{owner}/{repo}/issues/\${BLOCKER_NUM}" --jq '.node_id')
+  gh api "/repos/{owner}/{repo}/issues/${issue}/sub_issues" \
+    --method POST -f sub_issue_id="\$BLOCKER_NODE_ID" 2>/dev/null || true
+
+  gh issue comment ${issue} --body "Blocked by #\${BLOCKER_NUM}. Sub-issue relationship set via API."
 
 Output on its own line: RALPH_BLOCKED: [one-line reason]
 


### PR DESCRIPTION
Closes #1051

## What changed

- Added "If Blocked" section to `.claude/commands/ralph.md` with Sub-issues API commands for setting blocking relationships and querying blocker state
- Added API-based blocker check in Step 1 (issue ranking) so blocked issues aren't picked up
- Updated `scripts/ralph.sh` autonomous prompt to set sub-issue relationships when discovering blockers mid-implementation

## Testing
- Manual review: commands and API patterns are consistent with Phase 1 (`ralph.sh` unblock logic) and Phase 2 (`prd-to-issues` relationship creation)
- No app code changed — tooling/documentation only