### PR TITLE
fix(schema): add crossorigin=anonymous to organigram img tags for canvas export (#1222)

### DIFF
--- a/apps/web/src/components/organigram/chart/NodeRenderer.test.ts
+++ b/apps/web/src/components/organigram/chart/NodeRenderer.test.ts
@@ -53,6 +53,41 @@ const threeSharedNode: NodeData = {
   ],
 };
 
+// --- CORS: crossorigin="anonymous" on all img tags (#1222) ---
+
+function findImgTags(html: string): string[] {
+  return html.match(/<img\s[^>]*>/g) ?? [];
+}
+
+describe("img crossorigin attribute for canvas export (#1222)", () => {
+  it("single member node img has crossorigin=anonymous", () => {
+    const html = renderNode(singleMemberNode, false);
+    const imgs = findImgTags(html);
+    expect(imgs.length).toBeGreaterThan(0);
+    for (const img of imgs) {
+      expect(img).toContain('crossorigin="anonymous"');
+    }
+  });
+
+  it("shared node imgs have crossorigin=anonymous", () => {
+    const html = renderNode(sharedNode, false);
+    const imgs = findImgTags(html);
+    expect(imgs.length).toBeGreaterThan(0);
+    for (const img of imgs) {
+      expect(img).toContain('crossorigin="anonymous"');
+    }
+  });
+
+  it("compact single member node img has crossorigin=anonymous", () => {
+    const html = renderCompactNode(singleMemberNode, false);
+    const imgs = findImgTags(html);
+    expect(imgs.length).toBeGreaterThan(0);
+    for (const img of imgs) {
+      expect(img).toContain('crossorigin="anonymous"');
+    }
+  });
+});
+
 // --- renderNode ---
 
 describe("renderNode", () => {

--- a/apps/web/src/components/organigram/chart/NodeRenderer.tsx
+++ b/apps/web/src/components/organigram/chart/NodeRenderer.tsx
@@ -115,6 +115,7 @@ function renderSingleNode(
           <img
             src="${imageUrl}"
             alt="${displayName}"
+            crossorigin="anonymous"
             style="
               width: 64px;
               height: 64px;
@@ -282,6 +283,7 @@ function renderSharedNode(
         ? `<img
             src="${m.imageUrl}"
             alt="${m.name ?? ""}"
+            crossorigin="anonymous"
             style="
               width: 28px;
               height: 28px;
@@ -426,6 +428,7 @@ function renderCompactSingleNode(
           <img
             src="${imageUrl}"
             alt="${displayName}"
+            crossorigin="anonymous"
             style="
               width: 48px;
               height: 48px;


### PR DESCRIPTION
Closes #1222

## What changed
- Added `crossorigin="anonymous"` attribute to `<img>` tags in `NodeRenderer.tsx` so that staff photos loaded from Sanity CDN don't taint the canvas during organigram chart export
- Added test coverage for the crossorigin attribute rendering

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Manual: open organigram page → export chart → photos render correctly without CORS errors