### PR TITLE
fix(ui): update organigram member ID tracking for node/member split (#1119)

### DIFF
--- a/apps/web/src/components/organigram/UnifiedOrganigramClient.tsx
+++ b/apps/web/src/components/organigram/UnifiedOrganigramClient.tsx
@@ -240,7 +240,7 @@ export function UnifiedOrganigramClient({
   // Handle member click from any view
   // Uses silent URL update to preserve chart state while enabling URL sharing
   const handleMemberClick = (member: OrgChartNode) => {
-    trackMemberClicked(member.id, activeView);
+    trackMemberClicked(member, activeView);
     setSelectedMember(member);
     setIsModalOpen(true);
     updateUrlSilently({ memberId: member.id });

--- a/apps/web/src/hooks/useOrganigramAnalytics.test.ts
+++ b/apps/web/src/hooks/useOrganigramAnalytics.test.ts
@@ -57,30 +57,87 @@ describe("useOrganigramAnalytics", () => {
   });
 
   describe("organigram_member_clicked", () => {
-    it("fires with hashed member_id and current view", () => {
+    it("single member node: fires with hashed staffMember ID (members[0].id), not the node ID", () => {
       const { result } = renderHook(() => useOrganigramAnalytics());
 
+      const singleNode = {
+        id: "organigramNode-abc",
+        title: "Voorzitter",
+        members: [{ id: "staffMember-jan", name: "Jan Janssen" }],
+      };
+
       act(() => {
-        result.current.trackMemberClicked("voorzitter-id", "chart");
+        result.current.trackMemberClicked(singleNode, "chart");
       });
 
       expect(mockTrackEvent).toHaveBeenCalledWith("organigram_member_clicked", {
-        member_id: hashMemberId("voorzitter-id"),
+        member_id: hashMemberId("staffMember-jan"),
         view: "chart",
       });
     });
 
-    it("fires with hashed member_id and cards view", () => {
+    it("vacant node: fires without member_id when node has no members", () => {
       const { result } = renderHook(() => useOrganigramAnalytics());
 
+      const vacantNode = {
+        id: "organigramNode-vacant",
+        title: "Penningmeester",
+        members: [],
+      };
+
       act(() => {
-        result.current.trackMemberClicked("secretaris-id", "cards");
+        result.current.trackMemberClicked(vacantNode, "cards");
       });
 
       expect(mockTrackEvent).toHaveBeenCalledWith("organigram_member_clicked", {
-        member_id: hashMemberId("secretaris-id"),
         view: "cards",
       });
+    });
+
+    it("shared node: fires with hashed first member ID (members[0].id)", () => {
+      const { result } = renderHook(() => useOrganigramAnalytics());
+
+      // Shared node: 2+ members hold the same position
+      // Decision: track members[0].id — the first listed member is the primary contact.
+      // A future enhancement could track all member IDs if per-member click tracking is needed.
+      const sharedNode = {
+        id: "organigramNode-shared",
+        title: "Co-Penningmeester",
+        members: [
+          { id: "staffMember-piet", name: "Piet Pieters" },
+          { id: "staffMember-els", name: "Els Elsman" },
+        ],
+      };
+
+      act(() => {
+        result.current.trackMemberClicked(sharedNode, "chart");
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith("organigram_member_clicked", {
+        member_id: hashMemberId("staffMember-piet"),
+        view: "chart",
+      });
+    });
+
+    it("never sends raw organigramNode._id as member_id", () => {
+      const { result } = renderHook(() => useOrganigramAnalytics());
+
+      const node = {
+        id: "organigramNode-xyz",
+        title: "Secretaris",
+        members: [{ id: "staffMember-kaat", name: "Kaat Kaatsen" }],
+      };
+
+      act(() => {
+        result.current.trackMemberClicked(node, "cards");
+      });
+
+      const call = mockTrackEvent.mock.calls[0];
+      const params = call[1] as Record<string, unknown>;
+      // The hashed member_id must NOT be the hash of the node ID
+      expect(params.member_id).not.toBe(hashMemberId("organigramNode-xyz"));
+      // It must be the hash of the staffMember ID
+      expect(params.member_id).toBe(hashMemberId("staffMember-kaat"));
     });
   });
 

--- a/apps/web/src/hooks/useOrganigramAnalytics.ts
+++ b/apps/web/src/hooks/useOrganigramAnalytics.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { trackEvent } from "@/lib/analytics/track-event";
 import { sanitizeQuery } from "@/lib/analytics/sanitize-query";
+import type { OrgChartNode } from "@/types/organigram";
 
 type ViewType = "cards" | "chart" | "responsibilities";
 type ViewSource = "tab" | "swipe" | "keyboard";
@@ -19,12 +20,27 @@ export function useOrganigramAnalytics() {
     trackEvent("organigram_view_changed", { view, source });
   }, []);
 
-  const trackMemberClicked = useCallback((memberId: string, view: ViewType) => {
-    trackEvent("organigram_member_clicked", {
-      member_id: hashMemberId(memberId),
-      view,
-    });
-  }, []);
+  /**
+   * Track a node click. Uses the staffMember._id (members[0].id), NOT the
+   * organigramNode._id (node.id), so analytics consistently identify the person.
+   *
+   * - Vacant nodes (0 members): event fires without member_id.
+   * - Single nodes (1 member): member_id = hashed members[0].id.
+   * - Shared nodes (2+ members): member_id = hashed members[0].id — the first
+   *   listed member is treated as the primary contact for tracking purposes.
+   *   Per-member click tracking can be added later if the contact overlay or
+   *   modal exposes individual member actions.
+   */
+  const trackMemberClicked = useCallback(
+    (node: Pick<OrgChartNode, "members">, view: ViewType) => {
+      const staffMemberId = node.members[0]?.id;
+      trackEvent("organigram_member_clicked", {
+        ...(staffMemberId ? { member_id: hashMemberId(staffMemberId) } : {}),
+        view,
+      });
+    },
+    [],
+  );
 
   const trackSearchUsed = useCallback((queryText: string) => {
     trackEvent("organigram_search_used", {


### PR DESCRIPTION
Closes #1119

## What changed
- `trackMemberClicked` now accepts the full `OrgChartNode` and extracts `members[0].id` (staffMember._id) instead of using `node.id` (organigramNode._id)
- Vacant nodes (0 members) fire the analytics event without `member_id`
- Shared nodes (2+ members) track the first listed member — decision documented in code comment

## Testing
- 4 new test cases: single node, vacant node, shared node, raw-ID-never-sent guard
- All 2042 tests pass
- Lint + type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)