### PR TITLE
feat(api): resilient decoding for match detail endpoint (#942)

### DIFF
--- a/apps/api/src/footbalisto/schemas.ts
+++ b/apps/api/src/footbalisto/schemas.ts
@@ -92,8 +92,8 @@ export class FootbalistoLineupPlayer extends S.Class<FootbalistoLineupPlayer>(
 export class FootbalistoLineup extends S.Class<FootbalistoLineup>(
   "FootbalistoLineup",
 )({
-  home: S.Array(FootbalistoLineupPlayer),
-  away: S.Array(FootbalistoLineupPlayer),
+  home: S.Array(S.Unknown),
+  away: S.Array(S.Unknown),
 }) {}
 
 export class PsdCompetitionType extends S.Class<PsdCompetitionType>(
@@ -129,7 +129,7 @@ export class FootbalistoMatchDetailResponse extends S.Class<FootbalistoMatchDeta
   general: FootbalistoMatchDetailGeneral,
   lineup: S.optional(FootbalistoLineup),
   substitutes: S.optional(FootbalistoLineup),
-  events: S.optional(S.Array(FootbalistoMatchEvent)),
+  events: S.optional(S.Array(S.Unknown)),
 }) {}
 
 export class PsdSeason extends S.Class<PsdSeason>("PsdSeason")({

--- a/apps/api/src/footbalisto/service.test.ts
+++ b/apps/api/src/footbalisto/service.test.ts
@@ -1248,6 +1248,61 @@ describe("FootbalistoService.getMatchDetail - events", () => {
   });
 });
 
+describe("FootbalistoService.getMatchDetail - resilient decoding", () => {
+  it("filters out invalid lineup players and passes valid ones through", async () => {
+    const responseWithBadLineup = {
+      general: rawDetailResponse.general,
+      lineup: {
+        home: [
+          { playerName: "De Smet", number: 9, status: "basis" }, // valid
+          { number: 10, status: "basis" }, // invalid — missing required playerName
+        ],
+        away: [],
+      },
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => responseWithBadLineup,
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(99));
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.lineup?.home).toHaveLength(1);
+      expect(result.right.lineup?.home[0]?.name).toBe("De Smet");
+    }
+  });
+
+  it("filters out invalid events and passes valid ones through", async () => {
+    const responseWithBadEvent = {
+      ...rawDetailWithGoal,
+      events: [
+        {
+          action: { type: "GOAL", subtype: null, id: 10 },
+          minute: 23,
+          playerId: 55,
+          playerName: "De Smet",
+          clubId: 100,
+        }, // valid
+        { minute: 40, playerName: "Unknown" }, // invalid — missing required action field
+      ],
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => responseWithBadEvent,
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(123));
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.events).toHaveLength(1);
+      expect(result.right.events![0]?.type).toBe("goal");
+    }
+  });
+});
+
 describe("mapGameStatus", () => {
   it("returns an Effect that resolves to the correct status", async () => {
     const result = await Effect.runPromise(mapGameStatus(0, 3, 1));

--- a/apps/api/src/footbalisto/service.ts
+++ b/apps/api/src/footbalisto/service.ts
@@ -27,8 +27,8 @@ import {
   FootbalistoRankingEntry,
   PsdGame,
   type PsdCompetitionType,
-  type FootbalistoLineupPlayer,
-  type FootbalistoMatchEvent,
+  FootbalistoLineupPlayer,
+  FootbalistoMatchEvent,
   type FootbalistoMatchDetailResponse as RawDetailResponse,
 } from "./schemas";
 import { PsdTeamsSchema } from "./schemas-player-team";
@@ -333,51 +333,82 @@ function transformPlayerWithCard(
 function transformFootbalistoMatchDetail(
   response: RawDetailResponse,
 ): Effect.Effect<MatchDetail> {
-  const general = response.general;
-  const { date: matchDate, time: timePart } = parseDateString(general.date);
-  const cardMap = response.events ? buildPlayerCardMap(response.events) : null;
+  return Effect.gen(function* () {
+    const general = response.general;
+    const { date: matchDate, time: timePart } = parseDateString(general.date);
 
-  let lineup:
-    | { home: MatchLineupPlayer[]; away: MatchLineupPlayer[] }
-    | undefined;
-  if (response.lineup || response.substitutes) {
-    lineup = {
-      home: [
-        ...(response.lineup?.home ?? []).map((p) =>
-          transformPlayerWithCard(p, cardMap),
-        ),
-        ...(response.substitutes?.home ?? []).map((p) =>
-          transformPlayerWithCard(p, cardMap),
-        ),
-      ],
-      away: [
-        ...(response.lineup?.away ?? []).map((p) =>
-          transformPlayerWithCard(p, cardMap),
-        ),
-        ...(response.substitutes?.away ?? []).map((p) =>
-          transformPlayerWithCard(p, cardMap),
-        ),
-      ],
-    };
-  }
+    // Resilient event decoding — invalid items are filtered, valid ones pass through
+    let validEvents: FootbalistoMatchEvent[] = [];
+    if (response.events) {
+      const [eventErrors, decodedEvents] = yield* Effect.partition(
+        response.events,
+        (item) => S.decodeUnknown(FootbalistoMatchEvent)(item),
+      );
+      if (eventErrors.length > 0) {
+        yield* Effect.log(
+          `getMatchDetail(${general.id}): filtered ${eventErrors.length} invalid event(s)`,
+        );
+      }
+      validEvents = decodedEvents;
+    }
 
-  let events: MatchEvent[] | undefined;
-  if (response.events) {
-    const transformed = response.events
-      .map((e, i) =>
-        transformMatchEvent(e, i, general.homeClub.id, general.awayClub.id),
-      )
-      .filter((e): e is MatchEvent => e !== null);
-    events = transformed.length > 0 ? transformed : undefined;
-  }
+    const cardMap =
+      validEvents.length > 0 ? buildPlayerCardMap(validEvents) : null;
 
-  return mapGameStatus(
-    general.status,
-    general.goalsHomeTeam,
-    general.goalsAwayTeam,
-    general.cancelled,
-  ).pipe(
-    Effect.map((status) => ({
+    // Resilient lineup decoding — invalid players are filtered, valid ones pass through
+    let lineup:
+      | { home: MatchLineupPlayer[]; away: MatchLineupPlayer[] }
+      | undefined;
+    if (response.lineup || response.substitutes) {
+      const rawHome = [
+        ...(response.lineup?.home ?? []),
+        ...(response.substitutes?.home ?? []),
+      ];
+      const rawAway = [
+        ...(response.lineup?.away ?? []),
+        ...(response.substitutes?.away ?? []),
+      ];
+
+      const [homeErrors, homePlayers] = yield* Effect.partition(
+        rawHome,
+        (item) => S.decodeUnknown(FootbalistoLineupPlayer)(item),
+      );
+      const [awayErrors, awayPlayers] = yield* Effect.partition(
+        rawAway,
+        (item) => S.decodeUnknown(FootbalistoLineupPlayer)(item),
+      );
+
+      const totalErrors = homeErrors.length + awayErrors.length;
+      if (totalErrors > 0) {
+        yield* Effect.log(
+          `getMatchDetail(${general.id}): filtered ${totalErrors} invalid lineup player(s)`,
+        );
+      }
+
+      lineup = {
+        home: homePlayers.map((p) => transformPlayerWithCard(p, cardMap)),
+        away: awayPlayers.map((p) => transformPlayerWithCard(p, cardMap)),
+      };
+    }
+
+    let events: MatchEvent[] | undefined;
+    if (validEvents.length > 0) {
+      const transformed = validEvents
+        .map((e, i) =>
+          transformMatchEvent(e, i, general.homeClub.id, general.awayClub.id),
+        )
+        .filter((e): e is MatchEvent => e !== null);
+      events = transformed.length > 0 ? transformed : undefined;
+    }
+
+    const status = yield* mapGameStatus(
+      general.status,
+      general.goalsHomeTeam,
+      general.goalsAwayTeam,
+      general.cancelled,
+    );
+
+    return {
       id: general.id,
       date: matchDate,
       time: timePart,
@@ -399,8 +430,8 @@ function transformFootbalistoMatchDetail(
       lineup,
       events,
       hasReport: general.viewGameReport,
-    })),
-  );
+    };
+  });
 }
 
 /** Strip lineup from a MatchDetail to produce a basic Match */


### PR DESCRIPTION
Closes #942

## What changed
- `FootbalistoLineup.home`/`away` and `FootbalistoMatchDetailResponse.events` now use `S.Array(S.Unknown)` for per-item resilient decoding
- `transformFootbalistoMatchDetail` rewritten as `Effect.gen` using `Effect.partition` + `S.decodeUnknown` for both lineup players and events
- Invalid lineup players and events are filtered and logged; valid items pass through unchanged
- `general` (core match data) remains strict — if invalid, the request fails

## Testing
- All checks pass: `pnpm --filter @kcvv/api test`, `pnpm --filter @kcvv/api lint`, `pnpm --filter @kcvv/api type-check`
- 2 new tests: filters invalid lineup players, filters invalid events