### PR TITLE
feat(ui): replace PageTitle with PageHero on kalender page (#1139)

### DIFF
--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -13,7 +13,7 @@ import {
   type EventVM,
 } from "@/lib/repositories/event.repository";
 import type { Match } from "@/lib/effect/schemas/match.schema";
-import { PageTitle } from "@/components/layout";
+import { PageHero } from "@/components/design-system";
 import { CalendarWidget } from "@/components/calendar/CalendarWidget";
 import { transformMatchToCalendar } from "./utils";
 import type { CalendarMatch, CalendarEvent, CalendarTeamInfo } from "./utils";
@@ -131,7 +131,14 @@ export default async function CalendarPage() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <PageTitle title="Wedstrijdkalender" />
+      <PageHero
+        image="/images/youth-trainers.jpg"
+        imageAlt="KCVV jeugdtraining"
+        label="Kalender"
+        headline="Wedstrijdkalender"
+        body="Bekijk alle wedstrijden en activiteiten van KCVV Elewijt."
+        size="compact"
+      />
 
       <div className="max-w-5xl mx-auto px-4 py-10">
         <CalendarWidget

--- a/apps/web/src/components/design-system/PageHero/PageHero.stories.tsx
+++ b/apps/web/src/components/design-system/PageHero/PageHero.stories.tsx
@@ -16,6 +16,11 @@ const meta = {
     },
     label: { control: "text", description: "Small label above the headline" },
     body: { control: "text", description: "Body text below the headline" },
+    size: {
+      control: "select",
+      options: ["default", "compact"],
+      description: "Hero height variant",
+    },
   },
 } satisfies Meta<typeof PageHero>;
 
@@ -65,5 +70,16 @@ export const WithoutCta: Story = {
       </>
     ),
     body: "Meer dan 200 jonge voetballers. Gediplomeerde trainers. Eén missie: plezier, techniek en teamspirit.",
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    image: "/images/youth-trainers.jpg",
+    imageAlt: "KCVV jeugdtraining",
+    label: "Kalender",
+    headline: "Wedstrijdkalender",
+    body: "Bekijk alle wedstrijden en activiteiten van KCVV Elewijt.",
+    size: "compact",
   },
 };

--- a/apps/web/src/components/design-system/PageHero/PageHero.test.tsx
+++ b/apps/web/src/components/design-system/PageHero/PageHero.test.tsx
@@ -80,4 +80,19 @@ describe("PageHero", () => {
     const accentBar = container.querySelector(".bg-kcvv-green");
     expect(accentBar).toBeInTheDocument();
   });
+
+  it("renders with default min-h-[60vh] when no size prop", () => {
+    const { container } = render(<PageHero {...defaultProps} />);
+    const content = container.querySelector(".min-h-\\[60vh\\]");
+    expect(content).toBeInTheDocument();
+  });
+
+  it("renders with min-h-[35vh] when size is compact", () => {
+    const { container } = render(<PageHero {...defaultProps} size="compact" />);
+    const content = container.querySelector(".min-h-\\[35vh\\]");
+    expect(content).toBeInTheDocument();
+    expect(
+      container.querySelector(".min-h-\\[60vh\\]"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/design-system/PageHero/PageHero.tsx
+++ b/apps/web/src/components/design-system/PageHero/PageHero.tsx
@@ -9,6 +9,7 @@ export interface PageHeroProps {
   headline: ReactNode;
   body: string;
   cta?: { label: string; href: string };
+  size?: "default" | "compact";
 }
 
 export function PageHero({
@@ -18,6 +19,7 @@ export function PageHero({
   headline,
   body,
   cta,
+  size = "default",
 }: PageHeroProps) {
   return (
     <div className="relative">
@@ -42,7 +44,9 @@ export function PageHero({
       </div>
 
       {/* Content */}
-      <div className="relative z-10 min-h-[60vh] flex items-end">
+      <div
+        className={`relative z-10 flex items-end ${size === "compact" ? "min-h-[35vh]" : "min-h-[60vh]"}`}
+      >
         <div className="max-w-inner-lg mx-auto px-4 md:px-10 pt-10 pb-16 md:pt-16 md:pb-24 w-full">
           <div className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-label text-white/50 mb-6">
             <span className="block w-5 h-0.5 bg-kcvv-green" />


### PR DESCRIPTION
Closes #1139

## What changed
- Added `size` prop to `PageHero` component (`"default"` | `"compact"`) — compact renders `min-h-[35vh]`
- Added `Compact` story variant to `PageHero.stories.tsx`
- Replaced `PageTitle` with `PageHero` (compact, youth-trainers image) on `kalender/page.tsx`

## Testing
- All checks pass: `pnpm --filter @kcvv/web lint && type-check && test` (155 test files, 2109 tests)
- `build` has a pre-existing failure in `opengraph-image` route unrelated to this change
- PageHero tests cover both default and compact size variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)