### PR TITLE
feat(ui): sectionCta component — shared CTA section (#1063)

### DIFF
--- a/apps/web/src/app/(main)/club/page.tsx
+++ b/apps/web/src/app/(main)/club/page.tsx
@@ -4,7 +4,7 @@ import type { SectionConfig } from "@/components/design-system/SectionStack/Sect
 import { ClubHero } from "@/components/club/ClubHero/ClubHero";
 import { ClubEditorialGrid } from "@/components/club/ClubEditorialGrid/ClubEditorialGrid";
 import { MissionBanner } from "@/components/club/MissionBanner/MissionBanner";
-import { ClubContactCta } from "@/components/club/ClubContactCta/ClubContactCta";
+import { SectionCta } from "@/components/design-system/SectionCta/SectionCta";
 
 export const metadata: Metadata = {
   title: "Onze club | KCVV Elewijt",
@@ -51,7 +51,14 @@ const missionSection: SectionConfig = {
 
 const contactSection: SectionConfig = {
   bg: "gray-100",
-  content: <ClubContactCta />,
+  content: (
+    <SectionCta
+      heading="Vragen over de club?"
+      body="Neem contact op — we helpen je graag verder."
+      buttonLabel="Contacteer ons"
+      buttonHref="/club/contact"
+    />
+  ),
   paddingTop: "pt-16",
   paddingBottom: "pb-16",
   key: "contact",

--- a/apps/web/src/app/(main)/jeugd/page.tsx
+++ b/apps/web/src/app/(main)/jeugd/page.tsx
@@ -15,8 +15,7 @@ import type { SectionConfig } from "@/components/design-system/SectionStack/Sect
 import { JeugdHero } from "@/components/jeugd/JeugdHero/JeugdHero";
 import { JeugdEditorialGrid } from "@/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid";
 import { MissionBanner } from "@/components/club/MissionBanner/MissionBanner";
-import { ArrowRight } from "@/lib/icons";
-import Link from "next/link";
+import { SectionCta } from "@/components/design-system/SectionCta/SectionCta";
 
 export const metadata: Metadata = {
   title: "Jeugdopleiding | KCVV Elewijt",
@@ -162,29 +161,12 @@ export default async function JeugdPage() {
   const ctaSection: SectionConfig = {
     bg: "white",
     content: (
-      <div className="max-w-inner-lg mx-auto px-4 md:px-10">
-        <div className="grid grid-cols-[1fr_auto] items-center gap-8 max-sm:grid-cols-1 max-sm:text-center">
-          <div>
-            <h2 className="font-title font-extrabold text-kcvv-gray-blue text-xl md:text-4xl mb-2">
-              Interesse in onze jeugd?
-            </h2>
-            <p className="text-sm text-kcvv-gray">
-              Nieuwe spelers zijn altijd welkom — van U6 tot U21.
-            </p>
-          </div>
-          <Link
-            href="/club/register"
-            className="group inline-flex items-center gap-2 px-8 py-3.5 bg-kcvv-green text-kcvv-black font-bold text-sm uppercase tracking-[0.06em] rounded-sm whitespace-nowrap transition-colors hover:bg-kcvv-green-hover"
-          >
-            Word ook lid
-            <ArrowRight
-              size={16}
-              className="transition-transform duration-300 group-hover:translate-x-1"
-              aria-hidden="true"
-            />
-          </Link>
-        </div>
-      </div>
+      <SectionCta
+        heading="Interesse in onze jeugd?"
+        body="Nieuwe spelers zijn altijd welkom — van U6 tot U21."
+        buttonLabel="Word ook lid"
+        buttonHref="/club/register"
+      />
     ),
     paddingTop: "pt-16",
     paddingBottom: "pb-16",

--- a/apps/web/src/app/(main)/teams/page.tsx
+++ b/apps/web/src/app/(main)/teams/page.tsx
@@ -7,7 +7,7 @@ import { SectionStack } from "@/components/design-system/SectionStack/SectionSta
 import { TeamsHero } from "@/components/teams/TeamsHero";
 import { TeamFeaturedCard } from "@/components/teams/TeamFeaturedCard";
 import { YouthTeamsDirectory } from "@/components/teams/YouthTeamsDirectory";
-import { TeamsCta } from "@/components/teams/TeamsCta";
+import { SectionCta } from "@/components/design-system/SectionCta/SectionCta";
 
 export const metadata: Metadata = {
   title: "Onze ploegen | KCVV Elewijt",
@@ -67,7 +67,14 @@ export default async function TeamsPage() {
           bg: "gray-100",
           paddingTop: "pt-16",
           paddingBottom: "pb-16",
-          content: <TeamsCta />,
+          content: (
+            <SectionCta
+              heading="Aansluiten bij KCVV Elewijt?"
+              body="Vanaf de allerkleinsten tot de eerste ploeg — iedereen is welkom op Sportpark Elewijt."
+              buttonLabel="Meer info"
+              buttonHref="/club/aansluiten"
+            />
+          ),
         },
       ]}
     />

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.stories.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SectionCta } from "./SectionCta";
+
+const meta = {
+  title: "UI/SectionCta",
+  component: SectionCta,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    heading: {
+      control: "text",
+      description: "Section heading",
+    },
+    body: {
+      control: "text",
+      description: "Section body text",
+    },
+    buttonLabel: {
+      control: "text",
+      description: "CTA button label",
+    },
+    buttonHref: {
+      control: "text",
+      description: "CTA button link destination",
+    },
+  },
+} satisfies Meta<typeof SectionCta>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    heading: "Aansluiten bij KCVV Elewijt?",
+    body: "Vanaf de allerkleinsten tot de eerste ploeg — iedereen is welkom op Sportpark Elewijt.",
+    buttonLabel: "Meer info",
+    buttonHref: "/club/aansluiten",
+  },
+};
+
+export const Contact: Story = {
+  args: {
+    heading: "Vragen over de club?",
+    body: "Neem contact op — we helpen je graag verder.",
+    buttonLabel: "Contacteer ons",
+    buttonHref: "/club/contact",
+  },
+};
+
+export const Youth: Story = {
+  args: {
+    heading: "Interesse in onze jeugd?",
+    body: "Nieuwe spelers zijn altijd welkom — van U6 tot U21.",
+    buttonLabel: "Word ook lid",
+    buttonHref: "/club/register",
+  },
+};
+
+export const Playground: Story = {
+  args: {
+    heading: "Aansluiten bij KCVV Elewijt?",
+    body: "Vanaf de allerkleinsten tot de eerste ploeg — iedereen is welkom op Sportpark Elewijt.",
+    buttonLabel: "Meer info",
+    buttonHref: "/club/aansluiten",
+  },
+};

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.test.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SectionCta } from "./SectionCta";
+
+const defaultProps = {
+  heading: "Aansluiten bij KCVV Elewijt?",
+  body: "Vanaf de allerkleinsten tot de eerste ploeg — iedereen is welkom.",
+  buttonLabel: "Meer info",
+  buttonHref: "/club/aansluiten",
+};
+
+describe("SectionCta", () => {
+  describe("Rendering", () => {
+    it("should render heading, body, and button", () => {
+      render(<SectionCta {...defaultProps} />);
+
+      expect(
+        screen.getByRole("heading", { name: defaultProps.heading }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(defaultProps.body)).toBeInTheDocument();
+
+      const link = screen.getByRole("link", { name: /meer info/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", defaultProps.buttonHref);
+    });
+  });
+
+  describe("Layout", () => {
+    it("should use centered layout with max-w-[40rem]", () => {
+      const { container } = render(<SectionCta {...defaultProps} />);
+      const wrapper = container.firstElementChild;
+      expect(wrapper).toHaveClass("max-w-[40rem]", "mx-auto", "text-center");
+    });
+  });
+
+  describe("Typography", () => {
+    it("should style heading with font-title font-extrabold text-kcvv-black", () => {
+      render(<SectionCta {...defaultProps} />);
+      const heading = screen.getByRole("heading");
+      expect(heading).toHaveClass(
+        "font-title",
+        "font-extrabold",
+        "text-kcvv-black",
+      );
+    });
+
+    it("should style body with text-sm text-kcvv-gray leading-relaxed", () => {
+      render(<SectionCta {...defaultProps} />);
+      const body = screen.getByText(defaultProps.body);
+      expect(body).toHaveClass("text-sm", "text-kcvv-gray", "leading-relaxed");
+    });
+  });
+
+  describe("Button", () => {
+    it("should render LinkButton with withArrow", () => {
+      render(<SectionCta {...defaultProps} />);
+      const link = screen.getByRole("link", { name: /meer info/i });
+      // LinkButton primary variant class
+      expect(link).toHaveClass("bg-kcvv-green-bright");
+      // Arrow icon should be present
+      const icon = link.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.tsx
@@ -1,0 +1,32 @@
+import { LinkButton } from "../LinkButton";
+
+export interface SectionCtaProps {
+  heading: string;
+  body: string;
+  buttonLabel: string;
+  buttonHref: string;
+}
+
+export function SectionCta({
+  heading,
+  body,
+  buttonLabel,
+  buttonHref,
+}: SectionCtaProps) {
+  return (
+    <div className="max-w-[40rem] mx-auto px-4 md:px-10 text-center">
+      <h2
+        className="font-title font-extrabold text-kcvv-black mb-3"
+        style={{ fontSize: "clamp(1.5rem, 3vw, 2rem)" }}
+      >
+        {heading}
+      </h2>
+
+      <p className="text-sm text-kcvv-gray mb-8 leading-relaxed">{body}</p>
+
+      <LinkButton href={buttonHref} withArrow>
+        {buttonLabel}
+      </LinkButton>
+    </div>
+  );
+}

--- a/apps/web/src/components/design-system/SectionCta/index.ts
+++ b/apps/web/src/components/design-system/SectionCta/index.ts
@@ -1,0 +1,2 @@
+export { SectionCta } from "./SectionCta";
+export type { SectionCtaProps } from "./SectionCta";

--- a/apps/web/src/components/design-system/index.ts
+++ b/apps/web/src/components/design-system/index.ts
@@ -80,3 +80,7 @@ export type { DownloadButtonProps } from "./DownloadButton";
 // LinkButton
 export { LinkButton } from "./LinkButton";
 export type { LinkButtonProps } from "./LinkButton";
+
+// SectionCta
+export { SectionCta } from "./SectionCta";
+export type { SectionCtaProps } from "./SectionCta";


### PR DESCRIPTION
Closes #1063

## What changed
- Created `SectionCta` design system component with centered layout, responsive clamp heading, and `LinkButton` primary variant with `withArrow`
- Replaced `ClubContactCta`, inline jeugd CTA, and `TeamsCta` usage on `/club`, `/jeugd`, and `/teams` pages
- Added Storybook story at `UI/SectionCta` with Playground + variant stories

## Testing
- All checks pass: lint, type-check, 1803 tests (including 5 new SectionCta tests)
- Build failure is pre-existing (missing `SANITY_PROJECT_ID` env var in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)