### PR TITLE
fix(ui): prevent double-click race in SharePage generate

### DIFF
--- a/apps/web/src/components/share/SharePage/SharePage.test.tsx
+++ b/apps/web/src/components/share/SharePage/SharePage.test.tsx
@@ -520,4 +520,29 @@ describe("SharePage", () => {
 
     vi.mocked(document.createElement).mockRestore();
   });
+
+  it("ignores a second Generate click while the first is still in progress", async () => {
+    const { toPng } = await import("html-to-image");
+    let resolveToPng!: (value: string) => void;
+    vi.mocked(toPng).mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveToPng = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(<SharePage matches={MATCHES} players={PLAYERS} />);
+
+    const btn = screen.getByRole("button", { name: /genereer/i });
+    // First click starts generation
+    await user.click(btn);
+    // Second click should be ignored by the ref guard
+    await user.click(btn);
+
+    expect(toPng).toHaveBeenCalledTimes(1);
+
+    // Resolve to let the component settle
+    resolveToPng("data:image/png;base64,ABC");
+  });
 });

--- a/apps/web/src/components/share/SharePage/SharePage.tsx
+++ b/apps/web/src/components/share/SharePage/SharePage.tsx
@@ -233,6 +233,7 @@ function renderTemplate(
 export function SharePage({ matches, players }: SharePageProps) {
   const templateRef = useRef<HTMLDivElement>(null);
   const previewUrlRef = useRef<string | null>(null);
+  const isGeneratingRef = useRef(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [generatedBlob, setGeneratedBlob] = useState<Blob | null>(null);
@@ -293,7 +294,8 @@ export function SharePage({ matches, players }: SharePageProps) {
   }, []);
 
   const handleGenerate = async () => {
-    if (!templateRef.current) return;
+    if (!templateRef.current || isGeneratingRef.current) return;
+    isGeneratingRef.current = true;
     setIsGenerating(true);
     setExportError(null);
     clearPreview();
@@ -314,6 +316,7 @@ export function SharePage({ matches, players }: SharePageProps) {
         err instanceof Error ? err.message : "Export failed. Please try again.",
       );
     } finally {
+      isGeneratingRef.current = false;
       setIsGenerating(false);
     }
   };


### PR DESCRIPTION
## Summary
- Add a ref-based guard (`isGeneratingRef`) to `handleGenerate` that blocks re-entry synchronously, preventing a second `toPng` call when the user double-clicks before React re-renders with the disabled button state
- Add regression test that verifies `toPng` is only called once when the Generate button is clicked twice in quick succession

## Context
React batches `setIsGenerating(true)`, so the button's `disabled` prop doesn't take effect until the next render. A rapid second click starts a concurrent `toPng` call — the first fails fast (fonts not cached), the second succeeds slowly, leaving both `exportError` and `previewUrl` set simultaneously.

## Test plan
- [x] Existing 34 SharePage tests pass
- [x] New double-click guard regression test passes
- [x] Lint + type-check clean
- [ ] Manual: rapidly double-click Generate on `/share` — only one export should run

🤖 Generated with [Claude Code](https://claude.com/claude-code)