### PR TITLE
feat(ui): add empty state UI for events page (#1138)

### DIFF
--- a/apps/web/src/app/(main)/events/page.test.tsx
+++ b/apps/web/src/app/(main)/events/page.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock the data layer
+vi.mock("@/lib/effect/runtime", () => ({
+  runPromise: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/event.repository", () => ({
+  EventRepository: {},
+}));
+
+// Import after mocks
+const { runPromise } = await import("@/lib/effect/runtime");
+const mockRunPromise = vi.mocked(runPromise);
+
+describe("/events page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("empty state", () => {
+    beforeEach(() => {
+      mockRunPromise.mockResolvedValue([]);
+    });
+
+    it("renders empty state heading when no upcoming events", async () => {
+      const EventsPage = (await import("./page")).default;
+      const jsx = await EventsPage();
+      render(jsx);
+
+      expect(
+        screen.getByRole("heading", { name: /geen evenementen gepland/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders description text", async () => {
+      const EventsPage = (await import("./page")).default;
+      const jsx = await EventsPage();
+      render(jsx);
+
+      expect(
+        screen.getByText(/bekijk het laatste nieuws of de wedstrijdkalender/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders CTA links to /nieuws and /kalender", async () => {
+      const EventsPage = (await import("./page")).default;
+      const jsx = await EventsPage();
+      render(jsx);
+
+      const nieuwsLink = screen.getByRole("link", { name: /naar nieuws/i });
+      expect(nieuwsLink).toHaveAttribute("href", "/nieuws");
+
+      const kalenderLink = screen.getByRole("link", {
+        name: /wedstrijdkalender/i,
+      });
+      expect(kalenderLink).toHaveAttribute("href", "/kalender");
+    });
+
+    it("does not render EventsList", async () => {
+      const EventsPage = (await import("./page")).default;
+      const jsx = await EventsPage();
+      const { container } = render(jsx);
+
+      expect(
+        screen.queryByText(/geen evenementen gevonden/i),
+      ).not.toBeInTheDocument();
+      // The events list container should not be present
+      expect(container.querySelectorAll("article")).toHaveLength(0);
+    });
+  });
+
+  describe("with events", () => {
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+
+    beforeEach(() => {
+      mockRunPromise.mockResolvedValue([
+        {
+          title: "Pasta-avond",
+          href: "/events/pasta-avond",
+          dateStart: futureDate,
+          dateEnd: null,
+          coverImageUrl: null,
+        },
+      ]);
+    });
+
+    it("renders EventsList when events exist", async () => {
+      const EventsPage = (await import("./page")).default;
+      const jsx = await EventsPage();
+      render(jsx);
+
+      // Should NOT show empty state
+      expect(
+        screen.queryByRole("heading", { name: /geen evenementen gepland/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/(main)/events/page.tsx
+++ b/apps/web/src/app/(main)/events/page.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Effect } from "effect";
 import { runPromise } from "@/lib/effect/runtime";
 import {
@@ -11,6 +12,7 @@ import {
   type EventVM,
 } from "@/lib/repositories/event.repository";
 import { EventsList, type EventsListItem } from "@/components/event/EventsList";
+import { Calendar, Newspaper, CalendarDays } from "@/lib/icons";
 
 export const metadata: Metadata = {
   title: "Evenementen | KCVV Elewijt",
@@ -68,7 +70,47 @@ export default async function EventsPage() {
       </div>
 
       <div className="max-w-5xl mx-auto px-4 py-10">
-        <EventsList events={upcomingEvents} />
+        {upcomingEvents.length === 0 ? (
+          <div className="min-h-[40vh] flex flex-col items-center justify-center px-4 py-16">
+            <div className="text-center max-w-md">
+              <div className="mb-6">
+                <Calendar
+                  className="w-24 h-24 mx-auto text-kcvv-gray opacity-50"
+                  aria-hidden="true"
+                />
+              </div>
+
+              <h2 className="text-3xl font-bold text-kcvv-gray-dark mb-4">
+                Geen evenementen gepland
+              </h2>
+
+              <p className="text-kcvv-gray mb-8">
+                Er zijn momenteel geen aankomende evenementen. Bekijk het
+                laatste nieuws of de wedstrijdkalender.
+              </p>
+
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <Link
+                  href="/nieuws"
+                  className="inline-flex items-center justify-center px-6 py-3 bg-kcvv-green-bright text-white font-medium rounded-lg hover:bg-kcvv-green transition-colors"
+                >
+                  <Newspaper className="w-5 h-5 mr-2" aria-hidden="true" />
+                  Naar nieuws
+                </Link>
+
+                <Link
+                  href="/kalender"
+                  className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-kcvv-gray-dark font-medium rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  <CalendarDays className="w-5 h-5 mr-2" aria-hidden="true" />
+                  Wedstrijdkalender
+                </Link>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <EventsList events={upcomingEvents} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #1138

## What changed
- When `upcomingEvents.length === 0`, the events page now renders a rich empty state instead of the basic `EventsList` empty message
- Empty state includes a Calendar icon, Dutch heading ("Geen evenementen gepland"), description, and two CTA buttons (Naar nieuws → `/nieuws`, Wedstrijdkalender → `/kalender`)
- Follows the same visual pattern as `/ploegen/[slug]/not-found.tsx` (icon + heading + description + CTA buttons)

## Testing
- Added `page.test.tsx` with 5 tests covering empty state rendering and regression (events still render normally)
- `pnpm --filter @kcvv/web type-check` ✅
- `pnpm --filter @kcvv/web lint` ✅
- `pnpm --filter @kcvv/web test` — 155 files, 2107 tests passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)