### PR TITLE
feat(config): custom domain for Cloudflare Worker BFF (#1083)

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -14,6 +14,10 @@ SANITY_DATASET = "production"
 # SANITY_API_TOKEN is a secret — set via: wrangler secret put SANITY_API_TOKEN
 # SANITY_WEBHOOK_SECRET is a secret — set via: wrangler secret put SANITY_WEBHOOK_SECRET
 
+routes = [
+  { pattern = "bff.kcvvelewijt.be", custom_domain = true }
+]
+
 [observability.logs]
 enabled = true
 invocation_logs = true # captures all console.log / Effect.log output per cron invocation

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,5 +1,5 @@
 # BFF (Cloudflare Worker) base URL
-# Production:  https://kcvv-api.kevin-van-ransbeeck.workers.dev
+# Production:  https://bff.kcvvelewijt.be
 # Staging:     https://kcvv-api-staging.kevin-van-ransbeeck.workers.dev
 # Local dev:   http://localhost:8787  (run: pnpm --filter @kcvv/api dev)
 KCVV_API_URL=http://localhost:8787


### PR DESCRIPTION
Closes #1083

## What changed
- Added `bff.kcvvelewijt.be` as a custom domain route in `apps/api/wrangler.toml`
- Updated production URL comment in `apps/web/.env.local.example`

## Testing
- Lint, type-check, and all 2054 tests pass
- Build failure is pre-existing (missing Sanity env var in local build — works on Vercel)
- Manual prerequisites (DNS migration, Vercel env var, Sanity webhook) are documented in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)