### PR TITLE
feat(ui): instrument responsibility finder funnel events (#897)

### DIFF
--- a/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
+++ b/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
@@ -141,6 +141,7 @@ export function ResponsibilityFinder({
   } = useSemanticSearch({ type: "responsibility", limit: 5 });
 
   const analytics = useResponsibilityAnalytics();
+  const userInitiatedQuestionRef = useRef(false);
 
   useEffect(() => {
     semanticSearch(questionText);
@@ -160,17 +161,23 @@ export function ResponsibilityFinder({
           .map((p) => ({ path: p, score: 100 }))
       : [];
 
-  // Track search events when results arrive
+  // Track search events when results arrive (only for user-initiated searches)
   const prevLoadingRef = useRef(false);
   useEffect(() => {
-    if (prevLoadingRef.current && !semanticLoading && questionText?.trim()) {
+    if (
+      prevLoadingRef.current &&
+      !semanticLoading &&
+      questionText?.trim() &&
+      userInitiatedQuestionRef.current
+    ) {
+      userInitiatedQuestionRef.current = false;
       analytics.trackSearch(
         questionText,
         selectedRole || "",
         suggestions.length,
       );
       if (suggestions.length === 0) {
-        analytics.trackNoResults(questionText, selectedRole || "");
+        analytics.trackNoResults(questionText.length, selectedRole || "");
       }
     }
     prevLoadingRef.current = semanticLoading;
@@ -184,6 +191,7 @@ export function ResponsibilityFinder({
 
   // Handle role selection
   const handleRoleSelect = (role: string) => {
+    analytics.resetSession();
     setSelectedRole(role as UserRole);
     setSelectedResult(null);
     setShowRoleDropdown(false);
@@ -233,6 +241,7 @@ export function ResponsibilityFinder({
     setShowSuggestions(false);
     setShowRoleDropdown(false);
     setActiveDescendantIdx(-1);
+    analytics.resetSession();
   };
 
   // Handle keyboard navigation in suggestion list
@@ -474,6 +483,7 @@ export function ResponsibilityFinder({
                 }
                 value={questionText}
                 onChange={(e) => {
+                  userInitiatedQuestionRef.current = true;
                   setQuestionText(e.target.value);
                   setShowSuggestions(true);
                   setSelectedResult(null);
@@ -725,13 +735,15 @@ function ResultCard({
     categoryColors.algemeen;
   const safeOrgLink = toSafeHref(path.primaryContact.orgLink);
 
-  // Dwell-time tracking
+  // Dwell-time tracking — destructure stable callbacks to avoid effect restart
+  // when the analytics object reference changes on parent re-renders
+  const { startDwell, stopDwell } = analytics;
   useEffect(() => {
-    analytics.startDwell(path.id, path.category);
+    startDwell(path.id, path.category);
     return () => {
-      analytics.stopDwell();
+      stopDwell();
     };
-  }, [path.id, path.category, analytics]);
+  }, [path.id, path.category, startDwell, stopDwell]);
 
   return (
     <div className="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden relative">
@@ -871,6 +883,15 @@ function ResultCard({
                 ) : safeOrgLink ? (
                   <a
                     href={safeOrgLink}
+                    onClick={() => {
+                      if (path.primaryContact.memberId) {
+                        analytics.trackOrganigramLink(
+                          path.id,
+                          path.primaryContact.memberId,
+                        );
+                        onMemberSelect?.(path.primaryContact.memberId);
+                      }
+                    }}
                     className="text-kcvv-green hover:text-kcvv-green-hover hover:underline inline-flex items-center gap-1 text-sm font-medium"
                   >
                     <svg

--- a/apps/web/src/hooks/useResponsibilityAnalytics.test.ts
+++ b/apps/web/src/hooks/useResponsibilityAnalytics.test.ts
@@ -52,15 +52,15 @@ describe("useResponsibilityAnalytics", () => {
   });
 
   describe("responsibility_no_results", () => {
-    it("fires with query text and role", () => {
+    it("fires with query length and role", () => {
       const { result } = renderHook(() => useResponsibilityAnalytics());
 
       act(() => {
-        result.current.trackNoResults("xyz", "ouder");
+        result.current.trackNoResults(3, "ouder");
       });
 
       expect(mockTrackEvent).toHaveBeenCalledWith("responsibility_no_results", {
-        query_text: "xyz",
+        query_length: 3,
         role: "ouder",
       });
     });

--- a/apps/web/src/hooks/useResponsibilityAnalytics.ts
+++ b/apps/web/src/hooks/useResponsibilityAnalytics.ts
@@ -28,9 +28,9 @@ export function useResponsibilityAnalytics() {
     [],
   );
 
-  const trackNoResults = useCallback((queryText: string, role: string) => {
+  const trackNoResults = useCallback((queryLength: number, role: string) => {
     trackEvent("responsibility_no_results", {
-      query_text: queryText,
+      query_length: queryLength,
       role,
     });
   }, []);
@@ -106,6 +106,14 @@ export function useResponsibilityAnalytics() {
     clearDwellTimers();
   }, [clearDwellTimers]);
 
+  const resetSession = useCallback(() => {
+    lastRoleRef.current = null;
+    lastQueryLengthRef.current = 0;
+    lastHadResultsRef.current = false;
+    hadContactInteractionRef.current = false;
+    clearDwellTimers();
+  }, [clearDwellTimers]);
+
   // Abandon tracking on unmount
   useEffect(() => {
     return () => {
@@ -131,5 +139,6 @@ export function useResponsibilityAnalytics() {
     trackStepLinkClicked,
     startDwell,
     stopDwell,
+    resetSession,
   };
 }


### PR DESCRIPTION
Closes #897

## What changed
- Created `useResponsibilityAnalytics` hook encapsulating all 9 responsibility finder analytics events
- Integrated hook into `ResponsibilityFinder` and `ResultCard` components
- Added 13 unit tests covering all events, dwell-time thresholds (5s/15s/30s), and abandon detection

## Events instrumented
| Event | Trigger |
|-------|---------|
| `responsibility_role_selected` | Role dropdown change |
| `responsibility_search` | Search results arrive |
| `responsibility_no_results` | Empty results |
| `responsibility_suggestion_clicked` | User clicks suggestion |
| `responsibility_contact_clicked` | Email/phone link clicked |
| `responsibility_organigram_link` | "Bekijk in organigram" clicked |
| `responsibility_step_link_clicked` | Step link followed |
| `responsibility_dwell` | ResultCard viewed 5s/15s/30s |
| `responsibility_abandon` | Unmount without contact interaction |

## Testing
- All 1872 tests pass (`pnpm --filter @kcvv/web test`)
- Lint clean (`pnpm --filter @kcvv/web lint`)
- Type-check passes (pre-existing api-contract build errors on base branch unrelated)
- No PII in events — path IDs, categories, and counts only