### PR TITLE
refactor(ui): route EnhancedOrgChart lucide icons through @/lib/icons barrel (#1265)

### DIFF
--- a/apps/web/src/components/organigram/chart/EnhancedOrgChart.tsx
+++ b/apps/web/src/components/organigram/chart/EnhancedOrgChart.tsx
@@ -35,8 +35,8 @@ import {
   Expand,
   Minimize,
   Download,
-} from "lucide-react";
-import { Menu } from "@/lib/icons";
+  Menu,
+} from "@/lib/icons";
 import { DepartmentFilter } from "../shared/DepartmentFilter";
 import { MobileNavigationDrawer } from "./MobileNavigationDrawer";
 import { ContactOverlay } from "./ContactOverlay";

--- a/apps/web/src/lib/icons.ts
+++ b/apps/web/src/lib/icons.ts
@@ -89,6 +89,17 @@ import {
   Pause,
   Play,
 
+  // Zoom & Viewport
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+  Minimize2,
+  Expand,
+  Minimize,
+
+  // Actions
+  Download,
+
   // Misc
   Plus,
   Zap,
@@ -182,6 +193,17 @@ export const icons = {
   // Media controls
   pause: Pause,
   play: Play,
+
+  // Zoom & Viewport
+  "zoom-in": ZoomIn,
+  "zoom-out": ZoomOut,
+  maximize2: Maximize2,
+  minimize2: Minimize2,
+  expand: Expand,
+  minimize: Minimize,
+
+  // Actions
+  download: Download,
 
   // Misc
   plus: Plus,
@@ -323,6 +345,17 @@ export {
   // Media controls
   Pause,
   Play,
+
+  // Zoom & Viewport
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+  Minimize2,
+  Expand,
+  Minimize,
+
+  // Actions
+  Download,
 
   // Misc
   Plus,

--- a/apps/web/src/stories/foundation/SpacingAndIcons.mdx
+++ b/apps/web/src/stories/foundation/SpacingAndIcons.mdx
@@ -13,7 +13,10 @@ import {
   Trophy, Activity, CircleDot, Flag, Timer, RectangleVertical, Square,
   Heart, Shield,
   Handshake, LayoutGrid, Network,
-  Pause, Play, Plus, Zap,
+  Pause, Play,
+  ZoomIn, ZoomOut, Maximize2, Minimize2, Expand, Minimize,
+  Download,
+  Plus, Zap,
 } from 'lucide-react';
 
 <Meta title="Foundation/Spacing & Icons" />
@@ -211,6 +214,19 @@ Use the `<Icon>` component or import directly from `@/lib/icons`.
 <IconGrid label="Media Controls" icons={[
   { Icon: Pause, name: 'pause' },
   { Icon: Play, name: 'play' },
+]} />
+
+<IconGrid label="Zoom & Viewport" icons={[
+  { Icon: ZoomIn, name: 'zoom-in' },
+  { Icon: ZoomOut, name: 'zoom-out' },
+  { Icon: Maximize2, name: 'maximize2' },
+  { Icon: Minimize2, name: 'minimize2' },
+  { Icon: Expand, name: 'expand' },
+  { Icon: Minimize, name: 'minimize' },
+]} />
+
+<IconGrid label="Actions" icons={[
+  { Icon: Download, name: 'download' },
 ]} />
 
 <IconGrid label="Misc" icons={[


### PR DESCRIPTION
Closes #1265

## What changed
- Exported 7 icons (`ZoomIn`, `ZoomOut`, `Maximize2`, `Minimize2`, `Expand`, `Minimize`, `Download`) from `apps/web/src/lib/icons.ts`
- Updated `EnhancedOrgChart.tsx` to import icons from `@/lib/icons` instead of directly from `lucide-react`
- Added the 7 new icons to the Storybook icon grid in `SpacingAndIcons.mdx`

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Verified organigram page renders correctly with icons intact