### PR TITLE
perf(ui): stream /hulp via Suspense boundary + skeleton fallback (#1267)

### DIFF
--- a/apps/web/src/app/(main)/__tests__/loading-envelope.test.tsx
+++ b/apps/web/src/app/(main)/__tests__/loading-envelope.test.tsx
@@ -22,6 +22,7 @@ import { resolve } from "node:path";
 // SectionStack loading components
 // ---------------------------------------------------------------------------
 import ClubLoading from "../club/loading";
+import HulpLoading from "../hulp/loading";
 import JeugdLoading from "../jeugd/loading";
 import PloegenLoading from "../ploegen/loading";
 import SponsorsLoading from "../sponsors/loading";
@@ -29,7 +30,6 @@ import SponsorsLoading from "../sponsors/loading";
 // ---------------------------------------------------------------------------
 // Non-SectionStack loading components
 // ---------------------------------------------------------------------------
-import HulpLoading from "../hulp/loading";
 import EventsLoading from "../events/loading";
 import KalenderLoading from "../kalender/loading";
 import NieuwsLoading from "../nieuws/loading";
@@ -64,6 +64,12 @@ const sectionStackRoutes: SectionStackRoute[] = [
     Loading: ClubLoading,
     expectedTransitions: 3,
     expectedBgClasses: ["bg-kcvv-black", "bg-gray-100", "bg-kcvv-green-dark"],
+  },
+  {
+    name: "/hulp",
+    Loading: HulpLoading,
+    expectedTransitions: 1,
+    expectedBgClasses: ["bg-kcvv-black", "bg-gray-100"],
   },
   {
     name: "/jeugd",
@@ -121,11 +127,6 @@ describe("loading.tsx envelope drift guard", () => {
   }
 
   const nonSectionStackRoutes: NonSectionStackRoute[] = [
-    {
-      name: "/hulp",
-      Loading: HulpLoading,
-      expectedRootClass: "min-h-screen",
-    },
     {
       name: "/events",
       Loading: EventsLoading,

--- a/apps/web/src/app/(main)/hulp/loading.tsx
+++ b/apps/web/src/app/(main)/hulp/loading.tsx
@@ -1,55 +1,53 @@
 /**
- * Help / Hulp page — server-render loading skeleton
+ * Help / Hulp page — route-level loading skeleton
  *
- * Mirrors the new HulpPage layout (post-#1237): real PageHero (props are
- * static, server-renders identically), search input shell, then the same
- * QuestionCardSkeletonGrid used for the in-search loading state. Sharing
- * the grid component prevents the two skeletons from drifting visually.
+ * Renders for full cold navigations (e.g. direct URL hit before the RSC
+ * payload arrives). Uses the same SectionStack + PageHero layout as
+ * page.tsx so the skeleton is structurally identical to the real page.
+ * The search shell and skeleton grid mirror the Suspense fallback.
  */
 
 import { PageHero } from "@/components/design-system/PageHero";
-import { Search } from "@/lib/icons";
+import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
+import { SearchInputShell } from "@/components/hulp/HulpPage/SearchInputShell";
 import { QuestionCardSkeletonGrid } from "@/components/hulp/HulpPage/QuestionCardSkeleton";
 
 export default function HulpLoading() {
   return (
-    <div className="min-h-screen">
-      {/* Real hero — props match HulpPage.tsx exactly so first paint is identical */}
-      <PageHero
-        size="compact"
-        gradient="dark"
-        label="Help"
-        headline="Vind de juiste persoon"
-        body="Stel je vraag of blader door de categorieën hieronder."
-      />
-
-      {/* Content section — gray background matches the real page */}
-      <div className="bg-gray-100">
-        <div className="mx-auto max-w-inner-lg space-y-12 px-4 py-20 md:px-10">
-          {/* Search input shell — visual mimic of HulpSearchInput.tsx */}
-          <div>
-            <div className="relative mx-auto w-full max-w-2xl">
-              <div className="pointer-events-none absolute inset-y-0 left-5 flex items-center text-kcvv-gray">
-                <Search className="h-6 w-6" aria-hidden="true" />
-              </div>
-              {/* Match HulpSearchInput's py-5 + base text + border + shadow.
-                  Empty div — no real input — keeps it non-interactive. */}
-              <div
-                className="w-full rounded-sm border border-gray-200 bg-white py-5 pl-14 pr-5 shadow-md"
-                style={{ height: "60px" }}
-                aria-hidden="true"
-              />
+    <SectionStack
+      sections={[
+        {
+          key: "hero",
+          bg: "kcvv-black",
+          paddingTop: "pt-0",
+          paddingBottom: "pb-0",
+          content: (
+            <PageHero
+              size="compact"
+              gradient="dark"
+              label="Help"
+              headline="Vind de juiste persoon"
+              body="Stel je vraag of blader door de categorieën hieronder."
+            />
+          ),
+          transition: {
+            type: "diagonal",
+            direction: "right",
+            overlap: "full",
+          },
+        },
+        {
+          key: "content",
+          bg: "gray-100",
+          content: (
+            <div className="mx-auto max-w-inner-lg space-y-12 px-4 md:px-10">
+              <SearchInputShell />
+              <QuestionCardSkeletonGrid count={4} label="Hulppagina laden..." />
             </div>
-            <p className="mt-3 text-center text-xs text-kcvv-gray">
-              Tip: probeer trefwoorden zoals <em>inschrijving</em>,{" "}
-              <em>sportongeval</em>, of <em>transfer</em>.
-            </p>
-          </div>
-
-          {/* Card grid skeleton — same component as the in-search loading */}
-          <QuestionCardSkeletonGrid count={4} label="Hulppagina laden..." />
-        </div>
-      </div>
-    </div>
+          ),
+          transition: { type: "diagonal", direction: "left" },
+        },
+      ]}
+    />
   );
 }

--- a/apps/web/src/app/(main)/hulp/page.tsx
+++ b/apps/web/src/app/(main)/hulp/page.tsx
@@ -27,25 +27,31 @@ import { ResponsibilityRepository } from "@/lib/repositories/responsibility.repo
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
-  title: "Hulp & Contact | KCVV Elewijt",
-  description:
-    "Vind snel de juiste contactpersoon voor jouw vraag. Stel je vraag of blader door de categorieën.",
-  keywords: [
-    "hulp",
-    "contact",
-    "vraag",
-    "verantwoordelijke",
-    "wie contacteren",
-    "KCVV Elewijt",
-  ],
-  openGraph: {
-    title: "Hulp & Contact - KCVV Elewijt",
-    description: "Vind snel de juiste contactpersoon voor jouw vraag",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const canonical = `${SITE_CONFIG.siteUrl}/hulp`;
+
+  return {
+    title: "Hulp & Contact | KCVV Elewijt",
+    description:
+      "Vind snel de juiste contactpersoon voor jouw vraag. Stel je vraag of blader door de categorieën.",
+    keywords: [
+      "hulp",
+      "contact",
+      "vraag",
+      "verantwoordelijke",
+      "wie contacteren",
+      "KCVV Elewijt",
+    ],
+    alternates: { canonical },
+    openGraph: {
+      title: "Hulp & Contact - KCVV Elewijt",
+      description: "Vind snel de juiste contactpersoon voor jouw vraag",
+      type: "website",
+      url: canonical,
+      images: [DEFAULT_OG_IMAGE],
+    },
+  };
+}
 
 /**
  * Suspense fallback — search input shell + skeleton grid.

--- a/apps/web/src/app/(main)/hulp/page.tsx
+++ b/apps/web/src/app/(main)/hulp/page.tsx
@@ -1,15 +1,21 @@
 /**
  * Help / Hulp Page
  *
- * Search + browse + answer view for the responsibility paths fetched
- * from Sanity. The new HulpPage UX replaces the legacy
- * "Ik ben … en ik …" inline-sentence finder.
+ * Server-side shell renders the PageHero immediately (consistent with
+ * every other route), then streams the data-dependent content inside a
+ * Suspense boundary. The interactive HulpPage client component receives
+ * `paths` only after `ResponsibilityRepository.findAll()` resolves.
  */
 
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Effect } from "effect";
 import { DEFAULT_OG_IMAGE, SITE_CONFIG } from "@/lib/constants";
 import { HulpPage } from "@/components/hulp/HulpPage";
+import { PageHero } from "@/components/design-system/PageHero";
+import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
+import { SearchInputShell } from "@/components/hulp/HulpPage/SearchInputShell";
+import { QuestionCardSkeletonGrid } from "@/components/hulp/HulpPage/QuestionCardSkeleton";
 import { JsonLd } from "@/components/seo/JsonLd";
 import {
   buildBreadcrumbJsonLd,
@@ -18,6 +24,8 @@ import {
 } from "@/lib/seo/jsonld";
 import { runPromise } from "@/lib/effect/runtime";
 import { ResponsibilityRepository } from "@/lib/repositories/responsibility.repository";
+
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "Hulp & Contact | KCVV Elewijt",
@@ -39,7 +47,26 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function HulpPageRoute() {
+/**
+ * Suspense fallback — search input shell + skeleton grid.
+ * Mirrors the visual appearance of HulpPage's search + browse layout
+ * so the user sees a complete shell while data loads.
+ */
+function HulpSkeleton() {
+  return (
+    <>
+      <SearchInputShell />
+      <QuestionCardSkeletonGrid count={4} label="Hulppagina laden..." />
+    </>
+  );
+}
+
+/**
+ * Async server component — fetches responsibility paths and renders
+ * the interactive HulpPage client component + FAQ structured data.
+ * Lives inside the Suspense boundary so the hero streams immediately.
+ */
+async function HulpContent() {
   const paths = await runPromise(
     Effect.gen(function* () {
       const responsibilityRepo = yield* ResponsibilityRepository;
@@ -47,9 +74,6 @@ export default async function HulpPageRoute() {
     }),
   );
 
-  // Project each responsibility path to a FAQ entry — the answer is the
-  // summary plus the numbered steps joined into a single paragraph so it
-  // works as a Schema.org `Answer.text` payload.
   const faqEntries: FAQEntry[] = paths.map((path) => {
     const stepsText = path.steps
       .map((step, i) => `${i + 1}. ${step.description}`)
@@ -63,12 +87,6 @@ export default async function HulpPageRoute() {
 
   return (
     <>
-      <JsonLd
-        data={buildBreadcrumbJsonLd([
-          { name: "Home", url: SITE_CONFIG.siteUrl },
-          { name: "Hulp", url: `${SITE_CONFIG.siteUrl}/hulp` },
-        ])}
-      />
       {faqEntries.length > 0 && (
         <JsonLd data={buildFAQPageJsonLd(faqEntries)} />
       )}
@@ -77,4 +95,51 @@ export default async function HulpPageRoute() {
   );
 }
 
-export const revalidate = 3600;
+export default function HulpPageRoute() {
+  return (
+    <>
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: SITE_CONFIG.siteUrl },
+          { name: "Hulp", url: `${SITE_CONFIG.siteUrl}/hulp` },
+        ])}
+      />
+      <SectionStack
+        sections={[
+          {
+            key: "hero",
+            bg: "kcvv-black",
+            paddingTop: "pt-0",
+            paddingBottom: "pb-0",
+            content: (
+              <PageHero
+                size="compact"
+                gradient="dark"
+                label="Help"
+                headline="Vind de juiste persoon"
+                body="Stel je vraag of blader door de categorieën hieronder."
+              />
+            ),
+            transition: {
+              type: "diagonal",
+              direction: "right",
+              overlap: "full",
+            },
+          },
+          {
+            key: "content",
+            bg: "gray-100",
+            content: (
+              <div className="mx-auto max-w-inner-lg space-y-12 px-4 md:px-10">
+                <Suspense fallback={<HulpSkeleton />}>
+                  <HulpContent />
+                </Suspense>
+              </div>
+            ),
+            transition: { type: "diagonal", direction: "left" },
+          },
+        ]}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/hulp/HulpPage/HulpPage.test.tsx
+++ b/apps/web/src/components/hulp/HulpPage/HulpPage.test.tsx
@@ -79,12 +79,13 @@ function resetMocks() {
 describe("HulpPage", () => {
   beforeEach(resetMocks);
 
-  it("renders the PageHero with the Help label and headline", () => {
+  it("does not render PageHero — hero is owned by the server layer", () => {
     render(<HulpPage paths={FIXTURE_PATHS} />);
-    expect(screen.getByText("Help")).toBeInTheDocument();
+    // PageHero renders a heading with the headline text. After extracting
+    // the hero to page.tsx (server), HulpPage should NOT render it.
     expect(
-      screen.getByRole("heading", { name: /vind de juiste persoon/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: /vind de juiste persoon/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders BrowseContent with all categories when no question is selected", () => {

--- a/apps/web/src/components/hulp/HulpPage/HulpPage.tsx
+++ b/apps/web/src/components/hulp/HulpPage/HulpPage.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 /**
- * HulpPage — top-level orchestration for the redesigned /hulp page
+ * HulpPage — content-only orchestration for the /hulp page
  *
- * Composes a `SectionStack` with hero / content / CTA sections. The
- * content section switches between three views:
+ * Renders the search input, browse/search/answer views, and closing CTA.
+ * The PageHero and SectionStack layout are owned by the server layer
+ * (`page.tsx`) so the hero streams immediately and the data-dependent
+ * content loads inside a Suspense boundary.
+ *
+ * Three view modes (selected by URL + search state):
  *
  *   1. **Browse** — default; shows all paths grouped by category
  *   2. **Search results** — when the user types in the search input
@@ -21,11 +25,6 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import {
-  SectionStack,
-  type SectionConfig,
-} from "@/components/design-system/SectionStack/SectionStack";
-import { PageHero } from "@/components/design-system/PageHero/PageHero";
 import { useResponsibilityAnalytics } from "@/hooks/useResponsibilityAnalytics";
 import { useSemanticSearch } from "@/hooks/useSemanticSearch";
 import { sanitizeQuery } from "@/lib/analytics/sanitize-query";
@@ -401,54 +400,29 @@ export function HulpPage({ paths }: HulpPageProps) {
     );
   };
 
-  const sections: SectionConfig[] = [
-    {
-      key: "hero",
-      bg: "kcvv-black",
-      paddingTop: "pt-0",
-      paddingBottom: "pb-0",
-      content: (
-        <PageHero
-          size="compact"
-          gradient="dark"
-          label="Help"
-          headline="Vind de juiste persoon"
-          body="Stel je vraag of blader door de categorieën hieronder."
+  return (
+    <>
+      <div>
+        <HulpSearchInput value={searchQuery} onChange={setSearchQuery} />
+        <p className="mt-3 text-center text-xs text-kcvv-gray">
+          Tip: probeer trefwoorden zoals <em>inschrijving</em>,{" "}
+          <em>sportongeval</em>, of <em>transfer</em>.
+        </p>
+      </div>
+      {renderContent()}
+
+      {/* Closing "still no answer?" callout — sits inside the gray
+          content section so the page footer's diagonal transition
+          flows directly out of gray. Avoids the green→gray→green
+          sandwich a separate CTA section would create above the
+          footer. Suppressed when `paths` is empty since the empty-
+          data state already shows its own contact CTA. */}
+      {paths.length > 0 && (
+        <ContactCtaCard
+          heading="Niet gevonden wat je zocht?"
+          body="Stuur ons een bericht en we helpen je graag verder."
         />
-      ),
-      transition: { type: "diagonal", direction: "right", overlap: "full" },
-    },
-    {
-      key: "content",
-      bg: "gray-100",
-      content: (
-        <div className="mx-auto max-w-inner-lg space-y-12 px-4 md:px-10">
-          <div>
-            <HulpSearchInput value={searchQuery} onChange={setSearchQuery} />
-            <p className="mt-3 text-center text-xs text-kcvv-gray">
-              Tip: probeer trefwoorden zoals <em>inschrijving</em>,{" "}
-              <em>sportongeval</em>, of <em>transfer</em>.
-            </p>
-          </div>
-          {renderContent()}
-
-          {/* Closing "still no answer?" callout — sits inside the gray
-              content section so the page footer's diagonal transition
-              flows directly out of gray. Avoids the green→gray→green
-              sandwich a separate CTA section would create above the
-              footer. Suppressed when `paths` is empty since the empty-
-              data state already shows its own contact CTA. */}
-          {paths.length > 0 && (
-            <ContactCtaCard
-              heading="Niet gevonden wat je zocht?"
-              body="Stuur ons een bericht en we helpen je graag verder."
-            />
-          )}
-        </div>
-      ),
-      transition: { type: "diagonal", direction: "left" },
-    },
-  ];
-
-  return <SectionStack sections={sections} />;
+      )}
+    </>
+  );
 }

--- a/apps/web/src/components/hulp/HulpPage/SearchInputShell.tsx
+++ b/apps/web/src/components/hulp/HulpPage/SearchInputShell.tsx
@@ -1,0 +1,30 @@
+/**
+ * SearchInputShell — Non-interactive visual mimic of HulpSearchInput.
+ *
+ * Used in Suspense fallbacks and route-level loading skeletons so the
+ * search area appears immediately while data loads. Server component —
+ * no "use client" needed.
+ */
+
+import { Search } from "@/lib/icons";
+
+export function SearchInputShell() {
+  return (
+    <div>
+      <div className="relative mx-auto w-full max-w-2xl">
+        <div className="pointer-events-none absolute inset-y-0 left-5 flex items-center text-kcvv-gray">
+          <Search className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <div
+          className="w-full rounded-sm border border-gray-200 bg-white py-5 pl-14 pr-5 shadow-md"
+          style={{ height: "60px" }}
+          aria-hidden="true"
+        />
+      </div>
+      <p className="mt-3 text-center text-xs text-kcvv-gray">
+        Tip: probeer trefwoorden zoals <em>inschrijving</em>,{" "}
+        <em>sportongeval</em>, of <em>transfer</em>.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/hulp/HulpPage/index.ts
+++ b/apps/web/src/components/hulp/HulpPage/index.ts
@@ -4,6 +4,8 @@ export type { HulpPageProps } from "./HulpPage";
 export { HulpSearchInput } from "./HulpSearchInput";
 export type { HulpSearchInputProps } from "./HulpSearchInput";
 
+export { SearchInputShell } from "./SearchInputShell";
+
 export { QuestionCard } from "./QuestionCard";
 export type { QuestionCardProps } from "./QuestionCard";
 


### PR DESCRIPTION
Closes #1267

## What changed
- Lifted `PageHero` out of the `HulpPage` client boundary into the server-rendered `page.tsx`, aligning `/hulp` with every other route
- Wrapped the data-dependent `HulpPage` client component in a `<Suspense>` boundary with a skeleton fallback so the hero and shell stream immediately
- Extracted `SearchInputShell` as a static placeholder to avoid layout shift during loading

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Verified `/hulp` streams the hero instantly with skeleton fallback visible until data loads