### PR TITLE
feat(ui): label youth teams with Bovenbouw/Middenbouw/Onderbouw divisions (#1256)

### DIFF
--- a/apps/web/src/components/team/TeamDetail/TeamDetail.test.tsx
+++ b/apps/web/src/components/team/TeamDetail/TeamDetail.test.tsx
@@ -258,6 +258,24 @@ describe("TeamDetail", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("renders division badge in hero label for youth teams", () => {
+    const youthHeader: TeamDetailHeader = {
+      name: "KCVV Elewijt U15",
+      teamType: "youth",
+      ageGroup: "U15",
+    };
+    render(<TeamDetail header={youthHeader} />);
+    expect(screen.getByText(/Jeugd.*Middenbouw/)).toBeInTheDocument();
+  });
+
+  it("does not render division badge for senior teams", () => {
+    render(<TeamDetail header={header} />);
+    expect(screen.getByText("Eerste ploeg")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Bovenbouw|Middenbouw|Onderbouw/),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the closing CTA pointing at /hulp", () => {
     render(<TeamDetail header={header} />);
     const cta = screen.getByRole("link", { name: /meer info/i });

--- a/apps/web/src/components/team/TeamDetail/TeamDetail.tsx
+++ b/apps/web/src/components/team/TeamDetail/TeamDetail.tsx
@@ -26,6 +26,7 @@ import { TeamRoster, type RosterPlayer, type StaffMember } from "../TeamRoster";
 import { TeamSchedule, type ScheduleMatch } from "../TeamSchedule";
 import { TeamStandings, type StandingsEntry } from "../TeamStandings";
 import { TeamDetailTabs, type TeamDetailTabPanel } from "./TeamDetailTabs";
+import { getYouthDivision } from "@/lib/utils/group-teams";
 
 /**
  * CMS authors can set `target="_blank"` on a link, but `sanitize-html`'s
@@ -224,7 +225,11 @@ export function TeamDetail({
   // instead of an empty page body).
   const showInfoTab = hasInfoContent || !hasAnyOtherTab;
 
-  const heroLabel = HERO_LABELS[header.teamType ?? "senior"];
+  const baseLabel = HERO_LABELS[header.teamType ?? "senior"];
+  const division = getYouthDivision(header.ageGroup);
+  const heroLabel = division
+    ? `${baseLabel} · ${division}`
+    : (header.ageGroup ?? baseLabel);
 
   const panels: TeamDetailTabPanel[] = [];
 
@@ -333,7 +338,7 @@ export function TeamDetail({
           size="compact"
           image={header.imageUrl}
           imageAlt={`${header.name} teamfoto`}
-          label={header.ageGroup ?? heroLabel}
+          label={heroLabel}
           headline={header.name}
           body={header.tagline ?? ""}
         />

--- a/apps/web/src/components/team/TeamOverview/TeamOverview.test.tsx
+++ b/apps/web/src/components/team/TeamOverview/TeamOverview.test.tsx
@@ -10,6 +10,7 @@ import { TeamOverview, type TeamData } from "./TeamOverview";
 const mockYouthTeams: TeamData[] = [
   { name: "U15", href: "/ploegen/u15", ageGroup: "U15", teamType: "youth" },
   { name: "U10", href: "/ploegen/u10", ageGroup: "U10", teamType: "youth" },
+  { name: "U19", href: "/ploegen/u19", ageGroup: "U19", teamType: "youth" },
   { name: "U17", href: "/ploegen/u17", ageGroup: "U17", teamType: "youth" },
   { name: "U6", href: "/ploegen/u6", ageGroup: "U6", teamType: "youth" },
 ];
@@ -64,7 +65,7 @@ describe("TeamOverview", () => {
       const names = articles.map(
         (a) => within(a).getByRole("heading").textContent,
       );
-      expect(names).toEqual(["U6", "U10", "U15", "U17"]);
+      expect(names).toEqual(["U6", "U10", "U15", "U17", "U19"]);
     });
 
     it("should sort senior teams alphabetically", () => {
@@ -156,20 +157,20 @@ describe("TeamOverview", () => {
         />,
       );
       // Should have 3-tier section headings
-      expect(screen.getByText("Onderbouw (U6–U9)")).toBeInTheDocument();
-      expect(screen.getByText("Middenbouw (U10–U13)")).toBeInTheDocument();
-      expect(screen.getByText("Bovenbouw (U14–U21)")).toBeInTheDocument();
+      expect(screen.getByText("Onderbouw (U6–U11)")).toBeInTheDocument();
+      expect(screen.getByText("Middenbouw (U12–U16)")).toBeInTheDocument();
+      expect(screen.getByText("Bovenbouw (U17–U21)")).toBeInTheDocument();
 
       // Old 7-category headings should NOT appear
       expect(screen.queryByText("Kleuters (U6-U7)")).not.toBeInTheDocument();
       expect(screen.queryByText("Duiveltjes (U8-U9)")).not.toBeInTheDocument();
       expect(screen.queryByText("Kadetten (U14-U15)")).not.toBeInTheDocument();
 
-      // Bovenbouw should have U15, U15B, U17 = 3 teams
+      // Bovenbouw should have U17 + U19 = 2 teams (U15/U15B are now Middenbouw)
       const bovenbouw = screen
-        .getByText("Bovenbouw (U14–U21)")
+        .getByText("Bovenbouw (U17–U21)")
         .closest("section");
-      expect(within(bovenbouw!).getAllByRole("article").length).toBe(3);
+      expect(within(bovenbouw!).getAllByRole("article").length).toBe(2);
     });
 
     it("should group U21 teams in Bovenbouw tier", () => {
@@ -183,7 +184,7 @@ describe("TeamOverview", () => {
         },
       ];
       render(<TeamOverview teams={teamsWithU21} groupByAge teamType="youth" />);
-      const bovenbouwHeading = screen.getByText("Bovenbouw (U14–U21)");
+      const bovenbouwHeading = screen.getByText("Bovenbouw (U17–U21)");
       expect(bovenbouwHeading).toBeInTheDocument();
       const bovenbouwSection = bovenbouwHeading.closest("section")!;
       expect(
@@ -216,9 +217,9 @@ describe("TeamOverview", () => {
         (s) => s.querySelector("h3")?.textContent,
       );
       expect(tierNames).toEqual([
-        "Bovenbouw (U14–U21)",
-        "Middenbouw (U10–U13)",
-        "Onderbouw (U6–U9)",
+        "Bovenbouw (U17–U21)",
+        "Middenbouw (U12–U16)",
+        "Onderbouw (U6–U11)",
       ]);
     });
 
@@ -230,8 +231,8 @@ describe("TeamOverview", () => {
 
     it("should not group when groupByAge is false", () => {
       render(<TeamOverview teams={mockYouthTeams} teamType="youth" />);
-      expect(screen.queryByText("Onderbouw (U6–U9)")).not.toBeInTheDocument();
-      expect(screen.queryByText("Bovenbouw (U14–U21)")).not.toBeInTheDocument();
+      expect(screen.queryByText("Onderbouw (U6–U11)")).not.toBeInTheDocument();
+      expect(screen.queryByText("Bovenbouw (U17–U21)")).not.toBeInTheDocument();
     });
   });
 
@@ -348,11 +349,12 @@ describe("TeamOverview", () => {
       expect(names[1]).toBe("U10");
       expect(names[2]).toBe("U15");
       expect(names[3]).toBe("U17");
+      expect(names[4]).toBe("U19");
       // Then senior teams (alphabetically)
-      expect(names[4]).toBe("A-Ploeg");
-      expect(names[5]).toBe("B-Ploeg");
+      expect(names[5]).toBe("A-Ploeg");
+      expect(names[6]).toBe("B-Ploeg");
       // Then club teams
-      expect(names[6]).toBe("Bestuur");
+      expect(names[7]).toBe("Bestuur");
     });
 
     it("should default to senior team type if missing", () => {
@@ -446,7 +448,7 @@ describe("TeamOverview", () => {
       render(
         <TeamOverview teams={mockYouthTeams} groupByAge teamType="youth" />,
       );
-      const heading = screen.getByText("Onderbouw (U6–U9)");
+      const heading = screen.getByText("Onderbouw (U6–U11)");
       expect(heading.className).toContain("text-gray-900");
     });
 
@@ -459,7 +461,7 @@ describe("TeamOverview", () => {
           colorScheme="dark"
         />,
       );
-      const heading = screen.getByText("Onderbouw (U6–U9)");
+      const heading = screen.getByText("Onderbouw (U6–U11)");
       expect(heading.className).toContain("text-white");
       expect(heading.className).not.toContain("text-gray-900");
     });

--- a/apps/web/src/components/team/TeamOverview/TeamOverview.tsx
+++ b/apps/web/src/components/team/TeamOverview/TeamOverview.tsx
@@ -16,6 +16,7 @@
 
 import { useMemo, useState, useEffect } from "react";
 import { cn } from "@/lib/utils/cn";
+import { getYouthDivision } from "@/lib/utils/group-teams";
 import { TeamCard, type TeamCardProps } from "../TeamCard";
 
 export interface TeamData extends Omit<TeamCardProps, "variant" | "isLoading"> {
@@ -44,11 +45,14 @@ export interface TeamOverviewProps {
   className?: string;
 }
 
+const DIVISION_RANGE_LABELS: Record<string, string> = {
+  Bovenbouw: "Bovenbouw (U17–U21)",
+  Middenbouw: "Middenbouw (U12–U16)",
+  Onderbouw: "Onderbouw (U6–U11)",
+};
+
 /**
  * Convert an age-group label (e.g., "U15") to its numeric age.
- *
- * @param ageGroup - A string like `"U15"` or a number-only string; may be undefined
- * @returns The parsed age as a number, or `999` if `ageGroup` is undefined or cannot be parsed
  */
 function parseAgeGroup(ageGroup: string | undefined): number {
   if (!ageGroup) return 999;
@@ -58,17 +62,11 @@ function parseAgeGroup(ageGroup: string | undefined): number {
 
 /**
  * Map an age-group identifier to its 3-tier category label.
- *
- * @param ageGroup - Age group string such as `"U15"`, or `undefined` when not available.
- * @returns One of: `"Onderbouw (U6–U9)"`, `"Middenbouw (U10–U13)"`,
- * `"Bovenbouw (U14–U21)"`, or `"Overig"` depending on the parsed age.
+ * Delegates to `getYouthDivision()` for classification.
  */
 function getAgeCategory(ageGroup: string | undefined): string {
-  const age = parseAgeGroup(ageGroup);
-  if (age >= 6 && age <= 9) return "Onderbouw (U6–U9)";
-  if (age >= 10 && age <= 13) return "Middenbouw (U10–U13)";
-  if (age >= 14 && age <= 21) return "Bovenbouw (U14–U21)";
-  return "Overig";
+  const division = getYouthDivision(ageGroup);
+  return division ? DIVISION_RANGE_LABELS[division] : "Overig";
 }
 
 /**
@@ -138,9 +136,9 @@ export function TeamOverview({
     if (!groupByAge) return null;
 
     const tierOrder = [
-      "Bovenbouw (U14–U21)",
-      "Middenbouw (U10–U13)",
-      "Onderbouw (U6–U9)",
+      "Bovenbouw (U17–U21)",
+      "Middenbouw (U12–U16)",
+      "Onderbouw (U6–U11)",
       "Overig",
     ];
 

--- a/apps/web/src/components/teams/YouthTeamsDirectory/YouthTeamsDirectory.stories.tsx
+++ b/apps/web/src/components/teams/YouthTeamsDirectory/YouthTeamsDirectory.stories.tsx
@@ -38,28 +38,31 @@ export const FullList: Story = {
     divisions: [
       {
         label: "Bovenbouw",
-        range: "U14–U21",
-        teams: [
-          makeTeam("U21"),
-          makeTeam("U17"),
-          makeTeam("U15"),
-          makeTeam("U14"),
-        ],
+        range: "U17–U21",
+        teams: [makeTeam("U21"), makeTeam("U19"), makeTeam("U17")],
       },
       {
         label: "Middenbouw",
-        range: "U10–U13",
+        range: "U12–U16",
         teams: [
+          makeTeam("U16"),
+          makeTeam("U15"),
+          makeTeam("U14"),
           makeTeam("U13"),
           makeTeam("U12"),
-          makeTeam("U11"),
-          makeTeam("U10"),
         ],
       },
       {
         label: "Onderbouw",
-        range: "U6–U9",
-        teams: [makeTeam("U9"), makeTeam("U8"), makeTeam("U7"), makeTeam("U6")],
+        range: "U6–U11",
+        teams: [
+          makeTeam("U11"),
+          makeTeam("U10"),
+          makeTeam("U9"),
+          makeTeam("U8"),
+          makeTeam("U7"),
+          makeTeam("U6"),
+        ],
       },
     ],
   },
@@ -68,9 +71,9 @@ export const FullList: Story = {
 export const EmptyState: Story = {
   args: {
     divisions: [
-      { label: "Bovenbouw", range: "U14–U21", teams: [] },
-      { label: "Middenbouw", range: "U10–U13", teams: [] },
-      { label: "Onderbouw", range: "U6–U9", teams: [] },
+      { label: "Bovenbouw", range: "U17–U21", teams: [] },
+      { label: "Middenbouw", range: "U12–U16", teams: [] },
+      { label: "Onderbouw", range: "U6–U11", teams: [] },
     ],
   },
 };

--- a/apps/web/src/components/teams/YouthTeamsDirectory/YouthTeamsDirectory.test.tsx
+++ b/apps/web/src/components/teams/YouthTeamsDirectory/YouthTeamsDirectory.test.tsx
@@ -21,7 +21,7 @@ vi.mock("next/link", () => ({
 const divisions: YouthDivisionGroup[] = [
   {
     label: "Bovenbouw",
-    range: "U14–U21",
+    range: "U17–U21",
     teams: [
       {
         _id: "u21",
@@ -34,6 +34,12 @@ const divisions: YouthDivisionGroup[] = [
         teamImageUrl: null,
         staff: null,
       },
+    ],
+  },
+  {
+    label: "Middenbouw",
+    range: "U12–U16",
+    teams: [
       {
         _id: "u15",
         name: "U15",
@@ -45,12 +51,6 @@ const divisions: YouthDivisionGroup[] = [
         teamImageUrl: null,
         staff: null,
       },
-    ],
-  },
-  {
-    label: "Middenbouw",
-    range: "U10–U13",
-    teams: [
       {
         _id: "u13",
         name: "U13",
@@ -66,7 +66,7 @@ const divisions: YouthDivisionGroup[] = [
   },
   {
     label: "Onderbouw",
-    range: "U6–U9",
+    range: "U6–U11",
     teams: [],
   },
 ];

--- a/apps/web/src/lib/utils/group-teams.test.ts
+++ b/apps/web/src/lib/utils/group-teams.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { groupTeamsForLanding, type TeamLandingItem } from "./group-teams";
+import {
+  groupTeamsForLanding,
+  getYouthDivision,
+  type TeamLandingItem,
+} from "./group-teams";
 
 const makeTeam = (
   overrides: Partial<TeamLandingItem> = {},
@@ -43,22 +47,20 @@ describe("groupTeamsForLanding", () => {
 
     expect(result.youthByDivision).toHaveLength(3);
     expect(result.youthByDivision[0].label).toBe("Bovenbouw");
-    expect(result.youthByDivision[0].range).toBe("U14–U21");
+    expect(result.youthByDivision[0].range).toBe("U17–U21");
     expect(result.youthByDivision[0].teams.map((t) => t.age)).toEqual([
       "U21",
       "U17",
     ]);
 
     expect(result.youthByDivision[1].label).toBe("Middenbouw");
-    expect(result.youthByDivision[1].range).toBe("U10–U13");
-    expect(result.youthByDivision[1].teams.map((t) => t.age)).toEqual([
-      "U13",
-      "U10",
-    ]);
+    expect(result.youthByDivision[1].range).toBe("U12–U16");
+    expect(result.youthByDivision[1].teams.map((t) => t.age)).toEqual(["U13"]);
 
     expect(result.youthByDivision[2].label).toBe("Onderbouw");
-    expect(result.youthByDivision[2].range).toBe("U6–U9");
+    expect(result.youthByDivision[2].range).toBe("U6–U11");
     expect(result.youthByDivision[2].teams.map((t) => t.age)).toEqual([
+      "U10",
       "U9",
       "U6",
     ]);
@@ -83,9 +85,13 @@ describe("groupTeamsForLanding", () => {
 
     const result = groupTeamsForLanding(teams);
 
+    // Bovenbouw: U21, U17
     expect(result.youthByDivision[0].teams.map((t) => t.age)).toEqual([
       "U21",
       "U17",
+    ]);
+    // Middenbouw: U15, U15, U14
+    expect(result.youthByDivision[1].teams.map((t) => t.age)).toEqual([
       "U15",
       "U15",
       "U14",
@@ -99,9 +105,17 @@ describe("groupTeamsForLanding", () => {
     ];
     const result = groupTeamsForLanding(teams);
 
-    expect(result.youthByDivision[0].teams).toHaveLength(1); // Bovenbouw: U15
-    expect(result.youthByDivision[1].teams).toHaveLength(0); // Middenbouw: empty
+    expect(result.youthByDivision[0].teams).toHaveLength(0); // Bovenbouw: empty
+    expect(result.youthByDivision[1].teams).toHaveLength(1); // Middenbouw: U15
     expect(result.youthByDivision[2].teams).toHaveLength(0); // Onderbouw: empty
+  });
+
+  it("should handle U19 in Bovenbouw", () => {
+    const teams = [
+      makeTeam({ _id: "u19", age: "U19", name: "KCVV Elewijt U19" }),
+    ];
+    const result = groupTeamsForLanding(teams);
+    expect(result.youthByDivision[0].teams.map((t) => t.age)).toEqual(["U19"]);
   });
 
   it("should not include senior teams in youth divisions", () => {
@@ -116,5 +130,39 @@ describe("groupTeamsForLanding", () => {
 
     expect(allYouth).toHaveLength(1);
     expect(allYouth[0].age).toBe("U15");
+  });
+});
+
+describe("getYouthDivision", () => {
+  it("should return Bovenbouw for U17–U21", () => {
+    expect(getYouthDivision("U21")).toBe("Bovenbouw");
+    expect(getYouthDivision("U19")).toBe("Bovenbouw");
+    expect(getYouthDivision("U17")).toBe("Bovenbouw");
+  });
+
+  it("should return Middenbouw for U12–U16", () => {
+    expect(getYouthDivision("U16")).toBe("Middenbouw");
+    expect(getYouthDivision("U15")).toBe("Middenbouw");
+    expect(getYouthDivision("U14")).toBe("Middenbouw");
+    expect(getYouthDivision("U13")).toBe("Middenbouw");
+    expect(getYouthDivision("U12")).toBe("Middenbouw");
+  });
+
+  it("should return Onderbouw for U6–U11", () => {
+    expect(getYouthDivision("U11")).toBe("Onderbouw");
+    expect(getYouthDivision("U10")).toBe("Onderbouw");
+    expect(getYouthDivision("U9")).toBe("Onderbouw");
+    expect(getYouthDivision("U6")).toBe("Onderbouw");
+  });
+
+  it("should handle age groups not in the standard roster via numeric parsing", () => {
+    expect(getYouthDivision("U18")).toBe("Bovenbouw");
+    expect(getYouthDivision("U5")).toBeNull();
+    expect(getYouthDivision("U22")).toBeNull();
+  });
+
+  it("should return null for non-youth age groups", () => {
+    expect(getYouthDivision("A")).toBeNull();
+    expect(getYouthDivision(undefined)).toBeNull();
   });
 });

--- a/apps/web/src/lib/utils/group-teams.ts
+++ b/apps/web/src/lib/utils/group-teams.ts
@@ -22,7 +22,7 @@ export type GroupedTeams = {
   youthByDivision: YouthDivisionGroup[];
 };
 
-const BOVENBOUW = ["U21", "U19", "U17"];
+const BOVENBOUW = ["U21", "U20", "U19", "U18", "U17"];
 const MIDDENBOUW = ["U16", "U15", "U14", "U13", "U12"];
 const ONDERBOUW = ["U11", "U10", "U9", "U8", "U7", "U6"];
 
@@ -48,8 +48,14 @@ export function getYouthDivision(
 }
 
 function sortByAgeDesc(ageOrder: string[]) {
-  return (a: TeamLandingItem, b: TeamLandingItem) =>
-    ageOrder.indexOf(a.age) - ageOrder.indexOf(b.age);
+  return (a: TeamLandingItem, b: TeamLandingItem) => {
+    const idxA = ageOrder.indexOf(a.age);
+    const idxB = ageOrder.indexOf(b.age);
+    if (idxA !== -1 && idxB !== -1) return idxA - idxB;
+    if (idxA !== -1) return -1;
+    if (idxB !== -1) return 1;
+    return (parseAge(b.age) ?? 0) - (parseAge(a.age) ?? 0);
+  };
 }
 
 /** Extract the trailing single letter from a team name, e.g. "Eerste Elftallen A" → "A" */

--- a/apps/web/src/lib/utils/group-teams.ts
+++ b/apps/web/src/lib/utils/group-teams.ts
@@ -11,7 +11,7 @@ export type TeamLandingItem = {
 };
 
 export type YouthDivisionGroup = {
-  label: string;
+  label: YouthDivisionName;
   range: string;
   teams: TeamLandingItem[];
 };
@@ -22,9 +22,30 @@ export type GroupedTeams = {
   youthByDivision: YouthDivisionGroup[];
 };
 
-const BOVENBOUW = ["U21", "U17", "U15", "U14"];
-const MIDDENBOUW = ["U13", "U12", "U11", "U10"];
-const ONDERBOUW = ["U9", "U8", "U7", "U6"];
+const BOVENBOUW = ["U21", "U19", "U17"];
+const MIDDENBOUW = ["U16", "U15", "U14", "U13", "U12"];
+const ONDERBOUW = ["U11", "U10", "U9", "U8", "U7", "U6"];
+
+export type YouthDivisionName = "Bovenbouw" | "Middenbouw" | "Onderbouw";
+
+/** Parse the numeric age from an age-group string (e.g. "U15" → 15). Returns null if unparseable. */
+function parseAge(ageGroup: string): number | null {
+  const match = ageGroup.match(/^U(\d+)/i);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/** Derive the youth division name from an age group string (e.g. "U15" → "Middenbouw"). */
+export function getYouthDivision(
+  ageGroup: string | undefined,
+): YouthDivisionName | null {
+  if (!ageGroup) return null;
+  const age = parseAge(ageGroup);
+  if (age == null) return null;
+  if (age >= 17 && age <= 21) return "Bovenbouw";
+  if (age >= 12 && age <= 16) return "Middenbouw";
+  if (age >= 6 && age <= 11) return "Onderbouw";
+  return null;
+}
 
 function sortByAgeDesc(ageOrder: string[]) {
   return (a: TeamLandingItem, b: TeamLandingItem) =>
@@ -48,23 +69,23 @@ export function groupTeamsForLanding(teams: TeamLandingItem[]): GroupedTeams {
     youthByDivision: [
       {
         label: "Bovenbouw",
-        range: "U14–U21",
+        range: "U17–U21",
         teams: teams
-          .filter((t) => BOVENBOUW.includes(t.age))
+          .filter((t) => getYouthDivision(t.age) === "Bovenbouw")
           .sort(sortByAgeDesc(BOVENBOUW)),
       },
       {
         label: "Middenbouw",
-        range: "U10–U13",
+        range: "U12–U16",
         teams: teams
-          .filter((t) => MIDDENBOUW.includes(t.age))
+          .filter((t) => getYouthDivision(t.age) === "Middenbouw")
           .sort(sortByAgeDesc(MIDDENBOUW)),
       },
       {
         label: "Onderbouw",
-        range: "U6–U9",
+        range: "U6–U11",
         teams: teams
-          .filter((t) => ONDERBOUW.includes(t.age))
+          .filter((t) => getYouthDivision(t.age) === "Onderbouw")
           .sort(sortByAgeDesc(ONDERBOUW)),
       },
     ],

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -147,6 +147,20 @@ The age category of a team, from PSD.
 
 Multiple teams can share the same age group (e.g. three U9 teams distinguished by `division`).
 
+### Youth Division (Afdeling)
+
+The three-tier grouping of youth teams used by the club internally and by parents. Derived client-side from the age group — not stored in any data source.
+
+| Code / Label   | Dutch      | Age range | Teams                    |
+| -------------- | ---------- | --------- | ------------------------ |
+| `"Bovenbouw"`  | Bovenbouw  | U17–U21   | U21, U19, U17            |
+| `"Middenbouw"` | Middenbouw | U12–U16   | U16, U15, U14, U13, U12  |
+| `"Onderbouw"`  | Onderbouw  | U6–U11    | U11, U10, U9, U8, U7, U6 |
+
+**Implementation:** `getYouthDivision()` in `apps/web/src/lib/utils/group-teams.ts`. Used for section headers on `/ploegen` and `/jeugd`, and as a badge on individual team detail pages.
+
+**Vocabulary rule:** Always use Bovenbouw/Middenbouw/Onderbouw — never the older terms "scholieren" or "duiveltjes."
+
 ---
 
 ## Player


### PR DESCRIPTION
Closes #1256

## What changed
- Added youth division labels (Bovenbouw/Middenbouw/Onderbouw) to team names in TeamOverview and TeamDetail components
- Updated `group-teams` utility to classify youth teams by age group and append division suffixes
- Added domain terms to ubiquitous language glossary

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Unit tests cover division classification logic and component rendering with division labels