### PR TITLE
refactor(api): extract SanityProjection from SanityWriteClient (#1187)

### DIFF
--- a/apps/api/src/footbalisto/fetch-json.test.ts
+++ b/apps/api/src/footbalisto/fetch-json.test.ts
@@ -5,9 +5,9 @@ import { WorkerEnvTag } from "../env";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { UpstreamUnavailableError } from "./errors";
 import {
-  SanityWriteClient,
-  type SanityWriteClientInterface,
-} from "../sanity/client";
+  SanityProjection,
+  type SanityProjectionInterface,
+} from "../sanity/projection";
 
 global.fetch = vi.fn();
 
@@ -35,20 +35,12 @@ const cacheMock: KvCacheInterface = {
   increment: () => Effect.succeed(undefined),
 };
 
-const sanityMock: SanityWriteClientInterface = {
-  upsertPlayer: () => Effect.succeed(undefined as void),
-  upsertTeam: () => Effect.succeed(undefined as void),
-  upsertStaff: () => Effect.succeed(undefined as void),
-  uploadPlayerImage: () => Effect.succeed(undefined as void),
+const projectionMock: SanityProjectionInterface = {
+  getVisibleTeamPsdIds: () => Effect.succeed([]),
   getPlayersImageState: () => Effect.succeed(new Map()),
   getActivePlayerPsdIds: () => Effect.succeed([]),
-  archivePlayers: () => Effect.succeed(undefined as void),
   getActiveStaffPsdIds: () => Effect.succeed([]),
-  archiveStaff: () => Effect.succeed(undefined as void),
   getActiveTeamPsdIds: () => Effect.succeed([]),
-  archiveTeams: () => Effect.succeed(undefined as void),
-  writeFeedback: () => Effect.succeed(undefined as void),
-  getVisibleTeamPsdIds: () => Effect.succeed([]),
 };
 
 const seasons = [
@@ -76,7 +68,7 @@ function runGetTeamMatches(teamId: number) {
         Effect.provide(FootbalistoServiceLive),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
-        Effect.provide(Layer.succeed(SanityWriteClient, sanityMock)),
+        Effect.provide(Layer.succeed(SanityProjection, projectionMock)),
       ),
     ),
   );

--- a/apps/api/src/footbalisto/opponent.test.ts
+++ b/apps/api/src/footbalisto/opponent.test.ts
@@ -6,9 +6,9 @@ import { UpstreamUnavailableError, type BffError } from "./errors";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import {
-  SanityWriteClient,
-  type SanityWriteClientInterface,
-} from "../sanity/client";
+  SanityProjection,
+  type SanityProjectionInterface,
+} from "../sanity/projection";
 
 global.fetch = vi.fn();
 
@@ -36,20 +36,12 @@ const cacheMock: KvCacheInterface = {
   increment: () => Effect.succeed(undefined),
 };
 
-const sanityClientMock: SanityWriteClientInterface = {
-  upsertPlayer: () => Effect.succeed(undefined),
-  upsertTeam: () => Effect.succeed(undefined),
-  upsertStaff: () => Effect.succeed(undefined),
+const projectionMock: SanityProjectionInterface = {
+  getVisibleTeamPsdIds: () => Effect.succeed([]),
   getPlayersImageState: () => Effect.succeed(new Map()),
   getActivePlayerPsdIds: () => Effect.succeed([]),
-  archivePlayers: () => Effect.succeed(undefined),
   getActiveStaffPsdIds: () => Effect.succeed([]),
-  archiveStaff: () => Effect.succeed(undefined),
   getActiveTeamPsdIds: () => Effect.succeed([]),
-  archiveTeams: () => Effect.succeed(undefined),
-  uploadPlayerImage: () => Effect.succeed(undefined),
-  writeFeedback: () => Effect.succeed(undefined),
-  getVisibleTeamPsdIds: () => Effect.succeed([]),
 };
 
 function runService<A>(
@@ -67,7 +59,7 @@ function runService<A>(
         Effect.provide(FootbalistoServiceLive),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
-        Effect.provide(Layer.succeed(SanityWriteClient, sanityClientMock)),
+        Effect.provide(Layer.succeed(SanityProjection, projectionMock)),
       ),
     ),
   );

--- a/apps/api/src/footbalisto/service.test.ts
+++ b/apps/api/src/footbalisto/service.test.ts
@@ -11,9 +11,9 @@ import { UpstreamUnavailableError, type BffError } from "./errors";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import {
-  SanityWriteClient,
-  type SanityWriteClientInterface,
-} from "../sanity/client";
+  SanityProjection,
+  type SanityProjectionInterface,
+} from "../sanity/projection";
 
 global.fetch = vi.fn();
 
@@ -41,23 +41,15 @@ const cacheMock: KvCacheInterface = {
   increment: () => Effect.succeed(undefined),
 };
 
-function makeSanityMock(
+function makeProjectionMock(
   visiblePsdIds: string[] = ["1"],
-): SanityWriteClientInterface {
+): SanityProjectionInterface {
   return {
-    upsertPlayer: () => Effect.succeed(undefined as void),
-    upsertTeam: () => Effect.succeed(undefined as void),
-    upsertStaff: () => Effect.succeed(undefined as void),
-    uploadPlayerImage: () => Effect.succeed(undefined as void),
+    getVisibleTeamPsdIds: () => Effect.succeed(visiblePsdIds),
     getPlayersImageState: () => Effect.succeed(new Map()),
     getActivePlayerPsdIds: () => Effect.succeed([]),
-    archivePlayers: () => Effect.succeed(undefined as void),
     getActiveStaffPsdIds: () => Effect.succeed([]),
-    archiveStaff: () => Effect.succeed(undefined as void),
     getActiveTeamPsdIds: () => Effect.succeed([]),
-    archiveTeams: () => Effect.succeed(undefined as void),
-    writeFeedback: () => Effect.succeed(undefined as void),
-    getVisibleTeamPsdIds: () => Effect.succeed(visiblePsdIds),
   };
 }
 
@@ -143,11 +135,11 @@ function runService<A>(
     svc: (typeof FootbalistoService)["Service"],
   ) => Effect.Effect<A, BffError>,
   options: {
-    sanityMock?: SanityWriteClientInterface;
+    projectionMock?: SanityProjectionInterface;
     kvMock?: KvCacheInterface;
   } = {},
 ) {
-  const sanity = options.sanityMock ?? makeSanityMock();
+  const projection = options.projectionMock ?? makeProjectionMock();
   const kv = options.kvMock ?? cacheMock;
   const program = Effect.gen(function* () {
     const service = yield* FootbalistoService;
@@ -159,7 +151,7 @@ function runService<A>(
         Effect.provide(FootbalistoServiceLive),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, kv)),
-        Effect.provide(Layer.succeed(SanityWriteClient, sanity)),
+        Effect.provide(Layer.succeed(SanityProjection, projection)),
       ),
     ),
   );
