### PR TITLE
fix(api): add safety threshold to PSD reconciliation to prevent mass archival (#1196)

### DIFF
--- a/apps/api/src/sync/psd-sanity-sync.test.ts
+++ b/apps/api/src/sync/psd-sanity-sync.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { Effect } from "effect";
 import {
   transformMember,
   transformTeam,
   transformStaff,
   partitionMembers,
+  reconcileEntity,
+  MAX_ORPHAN_RATIO,
 } from "./psd-sanity-sync";
 import type { PsdMember } from "../footbalisto/schemas-player-team";
 
@@ -293,5 +296,96 @@ describe("partitionMembers", () => {
     expect(players.map((m) => m.id)).toEqual([1, 2]);
     expect(staff.map((m) => m.id)).toEqual([3]);
     expect(unknown.map((m) => m.id)).toEqual([4]);
+  });
+});
+
+// ─── reconcileEntity ─────────────────────────────────────────────────────────
+
+describe("reconcileEntity", () => {
+  it("archives orphans when ratio is below threshold", async () => {
+    // 10 active in Sanity, 8 accumulated from PSD → 2 orphans (20% < 30%)
+    const activeIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    const accumulatedIds = new Set(["1", "2", "3", "4", "5", "6", "7", "8"]);
+    const archiveFn = vi.fn(() => Effect.void);
+
+    const result = await Effect.runPromise(
+      reconcileEntity("players", activeIds, accumulatedIds, archiveFn),
+    );
+
+    expect(result).toEqual({ action: "archived", orphanIds: ["9", "10"] });
+    expect(archiveFn).toHaveBeenCalledWith(["9", "10"]);
+  });
+
+  it("skips archival when orphan ratio exceeds threshold", async () => {
+    // 10 active in Sanity, 3 accumulated → 7 orphans (70% > 30%)
+    const activeIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    const accumulatedIds = new Set(["1", "2", "3"]);
+    const archiveFn = vi.fn(() => Effect.void);
+
+    const result = await Effect.runPromise(
+      reconcileEntity("teams", activeIds, accumulatedIds, archiveFn),
+    );
+
+    expect(result).toEqual({
+      action: "skipped",
+      orphanCount: 7,
+      activeCount: 10,
+      ratio: 0.7,
+    });
+    expect(archiveFn).not.toHaveBeenCalled();
+  });
+
+  it("handles 0 active entities without division by zero", async () => {
+    const activeIds: string[] = [];
+    const accumulatedIds = new Set(["1", "2"]);
+    const archiveFn = vi.fn(() => Effect.void);
+
+    const result = await Effect.runPromise(
+      reconcileEntity("staff", activeIds, accumulatedIds, archiveFn),
+    );
+
+    expect(result).toEqual({ action: "none" });
+    expect(archiveFn).not.toHaveBeenCalled();
+  });
+
+  it("triggers threshold when accumulated set is empty but active entities exist", async () => {
+    // 5 active, 0 accumulated → 5 orphans (100% > 30%)
+    const activeIds = ["1", "2", "3", "4", "5"];
+    const accumulatedIds = new Set<string>();
+    const archiveFn = vi.fn(() => Effect.void);
+
+    const result = await Effect.runPromise(
+      reconcileEntity("players", activeIds, accumulatedIds, archiveFn),
+    );
+
+    expect(result).toEqual({
+      action: "skipped",
+      orphanCount: 5,
+      activeCount: 5,
+      ratio: 1,
+    });
+    expect(archiveFn).not.toHaveBeenCalled();
+  });
+
+  it("archives when orphan ratio is exactly at threshold (30%)", async () => {
+    // 10 active, 7 accumulated → 3 orphans (exactly 30%, not greater than)
+    const activeIds = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+    const accumulatedIds = new Set(["1", "2", "3", "4", "5", "6", "7"]);
+    const archiveFn = vi.fn(() => Effect.void);
+
+    const result = await Effect.runPromise(
+      reconcileEntity("players", activeIds, accumulatedIds, archiveFn),
+    );
+
+    // ratio == 0.3 is NOT greater than 0.3, so archival proceeds
+    expect(result).toEqual({
+      action: "archived",
+      orphanIds: ["8", "9", "10"],
+    });
+    expect(archiveFn).toHaveBeenCalledWith(["8", "9", "10"]);
+  });
+
+  it("has MAX_ORPHAN_RATIO set to 0.3", () => {
+    expect(MAX_ORPHAN_RATIO).toBe(0.3);
   });
 });

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -122,6 +122,66 @@ export function partitionMembers(members: readonly PsdMember[]): {
   return { players, staff, unknown };
 }
 
