### PR TITLE
fix(api): skip archiving staff referenced by organigram/responsibility (#1211)

### DIFF
--- a/apps/api/src/psd/fetch-json.test.ts
+++ b/apps/api/src/psd/fetch-json.test.ts
@@ -41,6 +41,7 @@ const sanityMock: SanityProjectionInterface = {
   getActiveStaffPsdIds: () => Effect.succeed([]),
   getActiveTeamPsdIds: () => Effect.succeed([]),
   getVisibleTeamPsdIds: () => Effect.succeed([]),
+  getProtectedStaffPsdIds: () => Effect.succeed([]),
 };
 
 const seasons = [

--- a/apps/api/src/psd/opponent.test.ts
+++ b/apps/api/src/psd/opponent.test.ts
@@ -42,6 +42,7 @@ const sanityProjectionMock: SanityProjectionInterface = {
   getActiveStaffPsdIds: () => Effect.succeed([]),
   getActiveTeamPsdIds: () => Effect.succeed([]),
   getVisibleTeamPsdIds: () => Effect.succeed([]),
+  getProtectedStaffPsdIds: () => Effect.succeed([]),
 };
 
 function runService<A>(

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -45,6 +45,7 @@ function makeSanityMock(
     getActiveStaffPsdIds: () => Effect.succeed([]),
     getActiveTeamPsdIds: () => Effect.succeed([]),
     getVisibleTeamPsdIds: () => Effect.succeed(visiblePsdIds),
+    getProtectedStaffPsdIds: () => Effect.succeed([]),
   };
 }
 

--- a/apps/api/src/sanity/projection.ts
+++ b/apps/api/src/sanity/projection.ts
@@ -42,6 +42,11 @@ export interface SanityProjectionInterface {
   >;
   /** Fetch PSD IDs of all non-archived teams. */
   readonly getActiveTeamPsdIds: () => Effect.Effect<string[], SanityQueryError>;
+  /** Fetch PSD IDs of staff members referenced by active organigramNode or responsibility documents. */
+  readonly getProtectedStaffPsdIds: () => Effect.Effect<
+    string[],
+    SanityQueryError
+  >;
 }
 
 export class SanityProjection extends Context.Tag("SanityProjection")<
@@ -135,6 +140,29 @@ export const SanityProjectionLive = Layer.effect(
           },
           catch: (cause) =>
             new SanityQueryError("Failed to fetch active team PSD IDs", cause),
+        }),
+
+      getProtectedStaffPsdIds: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const rows = await client.fetch<Array<string | null>>(
+              `*[_type == "staffMember" && defined(psdId) && psdId != "" && (
+                _id in *[_type == "organigramNode" && active == true].members[]._ref
+                ||
+                _id in *[_type == "responsibility" && active == true].primaryContact.staffMember._ref
+                ||
+                _id in *[_type == "responsibility" && active == true].steps[].contact.staffMember._ref
+              )].psdId`,
+            );
+            return rows.filter(
+              (id): id is string => typeof id === "string" && id.length > 0,
+            );
+          },
+          catch: (cause) =>
+            new SanityQueryError(
+              "Failed to fetch protected staff PSD IDs",
+              cause,
+            ),
         }),
     };
   }),

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -402,6 +402,13 @@ export const runSync = Effect.gen(function* () {
     );
 
     const activeStaffInSanity = yield* sanityReader.getActiveStaffPsdIds();
+    const protectedStaffIds = yield* sanityReader.getProtectedStaffPsdIds();
+    for (const id of protectedStaffIds) accumulatedStaffIds.add(id);
+    if (protectedStaffIds.length > 0) {
+      yield* Effect.log(
+        `reconciliation: ${protectedStaffIds.length} staff protected by organigram/responsibility refs: ${protectedStaffIds.join(", ")}`,
+      );
+    }
     yield* reconcileEntity(
       "staff",
       activeStaffInSanity,

--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -58,6 +58,7 @@ function makeSanityMocks() {
   const getActiveStaffPsdIds = vi.fn(() => Effect.succeed([] as string[]));
   const getActiveTeamPsdIds = vi.fn(() => Effect.succeed([] as string[]));
   const getVisibleTeamPsdIds = vi.fn(() => Effect.succeed([] as string[]));
+  const getProtectedStaffPsdIds = vi.fn(() => Effect.succeed([] as string[]));
 
   const writerMock: SanityMutationInterface = {
     upsertPlayer,
@@ -76,6 +77,7 @@ function makeSanityMocks() {
     getActiveStaffPsdIds,
     getActiveTeamPsdIds,
     getVisibleTeamPsdIds,
+    getProtectedStaffPsdIds,
   };
 
   return {
@@ -90,6 +92,7 @@ function makeSanityMocks() {
     getActivePlayerPsdIds,
     getActiveStaffPsdIds,
     getActiveTeamPsdIds,
+    getProtectedStaffPsdIds,
     writerMock,
     readerMock,
   };
@@ -378,6 +381,7 @@ describe("runSync", () => {
       getActiveStaffPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       getActiveTeamPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       getVisibleTeamPsdIds: vi.fn(() => Effect.succeed([] as string[])),
+      getProtectedStaffPsdIds: vi.fn(() => Effect.succeed([] as string[])),
     };
     const psdMock = makePsdTeamClientMock(
       [ONE_TEAM],
@@ -824,5 +828,124 @@ describe("runSync", () => {
 
     expect(archiveStaff).not.toHaveBeenCalled();
     expect(archiveTeams).not.toHaveBeenCalled();
+  });
+
+  // ─── Reconciliation safety net: organigram/responsibility protection ────────
+
+  it("skips archiving orphan staff referenced by active organigramNode", async () => {
+    const kvStub = makeKvStub();
+
+    // PSD returns 4 staff for the single team
+    const psdStaff: PsdMember[] = [
+      { ...ONE_STAFF, id: 500 },
+      { ...ONE_STAFF, id: 600 },
+      { ...ONE_STAFF, id: 700 },
+      { ...ONE_STAFF, id: 800 },
+    ];
+
+    const {
+      getActiveStaffPsdIds,
+      getProtectedStaffPsdIds,
+      archiveStaff,
+      writerMock,
+      readerMock,
+    } = makeSanityMocks();
+
+    // Sanity has 6 active staff — 900 and 950 are orphans (not in PSD)
+    getActiveStaffPsdIds.mockReturnValue(
+      Effect.succeed(["500", "600", "700", "800", "900", "950"]),
+    );
+    // Staff 900 is referenced by an active organigramNode → protected
+    getProtectedStaffPsdIds.mockReturnValue(Effect.succeed(["900"]));
+
+    const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER], psdStaff);
+
+    await Effect.runPromise(
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, writerMock, readerMock, psdMock)),
+      ),
+    );
+
+    // Only 950 should be archived — 900 is protected by organigram ref
+    expect(archiveStaff).toHaveBeenCalledOnce();
+    expect(archiveStaff).toHaveBeenCalledWith(["950"]);
+  });
+
+  it("skips archiving orphan staff referenced by active responsibility", async () => {
+    const kvStub = makeKvStub();
+
+    // PSD returns 4 staff for the single team
+    const psdStaff: PsdMember[] = [
+      { ...ONE_STAFF, id: 500 },
+      { ...ONE_STAFF, id: 600 },
+      { ...ONE_STAFF, id: 700 },
+      { ...ONE_STAFF, id: 800 },
+    ];
+
+    const {
+      getActiveStaffPsdIds,
+      getProtectedStaffPsdIds,
+      archiveStaff,
+      writerMock,
+      readerMock,
+    } = makeSanityMocks();
+
+    // Sanity has 6 active staff — 900 and 950 are orphans
+    getActiveStaffPsdIds.mockReturnValue(
+      Effect.succeed(["500", "600", "700", "800", "900", "950"]),
+    );
+    // Staff 950 is referenced by an active responsibility → protected
+    getProtectedStaffPsdIds.mockReturnValue(Effect.succeed(["950"]));
+
+    const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER], psdStaff);
+
+    await Effect.runPromise(
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, writerMock, readerMock, psdMock)),
+      ),
+    );
+
+    // Only 900 should be archived — 950 is protected by responsibility ref
+    expect(archiveStaff).toHaveBeenCalledOnce();
+    expect(archiveStaff).toHaveBeenCalledWith(["900"]);
+  });
+
+  it("archives orphan staff without organigram or responsibility refs", async () => {
+    const kvStub = makeKvStub();
+
+    // PSD returns 4 staff for the single team
+    const psdStaff: PsdMember[] = [
+      { ...ONE_STAFF, id: 500 },
+      { ...ONE_STAFF, id: 600 },
+      { ...ONE_STAFF, id: 700 },
+      { ...ONE_STAFF, id: 800 },
+    ];
+
+    const {
+      getActiveStaffPsdIds,
+      getProtectedStaffPsdIds,
+      archiveStaff,
+      writerMock,
+      readerMock,
+    } = makeSanityMocks();
+
+    // Sanity has 5 active staff — 900 is the orphan (1/5 = 20% < 30%)
+    getActiveStaffPsdIds.mockReturnValue(
+      Effect.succeed(["500", "600", "700", "800", "900"]),
+    );
+    // No protected staff — 900 has no organigram or responsibility refs
+    getProtectedStaffPsdIds.mockReturnValue(Effect.succeed([]));
+
+    const psdMock = makePsdTeamClientMock([ONE_TEAM], [ONE_PLAYER], psdStaff);
+
+    await Effect.runPromise(
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, writerMock, readerMock, psdMock)),
+      ),
+    );
+
+    // 900 should be archived — no protection
+    expect(archiveStaff).toHaveBeenCalledOnce();
+    expect(archiveStaff).toHaveBeenCalledWith(["900"]);
   });
 });


### PR DESCRIPTION
Closes #1211

## What changed
- Reconciliation now queries Sanity for active `organigramNode` and `responsibility` documents to collect referenced staff member IDs
- Staff members referenced by these documents are excluded from archival during PSD sync reconciliation
- Added Vitest tests covering organigram-ref, responsibility-ref, and unreferenced orphan scenarios

## Testing
- All checks pass: `pnpm --filter @kcvv/api check-all`
- Vitest: orphan with organigram ref → not archived; orphan with responsibility ref → not archived; orphan without refs → archived