### PR TITLE
feat(teams): storybook stories for jeugd components (#1041)

### DIFF
--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { JeugdEditorialGrid } from "./JeugdEditorialGrid";
+import type { ArticleVM } from "@/lib/repositories/article.repository";
+
+function makeArticle(
+  overrides: Partial<ArticleVM> & { id: string },
+): ArticleVM {
+  return {
+    title: `Jeugd artikel ${overrides.id}`,
+    slug: `jeugd-artikel-${overrides.id}`,
+    publishedAt: "2026-03-20",
+    featured: false,
+    coverImageUrl: undefined,
+    tags: ["Jeugd"],
+    ...overrides,
+  };
+}
+
+const threeArticles: ArticleVM[] = [
+  makeArticle({
+    id: "1",
+    title: "U15 wint in stijl tegen Wolvertem",
+    tags: ["Jeugd", "Bovenbouw"],
+  }),
+  makeArticle({ id: "2", title: "Nieuwe keeperstrainer voor de jeugd" }),
+  makeArticle({ id: "3", title: "Inschrijvingen zomerstage geopend" }),
+];
+
+const meta = {
+  title: "Features/Jeugd/JeugdEditorialGrid",
+  component: JeugdEditorialGrid,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "9-item editorial grid for the /jeugd landing page. Interleaves up to 3 dynamic article cards with 6 hardcoded navigation cards in an asymmetric 12-column layout.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="bg-gray-100 py-20">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof JeugdEditorialGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Full grid with 3 articles interleaved between navigation cards.
+ */
+export const WithArticles: Story = {
+  args: {
+    articles: threeArticles,
+  },
+};
+
+/**
+ * Fallback layout when no jeugd articles are available — shows a 3x2 nav card grid.
+ */
+export const NoArticles: Story = {
+  args: {
+    articles: [],
+  },
+};
+
+/**
+ * Partial layout with only 1 article — featured slot filled, other article slots omitted.
+ */
+export const OneArticle: Story = {
+  args: {
+    articles: [threeArticles[0]],
+  },
+};
+
+/**
+ * Partial layout with 2 articles — featured + second slot filled, third omitted.
+ */
+export const TwoArticles: Story = {
+  args: {
+    articles: threeArticles.slice(0, 2),
+  },
+};

--- a/apps/web/src/components/jeugd/JeugdHero/JeugdHero.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdHero/JeugdHero.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { JeugdHero } from "./JeugdHero";
+
+const meta = {
+  title: "Features/Jeugd/JeugdHero",
+  component: JeugdHero,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: { default: "dark" },
+    docs: {
+      description: {
+        component:
+          "Hero section for the /jeugd landing page. Full-bleed background image with dark overlay, section label, large title with green accent, subtitle, and a built-in diagonal divider at the bottom.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof JeugdHero>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default hero with background image, title, and diagonal divider.
+ */
+export const Default: Story = {};


### PR DESCRIPTION
Closes #1041

## What changed
- Added `JeugdHero` story under `Features/Jeugd/JeugdHero` with fullscreen dark background
- Added `JeugdEditorialGrid` stories under `Features/Jeugd/JeugdEditorialGrid` with 4 variants: full articles, no articles, 1 article, and 2 articles
- Verified existing `MissionBanner` `CustomQuote` story already covers the jeugd quote usage (`JeugdQuote` acceptance criterion)

## Testing
- Lint: clean
- Type-check: clean
- Tests: all 1783 pass
- Build: fails on missing Sanity `projectId` env var (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)