@@ -520,9 +512,9 @@ describe("FootbalistoService.getNextMatches", () => {
     });
 
     // Only team 1 is visible in Sanity (team 2 and 23 excluded)
-    const sanityMock = makeSanityMock(["1"]);
+    const projectionMock = makeProjectionMock(["1"]);
     const result = await runService((svc) => svc.getNextMatches(), {
-      sanityMock,
+      projectionMock,
     });
 
     expect(result._tag).toBe("Right");
@@ -564,9 +556,9 @@ describe("FootbalistoService.getNextMatches", () => {
       increment: () => Effect.succeed(undefined),
     };
 
-    const sanityMock = makeSanityMock(["1"]);
+    const projectionMock = makeProjectionMock(["1"]);
     await runService((svc) => svc.getNextMatches(), {
-      sanityMock,
+      projectionMock,
       kvMock: trackingKv,
     });
 
@@ -602,8 +594,8 @@ describe("FootbalistoService.getNextMatches", () => {
     };
 
     let sanityCallCount = 0;
-    const spySanityMock: SanityWriteClientInterface = {
-      ...makeSanityMock(["1"]),
+    const spyProjectionMock: SanityProjectionInterface = {
+      ...makeProjectionMock(["1"]),
       getVisibleTeamPsdIds: () => {
         sanityCallCount++;
         return Effect.succeed(["1"]);
@@ -611,7 +603,7 @@ describe("FootbalistoService.getNextMatches", () => {
     };
 
     await runService((svc) => svc.getNextMatches(), {
-      sanityMock: spySanityMock,
+      projectionMock: spyProjectionMock,
       kvMock: hitKv,
     });
 
@@ -869,7 +861,7 @@ describe("FootbalistoService.getRanking", () => {
         Effect.provide(FootbalistoServiceLive),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
-        Effect.provide(Layer.succeed(SanityWriteClient, makeSanityMock())),
+        Effect.provide(Layer.succeed(SanityProjection, makeProjectionMock())),
         Effect.provide(Logger.replace(Logger.defaultLogger, TestLogger)),
       ),
     );

--- a/apps/api/src/footbalisto/service.ts
+++ b/apps/api/src/footbalisto/service.ts
@@ -1,7 +1,7 @@
 import { Context, Effect, Layer, Option, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService } from "../cache/kv-cache";
-import { SanityWriteClient } from "../sanity/client";
+import { SanityProjection } from "../sanity/projection";
 import {
   UpstreamUnavailableError,
   UpstreamClientError,
@@ -617,7 +617,7 @@ export const FootbalistoServiceLive = Layer.effect(
   Effect.gen(function* () {
     const env = yield* WorkerEnvTag;
     const cache = yield* KvCacheService;
-    const sanityClient = yield* SanityWriteClient;
+    const sanityProjection = yield* SanityProjection;
     const base = env.PSD_API_BASE_URL;
 
     const psdHeaders = {
@@ -702,7 +702,7 @@ export const FootbalistoServiceLive = Layer.effect(
             return parsed.value as string[];
           }
         }
-        const ids = yield* sanityClient
+        const ids = yield* sanityProjection
           .getVisibleTeamPsdIds()
           .pipe(
             Effect.catchAll((e) =>

--- a/apps/api/src/handlers/feedback.test.ts
+++ b/apps/api/src/handlers/feedback.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect";
 import {
   SanityWriteClient,
   type SanityWriteClientInterface,
-  SanityWriteError,
+  SanityError,
 } from "../sanity/client";
 import { handleFeedback } from "./feedback";
 
@@ -14,16 +14,11 @@ function makeSanityMock(
     upsertPlayer: () => Effect.succeed(undefined),
     upsertTeam: () => Effect.succeed(undefined),
     upsertStaff: () => Effect.succeed(undefined),
-    getPlayersImageState: () => Effect.succeed(new Map()),
     uploadPlayerImage: () => Effect.succeed(undefined),
-    getActivePlayerPsdIds: () => Effect.succeed([]),
     archivePlayers: () => Effect.succeed(undefined),
-    getActiveStaffPsdIds: () => Effect.succeed([]),
     archiveStaff: () => Effect.succeed(undefined),
-    getActiveTeamPsdIds: () => Effect.succeed([]),
     archiveTeams: () => Effect.succeed(undefined),
     writeFeedback: writeFeedbackImpl ?? (() => Effect.succeed(undefined)),
-    getVisibleTeamPsdIds: () => Effect.succeed([]),
   };
 }
 
@@ -52,9 +47,9 @@ describe("handleFeedback", () => {
     });
   });
 
-  it("propagates SanityWriteError as die", async () => {
+  it("propagates SanityError as die", async () => {
     const mock = makeSanityMock(() =>
-      Effect.fail(new SanityWriteError("Sanity is down")),
+      Effect.fail(new SanityError("Sanity is down")),
     );
     const layer = Layer.succeed(SanityWriteClient, mock);
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -31,6 +31,7 @@ import { VectorizeServiceLive } from "./search/vectorize";
 import { AiAnswerServiceLive } from "./search/ai-answer";
 import { runSanityIndexSync } from "./search/sanity-index-sync";
 import { SanityWriteClientLive } from "./sanity/client";
+import { SanityProjectionLive } from "./sanity/projection";
 import { runSync } from "./sync/psd-sanity-sync";
 import { handleIndexWebhook } from "./webhooks/index-handler";
 
@@ -63,6 +64,7 @@ function buildAppLayer(env: WorkerEnv) {
     Layer.provide(VectorizeServiceLive),
     Layer.provide(AiAnswerServiceLive),
     Layer.provide(FootbalistoServiceLive),
+    Layer.provide(SanityProjectionLive),
     Layer.provide(SanityWriteClientLive),
     Layer.provide(KvCacheLive),
     Layer.provide(Layer.succeed(WorkerEnvTag, env)),
@@ -131,6 +133,7 @@ export default {
       const layer = Layer.mergeAll(
         PsdTeamClientLive,
         SanityWriteClientLive,
+        SanityProjectionLive,
         envLayer,
       ).pipe(Layer.provide(KvCacheLive), Layer.provide(envLayer));
       ctx.waitUntil(

--- a/apps/api/src/sanity/client.ts
+++ b/apps/api/src/sanity/client.ts
@@ -35,14 +35,14 @@ export interface SanityStaffDoc {
 
 // ─── Error ────────────────────────────────────────────────────────────────────
 
-export class SanityWriteError extends Error {
-  readonly _tag = "SanityWriteError" as const;
+export class SanityError extends Error {
+  readonly _tag = "SanityError" as const;
   constructor(
     message: string,
     readonly cause?: unknown,
   ) {
     super(message);
-    this.name = "SanityWriteError";
+    this.name = "SanityError";
   }
 }
 
@@ -56,42 +56,19 @@ export interface PlayerImageState {
 export interface SanityWriteClientInterface {
   readonly upsertPlayer: (
     doc: SanityPlayerDoc,
-  ) => Effect.Effect<void, SanityWriteError>;
-  readonly upsertTeam: (
-    doc: SanityTeamDoc,
-  ) => Effect.Effect<void, SanityWriteError>;
+  ) => Effect.Effect<void, SanityError>;
+  readonly upsertTeam: (doc: SanityTeamDoc) => Effect.Effect<void, SanityError>;
   readonly upsertStaff: (
     doc: SanityStaffDoc,
-  ) => Effect.Effect<void, SanityWriteError>;
-  /** Fetch existing psdImageUrl + psdImage presence for all player docs. */
-  readonly getPlayersImageState: () => Effect.Effect<
-    Map<string, PlayerImageState>,
-    SanityWriteError
-  >;
-  /** Fetch PSD IDs of all non-archived players. */
-  readonly getActivePlayerPsdIds: () => Effect.Effect<
-    string[],
-    SanityWriteError
-  >;
+  ) => Effect.Effect<void, SanityError>;
   /** Set archived: true on players with these PSD IDs. */
   readonly archivePlayers: (
     psdIds: string[],
-  ) => Effect.Effect<void, SanityWriteError>;
-  /** Fetch PSD IDs of all non-archived staff members. */
-  readonly getActiveStaffPsdIds: () => Effect.Effect<
-    string[],
-    SanityWriteError
-  >;
+  ) => Effect.Effect<void, SanityError>;
   /** Set archived: true on staff members with these PSD IDs. */
-  readonly archiveStaff: (
-    psdIds: string[],
-  ) => Effect.Effect<void, SanityWriteError>;
-  /** Fetch PSD IDs of all non-archived teams. */
-  readonly getActiveTeamPsdIds: () => Effect.Effect<string[], SanityWriteError>;
+  readonly archiveStaff: (psdIds: string[]) => Effect.Effect<void, SanityError>;
   /** Set archived: true on teams with these PSD IDs. */
-  readonly archiveTeams: (
-    psdIds: string[],
-  ) => Effect.Effect<void, SanityWriteError>;
+  readonly archiveTeams: (psdIds: string[]) => Effect.Effect<void, SanityError>;
   /** Download image from fetchUrl and upload to Sanity, patching psdImage + psdImageUrl.
    * stableUrl is persisted as psdImageUrl for dedup on future syncs — must match
    * the value produced by transformMember._psdImageUrl (includes ?v=N if present). */
@@ -99,18 +76,13 @@ export interface SanityWriteClientInterface {
     psdId: string,
     fetchUrl: string,
     stableUrl: string,
-  ) => Effect.Effect<void, SanityWriteError>;
+  ) => Effect.Effect<void, SanityError>;
   /** Create a searchFeedback document in Sanity. */
   readonly writeFeedback: (doc: {
     pathSlug: string;
     pathTitle: string;
     vote: "up" | "down";
-  }) => Effect.Effect<void, SanityWriteError>;
-  /** Fetch PSD IDs of all teams where showInNavigation is not false. */
-  readonly getVisibleTeamPsdIds: () => Effect.Effect<
-    string[],
-    SanityWriteError
-  >;
+  }) => Effect.Effect<void, SanityError>;
 }
 
 export class SanityWriteClient extends Context.Tag("SanityWriteClient")<
@@ -151,7 +123,7 @@ export const SanityWriteClientLive = Layer.effect(
           await tx.commit();
         },
         catch: (cause) =>
-          new SanityWriteError(`Failed to archive ${type} documents`, cause),
+          new SanityError(`Failed to archive ${type} documents`, cause),
       }).pipe(Effect.asVoid);
 
     const upsert = <T extends Record<string, unknown>>(
@@ -167,7 +139,7 @@ export const SanityWriteClientLive = Layer.effect(
             .patch(docId(type, psdId), (p) => p.set(psdFields))
             .commit(),
         catch: (cause) =>
-          new SanityWriteError(`Failed to upsert ${type} ${psdId}`, cause),
+          new SanityError(`Failed to upsert ${type} ${psdId}`, cause),
       }).pipe(Effect.asVoid);
 
     return {
@@ -183,29 +155,6 @@ export const SanityWriteClientLive = Layer.effect(
           archived: false,
         }),
 
-      getPlayersImageState: () =>
-        Effect.tryPromise({
-          try: async () => {
-            const rows = await client.fetch<
-              Array<{
-                psdId: string;
-                psdImageUrl: string | null;
-                hasPsdImage: boolean;
-              }>
-            >(
-              `*[_type == "player"] { psdId, psdImageUrl, "hasPsdImage": defined(psdImage) }`,
-            );
-            return new Map(
-              rows.map((r) => [
-                r.psdId,
-                { psdImageUrl: r.psdImageUrl, hasPsdImage: r.hasPsdImage },
-              ]),
-            );
-          },
-          catch: (cause) =>
-            new SanityWriteError("Failed to fetch player image state", cause),
-        }),
-
       uploadPlayerImage: (psdId, imageUrl, stableUrl) =>
         Effect.gen(function* () {
           // Validate imageUrl before attaching PSD credentials
@@ -214,7 +163,7 @@ export const SanityWriteClientLive = Layer.effect(
             parsedUrl = new URL(imageUrl);
           } catch {
             return yield* Effect.fail(
-              new SanityWriteError(`Invalid image URL: ${imageUrl}`),
+              new SanityError(`Invalid image URL: ${imageUrl}`),
             );
           }
           const expectedHost = new URL(env.PSD_IMAGE_BASE_URL).hostname;
@@ -223,7 +172,7 @@ export const SanityWriteClientLive = Layer.effect(
             parsedUrl.hostname !== expectedHost
           ) {
             return yield* Effect.fail(
-              new SanityWriteError(
+              new SanityError(
                 `Image URL host not allowed: ${parsedUrl.hostname}`,
               ),
             );
@@ -267,7 +216,7 @@ export const SanityWriteClientLive = Layer.effect(
               }
             },
             catch: (cause) =>
-              new SanityWriteError(
+              new SanityError(
                 `Failed to upload image for player ${psdId}`,
                 cause,
               ),
@@ -281,7 +230,7 @@ export const SanityWriteClientLive = Layer.effect(
           if (response.status === 404) return;
           if (!response.ok) {
             return yield* Effect.fail(
-              new SanityWriteError(
+              new SanityError(
                 `PSD image fetch failed: ${response.status} ${response.statusText}`,
               ),
             );
@@ -292,7 +241,7 @@ export const SanityWriteClientLive = Layer.effect(
           const arrayBuffer = yield* Effect.tryPromise({
             try: () => response.arrayBuffer(),
             catch: (cause) =>
-              new SanityWriteError(
+              new SanityError(
                 `Failed to read image body for player ${psdId}`,
                 cause,
               ),
@@ -333,7 +282,7 @@ export const SanityWriteClientLive = Layer.effect(
               return document;
             },
             catch: (cause) =>
-              new SanityWriteError(
+              new SanityError(
                 `Failed to upload image for player ${psdId}`,
                 cause,
               ),
@@ -358,7 +307,7 @@ export const SanityWriteClientLive = Layer.effect(
                 })
                 .commit(),
             catch: (cause) =>
-              new SanityWriteError(
+              new SanityError(
                 `Failed to patch player ${psdId} with image`,
                 cause,
               ),
@@ -368,21 +317,6 @@ export const SanityWriteClientLive = Layer.effect(
             `[uploadPlayerImage] player=${psdId} patch committed — image upload complete`,
           );
         }).pipe(Effect.asVoid),
-
-      getActivePlayerPsdIds: () =>
-        Effect.tryPromise({
-          try: async () => {
-            const rows = await client.fetch<Array<{ psdId: string }>>(
-              `*[_type == "player" && archived != true] { psdId }`,
-            );
-            return rows.map((r) => r.psdId);
-          },
-          catch: (cause) =>
-            new SanityWriteError(
-              "Failed to fetch active player PSD IDs",
-              cause,
-            ),
-        }),
 
       archivePlayers: (psdIds) => archiveByPsdIds("player", psdIds),
 
@@ -421,31 +355,7 @@ export const SanityWriteClientLive = Layer.effect(
         return upsert("staffMember", doc.psdId, fields);
       },
 
-      getActiveStaffPsdIds: () =>
-        Effect.tryPromise({
-          try: async () => {
-            const rows = await client.fetch<Array<{ psdId: string }>>(
-              `*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] { psdId }`,
-            );
-            return rows.map((r) => r.psdId);
-          },
-          catch: (cause) =>
-            new SanityWriteError("Failed to fetch active staff PSD IDs", cause),
-        }),
-
       archiveStaff: (psdIds) => archiveByPsdIds("staffMember", psdIds),
-
-      getActiveTeamPsdIds: () =>
-        Effect.tryPromise({
-          try: async () => {
-            const rows = await client.fetch<Array<{ psdId: string }>>(
-              `*[_type == "team" && archived != true && defined(psdId) && psdId != ""] { psdId }`,
-            );
-            return rows.map((r) => r.psdId);
-          },
-          catch: (cause) =>
-            new SanityWriteError("Failed to fetch active team PSD IDs", cause),
-        }),
 
       archiveTeams: (psdIds) => archiveByPsdIds("team", psdIds),
 
@@ -459,22 +369,8 @@ export const SanityWriteClientLive = Layer.effect(
               vote: doc.vote,
             }),
           catch: (cause) =>
-            new SanityWriteError("Failed to write search feedback", cause),
+            new SanityError("Failed to write search feedback", cause),
         }).pipe(Effect.asVoid),
-
-      getVisibleTeamPsdIds: () =>
-        Effect.tryPromise({
-          try: async () => {
-            const rows = await client.fetch<Array<string | null>>(
-              `*[_type == "team" && showInNavigation != false].psdId`,
-            );
-            return rows.filter(
-              (id): id is string => typeof id === "string" && id.length > 0,
-            );
-          },
-          catch: (cause) =>
-            new SanityWriteError("Failed to fetch visible team PSD IDs", cause),
-        }),
     };
   }),
 );

--- a/apps/api/src/sanity/projection.test.ts
+++ b/apps/api/src/sanity/projection.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { SanityProjection, SanityProjectionLive } from "./projection";
+import { WorkerEnvTag } from "../env";
+
+const fetchMock = vi.fn();
+
+vi.mock("@sanity/client", () => ({
+  createClient: () => ({ fetch: fetchMock }),
+}));
+
+function makeEnvLayer() {
+  return Layer.succeed(WorkerEnvTag, {
+    PSD_API_BASE_URL: "https://clubapi.prosoccerdata.com",
+    PSD_IMAGE_BASE_URL: "https://kcvv.prosoccerdata.com",
+    FOOTBALISTO_LOGO_CDN_URL: "https://cdn.example.com",
+    PSD_API_KEY: "test-key",
+    PSD_API_CLUB: "test-club",
+    PSD_API_AUTH: "test-auth",
+    PSD_CACHE: {} as KVNamespace,
+    SANITY_PROJECT_ID: "test-project",
+    SANITY_DATASET: "test",
+    SANITY_API_TOKEN: "test-token",
+    SANITY_WEBHOOK_SECRET: "",
+    AI: {} as Ai,
+    SEARCH_INDEX: {} as VectorizeIndex,
+  });
+}
+
+const layer = SanityProjectionLive.pipe(Layer.provide(makeEnvLayer()));
+
+function run<A>(effect: Effect.Effect<A, unknown, SanityProjection>) {
+  return Effect.runPromise(Effect.provide(effect, layer));
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("SanityProjection", () => {
+  describe("getVisibleTeamPsdIds", () => {
+    it("returns filtered PSD IDs, excluding nulls and empty strings", async () => {
+      fetchMock.mockResolvedValue(["101", null, "", "202", null]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getVisibleTeamPsdIds();
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `*[_type == "team" && showInNavigation != false].psdId`,
+      );
+      expect(result).toEqual(["101", "202"]);
+    });
+
+    it("returns empty array when no teams are visible", async () => {
+      fetchMock.mockResolvedValue([]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getVisibleTeamPsdIds();
+        }),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getPlayersImageState", () => {
+    it("returns a Map keyed by psdId with image state", async () => {
+      fetchMock.mockResolvedValue([
+        { psdId: "p1", psdImageUrl: "https://img/1.jpg", hasPsdImage: true },
+        { psdId: "p2", psdImageUrl: null, hasPsdImage: false },
+      ]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getPlayersImageState();
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `*[_type == "player"] { psdId, psdImageUrl, "hasPsdImage": defined(psdImage) }`,
+      );
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get("p1")).toEqual({
+        psdImageUrl: "https://img/1.jpg",
+        hasPsdImage: true,
+      });
+      expect(result.get("p2")).toEqual({
+        psdImageUrl: null,
+        hasPsdImage: false,
+      });
+    });
+
+    it("returns empty Map when no players exist", async () => {
+      fetchMock.mockResolvedValue([]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getPlayersImageState();
+        }),
+      );
+
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe("getActivePlayerPsdIds", () => {
+    it("returns PSD IDs of non-archived players", async () => {
+      fetchMock.mockResolvedValue([{ psdId: "p1" }, { psdId: "p2" }]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getActivePlayerPsdIds();
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `*[_type == "player" && archived != true] { psdId }`,
+      );
+      expect(result).toEqual(["p1", "p2"]);
+    });
+
+    it("returns empty array when no active players", async () => {
+      fetchMock.mockResolvedValue([]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getActivePlayerPsdIds();
+        }),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getActiveStaffPsdIds", () => {
+    it("returns PSD IDs of non-archived staff with defined psdId", async () => {
+      fetchMock.mockResolvedValue([{ psdId: "s1" }, { psdId: "s2" }]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getActiveStaffPsdIds();
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] { psdId }`,
+      );
+      expect(result).toEqual(["s1", "s2"]);
+    });
+  });
+
+  describe("getActiveTeamPsdIds", () => {
+    it("returns PSD IDs of non-archived teams with defined psdId", async () => {
+      fetchMock.mockResolvedValue([{ psdId: "t1" }]);
+
+      const result = await run(
+        Effect.gen(function* () {
+          const projection = yield* SanityProjection;
+          return yield* projection.getActiveTeamPsdIds();
+        }),
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `*[_type == "team" && archived != true && defined(psdId) && psdId != ""] { psdId }`,
+      );
+      expect(result).toEqual(["t1"]);
+    });
+  });
+});

--- a/apps/api/src/sanity/projection.ts
+++ b/apps/api/src/sanity/projection.ts
@@ -1,0 +1,121 @@
+import { Context, Effect, Layer } from "effect";
+import { WorkerEnvTag } from "../env";
+import { createClient } from "@sanity/client";
+import { SanityError, type PlayerImageState } from "./client";
+
+// ─── Interface ───────────────────────────────────────────────────────────────
+
+export interface SanityProjectionInterface {
+  /** Fetch PSD IDs of all teams where showInNavigation is not false. */
+  readonly getVisibleTeamPsdIds: () => Effect.Effect<string[], SanityError>;
+  /** Fetch existing psdImageUrl + psdImage presence for all player docs. */
+  readonly getPlayersImageState: () => Effect.Effect<
+    Map<string, PlayerImageState>,
+    SanityError
+  >;
+  /** Fetch PSD IDs of all non-archived players. */
+  readonly getActivePlayerPsdIds: () => Effect.Effect<string[], SanityError>;
+  /** Fetch PSD IDs of all non-archived staff members. */
+  readonly getActiveStaffPsdIds: () => Effect.Effect<string[], SanityError>;
+  /** Fetch PSD IDs of all non-archived teams. */
+  readonly getActiveTeamPsdIds: () => Effect.Effect<string[], SanityError>;
+}
+
+// ─── Tag ─────────────────────────────────────────────────────────────────────
+
+export class SanityProjection extends Context.Tag("SanityProjection")<
+  SanityProjection,
+  SanityProjectionInterface
+>() {}
+
+// ─── Live layer ──────────────────────────────────────────────────────────────
+
+/** Projections use `useCdn: true` for faster reads; writes in SanityWriteClient use `useCdn: false`. */
+export const SanityProjectionLive = Layer.effect(
+  SanityProjection,
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvTag;
+    const client = createClient({
+      projectId: env.SANITY_PROJECT_ID,
+      dataset: env.SANITY_DATASET,
+      apiVersion: "2024-01-01",
+      token: env.SANITY_API_TOKEN,
+      useCdn: true,
+    });
+
+    return {
+      getVisibleTeamPsdIds: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const rows = await client.fetch<Array<string | null>>(
+              `*[_type == "team" && showInNavigation != false].psdId`,
+            );
+            return rows.filter(
+              (id): id is string => typeof id === "string" && id.length > 0,
+            );
+          },
+          catch: (cause) =>
+            new SanityError("Failed to fetch visible team PSD IDs", cause),
+        }),
+
+      getPlayersImageState: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const rows = await client.fetch<
+              Array<{
+                psdId: string;
+                psdImageUrl: string | null;
+                hasPsdImage: boolean;
+              }>
+            >(
+              `*[_type == "player"] { psdId, psdImageUrl, "hasPsdImage": defined(psdImage) }`,
+            );
+            return new Map(
+              rows.map((r) => [
+                r.psdId,
+                { psdImageUrl: r.psdImageUrl, hasPsdImage: r.hasPsdImage },
+              ]),
+            );
+          },
+          catch: (cause) =>
+            new SanityError("Failed to fetch player image state", cause),
+        }),
+
+      getActivePlayerPsdIds: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const rows = await client.fetch<Array<{ psdId: string }>>(
+              `*[_type == "player" && archived != true] { psdId }`,
+            );
+            return rows.map((r) => r.psdId);
+          },
+          catch: (cause) =>
+            new SanityError("Failed to fetch active player PSD IDs", cause),
+        }),
+
+      getActiveStaffPsdIds: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const rows = await client.fetch<Array<{ psdId: string }>>(
+              `*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] { psdId }`,
+            );
+            return rows.map((r) => r.psdId);
+          },
+          catch: (cause) =>
+            new SanityError("Failed to fetch active staff PSD IDs", cause),
+        }),
+
+      getActiveTeamPsdIds: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const rows = await client.fetch<Array<{ psdId: string }>>(
+              `*[_type == "team" && archived != true && defined(psdId) && psdId != ""] { psdId }`,
+            );
+            return rows.map((r) => r.psdId);
+          },
+          catch: (cause) =>
+            new SanityError("Failed to fetch active team PSD IDs", cause),
+        }),
+    };
+  }),
+);

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -6,6 +6,7 @@ import type {
   SanityStaffDoc,
 } from "../sanity/client";
 import { SanityWriteClient } from "../sanity/client";
+import { SanityProjection } from "../sanity/projection";
 import { PsdTeamClient } from "./psd-team-client";
 import { WorkerEnvTag } from "../env";
 import { extractStableImageUrl, needsUpload } from "./image-upload-utils";
@@ -140,6 +141,7 @@ const CYCLE_TEAM_IDS_KEY = "sync:cycle-team-ids";
 export const runSync = Effect.gen(function* () {
   const psd = yield* PsdTeamClient;
   const sanity = yield* SanityWriteClient;
+  const projection = yield* SanityProjection;
   const env = yield* WorkerEnvTag;
   // PSD serves images from the club subdomain (PSD_IMAGE_BASE_URL), not the
   // API domain (PSD_API_BASE_URL). profilePictureURL is a relative path.
@@ -156,7 +158,7 @@ export const runSync = Effect.gen(function* () {
 
   // Pre-fetch existing player image state to avoid redundant uploads
   yield* Effect.log("fetching player image state from Sanity");
-  const imageState = yield* sanity.getPlayersImageState();
+  const imageState = yield* projection.getPlayersImageState();
   yield* Effect.log(`player image state fetched: ${imageState.size} records`);
 
   yield* Effect.log("fetching teams from PSD");
@@ -331,7 +333,7 @@ export const runSync = Effect.gen(function* () {
   // ─── Reconciliation at cycle end ─────────────────────────────────────
   if (nextCursor === 0) {
     yield* Effect.log("cycle complete — running player reconciliation");
-    const activeInSanity = yield* sanity.getActivePlayerPsdIds();
+    const activeInSanity = yield* projection.getActivePlayerPsdIds();
     const orphanIds = activeInSanity.filter((id) => !accumulatedIds.has(id));
 
     if (orphanIds.length > 0) {
@@ -345,7 +347,7 @@ export const runSync = Effect.gen(function* () {
 
     // ─── Staff reconciliation ─────────────────────────────────────────
     yield* Effect.log("running staff reconciliation");
-    const activeStaffInSanity = yield* sanity.getActiveStaffPsdIds();
+    const activeStaffInSanity = yield* projection.getActiveStaffPsdIds();
     const orphanStaffIds = activeStaffInSanity.filter(
       (id) => !accumulatedStaffIds.has(id),
     );
@@ -361,7 +363,7 @@ export const runSync = Effect.gen(function* () {
 
     // ─── Team reconciliation ──────────────────────────────────────────
     yield* Effect.log("running team reconciliation");
-    const activeTeamsInSanity = yield* sanity.getActiveTeamPsdIds();
+    const activeTeamsInSanity = yield* projection.getActiveTeamPsdIds();
     const orphanTeamIds = activeTeamsInSanity.filter(
       (id) => !accumulatedTeamIds.has(id),
     );

--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import { Effect, Layer } from "effect";
 import { runSync } from "./psd-sanity-sync";
 import type { SanityWriteClientInterface } from "../sanity/client";
-import { SanityWriteClient, SanityWriteError } from "../sanity/client";
+import { SanityWriteClient, SanityError } from "../sanity/client";
+import type { SanityProjectionInterface } from "../sanity/projection";
+import { SanityProjection } from "../sanity/projection";
 import type { PsdTeamClientInterface } from "./psd-team-client";
 import { PsdTeamClient } from "./psd-team-client";
 import { WorkerEnvTag } from "../env";
@@ -35,40 +37,54 @@ const ONE_PLAYER: PsdMember = {
 
 // ─── Mock factories ──────────────────────────────────────────────────────────
 
-function makeSanityWriteClientMock() {
-  const upsertPlayer = vi.fn(() => Effect.succeed(undefined as void));
-  const upsertTeam = vi.fn(() => Effect.succeed(undefined as void));
-  const upsertStaff = vi.fn(() => Effect.succeed(undefined as void));
-  const uploadPlayerImage = vi.fn(() => Effect.succeed(undefined as void));
+function makeSanityProjectionMock() {
   const getPlayersImageState = vi.fn(() =>
     Effect.succeed(
       new Map<string, { psdImageUrl: string | null; hasPsdImage: boolean }>(),
     ),
   );
   const getActivePlayerPsdIds = vi.fn(() => Effect.succeed([] as string[]));
-  const archivePlayers = vi.fn(() => Effect.succeed(undefined as void));
   const getActiveStaffPsdIds = vi.fn(() => Effect.succeed([] as string[]));
-  const archiveStaff = vi.fn(() => Effect.succeed(undefined as void));
   const getActiveTeamPsdIds = vi.fn(() => Effect.succeed([] as string[]));
-  const archiveTeams = vi.fn(() => Effect.succeed(undefined as void));
-
-  const writeFeedback = vi.fn(() => Effect.succeed(undefined as void));
   const getVisibleTeamPsdIds = vi.fn(() => Effect.succeed([] as string[]));
+
+  const mock: SanityProjectionInterface = {
+    getPlayersImageState,
+    getActivePlayerPsdIds,
+    getActiveStaffPsdIds,
+    getActiveTeamPsdIds,
+    getVisibleTeamPsdIds,
+  };
+
+  return {
+    getPlayersImageState,
+    getActivePlayerPsdIds,
+    getActiveStaffPsdIds,
+    getActiveTeamPsdIds,
+    getVisibleTeamPsdIds,
+    mock,
+  };
+}
+
+function makeSanityWriteClientMock() {
+  const upsertPlayer = vi.fn(() => Effect.succeed(undefined as void));
+  const upsertTeam = vi.fn(() => Effect.succeed(undefined as void));
+  const upsertStaff = vi.fn(() => Effect.succeed(undefined as void));
+  const uploadPlayerImage = vi.fn(() => Effect.succeed(undefined as void));
+  const archivePlayers = vi.fn(() => Effect.succeed(undefined as void));
+  const archiveStaff = vi.fn(() => Effect.succeed(undefined as void));
+  const archiveTeams = vi.fn(() => Effect.succeed(undefined as void));
+  const writeFeedback = vi.fn(() => Effect.succeed(undefined as void));
 
   const mock: SanityWriteClientInterface = {
     upsertPlayer,
     upsertTeam,
     upsertStaff,
     uploadPlayerImage,
-    getPlayersImageState,
-    getActivePlayerPsdIds,
     archivePlayers,
-    getActiveStaffPsdIds,
     archiveStaff,
-    getActiveTeamPsdIds,
     archiveTeams,
     writeFeedback,
-    getVisibleTeamPsdIds,
   };
 
   return {
@@ -76,12 +92,8 @@ function makeSanityWriteClientMock() {
     upsertTeam,
     upsertStaff,
     uploadPlayerImage,
-    getPlayersImageState,
-    getActivePlayerPsdIds,
     archivePlayers,
-    getActiveStaffPsdIds,
     archiveStaff,
-    getActiveTeamPsdIds,
     archiveTeams,
     mock,
   };
@@ -213,9 +225,12 @@ function buildTestLayer(
   kvStub: KVNamespace,
   sanityMock: SanityWriteClientInterface,
   psdMock: PsdTeamClientInterface,
+  projectionMock?: SanityProjectionInterface,
 ) {
+  const projection = projectionMock ?? makeSanityProjectionMock().mock;
   return Layer.mergeAll(
     Layer.succeed(SanityWriteClient, sanityMock),
+    Layer.succeed(SanityProjection, projection),
     Layer.succeed(PsdTeamClient, psdMock),
     makeEnvLayer(kvStub),
   );
@@ -236,11 +251,7 @@ describe("runSync", () => {
     const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER]);
 
     await Effect.runPromise(
-      runSync.pipe(
-        Effect.provide(Layer.succeed(SanityWriteClient, sanityMock)),
-        Effect.provide(Layer.succeed(PsdTeamClient, psdMock)),
-        Effect.provide(makeEnvLayer(kvStub)),
-      ),
+      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
     );
 
     // upsertPlayer called once with psdId "6453"
@@ -348,22 +359,10 @@ describe("runSync", () => {
         return Effect.succeed(undefined as void);
       }),
       uploadPlayerImage: vi.fn(() => Effect.succeed(undefined as void)),
-      getPlayersImageState: vi.fn(() =>
-        Effect.succeed(
-          new Map<
-            string,
-            { psdImageUrl: string | null; hasPsdImage: boolean }
-          >(),
-        ),
-      ),
-      getActivePlayerPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       archivePlayers: vi.fn(() => Effect.succeed(undefined as void)),
-      getActiveStaffPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       archiveStaff: vi.fn(() => Effect.succeed(undefined as void)),
-      getActiveTeamPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       archiveTeams: vi.fn(() => Effect.succeed(undefined as void)),
       writeFeedback: vi.fn(() => Effect.succeed(undefined as void)),
-      getVisibleTeamPsdIds: vi.fn(() => Effect.succeed([] as string[])),
     };
     const psdMock = makePsdTeamClientMock(
       [ONE_TEAM],
@@ -413,9 +412,10 @@ describe("runSync", () => {
     const {
       upsertPlayer,
       uploadPlayerImage,
-      getPlayersImageState,
       mock: sanityMock,
     } = makeSanityWriteClientMock();
+
+    const { getPlayersImageState, mock: projMock } = makeSanityProjectionMock();
 
     // The stable URL that transformMember will produce for PLAYER_WITH_IMAGE
     const expectedStableUrl =
@@ -433,7 +433,9 @@ describe("runSync", () => {
     const psdMock = makePsdTeamClientMock([ONE_TEAM], [PLAYER_WITH_IMAGE]);
 
     await Effect.runPromise(
-      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock, projMock)),
+      ),
     );
 
     expect(upsertPlayer).toHaveBeenCalledOnce();
@@ -453,7 +455,7 @@ describe("runSync", () => {
     // Make uploadPlayerImage fail
     uploadPlayerImage.mockReturnValue(
       Effect.fail(
-        new SanityWriteError("Sanity asset upload timeout"),
+        new SanityError("Sanity asset upload timeout"),
       ) as unknown as Effect.Effect<void>,
     );
 
@@ -490,11 +492,10 @@ describe("runSync", () => {
       { ...ONE_PLAYER, id: 200 },
     ];
 
-    const {
-      getActivePlayerPsdIds,
-      archivePlayers,
-      mock: sanityMock,
-    } = makeSanityWriteClientMock();
+    const { archivePlayers, mock: sanityMock } = makeSanityWriteClientMock();
+
+    const { getActivePlayerPsdIds, mock: projMock } =
+      makeSanityProjectionMock();
 
     // Sanity has 3 active players — player 300 is the orphan
     getActivePlayerPsdIds.mockReturnValue(
@@ -504,7 +505,9 @@ describe("runSync", () => {
     const psdMock = makePsdTeamClientMock([ONE_TEAM], psdPlayers);
 
     await Effect.runPromise(
-      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock, projMock)),
+      ),
     );
 
     // With 1 team, cursor wraps to 0 immediately → reconciliation runs
@@ -568,14 +571,17 @@ describe("runSync", () => {
 
     // Run 2: processes Team B (cursor 1 → 0, cycle complete)
     const sanity2 = makeSanityWriteClientMock();
+    const proj2 = makeSanityProjectionMock();
     // Sanity has 4 active players — player 400 is the orphan
-    sanity2.getActivePlayerPsdIds.mockReturnValue(
+    proj2.getActivePlayerPsdIds.mockReturnValue(
       Effect.succeed(["100", "200", "300", "400"]),
     );
 
     await Effect.runPromise(
       runSync.pipe(
-        Effect.provide(buildTestLayer(kvStub, sanity2.mock, psdMock)),
+        Effect.provide(
+          buildTestLayer(kvStub, sanity2.mock, psdMock, proj2.mock),
+        ),
       ),
     );
 
@@ -597,11 +603,9 @@ describe("runSync", () => {
       { ...ONE_STAFF, id: 600 },
     ];
 
-    const {
-      getActiveStaffPsdIds,
-      archiveStaff,
-      mock: sanityMock,
-    } = makeSanityWriteClientMock();
+    const { archiveStaff, mock: sanityMock } = makeSanityWriteClientMock();
+
+    const { getActiveStaffPsdIds, mock: projMock } = makeSanityProjectionMock();
 
     // Sanity has 3 active staff — staff 700 is the orphan
     getActiveStaffPsdIds.mockReturnValue(Effect.succeed(["500", "600", "700"]));
@@ -609,7 +613,9 @@ describe("runSync", () => {
     const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER], psdStaff);
 
     await Effect.runPromise(
-      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock, projMock)),
+      ),
     );
 
     // With 1 team, cursor wraps to 0 immediately → reconciliation runs
@@ -620,11 +626,9 @@ describe("runSync", () => {
   it("archives orphan team when cycle completes (team disappears from PSD)", async () => {
     const kvStub = makeKvStub();
 
-    const {
-      getActiveTeamPsdIds,
-      archiveTeams,
-      mock: sanityMock,
-    } = makeSanityWriteClientMock();
+    const { archiveTeams, mock: sanityMock } = makeSanityWriteClientMock();
+
+    const { getActiveTeamPsdIds, mock: projMock } = makeSanityProjectionMock();
 
     // Sanity has 2 active teams — team 99 is in PSD, team 77 is the orphan
     getActiveTeamPsdIds.mockReturnValue(Effect.succeed(["42", "77"]));
@@ -633,7 +637,9 @@ describe("runSync", () => {
     const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER]);
 
     await Effect.runPromise(
-      runSync.pipe(Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock))),
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, sanityMock, psdMock, projMock)),
+      ),
     );
 
     // With 1 team, cursor wraps to 0 → reconciliation runs
@@ -675,14 +681,17 @@ describe("runSync", () => {
 
     // Run 2: processes Team B (cursor 1 → 0, cycle complete)
     const sanity2 = makeSanityWriteClientMock();
+    const proj2 = makeSanityProjectionMock();
     // Sanity has 3 active staff — staff 700 is the orphan
-    sanity2.getActiveStaffPsdIds.mockReturnValue(
+    proj2.getActiveStaffPsdIds.mockReturnValue(
       Effect.succeed(["500", "600", "700"]),
     );
 
     await Effect.runPromise(
       runSync.pipe(
-        Effect.provide(buildTestLayer(kvStub, sanity2.mock, psdMock)),
+        Effect.provide(
+          buildTestLayer(kvStub, sanity2.mock, psdMock, proj2.mock),
+        ),
       ),
     );
 


### PR DESCRIPTION
Closes #1187

## What changed
- Extracted `SanityProjection` as an independent module (`apps/api/src/sanity/projection.ts`) with its own test suite, decoupled from the Sanity write client
- Consolidated `transforms.ts` into `service.ts` — FootbalistoService now owns its own data transformations, eliminating the intermediate module
- Added `responsibilityPath` schema to `packages/sanity-schemas/` for structured player responsibility data

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- New projection unit tests: `apps/api/src/sanity/projection.test.ts`
- Updated service tests cover the consolidated transforms