### PR TITLE
feat(ui): migrate club sub-pages to PageHero (#1136)

### DIFF
--- a/apps/web/src/app/(main)/club/[slug]/page.test.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Effect, Layer } from "effect";
+import {
+  PageRepository,
+  type PageVM,
+} from "@/lib/repositories/page.repository";
+
+// Mock runtime to provide the PageRepository layer
+vi.mock("@/lib/effect/runtime", () => ({
+  runPromise: <A,>(effect: Effect.Effect<A, never, PageRepository>) =>
+    Effect.runPromise(Effect.provide(effect, testLayer)),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+const mockFindBySlug = vi.fn<(slug: string) => Effect.Effect<PageVM | null>>();
+const testLayer = Layer.succeed(PageRepository, {
+  findBySlug: (slug) => mockFindBySlug(slug),
+});
+
+// Dynamic import after mocks are set up
+const { default: DynamicClubPage } = await import("./page");
+
+function makePage(overrides: Partial<PageVM> = {}): PageVM {
+  return {
+    id: "page-1",
+    title: "Downloads",
+    slug: "downloads",
+    heroImageUrl: null,
+    body: [
+      {
+        _type: "block" as const,
+        _key: "k1",
+        children: [
+          {
+            _type: "span" as const,
+            _key: "s1",
+            text: "Page content",
+            marks: [] as string[],
+          },
+        ],
+        style: "normal" as const,
+        markDefs: [],
+        fileUrl: null,
+        fileSize: null,
+        fileMimeType: null,
+        fileOriginalFilename: null,
+        asset: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("/club/[slug] page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders PageTitle when heroImage is not set", async () => {
+    mockFindBySlug.mockReturnValue(Effect.succeed(makePage()));
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "downloads" }),
+    });
+    const { container } = render(page);
+
+    // PageTitle renders an h1 with the title
+    expect(screen.getByText("Downloads")).toBeInTheDocument();
+    // Should NOT have the PageHero label
+    expect(container.querySelector(".tracking-label")).toBeNull();
+  });
+
+  it("renders PageHero when heroImage is set", async () => {
+    mockFindBySlug.mockReturnValue(
+      Effect.succeed(
+        makePage({
+          heroImageUrl:
+            "https://cdn.sanity.io/images/proj/dataset/abc.jpg?w=1600&q=80&fm=webp&fit=max",
+        }),
+      ),
+    );
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "downloads" }),
+    });
+    render(page);
+
+    // PageHero renders the label
+    expect(screen.getByText("Club")).toBeInTheDocument();
+    expect(screen.getByText("Downloads")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(main)/club/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.tsx
@@ -5,6 +5,7 @@ import type { PortableTextBlock } from "@portabletext/react";
 import { runPromise } from "@/lib/effect/runtime";
 import { PageRepository } from "@/lib/repositories/page.repository";
 import { PageTitle } from "@/components/layout";
+import { PageHero } from "@/components/design-system/PageHero";
 import { SanityArticleBody } from "@/components/article/SanityArticleBody/SanityArticleBody";
 
 interface Props {
@@ -44,7 +45,17 @@ export default async function DynamicClubPage({ params }: Props) {
 
   return (
     <>
-      <PageTitle title={page.title} />
+      {page.heroImageUrl ? (
+        <PageHero
+          image={page.heroImageUrl}
+          imageAlt={page.title}
+          label="Club"
+          headline={page.title}
+          body=""
+        />
+      ) : (
+        <PageTitle title={page.title} />
+      )}
       <div className="mx-auto max-w-inner-lg px-4 py-8 content">
         <SanityArticleBody content={(page.body ?? []) as PortableTextBlock[]} />
       </div>

--- a/apps/web/src/app/(main)/club/geschiedenis/HistoryContent.test.tsx
+++ b/apps/web/src/app/(main)/club/geschiedenis/HistoryContent.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HistoryContent } from "./HistoryContent";
+
+describe("HistoryContent", () => {
+  it("renders PageHero with history content", () => {
+    render(<HistoryContent />);
+
+    expect(screen.getByText("Onze club")).toBeInTheDocument();
+    expect(
+      screen.getByText(/meer dan een eeuw voetbalpassie/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders timeline sections", () => {
+    render(<HistoryContent />);
+
+    expect(screen.getByText("1909 - 1935")).toBeInTheDocument();
+    expect(screen.getByText("2025 - ...")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(main)/club/geschiedenis/HistoryContent.tsx
+++ b/apps/web/src/app/(main)/club/geschiedenis/HistoryContent.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from "react";
 import Image from "next/image";
-import { PageTitle } from "@/components/layout";
+import { PageHero } from "@/components/design-system/PageHero";
 import { useScrollReveal } from "@/hooks/useScrollReveal";
 
 function TimelineItem({
@@ -109,7 +109,17 @@ export function HistoryContent() {
 
   return (
     <div ref={containerRef}>
-      <PageTitle title="Geschiedenis" />
+      <PageHero
+        image="/images/history/history-24-25.jpg"
+        imageAlt="KCVV Elewijt kampioen 2024-2025"
+        label="Onze club"
+        headline={
+          <>
+            Onze <span className="text-kcvv-green">geschiedenis</span>
+          </>
+        }
+        body="Van 1909 tot vandaag — meer dan een eeuw voetbalpassie in Elewijt."
+      />
 
       <div className="max-w-5xl mx-auto px-4 py-12">
         {/* 1909 - 1941 */}

--- a/apps/web/src/app/(main)/club/ultras/page.test.tsx
+++ b/apps/web/src/app/(main)/club/ultras/page.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import UltrasPage from "./page";
+
+describe("/club/ultras page", () => {
+  it("renders PageHero with ultras content", () => {
+    render(<UltrasPage />);
+
+    expect(screen.getByText("Supporters")).toBeInTheDocument();
+    expect(screen.getByText(/Ultra's/)).toBeInTheDocument();
+  });
+
+  it("renders editorial sections below the hero", () => {
+    render(<UltrasPage />);
+
+    expect(screen.getByText("Wie zijn we")).toBeInTheDocument();
+    expect(screen.getByText("Wat doen we")).toBeInTheDocument();
+    expect(screen.getByText("Lid worden")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(main)/club/ultras/page.tsx
+++ b/apps/web/src/app/(main)/club/ultras/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
-import { PageTitle } from "@/components/layout";
+import { PageHero } from "@/components/design-system/PageHero";
 
 export const metadata: Metadata = {
   title: "KCVV Ultras | KCVV Elewijt",
@@ -27,19 +27,21 @@ export default function UltrasPage() {
           { name: "Ultras", url: `${SITE_CONFIG.siteUrl}/club/ultras` },
         ])}
       />
-      <PageTitle title="KCVV Ultras" />
-
-      {/* Hero image */}
-      <div className="relative h-64 w-full md:h-96">
-        <Image
-          src="/images/ultras/header-ultras.jpg"
-          alt="KCVV Ultra's"
-          fill
-          sizes="100vw"
-          className="object-cover"
-          priority
-        />
-      </div>
+      <PageHero
+        image="/images/ultras/header-ultras.jpg"
+        imageAlt="KCVV Ultra's sfeeractie"
+        label="Supporters"
+        headline={
+          <>
+            KCVV <span className="text-kcvv-green">Ultra&apos;s</span>
+          </>
+        }
+        body="Positief aanmoedigen van onze ploeg — vocaal, met trommels, met sfeermateriaal."
+        cta={{
+          label: "Word lid via Facebook",
+          href: "https://www.facebook.com/KCVV.ULTRAS.55/",
+        }}
+      />
 
       <main className="mx-auto max-w-inner-lg px-4 py-8 content">
         {/* Wie zijn we */}

--- a/apps/web/src/lib/repositories/page.repository.test.ts
+++ b/apps/web/src/lib/repositories/page.repository.test.ts
@@ -65,6 +65,7 @@ describe("PageRepository", () => {
         id: "page-1",
         title: "Praktische Info",
         slug: "praktische-info",
+        heroImageUrl: null,
         body: row.body!,
       });
     });
@@ -106,6 +107,39 @@ describe("PageRepository", () => {
       );
 
       expect(page?.body).toEqual([]);
+    });
+
+    it("maps heroImageUrl when heroImage is set", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makePageRow({
+          heroImageUrl:
+            "https://cdn.sanity.io/images/proj/dataset/abc.jpg?w=1600&q=80&fm=webp&fit=max",
+        } as Record<string, unknown>),
+      );
+
+      const page = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* PageRepository;
+          return yield* repo.findBySlug("test");
+        }),
+      );
+
+      expect(page?.heroImageUrl).toBe(
+        "https://cdn.sanity.io/images/proj/dataset/abc.jpg?w=1600&q=80&fm=webp&fit=max",
+      );
+    });
+
+    it("heroImageUrl is null when heroImage is not set", async () => {
+      mockFetch.mockResolvedValueOnce(makePageRow());
+
+      const page = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* PageRepository;
+          return yield* repo.findBySlug("test");
+        }),
+      );
+
+      expect(page?.heroImageUrl).toBeNull();
     });
   });
 });

--- a/apps/web/src/lib/repositories/page.repository.ts
+++ b/apps/web/src/lib/repositories/page.repository.ts
@@ -10,6 +10,7 @@ export const PAGE_BY_SLUG_QUERY =
   _id,
   title,
   slug,
+  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }
 }`);
 
@@ -17,6 +18,7 @@ export interface PageVM {
   id: string;
   title: string;
   slug: string;
+  heroImageUrl: string | null;
   body: NonNullable<NonNullable<PAGE_BY_SLUG_QUERY_RESULT>["body"]>;
 }
 
@@ -25,6 +27,8 @@ export function toPageVM(row: NonNullable<PAGE_BY_SLUG_QUERY_RESULT>): PageVM {
     id: row._id,
     title: row.title ?? "",
     slug: row.slug?.current ?? "",
+    heroImageUrl:
+      ((row as Record<string, unknown>).heroImageUrl as string | null) ?? null,
     body: row.body ?? [],
   };
 }

--- a/packages/sanity-schemas/src/page.ts
+++ b/packages/sanity-schemas/src/page.ts
@@ -19,6 +19,12 @@ export const page = defineType({
       validation: (r) => r.required(),
     }),
     defineField({
+      name: 'heroImage',
+      title: 'Hero image',
+      type: 'image',
+      options: {hotspot: true},
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'array',


### PR DESCRIPTION
Closes #1136

## What changed
- Added optional `heroImage` field to Sanity `page` schema (`packages/sanity-schemas/src/page.ts`) and updated the GROQ query + `PageVM` to surface `heroImageUrl`
- Replaced `PageTitle` + manual hero `<div>` with `PageHero` on `club/ultras` and `club/geschiedenis` pages
- `club/[slug]` now conditionally renders `PageHero` when a hero image is set in Sanity, falling back to `PageTitle` otherwise

## Testing
- All checks pass: lint, type-check, 154 test files (2090 tests)
- New tests for `club/ultras`, `club/geschiedenis`, and `club/[slug]` pages
- Build requires Sanity env vars (pre-existing; not related to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)