### PR TITLE
refactor(news): push transforms into GROQ projections for article repository (#1191)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.stories.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.stories.tsx
@@ -112,7 +112,7 @@ export const WithActiveCategory: Story = {
   args: {
     featuredArticles,
     initialArticles: gridArticles.filter((a) =>
-      a.tags.includes("Wedstrijdverslagen"),
+      (a.tags as string[]).includes("Wedstrijdverslagen"),
     ),
     categories: mockCategories,
     hasMore: false,

--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.test.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.test.tsx
@@ -21,6 +21,7 @@ function makeArticle(overrides: Partial<ArticleVM> = {}): ArticleVM {
     slug: overrides.title?.toLowerCase().replace(/\s/g, "-") ?? "test",
     publishedAt: "2026-03-15T10:00:00Z",
     featured: false,
+    coverImageUrl: null,
     tags: overrides.tags ?? [],
     ...overrides,
   };

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -164,7 +164,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
             datePublished: article.publishedAt,
             dateModified: article.updatedAt ?? undefined,
             author: "KCVV Elewijt",
-            image: article.coverImageUrl,
+            image: article.coverImageUrl ?? undefined,
             url: shareConfig.url,
           })}
         />

--- a/apps/web/src/app/(main)/nieuws/actions.test.ts
+++ b/apps/web/src/app/(main)/nieuws/actions.test.ts
@@ -9,6 +9,7 @@ function makeArticle(overrides: Partial<ArticleVM> = {}): ArticleVM {
     slug: "test-article",
     publishedAt: "2026-03-15T10:00:00Z",
     featured: false,
+    coverImageUrl: null,
     tags: [],
     ...overrides,
   };