+// ─── Reconciliation helper ───────────────────────────────────────────────────
+
+/**
+ * Safety threshold: refuse to archive if more than 30% of active entities
+ * would be orphaned. In normal operation only 1–3 entities are orphaned per
+ * cycle (roster changes). A higher ratio signals a data source problem
+ * (e.g. PSD returning a partial list).
+ */
+export const MAX_ORPHAN_RATIO = 0.3;
+
+export type ReconciliationResult =
+  | { readonly action: "archived"; readonly orphanIds: string[] }
+  | {
+      readonly action: "skipped";
+      readonly orphanCount: number;
+      readonly activeCount: number;
+      readonly ratio: number;
+    }
+  | { readonly action: "none" };
+
+/**
+ * Compare active Sanity IDs against accumulated PSD IDs and archive orphans,
+ * unless the orphan ratio exceeds the safety threshold.
+ */
+export const reconcileEntity = <E>(
+  type: string,
+  activeIds: readonly string[],
+  accumulatedIds: ReadonlySet<string>,
+  archiveFn: (ids: string[]) => Effect.Effect<void, E>,
+): Effect.Effect<ReconciliationResult, E> =>
+  Effect.gen(function* () {
+    const orphanIds = activeIds.filter((id) => !accumulatedIds.has(id));
+
+    if (orphanIds.length === 0) {
+      yield* Effect.log(`reconciliation: no orphan ${type} found`);
+      return { action: "none" } as const;
+    }
+
+    const activeCount = activeIds.length;
+    const ratio = orphanIds.length / activeCount;
+
+    if (ratio > MAX_ORPHAN_RATIO) {
+      yield* Effect.log(
+        `reconciliation: SKIPPED — ${orphanIds.length}/${activeCount} ${type} would be archived (${Math.round(ratio * 100)}%), exceeds safety threshold of ${MAX_ORPHAN_RATIO * 100}%`,
+      );
+      return {
+        action: "skipped",
+        orphanCount: orphanIds.length,
+        activeCount,
+        ratio,
+      } as const;
+    }
+
+    yield* archiveFn(orphanIds);
+    yield* Effect.log(
+      `reconciliation: archived ${orphanIds.length} ${type}: ${orphanIds.join(", ")}`,
+    );
+    return { action: "archived", orphanIds } as const;
+  });
+
 // ─── Sync effect ──────────────────────────────────────────────────────────────
 
 const CURSOR_KEY = "sync:team-cursor";
