### PR TITLE
fix(ui): mobile menu submenu affordance + keyboard dismiss (#1255)

### DIFF
--- a/apps/web/src/components/layout/MobileMenu/MobileMenu.test.tsx
+++ b/apps/web/src/components/layout/MobileMenu/MobileMenu.test.tsx
@@ -244,6 +244,37 @@ describe("MobileMenu", () => {
       expect(screen.getByText("U21")).toBeInTheDocument();
       expect(screen.getByText("U17")).toBeInTheDocument();
     });
+
+    it("should set aria-expanded on submenu toggle buttons", async () => {
+      const user = userEvent.setup();
+      render(<MobileMenu {...defaultProps} />);
+
+      const jeugdButton = screen.getByRole("button", { name: /jeugd/i });
+      expect(jeugdButton).toHaveAttribute("aria-expanded", "false");
+
+      await user.click(jeugdButton);
+      expect(jeugdButton).toHaveAttribute("aria-expanded", "true");
+
+      await user.click(jeugdButton);
+      expect(jeugdButton).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("should render chevron icon at sm size (20px) with rotation animation", () => {
+      render(<MobileMenu {...defaultProps} />);
+
+      // Find the chevron SVG inside a submenu button
+      const jeugdButton = screen.getByRole("button", { name: /jeugd/i });
+      const chevronSvg = jeugdButton.querySelector("svg");
+      expect(chevronSvg).toBeInTheDocument();
+      // sm size = 20px
+      expect(chevronSvg).toHaveAttribute("width", "20");
+      expect(chevronSvg).toHaveAttribute("height", "20");
+
+      // Should have transition classes for animation
+      const chevronWrapper = chevronSvg!.closest("span");
+      expect(chevronWrapper).toHaveClass("transition-transform");
+      expect(chevronWrapper).toHaveClass("duration-200");
+    });
   });
 
   describe("Touch targets", () => {

--- a/apps/web/src/components/layout/MobileMenu/MobileMenu.tsx
+++ b/apps/web/src/components/layout/MobileMenu/MobileMenu.tsx
@@ -174,6 +174,7 @@ export const MobileMenu = ({
                       {/* Parent with submenu */}
                       <button
                         onClick={() => toggleSubmenu(item.href)}
+                        aria-expanded={isSubmenuOpen}
                         className={cn(
                           "mobile-nav-link w-full flex items-center justify-between px-8 py-4 text-left border-b border-kcvv-gray-dark text-white text-[0.6875rem] uppercase font-bold transition-colors",
                           active && "active",
@@ -182,9 +183,9 @@ export const MobileMenu = ({
                         <span>{item.label}</span>
                         <Icon
                           icon={ChevronDown}
-                          size="xs"
+                          size="sm"
                           className={cn(
-                            "transition-transform",
+                            "transition-transform duration-200",
                             isSubmenuOpen && "rotate-180",
                           )}
                         />

--- a/apps/web/src/components/layout/Navigation/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation/Navigation.test.tsx
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Navigation } from "./Navigation";
 
 // Mock variables to control test behavior
@@ -234,6 +235,71 @@ describe("Navigation", () => {
       render(<Navigation seniorTeams={seniorTeams} className="custom-class" />);
       const nav = screen.getByRole("navigation");
       expect(nav).toHaveClass("custom-class");
+    });
+  });
+
+  describe("Keyboard dismiss", () => {
+    it("should close dropdown when Escape is pressed", async () => {
+      const { container } = render(<Navigation seniorTeams={seniorTeams} />);
+
+      // Open the A-Ploeg dropdown by hovering
+      const aPloegListItem = screen.getByText("A-Ploeg").closest("li");
+      fireEvent.mouseEnter(aPloegListItem!);
+
+      // Wait for dropdown to render
+      await waitFor(() => {
+        expect(
+          container.querySelector(
+            'a[href="/ploegen/eerste-elftallen-a?tab=opstelling"]',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      // Press Escape
+      const user = userEvent.setup();
+      await user.keyboard("{Escape}");
+
+      // Dropdown should be closed
+      expect(
+        container.querySelector(
+          'a[href="/ploegen/eerste-elftallen-a?tab=opstelling"]',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Click-outside dismiss", () => {
+    it("should close dropdown when clicking outside the nav", async () => {
+      const { container } = render(
+        <div>
+          <Navigation seniorTeams={seniorTeams} />
+          <div data-testid="outside">Outside content</div>
+        </div>,
+      );
+
+      // Open the A-Ploeg dropdown by hovering
+      const aPloegListItem = screen.getByText("A-Ploeg").closest("li");
+      fireEvent.mouseEnter(aPloegListItem!);
+
+      // Wait for dropdown to render
+      await waitFor(() => {
+        expect(
+          container.querySelector(
+            'a[href="/ploegen/eerste-elftallen-a?tab=opstelling"]',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      // Click outside
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId("outside"));
+
+      // Dropdown should be closed
+      expect(
+        container.querySelector(
+          'a[href="/ploegen/eerste-elftallen-a?tab=opstelling"]',
+        ),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/layout/Navigation/Navigation.test.tsx
+++ b/apps/web/src/components/layout/Navigation/Navigation.test.tsx
@@ -239,6 +239,20 @@ describe("Navigation", () => {
   });
 
   describe("Keyboard dismiss", () => {
+    it("should not error when Escape is pressed with no dropdown open", async () => {
+      const { container } = render(<Navigation seniorTeams={seniorTeams} />);
+
+      // No dropdown open — Escape should be a no-op
+      const user = userEvent.setup();
+      await user.keyboard("{Escape}");
+
+      expect(
+        container.querySelector(
+          'a[href="/ploegen/eerste-elftallen-a?tab=opstelling"]',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
     it("should close dropdown when Escape is pressed", async () => {
       const { container } = render(<Navigation seniorTeams={seniorTeams} />);
 
@@ -269,6 +283,25 @@ describe("Navigation", () => {
   });
 
   describe("Click-outside dismiss", () => {
+    it("should not error when clicking outside with no dropdown open", async () => {
+      const { container } = render(
+        <div>
+          <Navigation seniorTeams={seniorTeams} />
+          <div data-testid="outside">Outside content</div>
+        </div>,
+      );
+
+      // No dropdown open — clicking outside should be a no-op
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId("outside"));
+
+      expect(
+        container.querySelector(
+          'a[href="/ploegen/eerste-elftallen-a?tab=opstelling"]',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
     it("should close dropdown when clicking outside the nav", async () => {
       const { container } = render(
         <div>

--- a/apps/web/src/components/layout/Navigation/Navigation.tsx
+++ b/apps/web/src/components/layout/Navigation/Navigation.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
@@ -52,6 +52,33 @@ export const Navigation = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+  const navRef = useRef<HTMLElement>(null);
+
+  const closeDropdown = useCallback(() => setOpenDropdown(null), []);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!openDropdown) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeDropdown();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [openDropdown, closeDropdown]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!openDropdown) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) {
+        closeDropdown();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [openDropdown, closeDropdown]);
 
   const jeugdItem = buildJeugdItem(youthTeams);
 
@@ -69,7 +96,7 @@ export const Navigation = ({
   };
 
   return (
-    <nav className={cn("flex grow max-w-[90%]", className)}>
+    <nav ref={navRef} className={cn("flex grow max-w-[90%]", className)}>
       <ul className="flex items-center justify-between grow flex-nowrap list-none m-0 p-0">
         {menuItems.map((item, index) => {
           const active = isActive(item.href) || hasActiveChild(item);

--- a/apps/web/src/components/layout/PageHeader/PageHeader.test.tsx
+++ b/apps/web/src/components/layout/PageHeader/PageHeader.test.tsx
@@ -129,6 +129,25 @@ describe("PageHeader", () => {
   });
 
   describe("Focus management", () => {
+    it("does not move focus when close is called while menu already closed", async () => {
+      render(<PageHeader />);
+
+      const menuButton = screen.getByLabelText(/toggle navigation menu/i);
+
+      // Menu is initially closed
+      expect(menuButton).not.toHaveAttribute("aria-expanded", "true");
+
+      // Close button should not be present when menu is closed
+      const closeButton = screen.queryByLabelText(/close menu/i);
+      if (closeButton) {
+        const user = userEvent.setup();
+        await user.click(closeButton);
+      }
+
+      // Hamburger should NOT have focus — handleClose was a no-op
+      expect(menuButton).not.toHaveFocus();
+    });
+
     it("should return focus to hamburger button when mobile menu is closed", async () => {
       const user = userEvent.setup();
       render(<PageHeader />);

--- a/apps/web/src/components/layout/PageHeader/PageHeader.test.tsx
+++ b/apps/web/src/components/layout/PageHeader/PageHeader.test.tsx
@@ -128,6 +128,23 @@ describe("PageHeader", () => {
     });
   });
 
+  describe("Focus management", () => {
+    it("should return focus to hamburger button when mobile menu is closed", async () => {
+      const user = userEvent.setup();
+      render(<PageHeader />);
+
+      const menuButton = screen.getByLabelText(/toggle navigation menu/i);
+      await user.click(menuButton);
+
+      // Menu is open — close it via the close button
+      const closeButton = screen.getByLabelText(/close menu/i);
+      await user.click(closeButton);
+
+      // Focus should return to the hamburger button
+      expect(menuButton).toHaveFocus();
+    });
+  });
+
   describe("Custom Props", () => {
     it("should accept custom className", () => {
       const { container } = render(<PageHeader className="custom-class" />);

--- a/apps/web/src/components/layout/PageHeader/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader/PageHeader.tsx
@@ -6,7 +6,7 @@
 
 "use client";
 
-import { useState, useCallback, Suspense } from "react";
+import { useState, useCallback, useRef, Suspense } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { cn } from "@/lib/utils/cn";
@@ -41,9 +41,13 @@ export const PageHeader = ({
   className,
 }: PageHeaderProps) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const hamburgerRef = useRef<HTMLButtonElement>(null);
 
   const handleClose = useCallback(() => {
-    setIsMobileMenuOpen(false);
+    setIsMobileMenuOpen((wasOpen) => {
+      if (wasOpen) hamburgerRef.current?.focus();
+      return false;
+    });
   }, []);
 
   return (
@@ -55,6 +59,7 @@ export const PageHeader = ({
           <div className="lg:hidden h-full relative">
             {/* Hamburger Button - left 34px */}
             <button
+              ref={hamburgerRef}
               type="button"
               onClick={() => setIsMobileMenuOpen(true)}
               aria-label="Toggle navigation menu"


### PR DESCRIPTION
## Summary

- Enlarge MobileMenu chevron from `xs` to `sm` (20px) with clear rotation animation (`transition-transform duration-200`)
- Add `aria-expanded` attribute to submenu toggle buttons for screen reader support
- Add Escape key handler to close desktop Navigation dropdowns
- Add click-outside detection (`mousedown` + `ref`) to dismiss desktop dropdowns
- Return focus to hamburger button when mobile menu closes

Closes #1255

## Test plan

- [x] `aria-expanded` toggles correctly on submenu open/close
- [x] Chevron renders at 20px with transition classes
- [x] Desktop dropdown closes on Escape keypress
- [x] Desktop dropdown closes on click outside nav
- [x] Focus returns to hamburger button after mobile menu close
- [x] All 2293 existing tests pass (176 files), no regressions
- [x] Lint + type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)