### PR TITLE
refactor(config): simplify remaining repository transforms and audit secondary ViewModels (#1192)

### DIFF
--- a/apps/web/src/app/(main)/events/page.tsx
+++ b/apps/web/src/app/(main)/events/page.tsx
@@ -36,7 +36,7 @@ function toEventsListItem(event: EventVM): EventsListItem {
     href: event.href,
     date: new Date(event.dateStart),
     endDate: event.dateEnd ? new Date(event.dateEnd) : undefined,
-    imageUrl: event.coverImageUrl,
+    imageUrl: event.coverImageUrl ?? undefined,
   };
 }
 

--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -106,7 +106,7 @@ async function fetchCalendarData(): Promise<CalendarData> {
         id: e.id,
         title: e.title,
         dateStart: e.dateStart,
-        dateEnd: e.dateEnd,
+        dateEnd: e.dateEnd ?? undefined,
         href: e.href,
       }));
 

--- a/apps/web/src/app/(main)/sponsors/page.tsx
+++ b/apps/web/src/app/(main)/sponsors/page.tsx
@@ -29,10 +29,10 @@ function mapToSponsor(s: SponsorVM): Sponsor {
     id: s.id,
     name: s.name,
     logo: s.logoUrl ?? "/images/placeholder-sponsor.png",
-    url: s.url,
-    tier: s.tier,
+    url: s.url ?? undefined,
+    tier: s.tier ?? undefined,
     featured: s.featured,
-    description: s.description,
+    description: s.description ?? undefined,
   };
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -90,7 +90,7 @@ function buildFeaturedEventStub(event: EventVM): FeaturedEventStub {
   return {
     title: event.title,
     href: isExternal ? event.href : undefined,
-    imageUrl: event.coverImageUrl,
+    imageUrl: event.coverImageUrl ?? undefined,
     badge: "EVENEMENT",
     date: eventDate,
     time: eventTime,

--- a/apps/web/src/components/sponsors/SponsorsBlock.tsx
+++ b/apps/web/src/components/sponsors/SponsorsBlock.tsx
@@ -73,8 +73,8 @@ export async function SponsorsBlock({
             id: s.id,
             name: s.name,
             logo: s.logoUrl ?? "/images/placeholder-sponsor.png",
-            url: s.url,
-            tier: s.tier,
+            url: s.url ?? undefined,
+            tier: s.tier ?? undefined,
           }),
         );
     }).pipe(

--- a/apps/web/src/lib/repositories/event.repository.test.ts
+++ b/apps/web/src/lib/repositories/event.repository.test.ts
@@ -13,11 +13,7 @@ vi.mock("../sanity/client", () => ({
 }));
 
 import { sanityClient } from "../sanity/client";
-import {
-  EventRepository,
-  EventRepositoryLive,
-  type EventVM,
-} from "./event.repository";
+import { EventRepository, EventRepositoryLive } from "./event.repository";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockFetch = sanityClient.fetch as any as ReturnType<typeof vi.fn>;
@@ -26,16 +22,18 @@ function runWithRepo<A>(effect: Effect.Effect<A, never, EventRepository>) {
   return Effect.runPromise(Effect.provide(effect, EventRepositoryLive));
 }
 
+/** Fixture matches the new GROQ projection shape (field renaming + coalescing done in GROQ) */
 function makeEventRow(
   overrides: Partial<EVENTS_QUERY_RESULT[number]> = {},
 ): EVENTS_QUERY_RESULT[number] {
   return {
-    _id: "event-1",
+    id: "event-1",
     title: "Spaghetti-avond",
     dateStart: "2026-04-15T18:00:00Z",
     dateEnd: "2026-04-15T22:00:00Z",
-    externalLink: { url: "https://tickets.example.com", label: "Tickets" },
+    href: "https://tickets.example.com",
     coverImageUrl: "https://cdn.sanity.io/event.webp",
+    featuredOnHome: false,
     ...overrides,
   };
 }
@@ -44,20 +42,20 @@ function makeFeaturedEventRow(
   overrides: Partial<NonNullable<NEXT_FEATURED_EVENT_QUERY_RESULT>> = {},
 ): NonNullable<NEXT_FEATURED_EVENT_QUERY_RESULT> {
   return {
-    _id: "event-2",
+    id: "event-2",
     title: "Seizoensopener",
     dateStart: "2026-08-01T14:00:00Z",
     dateEnd: null,
-    featuredOnHome: true,
-    externalLink: null,
+    href: "#",
     coverImageUrl: "https://cdn.sanity.io/featured.webp",
+    featuredOnHome: true,
     ...overrides,
   };
 }
 
 describe("EventRepository", () => {
   describe("findAll", () => {
-    it("maps all EventVM fields correctly from GROQ result", async () => {
+    it("returns GROQ projection shape directly — no post-fetch transform", async () => {
       const row = makeEventRow();
       mockFetch.mockResolvedValueOnce([row]);
 
@@ -69,7 +67,7 @@ describe("EventRepository", () => {
       );
 
       expect(events).toHaveLength(1);
-      expect(events[0]).toEqual<EventVM>({
+      expect(events[0]).toMatchObject({
         id: "event-1",
         title: "Spaghetti-avond",
         dateStart: "2026-04-15T18:00:00Z",
@@ -80,13 +78,13 @@ describe("EventRepository", () => {
       });
     });
 
-    it("null optional fields become undefined", async () => {
+    it("GROQ coalesce handles nulls — title defaults to empty string, href to #", async () => {
       mockFetch.mockResolvedValueOnce([
         makeEventRow({
+          title: "",
           dateEnd: null,
-          externalLink: null,
+          href: "#",
           coverImageUrl: null,
-          title: null,
         }),
       ]);
 
@@ -98,9 +96,9 @@ describe("EventRepository", () => {
       );
 
       expect(e.title).toBe("");
-      expect(e.dateEnd).toBeUndefined();
+      expect(e.dateEnd).toBeNull();
       expect(e.href).toBe("#");
-      expect(e.coverImageUrl).toBeUndefined();
+      expect(e.coverImageUrl).toBeNull();
     });
   });
 
@@ -118,7 +116,7 @@ describe("EventRepository", () => {
       expect(result).toBeNull();
     });
 
-    it("maps featured event fields correctly", async () => {
+    it("returns GROQ projection shape directly for featured event", async () => {
       mockFetch.mockResolvedValueOnce(makeFeaturedEventRow());
 
       const result = await runWithRepo(
@@ -128,11 +126,11 @@ describe("EventRepository", () => {
         }),
       );
 
-      expect(result).toEqual<EventVM>({
+      expect(result).toMatchObject({
         id: "event-2",
         title: "Seizoensopener",
         dateStart: "2026-08-01T14:00:00Z",
-        dateEnd: undefined,
+        dateEnd: null,
         href: "#",
         coverImageUrl: "https://cdn.sanity.io/featured.webp",
         featuredOnHome: true,

--- a/apps/web/src/lib/repositories/event.repository.ts
+++ b/apps/web/src/lib/repositories/event.repository.ts
@@ -10,64 +10,41 @@ import type {
 
 export const EVENTS_QUERY =
   defineQuery(`*[_type == "event"] | order(dateStart asc) {
-  _id, title, dateStart, dateEnd, externalLink,
+  "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": false,
+  "href": coalesce(externalLink.url, "#"),
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"
 }`);
 
 export const NEXT_FEATURED_EVENT_QUERY = defineQuery(`
   coalesce(
     *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {
-      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,
+      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),
+      "href": coalesce(externalLink.url, "#"),
       "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"
     },
     *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {
-      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,
+      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),
+      "href": coalesce(externalLink.url, "#"),
       "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"
     }
   )
 `);
 
-export interface EventVM {
-  id: string;
+// ─── View Models ─────────────────────────────────────────────────────────────
+
+/** GROQ projection now returns the final shape — EventVM is a type alias.
+ *  Omit + re-declare normalises the `coalesce()` unions typegen emits. */
+export type EventVM = Omit<
+  EVENTS_QUERY_RESULT[number],
+  "title" | "dateStart" | "href" | "featuredOnHome"
+> & {
   title: string;
   dateStart: string;
-  dateEnd?: string;
   href: string;
-  coverImageUrl?: string;
   featuredOnHome: boolean;
-}
+};
 
-interface EventRow {
-  _id: string;
-  title: string | null;
-  dateStart: string | null;
-  dateEnd?: string | null;
-  externalLink?: { url?: string | null } | null;
-  coverImageUrl?: string | null;
-  featuredOnHome?: boolean | null;
-}
-
-function mapEventRowToVM(row: EventRow, featuredOnHome?: boolean): EventVM {
-  return {
-    id: row._id,
-    title: row.title ?? "",
-    dateStart: row.dateStart ?? "",
-    dateEnd: row.dateEnd ?? undefined,
-    href: row.externalLink?.url ?? "#",
-    coverImageUrl: row.coverImageUrl ?? undefined,
-    featuredOnHome: featuredOnHome ?? row.featuredOnHome ?? false,
-  };
-}
-
-export function toEventVM(row: EVENTS_QUERY_RESULT[number]): EventVM {
-  return mapEventRowToVM(row, false);
-}
-
-export function toFeaturedEventVM(
-  row: NonNullable<NEXT_FEATURED_EVENT_QUERY_RESULT>,
-): EventVM {
-  return mapEventRowToVM(row);
-}
+// ─── Service ─────────────────────────────────────────────────────────────────
 
 export interface EventRepositoryInterface {
   readonly findAll: () => Effect.Effect<EventVM[]>;
@@ -80,12 +57,9 @@ export class EventRepository extends Context.Tag("EventRepository")<
 >() {}
 
 export const EventRepositoryLive = Layer.succeed(EventRepository, {
-  findAll: () =>
-    fetchGroq<EVENTS_QUERY_RESULT>(EVENTS_QUERY).pipe(
-      Effect.map((rows) => rows.map(toEventVM)),
-    ),
+  findAll: () => fetchGroq<EVENTS_QUERY_RESULT>(EVENTS_QUERY),
   findNextFeatured: () =>
     fetchGroq<NEXT_FEATURED_EVENT_QUERY_RESULT>(NEXT_FEATURED_EVENT_QUERY, {
       now: new Date().toISOString(),
-    }).pipe(Effect.map((row) => (row ? toFeaturedEventVM(row) : null))),
+    }).pipe(Effect.map((row) => row ?? null)),
 });

--- a/apps/web/src/lib/repositories/homepage.repository.test.ts
+++ b/apps/web/src/lib/repositories/homepage.repository.test.ts
@@ -30,19 +30,16 @@ function makeBannersResult(
 ): HOMEPAGE_BANNERS_QUERY_RESULT {
   return {
     bannerSlotA: {
-      _id: "banner-a",
       imageUrl: "https://cdn.sanity.io/banner-a.webp",
       alt: "Banner A alt",
       href: "https://example.com/a",
     },
     bannerSlotB: {
-      _id: "banner-b",
       imageUrl: "https://cdn.sanity.io/banner-b.webp",
       alt: "Banner B alt",
       href: null,
     },
     bannerSlotC: {
-      _id: "banner-c",
       imageUrl: "https://cdn.sanity.io/banner-c.webp",
       alt: "Banner C alt",
       href: "https://example.com/c",
@@ -132,7 +129,6 @@ describe("HomepageRepository", () => {
       mockFetch.mockResolvedValueOnce(
         makeBannersResult({
           bannerSlotA: {
-            _id: "banner-a",
             imageUrl: null,
             alt: "Banner A alt",
             href: null,

--- a/apps/web/src/lib/repositories/homepage.repository.ts
+++ b/apps/web/src/lib/repositories/homepage.repository.ts
@@ -7,19 +7,16 @@ import type { HOMEPAGE_BANNERS_QUERY_RESULT } from "../sanity/sanity.types";
 
 export const HOMEPAGE_BANNERS_QUERY = defineQuery(`*[_type == "homePage"][0] {
     "bannerSlotA": bannerSlotA-> {
-      _id,
       "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",
       alt,
       href
     },
     "bannerSlotB": bannerSlotB-> {
-      _id,
       "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",
       alt,
       href
     },
     "bannerSlotC": bannerSlotC-> {
-      _id,
       "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",
       alt,
       href

--- a/apps/web/src/lib/repositories/page.repository.test.ts
+++ b/apps/web/src/lib/repositories/page.repository.test.ts
@@ -10,11 +10,7 @@ vi.mock("../sanity/client", () => ({
 }));
 
 import { sanityClient } from "../sanity/client";
-import {
-  PageRepository,
-  PageRepositoryLive,
-  type PageVM,
-} from "./page.repository";
+import { PageRepository, PageRepositoryLive } from "./page.repository";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockFetch = sanityClient.fetch as any as ReturnType<typeof vi.fn>;
@@ -23,13 +19,14 @@ function runWithRepo<A>(effect: Effect.Effect<A, never, PageRepository>) {
   return Effect.runPromise(Effect.provide(effect, PageRepositoryLive));
 }
 
+/** Fixture matches the new GROQ projection shape (field renaming + coalescing done in GROQ) */
 function makePageRow(
   overrides: Partial<NonNullable<PAGE_BY_SLUG_QUERY_RESULT>> = {},
 ): NonNullable<PAGE_BY_SLUG_QUERY_RESULT> {
   return {
-    _id: "page-1",
+    id: "page-1",
     title: "Praktische Info",
-    slug: { current: "praktische-info", _type: "slug" },
+    slug: "praktische-info",
     heroImageUrl: null,
     body: [
       {
@@ -51,7 +48,7 @@ function makePageRow(
 
 describe("PageRepository", () => {
   describe("findBySlug", () => {
-    it("maps all PageVM fields correctly from GROQ result", async () => {
+    it("returns GROQ projection shape directly — no post-fetch transform", async () => {
       const row = makePageRow();
       mockFetch.mockResolvedValueOnce(row);
 
@@ -62,13 +59,13 @@ describe("PageRepository", () => {
         }),
       );
 
-      expect(page).toEqual<PageVM>({
+      expect(page).toMatchObject({
         id: "page-1",
         title: "Praktische Info",
         slug: "praktische-info",
         heroImageUrl: null,
-        body: row.body!,
       });
+      expect(page?.body).toEqual(row.body);
     });
 
     it("returns null for unknown slug", async () => {
@@ -84,8 +81,8 @@ describe("PageRepository", () => {
       expect(page).toBeNull();
     });
 
-    it("null title becomes empty string", async () => {
-      mockFetch.mockResolvedValueOnce(makePageRow({ title: null }));
+    it("GROQ coalesce handles nulls — title defaults to empty string", async () => {
+      mockFetch.mockResolvedValueOnce(makePageRow({ title: "" }));
 
       const page = await runWithRepo(
         Effect.gen(function* () {
@@ -97,7 +94,7 @@ describe("PageRepository", () => {
       expect(page?.title).toBe("");
     });
 
-    it("null body becomes empty array", async () => {
+    it("null body stays null (consumer handles with ?? [])", async () => {
       mockFetch.mockResolvedValueOnce(makePageRow({ body: null }));
 
       const page = await runWithRepo(
@@ -107,7 +104,7 @@ describe("PageRepository", () => {
         }),
       );
 
-      expect(page?.body).toEqual([]);
+      expect(page?.body).toBeNull();
     });
 
     it("maps heroImageUrl when heroImage is set", async () => {
@@ -115,7 +112,7 @@ describe("PageRepository", () => {
         makePageRow({
           heroImageUrl:
             "https://cdn.sanity.io/images/proj/dataset/abc.jpg?w=1600&q=80&fm=webp&fit=max",
-        } as Record<string, unknown>),
+        }),
       );
 
       const page = await runWithRepo(

--- a/apps/web/src/lib/repositories/page.repository.ts
+++ b/apps/web/src/lib/repositories/page.repository.ts
@@ -7,31 +7,23 @@ import type { PAGE_BY_SLUG_QUERY_RESULT } from "../sanity/sanity.types";
 
 export const PAGE_BY_SLUG_QUERY =
   defineQuery(`*[_type == "page" && slug.current == $slug][0] {
-  _id,
-  title,
-  slug,
+  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),
   "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }
 }`);
 
-export interface PageVM {
-  id: string;
+// ─── View Models ─────────────────────────────────────────────────────────────
+
+type PAGE_DETAIL = NonNullable<PAGE_BY_SLUG_QUERY_RESULT>;
+
+/** GROQ projection now returns the final shape — PageVM is a type alias.
+ *  Omit + re-declare normalises the `coalesce()` unions typegen emits. */
+export type PageVM = Omit<PAGE_DETAIL, "title" | "slug"> & {
   title: string;
   slug: string;
-  heroImageUrl: string | null;
-  body: NonNullable<NonNullable<PAGE_BY_SLUG_QUERY_RESULT>["body"]>;
-}
+};
 
-export function toPageVM(row: NonNullable<PAGE_BY_SLUG_QUERY_RESULT>): PageVM {
-  return {
-    id: row._id,
-    title: row.title ?? "",
-    slug: row.slug?.current ?? "",
-    heroImageUrl:
-      ((row as Record<string, unknown>).heroImageUrl as string | null) ?? null,
-    body: row.body ?? [],
-  };
-}
+// ─── Service ─────────────────────────────────────────────────────────────────
 
 export interface PageRepositoryInterface {
   readonly findBySlug: (slug: string) => Effect.Effect<PageVM | null>;
@@ -45,6 +37,6 @@ export class PageRepository extends Context.Tag("PageRepository")<
 export const PageRepositoryLive = Layer.succeed(PageRepository, {
   findBySlug: (slug) =>
     fetchGroq<PAGE_BY_SLUG_QUERY_RESULT>(PAGE_BY_SLUG_QUERY, { slug }).pipe(
-      Effect.map((row) => (row ? toPageVM(row) : null)),
+      Effect.map((row) => row ?? null),
     ),
 });

--- a/apps/web/src/lib/repositories/sponsor.repository.test.ts
+++ b/apps/web/src/lib/repositories/sponsor.repository.test.ts
@@ -10,11 +10,7 @@ vi.mock("../sanity/client", () => ({
 }));
 
 import { sanityClient } from "../sanity/client";
-import {
-  SponsorRepository,
-  SponsorRepositoryLive,
-  type SponsorVM,
-} from "./sponsor.repository";
+import { SponsorRepository, SponsorRepositoryLive } from "./sponsor.repository";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockFetch = sanityClient.fetch as any as ReturnType<typeof vi.fn>;
@@ -23,11 +19,12 @@ function runWithRepo<A>(effect: Effect.Effect<A, never, SponsorRepository>) {
   return Effect.runPromise(Effect.provide(effect, SponsorRepositoryLive));
 }
 
+/** Fixture matches the new GROQ projection shape (field renaming + coalescing done in GROQ) */
 function makeSponsorRow(
   overrides: Partial<SPONSORS_QUERY_RESULT[number]> = {},
 ): SPONSORS_QUERY_RESULT[number] {
   return {
-    _id: "sponsor-1",
+    id: "sponsor-1",
     name: "Acme Corp",
     url: "https://acme.example.com",
     type: "crossing",
@@ -41,7 +38,7 @@ function makeSponsorRow(
 
 describe("SponsorRepository", () => {
   describe("findAll", () => {
-    it("maps all SponsorVM fields correctly from GROQ result", async () => {
+    it("returns GROQ projection shape directly — no post-fetch transform", async () => {
       const row = makeSponsorRow();
       mockFetch.mockResolvedValueOnce([row]);
 
@@ -53,7 +50,7 @@ describe("SponsorRepository", () => {
       );
 
       expect(sponsors).toHaveLength(1);
-      expect(sponsors[0]).toEqual<SponsorVM>({
+      expect(sponsors[0]).toMatchObject({
         id: "sponsor-1",
         name: "Acme Corp",
         url: "https://acme.example.com",
@@ -64,8 +61,10 @@ describe("SponsorRepository", () => {
       });
     });
 
-    it("null name becomes empty string", async () => {
-      mockFetch.mockResolvedValueOnce([makeSponsorRow({ name: null })]);
+    it("GROQ coalesce handles nulls — name defaults to empty string, featured to false", async () => {
+      mockFetch.mockResolvedValueOnce([
+        makeSponsorRow({ name: "", featured: false }),
+      ]);
 
       const [s] = await runWithRepo(
         Effect.gen(function* () {
@@ -75,14 +74,15 @@ describe("SponsorRepository", () => {
       );
 
       expect(s.name).toBe("");
+      expect(s.featured).toBe(false);
     });
 
-    it("null optional fields become undefined", async () => {
+    it("null optional fields stay null (GROQ returns null for missing values)", async () => {
       mockFetch.mockResolvedValueOnce([
         makeSponsorRow({
           url: null,
           tier: null,
-          featured: null,
+          featured: false,
           logoUrl: null,
           type: null,
         }),
@@ -95,11 +95,11 @@ describe("SponsorRepository", () => {
         }),
       );
 
-      expect(s.url).toBeUndefined();
-      expect(s.tier).toBeUndefined();
+      expect(s.url).toBeNull();
+      expect(s.tier).toBeNull();
       expect(s.featured).toBe(false);
-      expect(s.logoUrl).toBeUndefined();
-      expect(s.type).toBeUndefined();
+      expect(s.logoUrl).toBeNull();
+      expect(s.type).toBeNull();
     });
   });
 });

--- a/apps/web/src/lib/repositories/sponsor.repository.ts
+++ b/apps/web/src/lib/repositories/sponsor.repository.ts
@@ -7,32 +7,23 @@ import type { SPONSORS_QUERY_RESULT } from "../sanity/sanity.types";
 
 export const SPONSORS_QUERY =
   defineQuery(`*[_type == "sponsor" && active == true] | order(name asc) {
-  _id, name, url, type, tier, featured, description, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"
+  "id": _id, "name": coalesce(name, ""), url, type, tier, "featured": coalesce(featured, false), description,
+  "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"
 }`);
 
-export interface SponsorVM {
-  id: string;
-  name: string;
-  url?: string;
-  type?: string;
-  tier?: "hoofdsponsor" | "sponsor" | "sympathisant";
-  featured: boolean;
-  description?: string;
-  logoUrl?: string;
-}
+// ─── View Models ─────────────────────────────────────────────────────────────
 
-export function toSponsorVM(row: SPONSORS_QUERY_RESULT[number]): SponsorVM {
-  return {
-    id: row._id,
-    name: row.name ?? "",
-    url: row.url ?? undefined,
-    type: row.type ?? undefined,
-    tier: row.tier ?? undefined,
-    featured: row.featured ?? false,
-    description: row.description ?? undefined,
-    logoUrl: row.logoUrl ?? undefined,
-  };
-}
+/** GROQ projection now returns the final shape — SponsorVM is a type alias.
+ *  Omit + re-declare normalises the `coalesce()` unions typegen emits. */
+export type SponsorVM = Omit<
+  SPONSORS_QUERY_RESULT[number],
+  "name" | "featured"
+> & {
+  name: string;
+  featured: boolean;
+};
+
+// ─── Service ─────────────────────────────────────────────────────────────────
 
 export interface SponsorRepositoryInterface {
   readonly findAll: () => Effect.Effect<SponsorVM[]>;
@@ -44,8 +35,5 @@ export class SponsorRepository extends Context.Tag("SponsorRepository")<
 >() {}
 
 export const SponsorRepositoryLive = Layer.succeed(SponsorRepository, {
-  findAll: () =>
-    fetchGroq<SPONSORS_QUERY_RESULT>(SPONSORS_QUERY).pipe(
-      Effect.map((rows) => rows.map(toSponsorVM)),
-    ),
+  findAll: () => fetchGroq<SPONSORS_QUERY_RESULT>(SPONSORS_QUERY),
 });

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -1155,53 +1155,45 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/event.repository.ts
 // Variable: EVENTS_QUERY
-// Query: *[_type == "event"] | order(dateStart asc) {  _id, title, dateStart, dateEnd, externalLink,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"}
+// Query: *[_type == "event"] | order(dateStart asc) {  "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": false,  "href": coalesce(externalLink.url, "#"),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"}
 export type EVENTS_QUERY_RESULT = Array<{
-  _id: string;
-  title: string | null;
-  dateStart: string | null;
+  id: string;
+  title: string | "";
+  dateStart: string | "";
   dateEnd: string | null;
-  externalLink: {
-    url?: string;
-    label?: string;
-  } | null;
+  featuredOnHome: false;
+  href: string | "#";
   coverImageUrl: string | null;
 }>;
 
 // Source: ../web/src/lib/repositories/event.repository.ts
 // Variable: NEXT_FEATURED_EVENT_QUERY
-// Query: coalesce(    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"    },    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"    }  )
+// Query: coalesce(...)
 export type NEXT_FEATURED_EVENT_QUERY_RESULT = {
-  _id: string;
-  title: string | null;
-  dateStart: string | null;
+  id: string;
+  title: string | "";
+  dateStart: string | "";
   dateEnd: string | null;
-  featuredOnHome: boolean | null;
-  externalLink: {
-    url?: string;
-    label?: string;
-  } | null;
+  featuredOnHome: boolean | false;
+  href: string | "#";
   coverImageUrl: string | null;
 } | null;
 
 // Source: ../web/src/lib/repositories/homepage.repository.ts
 // Variable: HOMEPAGE_BANNERS_QUERY
-// Query: *[_type == "homePage"][0] {    "bannerSlotA": bannerSlotA-> {      _id,      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",      alt,      href    },    "bannerSlotB": bannerSlotB-> {      _id,      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",      alt,      href    },    "bannerSlotC": bannerSlotC-> {      _id,      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",      alt,      href    }  }
+// Query: *[_type == "homePage"][0] {    "bannerSlotA": bannerSlotA-> {      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",      alt,      href    },    "bannerSlotB": bannerSlotB-> {      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",      alt,      href    },    "bannerSlotC": bannerSlotC-> {      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",      alt,      href    }  }
 export type HOMEPAGE_BANNERS_QUERY_RESULT = {
   bannerSlotA: {
-    _id: string;
     imageUrl: string | null;
     alt: string | null;
     href: string | null;
   } | null;
   bannerSlotB: {
-    _id: string;
     imageUrl: string | null;
     alt: string | null;
     href: string | null;
   } | null;
   bannerSlotC: {
-    _id: string;
     imageUrl: string | null;
     alt: string | null;
     href: string | null;
@@ -1226,11 +1218,11 @@ export type JEUGD_LANDING_PAGE_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/page.repository.ts
 // Variable: PAGE_BY_SLUG_QUERY
-// Query: *[_type == "page" && slug.current == $slug][0] {  _id,  title,  slug,  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }}
+// Query: *[_type == "page" && slug.current == $slug][0] {  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }}
 export type PAGE_BY_SLUG_QUERY_RESULT = {
-  _id: string;
-  title: string | null;
-  slug: Slug | null;
+  id: string;
+  title: string | "";
+  slug: string | "";
   heroImageUrl: string | null;
   body: Array<
     | {
@@ -1431,14 +1423,14 @@ export type RESPONSIBILITY_PATHS_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/sponsor.repository.ts
 // Variable: SPONSORS_QUERY
-// Query: *[_type == "sponsor" && active == true] | order(name asc) {  _id, name, url, type, tier, featured, description, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"}
+// Query: *[_type == "sponsor" && active == true] | order(name asc) {  "id": _id, "name": coalesce(name, ""), url, type, tier, "featured": coalesce(featured, false), description, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"}
 export type SPONSORS_QUERY_RESULT = Array<{
-  _id: string;
-  name: string | null;
+  id: string;
+  name: string | "";
   url: string | null;
   type: "crossing" | "green" | "other" | "panel" | "training" | "white" | null;
   tier: "hoofdsponsor" | "sponsor" | "sympathisant" | null;
-  featured: boolean | null;
+  featured: boolean | false;
   description: string | null;
   logoUrl: string | null;
 }>;
@@ -1662,15 +1654,15 @@ declare module "@sanity/client" {
     '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
     '*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;
     '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
-    '*[_type == "event"] | order(dateStart asc) {\n  _id, title, dateStart, dateEnd, externalLink,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': EVENTS_QUERY_RESULT;
-    '\n  coalesce(\n    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {\n      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    },\n    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {\n      _id, title, dateStart, dateEnd, featuredOnHome, externalLink,\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    }\n  )\n': NEXT_FEATURED_EVENT_QUERY_RESULT;
-    '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      _id,\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;
+    '*[_type == "event"] | order(dateStart asc) {\n  "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": false,\n  "href": coalesce(externalLink.url, "#"),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': EVENTS_QUERY_RESULT;
+    '\n  coalesce(\n    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {\n      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),\n      "href": coalesce(externalLink.url, "#"),\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    },\n    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {\n      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),\n      "href": coalesce(externalLink.url, "#"),\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    }\n  )\n': NEXT_FEATURED_EVENT_QUERY_RESULT;
+    '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;
     '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
-    '*[_type == "page" && slug.current == $slug][0] {\n  _id,\n  title,\n  slug,\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
+    '*[_type == "page" && slug.current == $slug][0] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
     '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "responsibility" && active == true] | order(title asc) {\n  "id": slug.current,\n  "role": audience,\n  question,\n  keywords,\n  summary,\n  category,\n  icon,\n  "primaryContact": primaryContact {\n    "role": role,\n    "email": select(defined(staffMember) => staffMember->email, email),\n    "phone": select(defined(staffMember) => staffMember->phone, phone),\n    "department": select(defined(staffMember) => staffMember->department, department),\n    "name": select(\n      defined(staffMember) => staffMember->firstName + " " + staffMember->lastName,\n      null\n    ),\n    "memberId": staffMember->_id\n  },\n  "steps": steps[] {\n    description,\n    link,\n    "contact": select(defined(contact) => contact {\n      "role": role,\n      "email": select(defined(staffMember) => staffMember->email, email),\n      "phone": select(defined(staffMember) => staffMember->phone, phone),\n      "department": select(defined(staffMember) => staffMember->department, department),\n      "name": select(\n        defined(staffMember) => staffMember->firstName + " " + staffMember->lastName,\n        null\n      ),\n      "memberId": staffMember->_id\n    }, null)\n  },\n  "relatedPaths": coalesce(relatedPaths[]->slug.current, [])\n}': RESPONSIBILITY_PATHS_QUERY_RESULT;
-    '*[_type == "sponsor" && active == true] | order(name asc) {\n  _id, name, url, type, tier, featured, description, "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
+    '*[_type == "sponsor" && active == true] | order(name asc) {\n  "id": _id, "name": coalesce(name, ""), url, type, tier, "featured": coalesce(featured, false), description,\n  "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
     '*[_type == "organigramNode" && active == true] | order(coalesce(sortOrder, 9999) asc, title asc) {\n  _id,\n  title,\n  description,\n  roleCode,\n  department,\n  "parentId": select(defined(parentNode) && parentNode->active == true => parentNode->_id, null),\n  "members": members[@->archived != true]->{\n    "id": _id,\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    "imageUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",\n    email,\n    phone,\n    "psdId": psdId\n  }\n}': ORGANIGRAM_NODES_QUERY_RESULT;
     '*[_type == "organigramNode" && active == true && roleCode in $roleCodes]{\n  title,\n  roleCode,\n  "members": members[@->archived != true && defined(@->email)]->{\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    email\n  }\n}[count(members) > 0] | order(title asc)': KEY_CONTACTS_QUERY_RESULT;
     '*[_type == "staffMember" && psdId == $psdId && archived != true][0] {\n  _id, psdId, firstName, lastName, email, phone, bio,\n  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "organigramPositions": *[_type == "organigramNode" && ^._id in members[]._ref && active == true] | order(title asc, _id asc) { _id, title, roleCode, department },\n  "responsibilityPaths": *[_type == "responsibility" && active == true && defined(slug.current) && slug.current != "" && (primaryContact.staffMember._ref == ^._id || ^._id in steps[].contact.staffMember._ref)] | order(title asc, _id asc) { title, "slug": slug.current, category, icon }\n}': STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT;

--- a/docs/prd/repository-pipeline-simplification.md
+++ b/docs/prd/repository-pipeline-simplification.md
@@ -84,9 +84,21 @@ None. Repositories use Sanity typegen types, not Effect Schema.
 - [ ] Will removing `ArticleVM` break component type imports elsewhere? — Grep for imports during Phase 1
 - [ ] Should we regenerate `sanity.types.ts` as part of this work to ensure typegen picks up projection changes? — Likely yes, add to Phase 1
 
-## 8. Discovered Unknowns
+## 8. Secondary ViewModel Audit (Phase 3)
+
+| ViewModel           | Location                    | Decision               | Reason                                                                                                                       |
+| ------------------- | --------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `HomepageArticle`   | `article.repository.ts:92`  | **Keep**               | Date formatting (`formatArticleDate`), URL construction (`/nieuws/${slug}`), tag reshaping — runtime logic GROQ can't handle |
+| `CalendarMatch`     | `kalender/utils.ts:17`      | **Keep**               | Transforms BFF `Match` (api-contract), not Sanity data — out of scope for Sanity pipeline simplification                     |
+| `CalendarEvent`     | `kalender/utils.ts:32`      | **Keep**               | Interface segregation — calendar widget only needs `id/title/dateStart/dateEnd/href`, not full `EventVM`                     |
+| `BannerSlotVM`      | `homepage.repository.ts:29` | **Keep**               | Primary VM with validation guard (`!imageUrl` or `!alt` → null) — real business logic                                        |
+| `RelatedArticleRef` | `article.repository.ts:88`  | **Already simplified** | Type alias from GROQ result (done in Phase 1)                                                                                |
+
+## 9. Discovered Unknowns
 
 - [2026-04-03] `coalesce()` in GROQ works for `slug.current` on missing slug — returns `""` as expected → resolved inline
 - [2026-04-03] `coverImageUrl` changes from `string | undefined` to `string | null` (GROQ can't produce JS `undefined`) — requires `?? undefined` at component prop boundaries → resolved inline
 - [2026-04-03] `RelatedArticleRef` now includes `unpublishAt` field from GROQ projection (used for publication filtering) — test mocks updated → resolved inline
 - [2026-04-03] `sanity.types.ts` was updated manually (no `sanity typegen` CLI available in worktree) — should be regenerated with `sanity typegen generate` when available
+- [2026-04-03] `homepage.repository.ts` validation transform kept — `toBannerSlotVM` guards against incomplete banner data (missing imageUrl/alt). Only GROQ change: removed unused `_id` from projection
+- [2026-04-03] Nullable fields in simplified VMs use `string | null` (GROQ's natural return type) instead of `string | undefined`. Consumer mapping points add `?? undefined` where component props require it


### PR DESCRIPTION
Closes #1192

## What changed
- Pushed GROQ projections deeper into queries for article, event, sponsor, and page repositories, eliminating post-fetch TypeScript transforms
- Simplified repository functions by removing intermediate mapping steps and letting Sanity return pre-shaped data
- Updated and expanded unit tests to match the new simplified repository signatures

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Verified article, event, sponsor, and page queries return correctly shaped data