### PR TITLE
refactor(ui): staff repository (#888)

### DIFF
--- a/apps/web/src/app/(main)/club/organigram/page.tsx
+++ b/apps/web/src/app/(main)/club/organigram/page.tsx
@@ -13,6 +13,7 @@ import { Effect } from "effect";
 import { UnifiedOrganigramClient } from "@/components/organigram";
 import { runPromise } from "@/lib/effect/runtime";
 import { SanityService } from "@/lib/effect/services/SanityService";
+import { StaffRepository } from "@/lib/repositories/staff.repository";
 
 export const metadata: Metadata = {
   title: "Organigram & Hulp | KCVV Elewijt",
@@ -47,9 +48,10 @@ export const metadata: Metadata = {
 export default async function OrganigramPage() {
   const [members, responsibilityPaths] = await runPromise(
     Effect.gen(function* () {
+      const staffRepo = yield* StaffRepository;
       const sanity = yield* SanityService;
       return yield* Effect.all(
-        [sanity.getStaffMembers(), sanity.getResponsibilityPaths()],
+        [staffRepo.findAll(), sanity.getResponsibilityPaths()],
         { concurrency: 2 },
       );
     }),

--- a/apps/web/src/components/organigram/__fixtures__/staff-members.fixture.ts
+++ b/apps/web/src/components/organigram/__fixtures__/staff-members.fixture.ts
@@ -2,7 +2,7 @@ import type { OrgChartNode } from "@/types/organigram";
 
 /**
  * Fixture data for Storybook stories — mirrors the shape returned by
- * SanityService.getStaffMembers() so stories stay realistic.
+ * StaffRepository.findAll() so stories stay realistic.
  */
 export const staffMembersFixture: OrgChartNode[] = [
   // Root

--- a/apps/web/src/lib/effect/runtime.ts
+++ b/apps/web/src/lib/effect/runtime.ts
@@ -17,6 +17,10 @@ import {
   SponsorRepository,
   SponsorRepositoryLive,
 } from "../repositories/sponsor.repository";
+import {
+  StaffRepository,
+  StaffRepositoryLive,
+} from "../repositories/staff.repository";
 
 export const AppLayer = Layer.mergeAll(
   BffServiceLive,
@@ -25,6 +29,7 @@ export const AppLayer = Layer.mergeAll(
   TeamRepositoryLive,
   ArticleRepositoryLive,
   SponsorRepositoryLive,
+  StaffRepositoryLive,
 );
 export const runtime = ManagedRuntime.make(AppLayer);
 
@@ -38,6 +43,7 @@ export const runPromise = <A, E>(
     | TeamRepository
     | ArticleRepository
     | SponsorRepository
+    | StaffRepository
   >,
 ) => runtime.runPromise(effect);
 
@@ -51,6 +57,7 @@ export const runPromiseWithLogging = <A, E>(
     | TeamRepository
     | ArticleRepository
     | SponsorRepository
+    | StaffRepository
   >,
 ) =>
   runtime.runPromise(
@@ -73,4 +80,5 @@ export {
   TeamRepository,
   ArticleRepository,
   SponsorRepository,
+  StaffRepository,
 };

--- a/apps/web/src/lib/effect/services/SanityService.test.ts
+++ b/apps/web/src/lib/effect/services/SanityService.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, type Mock } from "vitest";
 import { Effect } from "effect";
 import { SanityService, SanityServiceLive } from "./SanityService";
 import { sanityClient } from "../../sanity/client";
-import { STAFF_MEMBERS_QUERY } from "../../sanity/queries/staffMembers";
 import { RESPONSIBILITY_PATHS_QUERY } from "../../sanity/queries/responsibilityPaths";
 import { PAGE_BY_SLUG_QUERY } from "../../sanity/queries/pages";
 
@@ -15,100 +14,6 @@ vi.mock("../../sanity/client", () => ({
 function mockFetch(value: unknown) {
   (vi.mocked(sanityClient.fetch) as Mock).mockResolvedValueOnce(value);
 }
-
-describe("SanityService.getStaffMembers", () => {
-  it("prepends the club root node and maps a staffMember doc to OrgChartNode", async () => {
-    mockFetch([
-      {
-        _id: "staffMember-psd-42",
-        firstName: "Jan",
-        lastName: "Smeets",
-        positionTitle: "Jeugdcoördinator",
-        positionShort: "JC",
-        department: "jeugdbestuur",
-        email: "jeugd@kcvvelewijt.be",
-        phone: null,
-        photoUrl: "https://cdn.sanity.io/images/test/photo.jpg",
-        responsibilities: "Coördinatie jeugdwerking",
-        parentId: null,
-      },
-    ]);
-
-    const program = Effect.gen(function* () {
-      const svc = yield* SanityService;
-      return yield* svc.getStaffMembers();
-    }).pipe(Effect.provide(SanityServiceLive));
-
-    const nodes = await Effect.runPromise(program);
-
-    expect(vi.mocked(sanityClient.fetch)).toHaveBeenCalledWith(
-      STAFF_MEMBERS_QUERY,
-      expect.any(Object),
-    );
-
-    expect(nodes[0]).toEqual({
-      id: "club",
-      name: "KCVV Elewijt",
-      title: "Voetbalclub",
-      imageUrl: "/images/logo-flat.png",
-      department: "algemeen",
-      parentId: null,
-    });
-
-    expect(nodes[1]).toEqual({
-      id: "staffMember-psd-42",
-      name: "Jan Smeets",
-      title: "Jeugdcoördinator",
-      positionShort: "JC",
-      imageUrl: "https://cdn.sanity.io/images/test/photo.jpg",
-      email: "jeugd@kcvvelewijt.be",
-      phone: undefined,
-      responsibilities: "Coördinatie jeugdwerking",
-      department: "jeugdbestuur",
-      parentId: "club", // null parentId → root → "club"
-    });
-  });
-
-  it("preserves parentId when parentMember is set", async () => {
-    mockFetch([
-      {
-        _id: "staffMember-psd-1",
-        firstName: "Root",
-        lastName: "Person",
-        positionTitle: "Voorzitter",
-        positionShort: "PRES",
-        department: "hoofdbestuur",
-        email: null,
-        phone: null,
-        photoUrl: null,
-        responsibilities: null,
-        parentId: null,
-      },
-      {
-        _id: "staffMember-psd-2",
-        firstName: "Child",
-        lastName: "Person",
-        positionTitle: "Secretaris",
-        positionShort: "SEC",
-        department: "hoofdbestuur",
-        email: null,
-        phone: null,
-        photoUrl: null,
-        responsibilities: null,
-        parentId: "staffMember-psd-1",
-      },
-    ]);
-
-    const program = Effect.gen(function* () {
-      const svc = yield* SanityService;
-      return yield* svc.getStaffMembers();
-    }).pipe(Effect.provide(SanityServiceLive));
-
-    const nodes = await Effect.runPromise(program);
-    // nodes[0]=club root, nodes[1]=Root Person, nodes[2]=Child Person
-    expect(nodes[2]?.parentId).toBe("staffMember-psd-1");
-  });
-});
 
 describe("SanityService.getResponsibilityPaths — memberId", () => {
   it("forwards memberId from staffMember reference", async () => {

--- a/apps/web/src/lib/effect/services/SanityService.ts
+++ b/apps/web/src/lib/effect/services/SanityService.ts
@@ -7,7 +7,6 @@ import {
 } from "../../sanity/queries/events";
 import { HOMEPAGE_BANNERS_QUERY } from "../../sanity/queries/homePage";
 import { RESPONSIBILITY_PATHS_QUERY } from "../../sanity/queries/responsibilityPaths";
-import { STAFF_MEMBERS_QUERY } from "../../sanity/queries/staffMembers";
 import { PAGE_BY_SLUG_QUERY } from "../../sanity/queries/pages";
 import type { TeamLandingItem } from "../../utils/group-teams";
 import type { PortableTextBlock } from "@portabletext/react";
@@ -15,8 +14,6 @@ import type {
   ResponsibilityPath,
   Contact,
 } from "../../../types/responsibility";
-import type { OrgChartNode } from "../../../types/organigram";
-
 // ─── Types ────────────────────────────────────────────────────────────────────
 // Simple interfaces — no Effect Schema validation yet.
 // Add per content type as pages are cut over from DrupalService.
@@ -72,20 +69,6 @@ export interface SanityResponsibilityPath {
   relatedPaths: string[];
 }
 
-export interface SanityOrgMember {
-  _id: string;
-  firstName: string | null;
-  lastName: string | null;
-  positionTitle: string | null;
-  positionShort: string | null;
-  department: string | null;
-  email: string | null;
-  phone: string | null;
-  photoUrl: string | null;
-  responsibilities: string | null;
-  parentId: string | null; // resolved from parentMember->_id
-}
-
 export interface SanityPage {
   _id: string;
   title: string;
@@ -101,7 +84,6 @@ export interface SanityServiceInterface {
   readonly getNextFeaturedEvent: () => Effect.Effect<SanityEvent | null>;
   readonly getHomepageBanners: () => Effect.Effect<SanityHomepageBanners>;
   readonly getResponsibilityPaths: () => Effect.Effect<ResponsibilityPath[]>;
-  readonly getStaffMembers: () => Effect.Effect<OrgChartNode[]>;
   readonly getPage: (slug: string) => Effect.Effect<SanityPage | null>;
 }
 
@@ -165,28 +147,6 @@ function mapResponsibilityPath(
   };
 }
 
-const CLUB_ROOT_NODE: OrgChartNode = {
-  id: "club",
-  name: "KCVV Elewijt",
-  title: "Voetbalclub",
-  imageUrl: "/images/logo-flat.png",
-  department: "algemeen",
-  parentId: null,
-};
-
-const mapOrgMember = (m: SanityOrgMember): OrgChartNode => ({
-  id: m._id,
-  name: `${m.firstName ?? ""} ${m.lastName ?? ""}`.trim(),
-  title: m.positionTitle ?? "",
-  positionShort: m.positionShort ?? undefined,
-  imageUrl: m.photoUrl ?? undefined,
-  email: m.email ?? undefined,
-  phone: m.phone ?? undefined,
-  responsibilities: m.responsibilities ?? undefined,
-  department: (m.department ?? undefined) as OrgChartNode["department"],
-  parentId: m.parentId ?? "club",
-});
-
 export const SanityServiceLive = Layer.succeed(SanityService, {
   getTeamsLanding: () => fetchGroq<TeamLandingItem[]>(TEAMS_LANDING_QUERY),
   getEvents: () => fetchGroq<SanityEvent[]>(EVENTS_QUERY),
@@ -204,10 +164,6 @@ export const SanityServiceLive = Layer.succeed(SanityService, {
   getResponsibilityPaths: () =>
     fetchGroq<SanityResponsibilityPath[]>(RESPONSIBILITY_PATHS_QUERY).pipe(
       Effect.map((paths) => paths.map(mapResponsibilityPath)),
-    ),
-  getStaffMembers: () =>
-    fetchGroq<SanityOrgMember[]>(STAFF_MEMBERS_QUERY).pipe(
-      Effect.map((members) => [CLUB_ROOT_NODE, ...members.map(mapOrgMember)]),
     ),
   getPage: (slug) => fetchGroq<SanityPage | null>(PAGE_BY_SLUG_QUERY, { slug }),
 });

--- a/apps/web/src/lib/repositories/staff.repository.test.ts
+++ b/apps/web/src/lib/repositories/staff.repository.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import { Effect } from "effect";
+import type { STAFF_MEMBERS_QUERY_RESULT } from "../sanity/sanity.types";
+import type { OrgChartNode } from "@/types/organigram";
+
+// Mock the sanity client before importing the repository
+vi.mock("../sanity/client", () => ({
+  sanityClient: {
+    fetch: vi.fn(),
+  },
+}));
+
+import { sanityClient } from "../sanity/client";
+import { StaffRepository, StaffRepositoryLive } from "./staff.repository";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFetch = sanityClient.fetch as any as ReturnType<typeof vi.fn>;
+
+function runWithRepo<A>(effect: Effect.Effect<A, never, StaffRepository>) {
+  return Effect.runPromise(Effect.provide(effect, StaffRepositoryLive));
+}
+
+type StaffRow = STAFF_MEMBERS_QUERY_RESULT[number];
+
+function makeStaffRow(overrides: Partial<StaffRow> = {}): StaffRow {
+  return {
+    _id: "staff-1",
+    firstName: "Jan",
+    lastName: "Janssens",
+    positionTitle: "Voorzitter",
+    positionShort: "VZ",
+    department: "hoofdbestuur",
+    email: "jan@kcvv.be",
+    phone: "+32 123 456 789",
+    photoUrl: "https://cdn.sanity.io/photo.webp",
+    responsibilities: "Algemene leiding",
+    parentId: null,
+    ...overrides,
+  };
+}
+
+describe("StaffRepository", () => {
+  describe("findAll", () => {
+    it("prepends CLUB_ROOT_NODE and maps all OrgChartNode fields", async () => {
+      const row = makeStaffRow();
+      mockFetch.mockResolvedValueOnce([row]);
+
+      const members = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* StaffRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      expect(members).toHaveLength(2);
+
+      // First element is the club root node
+      expect(members[0]).toEqual<OrgChartNode>({
+        id: "club",
+        name: "KCVV Elewijt",
+        title: "Voetbalclub",
+        imageUrl: "/images/logo-flat.png",
+        department: "algemeen",
+        parentId: null,
+      });
+
+      // Second element is the mapped staff member
+      expect(members[1]).toEqual<OrgChartNode>({
+        id: "staff-1",
+        name: "Jan Janssens",
+        title: "Voorzitter",
+        positionShort: "VZ",
+        imageUrl: "https://cdn.sanity.io/photo.webp",
+        email: "jan@kcvv.be",
+        phone: "+32 123 456 789",
+        responsibilities: "Algemene leiding",
+        department: "hoofdbestuur",
+        parentId: "club",
+      });
+    });
+
+    it("parentId null defaults to 'club'", async () => {
+      mockFetch.mockResolvedValueOnce([makeStaffRow({ parentId: null })]);
+
+      const members = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* StaffRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      expect(members[1].parentId).toBe("club");
+    });
+
+    it("parentId set when parent is in organigram", async () => {
+      mockFetch.mockResolvedValueOnce([
+        makeStaffRow({ _id: "parent-1", parentId: null }),
+        makeStaffRow({ _id: "child-1", parentId: "parent-1" }),
+      ]);
+
+      const members = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* StaffRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      const child = members.find((m) => m.id === "child-1");
+      expect(child?.parentId).toBe("parent-1");
+    });
+
+    it("null optional fields become undefined", async () => {
+      mockFetch.mockResolvedValueOnce([
+        makeStaffRow({
+          positionShort: null,
+          photoUrl: null,
+          email: null,
+          phone: null,
+          responsibilities: null,
+          department: null,
+        }),
+      ]);
+
+      const members = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* StaffRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      const member = members[1];
+      expect(member.positionShort).toBeUndefined();
+      expect(member.imageUrl).toBeUndefined();
+      expect(member.email).toBeUndefined();
+      expect(member.phone).toBeUndefined();
+      expect(member.responsibilities).toBeUndefined();
+      expect(member.department).toBeUndefined();
+    });
+
+    it("null firstName/lastName produce trimmed name", async () => {
+      mockFetch.mockResolvedValueOnce([
+        makeStaffRow({ firstName: null, lastName: "Janssens" }),
+      ]);
+
+      const members = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* StaffRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      expect(members[1].name).toBe("Janssens");
+    });
+
+    it("null positionTitle defaults to empty string", async () => {
+      mockFetch.mockResolvedValueOnce([makeStaffRow({ positionTitle: null })]);
+
+      const members = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* StaffRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      expect(members[1].title).toBe("");
+    });
+  });
+});

--- a/apps/web/src/lib/repositories/staff.repository.ts
+++ b/apps/web/src/lib/repositories/staff.repository.ts
@@ -1,0 +1,53 @@
+import { Context, Effect, Layer } from "effect";
+import { sanityClient } from "../sanity/client";
+import { STAFF_MEMBERS_QUERY } from "../sanity/queries/staffMembers";
+import type { STAFF_MEMBERS_QUERY_RESULT } from "../sanity/sanity.types";
+import type { OrgChartNode } from "@/types/organigram";
+
+const CLUB_ROOT_NODE: OrgChartNode = {
+  id: "club",
+  name: "KCVV Elewijt",
+  title: "Voetbalclub",
+  imageUrl: "/images/logo-flat.png",
+  department: "algemeen",
+  parentId: null,
+};
+
+export function toOrgChartNode(
+  m: STAFF_MEMBERS_QUERY_RESULT[number],
+): OrgChartNode {
+  return {
+    id: m._id,
+    name: `${m.firstName ?? ""} ${m.lastName ?? ""}`.trim(),
+    title: m.positionTitle ?? "",
+    positionShort: m.positionShort ?? undefined,
+    imageUrl: m.photoUrl ?? undefined,
+    email: m.email ?? undefined,
+    phone: m.phone ?? undefined,
+    responsibilities: m.responsibilities ?? undefined,
+    department: (m.department ?? undefined) as OrgChartNode["department"],
+    parentId: m.parentId ?? "club",
+  };
+}
+
+export interface StaffRepositoryInterface {
+  readonly findAll: () => Effect.Effect<OrgChartNode[]>;
+}
+
+export class StaffRepository extends Context.Tag("StaffRepository")<
+  StaffRepository,
+  StaffRepositoryInterface
+>() {}
+
+const fetchGroq = <T>(query: string, params?: Record<string, unknown>) =>
+  Effect.tryPromise({
+    try: () => sanityClient.fetch<T>(query, params ?? {}),
+    catch: (cause) => new Error(`Sanity fetch failed: ${String(cause)}`),
+  }).pipe(Effect.orDie);
+
+export const StaffRepositoryLive = Layer.succeed(StaffRepository, {
+  findAll: () =>
+    fetchGroq<STAFF_MEMBERS_QUERY_RESULT>(STAFF_MEMBERS_QUERY).pipe(
+      Effect.map((members) => [CLUB_ROOT_NODE, ...members.map(toOrgChartNode)]),
+    ),
+});

--- a/apps/web/src/lib/sanity/queries/staffMembers.ts
+++ b/apps/web/src/lib/sanity/queries/staffMembers.ts
@@ -1,8 +1,11 @@
+import { defineQuery } from "groq";
+
 /**
  * Fetches all staffMember documents marked for the organigram, ordered by last name.
  * Only documents with inOrganigram == true are returned.
  */
-export const STAFF_MEMBERS_QUERY = `*[_type == "staffMember" && archived != true && inOrganigram == true] | order(lastName asc) {
+export const STAFF_MEMBERS_QUERY =
+  defineQuery(`*[_type == "staffMember" && archived != true && inOrganigram == true] | order(lastName asc) {
   _id,
   firstName,
   lastName,
@@ -14,4 +17,4 @@ export const STAFF_MEMBERS_QUERY = `*[_type == "staffMember" && archived != true
   "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",
   responsibilities,
   "parentId": select(defined(parentMember) && parentMember->inOrganigram == true && parentMember->archived != true => parentMember->_id, null)
-}`;
+}`);

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -442,6 +442,7 @@ export type StaffMember = {
   positionShort?: string;
   responsibilities?: string;
   psdId?: string;
+  archived?: boolean;
 };
 
 export type TrainingSession = {
@@ -536,6 +537,7 @@ export type Team = {
       _key: string;
     } & StaffMemberReference
   >;
+  archived?: boolean;
 };
 
 export type Player = {
@@ -551,6 +553,7 @@ export type Player = {
   nationality?: string;
   keeper?: boolean;
   positionPsd?: string;
+  archived?: boolean;
   jerseyNumber?: number;
   height?: number;
   weight?: number;
@@ -1098,7 +1101,7 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
 
 // Source: ../web/src/lib/sanity/queries/players.ts
 // Variable: PLAYERS_QUERY
-// Query: *[_type == "player"] | order(lastName asc) {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate, nationality, height, weight,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio}
+// Query: *[_type == "player" && archived != true] | order(lastName asc) {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate, nationality, height, weight,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio}
 export type PLAYERS_QUERY_RESULT = Array<{
   _id: string;
   psdId: string | null;
@@ -1199,9 +1202,26 @@ export type SPONSORS_QUERY_RESULT = Array<{
   logoUrl: string | null;
 }>;
 
+// Source: ../web/src/lib/sanity/queries/staffMembers.ts
+// Variable: STAFF_MEMBERS_QUERY
+// Query: *[_type == "staffMember" && archived != true && inOrganigram == true] | order(lastName asc) {  _id,  firstName,  lastName,  positionTitle,  positionShort,  department,  email,  phone,  "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",  responsibilities,  "parentId": select(defined(parentMember) && parentMember->inOrganigram == true && parentMember->archived != true => parentMember->_id, null)}
+export type STAFF_MEMBERS_QUERY_RESULT = Array<{
+  _id: string;
+  firstName: string | null;
+  lastName: string | null;
+  positionTitle: string | null;
+  positionShort: string | null;
+  department: "algemeen" | "hoofdbestuur" | "jeugdbestuur" | null;
+  email: string | null;
+  phone: string | null;
+  photoUrl: string | null;
+  responsibilities: string | null;
+  parentId: string | null;
+}>;
+
 // Source: ../web/src/lib/sanity/queries/teams.ts
 // Variable: TEAMS_QUERY
-// Query: *[_type == "team" && showInNavigation != false] | order(name asc) {  _id, psdId, name, "slug": slug.current, age, gender, footbelId, leagueId, division, divisionFull,  tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"}
+// Query: *[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {  _id, psdId, name, "slug": slug.current, age, gender, footbelId, leagueId, division, divisionFull,  tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"}
 export type TEAMS_QUERY_RESULT = Array<{
   _id: string;
   psdId: string | null;
@@ -1328,7 +1348,7 @@ export type TEAM_BY_SLUG_QUERY_RESULT = {
 
 // Source: ../web/src/lib/sanity/queries/teams.ts
 // Variable: TEAMS_LANDING_QUERY
-// Query: *[_type == "team" && showInNavigation != false && defined(age)] | order(name asc) {  _id, name, "slug": slug.current, age,  division, divisionFull, tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  staff[]-> { firstName, lastName, role }}
+// Query: *[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {  _id, name, "slug": slug.current, age,  division, divisionFull, tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  staff[]-> { firstName, lastName, role }}
 export type TEAMS_LANDING_QUERY_RESULT = Array<{
   _id: string;
   name: string | null;
@@ -1377,11 +1397,12 @@ declare module "@sanity/client" {
     'array::unique(*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])': ARTICLE_TAGS_QUERY_RESULT;
     '*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;
     '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName, positionTitle,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
-    '*[_type == "player"] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
+    '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
     '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "sponsor" && active == true] | order(name asc) {\n  _id, name, url, type, tier, featured, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
-    '*[_type == "team" && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, leagueId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': TEAMS_QUERY_RESULT;
+    '*[_type == "staffMember" && archived != true && inOrganigram == true] | order(lastName asc) {\n  _id,\n  firstName,\n  lastName,\n  positionTitle,\n  positionShort,\n  department,\n  email,\n  phone,\n  "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",\n  responsibilities,\n  "parentId": select(defined(parentMember) && parentMember->inOrganigram == true && parentMember->archived != true => parentMember->_id, null)\n}': STAFF_MEMBERS_QUERY_RESULT;
+    '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, leagueId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': TEAMS_QUERY_RESULT;
     '*[_type == "team" && slug.current == $slug][0] {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, leagueId, division, divisionFull,\n  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  trainingSchedule,\n  players[]-> {\n    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"\n  },\n  staff[]-> { _id, firstName, lastName, role, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max" }\n}': TEAM_BY_SLUG_QUERY_RESULT;
-    '*[_type == "team" && showInNavigation != false && defined(age)] | order(name asc) {\n  _id, name, "slug": slug.current, age,\n  division, divisionFull, tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  staff[]-> { firstName, lastName, role }\n}': TEAMS_LANDING_QUERY_RESULT;
+    '*[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {\n  _id, name, "slug": slug.current, age,\n  division, divisionFull, tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  staff[]-> { firstName, lastName, role }\n}': TEAMS_LANDING_QUERY_RESULT;
   }
 }


### PR DESCRIPTION
Closes #888

## What changed
- Created `StaffRepository` with `findAll()` returning `OrgChartNode[]`, absorbing `CLUB_ROOT_NODE` and `mapOrgMember()` from SanityService
- Annotated `STAFF_MEMBERS_QUERY` with `defineQuery` for typegen — generated types replace hand-maintained `SanityOrgMember` interface
- Migrated organigram page to use `StaffRepository.findAll()` and deleted `SanityService.getStaffMembers()`

## Testing
- 6 new tests covering: field mapping, parentId defaults, null handling, name trimming
- All checks pass: lint, type-check, 1801 tests (115 files)
- Build requires `SANITY_PROJECT_ID` env var (pre-existing, not related to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)