### PR TITLE
fix(calendar): use BFF-computed isHome for home/away icons

### DIFF
--- a/apps/web/src/app/(main)/kalender/utils.test.ts
+++ b/apps/web/src/app/(main)/kalender/utils.test.ts
@@ -45,7 +45,7 @@ describe("transformMatchToCalendar", () => {
       status: "finished",
       competition: "2e Nationale",
       team: "A-Ploeg",
-      kcvvTeamId: undefined,
+      isHome: undefined,
     });
   });
 
@@ -216,32 +216,53 @@ describe("getDaysInWeek", () => {
 // ── getMatchDotType ───────────────────────────────────────────────────────
 
 describe("getMatchDotType", () => {
-  it("returns 'home' when kcvvTeamId matches homeTeam.id", () => {
+  it("returns 'home' when isHome is true", () => {
     const match = makeCalendarMatch({
       id: 1,
-      kcvvTeamId: 1,
-      homeTeam: { id: 1, name: "KCVV Elewijt A" },
-      awayTeam: { id: 2, name: "Racing Mechelen" },
+      isHome: true,
+      // Club IDs differ from team IDs in PSD — isHome is the authority
+      homeTeam: { id: 1235, name: "KCVV Elewijt A" },
+      awayTeam: { id: 999, name: "Racing Mechelen" },
     });
     expect(getMatchDotType(match)).toBe("home");
   });
 
-  it("returns 'away' when kcvvTeamId matches awayTeam.id", () => {
+  it("returns 'away' when isHome is false", () => {
     const match = makeCalendarMatch({
       id: 1,
-      kcvvTeamId: 1,
-      homeTeam: { id: 2, name: "Racing Mechelen" },
-      awayTeam: { id: 1, name: "KCVV Elewijt A" },
+      isHome: false,
+      homeTeam: { id: 999, name: "Racing Mechelen" },
+      awayTeam: { id: 1235, name: "KCVV Elewijt A" },
     });
     expect(getMatchDotType(match)).toBe("away");
   });
 
-  it("falls back to name matching when kcvvTeamId is absent", () => {
+  it("returns 'home' when isHome is true even with non-KCVV home team name", () => {
+    // Regression: isHome from BFF is the source of truth, not team names
+    const match = makeCalendarMatch({
+      id: 1,
+      isHome: true,
+      homeTeam: { id: 42, name: "Some Club" },
+      awayTeam: { id: 99, name: "Other Club" },
+    });
+    expect(getMatchDotType(match)).toBe("home");
+  });
+
+  it("falls back to name matching when isHome is absent", () => {
     const match = makeCalendarMatch({
       id: 1,
       homeTeam: { id: 1, name: "KCVV Elewijt A" },
       awayTeam: { id: 2, name: "Racing Mechelen" },
     });
     expect(getMatchDotType(match)).toBe("home");
+  });
+
+  it("falls back to away when isHome is absent and name does not match", () => {
+    const match = makeCalendarMatch({
+      id: 1,
+      homeTeam: { id: 1, name: "Racing Mechelen" },
+      awayTeam: { id: 2, name: "KCVV Elewijt A" },
+    });
+    expect(getMatchDotType(match)).toBe("away");
   });
 });

--- a/apps/web/src/app/(main)/kalender/utils.test.ts
+++ b/apps/web/src/app/(main)/kalender/utils.test.ts
@@ -65,6 +65,14 @@ describe("transformMatchToCalendar", () => {
     expect(result.date).toBe("2026-06-15T18:30:00.000Z");
   });
 
+  it("passes through is_home as isHome", () => {
+    const home = createMatch({ is_home: true } as Partial<Match>);
+    expect(transformMatchToCalendar(home).isHome).toBe(true);
+
+    const away = createMatch({ is_home: false } as Partial<Match>);
+    expect(transformMatchToCalendar(away).isHome).toBe(false);
+  });
+
   it("passes through undefined scores", () => {
     const match = createMatch({
       home_team: { id: 1, name: "KCVV Elewijt" },

--- a/apps/web/src/app/(main)/kalender/utils.ts
+++ b/apps/web/src/app/(main)/kalender/utils.ts
@@ -26,7 +26,7 @@ export interface CalendarMatch {
   status: MatchStatus;
   competition?: string;
   team?: string;
-  kcvvTeamId?: number;
+  isHome?: boolean;
 }
 
 export interface CalendarEvent {
@@ -65,7 +65,7 @@ export function transformMatchToCalendar(match: Match): CalendarMatch {
     status: match.status,
     competition: match.competition,
     team: match.kcvv_team_label,
-    kcvvTeamId: match.kcvv_team_id,
+    isHome: match.is_home,
   };
 }
 
@@ -140,9 +140,9 @@ export function getDaysInWeek(dateStr: string): string[] {
 
 /** Determine if a match is home or away for KCVV */
 export function getMatchDotType(match: CalendarMatch): "home" | "away" {
-  if (match.kcvvTeamId != null) {
-    return match.homeTeam.id === match.kcvvTeamId ? "home" : "away";
+  if (match.isHome != null) {
+    return match.isHome ? "home" : "away";
   }
-  // Fallback for matches without kcvvTeamId
+  // Fallback for matches without BFF-computed isHome
   return match.homeTeam.name.toLowerCase().includes("kcvv") ? "home" : "away";
 }


### PR DESCRIPTION
## Summary

- **Bug:** Calendar page showed all matches as "uitwedstrijd" (away) — the home/away dot icon was always hollow
- **Root cause:** `getMatchDotType()` compared `homeTeam.id` (a PSD **club** ID) with `kcvvTeamId` (a PSD **team** ID). These are different ID spaces that never match, so every game returned "away"
- **Fix:** Use the BFF-computed `is_home` boolean (which correctly compares `homeTeamId === teamId`) instead of the broken cross-ID-space comparison

## Test plan

- [x] All 2268 existing tests pass
- [x] Updated `getMatchDotType` tests to use realistic PSD IDs (club IDs ≠ team IDs) that would have caught this bug
- [x] Added regression test: `isHome: true` with non-KCVV home team name still returns "home"
- [x] Type check passes across all packages
- [ ] Visual: verify /kalender shows filled dots for home games and hollow dots for away games

🤖 Generated with [Claude Code](https://claude.com/claude-code)