### PR TITLE
fix(ui): branded tabs touch affordance + unified scroll-hint utility (#1260)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -434,6 +434,15 @@
   padding-right: env(safe-area-inset-right, 0);
 }
 
+/* Hide native scrollbar — cross-browser utility for horizontal scroll containers */
+@utility scrollbar-hide {
+  scrollbar-width: none;            /* Firefox */
+  -ms-overflow-style: none;         /* IE / Edge */
+  &::-webkit-scrollbar {
+    display: none;                  /* Chrome, Safari, Opera */
+  }
+}
+
 /* Touch Optimization: Prevent text selection during swipe gestures */
 .touch-pan-x {
   touch-action: pan-x;

--- a/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
+++ b/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
@@ -7,11 +7,12 @@ import type {
 } from "@portabletext/react";
 import Image from "next/image";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import sanitizeHtml from "sanitize-html";
 import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { DownloadButton } from "@/components/design-system/DownloadButton";
+import { useScrollHint } from "@/components/design-system/ScrollHint/useScrollHint";
 
 const TABLE_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: [
@@ -104,33 +105,14 @@ interface HtmlTableValue {
 }
 
 function HtmlTableBlock({ value }: { value: HtmlTableValue }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [showOverflowHint, setShowOverflowHint] = useState(false);
-
-  const checkOverflow = useCallback(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    setShowOverflowHint(el.scrollWidth > el.clientWidth);
-  }, []);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-
-    checkOverflow();
-
-    const resizeObserver = new ResizeObserver(checkOverflow);
-    resizeObserver.observe(el);
-
-    return () => resizeObserver.disconnect();
-  }, [checkOverflow]);
+  const { scrollRef, canScrollRight } = useScrollHint<HTMLDivElement>();
 
   if (!value.html) return null;
 
   return (
     <div className="relative my-4">
       <div
-        ref={containerRef}
+        ref={scrollRef}
         role="region"
         aria-label="Scrollable table"
         tabIndex={0}
@@ -143,7 +125,7 @@ function HtmlTableBlock({ value }: { value: HtmlTableValue }) {
           "[&>table_td]:border [&>table_td]:border-table-border [&>table_td]:p-2 [&>table_td]:align-top",
           "[&>table>tbody>tr:nth-child(odd)_td]:bg-white",
           "[&>table>tbody>tr:nth-child(even)_td]:bg-table-row-even",
-          showOverflowHint && [
+          canScrollRight && [
             "[&>table_td:first-child]:sticky [&>table_td:first-child]:left-0 [&>table_td:first-child]:z-10",
             "[&>table>tbody>tr:nth-child(odd)>td:first-child]:bg-white",
             "[&>table>tbody>tr:nth-child(even)>td:first-child]:bg-table-row-even",
@@ -156,7 +138,7 @@ function HtmlTableBlock({ value }: { value: HtmlTableValue }) {
           __html: sanitizeHtml(value.html, TABLE_SANITIZE_OPTIONS),
         }}
       />
-      {showOverflowHint && (
+      {canScrollRight && (
         <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-white/90 to-transparent" />
       )}
     </div>
@@ -219,7 +201,7 @@ const components: PortableTextComponents = {
       children,
       value,
     }: {
-      children: React.ReactNode;
+      children: ReactNode;
       value?: InternalLinkValue;
     }) => {
       const href = resolveInternalLinkHref(value?.reference);

--- a/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.stories.tsx
+++ b/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.stories.tsx
@@ -10,6 +10,17 @@ const TABS: BrandedTab[] = [
   { id: "klassement", label: "Klassement" },
 ];
 
+const MANY_TABS: BrandedTab[] = [
+  { id: "info", label: "Info" },
+  { id: "spelers", label: "Spelers" },
+  { id: "wedstrijden", label: "Wedstrijden" },
+  { id: "klassement", label: "Klassement" },
+  { id: "statistieken", label: "Statistieken" },
+  { id: "transfers", label: "Transfers" },
+  { id: "geschiedenis", label: "Geschiedenis" },
+  { id: "media", label: "Media" },
+];
+
 const meta = {
   title: "UI/BrandedTabs",
   component: BrandedTabs,
@@ -63,5 +74,48 @@ export const Interactive: Story = {
       );
     }
     return <Playground />;
+  },
+};
+
+/**
+ * Many tabs — demonstrates scroll arrows when tabs overflow on narrow screens.
+ * Resize the viewport to see the navigation arrows appear.
+ */
+export const ManyTabs: Story = {
+  args: {
+    tabs: MANY_TABS,
+    activeTabId: "info",
+  },
+  render: (args) => {
+    function Playground() {
+      const [active, setActive] = useState(args.activeTabId);
+      return (
+        <div style={{ maxWidth: 400 }}>
+          <BrandedTabs
+            tabs={args.tabs}
+            activeTabId={active}
+            onTabChange={(id) => {
+              setActive(id);
+              args.onTabChange(id);
+            }}
+            ariaLabel={args.ariaLabel}
+          />
+        </div>
+      );
+    }
+    return <Playground />;
+  },
+};
+
+/**
+ * Mobile viewport — shows scroll arrows with constrained width.
+ */
+export const Mobile: Story = {
+  args: {
+    tabs: MANY_TABS,
+    activeTabId: "spelers",
+  },
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
   },
 };

--- a/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.test.tsx
+++ b/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { BrandedTabs, type BrandedTab } from "./BrandedTabs";
 
 const tabs: BrandedTab[] = [
@@ -42,7 +42,7 @@ describe("BrandedTabs", () => {
     );
     const inactive = screen.getByRole("tab", { name: "Spelers" });
     expect(inactive).toHaveClass("border-transparent");
-    expect(inactive).toHaveClass("text-kcvv-gray");
+    expect(inactive).toHaveClass("text-kcvv-gray-blue");
     expect(inactive).toHaveAttribute("aria-selected", "false");
     expect(inactive).toHaveAttribute("tabindex", "-1");
   });
@@ -112,5 +112,149 @@ describe("BrandedTabs", () => {
     expect(
       screen.getByRole("tablist", { name: "Team detail secties" }),
     ).toBeInTheDocument();
+  });
+
+  it("applies touch-active pressed state classes on tab buttons", () => {
+    render(
+      <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+    );
+    const tab = screen.getByRole("tab", { name: "Spelers" });
+    expect(tab.className).toContain("active:scale-[0.98]");
+  });
+
+  it("uses higher-contrast text for inactive tabs", () => {
+    render(
+      <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+    );
+    const inactive = screen.getByRole("tab", { name: "Spelers" });
+    expect(inactive).toHaveClass("text-kcvv-gray-blue");
+  });
+
+  it("applies transition classes for smooth active-state changes", () => {
+    render(
+      <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+    );
+    const tab = screen.getByRole("tab", { name: "Info" });
+    expect(tab.className).toContain("transition-");
+  });
+
+  it("preserves focus-visible ring for keyboard navigation", () => {
+    render(
+      <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+    );
+    const tab = screen.getByRole("tab", { name: "Info" });
+    expect(tab.className).toContain("focus-visible:ring-2");
+  });
+
+  describe("Scroll Arrows", () => {
+    let savedScrollWidth: PropertyDescriptor | undefined;
+    let savedClientWidth: PropertyDescriptor | undefined;
+    let savedScrollTo: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      savedScrollWidth = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "scrollWidth",
+      );
+      savedClientWidth = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "clientWidth",
+      );
+      savedScrollTo = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "scrollTo",
+      );
+    });
+
+    afterEach(() => {
+      const restore = (prop: string, desc: PropertyDescriptor | undefined) => {
+        if (desc) {
+          Object.defineProperty(HTMLElement.prototype, prop, desc);
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          delete (HTMLElement.prototype as any)[prop];
+        }
+      };
+      restore("scrollWidth", savedScrollWidth);
+      restore("clientWidth", savedClientWidth);
+      restore("scrollTo", savedScrollTo);
+      vi.restoreAllMocks();
+    });
+
+    it("shows right scroll arrow when tabs overflow", () => {
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        get: () => 1000,
+      });
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(HTMLElement.prototype, "scrollLeft", {
+        configurable: true,
+        get: () => 0,
+      });
+
+      render(
+        <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+      );
+
+      expect(screen.getByLabelText("Scroll right")).toBeInTheDocument();
+    });
+
+    it("does not show scroll arrows when tabs fit", () => {
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(HTMLElement.prototype, "scrollLeft", {
+        configurable: true,
+        get: () => 0,
+      });
+
+      render(
+        <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+      );
+
+      expect(screen.queryByLabelText("Scroll left")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Scroll right")).not.toBeInTheDocument();
+    });
+
+    it("shows left arrow after scrolling away from start", () => {
+      let scrollLeftVal = 0;
+
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        get: () => 1000,
+      });
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(HTMLElement.prototype, "scrollLeft", {
+        configurable: true,
+        get: () => scrollLeftVal,
+      });
+
+      const { container } = render(
+        <BrandedTabs tabs={tabs} activeTabId="info" onTabChange={() => {}} />,
+      );
+
+      expect(screen.queryByLabelText("Scroll left")).not.toBeInTheDocument();
+
+      scrollLeftVal = 200;
+      const scrollContainer = container.querySelector(
+        "[data-scroll-container]",
+      );
+      act(() => {
+        scrollContainer?.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(screen.getByLabelText("Scroll left")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.test.tsx
+++ b/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.test.tsx
@@ -150,6 +150,7 @@ describe("BrandedTabs", () => {
     let savedScrollWidth: PropertyDescriptor | undefined;
     let savedClientWidth: PropertyDescriptor | undefined;
     let savedScrollTo: PropertyDescriptor | undefined;
+    let savedScrollLeft: PropertyDescriptor | undefined;
 
     beforeEach(() => {
       savedScrollWidth = Object.getOwnPropertyDescriptor(
@@ -163,6 +164,10 @@ describe("BrandedTabs", () => {
       savedScrollTo = Object.getOwnPropertyDescriptor(
         HTMLElement.prototype,
         "scrollTo",
+      );
+      savedScrollLeft = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        "scrollLeft",
       );
     });
 
@@ -178,6 +183,7 @@ describe("BrandedTabs", () => {
       restore("scrollWidth", savedScrollWidth);
       restore("clientWidth", savedClientWidth);
       restore("scrollTo", savedScrollTo);
+      restore("scrollLeft", savedScrollLeft);
       vi.restoreAllMocks();
     });
 

--- a/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.tsx
+++ b/apps/web/src/components/design-system/BrandedTabs/BrandedTabs.tsx
@@ -7,6 +7,9 @@
  * uppercase, tracked, with a 4px green bottom border on the active tab
  * and a hover state on the inactive ones.
  *
+ * When tabs overflow on narrow screens, navigation arrows appear at the
+ * edges (shared scroll-hint pattern via `useScrollHint`).
+ *
  * State management is left to the parent — pass `activeTabId` and
  * `onTabChange`. Use this with `useState`, `useUrlTab`, or any other
  * mechanism that suits the consumer.
@@ -14,6 +17,8 @@
 
 import { useRef, type KeyboardEvent } from "react";
 import { cn } from "@/lib/utils/cn";
+import { useScrollHint } from "@/components/design-system/ScrollHint/useScrollHint";
+import { ScrollArrowButton } from "@/components/design-system/ScrollHint/ScrollArrowButton";
 
 export interface BrandedTab {
   /** Stable ID used by the parent for state */
@@ -39,6 +44,8 @@ export function BrandedTabs({
   className,
 }: BrandedTabsProps) {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const { scrollRef, canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
+    useScrollHint<HTMLDivElement>();
 
   const handleSelect = (tabId: string) => {
     if (tabId === activeTabId) return;
@@ -59,37 +66,57 @@ export function BrandedTabs({
   };
 
   return (
-    <div
-      role="tablist"
-      aria-label={ariaLabel}
-      className={cn("flex gap-8 border-b border-gray-200", className)}
-    >
-      {tabs.map((tab, index) => {
-        const isActive = tab.id === activeTabId;
-        return (
-          <button
-            key={tab.id}
-            id={tab.id}
-            ref={(el) => {
-              tabRefs.current[index] = el;
-            }}
-            type="button"
-            role="tab"
-            aria-selected={isActive}
-            tabIndex={isActive ? 0 : -1}
-            onClick={() => handleSelect(tab.id)}
-            onKeyDown={handleKeyDown}
-            className={cn(
-              "border-b-4 px-1 py-4 text-sm font-bold uppercase tracking-[0.05em] transition-colors",
-              isActive
-                ? "border-kcvv-green-bright text-kcvv-green-dark"
-                : "border-transparent text-kcvv-gray hover:text-kcvv-black",
-            )}
-          >
-            {tab.label}
-          </button>
-        );
-      })}
+    <div className={cn("relative", className)}>
+      {canScrollLeft && (
+        <ScrollArrowButton direction="left" onClick={scrollLeft} />
+      )}
+
+      <div
+        ref={scrollRef}
+        role="tablist"
+        aria-label={ariaLabel}
+        data-scroll-container
+        className={cn(
+          "flex gap-8 border-b border-gray-200 overflow-x-auto scrollbar-hide",
+          /* scrollbar-hide: @utility in globals.css — hides native scrollbar across all browsers */
+          canScrollLeft ? "pl-12" : "pl-0",
+          canScrollRight ? "pr-12" : "pr-0",
+        )}
+      >
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeTabId;
+          return (
+            <button
+              key={tab.id}
+              id={tab.id}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => handleSelect(tab.id)}
+              onKeyDown={handleKeyDown}
+              className={cn(
+                "border-b-4 px-1 py-4 text-sm font-bold uppercase tracking-[0.05em] whitespace-nowrap flex-shrink-0",
+                "transition-all duration-200",
+                "active:scale-[0.98]",
+                "focus-visible:ring-2 focus-visible:ring-kcvv-green-bright focus-visible:ring-offset-2 focus-visible:outline-none",
+                isActive
+                  ? "border-kcvv-green-bright text-kcvv-green-dark"
+                  : "border-transparent text-kcvv-gray-blue hover:text-kcvv-black active:bg-kcvv-green-dark/10",
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {canScrollRight && (
+        <ScrollArrowButton direction="right" onClick={scrollRight} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/design-system/FilterTabs/FilterTabs.tsx
+++ b/apps/web/src/components/design-system/FilterTabs/FilterTabs.tsx
@@ -21,8 +21,9 @@
  * - Hover: bg-kcvv-green-bright text-white
  */
 
-import { useRef, useState, useEffect, useCallback } from "react";
-import { ChevronLeft, ChevronRight, type LucideIcon } from "@/lib/icons";
+import { useScrollHint } from "@/components/design-system/ScrollHint/useScrollHint";
+import { ScrollArrowButton } from "@/components/design-system/ScrollHint/ScrollArrowButton";
+import { type LucideIcon } from "@/lib/icons";
 
 export interface FilterTab {
   /** Unique identifier */
@@ -79,51 +80,8 @@ export function FilterTabs({
   ariaLabel = "Filter tabs",
   renderAsLinks = false,
 }: FilterTabsProps) {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [showLeftArrow, setShowLeftArrow] = useState(false);
-  const [showRightArrow, setShowRightArrow] = useState(false);
-
-  // Check scroll position for arrow visibility
-  const checkScrollPosition = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const { scrollLeft, scrollWidth, clientWidth } = container;
-    setShowLeftArrow(scrollLeft > 10);
-    setShowRightArrow(scrollLeft < scrollWidth - clientWidth - 10);
-  }, []);
-
-  // Update arrows on mount, scroll, and resize
-  useEffect(() => {
-    checkScrollPosition();
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    container.addEventListener("scroll", checkScrollPosition);
-    window.addEventListener("resize", checkScrollPosition);
-
-    return () => {
-      container.removeEventListener("scroll", checkScrollPosition);
-      window.removeEventListener("resize", checkScrollPosition);
-    };
-  }, [checkScrollPosition, tabs]);
-
-  // Scroll handlers
-  const scroll = (direction: "left" | "right") => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const scrollAmount = 200;
-    const newScrollLeft =
-      direction === "left"
-        ? container.scrollLeft - scrollAmount
-        : container.scrollLeft + scrollAmount;
-
-    container.scrollTo({
-      left: newScrollLeft,
-      behavior: "smooth",
-    });
-  };
+  const { scrollRef, canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
+    useScrollHint<HTMLDivElement>();
 
   // Size-based styles
   const sizeClasses = {
@@ -236,77 +194,35 @@ export function FilterTabs({
 
   return (
     <div className={`relative ${className}`}>
-      {/* Left Arrow */}
-      {showLeftArrow && (
-        <button
-          type="button"
-          onClick={() => scroll("left")}
-          className={`
-            absolute left-0 top-1/2 -translate-y-1/2 z-10
-            ${currentSize.arrow}
-            bg-white
-            rounded-full
-            shadow-md
-            flex items-center justify-center
-            text-kcvv-green-bright
-            hover:bg-kcvv-green-bright hover:text-white
-            transition-colors
-            focus:outline-none focus:ring-2 focus:ring-kcvv-green-bright focus:ring-offset-2
-          `}
-          aria-label="Scroll left"
-        >
-          <ChevronLeft size={size === "sm" ? 16 : size === "lg" ? 24 : 20} />
-        </button>
+      {canScrollLeft && (
+        <ScrollArrowButton
+          direction="left"
+          onClick={scrollLeft}
+          className={currentSize.arrow}
+        />
       )}
 
-      {/* Scrollable Container */}
       <div
-        ref={scrollContainerRef}
+        ref={scrollRef}
         role="tablist"
         aria-label={ariaLabel}
         className={`
           flex gap-2 overflow-x-auto scroll-smooth
-          ${showLeftArrow ? (size === "sm" ? "pl-10" : size === "lg" ? "pl-14" : "pl-12") : "pl-0"}
-          ${showRightArrow ? (size === "sm" ? "pr-10" : size === "lg" ? "pr-14" : "pr-12") : "pr-0"}
+          ${canScrollLeft ? (size === "sm" ? "pl-10" : size === "lg" ? "pl-14" : "pl-12") : "pl-0"}
+          ${canScrollRight ? (size === "sm" ? "pr-10" : size === "lg" ? "pr-14" : "pr-12") : "pr-0"}
           scrollbar-hide
         `}
-        style={{
-          scrollbarWidth: "none",
-          msOverflowStyle: "none",
-        }}
       >
         {tabs.map(renderTab)}
       </div>
 
-      {/* Right Arrow */}
-      {showRightArrow && (
-        <button
-          type="button"
-          onClick={() => scroll("right")}
-          className={`
-            absolute right-0 top-1/2 -translate-y-1/2 z-10
-            ${currentSize.arrow}
-            bg-white
-            rounded-full
-            shadow-md
-            flex items-center justify-center
-            text-kcvv-green-bright
-            hover:bg-kcvv-green-bright hover:text-white
-            transition-colors
-            focus:outline-none focus:ring-2 focus:ring-kcvv-green-bright focus:ring-offset-2
-          `}
-          aria-label="Scroll right"
-        >
-          <ChevronRight size={size === "sm" ? 16 : size === "lg" ? 24 : 20} />
-        </button>
+      {canScrollRight && (
+        <ScrollArrowButton
+          direction="right"
+          onClick={scrollRight}
+          className={currentSize.arrow}
+        />
       )}
-
-      {/* Hide scrollbar CSS */}
-      <style jsx>{`
-        .scrollbar-hide::-webkit-scrollbar {
-          display: none;
-        }
-      `}</style>
     </div>
   );
 }

--- a/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.stories.tsx
+++ b/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "storybook/test";
+import { ScrollArrowButton } from "./ScrollArrowButton";
+
+const meta = {
+  title: "UI/ScrollArrowButton",
+  component: ScrollArrowButton,
+  tags: ["autodocs"],
+  args: {
+    direction: "right",
+    onClick: fn(),
+  },
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ position: "relative", width: 200, height: 80 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ScrollArrowButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Right arrow — light variant (default).
+ */
+export const RightLight: Story = {};
+
+/**
+ * Left arrow — light variant.
+ */
+export const LeftLight: Story = {
+  args: {
+    direction: "left",
+  },
+};
+
+/**
+ * Right arrow — dark variant for use on dark backgrounds.
+ */
+export const RightDark: Story = {
+  args: {
+    variant: "dark",
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: "relative",
+          width: 200,
+          height: 80,
+          backgroundColor: "#1a1a1a",
+          borderRadius: 8,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * Left arrow — dark variant.
+ */
+export const LeftDark: Story = {
+  args: {
+    direction: "left",
+    variant: "dark",
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: "relative",
+          width: 200,
+          height: 80,
+          backgroundColor: "#1a1a1a",
+          borderRadius: 8,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.stories.tsx
+++ b/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.stories.tsx
@@ -26,6 +26,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
+ * Interactive playground with all controls.
+ */
+export const Playground: Story = {};
+
+/**
  * Right arrow — light variant (default).
  */
 export const RightLight: Story = {};

--- a/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.test.tsx
+++ b/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ScrollArrowButton } from "./ScrollArrowButton";
+
+describe("ScrollArrowButton", () => {
+  it("renders a button with the correct aria-label for left direction", () => {
+    render(<ScrollArrowButton direction="left" onClick={vi.fn()} />);
+    expect(screen.getByLabelText("Scroll left")).toBeInTheDocument();
+  });
+
+  it("renders a button with the correct aria-label for right direction", () => {
+    render(<ScrollArrowButton direction="right" onClick={vi.fn()} />);
+    expect(screen.getByLabelText("Scroll right")).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<ScrollArrowButton direction="right" onClick={onClick} />);
+
+    await user.click(screen.getByLabelText("Scroll right"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies light variant classes by default", () => {
+    render(<ScrollArrowButton direction="left" onClick={vi.fn()} />);
+    const button = screen.getByLabelText("Scroll left");
+    expect(button).toHaveClass("bg-white");
+    expect(button).toHaveClass("text-kcvv-green-bright");
+  });
+
+  it("applies dark variant classes when variant is dark", () => {
+    render(
+      <ScrollArrowButton direction="left" onClick={vi.fn()} variant="dark" />,
+    );
+    const button = screen.getByLabelText("Scroll left");
+    expect(button).toHaveClass("bg-white/20");
+    expect(button).toHaveClass("text-white");
+  });
+});

--- a/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.tsx
+++ b/apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.tsx
@@ -1,0 +1,41 @@
+import { ChevronLeft, ChevronRight } from "@/lib/icons";
+import { cn } from "@/lib/utils/cn";
+
+export interface ScrollArrowButtonProps {
+  direction: "left" | "right";
+  onClick: () => void;
+  variant?: "light" | "dark";
+  className?: string;
+}
+
+export function ScrollArrowButton({
+  direction,
+  onClick,
+  variant = "light",
+  className,
+}: ScrollArrowButtonProps) {
+  const Icon = direction === "left" ? ChevronLeft : ChevronRight;
+  const positionClass = direction === "left" ? "left-0" : "right-0";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "absolute top-1/2 -translate-y-1/2 z-10",
+        "w-10 h-10 rounded-full shadow-md",
+        "flex items-center justify-center",
+        "transition-colors",
+        "focus:outline-none focus:ring-2 focus:ring-kcvv-green-bright focus:ring-offset-2",
+        variant === "light"
+          ? "bg-white text-kcvv-green-bright hover:bg-kcvv-green-bright hover:text-white"
+          : "bg-white/20 text-white hover:bg-white/30",
+        positionClass,
+        className,
+      )}
+      aria-label={`Scroll ${direction}`}
+    >
+      <Icon size={20} />
+    </button>
+  );
+}

--- a/apps/web/src/components/design-system/ScrollHint/index.ts
+++ b/apps/web/src/components/design-system/ScrollHint/index.ts
@@ -1,0 +1,4 @@
+export { useScrollHint } from "./useScrollHint";
+export type { UseScrollHintReturn } from "./useScrollHint";
+export { ScrollArrowButton } from "./ScrollArrowButton";
+export type { ScrollArrowButtonProps } from "./ScrollArrowButton";

--- a/apps/web/src/components/design-system/ScrollHint/useScrollHint.test.ts
+++ b/apps/web/src/components/design-system/ScrollHint/useScrollHint.test.ts
@@ -21,21 +21,42 @@ function TestHost({ onHook }: { onHook: (h: UseScrollHintReturn) => void }) {
 
 describe("useScrollHint", () => {
   let savedScrollTo: PropertyDescriptor | undefined;
+  let savedScrollWidth: PropertyDescriptor | undefined;
+  let savedClientWidth: PropertyDescriptor | undefined;
+  let savedScrollLeft: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     savedScrollTo = Object.getOwnPropertyDescriptor(
       HTMLElement.prototype,
       "scrollTo",
     );
+    savedScrollWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollWidth",
+    );
+    savedClientWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientWidth",
+    );
+    savedScrollLeft = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollLeft",
+    );
   });
 
   afterEach(() => {
-    if (savedScrollTo) {
-      Object.defineProperty(HTMLElement.prototype, "scrollTo", savedScrollTo);
-    } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (HTMLElement.prototype as any).scrollTo;
-    }
+    const restore = (prop: string, desc: PropertyDescriptor | undefined) => {
+      if (desc) {
+        Object.defineProperty(HTMLElement.prototype, prop, desc);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (HTMLElement.prototype as any)[prop];
+      }
+    };
+    restore("scrollTo", savedScrollTo);
+    restore("scrollWidth", savedScrollWidth);
+    restore("clientWidth", savedClientWidth);
+    restore("scrollLeft", savedScrollLeft);
     vi.restoreAllMocks();
   });
 

--- a/apps/web/src/components/design-system/ScrollHint/useScrollHint.test.ts
+++ b/apps/web/src/components/design-system/ScrollHint/useScrollHint.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { createElement, useEffect } from "react";
+import { useScrollHint, type UseScrollHintReturn } from "./useScrollHint";
+
+/**
+ * Test helper: renders a div with the hook's scrollRef attached,
+ * and captures the hook return value via a callback.
+ */
+function TestHost({ onHook }: { onHook: (h: UseScrollHintReturn) => void }) {
+  const hook = useScrollHint();
+  useEffect(() => {
+    onHook(hook);
+  });
+  return createElement("div", {
+    ref: hook.scrollRef,
+    "data-testid": "scroll-container",
+    style: { overflow: "auto" },
+  });
+}
+
+describe("useScrollHint", () => {
+  let savedScrollTo: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    savedScrollTo = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollTo",
+    );
+  });
+
+  afterEach(() => {
+    if (savedScrollTo) {
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", savedScrollTo);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (HTMLElement.prototype as any).scrollTo;
+    }
+    vi.restoreAllMocks();
+  });
+
+  function renderScrollHint(scrollProps: {
+    scrollWidth: number;
+    clientWidth: number;
+    scrollLeft: number;
+  }) {
+    let hookResult: UseScrollHintReturn | undefined;
+
+    // Mock scrollWidth/clientWidth/scrollLeft on HTMLElement.prototype
+    // so the element gets these values once the hook reads them
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      get() {
+        return scrollProps.scrollWidth;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return scrollProps.clientWidth;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollLeft", {
+      configurable: true,
+      get() {
+        return scrollProps.scrollLeft;
+      },
+    });
+
+    const utils = render(
+      createElement(TestHost, {
+        onHook: (h: UseScrollHintReturn) => {
+          hookResult = h;
+        },
+      }),
+    );
+
+    return { hookResult: hookResult!, ...utils };
+  }
+
+  it("returns canScrollLeft=false and canScrollRight=false when no overflow", () => {
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 500,
+      clientWidth: 500,
+      scrollLeft: 0,
+    });
+
+    expect(hookResult.canScrollLeft).toBe(false);
+    expect(hookResult.canScrollRight).toBe(false);
+  });
+
+  it("returns canScrollRight=true when content overflows to the right", () => {
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 1000,
+      clientWidth: 500,
+      scrollLeft: 0,
+    });
+
+    expect(hookResult.canScrollRight).toBe(true);
+    expect(hookResult.canScrollLeft).toBe(false);
+  });
+
+  it("returns canScrollLeft=true when scrolled past dead-zone", () => {
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 1000,
+      clientWidth: 500,
+      scrollLeft: 100,
+    });
+
+    expect(hookResult.canScrollLeft).toBe(true);
+    expect(hookResult.canScrollRight).toBe(true);
+  });
+
+  it("uses 10px dead-zone — scrollLeft=5 means canScrollLeft=false", () => {
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 1000,
+      clientWidth: 500,
+      scrollLeft: 5,
+    });
+
+    expect(hookResult.canScrollLeft).toBe(false);
+  });
+
+  it("uses 10px dead-zone — 10px overflow means canScrollRight=false", () => {
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 510,
+      clientWidth: 500,
+      scrollLeft: 0,
+    });
+
+    expect(hookResult.canScrollRight).toBe(false);
+  });
+
+  it("scrollLeft() calls scrollTo with decreased offset", () => {
+    const scrollToMock = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollToMock,
+    });
+
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 1000,
+      clientWidth: 500,
+      scrollLeft: 300,
+    });
+
+    act(() => {
+      hookResult.scrollLeft();
+    });
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      left: 100,
+      behavior: "smooth",
+    });
+  });
+
+  it("scrollRight() calls scrollTo with increased offset", () => {
+    const scrollToMock = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: scrollToMock,
+    });
+
+    const { hookResult } = renderScrollHint({
+      scrollWidth: 1000,
+      clientWidth: 500,
+      scrollLeft: 0,
+    });
+
+    act(() => {
+      hookResult.scrollRight();
+    });
+
+    expect(scrollToMock).toHaveBeenCalledWith({
+      left: 200,
+      behavior: "smooth",
+    });
+  });
+
+  it("updates when scroll event fires on the container", () => {
+    let scrollLeftValue = 0;
+
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      get() {
+        return 1000;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get() {
+        return 500;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollLeft", {
+      configurable: true,
+      get() {
+        return scrollLeftValue;
+      },
+    });
+
+    let hookResult: UseScrollHintReturn | undefined;
+    render(
+      createElement(TestHost, {
+        onHook: (h: UseScrollHintReturn) => {
+          hookResult = h;
+        },
+      }),
+    );
+
+    expect(hookResult!.canScrollLeft).toBe(false);
+
+    // Change the scrollLeft value and fire scroll event
+    scrollLeftValue = 200;
+    const container = screen.getByTestId("scroll-container");
+    act(() => {
+      container.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(hookResult!.canScrollLeft).toBe(true);
+    expect(hookResult!.canScrollRight).toBe(true);
+  });
+});

--- a/apps/web/src/components/design-system/ScrollHint/useScrollHint.ts
+++ b/apps/web/src/components/design-system/ScrollHint/useScrollHint.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+
+const SCROLL_AMOUNT = 200;
+const DEAD_ZONE = 10;
+
+export interface UseScrollHintReturn<T extends HTMLElement = HTMLElement> {
+  scrollRef: React.RefObject<T | null>;
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+  scrollLeft: () => void;
+  scrollRight: () => void;
+}
+
+export function useScrollHint<
+  T extends HTMLElement = HTMLElement,
+>(): UseScrollHintReturn<T> {
+  const scrollRef = useRef<T | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const checkScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    setCanScrollLeft(scrollLeft > DEAD_ZONE);
+    setCanScrollRight(scrollLeft < scrollWidth - clientWidth - DEAD_ZONE);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    checkScroll();
+
+    el.addEventListener("scroll", checkScroll);
+    window.addEventListener("resize", checkScroll);
+
+    const observer = new ResizeObserver(checkScroll);
+    observer.observe(el);
+
+    return () => {
+      el.removeEventListener("scroll", checkScroll);
+      window.removeEventListener("resize", checkScroll);
+      observer.disconnect();
+    };
+  }, [checkScroll]);
+
+  const scrollLeftFn = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({
+      left: el.scrollLeft - SCROLL_AMOUNT,
+      behavior: "smooth",
+    });
+  }, []);
+
+  const scrollRightFn = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({
+      left: el.scrollLeft + SCROLL_AMOUNT,
+      behavior: "smooth",
+    });
+  }, []);
+
+  return {
+    scrollRef,
+    canScrollLeft,
+    canScrollRight,
+    scrollLeft: scrollLeftFn,
+    scrollRight: scrollRightFn,
+  };
+}

