### PR TITLE
feat(ui): redesign YouthSection — editorial layout, diagonal coverage fix (#1294)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -263,16 +263,14 @@ export default async function HomePage() {
     content: (
       <MatchesSliderSection matches={sliderMatches} highlightTeamId={1235} />
     ),
-    transition: { type: "diagonal", direction: "right" },
   };
 
   const youthSection: SectionConfig = {
     key: "youth",
     bg: "kcvv-green-dark",
-    content: <YouthSection />,
+    content: <YouthSection prevBgColor="#1E2024" nextBgColor="#f3f4f6" />,
     paddingTop: "pt-0",
     paddingBottom: "pb-0",
-    transition: { type: "diagonal", direction: "left" },
   };
 
   const bannerSlotCSection: SectionConfig | null = banners.bannerSlotC

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -268,7 +268,7 @@ export default async function HomePage() {
   const youthSection: SectionConfig = {
     key: "youth",
     bg: "kcvv-green-dark",
-    content: <YouthSection prevBgColor="#1E2024" nextBgColor="#f3f4f6" />,
+    content: <YouthSection prevBg="kcvv-black" nextBg="gray-100" />,
     paddingTop: "pt-0",
     paddingBottom: "pb-0",
   };

--- a/apps/web/src/components/design-system/SectionTransition/SectionTransition.tsx
+++ b/apps/web/src/components/design-system/SectionTransition/SectionTransition.tsx
@@ -34,7 +34,7 @@ export interface SectionTransitionProps {
 // NOTE: Use resolved hex values, not CSS custom properties — SVG fill rendering
 // uses a different pipeline from CSS background-color, and CSS variables in SVG
 // attributes can produce sub-pixel color mismatches visible as a 1px seam line.
-const BG_COLOR: Record<SectionBg, string> = {
+export const BG_COLOR: Record<SectionBg, string> = {
   white: "#ffffff",
   "gray-100": "#f3f4f6",
   "kcvv-black": "#1E2024",
@@ -70,7 +70,7 @@ function shiftY(points: string, dy: number): string {
     .join(" ");
 }
 
-const DIAGONAL_HEIGHT = "clamp(2rem, 6vw, 5rem)";
+export const DIAGONAL_HEIGHT = "clamp(2rem, 6vw, 5rem)";
 const DIAGONAL_HALF = "clamp(1rem, 3vw, 2.5rem)";
 
 export function SectionTransition({

--- a/apps/web/src/components/design-system/SectionTransition/index.ts
+++ b/apps/web/src/components/design-system/SectionTransition/index.ts
@@ -1,4 +1,8 @@
-export { SectionTransition } from "./SectionTransition";
+export {
+  SectionTransition,
+  DIAGONAL_HEIGHT,
+  BG_COLOR,
+} from "./SectionTransition";
 export type {
   SectionTransitionProps,
   SectionBg,

--- a/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
@@ -35,7 +35,7 @@ export const WithDiagonalTransitions: Story = {
         {
           key: "youth",
           bg: "kcvv-green-dark",
-          content: <YouthSection prevBgColor="#1E2024" nextBgColor="#f3f4f6" />,
+          content: <YouthSection prevBg="kcvv-black" nextBg="gray-100" />,
           paddingTop: "pt-0",
           paddingBottom: "pb-0",
         },

--- a/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
@@ -16,8 +16,9 @@ export const Default: Story = {
   args: {},
 };
 
-/** Shows the YouthSection sandwiched between sections with diagonal transitions,
- *  verifying that the background image covers the diagonal transition areas. */
+/** Shows the YouthSection sandwiched between sections. Both the top and bottom
+ *  diagonals are rendered inside the component so the background image shows
+ *  through the transparent triangles. No SectionTransition needed around it. */
 export const WithDiagonalTransitions: Story = {
   render: () => (
     <SectionStack
@@ -30,15 +31,13 @@ export const WithDiagonalTransitions: Story = {
               Previous section (kcvv-black)
             </div>
           ),
-          transition: { type: "diagonal", direction: "right" },
         },
         {
           key: "youth",
           bg: "kcvv-green-dark",
-          content: <YouthSection />,
+          content: <YouthSection prevBgColor="#1E2024" nextBgColor="#f3f4f6" />,
           paddingTop: "pt-0",
           paddingBottom: "pb-0",
-          transition: { type: "diagonal", direction: "left" },
         },
         {
           key: "after",

--- a/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { YouthSection } from "./YouthSection";
+import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
 
 const meta = {
   title: "Features/Homepage/YouthSection",
@@ -13,4 +14,42 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {},
+};
+
+/** Shows the YouthSection sandwiched between sections with diagonal transitions,
+ *  verifying that the background image covers the diagonal transition areas. */
+export const WithDiagonalTransitions: Story = {
+  render: () => (
+    <SectionStack
+      sections={[
+        {
+          key: "before",
+          bg: "kcvv-black",
+          content: (
+            <div className="px-8 py-12 text-center text-white/60">
+              Previous section (kcvv-black)
+            </div>
+          ),
+          transition: { type: "diagonal", direction: "right" },
+        },
+        {
+          key: "youth",
+          bg: "kcvv-green-dark",
+          content: <YouthSection />,
+          paddingTop: "pt-0",
+          paddingBottom: "pb-0",
+          transition: { type: "diagonal", direction: "left" },
+        },
+        {
+          key: "after",
+          bg: "gray-100",
+          content: (
+            <div className="px-8 py-12 text-center text-gray-400">
+              Next section (gray-100)
+            </div>
+          ),
+        },
+      ]}
+    />
+  ),
 };

--- a/apps/web/src/components/home/YouthSection/YouthSection.test.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { YouthSection } from "./YouthSection";
+
+describe("YouthSection", () => {
+  it("renders the section label", () => {
+    render(<YouthSection />);
+    expect(screen.getByText("Jeugdwerking")).toBeInTheDocument();
+  });
+
+  it("renders the editorial title", () => {
+    render(<YouthSection />);
+    expect(
+      screen.getByRole("heading", { name: /de toekomst van elewijt/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the body text", () => {
+    render(<YouthSection />);
+    expect(screen.getByText(/meer dan 220 jonge spelers/i)).toBeInTheDocument();
+  });
+
+  it("renders the stats line", () => {
+    render(<YouthSection />);
+    expect(screen.getByText(/220\+ spelers · 16 ploegen/i)).toBeInTheDocument();
+  });
+
+  it("renders a CTA link to /jeugd", () => {
+    render(<YouthSection />);
+    const link = screen.getByRole("link", { name: /ontdek onze jeugd/i });
+    expect(link).toHaveAttribute("href", "/jeugd");
+  });
+
+  it("does not clip section overflow so background can bleed into diagonal transitions", () => {
+    const { container } = render(<YouthSection />);
+    const section = container.querySelector("section");
+    expect(section?.className).not.toContain("overflow-hidden");
+  });
+});

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -10,81 +10,84 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
   return (
     <section
       className={cn(
-        "relative overflow-hidden bg-kcvv-green-dark py-20 text-center",
+        "relative bg-kcvv-green-dark py-16 text-left md:py-24",
         className,
       )}
     >
-      {/* Section background — atmospheric photo, slightly blurred.
-          Outer wrapper clips at section boundary; inner div extends beyond it
-          so the blur has pixel data at all edges (prevents compositing seams). */}
-      <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
+      {/* Background image container — extends beyond section bounds so the
+          photo visually spans into adjacent diagonal transition areas.
+          overflow-hidden lives here (not on <section>) to clip blur edges
+          while allowing the image to bleed vertically. */}
+      <div
+        className="absolute inset-x-0 overflow-hidden"
+        style={{
+          top: "calc(-1 * clamp(2rem, 6vw, 5rem))",
+          bottom: "calc(-1 * clamp(2rem, 6vw, 5rem))",
+        }}
+        aria-hidden="true"
+      >
         <div className="absolute -inset-4">
           <Image
             src="/images/youth-trainers.jpg"
             alt=""
             fill
-            className="object-cover object-top blur-sm"
+            className="object-cover object-top blur-[2px]"
             sizes="100vw"
           />
         </div>
-        {/* Dark tint overlay — preserves green-dark mood while letting the photo breathe */}
-        <div className="absolute inset-0 bg-kcvv-green-dark/55" />
+        {/* Directional gradient overlay — lets the photo breathe on the right (desktop)
+            or bottom (mobile) while keeping text readable on the left/top. */}
+        <div
+          className={cn(
+            "absolute inset-0",
+            "bg-gradient-to-b from-kcvv-green-dark/80 via-kcvv-green-dark/60 to-kcvv-green-dark/30",
+            "md:bg-gradient-to-r md:from-kcvv-green-dark/80 md:via-kcvv-green-dark/60 md:to-kcvv-green-dark/30",
+          )}
+        />
       </div>
 
-      {/* Content — floats above the blurred background */}
-      <div className="relative z-10">
+      {/* Content — left-aligned editorial block */}
+      <div className="relative z-10 mx-auto max-w-7xl px-4 md:px-8">
         {/* Section label */}
-        <div className="relative max-w-7xl mx-auto px-4 md:px-8 mb-6">
-          <p className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-label text-white/50">
-            <span aria-hidden="true" className="block w-5 h-0.5 bg-white/30" />
-            Jeugdwerking
-          </p>
-        </div>
+        <p className="mb-6 flex items-center gap-2 text-[11px] font-bold uppercase tracking-label text-white/50">
+          <span aria-hidden="true" className="block h-0.5 w-5 bg-white/30" />
+          Jeugdwerking
+        </p>
 
-        <div className="relative max-w-3xl mx-auto px-4 md:px-8">
-          {/* Stat row */}
-          <div className="flex items-center justify-center gap-8 md:gap-16 mb-10">
-            <div>
-              <div
-                className="font-title font-black text-kcvv-green leading-none"
-                style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
-              >
-                220+
-              </div>
-              <div className="text-xs tracking-widest uppercase text-white/50 mt-1">
-                Spelers
-              </div>
-            </div>
-            <div className="w-px h-16 bg-white/15" aria-hidden="true" />
-            <div>
-              <div
-                className="font-title font-black text-kcvv-green leading-none"
-                style={{ fontSize: "clamp(3rem, 8vw, 5.5rem)" }}
-              >
-                16
-              </div>
-              <div className="text-xs tracking-widest uppercase text-white/50 mt-1">
-                Ploegen
-              </div>
-            </div>
-          </div>
+        {/* Editorial title */}
+        <h2
+          className="mb-6 font-title font-black uppercase leading-[0.95] text-white"
+          style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}
+        >
+          De toekomst
+          <br />
+          van Elewijt
+        </h2>
 
-          {/* CTA */}
-          <div>
-            <Link
-              href="/jeugd"
-              className="group inline-flex items-center gap-2 px-6 py-3 bg-white text-kcvv-black font-bold text-sm uppercase tracking-wider rounded-sm hover:bg-kcvv-green transition-colors"
-            >
-              Ontdek onze jeugd
-              <span
-                className="inline-block transition-transform group-hover:translate-x-1"
-                aria-hidden="true"
-              >
-                →
-              </span>
-            </Link>
-          </div>
-        </div>
+        {/* Body text */}
+        <p className="mb-6 max-w-lg text-base leading-relaxed text-white/80">
+          Meer dan 220 jonge spelers en 16 ploegen trainen elke week op
+          Sportpark Elewijt. Van de allerkleinsten tot de U21.
+        </p>
+
+        {/* Stats line */}
+        <p className="mb-8 text-sm font-bold uppercase tracking-wider text-kcvv-green">
+          220+ spelers · 16 ploegen
+        </p>
+
+        {/* CTA */}
+        <Link
+          href="/jeugd"
+          className="group inline-flex items-center gap-2 rounded-sm bg-white px-6 py-3 text-sm font-bold uppercase tracking-wider text-kcvv-black transition-colors hover:bg-kcvv-green"
+        >
+          Ontdek onze jeugd
+          <span
+            className="inline-block transition-transform group-hover:translate-x-1"
+            aria-hidden="true"
+          >
+            →
+          </span>
+        </Link>
       </div>
     </section>
   );

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -1,28 +1,34 @@
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
-
-const DIAGONAL_HEIGHT = "clamp(2rem, 6vw, 5rem)";
+import {
+  DIAGONAL_HEIGHT,
+  BG_COLOR,
+  type SectionBg,
+} from "@/components/design-system/SectionTransition";
 
 export interface YouthSectionProps {
   className?: string;
-  /** Hex color for the top diagonal's previous-section triangle. */
-  prevBgColor?: string;
-  /** Hex color for the bottom diagonal's next-section triangle. */
-  nextBgColor?: string;
+  /** Background key for the section above (top diagonal). */
+  prevBg?: SectionBg;
+  /** Background key for the section below (bottom diagonal). */
+  nextBg?: SectionBg;
 }
 
 export const YouthSection = ({
   className,
-  prevBgColor = "#1E2024",
-  nextBgColor = "#f3f4f6",
+  prevBg = "kcvv-black",
+  nextBg = "gray-100",
 }: YouthSectionProps) => {
+  const prevBgColor = BG_COLOR[prevBg];
+  const nextBgColor = BG_COLOR[nextBg];
+
   return (
     <section
       className={cn("relative bg-kcvv-green-dark text-left", className)}
       style={{
         marginTop: `calc(-1 * ${DIAGONAL_HEIGHT})`,
-        marginBottom: `calc(-1 * ${DIAGONAL_HEIGHT})`,
+        paddingBottom: DIAGONAL_HEIGHT,
       }}
     >
       {/* Background image — covers the full section including both diagonal
@@ -117,10 +123,10 @@ export const YouthSection = ({
         </Link>
       </div>
 
-      {/* Bottom diagonal — transparent upper-left so the image shows through,
-          next section color in the lower-right triangle (direction "left"). */}
+      {/* Bottom diagonal — absolutely positioned in the padding area so it
+          does not push the next section down with a negative margin. */}
       <div
-        className="relative z-20"
+        className="absolute inset-x-0 bottom-0 z-20"
         style={{ height: DIAGONAL_HEIGHT }}
         aria-hidden="true"
       >

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -2,30 +2,32 @@ import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
 
+const DIAGONAL_HEIGHT = "clamp(2rem, 6vw, 5rem)";
+
 export interface YouthSectionProps {
   className?: string;
+  /** Hex color for the top diagonal's previous-section triangle. */
+  prevBgColor?: string;
+  /** Hex color for the bottom diagonal's next-section triangle. */
+  nextBgColor?: string;
 }
 
-export const YouthSection = ({ className }: YouthSectionProps) => {
+export const YouthSection = ({
+  className,
+  prevBgColor = "#1E2024",
+  nextBgColor = "#f3f4f6",
+}: YouthSectionProps) => {
   return (
     <section
-      className={cn(
-        "relative bg-kcvv-green-dark py-16 text-left md:py-24",
-        className,
-      )}
+      className={cn("relative bg-kcvv-green-dark text-left", className)}
+      style={{
+        marginTop: `calc(-1 * ${DIAGONAL_HEIGHT})`,
+        marginBottom: `calc(-1 * ${DIAGONAL_HEIGHT})`,
+      }}
     >
-      {/* Background image container — extends beyond section bounds so the
-          photo visually spans into adjacent diagonal transition areas.
-          overflow-hidden lives here (not on <section>) to clip blur edges
-          while allowing the image to bleed vertically. */}
-      <div
-        className="absolute inset-x-0 overflow-hidden"
-        style={{
-          top: "calc(-1 * clamp(2rem, 6vw, 5rem))",
-          bottom: "calc(-1 * clamp(2rem, 6vw, 5rem))",
-        }}
-        aria-hidden="true"
-      >
+      {/* Background image — covers the full section including both diagonal
+          areas. The diagonals' transparent triangles let the image show. */}
+      <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
         <div className="absolute -inset-4">
           <Image
             src="/images/youth-trainers.jpg"
@@ -35,22 +37,47 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
             sizes="100vw"
           />
         </div>
-        {/* Directional gradient overlay — lets the photo breathe on the right (desktop)
-            or bottom (mobile) while keeping text readable on the left/top. */}
+        {/* Directional gradient overlay — lets the photo breathe on the right
+            (desktop) or bottom (mobile) while keeping text readable. */}
         <div
           className={cn(
             "absolute inset-0",
-            "bg-gradient-to-b from-kcvv-green-dark/80 via-kcvv-green-dark/60 to-kcvv-green-dark/30",
-            "md:bg-gradient-to-r md:from-kcvv-green-dark/80 md:via-kcvv-green-dark/60 md:to-kcvv-green-dark/30",
+            "bg-gradient-to-b from-kcvv-green-dark/90 via-kcvv-green-dark/75 to-kcvv-green-dark/50",
+            "md:bg-gradient-to-r md:from-kcvv-green-dark/90 md:via-kcvv-green-dark/75 md:to-kcvv-green-dark/50",
           )}
         />
       </div>
 
+      {/* Top diagonal — previous section color in the upper-right triangle,
+          transparent lower-left so the image shows through (direction "right"). */}
+      <div
+        className="relative z-20"
+        style={{ height: DIAGONAL_HEIGHT }}
+        aria-hidden="true"
+      >
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="absolute inset-0 h-full w-full"
+        >
+          <polygon
+            points="0,0 100,0 100,100"
+            fill={prevBgColor}
+            shapeRendering="crispEdges"
+          />
+          <polygon
+            points="0,0 0,100 100,100"
+            fill="transparent"
+            shapeRendering="crispEdges"
+          />
+        </svg>
+      </div>
+
       {/* Content — left-aligned editorial block */}
-      <div className="relative z-10 mx-auto max-w-7xl px-4 md:px-8">
+      <div className="relative z-10 mx-auto max-w-7xl px-4 py-16 md:px-8 md:py-24">
         {/* Section label */}
-        <p className="mb-6 flex items-center gap-2 text-[11px] font-bold uppercase tracking-label text-white/50">
-          <span aria-hidden="true" className="block h-0.5 w-5 bg-white/30" />
+        <p className="mb-6 flex items-center gap-2 text-[11px] font-bold uppercase tracking-label text-white/70">
+          <span aria-hidden="true" className="block h-0.5 w-5 bg-white/50" />
           Jeugdwerking
         </p>
 
@@ -65,13 +92,13 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
         </h2>
 
         {/* Body text */}
-        <p className="mb-6 max-w-lg text-base leading-relaxed text-white/80">
+        <p className="mb-6 max-w-lg text-base leading-relaxed text-white/90">
           Meer dan 220 jonge spelers en 16 ploegen trainen elke week op
           Sportpark Elewijt. Van de allerkleinsten tot de U21.
         </p>
 
         {/* Stats line */}
-        <p className="mb-8 text-sm font-bold uppercase tracking-wider text-kcvv-green">
+        <p className="mb-8 text-sm font-bold uppercase tracking-wider text-white">
           220+ spelers · 16 ploegen
         </p>
 
@@ -88,6 +115,31 @@ export const YouthSection = ({ className }: YouthSectionProps) => {
             →
           </span>
         </Link>
+      </div>
+
+      {/* Bottom diagonal — transparent upper-left so the image shows through,
+          next section color in the lower-right triangle (direction "left"). */}
+      <div
+        className="relative z-20"
+        style={{ height: DIAGONAL_HEIGHT }}
+        aria-hidden="true"
+      >
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="absolute inset-0 h-full w-full"
+        >
+          <polygon
+            points="0,0 100,0 0,100"
+            fill="transparent"
+            shapeRendering="crispEdges"
+          />
+          <polygon
+            points="100,0 100,100 0,100"
+            fill={nextBgColor}
+            shapeRendering="crispEdges"
+          />
+        </svg>
       </div>
     </section>
   );


### PR DESCRIPTION
Closes #1294

## What changed
- Redesigned YouthSection with an editorial layout replacing the previous card-based design
- Fixed diagonal image coverage to properly span the section
- Added Storybook stories and unit tests for the component

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Visual verification in Storybook