### PR TITLE
perf(ui): add Sanity CDN params to homePage banner images (#953)

### DIFF
--- a/apps/web/src/lib/repositories/homepage.repository.test.ts
+++ b/apps/web/src/lib/repositories/homepage.repository.test.ts
@@ -11,6 +11,7 @@ vi.mock("../sanity/client", () => ({
 
 import { sanityClient } from "../sanity/client";
 import {
+  HOMEPAGE_BANNERS_QUERY,
   HomepageRepository,
   HomepageRepositoryLive,
   type HomepageBannersVM,
@@ -49,6 +50,18 @@ function makeBannersResult(
     ...overrides,
   };
 }
+
+describe("HOMEPAGE_BANNERS_QUERY", () => {
+  it("includes CDN optimization params for all three banner slots", () => {
+    const query = HOMEPAGE_BANNERS_QUERY as unknown as string;
+    const cdnParams = `"?w=1200&q=80&fm=webp&fit=max"`;
+    const matches = query.match(
+      /image\.asset->url \+ "\?w=1200&q=80&fm=webp&fit=max"/g,
+    );
+    expect(matches).toHaveLength(3);
+    expect(query).toContain(`"imageUrl": image.asset->url + ${cdnParams}`);
+  });
+});
 
 describe("HomepageRepository", () => {
   describe("getBanners", () => {


### PR DESCRIPTION
Closes #953

## What changed
- Added regression test asserting all three GROQ banner slot projections (`bannerSlotA`, `bannerSlotB`, `bannerSlotC`) include `?w=1200&q=80&fm=webp&fit=max` CDN optimization params
- The GROQ query in `homepage.repository.ts` already carried the CDN params (implemented during #760); this PR locks it down with a dedicated test

## Testing
- All checks pass: lint, type-check, 1904 tests passing
- New test: `HOMEPAGE_BANNERS_QUERY → includes CDN optimization params for all three banner slots`