### PR TITLE
feat(ui): page-hero component — shared hero section (#1064)

### DIFF
--- a/apps/web/src/app/(main)/club/page.tsx
+++ b/apps/web/src/app/(main)/club/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
 import type { SectionConfig } from "@/components/design-system/SectionStack/SectionStack";
-import { ClubHero } from "@/components/club/ClubHero/ClubHero";
+import { PageHero } from "@/components/design-system/PageHero";
 import { ClubEditorialGrid } from "@/components/club/ClubEditorialGrid/ClubEditorialGrid";
 import { MissionBanner } from "@/components/club/MissionBanner/MissionBanner";
 import { SectionCta } from "@/components/design-system/SectionCta/SectionCta";
@@ -14,7 +14,20 @@ export const metadata: Metadata = {
 
 const heroSection: SectionConfig = {
   bg: "kcvv-black",
-  content: <ClubHero />,
+  content: (
+    <PageHero
+      image="/images/hero-club.jpg"
+      label="Onze club"
+      headline={
+        <>
+          De plezantste
+          <br />
+          <span className="text-kcvv-green">compagnie</span>
+        </>
+      }
+      body="Al meer dan 75 jaar de thuishaven voor voetballiefhebbers in Elewijt. Van de allerkleinsten tot het eerste elftal — bij KCVV is iedereen welkom."
+    />
+  ),
   paddingTop: "pt-0",
   paddingBottom: "pb-0",
   transition: {

--- a/apps/web/src/app/(main)/jeugd/page.tsx
+++ b/apps/web/src/app/(main)/jeugd/page.tsx
@@ -12,7 +12,7 @@ import {
 import { TeamOverview, type TeamData } from "@/components/team/TeamOverview";
 import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
 import type { SectionConfig } from "@/components/design-system/SectionStack/SectionStack";
-import { JeugdHero } from "@/components/jeugd/JeugdHero/JeugdHero";
+import { PageHero } from "@/components/design-system/PageHero";
 import { JeugdEditorialGrid } from "@/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid";
 import { MissionBanner } from "@/components/club/MissionBanner/MissionBanner";
 import { SectionCta } from "@/components/design-system/SectionCta/SectionCta";
@@ -90,7 +90,20 @@ export default async function JeugdPage() {
 
   const heroSection: SectionConfig = {
     bg: "kcvv-black",
-    content: <JeugdHero />,
+    content: (
+      <PageHero
+        image="/images/hero-jeugd.jpg"
+        label="Jeugdopleiding"
+        headline={
+          <>
+            De toekomst
+            <br />
+            van <span className="text-kcvv-green">Elewijt</span>
+          </>
+        }
+        body="Meer dan 200 jonge voetballers. Gediplomeerde trainers. Eén missie: plezier, techniek en teamspirit."
+      />
+    ),
     paddingTop: "pt-0",
     paddingBottom: "pb-0",
     transition: {

--- a/apps/web/src/app/(main)/teams/page.tsx
+++ b/apps/web/src/app/(main)/teams/page.tsx
@@ -4,7 +4,7 @@ import { runPromise } from "@/lib/effect/runtime";
 import { SanityService } from "@/lib/effect/services/SanityService";
 import { groupTeamsForLanding } from "@/lib/utils/group-teams";
 import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
-import { TeamsHero } from "@/components/teams/TeamsHero";
+import { PageHero } from "@/components/design-system/PageHero";
 import { TeamFeaturedCard } from "@/components/teams/TeamFeaturedCard";
 import { YouthTeamsDirectory } from "@/components/teams/YouthTeamsDirectory";
 import { SectionCta } from "@/components/design-system/SectionCta/SectionCta";
@@ -40,7 +40,29 @@ export default async function TeamsPage() {
           bg: "kcvv-black",
           paddingTop: "pt-0",
           paddingBottom: "pb-0",
-          content: <TeamsHero team={aTeam} />,
+          content: (
+            <PageHero
+              image={aTeam.teamImageUrl ?? "/images/hero-club.jpg"}
+              imageAlt={`Team foto ${aTeam.name}`}
+              label="Eerste ploeg"
+              headline={(() => {
+                const parts = aTeam.name.split(/\s+/);
+                if (parts.length >= 2) {
+                  return (
+                    <>
+                      {parts[0]}
+                      <br />
+                      <span className="text-kcvv-green">{parts[1]}</span>
+                      {parts.length > 2 ? ` ${parts.slice(2).join(" ")}` : ""}
+                    </>
+                  );
+                }
+                return aTeam.name;
+              })()}
+              body={aTeam.divisionFull ?? ""}
+              cta={{ label: "Bekijk de A-ploeg", href: `/team/${aTeam.slug}` }}
+            />
+          ),
           transition: {
             type: "diagonal" as const,
             direction: "right" as const,

--- a/apps/web/src/components/design-system/PageHero/PageHero.stories.tsx
+++ b/apps/web/src/components/design-system/PageHero/PageHero.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PageHero } from "./PageHero";
+
+const meta = {
+  title: "Features/PageHero",
+  component: PageHero,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    image: { control: "text", description: "Background image URL" },
+    imageAlt: {
+      control: "text",
+      description: "Alt text for the background image",
+    },
+    label: { control: "text", description: "Small label above the headline" },
+    body: { control: "text", description: "Body text below the headline" },
+  },
+} satisfies Meta<typeof PageHero>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    image: "/images/hero-club.jpg",
+    label: "Onze club",
+    headline: (
+      <>
+        De plezantste
+        <br />
+        <span className="text-kcvv-green">compagnie</span>
+      </>
+    ),
+    body: "Al meer dan 75 jaar de thuishaven voor voetballiefhebbers in Elewijt. Van de allerkleinsten tot het eerste elftal — bij KCVV is iedereen welkom.",
+  },
+};
+
+export const WithCta: Story = {
+  args: {
+    image: "/images/hero-club.jpg",
+    label: "Eerste ploeg",
+    headline: (
+      <>
+        KCVV
+        <br />
+        <span className="text-kcvv-green">Elewijt</span>
+      </>
+    ),
+    body: "3de Provinciale B",
+    cta: { label: "Bekijk de A-ploeg", href: "/team/kcvv-elewijt-a" },
+  },
+};
+
+export const WithoutCta: Story = {
+  args: {
+    image: "/images/hero-jeugd.jpg",
+    label: "Jeugdopleiding",
+    headline: (
+      <>
+        De toekomst
+        <br />
+        van <span className="text-kcvv-green">Elewijt</span>
+      </>
+    ),
+    body: "Meer dan 200 jonge voetballers. Gediplomeerde trainers. Eén missie: plezier, techniek en teamspirit.",
+  },
+};

--- a/apps/web/src/components/design-system/PageHero/PageHero.test.tsx
+++ b/apps/web/src/components/design-system/PageHero/PageHero.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PageHero } from "./PageHero";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: Record<string, unknown>) => (
+    <img src={src as string} alt={alt as string} {...props} />
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("PageHero", () => {
+  const defaultProps = {
+    image: "/images/hero-club.jpg",
+    label: "Onze club",
+    headline: (
+      <>
+        De plezantste
+        <br />
+        <span className="text-kcvv-green">compagnie</span>
+      </>
+    ),
+    body: "Al meer dan 75 jaar de thuishaven voor voetballiefhebbers.",
+  };
+
+  it("renders label, headline, and body text", () => {
+    render(<PageHero {...defaultProps} />);
+
+    expect(screen.getByText("Onze club")).toBeInTheDocument();
+    expect(screen.getByText(/de plezantste/i)).toBeInTheDocument();
+    expect(screen.getByText(/compagnie/i)).toBeInTheDocument();
+    expect(screen.getByText(/Al meer dan 75 jaar/)).toBeInTheDocument();
+  });
+
+  it("does not render a built-in SVG diagonal", () => {
+    const { container } = render(<PageHero {...defaultProps} />);
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("renders LinkButton with arrow when cta prop is provided", () => {
+    render(
+      <PageHero
+        {...defaultProps}
+        cta={{ label: "Bekijk de ploeg", href: "/team/a" }}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /bekijk de ploeg/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/team/a");
+  });
+
+  it("does not render a CTA when cta prop is omitted", () => {
+    render(<PageHero {...defaultProps} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders background image with provided src and alt", () => {
+    render(<PageHero {...defaultProps} imageAlt="Club photo" />);
+    const img = screen.getByAltText("Club photo");
+    expect(img).toHaveAttribute("src", "/images/hero-club.jpg");
+  });
+
+  it("uses green accent bar in label", () => {
+    const { container } = render(<PageHero {...defaultProps} />);
+    const accentBar = container.querySelector(".bg-kcvv-green");
+    expect(accentBar).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/design-system/PageHero/PageHero.tsx
+++ b/apps/web/src/components/design-system/PageHero/PageHero.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import Image from "next/image";
+import { LinkButton } from "../LinkButton";
+
+export interface PageHeroProps {
+  image: string;
+  imageAlt?: string;
+  label: string;
+  headline: ReactNode;
+  body: string;
+  cta?: { label: string; href: string };
+}
+
+export function PageHero({
+  image,
+  imageAlt = "",
+  label,
+  headline,
+  body,
+  cta,
+}: PageHeroProps) {
+  return (
+    <div className="relative">
+      {/* Background layers */}
+      <div className="absolute inset-0">
+        <Image
+          src={image}
+          alt={imageAlt}
+          fill
+          className="object-cover object-[center_30%]"
+          style={{ filter: "brightness(0.25) saturate(0.7)" }}
+          priority
+          sizes="100vw"
+        />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "linear-gradient(to bottom, rgba(30, 32, 36, 0.2) 0%, rgba(30, 32, 36, 0.4) 40%, rgba(0, 135, 85, 0.25) 70%, rgba(30, 32, 36, 0.85) 100%)",
+          }}
+        />
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 min-h-[60vh] flex items-end">
+        <div className="max-w-inner-lg mx-auto px-4 md:px-10 py-10 md:py-16 w-full">
+          <div className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-label text-white/50 mb-6">
+            <span className="block w-5 h-0.5 bg-kcvv-green" />
+            {label}
+          </div>
+          <h1 className="font-title font-black text-white uppercase leading-hero mb-6 text-hero">
+            {headline}
+          </h1>
+          <p className="text-lg text-white/60 leading-loose max-w-lg">{body}</p>
+          {cta && (
+            <div className="mt-8">
+              <LinkButton href={cta.href} variant="primary" withArrow>
+                {cta.label}
+              </LinkButton>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/design-system/PageHero/index.ts
+++ b/apps/web/src/components/design-system/PageHero/index.ts
@@ -1,0 +1,2 @@
+export { PageHero } from "./PageHero";
+export type { PageHeroProps } from "./PageHero";

--- a/apps/web/src/components/design-system/index.ts
+++ b/apps/web/src/components/design-system/index.ts
@@ -84,3 +84,7 @@ export type { LinkButtonProps } from "./LinkButton";
 // SectionCta
 export { SectionCta } from "./SectionCta";
 export type { SectionCtaProps } from "./SectionCta";
+
+// PageHero
+export { PageHero } from "./PageHero";
+export type { PageHeroProps } from "./PageHero";


### PR DESCRIPTION
Closes #1064

## What changed
- Created shared `PageHero` design-system component with canonical spec (60vh min height, brightness/saturate filter, rgba gradient, green accent bar label, optional `LinkButton` CTA with arrow)
- Replaced `ClubHero`, `JeugdHero`, and `TeamsHero` usages in `/club`, `/jeugd`, and `/teams` landing pages
- Added Storybook story at `Features/PageHero` with Playground, WithCta, and WithoutCta variants

## Testing
- 6 unit tests covering: label/headline/body rendering, no SVG diagonal, CTA present/absent, image alt, green accent bar
- Lint, type-check, and all 1809 tests pass
- Build failure is pre-existing (missing Sanity env vars in CI — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)