### PR TITLE
refactor(schema): remove organigram fields from staffMember (#1117)

### DIFF
--- a/apps/web/src/app/(main)/staf/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/staf/[slug]/opengraph-image.tsx
@@ -32,8 +32,6 @@ export default async function Image({ params }: ImageProps) {
 
   let firstName = "";
   let lastName = "";
-  let roleDisplay = "";
-  let roleWatermark = "";
   const teamName = "KCVV Elewijt";
 
   try {
@@ -47,9 +45,6 @@ export default async function Image({ params }: ImageProps) {
     if (member) {
       firstName = member.firstName;
       lastName = member.lastName;
-      roleDisplay = member.roleDisplay ?? member.roleLabel ?? "";
-      // Use abbreviated role as watermark (max ~6 chars, uppercase)
-      roleWatermark = (roleDisplay ?? "").slice(0, 6).toUpperCase();
     } else {
       firstName = "KCVV";
       lastName = "Elewijt";
@@ -71,25 +66,6 @@ export default async function Image({ params }: ImageProps) {
         overflow: "hidden",
       }}
     >
-      {/* Role watermark */}
-      {roleWatermark && (
-        <div
-          style={{
-            position: "absolute",
-            right: 40,
-            top: 20,
-            fontSize: 260,
-            fontWeight: 900,
-            color: "rgba(75, 155, 72, 0.12)",
-            lineHeight: 0.9,
-            fontFamily: "system-ui, sans-serif",
-            letterSpacing: "-0.04em",
-          }}
-        >
-          {roleWatermark}
-        </div>
-      )}
-
       {/* Main content */}
       <div
         style={{
@@ -141,12 +117,6 @@ export default async function Image({ params }: ImageProps) {
             fontSize: 32,
           }}
         >
-          {roleDisplay && (
-            <>
-              <span style={{ fontWeight: 500 }}>{roleDisplay}</span>
-              <span style={{ color: "#4acf52" }}>•</span>
-            </>
-          )}
           <span>{teamName}</span>
         </div>
       </div>

--- a/apps/web/src/app/(main)/staf/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/staf/[slug]/page.tsx
@@ -46,9 +46,7 @@ export async function generateMetadata({
       return { title: "Stafmedewerker niet gevonden | KCVV Elewijt" };
 
     const fullName = `${member.firstName} ${member.lastName}`.trim() || "Staf";
-    const description = member.roleDisplay
-      ? `${member.roleDisplay} bij KCVV Elewijt`
-      : "KCVV Elewijt stafmedewerker";
+    const description = "KCVV Elewijt stafmedewerker";
 
     return {
       title: `${fullName} | KCVV Elewijt`,
@@ -128,18 +126,6 @@ export default async function StafPage({ params }: StaffPageProps) {
               <span className="font-semibold">{member.firstName}</span>{" "}
               <span className="font-light">{member.lastName}</span>
             </h1>
-
-            {member.roleDisplay && (
-              <p className="mt-2 text-lg text-kcvv-green-bright font-medium">
-                {member.roleDisplay}
-              </p>
-            )}
-
-            {member.departmentDisplay && (
-              <p className="mt-1 text-sm text-kcvv-gray uppercase tracking-wide">
-                {member.departmentDisplay}
-              </p>
-            )}
 
             {/* Contact info */}
             {(member.email || member.phone) && (

--- a/apps/web/src/lib/repositories/article.repository.test.ts
+++ b/apps/web/src/lib/repositories/article.repository.test.ts
@@ -99,7 +99,6 @@ function makeArticleDetailRow(
         _id: "staff-1",
         firstName: "Piet",
         lastName: "Pieters",
-        roleLabel: "Trainer",
         imageUrl: "https://cdn.sanity.io/staff.webp",
       },
     ],
@@ -325,7 +324,6 @@ describe("ArticleRepository", () => {
         _id: "staff-1",
         firstName: "Piet",
         lastName: "Pieters",
-        roleLabel: "Trainer",
         imageUrl: "https://cdn.sanity.io/staff.webp",
       });
     });

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -51,7 +51,7 @@ export const ARTICLE_BY_SLUG_QUERY =
     "slug": slug.current
   },
   "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {
-    _id, firstName, lastName, roleLabel,
+    _id, firstName, lastName,
     "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"
   }
 }`);

--- a/apps/web/src/lib/repositories/staff.repository.test.ts
+++ b/apps/web/src/lib/repositories/staff.repository.test.ts
@@ -236,9 +236,6 @@ describe("StaffRepository", () => {
         psdId: "psd-42",
         firstName: "Jan",
         lastName: "Janssens",
-        role: "voorzitter",
-        roleLabel: "Voorzitter",
-        department: "hoofdbestuur",
         email: "jan@kcvv.be",
         phone: "+32 123 456 789",
         bio: null,
@@ -262,9 +259,6 @@ describe("StaffRepository", () => {
         psdId: "psd-42",
         firstName: "Jan",
         lastName: "Janssens",
-        roleDisplay: "Voorzitter",
-        roleLabel: "Voorzitter",
-        departmentDisplay: "Hoofdbestuur",
         email: "jan@kcvv.be",
         phone: "+32 123 456 789",
         bio: undefined,
@@ -286,49 +280,6 @@ describe("StaffRepository", () => {
       expect(member).toBeNull();
     });
 
-    it("maps role enum to display label", async () => {
-      mockFetch.mockResolvedValueOnce(makeDetailRow({ role: "hoofdtrainer" }));
-
-      const member = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* StaffRepository;
-          return yield* repo.findByPsdId("psd-42");
-        }),
-      );
-
-      expect(member?.roleDisplay).toBe("Hoofdtrainer");
-    });
-
-    it("maps unknown role to roleLabel fallback", async () => {
-      mockFetch.mockResolvedValueOnce(
-        makeDetailRow({ role: null, roleLabel: "Custom Title" }),
-      );
-
-      const member = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* StaffRepository;
-          return yield* repo.findByPsdId("psd-42");
-        }),
-      );
-
-      expect(member?.roleDisplay).toBe("Custom Title");
-    });
-
-    it("maps department to display label", async () => {
-      mockFetch.mockResolvedValueOnce(
-        makeDetailRow({ department: "jeugdbestuur" }),
-      );
-
-      const member = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* StaffRepository;
-          return yield* repo.findByPsdId("psd-42");
-        }),
-      );
-
-      expect(member?.departmentDisplay).toBe("Jeugdbestuur");
-    });
-
     it("null optional fields become undefined", async () => {
       mockFetch.mockResolvedValueOnce(
         makeDetailRow({
@@ -336,7 +287,6 @@ describe("StaffRepository", () => {
           phone: null,
           photoUrl: null,
           bio: null,
-          department: null,
         }),
       );
 
@@ -351,7 +301,6 @@ describe("StaffRepository", () => {
       expect(member?.phone).toBeUndefined();
       expect(member?.imageUrl).toBeUndefined();
       expect(member?.bio).toBeUndefined();
-      expect(member?.departmentDisplay).toBeUndefined();
     });
   });
 

--- a/apps/web/src/lib/repositories/staff.repository.ts
+++ b/apps/web/src/lib/repositories/staff.repository.ts
@@ -30,7 +30,7 @@ export const ORGANIGRAM_NODES_QUERY =
 
 export const STAFF_MEMBER_BY_PSD_ID_QUERY =
   defineQuery(`*[_type == "staffMember" && psdId == $psdId && archived != true][0] {
-  _id, psdId, firstName, lastName, role, roleLabel, department, email, phone, bio,
+  _id, psdId, firstName, lastName, email, phone, bio,
   "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"
 }`);
 
@@ -38,46 +38,6 @@ export const STAFF_MEMBERS_PSDID_QUERY =
   defineQuery(`*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] | order(lastName asc) {
   _id, psdId
 }`);
-
-// ─── Display label maps ───────────────────────────────────────────────────────
-
-const ROLE_DISPLAY = {
-  hoofdtrainer: "Hoofdtrainer",
-  assistent: "Assistent-trainer",
-  keeperstrainer: "Keeperstrainer",
-  tvjo: "TVJO",
-  ploegdelegatie: "Ploegdelegatie",
-  afgevaardigde: "Afgevaardigde",
-  coach: "Coach",
-  voorzitter: "Voorzitter",
-  ondervoorzitter: "Ondervoorzitter",
-  secretaris: "Secretaris",
-  penningmeester: "Penningmeester",
-  jeugdcoordinator: "Jeugdcoördinator",
-  jeugdsecretaris: "Jeugdsecretaris",
-  "technisch-coordinator": "Technisch coördinator",
-  "sportief-verantwoordelijke": "Sportief verantwoordelijke",
-  "sponsoring-verantwoordelijke": "Verantwoordelijke sponsoring",
-  "verzekering-verantwoordelijke": "Verzekeringverantwoordelijke",
-  "evenementen-coordinator": "Evenementencoördinator",
-  "pr-verantwoordelijke": "PR-verantwoordelijke",
-  "kantine-verantwoordelijke": "Kantineverantwoordelijke",
-  webmaster: "Webmaster",
-  bestuur: "Bestuur",
-  other: "Andere",
-} satisfies Record<
-  NonNullable<NonNullable<STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT>["role"]>,
-  string
->;
-
-const DEPARTMENT_DISPLAY = {
-  hoofdbestuur: "Hoofdbestuur",
-  jeugdbestuur: "Jeugdbestuur",
-  algemeen: "Algemeen",
-} satisfies Record<
-  NonNullable<NonNullable<STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT>["department"]>,
-  string
->;
 
 // ─── View models ─────────────────────────────────────────────────────────────
 
@@ -100,12 +60,6 @@ export interface StaffDetailVM {
   psdId: string;
   firstName: string;
   lastName: string;
-  /** Mapped display label from role enum (falls back to roleLabel) */
-  roleDisplay?: string;
-  /** Free-text organigram title */
-  roleLabel?: string;
-  /** Mapped display label from department enum */
-  departmentDisplay?: string;
   email?: string;
   phone?: string;
   bio?: NonNullable<STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT>["bio"];
@@ -142,13 +96,6 @@ export function toOrgChartNode(
 export function toStaffDetailVM(
   row: NonNullable<STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT>,
 ): StaffDetailVM {
-  const roleDisplay =
-    (row.role ? ROLE_DISPLAY[row.role] : undefined) ??
-    row.roleLabel ??
-    undefined;
-  const departmentDisplay = row.department
-    ? DEPARTMENT_DISPLAY[row.department]
-    : undefined;
   const psdId = row.psdId?.trim() ?? "";
 
   return {
@@ -156,9 +103,6 @@ export function toStaffDetailVM(
     psdId,
     firstName: row.firstName ?? "",
     lastName: row.lastName ?? "",
-    roleDisplay,
-    roleLabel: row.roleLabel ?? undefined,
-    departmentDisplay,
     email: row.email ?? undefined,
     phone: row.phone ?? undefined,
     bio: row.bio ?? undefined,

--- a/apps/web/src/lib/repositories/team.repository.test.ts
+++ b/apps/web/src/lib/repositories/team.repository.test.ts
@@ -149,7 +149,7 @@ describe("TeamRepository", () => {
             _id: "staff-1",
             firstName: "Piet",
             lastName: "Pieters",
-            role: "hoofdtrainer",
+            role: null,
             photoUrl: "https://cdn.sanity.io/photo.webp",
           },
         ],
@@ -197,7 +197,7 @@ describe("TeamRepository", () => {
         id: "staff-1",
         firstName: "Piet",
         lastName: "Pieters",
-        role: "hoofdtrainer",
+        role: "",
         imageUrl: "https://cdn.sanity.io/photo.webp",
       });
     });
@@ -287,7 +287,7 @@ describe("TeamRepository", () => {
               _id: "s1",
               firstName: "A",
               lastName: "B",
-              role: "coach",
+              role: null,
               photoUrl: null,
             },
           ],
@@ -331,9 +331,7 @@ describe("TeamRepository", () => {
         divisionFull: "3de Afdeling VFV A",
         tagline: "Er is maar één plezante compagnie",
         teamImageUrl: "https://cdn.sanity.io/team.webp",
-        staff: [
-          { firstName: "Piet", lastName: "Pieters", role: "hoofdtrainer" },
-        ],
+        staff: [{ firstName: "Piet", lastName: "Pieters", role: null }],
         ...overrides,
       };
     }
@@ -358,9 +356,7 @@ describe("TeamRepository", () => {
         divisionFull: "3de Afdeling VFV A",
         tagline: "Er is maar één plezante compagnie",
         teamImageUrl: "https://cdn.sanity.io/team.webp",
-        staff: [
-          { firstName: "Piet", lastName: "Pieters", role: "hoofdtrainer" },
-        ],
+        staff: [{ firstName: "Piet", lastName: "Pieters", role: "" }],
       });
     });
 

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -15,6 +15,54 @@
 export declare const internalGroqTypeReferenceTo: unique symbol;
 
 // Source: schema.json
+export type SanityImageAssetReference = {
+  _ref: string;
+  _type: "reference";
+  _weak?: boolean;
+  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+};
+
+export type JeugdLandingPage = {
+  _id: string;
+  _type: "jeugdLandingPage";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  editorialCards?: Array<{
+    tag?: string;
+    title?: string;
+    description?: string;
+    arrowText?: string;
+    href?: string;
+    image?: {
+      asset?: SanityImageAssetReference;
+      media?: unknown;
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    };
+    position?: "featured" | "medium" | "third";
+    cardType?: "nav" | "article";
+    _key: string;
+  }>;
+};
+
+export type SanityImageCrop = {
+  _type: "sanity.imageCrop";
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+};
+
+export type SanityImageHotspot = {
+  _type: "sanity.imageHotspot";
+  x?: number;
+  y?: number;
+  height?: number;
+  width?: number;
+};
+
 export type BannerReference = {
   _ref: string;
   _type: "reference";
@@ -33,39 +81,6 @@ export type HomePage = {
   bannerSlotC?: BannerReference;
 };
 
-export type JeugdLandingPage = {
-  _id: string;
-  _type: "jeugdLandingPage";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
-  editorialCards?: Array<{
-    _key: string;
-    tag?: string;
-    title?: string;
-    description?: string;
-    arrowText?: string;
-    href?: string;
-    image?: {
-      _type: "image";
-      asset?: {
-        _ref: string;
-        _type: "reference";
-        _weak?: boolean;
-      };
-    };
-    position?: "featured" | "medium" | "third";
-    cardType?: "nav" | "article";
-  }>;
-};
-
-export type SanityImageAssetReference = {
-  _ref: string;
-  _type: "reference";
-  _weak?: boolean;
-  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-};
-
 export type Banner = {
   _id: string;
   _type: "banner";
@@ -81,22 +96,6 @@ export type Banner = {
   };
   alt?: string;
   href?: string;
-};
-
-export type SanityImageCrop = {
-  _type: "sanity.imageCrop";
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
-};
-
-export type SanityImageHotspot = {
-  _type: "sanity.imageHotspot";
-  x?: number;
-  y?: number;
-  height?: number;
-  width?: number;
 };
 
 export type SearchFeedback = {
@@ -447,31 +446,6 @@ export type StaffMember = {
   _rev: string;
   firstName?: string;
   lastName?: string;
-  role?:
-    | "hoofdtrainer"
-    | "assistent"
-    | "keeperstrainer"
-    | "tvjo"
-    | "ploegdelegatie"
-    | "afgevaardigde"
-    | "coach"
-    | "voorzitter"
-    | "ondervoorzitter"
-    | "secretaris"
-    | "penningmeester"
-    | "jeugdcoordinator"
-    | "jeugdsecretaris"
-    | "technisch-coordinator"
-    | "sportief-verantwoordelijke"
-    | "sponsoring-verantwoordelijke"
-    | "verzekering-verantwoordelijke"
-    | "evenementen-coordinator"
-    | "pr-verantwoordelijke"
-    | "kantine-verantwoordelijke"
-    | "webmaster"
-    | "bestuur"
-    | "other";
-  department?: "hoofdbestuur" | "jeugdbestuur" | "algemeen";
   email?: string;
   phone?: string;
   birthDate?: string;
@@ -501,11 +475,6 @@ export type StaffMember = {
     _type: "block";
     _key: string;
   }>;
-  inOrganigram?: boolean;
-  parentMember?: StaffMemberReference;
-  roleLabel?: string;
-  roleCode?: string;
-  responsibilities?: string;
   psdId?: string;
   archived?: boolean;
 };
@@ -761,12 +730,13 @@ export type Geopoint = {
 };
 
 export type AllSanitySchemaTypes =
-  | BannerReference
-  | HomePage
   | SanityImageAssetReference
-  | Banner
+  | JeugdLandingPage
   | SanityImageCrop
   | SanityImageHotspot
+  | BannerReference
+  | HomePage
+  | Banner
   | SearchFeedback
   | HtmlTable
   | SanityFileAssetReference
@@ -959,7 +929,7 @@ export type RELATED_ARTICLES_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLE_BY_SLUG_QUERY
-// Query: *[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {  _id, title, slug, publishAt, featured, tags,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {    _id, firstName, lastName, position,    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    psdId  },  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {    _id, name,    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "slug": slug.current  },  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {    _id, firstName, lastName, roleLabel,    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"  }}
+// Query: *[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {  _id, title, slug, publishAt, featured, tags,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {    _id, firstName, lastName, position,    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    psdId  },  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {    _id, name,    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "slug": slug.current  },  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {    _id, firstName, lastName,    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"  }}
 export type ARTICLE_BY_SLUG_QUERY_RESULT = {
   _id: string;
   title: string | null;
@@ -1157,21 +1127,18 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
         _id: string;
         firstName: null;
         lastName: null;
-        roleLabel: null;
         imageUrl: null;
       }
     | {
         _id: string;
         firstName: string | null;
         lastName: string | null;
-        roleLabel: null;
         imageUrl: null;
       }
     | {
         _id: string;
         firstName: string | null;
         lastName: string | null;
-        roleLabel: string | null;
         imageUrl: string | null;
       }
     | null
@@ -1235,7 +1202,7 @@ export type HOMEPAGE_BANNERS_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/jeugd-landing-page.repository.ts
 // Variable: JEUGD_LANDING_PAGE_QUERY
-// Query: *[_type == "jeugdLandingPage"][0] { editorialCards[] { tag, title, description, arrowText, href, "imageUrl": image.asset->url + "?w=900&q=80&fm=webp", position, cardType } }
+// Query: *[_type == "jeugdLandingPage"][0] {  editorialCards[] {    tag, title, description, arrowText, href,    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",    position, cardType  }}
 export type JEUGD_LANDING_PAGE_QUERY_RESULT = {
   editorialCards: Array<{
     tag: string | null;
@@ -1245,7 +1212,7 @@ export type JEUGD_LANDING_PAGE_QUERY_RESULT = {
     href: string | null;
     imageUrl: string | null;
     position: "featured" | "medium" | "third" | null;
-    cardType: "nav" | "article" | null;
+    cardType: "article" | "nav" | null;
   }> | null;
 } | null;
 
@@ -1434,7 +1401,7 @@ export type RESPONSIBILITY_PATHS_QUERY_RESULT = Array<{
     role: string | null;
     email: string | null;
     phone: string | null;
-    department: "algemeen" | "hoofdbestuur" | "jeugdbestuur" | null;
+    department: null | "algemeen" | "hoofdbestuur" | "jeugdbestuur";
     name: string | null;
     memberId: string | null;
   } | null;
@@ -1445,7 +1412,7 @@ export type RESPONSIBILITY_PATHS_QUERY_RESULT = Array<{
       role: string | null;
       email: string | null;
       phone: string | null;
-      department: "algemeen" | "hoofdbestuur" | "jeugdbestuur" | null;
+      department: null | "algemeen" | "hoofdbestuur" | "jeugdbestuur";
       name: string | null;
       memberId: string | null;
     } | null;
@@ -1489,39 +1456,12 @@ export type ORGANIGRAM_NODES_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/staff.repository.ts
 // Variable: STAFF_MEMBER_BY_PSD_ID_QUERY
-// Query: *[_type == "staffMember" && psdId == $psdId && archived != true][0] {  _id, psdId, firstName, lastName, role, roleLabel, department, email, phone, bio,  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"}
+// Query: *[_type == "staffMember" && psdId == $psdId && archived != true][0] {  _id, psdId, firstName, lastName, email, phone, bio,  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"}
 export type STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT = {
   _id: string;
   psdId: string | null;
   firstName: string | null;
   lastName: string | null;
-  role:
-    | "afgevaardigde"
-    | "assistent"
-    | "bestuur"
-    | "coach"
-    | "evenementen-coordinator"
-    | "hoofdtrainer"
-    | "jeugdcoordinator"
-    | "jeugdsecretaris"
-    | "kantine-verantwoordelijke"
-    | "keeperstrainer"
-    | "ondervoorzitter"
-    | "other"
-    | "penningmeester"
-    | "ploegdelegatie"
-    | "pr-verantwoordelijke"
-    | "secretaris"
-    | "sponsoring-verantwoordelijke"
-    | "sportief-verantwoordelijke"
-    | "technisch-coordinator"
-    | "tvjo"
-    | "verzekering-verantwoordelijke"
-    | "voorzitter"
-    | "webmaster"
-    | null;
-  roleLabel: string | null;
-  department: "algemeen" | "hoofdbestuur" | "jeugdbestuur" | null;
   email: string | null;
   phone: string | null;
   bio: Array<{
@@ -1649,31 +1589,7 @@ export type TEAM_BY_SLUG_QUERY_RESULT = {
     _id: string;
     firstName: string | null;
     lastName: string | null;
-    role:
-      | "afgevaardigde"
-      | "assistent"
-      | "bestuur"
-      | "coach"
-      | "evenementen-coordinator"
-      | "hoofdtrainer"
-      | "jeugdcoordinator"
-      | "jeugdsecretaris"
-      | "kantine-verantwoordelijke"
-      | "keeperstrainer"
-      | "ondervoorzitter"
-      | "other"
-      | "penningmeester"
-      | "ploegdelegatie"
-      | "pr-verantwoordelijke"
-      | "secretaris"
-      | "sponsoring-verantwoordelijke"
-      | "sportief-verantwoordelijke"
-      | "technisch-coordinator"
-      | "tvjo"
-      | "verzekering-verantwoordelijke"
-      | "voorzitter"
-      | "webmaster"
-      | null;
+    role: null;
     photoUrl: string | null;
   }> | null;
 } | null;
@@ -1693,31 +1609,7 @@ export type TEAMS_LANDING_QUERY_RESULT = Array<{
   staff: Array<{
     firstName: string | null;
     lastName: string | null;
-    role:
-      | "afgevaardigde"
-      | "assistent"
-      | "bestuur"
-      | "coach"
-      | "evenementen-coordinator"
-      | "hoofdtrainer"
-      | "jeugdcoordinator"
-      | "jeugdsecretaris"
-      | "kantine-verantwoordelijke"
-      | "keeperstrainer"
-      | "ondervoorzitter"
-      | "other"
-      | "penningmeester"
-      | "ploegdelegatie"
-      | "pr-verantwoordelijke"
-      | "secretaris"
-      | "sponsoring-verantwoordelijke"
-      | "sportief-verantwoordelijke"
-      | "technisch-coordinator"
-      | "tvjo"
-      | "verzekering-verantwoordelijke"
-      | "voorzitter"
-      | "webmaster"
-      | null;
+    role: null;
   }> | null;
 }>;
 
@@ -1729,18 +1621,18 @@ declare module "@sanity/client" {
     'array::unique(*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])': ARTICLE_TAGS_QUERY_RESULT;
     '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
     '*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;
-    '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName, roleLabel,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
+    '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
     '*[_type == "event"] | order(dateStart asc) {\n  _id, title, dateStart, dateEnd, externalLink,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': EVENTS_QUERY_RESULT;
     '\n  coalesce(\n    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {\n      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    },\n    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {\n      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    }\n  )\n': NEXT_FEATURED_EVENT_QUERY_RESULT;
-    '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
     '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;
+    '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
     '*[_type == "page" && slug.current == $slug][0] {\n  _id,\n  title,\n  slug,\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
     '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "responsibility" && active == true] | order(title asc) {\n  "id": slug.current,\n  "role": audience,\n  question,\n  keywords,\n  summary,\n  category,\n  icon,\n  "primaryContact": primaryContact {\n    "role": role,\n    "email": select(defined(staffMember) => staffMember->email, email),\n    "phone": select(defined(staffMember) => staffMember->phone, phone),\n    "department": select(defined(staffMember) => staffMember->department, department),\n    "name": select(\n      defined(staffMember) => staffMember->firstName + " " + staffMember->lastName,\n      null\n    ),\n    "memberId": staffMember->_id\n  },\n  "steps": steps[] {\n    description,\n    link,\n    "contact": select(defined(contact) => contact {\n      "role": role,\n      "email": select(defined(staffMember) => staffMember->email, email),\n      "phone": select(defined(staffMember) => staffMember->phone, phone),\n      "department": select(defined(staffMember) => staffMember->department, department),\n      "name": select(\n        defined(staffMember) => staffMember->firstName + " " + staffMember->lastName,\n        null\n      ),\n      "memberId": staffMember->_id\n    }, null)\n  },\n  "relatedPaths": coalesce(relatedPaths[]->slug.current, [])\n}': RESPONSIBILITY_PATHS_QUERY_RESULT;
     '*[_type == "sponsor" && active == true] | order(name asc) {\n  _id, name, url, type, tier, featured, description, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
     '*[_type == "organigramNode" && active == true] | order(coalesce(sortOrder, 9999) asc, title asc) {\n  _id,\n  title,\n  description,\n  roleCode,\n  department,\n  "parentId": select(defined(parentNode) && parentNode->active == true => parentNode->_id, null),\n  "members": members[@->archived != true]->{\n    "id": _id,\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    "imageUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",\n    email,\n    phone,\n    "psdId": psdId\n  }\n}': ORGANIGRAM_NODES_QUERY_RESULT;
-    '*[_type == "staffMember" && psdId == $psdId && archived != true][0] {\n  _id, psdId, firstName, lastName, role, roleLabel, department, email, phone, bio,\n  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"\n}': STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT;
+    '*[_type == "staffMember" && psdId == $psdId && archived != true][0] {\n  _id, psdId, firstName, lastName, email, phone, bio,\n  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"\n}': STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] | order(lastName asc) {\n  _id, psdId\n}': STAFF_MEMBERS_PSDID_QUERY_RESULT;
     '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': TEAMS_QUERY_RESULT;
     '*[_type == "team" && slug.current == $slug][0] {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  trainingSchedule,\n  players[]-> {\n    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"\n  },\n  staff[]-> { _id, firstName, lastName, role, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max" }\n}': TEAM_BY_SLUG_QUERY_RESULT;

--- a/apps/web/src/lib/utils/article-related-items.test.ts
+++ b/apps/web/src/lib/utils/article-related-items.test.ts
@@ -192,7 +192,6 @@ describe("mapMentionedStaff", () => {
       _id: "staff-1",
       firstName: "John",
       lastName: "Doe",
-      roleLabel: "Coach",
       imageUrl: "https://example.com/photo.jpg",
     };
     const result = mapMentionedStaff([null, staff, staff]);
@@ -203,7 +202,7 @@ describe("mapMentionedStaff", () => {
       id: "staff-1",
       firstName: "John",
       lastName: "Doe",
-      role: "Coach",
+      role: null,
       imageUrl: "https://example.com/photo.jpg",
     });
   });
@@ -214,7 +213,6 @@ describe("mapMentionedStaff", () => {
         _id: "staff-1",
         firstName: "John",
         lastName: "Doe",
-        roleLabel: "Coach",
         imageUrl: null,
       },
     ]);
@@ -226,7 +224,7 @@ describe("mapMentionedStaff", () => {
         id: "staff-1",
         firstName: "John",
         lastName: "Doe",
-        role: "Coach",
+        role: null,
         imageUrl: null,
       },
     ]);

--- a/apps/web/src/lib/utils/article-related-items.ts
+++ b/apps/web/src/lib/utils/article-related-items.ts
@@ -120,7 +120,7 @@ export function mapMentionedStaff(
     id: s._id,
     firstName: s.firstName,
     lastName: s.lastName,
-    role: s.roleLabel,
+    role: null,
     imageUrl: s.imageUrl,
   }));
 }

--- a/apps/web/src/lib/utils/related-content.test.ts
+++ b/apps/web/src/lib/utils/related-content.test.ts
@@ -29,7 +29,6 @@ describe("buildRelatedContent", () => {
       _id: "staff-1",
       firstName: "Marc",
       lastName: "De Trainer",
-      roleLabel: "Hoofdtrainer",
       imageUrl: null,
     },
   ];

--- a/apps/web/src/lib/utils/related-content.ts
+++ b/apps/web/src/lib/utils/related-content.ts
@@ -20,7 +20,6 @@ export interface MentionedStaffMember {
   _id: string;
   firstName: string | null;
   lastName: string | null;
-  roleLabel: string | null;
   imageUrl: string | null;
 }
 

--- a/packages/sanity-schemas/src/staffMember.ts
+++ b/packages/sanity-schemas/src/staffMember.ts
@@ -7,52 +7,6 @@ export const staffMember = defineType({
   fields: [
     defineField({name: 'firstName', title: 'First name', type: 'string'}),
     defineField({name: 'lastName', title: 'Last name', type: 'string'}),
-    defineField({
-      name: 'role',
-      title: 'Role',
-      type: 'string',
-      options: {
-        list: [
-          // Coaching staff
-          {title: 'Hoofdtrainer', value: 'hoofdtrainer'},
-          {title: 'Assistent-trainer', value: 'assistent'},
-          {title: 'Keeperstrainer', value: 'keeperstrainer'},
-          {title: 'TVJO', value: 'tvjo'},
-          {title: 'Ploegdelegatie', value: 'ploegdelegatie'},
-          {title: 'Afgevaardigde', value: 'afgevaardigde'},
-          {title: 'Coach', value: 'coach'},
-          // Board / admin
-          {title: 'Voorzitter', value: 'voorzitter'},
-          {title: 'Ondervoorzitter', value: 'ondervoorzitter'},
-          {title: 'Secretaris', value: 'secretaris'},
-          {title: 'Penningmeester', value: 'penningmeester'},
-          {title: 'Jeugdcoördinator', value: 'jeugdcoordinator'},
-          {title: 'Jeugdsecretaris', value: 'jeugdsecretaris'},
-          {title: 'Technisch coördinator', value: 'technisch-coordinator'},
-          {title: 'Sportief verantwoordelijke', value: 'sportief-verantwoordelijke'},
-          {title: 'Verantwoordelijke sponsoring', value: 'sponsoring-verantwoordelijke'},
-          {title: 'Verzekeringverantwoordelijke', value: 'verzekering-verantwoordelijke'},
-          {title: 'Evenementencoördinator', value: 'evenementen-coordinator'},
-          {title: 'PR-verantwoordelijke', value: 'pr-verantwoordelijke'},
-          {title: 'Kantineverantwoordelijke', value: 'kantine-verantwoordelijke'},
-          {title: 'Webmaster', value: 'webmaster'},
-          {title: 'Bestuur', value: 'bestuur'},
-          {title: 'Andere', value: 'other'},
-        ],
-      },
-    }),
-    defineField({
-      name: 'department',
-      title: 'Department',
-      type: 'string',
-      options: {
-        list: [
-          {title: 'Hoofdbestuur', value: 'hoofdbestuur'},
-          {title: 'Jeugdbestuur', value: 'jeugdbestuur'},
-          {title: 'Algemeen', value: 'algemeen'},
-        ],
-      },
-    }),
     defineField({name: 'email', title: 'Email', type: 'string'}),
     defineField({name: 'phone', title: 'Phone', type: 'string'}),
     defineField({name: 'birthDate', title: 'Birth date', type: 'date'}),
@@ -68,52 +22,6 @@ export const staffMember = defineType({
       title: 'Bio',
       type: 'array',
       of: [{type: 'block'}],
-    }),
-    defineField({
-      name: 'inOrganigram',
-      title: 'In organigram',
-      type: 'boolean',
-      initialValue: false,
-      description: 'Zet aan om deze persoon in het organigram te tonen. Laat uit voor inactieve of onvolledige leden.',
-    }),
-    defineField({
-      name: 'parentMember',
-      title: 'Rapporteert aan',
-      type: 'reference',
-      to: [{type: 'staffMember'}],
-      weak: true,
-      description: 'Hiërarchisch bovenliggende persoon. Leeg = rootniveau (rechtstreeks onder KCVV Elewijt).',
-      hidden: ({document}) => !document?.inOrganigram,
-      options: {
-        filter: ({document}) => ({
-          filter: 'inOrganigram == true && _id != $selfId',
-          params: {selfId: document._id as string},
-        }),
-      },
-    }),
-    defineField({
-      name: 'roleLabel',
-      title: 'Functietitel (organigram)',
-      type: 'string',
-      description:
-        'Vrije tekst zoals getoond in het organigram, bv. "Technisch Coördinator Jeugd". Mag afwijken van het Rol-veld.',
-      hidden: ({document}) => !document?.inOrganigram,
-    }),
-    defineField({
-      name: 'roleCode',
-      title: 'Korte functiecode',
-      type: 'string',
-      description: 'Badge in het diagram, bv. "T1", "VP", "JC". Max 6 tekens. Bij sync wordt de PSD functionTitle (bv. "Keeperstrainer") automatisch afgekorte tot deze code — sla de afkorting op, niet de volledige titel.',
-      validation: (Rule) => Rule.max(6),
-      hidden: ({document}) => !document?.inOrganigram,
-    }),
-    defineField({
-      name: 'responsibilities',
-      title: 'Verantwoordelijkheden',
-      type: 'text',
-      rows: 3,
-      description: 'Korte beschrijving van taken en verantwoordelijkheden. Getoond in het detail-venster van het organigram.',
-      hidden: ({document}) => !document?.inOrganigram,
     }),
     defineField({
       name: 'psdId',
@@ -136,13 +44,11 @@ export const staffMember = defineType({
     select: {
       firstName: 'firstName',
       lastName: 'lastName',
-      role: 'role',
       media: 'photo',
     },
-    prepare({firstName, lastName, role, media}) {
+    prepare({firstName, lastName, media}) {
       return {
         title: `${firstName ?? ''} ${lastName ?? ''}`.trim(),
-        subtitle: role,
         media,
       }
     },


### PR DESCRIPTION
Closes #1117

## What changed
- Removed 7 organigram-specific fields from `staffMember` schema: `role`, `parentMember`, `roleLabel`, `roleCode`, `inOrganigram`, `department`, `responsibilities`
- Removed `ROLE_DISPLAY`/`DEPARTMENT_DISPLAY` maps and `roleDisplay`/`roleLabel`/`departmentDisplay` from `StaffDetailVM`
- Cleaned up GROQ queries, staff detail page, OG image, related-content utils, and all affected tests
- Regenerated `sanity.types.ts`

## Testing
- All 143 test files pass (2036 tests): `pnpm --filter @kcvv/web test`
- Lint clean: `pnpm --filter @kcvv/web lint`
- Type-check clean: `pnpm --filter @kcvv/web type-check`
- Pre-commit hook passes (lint-staged + turbo type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)