### PR TITLE
perf(ui,config): self-host free fonts via next/font + defer Typekit (#1266)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -132,10 +132,10 @@
   /* Font Families
      - Montserrat & IBM Plex Mono: self-hosted via next/font/google (CSS vars injected on <html>)
      - Quasimoda & Stenciletta: loaded via Adobe Typekit (afterInteractive) */
-  --font-family-title: quasimoda, -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-body: var(--font-montserrat), -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-alt: stenciletta, -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-mono: var(--font-ibm-plex-mono), Consolas, "Liberation Mono", Courier, monospace;
+  --font-family-title: quasimoda, -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", sans-serif;
+  --font-family-body: var(--font-montserrat), -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", sans-serif;
+  --font-family-alt: stenciletta, -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", sans-serif;
+  --font-family-mono: var(--font-ibm-plex-mono), "Consolas", "Liberation Mono", "Courier", monospace;
 
   /* Font Sizes with Line Heights */
   --font-size-xs: 0.75rem;      /* 12px */
@@ -477,8 +477,7 @@
 /* Scoped to #cc-main so specificity beats the library's :root defaults
    regardless of CSS chunk load order (library CSS loads dynamically). */
 #cc-main {
-  --cc-font-family: var(--font-montserrat), -apple-system, system-ui, BlinkMacSystemFont,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --cc-font-family: var(--font-family-body);
 
   /* Surface — black base */
   --cc-bg: var(--color-kcvv-black);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -132,9 +132,9 @@
   /* Font Families
      - Montserrat & IBM Plex Mono: self-hosted via next/font/google (CSS vars injected on <html>)
      - Quasimoda & Stenciletta: loaded via Adobe Typekit (afterInteractive) */
-  --font-family-title: quasimoda, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-body: var(--font-montserrat), -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-alt: stenciletta, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-family-title: quasimoda, -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-family-body: var(--font-montserrat), -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-family-alt: stenciletta, -apple-system, system-ui, "BlinkMacSystemFont", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-family-mono: var(--font-ibm-plex-mono), Consolas, "Liberation Mono", Courier, monospace;
 
   /* Font Sizes with Line Heights */

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -129,11 +129,13 @@
 
   /* ===== Typography ===== */
 
-  /* Font Families - Note: Actual fonts need to be loaded via Typekit */
-  --font-family-title: quasimoda, acumin-pro, Montserrat, Verdana, sans-serif;
-  --font-family-body: montserrat, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  /* Font Families
+     - Montserrat & IBM Plex Mono: self-hosted via next/font/google (CSS vars injected on <html>)
+     - Quasimoda & Stenciletta: loaded via Adobe Typekit (afterInteractive) */
+  --font-family-title: quasimoda, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-family-body: var(--font-montserrat), -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-family-alt: stenciletta, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-family-mono: ibm-plex-mono, Consolas, "Liberation Mono", Courier, monospace;
+  --font-family-mono: var(--font-ibm-plex-mono), Consolas, "Liberation Mono", Courier, monospace;
 
   /* Font Sizes with Line Heights */
   --font-size-xs: 0.75rem;      /* 12px */
@@ -475,8 +477,8 @@
 /* Scoped to #cc-main so specificity beats the library's :root defaults
    regardless of CSS chunk load order (library CSS loads dynamically). */
 #cc-main {
-  --cc-font-family: "Montserrat", "-apple-system", system-ui, "BlinkMacSystemFont",
-    "Segoe UI", "Roboto", "Helvetica Neue", "Arial", sans-serif;
+  --cc-font-family: var(--font-montserrat), -apple-system, system-ui, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 
   /* Surface — black base */
   --cc-bg: var(--color-kcvv-black);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import Script from "next/script";
+import { Montserrat, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { AccentStrip } from "@/components/layout/AccentStrip";
 import { PageHeader } from "@/components/layout/PageHeader";
@@ -13,6 +14,20 @@ import {
   type TeamNavVM,
 } from "@/lib/repositories/team.repository";
 import { BRAND, SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+
+const montserrat = Montserrat({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-montserrat",
+});
+
+const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+  display: "swap",
+  variable: "--font-ibm-plex-mono",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_CONFIG.siteUrl),
@@ -83,16 +98,20 @@ export default async function RootLayout({
     .sort((a, b) => parseAge(b.age!) - parseAge(a.age!));
 
   return (
-    <html lang="nl" suppressHydrationWarning>
+    <html
+      lang="nl"
+      suppressHydrationWarning
+      className={`${montserrat.variable} ${ibmPlexMono.variable}`}
+    >
       <head>
-        {/* Adobe Typekit Fonts */}
+        {/* Adobe Typekit Fonts — deferred (only serves quasimoda + stenciletta) */}
         {typekitId && (
           <>
             <Script
               src={`https://use.typekit.net/${typekitId}.js`}
-              strategy="beforeInteractive"
+              strategy="afterInteractive"
             />
-            <Script id="typekit-init" strategy="beforeInteractive">
+            <Script id="typekit-init" strategy="afterInteractive">
               {`try{Typekit.load({ async: true });}catch(e){console.error('Typekit load error:', e);}`}
             </Script>
           </>

--- a/apps/web/src/components/design-system/FilterTabs/FilterTabs.tsx
+++ b/apps/web/src/components/design-system/FilterTabs/FilterTabs.tsx
@@ -153,7 +153,7 @@ export function FilterTabs({
                   : "bg-kcvv-green-bright/10 text-kcvv-green-bright group-hover:bg-white/20 group-hover:text-white"
               }
             `}
-            style={{ fontFamily: "ibm-plex-mono, monospace" }}
+            style={{ fontFamily: "var(--font-family-mono)" }}
           >
             {tab.count}
           </span>

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.test.tsx
@@ -136,6 +136,25 @@ describe("MatchWidget", () => {
       render(<MatchWidget match={mockLongTeamNames} />);
       expect(screen.getByText(/Verbroedering Hofstade/i)).toBeInTheDocument();
     });
+
+    it("score element uses font-mono without conflicting font-title", () => {
+      render(<MatchWidget match={mockFinishedMatchWin} />);
+      const scoreEl = screen.getByText("3 – 1");
+      expect(scoreEl.className).toContain("font-mono");
+      expect(scoreEl.className).not.toContain("font-title");
+    });
+
+    it("FT element uses font-mono without conflicting font-title", () => {
+      const noScoreMatch = {
+        ...mockFinishedMatchWin,
+        homeTeam: { ...mockFinishedMatchWin.homeTeam, score: undefined },
+        awayTeam: { ...mockFinishedMatchWin.awayTeam, score: undefined },
+      };
+      render(<MatchWidget match={noScoreMatch} />);
+      const ftEl = screen.getByText("FT");
+      expect(ftEl.className).toContain("font-mono");
+      expect(ftEl.className).not.toContain("font-title");
+    });
   });
 
   describe("Accessibility", () => {

--- a/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
+++ b/apps/web/src/components/home/MatchWidget/MatchWidget.tsx
@@ -102,7 +102,7 @@ export function MatchWidget({
 
             {!isPostponed && !isForfeited && hasScore && (
               <span
-                className="font-title font-black text-white font-mono leading-none tracking-[-0.04em]"
+                className="font-mono font-black text-white leading-none tracking-[-0.04em]"
                 style={{ fontSize: "clamp(1.75rem, 8vw, 4rem)" }}
               >
                 {match.homeTeam.score} – {match.awayTeam.score}
@@ -120,7 +120,7 @@ export function MatchWidget({
 
             {!isPostponed && isFinished && !isForfeited && !hasScore && (
               <span
-                className="font-title font-black text-white font-mono leading-none tracking-[-0.04em]"
+                className="font-mono font-black text-white leading-none tracking-[-0.04em]"
                 style={{ fontSize: "clamp(1.75rem, 8vw, 4rem)" }}
               >
                 FT

--- a/apps/web/src/components/organigram/chart/NodeRenderer.tsx
+++ b/apps/web/src/components/organigram/chart/NodeRenderer.tsx
@@ -135,7 +135,7 @@ function renderSingleNode(
           min-width: 0;
         ">
           <div style="
-            font-family: 'quasimoda', 'acumin-pro', 'Montserrat', sans-serif;
+            font-family: 'quasimoda', -apple-system, system-ui, 'Montserrat', sans-serif;
             font-size: 16px;
             font-weight: 700;
             color: ${NODE_TEXT_PRIMARY};
@@ -170,7 +170,7 @@ function renderSingleNode(
               border-radius: 4px;
               font-size: 11px;
               font-weight: 600;
-              font-family: 'ibm-plex-mono', monospace;
+              font-family: var(--font-family-mono);
               letter-spacing: 0.5px;
             ">${node.roleCode}</div>
           `
@@ -211,7 +211,7 @@ function renderVacantNode(
         text-align: center;
       ">
         <div style="
-          font-family: 'quasimoda', 'acumin-pro', 'Montserrat', sans-serif;
+          font-family: 'quasimoda', -apple-system, system-ui, 'Montserrat', sans-serif;
           font-size: 16px;
           font-weight: 700;
           color: ${NODE_TEXT_PRIMARY};
@@ -259,7 +259,7 @@ function renderVacantNode(
             border-radius: 4px;
             font-size: 11px;
             font-weight: 600;
-            font-family: 'ibm-plex-mono', monospace;
+            font-family: var(--font-family-mono);
             letter-spacing: 0.5px;
           ">${node.roleCode}</div>
         `
@@ -316,7 +316,7 @@ function renderSharedNode(
         ">
           ${chipImage}
           <span style="
-            font-family: 'quasimoda', 'acumin-pro', 'Montserrat', sans-serif;
+            font-family: 'quasimoda', -apple-system, system-ui, 'Montserrat', sans-serif;
             font-size: 13px;
             font-weight: 600;
             color: ${NODE_TEXT_PRIMARY};
@@ -363,7 +363,7 @@ function renderSharedNode(
               border-radius: 4px;
               font-size: 10px;
               font-weight: 600;
-              font-family: 'ibm-plex-mono', monospace;
+              font-family: var(--font-family-mono);
               letter-spacing: 0.5px;
             ">${node.roleCode}</span>`
             : ""
@@ -448,7 +448,7 @@ function renderCompactSingleNode(
           min-width: 0;
         ">
           <div style="
-            font-family: 'quasimoda', 'acumin-pro', 'Montserrat', sans-serif;
+            font-family: 'quasimoda', -apple-system, system-ui, 'Montserrat', sans-serif;
             font-size: 14px;
             font-weight: 700;
             color: ${NODE_TEXT_PRIMARY};
@@ -501,7 +501,7 @@ function renderCompactVacantNode(
         text-align: center;
       ">
         <div style="
-          font-family: 'quasimoda', 'acumin-pro', 'Montserrat', sans-serif;
+          font-family: 'quasimoda', -apple-system, system-ui, 'Montserrat', sans-serif;
           font-size: 14px;
           font-weight: 700;
           color: ${NODE_TEXT_PRIMARY};
@@ -537,7 +537,7 @@ function renderCompactSharedNode(
         gap: 4px;
       ">
         <span style="
-          font-family: 'quasimoda', 'acumin-pro', 'Montserrat', sans-serif;
+          font-family: 'quasimoda', -apple-system, system-ui, 'Montserrat', sans-serif;
           font-size: 11px;
           font-weight: 600;
           color: ${NODE_TEXT_PRIMARY};

--- a/apps/web/src/components/organigram/chart/NodeRenderer.tsx
+++ b/apps/web/src/components/organigram/chart/NodeRenderer.tsx
@@ -15,7 +15,9 @@
 import type { OrgChartNode } from "@/types/organigram";
 
 // Design-token equivalents used as literal values because d3-org-chart renders
-// raw HTML strings where CSS custom properties are not available.
+// raw HTML strings where most CSS custom properties are not reliably available.
+// Exception: --font-family-mono IS used via var() in node styles (phone/email
+// badges) because the rendered HTML lives inside the DOM where :root vars apply.
 const NODE_ACCENT_COLOR = "#4acf52";
 const NODE_ACCENT_GRADIENT_END = "#41b147";
 const NODE_TEXT_PRIMARY = "#31404b";

--- a/apps/web/src/components/organigram/shared/ContactCard.tsx
+++ b/apps/web/src/components/organigram/shared/ContactCard.tsx
@@ -114,7 +114,8 @@ export function ContactCard({
               truncate
             `}
             style={{
-              fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+              fontFamily:
+                "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
             }}
           >
             {displayName}
@@ -134,7 +135,7 @@ export function ContactCard({
           {member.roleCode && variant !== "compact" && (
             <span
               className="inline-block mt-2 px-2 py-1 bg-kcvv-green/10 text-kcvv-green rounded text-xs font-semibold self-start"
-              style={{ fontFamily: "ibm-plex-mono, monospace" }}
+              style={{ fontFamily: "var(--font-family-mono)" }}
             >
               {member.roleCode}
             </span>

--- a/apps/web/src/components/organigram/shared/DepartmentFilter.stories.tsx
+++ b/apps/web/src/components/organigram/shared/DepartmentFilter.stories.tsx
@@ -384,7 +384,8 @@ export const InPageHeader: Story = {
         <h1
           className="text-3xl font-bold text-white mb-6"
           style={{
-            fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+            fontFamily:
+              "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
           }}
         >
           Organigram KCVV Elewijt

--- a/apps/web/src/components/organigram/shared/SearchBar.stories.tsx
+++ b/apps/web/src/components/organigram/shared/SearchBar.stories.tsx
@@ -393,7 +393,8 @@ export const InPageHeader: Story = {
         <h1
           className="text-3xl font-bold text-white mb-4"
           style={{
-            fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+            fontFamily:
+              "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
           }}
         >
           Organigram KCVV Elewijt

--- a/apps/web/src/components/player/PlayerProfile/PlayerProfile.tsx
+++ b/apps/web/src/components/player/PlayerProfile/PlayerProfile.tsx
@@ -214,7 +214,7 @@ export const PlayerProfile = forwardRef<HTMLDivElement, PlayerProfileProps>(
                     className="block text-4xl lg:text-6xl uppercase font-semibold text-kcvv-gray-blue"
                     style={{
                       fontFamily:
-                        "quasimoda, acumin-pro, Montserrat, sans-serif",
+                        "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
                       lineHeight: 1,
                     }}
                   >
@@ -224,7 +224,7 @@ export const PlayerProfile = forwardRef<HTMLDivElement, PlayerProfileProps>(
                     className="block text-4xl lg:text-6xl uppercase font-thin text-kcvv-gray-blue"
                     style={{
                       fontFamily:
-                        "quasimoda, acumin-pro, Montserrat, sans-serif",
+                        "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
                       lineHeight: 1,
                     }}
                   >

--- a/apps/web/src/components/responsibility/ResponsibilityBlock.tsx
+++ b/apps/web/src/components/responsibility/ResponsibilityBlock.tsx
@@ -36,7 +36,8 @@ export function ResponsibilityBlock() {
           <h2
             className="text-3xl md:text-5xl font-bold text-gray-blue mb-4"
             style={{
-              fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+              fontFamily:
+                "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
             }}
           >
             Hoe kunnen we je helpen?

--- a/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
+++ b/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
@@ -394,8 +394,7 @@ export function ResponsibilityFinder({
         <div className="flex flex-wrap items-center gap-3 text-2xl md:text-4xl font-bold text-kcvv-gray-blue mb-8">
           <span
             style={{
-              fontFamily:
-                "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
+              fontFamily: "var(--font-family-title)",
             }}
           >
             Ik ben
@@ -462,8 +461,7 @@ export function ResponsibilityFinder({
 
           <span
             style={{
-              fontFamily:
-                "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
+              fontFamily: "var(--font-family-title)",
             }}
           >
             en ik

--- a/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
+++ b/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
@@ -394,7 +394,8 @@ export function ResponsibilityFinder({
         <div className="flex flex-wrap items-center gap-3 text-2xl md:text-4xl font-bold text-kcvv-gray-blue mb-8">
           <span
             style={{
-              fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+              fontFamily:
+                "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
             }}
           >
             Ik ben
@@ -461,7 +462,8 @@ export function ResponsibilityFinder({
 
           <span
             style={{
-              fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+              fontFamily:
+                "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
             }}
           >
             en ik
@@ -1064,7 +1066,8 @@ function ResultCard({
               <h3
                 className="text-2xl font-bold text-gray-900"
                 style={{
-                  fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+                  fontFamily:
+                    "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
                 }}
               >
                 {path.question}

--- a/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
+++ b/apps/web/src/components/responsibility/ResponsibilityFinder.tsx
@@ -1064,8 +1064,7 @@ function ResultCard({
               <h3
                 className="text-2xl font-bold text-gray-900"
                 style={{
-                  fontFamily:
-                    "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
+                  fontFamily: "var(--font-family-title)",
                 }}
               >
                 {path.question}

--- a/apps/web/src/components/share/FullTimeTemplate/FullTimeTemplate.tsx
+++ b/apps/web/src/components/share/FullTimeTemplate/FullTimeTemplate.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { CAPTURE_WIDTH, CAPTURE_HEIGHT } from "../constants";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import {
+  BODY_FONT,
+  CAPTURE_HEIGHT,
+  CAPTURE_WIDTH,
+  TITLE_FONT,
+} from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -104,7 +104,7 @@ export function FullTimeTemplate({
           position: "absolute",
           top: "180px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "380px",
           lineHeight: 1,
@@ -198,7 +198,7 @@ export function FullTimeTemplate({
           position: "absolute",
           top: "640px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: m.headlineSize,
           lineHeight: 0.84,
@@ -228,7 +228,7 @@ export function FullTimeTemplate({
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: m.accent,
@@ -240,7 +240,7 @@ export function FullTimeTemplate({
         </div>
         <div
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "68px",
             color: "white",
@@ -254,7 +254,7 @@ export function FullTimeTemplate({
           <>
             <div
               style={{
-                fontFamily: BODY,
+                fontFamily: BODY_FONT,
                 fontWeight: 800,
                 fontSize: "36px",
                 color: m.accent,
@@ -265,7 +265,7 @@ export function FullTimeTemplate({
             </div>
             <div
               style={{
-                fontFamily: TITLE,
+                fontFamily: TITLE_FONT,
                 fontWeight: 900,
                 fontSize: "68px",
                 color: "rgba(255,255,255,0.65)",
@@ -293,7 +293,7 @@ export function FullTimeTemplate({
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "rgba(255,255,255,0.35)",
@@ -325,7 +325,7 @@ export function FullTimeTemplate({
         />
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -364,7 +364,7 @@ export function FullTimeTemplate({
         />
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/FullTimeTemplate/FullTimeTemplate.tsx
+++ b/apps/web/src/components/share/FullTimeTemplate/FullTimeTemplate.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { CAPTURE_WIDTH, CAPTURE_HEIGHT } from "../constants";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/GoalKcvvTemplate/GoalKcvvTemplate.tsx
+++ b/apps/web/src/components/share/GoalKcvvTemplate/GoalKcvvTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/GoalKcvvTemplate/GoalKcvvTemplate.tsx
+++ b/apps/web/src/components/share/GoalKcvvTemplate/GoalKcvvTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 const TORN_POLYGON =
   "polygon(0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%, 17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%, 32% 38%, 35% 41%, 38% 38%, 41% 41%, 44% 38%, 47% 41%, 50% 38%, 53% 41%, 56% 38%, 59% 41%, 62% 38%, 65% 41%, 68% 38%, 71% 41%, 74% 38%, 77% 41%, 80% 38%, 83% 41%, 86% 38%, 89% 41%, 92% 38%, 95% 41%, 98% 38%, 100% 40%, 100% 100%, 0% 100%)";
@@ -42,7 +38,7 @@ export function GoalKcvvTemplate({
         background: "#121a14",
         position: "relative",
         overflow: "hidden",
-        fontFamily: BODY,
+        fontFamily: BODY_FONT,
       }}
     >
       {/* ── Upper zone: photo or no-photo fallback ── */}
@@ -117,7 +113,7 @@ export function GoalKcvvTemplate({
                 position: "absolute",
                 right: "20px",
                 top: "-20px",
-                fontFamily: TITLE,
+                fontFamily: TITLE_FONT,
                 fontWeight: 900,
                 fontSize: "580px",
                 lineHeight: 1,
@@ -242,7 +238,7 @@ export function GoalKcvvTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -259,7 +255,7 @@ export function GoalKcvvTemplate({
           position: "absolute",
           left: "80px",
           top: "635px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "260px",
           color: "white",
@@ -289,7 +285,7 @@ export function GoalKcvvTemplate({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: "#4acf52",
@@ -301,7 +297,7 @@ export function GoalKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "74px",
             color: "white",
@@ -314,7 +310,7 @@ export function GoalKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "40px",
             color: "#4acf52",
@@ -342,7 +338,7 @@ export function GoalKcvvTemplate({
         <div style={{ display: "flex", flexDirection: "column", gap: "0px" }}>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 400,
               fontSize: "24px",
               color: "rgba(255,255,255,0.45)",
@@ -352,7 +348,7 @@ export function GoalKcvvTemplate({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               color: "white",
@@ -379,7 +375,7 @@ export function GoalKcvvTemplate({
         <div style={{ display: "flex", flexDirection: "column", gap: "0px" }}>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 400,
               fontSize: "24px",
               color: "rgba(255,255,255,0.45)",
@@ -389,7 +385,7 @@ export function GoalKcvvTemplate({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "110px",
               color: "#4acf52",
@@ -418,7 +414,7 @@ export function GoalKcvvTemplate({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "54px",
             color: "white",
@@ -430,7 +426,7 @@ export function GoalKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",
@@ -468,7 +464,7 @@ export function GoalKcvvTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/GoalOpponentTemplate/GoalOpponentTemplate.tsx
+++ b/apps/web/src/components/share/GoalOpponentTemplate/GoalOpponentTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 const TORN_POLYGON =
   "polygon(0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%, 17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%, 32% 38%, 35% 41%, 38% 38%, 41% 41%, 44% 38%, 47% 41%, 50% 38%, 53% 41%, 56% 38%, 59% 41%, 62% 38%, 65% 41%, 68% 38%, 71% 41%, 74% 38%, 77% 41%, 80% 38%, 83% 41%, 86% 38%, 89% 41%, 92% 38%, 95% 41%, 98% 38%, 100% 40%, 100% 100%, 0% 100%)";
@@ -35,7 +31,7 @@ export function GoalOpponentTemplate({
         background: "#0d1810",
         position: "relative",
         overflow: "hidden",
-        fontFamily: BODY,
+        fontFamily: BODY_FONT,
       }}
     >
       {/* ── Upper zone: subtle radial gradient (no photo) ── */}
@@ -187,7 +183,7 @@ export function GoalOpponentTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.28)",
@@ -204,7 +200,7 @@ export function GoalOpponentTemplate({
           position: "absolute",
           left: "80px",
           top: "635px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "260px",
           color: "rgba(255,255,255,0.35)",
@@ -233,7 +229,7 @@ export function GoalOpponentTemplate({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.35)",
@@ -245,7 +241,7 @@ export function GoalOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "160px",
             color: "rgba(255,255,255,0.5)",
@@ -257,7 +253,7 @@ export function GoalOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "36px",
             color: "rgba(255,255,255,0.28)",
@@ -284,7 +280,7 @@ export function GoalOpponentTemplate({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "50px",
             color: "rgba(255,255,255,0.45)",
@@ -296,7 +292,7 @@ export function GoalOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "30px",
             color: "rgba(255,255,255,0.25)",
@@ -334,7 +330,7 @@ export function GoalOpponentTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.2)",

--- a/apps/web/src/components/share/GoalOpponentTemplate/GoalOpponentTemplate.tsx
+++ b/apps/web/src/components/share/GoalOpponentTemplate/GoalOpponentTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/HalftimeTemplate/HalftimeTemplate.tsx
+++ b/apps/web/src/components/share/HalftimeTemplate/HalftimeTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -74,7 +70,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
           position: "absolute",
           top: "220px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "340px",
           lineHeight: 1,
@@ -168,7 +164,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
           position: "absolute",
           top: "596px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "300px",
           lineHeight: 0.84,
@@ -198,7 +194,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: ACCENT_COLOR,
@@ -210,7 +206,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
         </div>
         <div
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "64px",
             color: "white",
@@ -224,7 +220,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
           <>
             <div
               style={{
-                fontFamily: BODY,
+                fontFamily: BODY_FONT,
                 fontWeight: 800,
                 fontSize: "36px",
                 color: ACCENT_COLOR,
@@ -235,7 +231,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
             </div>
             <div
               style={{
-                fontFamily: TITLE,
+                fontFamily: TITLE_FONT,
                 fontWeight: 900,
                 fontSize: "64px",
                 color: "rgba(255,255,255,0.65)",
@@ -263,7 +259,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "rgba(255,255,255,0.35)",
@@ -295,7 +291,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
         />
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -334,7 +330,7 @@ export function HalftimeTemplate({ matchName, score }: HalftimeTemplateProps) {
         />
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/HalftimeTemplate/HalftimeTemplate.tsx
+++ b/apps/web/src/components/share/HalftimeTemplate/HalftimeTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/KickoffTemplate/KickoffTemplate.tsx
+++ b/apps/web/src/components/share/KickoffTemplate/KickoffTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/KickoffTemplate/KickoffTemplate.tsx
+++ b/apps/web/src/components/share/KickoffTemplate/KickoffTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -178,7 +174,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
           position: "absolute",
           top: "460px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "235px",
           lineHeight: 0.84,
@@ -198,7 +194,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
           position: "absolute",
           top: "648px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "235px",
           lineHeight: 0.84,
@@ -227,7 +223,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: ACCENT_COLOR,
@@ -239,7 +235,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
         </div>
         <div
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "72px",
             color: "white",
@@ -254,7 +250,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
           <>
             <div
               style={{
-                fontFamily: BODY,
+                fontFamily: BODY_FONT,
                 fontWeight: 800,
                 fontSize: "36px",
                 color: ACCENT_COLOR,
@@ -266,7 +262,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
             </div>
             <div
               style={{
-                fontFamily: TITLE,
+                fontFamily: TITLE_FONT,
                 fontWeight: 900,
                 fontSize: "72px",
                 color: "rgba(255,255,255,0.65)",
@@ -294,7 +290,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "34px",
             color: "rgba(255,255,255,0.35)",
@@ -327,7 +323,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
         />
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -366,7 +362,7 @@ export function KickoffTemplate({ matchName }: KickoffTemplateProps) {
         />
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/RedCardKcvvTemplate/RedCardKcvvTemplate.tsx
+++ b/apps/web/src/components/share/RedCardKcvvTemplate/RedCardKcvvTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -191,7 +187,7 @@ export function RedCardKcvvTemplate({
           position: "absolute",
           top: "640px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "245px",
           lineHeight: 0.84,
@@ -224,7 +220,7 @@ export function RedCardKcvvTemplate({
         <img src="/images/kcvv-logo.png" alt="KCVV" width={88} height={88} />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -250,7 +246,7 @@ export function RedCardKcvvTemplate({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: ACCENT_COLOR,
@@ -262,7 +258,7 @@ export function RedCardKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "74px",
             lineHeight: 1,
@@ -275,7 +271,7 @@ export function RedCardKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "40px",
             color: ACCENT_COLOR,
@@ -303,7 +299,7 @@ export function RedCardKcvvTemplate({
         <div style={{ display: "flex", flexDirection: "column" }}>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "24px",
               color: "rgba(255,255,255,0.45)",
@@ -313,7 +309,7 @@ export function RedCardKcvvTemplate({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               color: "white",
@@ -351,7 +347,7 @@ export function RedCardKcvvTemplate({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "54px",
             color: "white",
@@ -362,7 +358,7 @@ export function RedCardKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",
@@ -396,7 +392,7 @@ export function RedCardKcvvTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/RedCardKcvvTemplate/RedCardKcvvTemplate.tsx
+++ b/apps/web/src/components/share/RedCardKcvvTemplate/RedCardKcvvTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/RedCardOpponentTemplate/RedCardOpponentTemplate.tsx
+++ b/apps/web/src/components/share/RedCardOpponentTemplate/RedCardOpponentTemplate.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { CAPTURE_WIDTH, CAPTURE_HEIGHT } from "../constants";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/RedCardOpponentTemplate/RedCardOpponentTemplate.tsx
+++ b/apps/web/src/components/share/RedCardOpponentTemplate/RedCardOpponentTemplate.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { CAPTURE_WIDTH, CAPTURE_HEIGHT } from "../constants";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import {
+  BODY_FONT,
+  CAPTURE_HEIGHT,
+  CAPTURE_WIDTH,
+  TITLE_FONT,
+} from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -188,7 +188,7 @@ export function RedCardOpponentTemplate({
           position: "absolute",
           top: "640px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "245px",
           lineHeight: 0.84,
@@ -221,7 +221,7 @@ export function RedCardOpponentTemplate({
         <img src="/images/kcvv-logo.png" alt="KCVV" width={88} height={88} />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -247,7 +247,7 @@ export function RedCardOpponentTemplate({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: ACCENT_COLOR,
@@ -259,7 +259,7 @@ export function RedCardOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "54px",
             lineHeight: 1,
@@ -270,7 +270,7 @@ export function RedCardOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "40px",
             color: ACCENT_COLOR,
@@ -298,7 +298,7 @@ export function RedCardOpponentTemplate({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "54px",
             color: "white",
@@ -309,7 +309,7 @@ export function RedCardOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",
@@ -343,7 +343,7 @@ export function RedCardOpponentTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/YellowCardKcvvTemplate/YellowCardKcvvTemplate.tsx
+++ b/apps/web/src/components/share/YellowCardKcvvTemplate/YellowCardKcvvTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -191,7 +187,7 @@ export function YellowCardKcvvTemplate({
           position: "absolute",
           top: "640px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "245px",
           lineHeight: 0.84,
@@ -224,7 +220,7 @@ export function YellowCardKcvvTemplate({
         <img src="/images/kcvv-logo.png" alt="KCVV" width={88} height={88} />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -250,7 +246,7 @@ export function YellowCardKcvvTemplate({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: ACCENT_COLOR,
@@ -262,7 +258,7 @@ export function YellowCardKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "74px",
             lineHeight: 1,
@@ -275,7 +271,7 @@ export function YellowCardKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "40px",
             color: ACCENT_COLOR,
@@ -303,7 +299,7 @@ export function YellowCardKcvvTemplate({
         <div style={{ display: "flex", flexDirection: "column" }}>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "24px",
               color: "rgba(255,255,255,0.45)",
@@ -313,7 +309,7 @@ export function YellowCardKcvvTemplate({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               color: "white",
@@ -351,7 +347,7 @@ export function YellowCardKcvvTemplate({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "54px",
             color: "white",
@@ -362,7 +358,7 @@ export function YellowCardKcvvTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",
@@ -396,7 +392,7 @@ export function YellowCardKcvvTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/YellowCardKcvvTemplate/YellowCardKcvvTemplate.tsx
+++ b/apps/web/src/components/share/YellowCardKcvvTemplate/YellowCardKcvvTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/YellowCardOpponentTemplate/YellowCardOpponentTemplate.tsx
+++ b/apps/web/src/components/share/YellowCardOpponentTemplate/YellowCardOpponentTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 const TORN_BOTTOM_CLIP = `polygon(

--- a/apps/web/src/components/share/YellowCardOpponentTemplate/YellowCardOpponentTemplate.tsx
+++ b/apps/web/src/components/share/YellowCardOpponentTemplate/YellowCardOpponentTemplate.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 const TORN_BOTTOM_CLIP = `polygon(
   0% 40%, 2% 38%, 5% 41%, 8% 38%, 11% 41%, 14% 38%,
   17% 41%, 20% 38%, 23% 41%, 26% 38%, 29% 41%,
@@ -186,7 +182,7 @@ export function YellowCardOpponentTemplate({
           position: "absolute",
           top: "640px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "245px",
           lineHeight: 0.84,
@@ -219,7 +215,7 @@ export function YellowCardOpponentTemplate({
         <img src="/images/kcvv-logo.png" alt="KCVV" width={88} height={88} />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -245,7 +241,7 @@ export function YellowCardOpponentTemplate({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: ACCENT_COLOR,
@@ -257,7 +253,7 @@ export function YellowCardOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "54px",
             lineHeight: 1,
@@ -268,7 +264,7 @@ export function YellowCardOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "40px",
             color: ACCENT_COLOR,
@@ -296,7 +292,7 @@ export function YellowCardOpponentTemplate({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "54px",
             color: "white",
@@ -307,7 +303,7 @@ export function YellowCardOpponentTemplate({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",
@@ -341,7 +337,7 @@ export function YellowCardOpponentTemplate({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/_exploration/Round3_Diagonal.tsx
+++ b/apps/web/src/components/share/_exploration/Round3_Diagonal.tsx
@@ -8,7 +8,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round3_Diagonal.tsx
+++ b/apps/web/src/components/share/_exploration/Round3_Diagonal.tsx
@@ -6,11 +6,7 @@
  * straddles both zones at extreme scale. Very graphic, very kinetic.
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 export function Round3_Diagonal({
   playerName,
@@ -96,7 +92,7 @@ export function Round3_Diagonal({
             position: "absolute",
             bottom: "200px",
             right: "80px",
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "560px",
             lineHeight: 1,
@@ -130,7 +126,7 @@ export function Round3_Diagonal({
           left: "-60px",
           right: "-60px",
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "520px",
           lineHeight: 0.84,
@@ -152,7 +148,7 @@ export function Round3_Diagonal({
           left: 0,
           right: 0,
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "480px",
           lineHeight: 0.84,
@@ -174,7 +170,7 @@ export function Round3_Diagonal({
           position: "absolute",
           top: "12%",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "220px",
           lineHeight: 1,
@@ -207,7 +203,7 @@ export function Round3_Diagonal({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             letterSpacing: "0.12em",
@@ -233,7 +229,7 @@ export function Round3_Diagonal({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 900,
             fontSize: "72px",
             lineHeight: 1,
@@ -247,7 +243,7 @@ export function Round3_Diagonal({
         <div style={{ display: "flex", alignItems: "center", gap: "32px" }}>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "80px",
               lineHeight: 1,
@@ -259,7 +255,7 @@ export function Round3_Diagonal({
           </span>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 600,
               fontSize: "44px",
               color: "rgba(255,255,255,0.5)",
@@ -270,7 +266,7 @@ export function Round3_Diagonal({
         </div>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 500,
             fontSize: "32px",
             color: "rgba(255,255,255,0.35)",

--- a/apps/web/src/components/share/_exploration/Round3_Frame.tsx
+++ b/apps/web/src/components/share/_exploration/Round3_Frame.tsx
@@ -9,7 +9,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round3_Frame.tsx
+++ b/apps/web/src/components/share/_exploration/Round3_Frame.tsx
@@ -7,11 +7,7 @@
  * Cinematic, like a match broadcast freeze-frame.
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 export function Round3_Frame({
   playerName,
@@ -143,7 +139,7 @@ export function Round3_Frame({
         <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "52px",
               lineHeight: 1,
@@ -156,7 +152,7 @@ export function Round3_Frame({
           </span>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 600,
               fontSize: "28px",
               color: "rgba(255,255,255,0.55)",
@@ -177,7 +173,7 @@ export function Round3_Frame({
           left: 0,
           right: 0,
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "520px",
           lineHeight: 0.84,
@@ -199,7 +195,7 @@ export function Round3_Frame({
           left: 0,
           right: 0,
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "480px",
           lineHeight: 0.84,
@@ -235,7 +231,7 @@ export function Round3_Frame({
           left: "-185px",
           top: "50%",
           transform: "translateY(-50%) rotate(-90deg)",
-          fontFamily: BODY,
+          fontFamily: BODY_FONT,
           fontWeight: 900,
           fontSize: "40px",
           letterSpacing: "0.28em",
@@ -299,7 +295,7 @@ export function Round3_Frame({
         {/* Score */}
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "140px",
             lineHeight: 0.9,
@@ -322,7 +318,7 @@ export function Round3_Frame({
         {/* Player + match */}
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "52px",
             lineHeight: 1.1,
@@ -335,7 +331,7 @@ export function Round3_Frame({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 500,
             fontSize: "30px",
             color: "rgba(255,255,255,0.5)",

--- a/apps/web/src/components/share/_exploration/Round3_Ripped.tsx
+++ b/apps/web/src/components/share/_exploration/Round3_Ripped.tsx
@@ -6,11 +6,7 @@
  * Quasimoda 900 for all display type. Bright green (#4acf52) for accents only.
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 const TORN_CLIP = `polygon(
   0% 22%,
@@ -88,7 +84,7 @@ export function Round3_Ripped({
             left: 0,
             right: 0,
             textAlign: "center",
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: `${size}px`,
             lineHeight: 0.84,
@@ -159,7 +155,7 @@ export function Round3_Ripped({
             left: 0,
             right: 0,
             textAlign: "center",
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "680px",
             lineHeight: 1,
@@ -181,7 +177,7 @@ export function Round3_Ripped({
           right: 0,
           transform: "translateY(-55%)",
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "500px",
           lineHeight: 0.84,
@@ -224,7 +220,7 @@ export function Round3_Ripped({
           left: "-200px",
           top: "50%",
           transform: "translateY(-50%) rotate(-90deg)",
-          fontFamily: BODY,
+          fontFamily: BODY_FONT,
           fontWeight: 900,
           fontSize: "42px",
           letterSpacing: "0.25em",
@@ -244,7 +240,7 @@ export function Round3_Ripped({
           right: "-200px",
           top: "50%",
           transform: "translateY(-50%) rotate(90deg)",
-          fontFamily: BODY,
+          fontFamily: BODY_FONT,
           fontWeight: 900,
           fontSize: "42px",
           letterSpacing: "0.25em",
@@ -278,7 +274,7 @@ export function Round3_Ripped({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             letterSpacing: "0.12em",
@@ -308,7 +304,7 @@ export function Round3_Ripped({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "130px",
             lineHeight: 1,
@@ -320,7 +316,7 @@ export function Round3_Ripped({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "36px",
             color: "rgba(255,255,255,0.5)",

--- a/apps/web/src/components/share/_exploration/Round3_Ripped.tsx
+++ b/apps/web/src/components/share/_exploration/Round3_Ripped.tsx
@@ -8,7 +8,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round4_SideBlob.tsx
+++ b/apps/web/src/components/share/_exploration/Round4_SideBlob.tsx
@@ -12,11 +12,7 @@
  * - Dark green footer with match context
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 /** Organic blob clip-path for right photo zone — wavy left edge, top to ~54% height */
 const SIDE_BLOB_CLIP = `polygon(
@@ -116,7 +112,7 @@ export function Round4_SideBlob({
             position: "absolute",
             top: "80px",
             right: "40px",
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "560px",
             lineHeight: 1,
@@ -211,7 +207,7 @@ export function Round4_SideBlob({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.45)",
@@ -233,7 +229,7 @@ export function Round4_SideBlob({
       >
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: "#4acf52",
@@ -248,7 +244,7 @@ export function Round4_SideBlob({
         {/* GOAL in white — extends beyond blob boundary */}
         <div
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "300px",
             lineHeight: 0.84,
@@ -265,7 +261,7 @@ export function Round4_SideBlob({
         {/* ! in bright green — anchors in the black zone */}
         <div
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "230px",
             lineHeight: 0.84,
@@ -301,7 +297,7 @@ export function Round4_SideBlob({
         >
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "24px",
               color: "rgba(255,255,255,0.42)",
@@ -314,7 +310,7 @@ export function Round4_SideBlob({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               lineHeight: 1,
@@ -346,7 +342,7 @@ export function Round4_SideBlob({
         >
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "24px",
               color: "rgba(255,255,255,0.42)",
@@ -359,7 +355,7 @@ export function Round4_SideBlob({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "110px",
               lineHeight: 1,
@@ -378,7 +374,7 @@ export function Round4_SideBlob({
           position: "absolute",
           top: "1120px",
           left: "40px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "420px",
           lineHeight: 1,
@@ -406,7 +402,7 @@ export function Round4_SideBlob({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "25px",
             color: "rgba(255,255,255,0.42)",
@@ -418,7 +414,7 @@ export function Round4_SideBlob({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "66px",
             lineHeight: 1.05,
@@ -431,7 +427,7 @@ export function Round4_SideBlob({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "36px",
             color: "#4acf52",
@@ -455,7 +451,7 @@ export function Round4_SideBlob({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 500,
             fontSize: "30px",
             color: "rgba(255,255,255,0.3)",
@@ -509,7 +505,7 @@ export function Round4_SideBlob({
       >
         <div
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "52px",
             color: "white",
@@ -522,7 +518,7 @@ export function Round4_SideBlob({
         </div>
         <div
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",

--- a/apps/web/src/components/share/_exploration/Round4_SideBlob.tsx
+++ b/apps/web/src/components/share/_exploration/Round4_SideBlob.tsx
@@ -14,7 +14,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round4_TopBlob.tsx
+++ b/apps/web/src/components/share/_exploration/Round4_TopBlob.tsx
@@ -12,7 +12,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round4_TopBlob.tsx
+++ b/apps/web/src/components/share/_exploration/Round4_TopBlob.tsx
@@ -10,11 +10,7 @@
  * - Bright green bottom bar with match name + chevron marks
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 /** Organic blob clip-path for the photo zone — jagged bottom, slight top irregularity */
 const BLOB_CLIP = `polygon(
@@ -150,7 +146,7 @@ export function Round4_TopBlob({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.45)",
@@ -218,7 +214,7 @@ export function Round4_TopBlob({
           >
             <span
               style={{
-                fontFamily: TITLE,
+                fontFamily: TITLE_FONT,
                 fontWeight: 900,
                 fontSize: "420px",
                 color: "rgba(0,0,0,0.18)",
@@ -259,7 +255,7 @@ export function Round4_TopBlob({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "380px",
             color: "white",
@@ -270,7 +266,7 @@ export function Round4_TopBlob({
         </span>
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "380px",
             color: "#008755",
@@ -303,7 +299,7 @@ export function Round4_TopBlob({
         >
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "28px",
               color: "rgba(255,255,255,0.5)",
@@ -315,7 +311,7 @@ export function Round4_TopBlob({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               lineHeight: 1,
@@ -327,7 +323,7 @@ export function Round4_TopBlob({
           </span>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 700,
               fontSize: "38px",
               color: "rgba(255,255,255,0.7)",
@@ -361,7 +357,7 @@ export function Round4_TopBlob({
           />
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "88px",
               color: "white",
@@ -383,7 +379,7 @@ export function Round4_TopBlob({
         >
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "28px",
               color: "rgba(255,255,255,0.5)",
@@ -395,7 +391,7 @@ export function Round4_TopBlob({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               lineHeight: 1,
@@ -407,7 +403,7 @@ export function Round4_TopBlob({
           </span>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 700,
               fontSize: "38px",
               color: "#4acf52",
@@ -465,7 +461,7 @@ export function Round4_TopBlob({
         >
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "58px",
               color: "white",
@@ -478,7 +474,7 @@ export function Round4_TopBlob({
           </span>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 700,
               fontSize: "34px",
               color: "#4acf52",

--- a/apps/web/src/components/share/_exploration/Round4_TornDown.tsx
+++ b/apps/web/src/components/share/_exploration/Round4_TornDown.tsx
@@ -9,11 +9,7 @@
  * All match info lives in the generous dark green space.
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 /** Torn-paper clip for the lower dark-green zone — jagged top edge at ~40% height */
 const TORN_BOTTOM_CLIP = `polygon(
@@ -98,7 +94,7 @@ export function Round4_TornDown({
               left: 0,
               right: 0,
               textAlign: "center",
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "520px",
               lineHeight: 0.9,
@@ -207,7 +203,7 @@ export function Round4_TornDown({
           left: 0,
           right: 0,
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "530px",
           lineHeight: 0.84,
@@ -229,7 +225,7 @@ export function Round4_TornDown({
           left: 0,
           right: 0,
           textAlign: "center",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "490px",
           lineHeight: 0.84,
@@ -266,7 +262,7 @@ export function Round4_TornDown({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -284,7 +280,7 @@ export function Round4_TornDown({
           left: "-205px",
           top: "50%",
           transform: "translateY(-50%) rotate(-90deg)",
-          fontFamily: BODY,
+          fontFamily: BODY_FONT,
           fontWeight: 900,
           fontSize: "38px",
           letterSpacing: "0.26em",
@@ -313,7 +309,7 @@ export function Round4_TornDown({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: "rgba(255,255,255,0.5)",
@@ -325,7 +321,7 @@ export function Round4_TornDown({
         </span>
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "200px",
             lineHeight: 0.88,
@@ -362,7 +358,7 @@ export function Round4_TornDown({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: "rgba(255,255,255,0.5)",
@@ -374,7 +370,7 @@ export function Round4_TornDown({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "72px",
             lineHeight: 1,
@@ -411,7 +407,7 @@ export function Round4_TornDown({
         />
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "90px",
             color: "#4acf52",
@@ -437,7 +433,7 @@ export function Round4_TornDown({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "30px",
             color: "rgba(255,255,255,0.45)",

--- a/apps/web/src/components/share/_exploration/Round4_TornDown.tsx
+++ b/apps/web/src/components/share/_exploration/Round4_TornDown.tsx
@@ -11,7 +11,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round5_TornLeft.tsx
+++ b/apps/web/src/components/share/_exploration/Round5_TornLeft.tsx
@@ -14,7 +14,7 @@
 import type { ExplorationProps } from "./StyleA_StackedType";
 
 const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, acumin-pro, Montserrat, Verdana, sans-serif";
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
 const BODY: React.CSSProperties["fontFamily"] =
   'montserrat, "Helvetica Neue", Arial, sans-serif';
 

--- a/apps/web/src/components/share/_exploration/Round5_TornLeft.tsx
+++ b/apps/web/src/components/share/_exploration/Round5_TornLeft.tsx
@@ -12,11 +12,7 @@
  * - Match name at the very bottom
  */
 import type { ExplorationProps } from "./StyleA_StackedType";
-
-const TITLE: React.CSSProperties["fontFamily"] =
-  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
-const BODY: React.CSSProperties["fontFamily"] =
-  'montserrat, "Helvetica Neue", Arial, sans-serif';
+import { BODY_FONT, TITLE_FONT } from "../constants";
 
 /** Torn-paper clip for the dark-green lower zone — jagged top edge at ~40% height */
 const TORN_BOTTOM_CLIP = `polygon(
@@ -98,7 +94,7 @@ export function Round5_TornLeft({
               position: "absolute",
               top: "-20px",
               right: "20px",
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "580px",
               lineHeight: 0.9,
@@ -228,7 +224,7 @@ export function Round5_TornLeft({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "28px",
             color: "rgba(255,255,255,0.48)",
@@ -246,7 +242,7 @@ export function Round5_TornLeft({
           position: "absolute",
           top: "635px",
           left: "80px",
-          fontFamily: TITLE,
+          fontFamily: TITLE_FONT,
           fontWeight: 900,
           fontSize: "260px",
           lineHeight: 0.84,
@@ -278,7 +274,7 @@ export function Round5_TornLeft({
       >
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "26px",
             color: "#4acf52",
@@ -290,7 +286,7 @@ export function Round5_TornLeft({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 800,
             fontSize: "74px",
             lineHeight: 1,
@@ -303,7 +299,7 @@ export function Round5_TornLeft({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "40px",
             color: "#4acf52",
@@ -331,7 +327,7 @@ export function Round5_TornLeft({
         <div style={{ display: "flex", flexDirection: "column" }}>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "24px",
               color: "rgba(255,255,255,0.45)",
@@ -344,7 +340,7 @@ export function Round5_TornLeft({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "160px",
               lineHeight: 1,
@@ -370,7 +366,7 @@ export function Round5_TornLeft({
         <div style={{ display: "flex", flexDirection: "column" }}>
           <span
             style={{
-              fontFamily: BODY,
+              fontFamily: BODY_FONT,
               fontWeight: 800,
               fontSize: "24px",
               color: "rgba(255,255,255,0.45)",
@@ -383,7 +379,7 @@ export function Round5_TornLeft({
           </span>
           <span
             style={{
-              fontFamily: TITLE,
+              fontFamily: TITLE_FONT,
               fontWeight: 900,
               fontSize: "110px",
               lineHeight: 1,
@@ -413,7 +409,7 @@ export function Round5_TornLeft({
       >
         <span
           style={{
-            fontFamily: TITLE,
+            fontFamily: TITLE_FONT,
             fontWeight: 900,
             fontSize: "54px",
             color: "white",
@@ -426,7 +422,7 @@ export function Round5_TornLeft({
         </span>
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 600,
             fontSize: "32px",
             color: "#4acf52",
@@ -463,7 +459,7 @@ export function Round5_TornLeft({
         />
         <span
           style={{
-            fontFamily: BODY,
+            fontFamily: BODY_FONT,
             fontWeight: 700,
             fontSize: "26px",
             color: "rgba(255,255,255,0.38)",

--- a/apps/web/src/components/share/constants.ts
+++ b/apps/web/src/components/share/constants.ts
@@ -1,3 +1,13 @@
+import type React from "react";
+
+/** Quasimoda title font stack for share templates (inline style usage). */
+export const TITLE_FONT: React.CSSProperties["fontFamily"] =
+  "quasimoda, -apple-system, system-ui, Montserrat, Verdana, sans-serif";
+
+/** Montserrat body font stack for share templates (inline style usage). */
+export const BODY_FONT: React.CSSProperties["fontFamily"] =
+  'montserrat, "Helvetica Neue", Arial, sans-serif';
+
 export const CAPTURE_WIDTH = 1080;
 export const CAPTURE_HEIGHT = 1920;
 

--- a/apps/web/src/components/team/TeamCard/TeamCard.tsx
+++ b/apps/web/src/components/team/TeamCard/TeamCard.tsx
@@ -218,7 +218,8 @@ export const TeamCard = forwardRef<HTMLElement, TeamCardProps>(
                 isCompact ? "text-base" : "text-lg",
               )}
               style={{
-                fontFamily: "quasimoda, acumin-pro, Montserrat, sans-serif",
+                fontFamily:
+                  "quasimoda, -apple-system, system-ui, Montserrat, sans-serif",
               }}
             >
               {name}

--- a/apps/web/src/stories/foundation/Typography.mdx
+++ b/apps/web/src/stories/foundation/Typography.mdx
@@ -26,14 +26,27 @@ export const FontSample = ({ label, cssVar, sample, size = '1.25rem', weight = 4
 
 # Typography
 
-All type tokens are defined in `src/app/globals.css`. The body font is **Montserrat** (loaded via
-Adobe Typekit); the heading font is **Quasimoda**. System-safe fallbacks are specified for all families.
+All type tokens are defined in `src/app/globals.css`.
+
+<table>
+  <thead><tr><th>Font</th><th>Source</th><th>Weights</th><th>Usage</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Montserrat</strong></td><td><code>next/font/google</code> (self-hosted)</td><td>400, 500, 600, 700</td><td>Body text, UI labels, buttons</td></tr>
+    <tr><td><strong>IBM Plex Mono</strong></td><td><code>next/font/google</code> (self-hosted)</td><td>400, 600, 700</td><td>Scores, timestamps, keyboard shortcuts</td></tr>
+    <tr><td><strong>Quasimoda</strong></td><td>Adobe Typekit (deferred)</td><td>700</td><td>All headings h1–h6</td></tr>
+    <tr><td><strong>Stenciletta</strong></td><td>Adobe Typekit (deferred)</td><td>400</td><td>Accent / display numbers</td></tr>
+  </tbody>
+</table>
+
+Montserrat and IBM Plex Mono are preloaded and self-hosted via `next/font/google` with `display: 'swap'`.
+Quasimoda and Stenciletta load via Adobe Typekit with `afterInteractive` strategy — they are not
+render-blocking. System-safe fallbacks are specified for all families.
 
 ---
 
 ## Font Families
 
-Fonts are loaded via Adobe Typekit. The samples below render live from the CSS variables.
+The samples below render live from the CSS variables.
 
 <FontSample label="font-title" cssVar="--font-family-title" size="2rem" weight={700} sample="KCVV Elewijt Football Club" note="All headings h1–h6" />
 <FontSample label="font-body" cssVar="--font-family-body" size="1rem" weight={400} sample="De wedstrijd begint om 15:00. Alle supporters zijn welkom op het veld van KCVV Elewijt." note="Default body text" />
@@ -91,8 +104,9 @@ Headings are set globally in CSS — no per-component overrides needed.
   <thead><tr><th>Token</th><th>Value</th><th>Usage</th></tr></thead>
   <tbody>
     <tr><td><code>font-normal</code></td><td>400</td><td>Body text</td></tr>
-    <tr><td><code>font-medium</code></td><td>500</td><td>Emphasis, labels</td></tr>
-    <tr><td><code>font-bold</code></td><td>700</td><td>Headings, CTAs</td></tr>
+    <tr><td><code>font-medium</code></td><td>500</td><td>UI labels</td></tr>
+    <tr><td><code>font-semibold</code></td><td>600</td><td>Buttons, badges</td></tr>
+    <tr><td><code>font-bold</code></td><td>700</td><td>Headings, CTAs, scores</td></tr>
   </tbody>
 </table>
 

--- a/apps/web/tests/setup.ts
+++ b/apps/web/tests/setup.ts
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
+
+// Mock next/font/google — font loaders are build-time only, not available in Vitest
+vi.mock("next/font/google", () => ({
+  Montserrat: () => ({ variable: "--font-montserrat" }),
+  IBM_Plex_Mono: () => ({ variable: "--font-ibm-plex-mono" }),
+}));
 
 // Cleanup after each test
 afterEach(() => {


### PR DESCRIPTION
Closes #1266

## What changed
- Self-host Montserrat and IBM Plex Mono via `next/font/google` instead of loading them through Adobe Typekit — eliminates two fonts from the render-blocking Typekit payload
- Switch Typekit `<Script>` from `beforeInteractive` to `afterInteractive` so first paint is no longer blocked by the external font request
- Replace hardcoded `font-family` strings across components with CSS custom properties (`var(--font-body)`, `var(--font-mono)`) for consistent font usage

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Verified font rendering in browser — Montserrat (body) and IBM Plex Mono (scores, timestamps) load immediately; Typekit fonts (quasimoda, stenciletta) appear after hydration without blocking paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)