### PR TITLE
feat(ui): add volunteer recruitment nav item (#1147)

### DIFF
--- a/apps/web/src/components/layout/menuItems.test.ts
+++ b/apps/web/src/components/layout/menuItems.test.ts
@@ -13,6 +13,21 @@ describe("staticMenuItems", () => {
     const labels = staticMenuItems.map((item) => item.label);
     expect(labels).not.toContain("Zoeken");
   });
+
+  it("includes 'Word vrijwilliger' in 'De club' children after 'Contact'", () => {
+    const deClub = staticMenuItems.find((item) => item.label === "De club");
+    expect(deClub).toBeDefined();
+    const children = deClub!.children!;
+    const labels = children.map((c) => c.label);
+    expect(labels).toContain("Word vrijwilliger");
+
+    const contactIdx = labels.indexOf("Contact");
+    const vrijwilligerIdx = labels.indexOf("Word vrijwilliger");
+    expect(vrijwilligerIdx).toBe(contactIdx + 1);
+
+    const vrijwilliger = children.find((c) => c.label === "Word vrijwilliger");
+    expect(vrijwilliger?.href).toBe("/club/vrijwilliger");
+  });
 });
 
 describe("buildMenuItems", () => {

--- a/apps/web/src/components/layout/menuItems.ts
+++ b/apps/web/src/components/layout/menuItems.ts
@@ -23,6 +23,7 @@ export const staticMenuItems: MenuItem[] = [
       { label: "KCVV Angels", href: "/club/angels" },
       { label: "KCVV Ultras", href: "/club/ultras" },
       { label: "Contact", href: "/club/contact" },
+      { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
       { label: "Downloads", href: "/club/downloads" },
       { label: "Praktische Info", href: "/club/inschrijven" },
       { label: "Cashless clubkaart", href: "/club/cashless" },


### PR DESCRIPTION
Closes #1147

## What changed
- Added `{ label: "Word vrijwilliger", href: "/club/vrijwilliger" }` to the "De club" dropdown children in `staticMenuItems`, positioned after "Contact"
- Added test verifying the nav item exists at the correct position with the correct href

## Testing
- `pnpm --filter @kcvv/web lint:fix` — passes
- `pnpm --filter @kcvv/web type-check` — passes
- `pnpm --filter @kcvv/web test` — 2147 tests pass (159 test files)

## Manual steps before go-live
- Publish a Sanity `page` document with slug `vrijwilliger` (content provided in issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)