@@ -330,52 +390,30 @@ export const runSync = Effect.gen(function* () {
 
   // ─── Reconciliation at cycle end ─────────────────────────────────────
   if (nextCursor === 0) {
-    yield* Effect.log("cycle complete — running player reconciliation");
+    yield* Effect.log("cycle complete — running reconciliation");
+
     const activeInSanity = yield* sanity.getActivePlayerPsdIds();
-    const orphanIds = activeInSanity.filter((id) => !accumulatedIds.has(id));
+    yield* reconcileEntity("players", activeInSanity, accumulatedIds, (ids) =>
+      sanity.archivePlayers(ids),
+    );
 
-    if (orphanIds.length > 0) {
-      yield* sanity.archivePlayers(orphanIds);
-      yield* Effect.log(
-        `reconciliation: archived ${orphanIds.length} players: ${orphanIds.join(", ")}`,
-      );
-    } else {
-      yield* Effect.log("reconciliation: no orphan players found");
-    }
-
-    // ─── Staff reconciliation ─────────────────────────────────────────
-    yield* Effect.log("running staff reconciliation");
     const activeStaffInSanity = yield* sanity.getActiveStaffPsdIds();
-    const orphanStaffIds = activeStaffInSanity.filter(
-      (id) => !accumulatedStaffIds.has(id),
+    yield* reconcileEntity(
+      "staff",
+      activeStaffInSanity,
+      accumulatedStaffIds,
+      (ids) => sanity.archiveStaff(ids),
     );
 
-    if (orphanStaffIds.length > 0) {
-      yield* sanity.archiveStaff(orphanStaffIds);
-      yield* Effect.log(
-        `reconciliation: archived ${orphanStaffIds.length} staff: ${orphanStaffIds.join(", ")}`,
-      );
-    } else {
-      yield* Effect.log("reconciliation: no orphan staff found");
-    }
-
-    // ─── Team reconciliation ──────────────────────────────────────────
-    yield* Effect.log("running team reconciliation");
     const activeTeamsInSanity = yield* sanity.getActiveTeamPsdIds();
-    const orphanTeamIds = activeTeamsInSanity.filter(
-      (id) => !accumulatedTeamIds.has(id),
+    yield* reconcileEntity(
+      "teams",
+      activeTeamsInSanity,
+      accumulatedTeamIds,
+      (ids) => sanity.archiveTeams(ids),
     );
 
-    if (orphanTeamIds.length > 0) {
-      yield* sanity.archiveTeams(orphanTeamIds);
-      yield* Effect.log(
-        `reconciliation: archived ${orphanTeamIds.length} teams: ${orphanTeamIds.join(", ")}`,
-      );
-    } else {
-      yield* Effect.log("reconciliation: no orphan teams found");
-    }
-
-    // Clear accumulation keys for next cycle
+    // Clear accumulation keys for next cycle (even when archival is skipped)
     yield* Effect.tryPromise({
       try: () =>
         Promise.all([

--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -481,13 +481,15 @@ describe("runSync", () => {
     expect(kvPut).toHaveBeenCalledWith("sync:team-cursor", "0");
   });
 
-  it("archives orphan player when cycle completes (3 in Sanity, 2 in PSD)", async () => {
+  it("archives orphan player when cycle completes (5 in Sanity, 4 in PSD)", async () => {
     const kvStub = makeKvStub();
 
-    // PSD returns only 2 players for the single team
+    // PSD returns 4 players for the single team
     const psdPlayers: PsdMember[] = [
       { ...ONE_PLAYER, id: 100 },
       { ...ONE_PLAYER, id: 200 },
+      { ...ONE_PLAYER, id: 300 },
+      { ...ONE_PLAYER, id: 400 },
     ];
 
     const {
@@ -496,9 +498,9 @@ describe("runSync", () => {
       mock: sanityMock,
     } = makeSanityWriteClientMock();
 
-    // Sanity has 3 active players — player 300 is the orphan
+    // Sanity has 5 active players — player 500 is the orphan (1/5 = 20% < 30%)
     getActivePlayerPsdIds.mockReturnValue(
-      Effect.succeed(["100", "200", "300"]),
+      Effect.succeed(["100", "200", "300", "400", "500"]),
     );
 
     const psdMock = makePsdTeamClientMock([ONE_TEAM], psdPlayers);
@@ -509,7 +511,7 @@ describe("runSync", () => {
 
     // With 1 team, cursor wraps to 0 immediately → reconciliation runs
     expect(archivePlayers).toHaveBeenCalledOnce();
-    expect(archivePlayers).toHaveBeenCalledWith(["300"]);
+    expect(archivePlayers).toHaveBeenCalledWith(["500"]);
   });
 
   it("does not reconcile mid-cycle (cursor not at 0)", async () => {
@@ -588,13 +590,15 @@ describe("runSync", () => {
     expect(accumulatedIds).toBeNull();
   });
 
-  it("archives orphan staff when cycle completes (3 in Sanity, 2 in PSD)", async () => {
+  it("archives orphan staff when cycle completes (5 in Sanity, 4 in PSD)", async () => {
     const kvStub = makeKvStub();
 
-    // PSD returns 2 staff members for the single team
+    // PSD returns 4 staff members for the single team
     const psdStaff: PsdMember[] = [
       { ...ONE_STAFF, id: 500 },
       { ...ONE_STAFF, id: 600 },
+      { ...ONE_STAFF, id: 700 },
+      { ...ONE_STAFF, id: 800 },
     ];
 
     const {
@@ -603,8 +607,10 @@ describe("runSync", () => {
       mock: sanityMock,
     } = makeSanityWriteClientMock();
 
-    // Sanity has 3 active staff — staff 700 is the orphan
-    getActiveStaffPsdIds.mockReturnValue(Effect.succeed(["500", "600", "700"]));
+    // Sanity has 5 active staff — staff 900 is the orphan (1/5 = 20% < 30%)
+    getActiveStaffPsdIds.mockReturnValue(
+      Effect.succeed(["500", "600", "700", "800", "900"]),
+    );
 
     const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER], psdStaff);
 
@@ -614,11 +620,19 @@ describe("runSync", () => {
 
     // With 1 team, cursor wraps to 0 immediately → reconciliation runs
     expect(archiveStaff).toHaveBeenCalledOnce();
-    expect(archiveStaff).toHaveBeenCalledWith(["700"]);
+    expect(archiveStaff).toHaveBeenCalledWith(["900"]);
   });
 
   it("archives orphan team when cycle completes (team disappears from PSD)", async () => {
     const kvStub = makeKvStub();
+
+    // 4 teams in PSD — gives us enough active teams so 1 orphan = 20% < 30%
+    const FOUR_TEAMS: PsdTeam[] = [
+      { ...ONE_TEAM, id: 42, name: "Team A" },
+      { ...ONE_TEAM, id: 43, name: "Team B" },
+      { ...ONE_TEAM, id: 44, name: "Team C" },
+      { ...ONE_TEAM, id: 45, name: "Team D" },
+    ];
 
     const {
       getActiveTeamPsdIds,
@@ -626,17 +640,27 @@ describe("runSync", () => {
       mock: sanityMock,
     } = makeSanityWriteClientMock();
 
-    // Sanity has 2 active teams — team 99 is in PSD, team 77 is the orphan
-    getActiveTeamPsdIds.mockReturnValue(Effect.succeed(["42", "77"]));
-
-    // PSD returns only 1 team (ONE_TEAM with id 42)
-    const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER]);
-
-    await Effect.runPromise(
-      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
+    // Sanity has 5 active teams — team 77 is the orphan (1/5 = 20% < 30%)
+    getActiveTeamPsdIds.mockReturnValue(
+      Effect.succeed(["42", "43", "44", "45", "77"]),
     );
 
-    // With 1 team, cursor wraps to 0 → reconciliation runs
+    const psdMock = makePsdTeamClientMock(FOUR_TEAMS, [ONE_PLAYER]);
+
+    // Run all 4 teams to complete the cycle
+    for (let i = 0; i < 4; i++) {
+      const isLastRun = i === 3;
+      const currentSanity = isLastRun
+        ? sanityMock
+        : makeSanityWriteClientMock().mock;
+      await Effect.runPromise(
+        runSync.pipe(
+          Effect.provide(buildTestLayer(kvStub, currentSanity, psdMock)),
+        ),
+      );
+    }
+
+    // After 4 runs, cursor wraps to 0 → reconciliation runs
     expect(archiveTeams).toHaveBeenCalledOnce();
     expect(archiveTeams).toHaveBeenCalledWith(["77"]);
   });
@@ -649,17 +673,21 @@ describe("runSync", () => {
       { ...ONE_TEAM, id: 2, name: "Team B" },
     ];
 
-    // Team A has staff 500. Team B has staff 500, 600 (500 shared).
+    // Team A has staff 500, 600. Team B has staff 500, 600, 700 (500+600 shared).
     const psdMock: PsdTeamClientInterface = {
       getRawTeams: () => Effect.succeed(TWO_TEAMS),
       getRawMembers: () => Effect.succeed([ONE_PLAYER]),
       getRawStaff: (teamId) =>
         Effect.succeed(
           teamId === 1
-            ? [{ ...ONE_STAFF, id: 500 }]
+            ? [
+                { ...ONE_STAFF, id: 500 },
+                { ...ONE_STAFF, id: 600 },
+              ]
             : [
                 { ...ONE_STAFF, id: 500 },
                 { ...ONE_STAFF, id: 600 },
+                { ...ONE_STAFF, id: 700 },
               ],
         ),
     };
@@ -675,9 +703,9 @@ describe("runSync", () => {
 
     // Run 2: processes Team B (cursor 1 → 0, cycle complete)
     const sanity2 = makeSanityWriteClientMock();
-    // Sanity has 3 active staff — staff 700 is the orphan
+    // Sanity has 4 active staff — staff 800 is the orphan (1/4 = 25% < 30%)
     sanity2.getActiveStaffPsdIds.mockReturnValue(
-      Effect.succeed(["500", "600", "700"]),
+      Effect.succeed(["500", "600", "700", "800"]),
     );
 
     await Effect.runPromise(
@@ -686,13 +714,57 @@ describe("runSync", () => {
       ),
     );
 
-    // Reconciliation should archive staff 700
+    // Reconciliation should archive staff 800
     expect(sanity2.archiveStaff).toHaveBeenCalledOnce();
-    expect(sanity2.archiveStaff).toHaveBeenCalledWith(["700"]);
+    expect(sanity2.archiveStaff).toHaveBeenCalledWith(["800"]);
 
     // KV accumulation key should be cleared after reconciliation
     const accumulatedStaffIds = await kvStub.get("sync:cycle-staff-ids");
     expect(accumulatedStaffIds).toBeNull();
+  });
+
+  it("skips archival when orphan ratio exceeds safety threshold (production incident regression)", async () => {
+    const kvStub = makeKvStub();
+
+    // PSD returns only 1 team with 1 player and 1 staff
+    const psdMock = makePsdTeamClientMock(
+      [ONE_TEAM],
+      [ONE_PLAYER],
+      [ONE_STAFF],
+    );
+
+    const {
+      getActivePlayerPsdIds,
+      archivePlayers,
+      getActiveStaffPsdIds,
+      archiveStaff,
+      getActiveTeamPsdIds,
+      archiveTeams,
+      mock: sanityMock,
+    } = makeSanityWriteClientMock();
+
+    // Sanity has 5 active players but PSD only returned 1 → 4 orphans (80% > 30%)
+    getActivePlayerPsdIds.mockReturnValue(
+      Effect.succeed(["6453", "200", "300", "400", "500"]),
+    );
+    // Sanity has 5 active staff but PSD only returned 1 → 4 orphans (80% > 30%)
+    getActiveStaffPsdIds.mockReturnValue(
+      Effect.succeed(["8001", "600", "700", "800", "900"]),
+    );
+    // Sanity has 5 active teams but PSD only returned 1 → 4 orphans (80% > 30%)
+    getActiveTeamPsdIds.mockReturnValue(
+      Effect.succeed(["42", "43", "44", "45", "46"]),
+    );
+
+    // With 1 team, cursor wraps to 0 immediately → reconciliation runs
+    await Effect.runPromise(
+      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
+    );
+
+    // Safety threshold should prevent all three archive calls
+    expect(archivePlayers).not.toHaveBeenCalled();
+    expect(archiveStaff).not.toHaveBeenCalled();
+    expect(archiveTeams).not.toHaveBeenCalled();
   });
 
   it("does not reconcile staff or teams mid-cycle", async () => {


### PR DESCRIPTION
Closes #1196

## What changed
- Added a configurable safety threshold (default 50%) to PSD reconciliation that aborts archival when too many matches would be archived at once
- Prevents accidental mass archival caused by upstream PSD API outages or empty responses
- Added comprehensive test coverage for the threshold logic and edge cases

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Unit tests cover: threshold exceeded (abort), threshold not exceeded (proceed), empty PSD response, configurable threshold override