--- a/apps/web/src/components/design-system/index.ts
+++ b/apps/web/src/components/design-system/index.ts
@@ -89,6 +89,10 @@ export type { SectionCtaProps } from "./SectionCta";
 export { PageHero } from "./PageHero";
 export type { PageHeroProps } from "./PageHero";
 
+// ScrollHint
+export { useScrollHint, ScrollArrowButton } from "./ScrollHint";
+export type { UseScrollHintReturn, ScrollArrowButtonProps } from "./ScrollHint";
+
 // BrandedTabs
 export { BrandedTabs } from "./BrandedTabs";
 export type { BrandedTab, BrandedTabsProps } from "./BrandedTabs";

--- a/docs/plans/2026-04-10-branded-tabs-scroll-hint-design.md
+++ b/docs/plans/2026-04-10-branded-tabs-scroll-hint-design.md
@@ -5,7 +5,7 @@
 
 ## Problem
 
-1. BrandedTabs has no touch pressed state and inactive tabs have low contrast
+1. BrandedTabs has no touch-pressed state and inactive tabs have low contrast
 2. Three components independently implement scroll overflow hints with two different patterns
 3. No shared utility for scroll overflow detection
 

--- a/docs/plans/2026-04-10-branded-tabs-scroll-hint-design.md
+++ b/docs/plans/2026-04-10-branded-tabs-scroll-hint-design.md
@@ -1,0 +1,90 @@
+# BrandedTabs Touch Affordance & Scroll Hint Unification
+
+**Issue:** #1260
+**Date:** 2026-04-10
+
+## Problem
+
+1. BrandedTabs has no touch pressed state and inactive tabs have low contrast
+2. Three components independently implement scroll overflow hints with two different patterns
+3. No shared utility for scroll overflow detection
+
+## Design
+
+### Part A: BrandedTabs Touch Affordance
+
+**Changes to `BrandedTabs.tsx`:**
+
+- **Pressed state:** Add `active:scale-[0.98] active:bg-kcvv-green-dark/10` to tab buttons for mobile touch feedback
+- **Inactive contrast:** Change inactive text from `text-kcvv-gray` to a higher-contrast color meeting WCAG AA on both light and dark backgrounds
+- **Active indicator:** The existing `border-b-4 border-kcvv-green-bright` serves as the active underline — add a transition for smooth tab switching
+- **Keyboard focus:** Preserve existing `focus-visible:ring-2` behavior
+
+### Part B: `useScrollHint` Hook
+
+**Location:** `apps/web/src/components/design-system/ScrollHint/useScrollHint.ts`
+
+```typescript
+interface UseScrollHintReturn {
+  scrollRef: React.RefObject<HTMLElement>;
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+  scrollLeft: () => void;
+  scrollRight: () => void;
+}
+
+function useScrollHint(): UseScrollHintReturn;
+```
+
+**Internals:**
+
+- `ResizeObserver` on the scroll container for overflow detection
+- `scroll` event listener for position tracking
+- 10px dead-zone threshold (matching FilterTabs behavior)
+- Cleanup on unmount
+
+**Consumers:**
+
+| Component      | Mode     | Rendering                                               |
+| -------------- | -------- | ------------------------------------------------------- |
+| BrandedTabs    | arrows   | `<ScrollArrowButton>` at left/right edges               |
+| FilterTabs     | arrows   | Refactor to use `useScrollHint` instead of inline logic |
+| HtmlTableBlock | gradient | Uses `canScrollRight` to show gradient overlay          |
+
+### `ScrollArrowButton` Component
+
+**Location:** `apps/web/src/components/design-system/ScrollHint/ScrollArrowButton.tsx`
+
+Presentational component for the arrow buttons. Extracted from FilterTabs's existing arrow UI.
+
+```typescript
+interface ScrollArrowButtonProps {
+  direction: "left" | "right";
+  onClick: () => void;
+  variant?: "light" | "dark";
+}
+```
+
+### File Structure
+
+```text
+apps/web/src/components/design-system/ScrollHint/
+├── useScrollHint.ts
+├── useScrollHint.test.ts
+├── ScrollArrowButton.tsx
+├── ScrollArrowButton.stories.tsx
+└── index.ts
+```
+
+## Testing Strategy
+
+- Unit tests for `useScrollHint` — mock `scrollWidth`/`clientWidth` on container, verify `canScrollLeft`/`canScrollRight` state
+- Update BrandedTabs tests — verify touch affordance classes, scroll arrow rendering
+- Update FilterTabs tests — verify behavior preserved after refactor to shared hook
+- Verify HtmlTableBlock gradient still works with shared hook
+
+## Consumers Audit
+
+- `BrandedTabs` — used only by `TeamDetailTabs` (team detail page)
+- `FilterTabs` — used by news category filters, sponsor tier filters
+- `HtmlTableBlock` — used in Sanity article body rendering


### PR DESCRIPTION
Closes #1260

## What changed
- Added active/pressed visual states to `BrandedTabs` for mobile touch affordance (scale + ring feedback)
- Extracted scroll-hint logic from `FilterTabs` into a reusable `useScrollHint` hook and `ScrollArrowButton` component
- Unified scroll indicators across `BrandedTabs` and `FilterTabs` using the shared `ScrollHint` utility

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- New unit tests for `useScrollHint` hook and `ScrollArrowButton`
- Extended `BrandedTabs` tests for touch states and scroll integration
- Storybook stories added for `BrandedTabs` and `ScrollArrowButton`

🤖 Generated with [Claude Code](https://claude.com/claude-code)