### PR TITLE
fix(ui): make homepage MatchWidget tappable → match detail (#1252)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -75,7 +75,7 @@ Every new user-facing feature or page **must** include an analytics section. Bef
 
 - [ ] **Events defined**: new user interactions have named events in the PRD event taxonomy
 - [ ] **`trackEvent` calls added**: all interactive components call `trackEvent` with the correct parameters
-- [ ] **GTM updated**: new event names not already matched by the `responsibility_|search_|organigram_|related_content_` regex need a new trigger/tag in GTM; new event parameters need a Data Layer Variable (DLV) created in GTM and mapped into the GA4 Event tag's parameter fields
+- [ ] **GTM updated**: new event names not already matched by the `responsibility_|search_|organigram_|related_content_|homepage_` regex need a new trigger/tag in GTM; new event parameters need a Data Layer Variable (DLV) created in GTM and mapped into the GA4 Event tag's parameter fields
 - [ ] **GA4 custom dimensions registered**: any new event parameters registered in GA4 → Admin → Data display → Custom definitions (run `node scripts/create-ga4-dimensions.mjs` or add manually)
 - [ ] **GA4 explorations updated**: existing explorations updated, or new exploration created, if the feature introduces a new funnel or metric worth tracking
 - [ ] **No PII**: no email addresses, phone numbers, names, or raw internal IDs in event parameters (hash internal IDs via `hashMemberId`)

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.mocks.ts
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.mocks.ts
@@ -80,6 +80,24 @@ export const mockPostponedMatch: UpcomingMatch = {
   competition: "3e Afdeling VV",
 };
 
+export const mockStoppedMatch: UpcomingMatch = {
+  id: 106,
+  date: new Date("2026-04-12T13:00:00Z"),
+  homeTeam: {
+    id: 1235,
+    name: "KCVV Elewijt",
+    logo: "https://dfaozfi7c7f3s.cloudfront.net/logos/extra_groot/1235.png?v=1",
+  },
+  awayTeam: {
+    id: 448,
+    name: "FC Wezel Sport",
+    logo: "https://dfaozfi7c7f3s.cloudfront.net/logos/extra_groot/448.png?v=1",
+  },
+  status: "stopped",
+  squadLabel: "A",
+  competition: "3e Afdeling VV",
+};
+
 export const mockForfeitedMatch: UpcomingMatch = {
   id: 104,
   date: new Date("2026-03-15T14:00:00Z"),

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.stories.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, within } from "storybook/test";
 import { MatchWidget } from "./MatchWidget";
 import {
   mockUpcomingMatch,
@@ -33,12 +34,28 @@ type Story = StoryObj<typeof meta>;
 
 export const Upcoming: Story = {
   args: { match: mockUpcomingMatch, teamLabel: "A-Ploeg" },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole("link");
+    await expect(link).toHaveAttribute(
+      "href",
+      "/ploegen/eerste-elftal-a?tab=wedstrijden",
+    );
+  },
 };
 
 export const Finished: Story = {
   args: { match: mockFinishedMatchWin, teamLabel: "A-Ploeg" },
   parameters: {
     docs: { description: { story: "Finished match with final score (win)." } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole("link");
+    await expect(link).toHaveAttribute(
+      "href",
+      `/wedstrijd/${mockFinishedMatchWin.id}`,
+    );
   },
 };
 
@@ -64,6 +81,14 @@ export const Forfeited: Story = {
   args: { match: mockForfeitedMatch, teamLabel: "A-Ploeg" },
   parameters: {
     docs: { description: { story: "Forfeited match — shows FF badge." } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole("link");
+    await expect(link).toHaveAttribute(
+      "href",
+      `/wedstrijd/${mockForfeitedMatch.id}`,
+    );
   },
 };
 

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
@@ -7,6 +7,7 @@ import {
   mockFinishedMatchWin,
   mockFinishedMatchDraw,
   mockPostponedMatch,
+  mockStoppedMatch,
   mockForfeitedMatch,
   mockLongTeamNames,
 } from "./MatchWidget.mocks";
@@ -171,6 +172,12 @@ describe("MatchWidget", () => {
 
     it("links postponed match to calendar page", () => {
       render(<MatchWidget match={mockPostponedMatch} />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute("href", "/kalender");
+    });
+
+    it("links stopped match to calendar page", () => {
+      render(<MatchWidget match={mockStoppedMatch} />);
       const link = screen.getByRole("link");
       expect(link).toHaveAttribute("href", "/kalender");
     });

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MatchWidget } from "./MatchWidget";
 import {
   mockUpcomingMatch,
@@ -9,6 +10,7 @@ import {
   mockForfeitedMatch,
   mockLongTeamNames,
 } from "./MatchWidget.mocks";
+import { trackEvent } from "@/lib/analytics/track-event";
 
 vi.mock("next/image", () => ({
   default: ({
@@ -21,6 +23,28 @@ vi.mock("next/image", () => ({
     [key: string]: unknown;
   }) => <img src={src} alt={alt} {...props} />,
 }));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+const trackEventMock = vi.mocked(trackEvent);
 
 describe("MatchWidget", () => {
   describe("Overline label", () => {
@@ -117,6 +141,95 @@ describe("MatchWidget", () => {
     it("renders as a section landmark", () => {
       render(<MatchWidget match={mockUpcomingMatch} />);
       expect(screen.getByRole("region")).toBeInTheDocument();
+    });
+  });
+
+  describe("Link wrapping", () => {
+    it("links finished match to /wedstrijd/:id", () => {
+      render(<MatchWidget match={mockFinishedMatchWin} />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute(
+        "href",
+        `/wedstrijd/${mockFinishedMatchWin.id}`,
+      );
+    });
+
+    it("links forfeited match to /wedstrijd/:id", () => {
+      render(<MatchWidget match={mockForfeitedMatch} />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute(
+        "href",
+        `/wedstrijd/${mockForfeitedMatch.id}`,
+      );
+    });
+
+    it("links upcoming match to team fixtures page", () => {
+      render(<MatchWidget match={mockUpcomingMatch} />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute(
+        "href",
+        "/ploegen/eerste-elftal-a?tab=wedstrijden",
+      );
+    });
+
+    it("links postponed match to team fixtures page", () => {
+      render(<MatchWidget match={mockPostponedMatch} />);
+      const link = screen.getByRole("link");
+      expect(link).toHaveAttribute(
+        "href",
+        "/ploegen/eerste-elftal-a?tab=wedstrijden",
+      );
+    });
+
+    it("wraps entire card content in one link", () => {
+      render(<MatchWidget match={mockUpcomingMatch} />);
+      const link = screen.getByRole("link");
+      expect(link).toContainElement(screen.getByText(/KCVV Elewijt/i));
+      expect(link).toContainElement(screen.getByText(/KVC Wilrijk/i));
+    });
+
+    it("link has visible focus state", () => {
+      render(<MatchWidget match={mockUpcomingMatch} />);
+      const link = screen.getByRole("link");
+      expect(link.className).toMatch(/focus-visible/);
+    });
+  });
+
+  describe("Analytics", () => {
+    beforeEach(() => {
+      trackEventMock.mockClear();
+    });
+
+    it("fires homepage_match_widget_clicked on click for finished match", async () => {
+      const user = userEvent.setup();
+      render(<MatchWidget match={mockFinishedMatchWin} />);
+      const link = screen.getByRole("link");
+      await user.click(link);
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+      expect(trackEventMock).toHaveBeenCalledWith(
+        "homepage_match_widget_clicked",
+        {
+          match_id: mockFinishedMatchWin.id,
+          match_status: "finished",
+          destination: `/wedstrijd/${mockFinishedMatchWin.id}`,
+        },
+      );
+    });
+
+    it("fires homepage_match_widget_clicked on click for upcoming match", async () => {
+      const user = userEvent.setup();
+      render(<MatchWidget match={mockUpcomingMatch} />);
+      const link = screen.getByRole("link");
+      await user.click(link);
+      expect(trackEventMock).toHaveBeenCalledTimes(1);
+      expect(trackEventMock).toHaveBeenCalledWith(
+        "homepage_match_widget_clicked",
+        {
+          match_id: mockUpcomingMatch.id,
+          match_status: "scheduled",
+          destination: "/ploegen/eerste-elftal-a?tab=wedstrijden",
+        },
+      );
     });
   });
 });

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
@@ -163,22 +163,16 @@ describe("MatchWidget", () => {
       );
     });
 
-    it("links upcoming match to team fixtures page", () => {
+    it("links upcoming match to calendar page", () => {
       render(<MatchWidget match={mockUpcomingMatch} />);
       const link = screen.getByRole("link");
-      expect(link).toHaveAttribute(
-        "href",
-        "/ploegen/eerste-elftal-a?tab=wedstrijden",
-      );
+      expect(link).toHaveAttribute("href", "/kalender");
     });
 
-    it("links postponed match to team fixtures page", () => {
+    it("links postponed match to calendar page", () => {
       render(<MatchWidget match={mockPostponedMatch} />);
       const link = screen.getByRole("link");
-      expect(link).toHaveAttribute(
-        "href",
-        "/ploegen/eerste-elftal-a?tab=wedstrijden",
-      );
+      expect(link).toHaveAttribute("href", "/kalender");
     });
 
     it("wraps entire card content in one link", () => {
@@ -227,7 +221,7 @@ describe("MatchWidget", () => {
         {
           match_id: mockUpcomingMatch.id,
           match_status: "scheduled",
-          destination: "/ploegen/eerste-elftal-a?tab=wedstrijden",
+          destination: "/kalender",
         },
       );
     });

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
@@ -1,7 +1,15 @@
+"use client";
+
 import Image from "next/image";
+import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
 import { formatWidgetDate } from "@/lib/utils/dates";
+import { trackEvent } from "@/lib/analytics/track-event";
 import type { UpcomingMatch } from "@/components/match/types";
+
+// The homepage only ever renders the A-team match (see page.tsx nextMatch query).
+// If MatchWidget is reused for other teams, derive the slug from match data or accept it as a prop.
+const TEAM_FIXTURES_FALLBACK = "/ploegen/eerste-elftal-a?tab=wedstrijden";
 
 export interface MatchWidgetProps {
   /** The match to display — typically the first result from BffService.getNextMatches() */
@@ -38,11 +46,25 @@ export function MatchWidget({
     .filter(Boolean)
     .join(" · ");
 
+  const href = isFinished ? `/wedstrijd/${match.id}` : TEAM_FIXTURES_FALLBACK;
+
+  const handleClick = () => {
+    trackEvent("homepage_match_widget_clicked", {
+      match_id: match.id,
+      match_status: match.status,
+      destination: href,
+    });
+  };
+
   return (
     <section
       aria-label={`Wedstrijd: ${match.homeTeam.name} vs ${match.awayTeam.name}`}
     >
-      <div className="px-4 md:px-8 max-w-7xl mx-auto">
+      <Link
+        href={href}
+        onClick={handleClick}
+        className="block px-4 md:px-8 max-w-7xl mx-auto rounded-lg transition-shadow hover:shadow-lg active:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
         {/* Overline — left-aligned, single leading rule */}
         <p className="flex items-center gap-2 mb-6 text-[11px] font-bold uppercase tracking-label text-white/50">
           <span aria-hidden="true" className="block w-5 h-0.5 bg-white/30" />
@@ -123,7 +145,7 @@ export function MatchWidget({
           {/* Away team — logo + name stacked, left-aligned */}
           <TeamColumn team={match.awayTeam} align="away" />
         </div>
-      </div>
+      </Link>
     </section>
   );
 }

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
@@ -7,8 +7,9 @@ import { formatWidgetDate } from "@/lib/utils/dates";
 import { trackEvent } from "@/lib/analytics/track-event";
 import type { UpcomingMatch } from "@/components/match/types";
 
-// The homepage only ever renders the A-team match (see page.tsx nextMatch query).
-// If MatchWidget is reused for other teams, derive the slug from match data or accept it as a prop.
+// Fallback for statuses that don't have a detail page or a calendar entry
+// (e.g. unknown future statuses). If MatchWidget is reused for other teams,
+// derive the slug from match data or accept it as a prop.
 const TEAM_FIXTURES_FALLBACK = "/ploegen/eerste-elftal-a?tab=wedstrijden";
 
 export interface MatchWidgetProps {
@@ -46,7 +47,13 @@ export function MatchWidget({
     .filter(Boolean)
     .join(" · ");
 
-  const href = isFinished ? `/wedstrijd/${match.id}` : TEAM_FIXTURES_FALLBACK;
+  const href = isFinished
+    ? `/wedstrijd/${match.id}`
+    : isPostponed
+      ? "/kalender"
+      : match.status === "scheduled"
+        ? "/kalender"
+        : TEAM_FIXTURES_FALLBACK;
 
   const handleClick = () => {
     trackEvent("homepage_match_widget_clicked", {
@@ -63,7 +70,7 @@ export function MatchWidget({
       <Link
         href={href}
         onClick={handleClick}
-        className="block px-4 md:px-8 max-w-7xl mx-auto rounded-lg transition-shadow hover:shadow-lg active:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        className="block px-4 py-4 md:px-8 md:py-6 max-w-7xl mx-auto rounded-lg transition-shadow hover:shadow-lg active:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
       >
         {/* Overline — left-aligned, single leading rule */}
         <p className="flex items-center gap-2 mb-6 text-[11px] font-bold uppercase tracking-label text-white/50">

--- a/docs/analytics-ga4-setup.md
+++ b/docs/analytics-ga4-setup.md
@@ -19,6 +19,7 @@ and at least one real user session with analytics consent given.
    - [4b. Search Funnel](#4b-search-funnel)
    - [4c. Organigram Usage Exploration](#4c-organigram-usage-exploration)
    - [4d. Related Content Funnel](#4d-related-content-funnel)
+   - [4e. Homepage Match Widget Clicks](#4e-homepage-match-widget-clicks)
 5. [Create custom reports](#5-create-custom-reports)
    - [5a. Responsibility Finder Success Rate](#5a-responsibility-finder-success-rate)
    - [5b. Responsibility No-Results (Content Gaps)](#5b-responsibility-no-results-content-gaps)
@@ -38,12 +39,12 @@ and at least one real user session with analytics consent given.
 When you open [analytics.google.com](https://analytics.google.com) and select the KCVV
 property, you land on the **Home** screen. The left sidebar has five sections:
 
-| Sidebar item    | What it is                                                         |
-| --------------- | ------------------------------------------------------------------ |
-| **Home**        | Overview dashboard with auto-generated cards                       |
-| **Reports**     | Standard reports: traffic, engagement, pages, devices              |
-| **Explore**     | Where you build custom funnels and reports (called "Explorations") |
-| **Advertising** | Attribution and conversion paths                                   |
+| Sidebar item    | What it is                                                                                                                                                                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Home**        | Overview dashboard with auto-generated cards                                                                                                                                                                                                                             |
+| **Reports**     | Standard reports: traffic, engagement, pages, devices                                                                                                                                                                                                                    |
+| **Explore**     | Where you build custom funnels and reports (called "Explorations")                                                                                                                                                                                                       |
+| **Advertising** | Attribution and conversion paths                                                                                                                                                                                                                                         |
 | **Admin**       | Custom definitions: Admin → Data display → Custom definitions; DebugView: Admin → Data display → DebugView; Events/Key events: Admin → Data display → Events; Audiences: Admin → Audience manager; Data streams: Admin → Data collection and modification → Data Streams |
 
 We will mostly work in **Explore** and **Admin**.
@@ -69,7 +70,7 @@ DebugView shows events from individual browser sessions in real time.
 1. Open the site in Chrome with GTM Preview active (or `?gtm_debug=x` appended) and accept the analytics cookie consent.
 2. Open Chrome DevTools → Console → run:
    ```javascript
-   dataLayer
+   dataLayer;
    ```
    You should see an array with `gtm.js`, `gtm.dom`, `gtm.load` entries.
 3. In GA4, go to **Configure** → **DebugView** (bottom of the left sidebar under Configure).
@@ -103,7 +104,7 @@ GA4 automatically tracks standard parameters (`page_location`, `session_id`, etc
 but **custom event parameters are invisible in reports unless you register them first**
 as Custom Dimensions.
 
-You have 50 custom dimension slots. We will use 20.
+You have 50 custom dimension slots. We will use 23.
 
 ### How to add a custom dimension
 
@@ -120,28 +121,31 @@ Repeat for each row in the table below.
 
 ### Dimensions to register
 
-| Dimension name     | Event parameter      | Where it appears                                                            |
-| ------------------ | -------------------- | --------------------------------------------------------------------------- |
-| Role               | `role`               | Responsibility finder events                                                |
-| Query text         | `query_text`         | Search & responsibility no-results events                                   |
-| Query length       | `query_length`       | Search & responsibility events                                              |
-| Results count      | `results_count`      | `search_results_shown`, `responsibility_search`                             |
-| Path ID            | `path_id`            | Responsibility finder events                                                |
-| Category           | `category`           | `responsibility_suggestion_clicked`, `responsibility_dwell`                 |
+| Dimension name     | Event parameter      | Where it appears                                                                      |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------- |
+| Role               | `role`               | Responsibility finder events                                                          |
+| Query text         | `query_text`         | Search & responsibility no-results events                                             |
+| Query length       | `query_length`       | Search & responsibility events                                                        |
+| Results count      | `results_count`      | `search_results_shown`, `responsibility_search`                                       |
+| Path ID            | `path_id`            | Responsibility finder events                                                          |
+| Category           | `category`           | `responsibility_suggestion_clicked`, `responsibility_dwell`                           |
 | Position           | `position`           | `responsibility_suggestion_clicked`, `search_result_clicked`, `related_content_click` |
-| Contact type       | `contact_type`       | `responsibility_contact_clicked` ("email" / "phone")                        |
-| Dwell seconds      | `dwell_seconds`      | `responsibility_dwell`                                                      |
-| Had results        | `had_results`        | `responsibility_abandon`                                                    |
-| Filter type        | `filter_type`        | `search_filter_changed`                                                     |
-| Result type        | `result_type`        | `search_result_clicked`, `related_content_click`                            |
-| Result title       | `result_title`       | `search_result_clicked`                                                     |
-| Organigram view    | `view`               | Organigram events                                                           |
-| Interaction source | `source`             | `organigram_view_changed`, `related_content_*`                              |
-| Department         | `department`         | `organigram_department_filtered`                                            |
-| Member ID          | `member_id`          | `organigram_member_clicked`                                                 |
-| Target type        | `target_type`        | `related_content_click`, `related_content_shown`                            |
-| Target ID          | `target_id`          | `related_content_click`                                                     |
-| Source entity type | `source_entity_type` | `related_content_shown`, `related_content_click`                            |
+| Contact type       | `contact_type`       | `responsibility_contact_clicked` ("email" / "phone")                                  |
+| Dwell seconds      | `dwell_seconds`      | `responsibility_dwell`                                                                |
+| Had results        | `had_results`        | `responsibility_abandon`                                                              |
+| Filter type        | `filter_type`        | `search_filter_changed`                                                               |
+| Result type        | `result_type`        | `search_result_clicked`, `related_content_click`                                      |
+| Result title       | `result_title`       | `search_result_clicked`                                                               |
+| Organigram view    | `view`               | Organigram events                                                                     |
+| Interaction source | `source`             | `organigram_view_changed`, `related_content_*`                                        |
+| Department         | `department`         | `organigram_department_filtered`                                                      |
+| Member ID          | `member_id`          | `organigram_member_clicked`                                                           |
+| Target type        | `target_type`        | `related_content_click`, `related_content_shown`                                      |
+| Target ID          | `target_id`          | `related_content_click`                                                               |
+| Source entity type | `source_entity_type` | `related_content_shown`, `related_content_click`                                      |
+| Match ID           | `match_id`           | `homepage_match_widget_clicked`                                                       |
+| Match status       | `match_status`       | `homepage_match_widget_clicked`                                                       |
+| Destination        | `destination`        | `homepage_match_widget_clicked`                                                       |
 
 > **Tip**: The dimension name is only a label for the GA4 UI. The event parameter must
 > match the code exactly (case-sensitive, snake_case).
@@ -170,21 +174,25 @@ make it accessible to anyone in the GA4 property.
 right panel to open the step editor:
 
 **Step 1 — Role selected**
+
 - Click **Add step**
 - Step name: `Role selected`
 - Click **Add condition** → Event name → `responsibility_role_selected`
 
 **Step 2 — Search performed**
+
 - Click **Add step**
 - Step name: `Search performed`
 - Condition: Event name → `responsibility_search`
 
 **Step 3 — Suggestion clicked**
+
 - Click **Add step**
 - Step name: `Suggestion clicked`
 - Condition: Event name → `responsibility_suggestion_clicked`
 
 **Step 4 — Success**
+
 - Click **Add step**
 - Step name: `Success (contact or dwell)`
 - Condition: Event name → `responsibility_contact_clicked`
@@ -193,7 +201,7 @@ right panel to open the step editor:
 Click **Apply** to close the step editor.
 
 > **Analyzing abandonment**: Do not add `responsibility_abandon` as a sequential
-> funnel step — GA4 models abandonment as drop-off *before* the final success step,
+> funnel step — GA4 models abandonment as drop-off _before_ the final success step,
 > not as a step after it. To analyze abandonment separately, use **Path exploration**
 > (Explore → + → Path exploration) filtered to `responsibility_abandon`, or create a
 > **segment comparison**: one segment for sessions containing
@@ -219,15 +227,19 @@ select the **Role** dimension. This shows which roles have the lowest completion
 **Steps:**
 
 **Step 1 — Search submitted**
+
 - Condition: Event name → `search_submitted`
 
 **Step 2 — Results shown**
+
 - Condition: Event name → `search_results_shown`
 
 **Step 3 — Result clicked**
+
 - Condition: Event name → `search_result_clicked`
 
 **Step 4 — Dead end (no results)**
+
 - Click **Add step**
 - Step name: `Dead end`
 - Condition: Event name → `search_no_results`
@@ -261,6 +273,7 @@ This is a **Free form** exploration (pivot table), not a funnel.
 **Add variables** (left panel — click **+** next to Dimensions and Metrics):
 
 Dimensions to add:
+
 - Event name
 - Organigram view
 - Interaction source
@@ -268,6 +281,7 @@ Dimensions to add:
 - Member ID
 
 Metrics to add:
+
 - Event count
 
 **Tab 1 — View distribution** (centre panel, Tab settings):
@@ -302,14 +316,49 @@ Name it "Member Clicks".
 **Steps:**
 
 **Step 1 — Content shown**
+
 - Condition: Event name → `related_content_shown`
 
 **Step 2 — Content clicked**
+
 - Condition: Event name → `related_content_click`
 
 **Breakdown:** Add **Interaction source** dimension (values: `ai` / `editorial` /
 `reference`). The drop-off from Step 1 to Step 2 per source directly answers whether
 AI suggestions are performing compared to manually curated content.
+
+**Share the exploration.**
+
+---
+
+### 4e. Homepage Match Widget Clicks
+
+**Key question**: Are users engaging with the match widget, and which match states drive the most clicks?
+
+1. **Explore** → **+** → leave Technique as **Free form**.
+2. Rename to **"Homepage Match Widget Clicks"**.
+
+**Add variables** (left panel):
+
+Dimensions to add:
+
+- Event name
+- Match status
+- Destination
+
+Metrics to add:
+
+- Event count
+
+**Tab settings:**
+
+- Rows: Match status
+- Values: Event count
+- Filter: Event name → exactly matches → `homepage_match_widget_clicked`
+
+This shows click distribution by match status (`finished`, `scheduled`, `postponed`, etc.).
+High `finished` counts relative to `scheduled` suggest users prefer reviewing past results
+over checking upcoming fixtures.
 
 **Share the exploration.**
 
@@ -329,6 +378,7 @@ All of these are **Free form** explorations.
 **Variables:** Dimensions: Event name — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Event name
 - Values: Event count
 - Filter: Event name → contains → `responsibility_`
@@ -355,6 +405,7 @@ Success rate = (responsibility_contact_clicked + responsibility_dwell) / respons
 **Variables:** Dimensions: Query text, Role — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Query text
 - Columns: Role
 - Values: Event count
@@ -376,6 +427,7 @@ content.
 **Variables:** Dimensions: Event name — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Event name
 - Values: Event count
 - Filter: Event name → one of → `search_submitted`, `search_results_shown`,
@@ -400,6 +452,7 @@ Dead-end rate = search_no_results     / search_submitted × 100
 **Variables:** Dimensions: Query text — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Query text
 - Values: Event count
 - Filter: Event name → exactly matches → `search_no_results`
@@ -417,6 +470,7 @@ Dead-end rate = search_no_results     / search_submitted × 100
 **Variables:** Dimensions: Organigram view, Interaction source — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Organigram view
 - Columns: Interaction source
 - Values: Event count
@@ -434,6 +488,7 @@ Dead-end rate = search_no_results     / search_submitted × 100
 **Variables:** Dimensions: Event name, Interaction source — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Interaction source
 - Columns: Event name
 - Values: Event count
@@ -454,6 +509,7 @@ Divide `related_content_click` by `related_content_shown` per row to get CTR.
 **Variables:** Dimensions: Target type, Interaction source — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Target type
 - Columns: Interaction source
 - Values: Event count
@@ -471,6 +527,7 @@ Divide `related_content_click` by `related_content_shown` per row to get CTR.
 **Variables:** Dimensions: Position, Target type — Metrics: Event count
 
 **Tab settings:**
+
 - Rows: Position
 - Columns: Target type
 - Values: Event count
@@ -517,33 +574,35 @@ download context is needed.
 
 ### Events by feature area
 
-| Feature area          | Event names                                                                                                                                                                                                                                                          |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Feature area          | Event names                                                                                                                                                                                                                                                                         |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Responsibility finder | `responsibility_role_selected`, `responsibility_search`, `responsibility_no_results`, `responsibility_suggestion_clicked`, `responsibility_contact_clicked`, `responsibility_organigram_link`, `responsibility_step_link_clicked`, `responsibility_dwell`, `responsibility_abandon` |
-| Search                | `search_submitted`, `search_results_shown`, `search_no_results`, `search_filter_changed`, `search_result_clicked`                                                                                                                                                    |
-| Organigram            | `organigram_view_changed`, `organigram_member_clicked`, `organigram_search_used`, `organigram_department_filtered`, `organigram_export_png`                                                                                                                          |
-| Related content       | `related_content_shown`, `related_content_click`                                                                                                                                                                                                                     |
-| Downloads (auto)      | `file_download` (GA4 Enhanced Measurement)                                                                                                                                                                                                                           |
+| Search                | `search_submitted`, `search_results_shown`, `search_no_results`, `search_filter_changed`, `search_result_clicked`                                                                                                                                                                   |
+| Organigram            | `organigram_view_changed`, `organigram_member_clicked`, `organigram_search_used`, `organigram_department_filtered`, `organigram_export_png`                                                                                                                                         |
+| Related content       | `related_content_shown`, `related_content_click`                                                                                                                                                                                                                                    |
+| Homepage              | `homepage_match_widget_clicked`                                                                                                                                                                                                                                                     |
+| Downloads (auto)      | `file_download` (GA4 Enhanced Measurement)                                                                                                                                                                                                                                          |
 
 ### Where to find each report
 
-| Report name                          | Location in GA4                              | Key metric                                    |
-| ------------------------------------ | -------------------------------------------- | --------------------------------------------- |
-| Responsibility Finder Funnel         | Explore → Responsibility Finder Funnel       | Step-to-step completion rate                  |
-| Search Funnel                        | Explore → Search Funnel                      | search_submitted → result_clicked drop-off    |
-| Organigram Usage                     | Explore → Organigram Usage                   | View mode distribution, member engagement     |
-| Related Content Funnel               | Explore → Related Content Funnel             | CTR by source (AI vs editorial vs reference)  |
-| Responsibility Finder — Success Rate | Explore → Responsibility Finder Success Rate | (contact_clicked + dwell) / search            |
-| Responsibility — No Results Queries  | Explore → Responsibility No Results Queries  | Queries with zero results (content gaps)      |
-| Search — Click-Through Rate          | Explore → Search Click-Through Rate          | result_clicked / submitted                    |
-| Search — No Results Queries          | Explore → Search No Results Queries          | Queries with zero results (index gaps)        |
-| Organigram — View Preference         | Explore → Organigram View Preference         | Which view is used most                       |
-| Related Content — CTR by Source      | Explore → Related Content CTR by Source      | Clicks / impressions per source               |
-| Related Content — Type Engagement    | Explore → Related Content Type Engagement    | Click counts per target_type                  |
-| Related Content — Position Bias      | Explore → Related Content Position Bias      | Click distribution by position                |
-| All events overview                  | Reports → Engagement → Events                | Raw event counts (24–72h delay)               |
-| Realtime events                      | Reports → Realtime                           | Live event counts                             |
-| DebugView                            | Configure → DebugView                        | Individual session event timeline             |
+| Report name                          | Location in GA4                               | Key metric                                   |
+| ------------------------------------ | --------------------------------------------- | -------------------------------------------- |
+| Responsibility Finder Funnel         | Explore → Responsibility Finder Funnel        | Step-to-step completion rate                 |
+| Search Funnel                        | Explore → Search Funnel                       | search_submitted → result_clicked drop-off   |
+| Organigram Usage                     | Explore → Organigram Usage                    | View mode distribution, member engagement    |
+| Related Content Funnel               | Explore → Related Content Funnel              | CTR by source (AI vs editorial vs reference) |
+| Responsibility Finder — Success Rate | Explore → Responsibility Finder Success Rate  | (contact_clicked + dwell) / search           |
+| Responsibility — No Results Queries  | Explore → Responsibility No Results Queries   | Queries with zero results (content gaps)     |
+| Search — Click-Through Rate          | Explore → Search Click-Through Rate           | result_clicked / submitted                   |
+| Search — No Results Queries          | Explore → Search No Results Queries           | Queries with zero results (index gaps)       |
+| Organigram — View Preference         | Explore → Organigram View Preference          | Which view is used most                      |
+| Related Content — CTR by Source      | Explore → Related Content CTR by Source       | Clicks / impressions per source              |
+| Related Content — Type Engagement    | Explore → Related Content Type Engagement     | Click counts per target_type                 |
+| Related Content — Position Bias      | Explore → Related Content Position Bias       | Click distribution by position               |
+| Homepage Match Widget Clicks         | Explore → Homepage Match Widget Clicks        | Click distribution by match status           |
+| All events overview                  | Reports → Engagement → Events                 | Raw event counts (24–72h delay)              |
+| Realtime events                      | Reports → Realtime                            | Live event counts                            |
+| DebugView                            | Configure → DebugView                         | Individual session event timeline            |
 | File downloads                       | Reports → Engagement → Events → file_download | file_name, file_extension breakdown          |
-| Traffic sources                      | Reports → Acquisition → Traffic acquisition  | Where visitors come from                      |
-| Top pages                            | Reports → Engagement → Pages and screens     | Most visited pages, bounce rate               |
+| Traffic sources                      | Reports → Acquisition → Traffic acquisition   | Where visitors come from                     |
+| Top pages                            | Reports → Engagement → Pages and screens      | Most visited pages, bounce rate              |

--- a/scripts/create-ga4-dimensions.mjs
+++ b/scripts/create-ga4-dimensions.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Creates all 20 KCVV custom dimensions in GA4 via the Analytics Admin API.
+ * Creates all 23 KCVV custom dimensions in GA4 via the Analytics Admin API.
  *
  * Prerequisites:
  *   1. gcloud CLI installed and authenticated:
@@ -46,6 +46,9 @@ const dimensions = [
   { parameterName: "target_type",        displayName: "Target type" },
   { parameterName: "target_id",          displayName: "Target ID" },
   { parameterName: "source_entity_type", displayName: "Source entity type" },
+  { parameterName: "match_id",          displayName: "Match ID" },
+  { parameterName: "match_status",      displayName: "Match status" },
+  { parameterName: "destination",       displayName: "Destination" },
 ];
 
 let token;


### PR DESCRIPTION
Closes #1252

## What changed
- Wrapped MatchWidget in a clickable `<Link>` to navigate to the match detail page
- Added hover/focus styles and accessibility attributes for the tappable card
- Added tests covering navigation behavior and story for the linked state

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Manual: tap/click a match widget on the homepage → navigates to `/match/{id}`