### PR TITLE
fix(sponsors): descriptive alt text on all sponsor logos (#1263)

### DIFF
--- a/apps/web/src/components/sponsors/SponsorCard/SponsorCard.test.tsx
+++ b/apps/web/src/components/sponsors/SponsorCard/SponsorCard.test.tsx
@@ -56,10 +56,10 @@ describe("SponsorCard", () => {
   });
 
   describe("rendering", () => {
-    it("renders sponsor logo with correct alt text", () => {
+    it("renders sponsor logo with descriptive alt text including sponsor name and club", () => {
       render(<SponsorCard sponsor={sponsor} />);
 
-      const img = screen.getByAltText("Test Sponsor");
+      const img = screen.getByAltText("Test Sponsor — sponsor KCVV Elewijt");
       expect(img).toBeInTheDocument();
     });
 

--- a/apps/web/src/components/sponsors/SponsorCard/SponsorCard.tsx
+++ b/apps/web/src/components/sponsors/SponsorCard/SponsorCard.tsx
@@ -7,6 +7,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
+import { formatSponsorAlt } from "../formatSponsorAlt";
 import type { Sponsor } from "../Sponsors";
 
 const sizeMap = {
@@ -44,7 +45,7 @@ export const SponsorCard = ({
     >
       <Image
         src={sponsor.logo}
-        alt={sponsor.name}
+        alt={formatSponsorAlt(sponsor.name)}
         width={image.width}
         height={image.height}
         className="w-full h-full object-contain grayscale group-hover:grayscale-0 transition-all duration-300"

--- a/apps/web/src/components/sponsors/SponsorGrid/SponsorGrid.test.tsx
+++ b/apps/web/src/components/sponsors/SponsorGrid/SponsorGrid.test.tsx
@@ -30,11 +30,15 @@ const sponsors: Sponsor[] = [
 ];
 
 describe("SponsorGrid", () => {
-  it("renders all sponsors", () => {
+  it("renders all sponsors with descriptive alt text", () => {
     render(<SponsorGrid sponsors={sponsors} />);
 
-    expect(screen.getByAltText("Sponsor A")).toBeInTheDocument();
-    expect(screen.getByAltText("Sponsor B")).toBeInTheDocument();
+    expect(
+      screen.getByAltText("Sponsor A — sponsor KCVV Elewijt"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByAltText("Sponsor B — sponsor KCVV Elewijt"),
+    ).toBeInTheDocument();
   });
 
   it("returns null for empty sponsors", () => {

--- a/apps/web/src/components/sponsors/SponsorLogo/SponsorLogo.tsx
+++ b/apps/web/src/components/sponsors/SponsorLogo/SponsorLogo.tsx
@@ -8,6 +8,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
+import { formatSponsorAlt } from "../formatSponsorAlt";
 
 const sizeMap = {
   xs: { width: 80, height: 53 },
@@ -41,7 +42,7 @@ export const SponsorLogo = ({
   const img = (
     <Image
       src={logo}
-      alt={name}
+      alt={formatSponsorAlt(name)}
       width={width}
       height={height}
       className={cn("object-contain", className)}

--- a/apps/web/src/components/sponsors/Sponsors.test.tsx
+++ b/apps/web/src/components/sponsors/Sponsors.test.tsx
@@ -52,6 +52,10 @@ describe("Sponsors", () => {
     },
   ];
 
+  const expectedAltTexts = mockSponsors.map(
+    (s) => `${s.name} — sponsor KCVV Elewijt`,
+  );
+
   describe("Rendering", () => {
     it("renders section with default title", () => {
       render(<Sponsors sponsors={mockSponsors} />);
@@ -90,23 +94,10 @@ describe("Sponsors", () => {
       render(<Sponsors sponsors={mockSponsors} />);
 
       const logos = screen.getAllByRole("img");
-      expect(logos).toHaveLength(4);
-      expect(logos[0]).toHaveAttribute(
-        "alt",
-        "Sponsor One — sponsor KCVV Elewijt",
-      );
-      expect(logos[1]).toHaveAttribute(
-        "alt",
-        "Sponsor Two — sponsor KCVV Elewijt",
-      );
-      expect(logos[2]).toHaveAttribute(
-        "alt",
-        "Sponsor Three — sponsor KCVV Elewijt",
-      );
-      expect(logos[3]).toHaveAttribute(
-        "alt",
-        "Sponsor Four — sponsor KCVV Elewijt",
-      );
+      expect(logos).toHaveLength(mockSponsors.length);
+      logos.forEach((logo, i) => {
+        expect(logo).toHaveAttribute("alt", expectedAltTexts[i]);
+      });
     });
 
     it('renders "View All" link by default', () => {
@@ -240,18 +231,9 @@ describe("Sponsors", () => {
     it("has descriptive alt text for all logos including club name", () => {
       render(<Sponsors sponsors={mockSponsors} />);
 
-      expect(
-        screen.getByAltText("Sponsor One — sponsor KCVV Elewijt"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByAltText("Sponsor Two — sponsor KCVV Elewijt"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByAltText("Sponsor Three — sponsor KCVV Elewijt"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByAltText("Sponsor Four — sponsor KCVV Elewijt"),
-      ).toBeInTheDocument();
+      for (const alt of expectedAltTexts) {
+        expect(screen.getByAltText(alt)).toBeInTheDocument();
+      }
     });
 
     it("has descriptive aria-labels for external links", () => {

--- a/apps/web/src/components/sponsors/Sponsors.test.tsx
+++ b/apps/web/src/components/sponsors/Sponsors.test.tsx
@@ -86,15 +86,27 @@ describe("Sponsors", () => {
       expect(screen.getByText("Thank you to our sponsors")).toBeInTheDocument();
     });
 
-    it("renders all sponsor logos", () => {
+    it("renders all sponsor logos with descriptive alt text", () => {
       render(<Sponsors sponsors={mockSponsors} />);
 
       const logos = screen.getAllByRole("img");
       expect(logos).toHaveLength(4);
-      expect(logos[0]).toHaveAttribute("alt", "Sponsor One");
-      expect(logos[1]).toHaveAttribute("alt", "Sponsor Two");
-      expect(logos[2]).toHaveAttribute("alt", "Sponsor Three");
-      expect(logos[3]).toHaveAttribute("alt", "Sponsor Four");
+      expect(logos[0]).toHaveAttribute(
+        "alt",
+        "Sponsor One — sponsor KCVV Elewijt",
+      );
+      expect(logos[1]).toHaveAttribute(
+        "alt",
+        "Sponsor Two — sponsor KCVV Elewijt",
+      );
+      expect(logos[2]).toHaveAttribute(
+        "alt",
+        "Sponsor Three — sponsor KCVV Elewijt",
+      );
+      expect(logos[3]).toHaveAttribute(
+        "alt",
+        "Sponsor Four — sponsor KCVV Elewijt",
+      );
     });
 
     it('renders "View All" link by default', () => {
@@ -225,13 +237,21 @@ describe("Sponsors", () => {
       expect(heading).toHaveTextContent("Onze sponsors");
     });
 
-    it("has descriptive alt text for all logos", () => {
+    it("has descriptive alt text for all logos including club name", () => {
       render(<Sponsors sponsors={mockSponsors} />);
 
-      expect(screen.getByAltText("Sponsor One")).toBeInTheDocument();
-      expect(screen.getByAltText("Sponsor Two")).toBeInTheDocument();
-      expect(screen.getByAltText("Sponsor Three")).toBeInTheDocument();
-      expect(screen.getByAltText("Sponsor Four")).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Sponsor One — sponsor KCVV Elewijt"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Sponsor Two — sponsor KCVV Elewijt"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Sponsor Three — sponsor KCVV Elewijt"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Sponsor Four — sponsor KCVV Elewijt"),
+      ).toBeInTheDocument();
     });
 
     it("has descriptive aria-labels for external links", () => {
@@ -276,7 +296,9 @@ describe("Sponsors", () => {
 
       render(<Sponsors sponsors={specialSponsors} />);
 
-      expect(screen.getByAltText("Café & Bar")).toBeInTheDocument();
+      expect(
+        screen.getByAltText("Café & Bar — sponsor KCVV Elewijt"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/components/sponsors/SponsorsSpotlight.tsx
+++ b/apps/web/src/components/sponsors/SponsorsSpotlight.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
+import { formatSponsorAlt } from "./formatSponsorAlt";
 
 export interface SpotlightSponsor {
   id: string;
@@ -71,7 +72,7 @@ export const SponsorsSpotlight = ({
               <div className="flex-shrink-0 w-64 h-48 relative">
                 <Image
                   src={activeSponsor.logo}
-                  alt={activeSponsor.name}
+                  alt={formatSponsorAlt(activeSponsor.name)}
                   fill
                   className="object-contain"
                   sizes="256px"

--- a/apps/web/src/components/sponsors/formatSponsorAlt.test.ts
+++ b/apps/web/src/components/sponsors/formatSponsorAlt.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { formatSponsorAlt } from "./formatSponsorAlt";
+
+describe("formatSponsorAlt", () => {
+  it("includes the sponsor name and the club name so screen readers and broken-image fallback announce the sponsor", () => {
+    expect(formatSponsorAlt("Acme")).toBe("Acme — sponsor KCVV Elewijt");
+  });
+
+  it("preserves diacritics and ampersands in sponsor names", () => {
+    expect(formatSponsorAlt("Café & Bar")).toBe(
+      "Café & Bar — sponsor KCVV Elewijt",
+    );
+  });
+});

--- a/apps/web/src/components/sponsors/formatSponsorAlt.ts
+++ b/apps/web/src/components/sponsors/formatSponsorAlt.ts
@@ -1,0 +1,2 @@
+export const formatSponsorAlt = (name: string): string =>
+  `${name} — sponsor KCVV Elewijt`;

--- a/apps/web/src/components/sponsors/index.ts
+++ b/apps/web/src/components/sponsors/index.ts
@@ -25,3 +25,5 @@ export type { SponsorGridProps } from "./SponsorGrid/SponsorGrid";
 
 export { SponsorLogo } from "./SponsorLogo/SponsorLogo";
 export type { SponsorLogoProps } from "./SponsorLogo/SponsorLogo";
+
+export { formatSponsorAlt } from "./formatSponsorAlt";


### PR DESCRIPTION
Closes #1263

## Summary

- All sponsor logos now use descriptive alt text via a shared `formatSponsorAlt` helper that returns `${name} — sponsor KCVV Elewijt`
- Routed every sponsor `<Image>` through the helper: `SponsorLogo`, `SponsorCard`, `SponsorsSpotlight` (audited — those are the only three render sites)
- No runtime fallback needed for broken images: browsers natively render `alt` text when an `<img>` fails to load, so the descriptive alt doubles as the visible fallback

## Why

- WCAG 1.1.1 / EN 301 549 — non-text content needs a meaningful text alternative
- Sponsors deserve to be named to assistive tech users, not announced as a generic "image"
- Broken-image states no longer leave a blank box

## Acceptance criteria (from #1263)

- [x] Every sponsor logo has descriptive alt text (sourced from Sanity → `sponsor.name`)
- [x] Screen readers announce the sponsor name (alt text on the image; existing link `aria-label` already names the sponsor at the link level)
- [x] Broken-image fallback shows sponsor name as text (native browser behavior — no extra code)
- [x] Covered by tests — added unit test for the helper, updated existing tests for `SponsorCard`, `SponsorGrid`, and `Sponsors` to assert the new format

## Test plan

- [x] `pnpm --filter @kcvv/web lint` — clean
- [x] `pnpm --filter @kcvv/web type-check` — clean
- [x] `pnpm --filter @kcvv/web test` — 2331 passed
- [x] `pnpm --filter @kcvv/web build` — clean
- [ ] Manual: load `/sponsors`, inspect a logo `<img>` element, confirm `alt="<Sponsor Name> — sponsor KCVV Elewijt"`
- [ ] Manual: temporarily break a logo URL, confirm the sponsor name is shown as fallback text
- [ ] Manual: VoiceOver/NVDA — focus a sponsor link, confirm announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)