--- a/apps/web/src/components/article/ArticleHeader/ArticleHeader.tsx
+++ b/apps/web/src/components/article/ArticleHeader/ArticleHeader.tsx
@@ -11,7 +11,7 @@ export interface ArticleHeaderProps {
   /** Article title */
   title: string;
   /** Hero image URL (optional — renders dark fallback when absent) */
-  imageUrl?: string;
+  imageUrl?: string | null;
   /** Hero image alt text */
   imageAlt?: string;
   /** Category badge */

--- a/apps/web/src/components/article/NewsCard/NewsCard.tsx
+++ b/apps/web/src/components/article/NewsCard/NewsCard.tsx
@@ -7,7 +7,7 @@ import { Calendar, Clock, ExternalLink } from "@/lib/icons";
 export interface NewsCardProps {
   title: string;
   href?: string; // now optional — cards without href are non-interactive
-  imageUrl?: string;
+  imageUrl?: string | null;
   imageAlt?: string;
   /** Single category label — shown above title and in footer */
   badge?: string;

--- a/apps/web/src/components/club/EditorialCard/EditorialCard.tsx
+++ b/apps/web/src/components/club/EditorialCard/EditorialCard.tsx
@@ -7,7 +7,7 @@ interface EditorialCardProps {
   description?: string;
   arrowText: string;
   featured?: boolean;
-  backgroundImage?: string;
+  backgroundImage?: string | null;
   variant?: "default" | "nav";
 }
 

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
@@ -118,7 +118,7 @@ export const WithoutImage: Story = {
     articles: [
       {
         ...mockArticles[0],
-        imageUrl: undefined,
+        imageUrl: null,
       },
     ],
     autoRotate: false,

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
@@ -220,7 +220,7 @@ describe("FeaturedArticles", () => {
     const articlesWithoutImages = [
       {
         ...mockArticles[0],
-        imageUrl: undefined,
+        imageUrl: null,
       },
     ];
 

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
@@ -28,7 +28,7 @@ export interface FeaturedArticle {
   /**
    * Featured image URL
    */
-  imageUrl?: string;
+  imageUrl: string | null;
   /**
    * Image alt text
    */

--- a/apps/web/src/components/home/NewsGrid/NewsGrid.stories.tsx
+++ b/apps/web/src/components/home/NewsGrid/NewsGrid.stories.tsx
@@ -99,7 +99,7 @@ export const WithFeaturedEventStub: Story = {
 /** Cards without cover images — fallback background */
 export const WithoutImages: Story = {
   args: {
-    articles: mockArticles.map((a) => ({ ...a, imageUrl: undefined })),
+    articles: mockArticles.map((a) => ({ ...a, imageUrl: null })),
     title: "Nieuws",
     showViewAll: true,
   },

--- a/apps/web/src/components/home/NewsGrid/NewsGrid.tsx
+++ b/apps/web/src/components/home/NewsGrid/NewsGrid.tsx
@@ -5,7 +5,7 @@ import { NewsCard } from "@/components/article/NewsCard";
 export interface NewsGridArticle {
   href: string;
   title: string;
-  imageUrl?: string;
+  imageUrl: string | null;
   imageAlt: string;
   date: string;
   tags?: Array<{ name: string }>;

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
@@ -10,7 +10,7 @@ function makeArticle(
     slug: `jeugd-artikel-${overrides.id}`,
     publishedAt: "2026-03-20",
     featured: false,
-    coverImageUrl: undefined,
+    coverImageUrl: null,
     tags: ["Jeugd"],
     ...overrides,
   };

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.test.tsx
@@ -11,6 +11,7 @@ function makeArticle(overrides: Partial<ArticleVM> = {}): ArticleVM {
     slug: "test-article",
     publishedAt: "2026-03-01",
     featured: false,
+    coverImageUrl: null,
     tags: ["jeugd"],
     ...overrides,
   };

--- a/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.test.tsx
+++ b/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.test.tsx
@@ -27,6 +27,7 @@ const mockArticles = [
     slug: "wedstrijdverslag",
     publishedAt: "2026-03-19T10:00:00Z",
     featured: false,
+    coverImageUrl: null,
     tags: [],
   },
 ];

--- a/apps/web/src/lib/repositories/article.repository.test.ts
+++ b/apps/web/src/lib/repositories/article.repository.test.ts
@@ -29,10 +29,10 @@ function makeArticleListRow(
   overrides: Partial<ARTICLES_QUERY_RESULT[number]> = {},
 ): ARTICLES_QUERY_RESULT[number] {
   return {
-    _id: "article-1",
+    id: "article-1",
     title: "Test Article",
-    slug: { _type: "slug", current: "test-article" },
-    publishAt: "2026-03-20T10:00:00Z",
+    slug: "test-article",
+    publishedAt: "2026-03-20T10:00:00Z",
     featured: false,
     tags: ["Eerste ploeg", "Wedstrijdverslag"],
     coverImageUrl: "https://cdn.sanity.io/cover.webp",
@@ -45,11 +45,11 @@ function makeArticleDetailRow(
   overrides: Partial<NonNullable<ARTICLE_BY_SLUG_QUERY_RESULT>> = {},
 ): NonNullable<ARTICLE_BY_SLUG_QUERY_RESULT> {
   return {
-    _id: "article-1",
-    _updatedAt: "2026-03-21T12:00:00Z",
+    id: "article-1",
+    updatedAt: "2026-03-21T12:00:00Z",
     title: "Test Article Detail",
-    slug: { _type: "slug", current: "test-article-detail" },
-    publishAt: "2026-03-20T10:00:00Z",
+    slug: "test-article-detail",
+    publishedAt: "2026-03-20T10:00:00Z",
     featured: true,
     tags: ["Eerste ploeg"],
     coverImageUrl: "https://cdn.sanity.io/cover.webp",
@@ -69,10 +69,10 @@ function makeArticleDetailRow(
     ],
     relatedArticles: [
       {
-        _id: "article-2",
+        id: "article-2",
         title: "Related Article",
-        slug: { _type: "slug", current: "related-article" },
-        publishAt: "2026-03-19T10:00:00Z",
+        slug: "related-article",
+        publishedAt: "2026-03-19T10:00:00Z",
         unpublishAt: null,
         coverImageUrl: "https://cdn.sanity.io/related.webp",
       },
@@ -109,7 +109,7 @@ function makeArticleDetailRow(
 
 describe("ArticleRepository", () => {
   describe("findAll", () => {
-    it("maps all ArticleVM fields correctly from GROQ result", async () => {
+    it("returns GROQ result directly without transform", async () => {
       const row = makeArticleListRow();
       mockFetch.mockResolvedValueOnce([row]);
 
@@ -121,7 +121,7 @@ describe("ArticleRepository", () => {
       );
 
       expect(articles).toHaveLength(1);
-      expect(articles[0]).toEqual<ArticleVM>({
+      expect(articles[0]).toMatchObject<ArticleVM>({
         id: "article-1",
         title: "Test Article",
         slug: "test-article",
@@ -132,7 +132,7 @@ describe("ArticleRepository", () => {
       });
     });
 
-    it("null coverImageUrl becomes undefined", async () => {
+    it("null coverImageUrl stays null (no conversion to undefined)", async () => {
       mockFetch.mockResolvedValueOnce([
         makeArticleListRow({ coverImageUrl: null }),
       ]);
@@ -144,46 +144,7 @@ describe("ArticleRepository", () => {
         }),
       );
 
-      expect(a.coverImageUrl).toBeUndefined();
-    });
-
-    it("null/empty tags become empty array", async () => {
-      mockFetch.mockResolvedValueOnce([makeArticleListRow({ tags: null })]);
-
-      const [a] = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* ArticleRepository;
-          return yield* repo.findAll();
-        }),
-      );
-
-      expect(a.tags).toEqual([]);
-    });
-
-    it("null title becomes empty string", async () => {
-      mockFetch.mockResolvedValueOnce([makeArticleListRow({ title: null })]);
-
-      const [a] = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* ArticleRepository;
-          return yield* repo.findAll();
-        }),
-      );
-
-      expect(a.title).toBe("");
-    });
-
-    it("null slug becomes empty string", async () => {
-      mockFetch.mockResolvedValueOnce([makeArticleListRow({ slug: null })]);
-
-      const [a] = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* ArticleRepository;
-          return yield* repo.findAll();
-        }),
-      );
-
-      expect(a.slug).toBe("");
+      expect(a.coverImageUrl).toBeNull();
     });
   });
 
@@ -226,11 +187,11 @@ describe("ArticleRepository", () => {
       const { toHomepageArticle } = await import("./article.repository");
       const hp = toHomepageArticle(articles[0]);
 
-      expect(hp.imageUrl).toBeUndefined();
+      expect(hp.imageUrl).toBeNull();
     });
 
     it("handles empty tags", async () => {
-      mockFetch.mockResolvedValueOnce([makeArticleListRow({ tags: null })]);
+      mockFetch.mockResolvedValueOnce([makeArticleListRow({ tags: [] })]);
 
       const articles = await runWithRepo(
         Effect.gen(function* () {

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -2,6 +2,7 @@ import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
 import type {
+  ARTICLES_PAGINATED_QUERY_RESULT,
   ARTICLES_QUERY_RESULT,
   ARTICLE_TAGS_QUERY_RESULT,
   ARTICLE_BY_SLUG_QUERY_RESULT,
@@ -13,7 +14,7 @@ import { formatArticleDate } from "../utils/dates";
 
 export const ARTICLES_QUERY =
   defineQuery(`*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {
-  _id, title, slug, publishAt, featured, tags,
+  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }
 }`);
@@ -24,22 +25,22 @@ export const ARTICLE_TAGS_QUERY = defineQuery(
 
 export const ARTICLES_PAGINATED_QUERY =
   defineQuery(`*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {
-  _id, title, slug, publishAt, featured, tags,
+  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"
 }`);
 
 export const RELATED_ARTICLES_QUERY =
   defineQuery(`*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {
-  _id, title, slug, publishAt, featured, tags,
+  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
   "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"
 }`);
 
 export const ARTICLE_BY_SLUG_QUERY =
   defineQuery(`*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {
-  _id, _updatedAt, title, slug, publishAt, featured, tags,
+  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },
-  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },
+  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },
   "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {
     _id, firstName, lastName, position,
     "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",
@@ -58,19 +59,14 @@ export const ARTICLE_BY_SLUG_QUERY =
 
 // ─── View Models ─────────────────────────────────────────────────────────────
 
-export interface ArticleVM {
-  id: string;
-  title: string;
-  slug: string;
-  publishedAt: string | null;
-  featured: boolean;
-  coverImageUrl?: string;
-  tags: string[];
-}
+/** Article list item — type alias for the GROQ projection result (no runtime transform needed). */
+export type ArticleVM = ARTICLES_PAGINATED_QUERY_RESULT[number];
+
+type ARTICLE_BY_SLUG_DETAIL = NonNullable<ARTICLE_BY_SLUG_QUERY_RESULT>;
 
 export interface ArticleDetailVM extends ArticleVM {
-  updatedAt: string | null;
-  body: NonNullable<ARTICLE_BY_SLUG_DETAIL>["body"];
+  updatedAt: string;
+  body: ARTICLE_BY_SLUG_DETAIL["body"];
   relatedArticles?: RelatedArticleRef[];
   mentionedPlayers?: ARTICLE_BY_SLUG_DETAIL["mentionedPlayers"];
   mentionedTeams?: ARTICLE_BY_SLUG_DETAIL["mentionedTeams"];
@@ -89,58 +85,33 @@ export interface HomepageArticle {
   href: string;
   title: string;
   description?: string;
-  imageUrl?: string;
+  imageUrl: string | null;
   imageAlt: string;
   date: string;
   dateIso: string;
   tags: Array<{ name: string }>;
 }
 
-type ARTICLE_BY_SLUG_DETAIL = NonNullable<ARTICLE_BY_SLUG_QUERY_RESULT>;
-
 // ─── Transforms ──────────────────────────────────────────────────────────────
 
-export function toArticleVM(row: ARTICLES_QUERY_RESULT[number]): ArticleVM {
-  return {
-    id: row._id,
-    title: row.title ?? "",
-    slug: row.slug?.current ?? "",
-    publishedAt: row.publishAt,
-    featured: row.featured ?? false,
-    coverImageUrl: row.coverImageUrl ?? undefined,
-    tags: row.tags ?? [],
-  };
-}
-
 function toArticleDetailVM(row: ARTICLE_BY_SLUG_DETAIL): ArticleDetailVM {
+  const now = new Date().toISOString();
   return {
-    id: row._id,
-    title: row.title ?? "",
-    slug: row.slug?.current ?? "",
-    publishedAt: row.publishAt,
-    updatedAt: row._updatedAt,
-    featured: row.featured ?? false,
-    coverImageUrl: row.coverImageUrl ?? undefined,
-    tags: row.tags ?? [],
-    body: row.body,
-    relatedArticles: (() => {
-      const now = new Date().toISOString();
-      return (
-        row.relatedArticles
-          ?.filter((a) => {
-            if (a.publishAt && a.publishAt > now) return false;
-            if (a.unpublishAt && a.unpublishAt <= now) return false;
-            return true;
-          })
-          .map((a) => ({
-            id: a._id,
-            title: a.title ?? "",
-            slug: a.slug?.current ?? "",
-            publishedAt: a.publishAt,
-            coverImageUrl: a.coverImageUrl,
-          })) ?? undefined
-      );
-    })(),
+    ...row,
+    relatedArticles:
+      row.relatedArticles
+        ?.filter((a) => {
+          if (a.publishedAt && a.publishedAt > now) return false;
+          if (a.unpublishAt && a.unpublishAt <= now) return false;
+          return true;
+        })
+        .map((a) => ({
+          id: a.id,
+          title: a.title,
+          slug: a.slug,
+          publishedAt: a.publishedAt,
+          coverImageUrl: a.coverImageUrl,
+        })) ?? undefined,
     mentionedPlayers: row.mentionedPlayers ?? undefined,
     mentionedTeams: row.mentionedTeams ?? undefined,
     mentionedStaffMembers: row.mentionedStaffMembers ?? undefined,
@@ -167,17 +138,6 @@ export function toHomepageArticles(
 
 // ─── Service ─────────────────────────────────────────────────────────────────
 
-/** The list item type returned by the paginated query (no typegen for variable slicing) */
-export type ArticleListRow = {
-  _id: string;
-  title: string | null;
-  slug: { _type: "slug"; current?: string } | null;
-  publishAt: string | null;
-  featured: boolean | null;
-  tags: string[] | null;
-  coverImageUrl: string | null;
-};
-
 export interface ArticleRepositoryInterface {
   readonly findAll: () => Effect.Effect<ArticleVM[]>;
   readonly findBySlug: (slug: string) => Effect.Effect<ArticleDetailVM | null>;
@@ -196,31 +156,20 @@ export class ArticleRepository extends Context.Tag("ArticleRepository")<
 >() {}
 
 export const ArticleRepositoryLive = Layer.succeed(ArticleRepository, {
-  findAll: () =>
-    fetchGroq<ARTICLES_QUERY_RESULT>(ARTICLES_QUERY).pipe(
-      Effect.map((rows) => rows.map(toArticleVM)),
-    ),
+  findAll: () => fetchGroq<ARTICLES_QUERY_RESULT>(ARTICLES_QUERY),
   findBySlug: (slug) =>
     fetchGroq<ARTICLE_BY_SLUG_QUERY_RESULT>(ARTICLE_BY_SLUG_QUERY, {
       slug,
     }).pipe(Effect.map((row) => (row ? toArticleDetailVM(row) : null))),
   findPaginated: ({ offset, limit, category }) =>
-    fetchGroq<ArticleListRow[]>(ARTICLES_PAGINATED_QUERY, {
+    fetchGroq<ARTICLES_PAGINATED_QUERY_RESULT>(ARTICLES_PAGINATED_QUERY, {
       offset,
       end: offset + limit,
       category: category ?? "",
-    }).pipe(
-      Effect.map((rows) =>
-        rows.map((row) => toArticleVM(row as ARTICLES_QUERY_RESULT[number])),
-      ),
-    ),
+    }),
   findTags: () => fetchGroq<ARTICLE_TAGS_QUERY_RESULT>(ARTICLE_TAGS_QUERY),
   findRelated: (documentId) =>
     fetchGroq<RELATED_ARTICLES_QUERY_RESULT>(RELATED_ARTICLES_QUERY, {
       documentId,
-    }).pipe(
-      Effect.map((rows) =>
-        rows.map((row) => toArticleVM(row as ARTICLES_QUERY_RESULT[number])),
-      ),
-    ),
+    }),
 });

--- a/apps/web/src/lib/repositories/page.repository.test.ts
+++ b/apps/web/src/lib/repositories/page.repository.test.ts
@@ -30,6 +30,7 @@ function makePageRow(
     _id: "page-1",
     title: "Praktische Info",
     slug: { current: "praktische-info", _type: "slug" },
+    heroImageUrl: null,
     body: [
       {
         _type: "block",

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -307,6 +307,13 @@ export type Page = {
   _rev: string;
   title?: string;
   slug?: Slug;
+  heroImage?: {
+    asset?: SanityImageAssetReference;
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: "image";
+  };
   body?: Array<
     | {
         children?: Array<{
@@ -771,14 +778,14 @@ export type AllSanitySchemaTypes =
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLES_QUERY
-// Query: *[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {  _id, title, slug, publishAt, featured, tags,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }}
+// Query: *[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }}
 export type ARTICLES_QUERY_RESULT = Array<{
-  _id: string;
-  title: string | null;
-  slug: Slug | null;
-  publishAt: string | null;
-  featured: boolean | null;
-  tags: Array<string> | null;
+  id: string;
+  title: string | "";
+  slug: string | "";
+  publishedAt: string | null;
+  featured: boolean | false;
+  tags: Array<string> | Array<never>;
   coverImageUrl: string | null;
   body: Array<
     | {
@@ -903,41 +910,41 @@ export type ARTICLE_TAGS_QUERY_RESULT = Array<string | null>;
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLES_PAGINATED_QUERY
-// Query: *[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {  _id, title, slug, publishAt, featured, tags,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"}
+// Query: *[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"}
 export type ARTICLES_PAGINATED_QUERY_RESULT = Array<{
-  _id: string;
-  title: string | null;
-  slug: Slug | null;
-  publishAt: string | null;
-  featured: boolean | null;
-  tags: Array<string> | null;
+  id: string;
+  title: string | "";
+  slug: string | "";
+  publishedAt: string | null;
+  featured: boolean | false;
+  tags: Array<string> | Array<never>;
   coverImageUrl: string | null;
 }>;
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: RELATED_ARTICLES_QUERY
-// Query: *[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {  _id, title, slug, publishAt, featured, tags,  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"}
+// Query: *[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"}
 export type RELATED_ARTICLES_QUERY_RESULT = Array<{
-  _id: string;
-  title: string | null;
-  slug: Slug | null;
-  publishAt: string | null;
-  featured: boolean | null;
-  tags: Array<string> | null;
+  id: string;
+  title: string | "";
+  slug: string | "";
+  publishedAt: string | null;
+  featured: boolean | false;
+  tags: Array<string> | Array<never>;
   coverImageUrl: string | null;
 }>;
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLE_BY_SLUG_QUERY
-// Query: *[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {  _id, _updatedAt, title, slug, publishAt, featured, tags,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {    _id, firstName, lastName, position,    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    psdId  },  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {    _id, name,    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "slug": slug.current  },  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {    _id, firstName, lastName,    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"  }}
+// Query: *[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {    _id, firstName, lastName, position,    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    psdId  },  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {    _id, name,    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "slug": slug.current  },  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {    _id, firstName, lastName,    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"  }}
 export type ARTICLE_BY_SLUG_QUERY_RESULT = {
-  _id: string;
-  _updatedAt: string;
-  title: string | null;
-  slug: Slug | null;
-  publishAt: string | null;
-  featured: boolean | null;
-  tags: Array<string> | null;
+  id: string;
+  updatedAt: string;
+  title: string | "";
+  slug: string | "";
+  publishedAt: string | null;
+  featured: boolean | false;
+  tags: Array<string> | Array<never>;
   coverImageUrl: string | null;
   body: Array<
     | {
@@ -1054,10 +1061,10 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
       }
   > | null;
   relatedArticles: Array<{
-    _id: string;
-    title: string | null;
-    slug: Slug | null;
-    publishAt: string | null;
+    id: string;
+    title: string | "";
+    slug: string | "";
+    publishedAt: string | null;
     unpublishAt: string | null;
     coverImageUrl: string | null;
   }> | null;
@@ -1219,11 +1226,12 @@ export type JEUGD_LANDING_PAGE_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/page.repository.ts
 // Variable: PAGE_BY_SLUG_QUERY
-// Query: *[_type == "page" && slug.current == $slug][0] {  _id,  title,  slug,  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }}
+// Query: *[_type == "page" && slug.current == $slug][0] {  _id,  title,  slug,  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }}
 export type PAGE_BY_SLUG_QUERY_RESULT = {
   _id: string;
   title: string | null;
   slug: Slug | null;
+  heroImageUrl: string | null;
   body: Array<
     | {
         children?: Array<{
@@ -1456,6 +1464,18 @@ export type ORGANIGRAM_NODES_QUERY_RESULT = Array<{
 }>;
 
 // Source: ../web/src/lib/repositories/staff.repository.ts
+// Variable: KEY_CONTACTS_QUERY
+// Query: *[_type == "organigramNode" && active == true && roleCode in $roleCodes]{  title,  roleCode,  "members": members[@->archived != true && defined(@->email)]->{    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),    email  }}[count(members) > 0] | order(title asc)
+export type KEY_CONTACTS_QUERY_RESULT = Array<{
+  title: string | null;
+  roleCode: string | null;
+  members: Array<{
+    name: string | " ";
+    email: string | null;
+  }> | null;
+}>;
+
+// Source: ../web/src/lib/repositories/staff.repository.ts
 // Variable: STAFF_MEMBER_BY_PSD_ID_QUERY
 // Query: *[_type == "staffMember" && psdId == $psdId && archived != true][0] {  _id, psdId, firstName, lastName, email, phone, bio,  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max",  "organigramPositions": *[_type == "organigramNode" && ^._id in members[]._ref && active == true] | order(title asc, _id asc) { _id, title, roleCode, department },  "responsibilityPaths": *[_type == "responsibility" && active == true && defined(slug.current) && slug.current != "" && (primaryContact.staffMember._ref == ^._id || ^._id in steps[].contact.staffMember._ref)] | order(title asc, _id asc) { title, "slug": slug.current, category, icon }}
 export type STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT = {
@@ -1637,21 +1657,22 @@ export type TEAMS_LANDING_QUERY_RESULT = Array<{
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
-    '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }\n}': ARTICLES_QUERY_RESULT;
+    '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }\n}': ARTICLES_QUERY_RESULT;
     'array::unique(*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])': ARTICLE_TAGS_QUERY_RESULT;
-    '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
-    '*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  _id, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;
-    '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  _id, _updatedAt, title, slug, publishAt, featured, tags,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { _id, title, slug, publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
+    '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
+    '*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;
+    '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
     '*[_type == "event"] | order(dateStart asc) {\n  _id, title, dateStart, dateEnd, externalLink,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': EVENTS_QUERY_RESULT;
     '\n  coalesce(\n    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {\n      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    },\n    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {\n      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    }\n  )\n': NEXT_FEATURED_EVENT_QUERY_RESULT;
     '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;
     '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
-    '*[_type == "page" && slug.current == $slug][0] {\n  _id,\n  title,\n  slug,\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
+    '*[_type == "page" && slug.current == $slug][0] {\n  _id,\n  title,\n  slug,\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
     '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "responsibility" && active == true] | order(title asc) {\n  "id": slug.current,\n  "role": audience,\n  question,\n  keywords,\n  summary,\n  category,\n  icon,\n  "primaryContact": primaryContact {\n    "role": role,\n    "email": select(defined(staffMember) => staffMember->email, email),\n    "phone": select(defined(staffMember) => staffMember->phone, phone),\n    "department": select(defined(staffMember) => staffMember->department, department),\n    "name": select(\n      defined(staffMember) => staffMember->firstName + " " + staffMember->lastName,\n      null\n    ),\n    "memberId": staffMember->_id\n  },\n  "steps": steps[] {\n    description,\n    link,\n    "contact": select(defined(contact) => contact {\n      "role": role,\n      "email": select(defined(staffMember) => staffMember->email, email),\n      "phone": select(defined(staffMember) => staffMember->phone, phone),\n      "department": select(defined(staffMember) => staffMember->department, department),\n      "name": select(\n        defined(staffMember) => staffMember->firstName + " " + staffMember->lastName,\n        null\n      ),\n      "memberId": staffMember->_id\n    }, null)\n  },\n  "relatedPaths": coalesce(relatedPaths[]->slug.current, [])\n}': RESPONSIBILITY_PATHS_QUERY_RESULT;
     '*[_type == "sponsor" && active == true] | order(name asc) {\n  _id, name, url, type, tier, featured, description, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
     '*[_type == "organigramNode" && active == true] | order(coalesce(sortOrder, 9999) asc, title asc) {\n  _id,\n  title,\n  description,\n  roleCode,\n  department,\n  "parentId": select(defined(parentNode) && parentNode->active == true => parentNode->_id, null),\n  "members": members[@->archived != true]->{\n    "id": _id,\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    "imageUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",\n    email,\n    phone,\n    "psdId": psdId\n  }\n}': ORGANIGRAM_NODES_QUERY_RESULT;
+    '*[_type == "organigramNode" && active == true && roleCode in $roleCodes]{\n  title,\n  roleCode,\n  "members": members[@->archived != true && defined(@->email)]->{\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    email\n  }\n}[count(members) > 0] | order(title asc)': KEY_CONTACTS_QUERY_RESULT;
     '*[_type == "staffMember" && psdId == $psdId && archived != true][0] {\n  _id, psdId, firstName, lastName, email, phone, bio,\n  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "organigramPositions": *[_type == "organigramNode" && ^._id in members[]._ref && active == true] | order(title asc, _id asc) { _id, title, roleCode, department },\n  "responsibilityPaths": *[_type == "responsibility" && active == true && defined(slug.current) && slug.current != "" && (primaryContact.staffMember._ref == ^._id || ^._id in steps[].contact.staffMember._ref)] | order(title asc, _id asc) { title, "slug": slug.current, category, icon }\n}': STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] | order(lastName asc) {\n  _id, psdId\n}': STAFF_MEMBERS_PSDID_QUERY_RESULT;
     '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': TEAMS_QUERY_RESULT;

--- a/apps/web/src/types/search.ts
+++ b/apps/web/src/types/search.ts
@@ -10,7 +10,7 @@ export interface SearchResult {
   title: string;
   description?: string;
   url: string;
-  imageUrl?: string;
+  imageUrl?: string | null;
   tags?: string[];
   date?: string;
 }

--- a/docs/prd/repository-pipeline-simplification.md
+++ b/docs/prd/repository-pipeline-simplification.md
@@ -87,3 +87,6 @@ None. Repositories use Sanity typegen types, not Effect Schema.
 ## 8. Discovered Unknowns
 
 _(filled during implementation)_
+
+- [2026-04-02] Discovered: coalesce() in GROQ handles all null-coalescing cases including slug.current on missing slug → resolved inline (returns empty string)
+- [2026-04-02] Discovered: coverImageUrl null→undefined conversion cannot be done in GROQ — resolved by changing downstream consumers to accept string|null instead of string|undefined


### PR DESCRIPTION
Closes #1191

## What changed
- Moved field renaming (`_id→id`, `slug.current→slug`, `publishAt→publishedAt`) and null coalescing (`coalesce(title,"")`, `coalesce(featured,false)`, `coalesce(tags,[])`) into GROQ projections
- Removed `toArticleVM` transform function — `ArticleVM` is now a type alias for the typegen result
- Updated downstream consumers to accept `string|null` for `coverImageUrl` instead of `string|undefined`

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Verified GROQ projections return correct shapes via typegen (`sanity.types.ts` updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)