### PR TITLE
feat(ui): instrument related content impressions and clicks (#1095)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -174,7 +174,11 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           )}
         </main>
 
-        <RelatedContentSlider items={relatedItems} />
+        <RelatedContentSlider
+          items={relatedItems}
+          pageType="article"
+          pageSlug={article.slug}
+        />
       </div>
     </>
   );

--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -183,6 +183,8 @@ export default async function TeamPage({ params }: TeamPageProps) {
 
       <RelatedArticlesSection
         articles={relatedArticles}
+        pageType="team"
+        pageSlug={slug}
         className="max-w-4xl mx-auto px-4 pb-8"
       />
     </>

--- a/apps/web/src/app/(main)/spelers/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/spelers/[slug]/page.tsx
@@ -133,6 +133,8 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
 
       <RelatedArticlesSection
         articles={relatedArticles}
+        pageType="player"
+        pageSlug={slug}
         className="max-w-4xl mx-auto px-4 pb-8"
       />
     </>

--- a/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.test.tsx
+++ b/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.test.tsx
@@ -1,30 +1,49 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { RelatedArticlesSection } from "./RelatedArticlesSection";
 
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+
+const trackEventMock = vi.mocked(trackEvent);
+
+const mockArticles = [
+  {
+    id: "article-1",
+    title: "Interview met Jan",
+    slug: "interview-jan",
+    publishedAt: "2026-03-20T10:00:00Z",
+    featured: false,
+    coverImageUrl: "https://cdn.sanity.io/img1.jpg",
+    tags: [],
+  },
+  {
+    id: "article-2",
+    title: "Wedstrijdverslag",
+    slug: "wedstrijdverslag",
+    publishedAt: "2026-03-19T10:00:00Z",
+    featured: false,
+    tags: [],
+  },
+];
+
 describe("RelatedArticlesSection", () => {
-  const mockArticles = [
-    {
-      id: "article-1",
-      title: "Interview met Jan",
-      slug: "interview-jan",
-      publishedAt: "2026-03-20T10:00:00Z",
-      featured: false,
-      coverImageUrl: "https://cdn.sanity.io/img1.jpg",
-      tags: [],
-    },
-    {
-      id: "article-2",
-      title: "Wedstrijdverslag",
-      slug: "wedstrijdverslag",
-      publishedAt: "2026-03-19T10:00:00Z",
-      featured: false,
-      tags: [],
-    },
-  ];
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
 
   it("renders section heading and article links", () => {
-    render(<RelatedArticlesSection articles={mockArticles} />);
+    render(
+      <RelatedArticlesSection
+        articles={mockArticles}
+        pageType="player"
+        pageSlug="12345"
+      />,
+    );
 
     expect(screen.getByText("Gerelateerd")).toBeInTheDocument();
     expect(screen.getByText("Interview met Jan")).toBeInTheDocument();
@@ -32,22 +51,140 @@ describe("RelatedArticlesSection", () => {
   });
 
   it("renders article links pointing to /nieuws/[slug]", () => {
-    render(<RelatedArticlesSection articles={mockArticles} />);
+    render(
+      <RelatedArticlesSection
+        articles={mockArticles}
+        pageType="player"
+        pageSlug="12345"
+      />,
+    );
 
     const link = screen.getByText("Interview met Jan").closest("a");
     expect(link).toHaveAttribute("href", "/nieuws/interview-jan");
   });
 
   it("returns null when articles array is empty", () => {
-    const { container } = render(<RelatedArticlesSection articles={[]} />);
+    const { container } = render(
+      <RelatedArticlesSection
+        articles={[]}
+        pageType="player"
+        pageSlug="12345"
+      />,
+    );
     expect(container.firstChild).toBeNull();
   });
 
   it("renders article cover images when available", () => {
-    render(<RelatedArticlesSection articles={mockArticles} />);
+    render(
+      <RelatedArticlesSection
+        articles={mockArticles}
+        pageType="player"
+        pageSlug="12345"
+      />,
+    );
 
     const images = screen.getAllByRole("img");
     expect(images).toHaveLength(1); // Only article-1 has a coverImageUrl
     expect(images[0]).toHaveAttribute("alt", "Interview met Jan");
+  });
+
+  describe("related_content_shown event", () => {
+    it("fires on mount with source 'reference' and correct parameters", () => {
+      render(
+        <RelatedArticlesSection
+          articles={mockArticles}
+          pageType="player"
+          pageSlug="12345"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_shown", {
+        source: "reference",
+        count: 2,
+        content_types: "article",
+        page_type: "player",
+        page_slug: "12345",
+      });
+    });
+
+    it("does not fire when articles array is empty", () => {
+      render(
+        <RelatedArticlesSection
+          articles={[]}
+          pageType="player"
+          pageSlug="12345"
+        />,
+      );
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("fires once on mount, not on re-renders", () => {
+      const { rerender } = render(
+        <RelatedArticlesSection
+          articles={mockArticles}
+          pageType="player"
+          pageSlug="12345"
+        />,
+      );
+
+      rerender(
+        <RelatedArticlesSection
+          articles={mockArticles}
+          pageType="player"
+          pageSlug="12345"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("related_content_click event", () => {
+    it("fires on article link click with correct parameters", async () => {
+      render(
+        <RelatedArticlesSection
+          articles={mockArticles}
+          pageType="team"
+          pageSlug="a-ploeg"
+        />,
+      );
+
+      trackEventMock.mockClear(); // clear impression event
+
+      await userEvent.click(screen.getByText("Interview met Jan"));
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "reference",
+        target_type: "article",
+        target_slug: "interview-jan",
+        position: 1,
+        page_type: "team",
+        page_slug: "a-ploeg",
+      });
+    });
+
+    it("fires with correct 1-indexed position for each article", async () => {
+      render(
+        <RelatedArticlesSection
+          articles={mockArticles}
+          pageType="team"
+          pageSlug="a-ploeg"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      await userEvent.click(screen.getByText("Wedstrijdverslag"));
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "reference",
+        target_type: "article",
+        target_slug: "wedstrijdverslag",
+        position: 2,
+        page_type: "team",
+        page_slug: "a-ploeg",
+      });
+    });
   });
 });

--- a/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.tsx
+++ b/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.tsx
@@ -1,27 +1,62 @@
+"use client";
+
+import { useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { trackEvent } from "@/lib/analytics/track-event";
 import type { ArticleVM } from "@/lib/repositories/article.repository";
+import type { RelatedPageType } from "../types";
 
 export interface RelatedArticlesSectionProps {
   articles: ArticleVM[];
+  pageType: RelatedPageType;
+  pageSlug: string;
   className?: string;
 }
 
 export const RelatedArticlesSection = ({
   articles,
+  pageType,
+  pageSlug,
   className,
 }: RelatedArticlesSectionProps) => {
+  const hasFired = useRef(false);
+
+  useEffect(() => {
+    if (hasFired.current || articles.length === 0) return;
+    hasFired.current = true;
+
+    trackEvent("related_content_shown", {
+      source: "reference",
+      count: articles.length,
+      content_types: "article",
+      page_type: pageType,
+      page_slug: pageSlug,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (articles.length === 0) return null;
 
   return (
     <section className={className}>
       <h3 className="text-lg font-bold mb-4">Gerelateerd</h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {articles.map((article) => (
+        {articles.map((article, index) => (
           <Link
             key={article.id}
             href={`/nieuws/${article.slug}`}
             className="group block overflow-hidden rounded-lg border border-gray-200 hover:border-kcvv-green-bright transition-colors"
+            onClick={() => {
+              trackEvent("related_content_click", {
+                source: "reference",
+                target_type: "article",
+                target_slug: article.slug,
+                position: index + 1,
+                page_type: pageType,
+                page_slug: pageSlug,
+              });
+            }}
           >
             {article.coverImageUrl && (
               <div className="relative aspect-video overflow-hidden">

--- a/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.stories.tsx
+++ b/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.stories.tsx
@@ -10,6 +10,7 @@ import type {
 
 const articleItem: RelatedArticleItem = {
   type: "article",
+  source: "editorial",
   id: "art-1",
   title: "Interview met de kapitein over het seizoen",
   slug: "interview-kapitein",
@@ -20,6 +21,7 @@ const articleItem: RelatedArticleItem = {
 
 const pageItem: RelatedPageItem = {
   type: "page",
+  source: "ai",
   id: "page-1",
   title: "Over de club",
   slug: "over-de-club",
@@ -29,6 +31,7 @@ const pageItem: RelatedPageItem = {
 
 const playerItem: RelatedPlayerItem = {
   type: "player",
+  source: "reference",
   id: "player-1",
   firstName: "Jan",
   lastName: "Janssens",
@@ -39,6 +42,7 @@ const playerItem: RelatedPlayerItem = {
 
 const teamItem: RelatedTeamItem = {
   type: "team",
+  source: "reference",
   id: "team-1",
   name: "A-ploeg",
   slug: "a-ploeg",
@@ -48,6 +52,7 @@ const teamItem: RelatedTeamItem = {
 
 const staffItem: RelatedStaffItem = {
   type: "staff",
+  source: "reference",
   id: "staff-1",
   firstName: "Piet",
   lastName: "Pieters",
@@ -83,40 +88,95 @@ type Story = StoryObj<typeof meta>;
 
 /** Article variant with image, title, date, and excerpt */
 export const Article: Story = {
-  args: { item: articleItem },
+  args: {
+    item: articleItem,
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
+  },
 };
 
 /** Page variant with title and excerpt */
 export const Page: Story = {
-  args: { item: pageItem },
+  args: {
+    item: pageItem,
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
+  },
 };
 
 /** Player variant with photo, name, and position */
 export const Player: Story = {
-  args: { item: playerItem },
+  args: {
+    item: playerItem,
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
+  },
 };
 
 /** Team variant with photo, name, and tagline */
 export const Team: Story = {
-  args: { item: teamItem },
+  args: {
+    item: teamItem,
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
+  },
 };
 
 /** Staff variant with photo, name, and role (no link) */
 export const Staff: Story = {
-  args: { item: staffItem },
+  args: {
+    item: staffItem,
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
+  },
 };
 
 /** All variants side-by-side to verify consistent dimensions */
 export const AllVariants: Story = {
-  args: { item: articleItem },
+  args: {
+    item: articleItem,
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
+  },
   decorators: [
     () => (
       <div className="flex gap-4 items-start">
-        <RelatedContentCard item={articleItem} />
-        <RelatedContentCard item={pageItem} />
-        <RelatedContentCard item={playerItem} />
-        <RelatedContentCard item={teamItem} />
-        <RelatedContentCard item={staffItem} />
+        <RelatedContentCard
+          item={articleItem}
+          position={1}
+          pageType="article"
+          pageSlug="example-article"
+        />
+        <RelatedContentCard
+          item={pageItem}
+          position={2}
+          pageType="article"
+          pageSlug="example-article"
+        />
+        <RelatedContentCard
+          item={playerItem}
+          position={3}
+          pageType="article"
+          pageSlug="example-article"
+        />
+        <RelatedContentCard
+          item={teamItem}
+          position={4}
+          pageType="article"
+          pageSlug="example-article"
+        />
+        <RelatedContentCard
+          item={staffItem}
+          position={5}
+          pageType="article"
+          pageSlug="example-article"
+        />
       </div>
     ),
   ],
@@ -126,5 +186,8 @@ export const AllVariants: Story = {
 export const NoImage: Story = {
   args: {
     item: { ...articleItem, imageUrl: null },
+    position: 1,
+    pageType: "article",
+    pageSlug: "example-article",
   },
 };

--- a/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.test.tsx
+++ b/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { RelatedContentCard } from "./RelatedContentCard";
 import type {
   RelatedArticleItem,
@@ -9,8 +10,17 @@ import type {
   RelatedStaffItem,
 } from "../types";
 
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+
+const trackEventMock = vi.mocked(trackEvent);
+
 const articleItem: RelatedArticleItem = {
   type: "article",
+  source: "editorial",
   id: "art-1",
   title: "Interview met de kapitein",
   slug: "interview-kapitein",
@@ -21,6 +31,7 @@ const articleItem: RelatedArticleItem = {
 
 const pageItem: RelatedPageItem = {
   type: "page",
+  source: "ai",
   id: "page-1",
   title: "Over de club",
   slug: "over-de-club",
@@ -30,6 +41,7 @@ const pageItem: RelatedPageItem = {
 
 const playerItem: RelatedPlayerItem = {
   type: "player",
+  source: "reference",
   id: "player-1",
   firstName: "Jan",
   lastName: "Janssens",
@@ -40,6 +52,7 @@ const playerItem: RelatedPlayerItem = {
 
 const teamItem: RelatedTeamItem = {
   type: "team",
+  source: "reference",
   id: "team-1",
   name: "A-ploeg",
   slug: "a-ploeg",
@@ -49,6 +62,7 @@ const teamItem: RelatedTeamItem = {
 
 const staffItem: RelatedStaffItem = {
   type: "staff",
+  source: "reference",
   id: "staff-1",
   firstName: "Piet",
   lastName: "Pieters",
@@ -57,9 +71,20 @@ const staffItem: RelatedStaffItem = {
 };
 
 describe("RelatedContentCard", () => {
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
+
   describe("article variant", () => {
     it("renders title, date, and excerpt", () => {
-      render(<RelatedContentCard item={articleItem} />);
+      render(
+        <RelatedContentCard
+          item={articleItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       expect(screen.getByText("Interview met de kapitein")).toBeInTheDocument();
       expect(
@@ -69,62 +94,184 @@ describe("RelatedContentCard", () => {
     });
 
     it("links to /nieuws/[slug]", () => {
-      render(<RelatedContentCard item={articleItem} />);
+      render(
+        <RelatedContentCard
+          item={articleItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const link = screen.getByText("Interview met de kapitein").closest("a");
       expect(link).toHaveAttribute("href", "/nieuws/interview-kapitein");
     });
 
     it("renders cover image when available", () => {
-      render(<RelatedContentCard item={articleItem} />);
+      render(
+        <RelatedContentCard
+          item={articleItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const img = screen.getByRole("img");
       expect(img).toHaveAttribute("alt", "Interview met de kapitein");
+    });
+
+    it("fires related_content_click with correct parameters on click", async () => {
+      render(
+        <RelatedContentCard
+          item={articleItem}
+          position={2}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
+
+      await userEvent.click(screen.getByText("Interview met de kapitein"));
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "editorial",
+        target_type: "article",
+        target_slug: "interview-kapitein",
+        position: 2,
+        page_type: "article",
+        page_slug: "current-article",
+      });
     });
   });
 
   describe("page variant", () => {
     it("renders title and excerpt", () => {
-      render(<RelatedContentCard item={pageItem} />);
+      render(
+        <RelatedContentCard
+          item={pageItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       expect(screen.getByText("Over de club")).toBeInTheDocument();
       expect(screen.getByText("Alles over KCVV Elewijt.")).toBeInTheDocument();
     });
 
     it("links to /[slug]", () => {
-      render(<RelatedContentCard item={pageItem} />);
+      render(
+        <RelatedContentCard
+          item={pageItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const link = screen.getByText("Over de club").closest("a");
       expect(link).toHaveAttribute("href", "/over-de-club");
+    });
+
+    it("fires related_content_click with source from item on click", async () => {
+      render(
+        <RelatedContentCard
+          item={pageItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
+
+      await userEvent.click(screen.getByText("Over de club"));
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "ai",
+        target_type: "page",
+        target_slug: "over-de-club",
+        position: 1,
+        page_type: "article",
+        page_slug: "current-article",
+      });
     });
   });
 
   describe("player variant", () => {
     it("renders name and position", () => {
-      render(<RelatedContentCard item={playerItem} />);
+      render(
+        <RelatedContentCard
+          item={playerItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       expect(screen.getByText("Jan Janssens")).toBeInTheDocument();
       expect(screen.getByText("Aanvaller")).toBeInTheDocument();
     });
 
     it("links to /spelers/[psdId]", () => {
-      render(<RelatedContentCard item={playerItem} />);
+      render(
+        <RelatedContentCard
+          item={playerItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const link = screen.getByText("Jan Janssens").closest("a");
       expect(link).toHaveAttribute("href", "/spelers/12345");
     });
 
     it("renders player photo when available", () => {
-      render(<RelatedContentCard item={playerItem} />);
+      render(
+        <RelatedContentCard
+          item={playerItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const img = screen.getByRole("img");
       expect(img).toHaveAttribute("alt", "Jan Janssens");
+    });
+
+    it("fires related_content_click on click", async () => {
+      render(
+        <RelatedContentCard
+          item={playerItem}
+          position={3}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
+
+      await userEvent.click(screen.getByText("Jan Janssens"));
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "reference",
+        target_type: "player",
+        target_slug: "12345",
+        position: 3,
+        page_type: "article",
+        page_slug: "current-article",
+      });
     });
   });
 
   describe("team variant", () => {
     it("renders name and tagline", () => {
-      render(<RelatedContentCard item={teamItem} />);
+      render(
+        <RelatedContentCard
+          item={teamItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       expect(screen.getByText("A-ploeg")).toBeInTheDocument();
       expect(
@@ -133,7 +280,14 @@ describe("RelatedContentCard", () => {
     });
 
     it("links to /ploegen/[slug]", () => {
-      render(<RelatedContentCard item={teamItem} />);
+      render(
+        <RelatedContentCard
+          item={teamItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const link = screen.getByText("A-ploeg").closest("a");
       expect(link).toHaveAttribute("href", "/ploegen/a-ploeg");
@@ -142,20 +296,41 @@ describe("RelatedContentCard", () => {
 
   describe("staff variant", () => {
     it("renders name and role", () => {
-      render(<RelatedContentCard item={staffItem} />);
+      render(
+        <RelatedContentCard
+          item={staffItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       expect(screen.getByText("Piet Pieters")).toBeInTheDocument();
       expect(screen.getByText("Hoofdtrainer")).toBeInTheDocument();
     });
 
     it("does not render a link (staff has no detail page)", () => {
-      const { container } = render(<RelatedContentCard item={staffItem} />);
+      const { container } = render(
+        <RelatedContentCard
+          item={staffItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       expect(container.querySelector("a")).toBeNull();
     });
 
     it("renders staff photo when available", () => {
-      render(<RelatedContentCard item={staffItem} />);
+      render(
+        <RelatedContentCard
+          item={staffItem}
+          position={1}
+          pageType="article"
+          pageSlug="current-article"
+        />,
+      );
 
       const img = screen.getByRole("img");
       expect(img).toHaveAttribute("alt", "Piet Pieters");
@@ -165,12 +340,29 @@ describe("RelatedContentCard", () => {
   describe("consistent dimensions", () => {
     it("all variants have the same fixed width class", () => {
       const { container: c1 } = render(
-        <RelatedContentCard item={articleItem} />,
+        <RelatedContentCard
+          item={articleItem}
+          position={1}
+          pageType="article"
+          pageSlug="test"
+        />,
       );
       const { container: c2 } = render(
-        <RelatedContentCard item={playerItem} />,
+        <RelatedContentCard
+          item={playerItem}
+          position={2}
+          pageType="article"
+          pageSlug="test"
+        />,
       );
-      const { container: c3 } = render(<RelatedContentCard item={teamItem} />);
+      const { container: c3 } = render(
+        <RelatedContentCard
+          item={teamItem}
+          position={3}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
 
       const card1 = c1.firstChild as HTMLElement;
       const card2 = c2.firstChild as HTMLElement;

--- a/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.tsx
+++ b/apps/web/src/components/related/RelatedContentCard/RelatedContentCard.tsx
@@ -1,11 +1,20 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
 import { cn } from "@/lib/utils/cn";
-import type { RelatedContentItem } from "../types";
+import { trackEvent } from "@/lib/analytics/track-event";
+import type { RelatedContentItem, RelatedPageType } from "../types";
 
 export interface RelatedContentCardProps {
   /** The related content item to display */
   item: RelatedContentItem;
+  /** 1-indexed position in the slider */
+  position: number;
+  /** Type of the page displaying the card */
+  pageType: RelatedPageType;
+  /** Slug of the page displaying the card */
+  pageSlug: string;
   /** Additional CSS classes */
   className?: string;
 }
@@ -22,6 +31,19 @@ function getHref(item: RelatedContentItem): string | null {
       return `/ploegen/${item.slug}`;
     case "staff":
       return null;
+  }
+}
+
+function getTargetSlug(item: RelatedContentItem): string {
+  switch (item.type) {
+    case "article":
+    case "page":
+    case "team":
+      return item.slug;
+    case "player":
+      return item.psdId;
+    case "staff":
+      return item.id;
   }
 }
 
@@ -127,6 +149,9 @@ function CardContent({ item }: { item: RelatedContentItem }) {
 
 export const RelatedContentCard = ({
   item,
+  position,
+  pageType,
+  pageSlug,
   className,
 }: RelatedContentCardProps) => {
   const href = getHref(item);
@@ -155,12 +180,24 @@ export const RelatedContentCard = ({
     <div className="aspect-video bg-gray-100" />
   );
 
+  const handleClick = () => {
+    trackEvent("related_content_click", {
+      source: item.source,
+      target_type: item.type,
+      target_slug: getTargetSlug(item),
+      position,
+      page_type: pageType,
+      page_slug: pageSlug,
+    });
+  };
+
   if (href) {
     return (
       <Link
         href={href}
         className={cn(cardClasses, "relative")}
         data-related-card={item.type}
+        onClick={handleClick}
       >
         <div
           className="absolute top-0 inset-x-0 h-[3px] bg-kcvv-green-bright z-20 pointer-events-none [clip-path:inset(0_50%)] group-hover:[clip-path:inset(0_0%)] transition-[clip-path] duration-300 ease-out"

--- a/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.stories.tsx
+++ b/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.stories.tsx
@@ -12,6 +12,7 @@ import type {
 const articles: RelatedArticleItem[] = [
   {
     type: "article",
+    source: "editorial",
     id: "art-1",
     title: "Interview met de kapitein",
     slug: "interview-kapitein",
@@ -21,6 +22,7 @@ const articles: RelatedArticleItem[] = [
   },
   {
     type: "article",
+    source: "editorial",
     id: "art-2",
     title: "Wedstrijdverslag: overwinning in de derby",
     slug: "wedstrijdverslag-derby",
@@ -32,6 +34,7 @@ const articles: RelatedArticleItem[] = [
 
 const page: RelatedPageItem = {
   type: "page",
+  source: "ai",
   id: "page-1",
   title: "Over de club",
   slug: "over-de-club",
@@ -42,6 +45,7 @@ const page: RelatedPageItem = {
 const players: RelatedPlayerItem[] = [
   {
     type: "player",
+    source: "reference",
     id: "player-1",
     firstName: "Jan",
     lastName: "Janssens",
@@ -51,6 +55,7 @@ const players: RelatedPlayerItem[] = [
   },
   {
     type: "player",
+    source: "reference",
     id: "player-2",
     firstName: "Pieter",
     lastName: "De Smet",
@@ -62,6 +67,7 @@ const players: RelatedPlayerItem[] = [
 
 const team: RelatedTeamItem = {
   type: "team",
+  source: "reference",
   id: "team-1",
   name: "A-ploeg",
   slug: "a-ploeg",
@@ -71,6 +77,7 @@ const team: RelatedTeamItem = {
 
 const staff: RelatedStaffItem = {
   type: "staff",
+  source: "reference",
   id: "staff-1",
   firstName: "Piet",
   lastName: "Pieters",
@@ -115,20 +122,20 @@ type Story = StoryObj<typeof meta>;
 
 /** Mixed content from multiple types, automatically sorted */
 export const MixedContent: Story = {
-  args: { items: mixedItems },
+  args: { items: mixedItems, pageType: "article", pageSlug: "example-article" },
 };
 
 /** Single type — articles only */
 export const ArticlesOnly: Story = {
-  args: { items: articles },
+  args: { items: articles, pageType: "article", pageSlug: "example-article" },
 };
 
 /** Single type — players only */
 export const PlayersOnly: Story = {
-  args: { items: players },
+  args: { items: players, pageType: "article", pageSlug: "example-article" },
 };
 
 /** Empty state — renders nothing */
 export const Empty: Story = {
-  args: { items: [] },
+  args: { items: [], pageType: "article", pageSlug: "example-article" },
 };

--- a/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.test.tsx
+++ b/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { RelatedContentSlider } from "./RelatedContentSlider";
 import type {
@@ -9,8 +9,17 @@ import type {
   RelatedStaffItem,
 } from "../types";
 
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+
+const trackEventMock = vi.mocked(trackEvent);
+
 const article: RelatedArticleItem = {
   type: "article",
+  source: "editorial",
   id: "art-1",
   title: "Wedstrijdverslag",
   slug: "wedstrijdverslag",
@@ -21,6 +30,7 @@ const article: RelatedArticleItem = {
 
 const page: RelatedPageItem = {
   type: "page",
+  source: "ai",
   id: "page-1",
   title: "Clubinfo",
   slug: "clubinfo",
@@ -30,6 +40,7 @@ const page: RelatedPageItem = {
 
 const player: RelatedPlayerItem = {
   type: "player",
+  source: "reference",
   id: "player-1",
   firstName: "Jan",
   lastName: "Janssens",
@@ -40,6 +51,7 @@ const player: RelatedPlayerItem = {
 
 const team: RelatedTeamItem = {
   type: "team",
+  source: "reference",
   id: "team-1",
   name: "A-ploeg",
   slug: "a-ploeg",
@@ -49,6 +61,7 @@ const team: RelatedTeamItem = {
 
 const staff: RelatedStaffItem = {
   type: "staff",
+  source: "reference",
   id: "staff-1",
   firstName: "Piet",
   lastName: "Pieters",
@@ -57,20 +70,38 @@ const staff: RelatedStaffItem = {
 };
 
 describe("RelatedContentSlider", () => {
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
+
   it("renders section heading 'Gerelateerd'", () => {
-    render(<RelatedContentSlider items={[article]} />);
+    render(
+      <RelatedContentSlider
+        items={[article]}
+        pageType="article"
+        pageSlug="test-slug"
+      />,
+    );
 
     expect(screen.getByText("Gerelateerd")).toBeInTheDocument();
   });
 
   it("returns null when items array is empty", () => {
-    const { container } = render(<RelatedContentSlider items={[]} />);
+    const { container } = render(
+      <RelatedContentSlider items={[]} pageType="article" pageSlug="test" />,
+    );
 
     expect(container.firstChild).toBeNull();
   });
 
   it("renders correct card variant per item type", () => {
-    render(<RelatedContentSlider items={[article, player, team]} />);
+    render(
+      <RelatedContentSlider
+        items={[article, player, team]}
+        pageType="article"
+        pageSlug="test"
+      />,
+    );
 
     expect(screen.getByText("Wedstrijdverslag")).toBeInTheDocument();
     expect(screen.getByText("Jan Janssens")).toBeInTheDocument();
@@ -80,7 +111,9 @@ describe("RelatedContentSlider", () => {
   it("orders items: articles/pages → players → staff → teams", () => {
     // Pass in reverse order — component should reorder
     const items = [team, staff, player, page, article];
-    const { container } = render(<RelatedContentSlider items={items} />);
+    const { container } = render(
+      <RelatedContentSlider items={items} pageType="article" pageSlug="test" />,
+    );
 
     const cards = container.querySelectorAll("[data-related-card]");
     const types = Array.from(cards).map((c) =>
@@ -92,7 +125,11 @@ describe("RelatedContentSlider", () => {
 
   it("renders all 5 variant types in a mixed array", () => {
     render(
-      <RelatedContentSlider items={[article, page, player, team, staff]} />,
+      <RelatedContentSlider
+        items={[article, page, player, team, staff]}
+        pageType="article"
+        pageSlug="test"
+      />,
     );
 
     expect(screen.getByText("Wedstrijdverslag")).toBeInTheDocument();
@@ -100,5 +137,78 @@ describe("RelatedContentSlider", () => {
     expect(screen.getByText("Jan Janssens")).toBeInTheDocument();
     expect(screen.getByText("A-ploeg")).toBeInTheDocument();
     expect(screen.getByText("Piet Pieters")).toBeInTheDocument();
+  });
+
+  describe("related_content_shown event", () => {
+    it("fires on mount with correct parameters for a single-source array", () => {
+      const editorialArticle: RelatedArticleItem = {
+        ...article,
+        source: "editorial",
+      };
+      render(
+        <RelatedContentSlider
+          items={[editorialArticle]}
+          pageType="article"
+          pageSlug="wedstrijdverslag"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_shown", {
+        source: "editorial",
+        count: 1,
+        content_types: "article",
+        page_type: "article",
+        page_slug: "wedstrijdverslag",
+      });
+    });
+
+    it("derives source as 'mixed' when items come from different sources", () => {
+      const aiArticle: RelatedArticleItem = { ...article, source: "ai" };
+      const refPlayer: RelatedPlayerItem = { ...player, source: "reference" };
+
+      render(
+        <RelatedContentSlider
+          items={[aiArticle, refPlayer]}
+          pageType="article"
+          pageSlug="test-article"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_shown", {
+        source: "mixed",
+        count: 2,
+        content_types: "article,player",
+        page_type: "article",
+        page_slug: "test-article",
+      });
+    });
+
+    it("does not fire when items array is empty", () => {
+      render(
+        <RelatedContentSlider items={[]} pageType="article" pageSlug="test" />,
+      );
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("fires once on mount, not on re-renders", () => {
+      const { rerender } = render(
+        <RelatedContentSlider
+          items={[article]}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
+
+      rerender(
+        <RelatedContentSlider
+          items={[article]}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.tsx
+++ b/apps/web/src/components/related/RelatedContentSlider/RelatedContentSlider.tsx
@@ -1,10 +1,22 @@
+"use client";
+
+import { useEffect, useRef } from "react";
 import { HorizontalSlider } from "@/components/design-system/HorizontalSlider/HorizontalSlider";
+import { trackEvent } from "@/lib/analytics/track-event";
 import { RelatedContentCard } from "../RelatedContentCard";
-import type { RelatedContentItem } from "../types";
+import type {
+  RelatedContentItem,
+  RelatedContentSource,
+  RelatedPageType,
+} from "../types";
 
 export interface RelatedContentSliderProps {
   /** Mixed array of related content items */
   items: RelatedContentItem[];
+  /** Type of the page displaying the slider */
+  pageType: RelatedPageType;
+  /** Slug of the page displaying the slider */
+  pageSlug: string;
   /** Additional CSS classes */
   className?: string;
 }
@@ -21,10 +33,38 @@ function sortItems(items: RelatedContentItem[]): RelatedContentItem[] {
   return [...items].sort((a, b) => TYPE_ORDER[a.type] - TYPE_ORDER[b.type]);
 }
 
+function deriveImpressionSource(
+  items: RelatedContentItem[],
+): RelatedContentSource | "mixed" {
+  const sources = new Set(items.map((item) => item.source));
+  if (sources.size === 1) return [...sources][0] as RelatedContentSource;
+  return "mixed";
+}
+
 export const RelatedContentSlider = ({
   items,
+  pageType,
+  pageSlug,
   className,
 }: RelatedContentSliderProps) => {
+  const hasFired = useRef(false);
+
+  useEffect(() => {
+    if (hasFired.current || items.length === 0) return;
+    hasFired.current = true;
+
+    const contentTypes = [...new Set(items.map((item) => item.type))].join(",");
+
+    trackEvent("related_content_shown", {
+      source: deriveImpressionSource(items),
+      count: items.length,
+      content_types: contentTypes,
+      page_type: pageType,
+      page_slug: pageSlug,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (items.length === 0) return null;
 
   const sorted = sortItems(items);
@@ -32,8 +72,14 @@ export const RelatedContentSlider = ({
   return (
     <section className={className}>
       <HorizontalSlider title="Gerelateerd">
-        {sorted.map((item) => (
-          <RelatedContentCard key={item.id} item={item} />
+        {sorted.map((item, index) => (
+          <RelatedContentCard
+            key={item.id}
+            item={item}
+            position={index + 1}
+            pageType={pageType}
+            pageSlug={pageSlug}
+          />
         ))}
       </HorizontalSlider>
     </section>

--- a/apps/web/src/components/related/types.ts
+++ b/apps/web/src/components/related/types.ts
@@ -1,7 +1,12 @@
 /** Discriminated union for all related content item types */
 
+export type RelatedContentSource = "editorial" | "ai" | "reference";
+
+export type RelatedPageType = "article" | "page" | "player" | "team" | "staff";
+
 export interface RelatedArticleItem {
   type: "article";
+  source: RelatedContentSource;
   id: string;
   title: string;
   slug: string;
@@ -12,6 +17,7 @@ export interface RelatedArticleItem {
 
 export interface RelatedPageItem {
   type: "page";
+  source: RelatedContentSource;
   id: string;
   title: string;
   slug: string;
@@ -21,6 +27,7 @@ export interface RelatedPageItem {
 
 export interface RelatedPlayerItem {
   type: "player";
+  source: RelatedContentSource;
   id: string;
   firstName: string | null;
   lastName: string | null;
@@ -31,6 +38,7 @@ export interface RelatedPlayerItem {
 
 export interface RelatedTeamItem {
   type: "team";
+  source: RelatedContentSource;
   id: string;
   name: string;
   slug: string;
@@ -40,6 +48,7 @@ export interface RelatedTeamItem {
 
 export interface RelatedStaffItem {
   type: "staff";
+  source: RelatedContentSource;
   id: string;
   firstName: string | null;
   lastName: string | null;

--- a/apps/web/src/lib/utils/article-related-items.test.ts
+++ b/apps/web/src/lib/utils/article-related-items.test.ts
@@ -22,6 +22,7 @@ describe("mapEditorialArticles", () => {
     expect(result).toEqual([
       {
         type: "article",
+        source: "editorial",
         id: "art-1",
         title: "Test Article",
         slug: "test-article",
@@ -62,6 +63,7 @@ describe("mapBffRelatedItems", () => {
     expect(result).toEqual([
       {
         type: "article",
+        source: "ai",
         id: "doc-1",
         title: "AI Article",
         slug: "some-article",
@@ -71,6 +73,7 @@ describe("mapBffRelatedItems", () => {
       },
       {
         type: "page",
+        source: "ai",
         id: "doc-2",
         title: "AI Page",
         slug: "some-page",
@@ -101,6 +104,7 @@ describe("mapMentionedPlayers", () => {
     expect(result).toEqual([
       {
         type: "player",
+        source: "reference",
         id: "player-1",
         firstName: "Kevin",
         lastName: "De Bruyne",
@@ -139,6 +143,7 @@ describe("mapMentionedTeams", () => {
     expect(result).toEqual([
       {
         type: "team",
+        source: "reference",
         id: "team-1",
         name: "KCVV Elewijt",
         slug: "kcvv-elewijt",
@@ -173,6 +178,7 @@ describe("mapMentionedStaff", () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       type: "staff",
+      source: "reference",
       id: "staff-1",
       firstName: "John",
       lastName: "Doe",
@@ -195,6 +201,7 @@ describe("mapMentionedStaff", () => {
     expect(result).toEqual([
       {
         type: "staff",
+        source: "reference",
         id: "staff-1",
         firstName: "John",
         lastName: "Doe",

--- a/apps/web/src/lib/utils/article-related-items.ts
+++ b/apps/web/src/lib/utils/article-related-items.ts
@@ -27,6 +27,7 @@ export function mapEditorialArticles(
   if (!articles?.length) return [];
   return articles.map((a) => ({
     type: "article" as const,
+    source: "editorial" as const,
     id: a.id,
     title: a.title,
     slug: a.slug,
@@ -43,6 +44,7 @@ export function mapBffRelatedItems(
     if (item.type === "page") {
       return {
         type: "page" as const,
+        source: "ai" as const,
         id: item.id,
         title: item.title,
         slug: item.slug,
@@ -52,6 +54,7 @@ export function mapBffRelatedItems(
     }
     return {
       type: "article" as const,
+      source: "ai" as const,
       id: item.id,
       title: item.title,
       slug: item.slug,
@@ -80,6 +83,7 @@ export function mapMentionedPlayers(
     .filter((p) => p.psdId != null)
     .map((p) => ({
       type: "player" as const,
+      source: "reference" as const,
       id: p._id,
       firstName: p.firstName,
       lastName: p.lastName,
@@ -97,6 +101,7 @@ export function mapMentionedTeams(
     .filter((t) => t.name != null && t.slug != null)
     .map((t) => ({
       type: "team" as const,
+      source: "reference" as const,
       id: t._id,
       name: t.name!,
       slug: t.slug!,
@@ -111,6 +116,7 @@ export function mapMentionedStaff(
   const valid = (staff ?? []).filter((s): s is MentionedStaff => s != null);
   return deduplicateById(valid).map((s) => ({
     type: "staff" as const,
+    source: "reference" as const,
     id: s._id,
     firstName: s.firstName,
     lastName: s.lastName,


### PR DESCRIPTION
Closes #1095

## What changed
- Added `RelatedContentSource` type (`"editorial" | "ai" | "reference"`) and `source` field to all `RelatedContentItem` variants in `types.ts`
- All 5 mapping functions in `article-related-items.ts` now tag items with the correct source (`"editorial"`, `"ai"`, or `"reference"`)
- `RelatedContentSlider`, `RelatedContentCard`, and `RelatedArticlesSection` converted to `"use client"` components with `pageType`/`pageSlug` props; fire `related_content_shown` on mount and `related_content_click` on link click
- Article, player, and team pages updated to pass `pageType` and `pageSlug` context props

## Testing
- All checks pass: `pnpm --filter @kcvv/web lint && pnpm --filter @kcvv/web type-check && pnpm --filter @kcvv/web test`
- 1902 tests pass (12 new analytics tests added across 3 test files)
- Pre-commit type-check hook passes