### PR TITLE
refactor(ui): replace hardcoded hex values with design tokens (#1141)

### DIFF
--- a/apps/web/src/components/layout/MobileMenu/MobileMenu.tsx
+++ b/apps/web/src/components/layout/MobileMenu/MobileMenu.tsx
@@ -116,7 +116,7 @@ export const MobileMenu = ({
             }
             .mobile-nav-link:hover::before,
             .mobile-nav-link.active::before {
-              background-color: #4acf52;
+              background-color: var(--color-kcvv-green-bright);
             }
           `,
         }}
@@ -135,7 +135,7 @@ export const MobileMenu = ({
       {/* Menu Panel */}
       <nav
         className={cn(
-          "fixed top-0 left-0 h-full w-[280px] bg-[#1E2024] z-50",
+          "fixed top-0 left-0 h-full w-[280px] bg-kcvv-black z-50",
           "transform transition-transform duration-500 ease-in-out",
           "shadow-[0_0_10px_rgba(0,0,0,0.7)]",
           "flex flex-col",
@@ -181,7 +181,7 @@ export const MobileMenu = ({
                       <button
                         onClick={() => toggleSubmenu(item.href)}
                         className={cn(
-                          "mobile-nav-link w-full flex items-center justify-between px-8 py-4 text-left border-b border-[#292c31] text-white text-[0.6875rem] uppercase font-bold transition-colors",
+                          "mobile-nav-link w-full flex items-center justify-between px-8 py-4 text-left border-b border-kcvv-gray-dark text-white text-[0.6875rem] uppercase font-bold transition-colors",
                           active && "active",
                         )}
                       >
@@ -204,10 +204,10 @@ export const MobileMenu = ({
                         )}
                       >
                         <ul
-                          className="list-none m-0 p-0 bg-[#292c31]"
+                          className="list-none m-0 p-0 bg-kcvv-gray-dark"
                           style={{
                             boxShadow:
-                              "inset 0 7px 9px -7px #1E2024, inset 0 -7px 9px -7px #1E2024",
+                              "inset 0 7px 9px -7px var(--color-kcvv-black), inset 0 -7px 9px -7px var(--color-kcvv-black)",
                           }}
                         >
                           {item.children?.map((child) => {
@@ -218,7 +218,7 @@ export const MobileMenu = ({
                                 <Link
                                   href={child.href}
                                   className={cn(
-                                    "mobile-nav-link block px-8 py-4 text-[0.6875rem] uppercase font-bold border-b border-[#62656A] no-underline transition-colors",
+                                    "mobile-nav-link block px-8 py-4 text-[0.6875rem] uppercase font-bold border-b border-kcvv-gray no-underline transition-colors",
                                     childActive
                                       ? "text-kcvv-green-bright active"
                                       : "text-white hover:text-kcvv-green-bright",
@@ -236,7 +236,7 @@ export const MobileMenu = ({
                     <Link
                       href={item.href}
                       className={cn(
-                        "mobile-nav-link block px-8 py-4 text-[0.6875rem] uppercase font-bold border-b border-[#292c31] text-white no-underline transition-colors",
+                        "mobile-nav-link block px-8 py-4 text-[0.6875rem] uppercase font-bold border-b border-kcvv-gray-dark text-white no-underline transition-colors",
                         active && "active",
                       )}
                     >

--- a/apps/web/src/components/layout/Navigation/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation/Navigation.tsx
@@ -84,7 +84,7 @@ export const Navigation = ({
               left: 50%;
               height: 2px;
               width: 0;
-              background: #4acf52;
+              background: var(--color-kcvv-green-bright);
               transition: width 0.3s ease 0s, left 0.3s ease 0s;
             }
             .nav-link:hover::after,
@@ -139,7 +139,7 @@ export const Navigation = ({
                 {hasDropdown && openDropdown === item.href && (
                   <div
                     className={cn(
-                      "absolute top-full mt-0 min-w-[200px] bg-[#1E2024] border border-gray-700 z-10",
+                      "absolute top-full mt-0 min-w-[200px] bg-kcvv-black border border-gray-700 z-10",
                       isNearEnd ? "right-0" : "left-0",
                     )}
                   >


### PR DESCRIPTION
Closes #1141

## What changed
- Replaced all hardcoded hex color values (`#4acf52`, `#1E2024`, `#292c31`, `#62656A`) with Tailwind design tokens (`kcvv-green-bright`, `kcvv-black`, `kcvv-gray-dark`, `kcvv-gray`) in `MobileMenu.tsx`
- Replaced hardcoded hex values in `Navigation.tsx` with the same design tokens
- Inline `boxShadow` style now uses `var(--color-kcvv-black)` instead of `#1E2024`

## Testing
- All 2107 tests pass
- Lint and type-check pass
- Visual output unchanged (same hex values resolved through tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)