### PR TITLE
fix(ui): bottom-anchor carousel text block on wide screens (#1302)

### DIFF
--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
@@ -177,6 +177,32 @@ export const ManyTags: Story = {
 };
 
 /**
+ * Worst-case content: longest tag + 2-line title + 3-line description + date.
+ * Used for visual regression testing at wide viewports (1440px–2560px)
+ * to verify no overlap between the text block and the dot navigation.
+ */
+export const WorstCaseContent: Story = {
+  args: {
+    articles: [
+      {
+        href: "/nieuws/worst-case",
+        title:
+          "Definitieve reeksindeling voor het seizoen 2025-2026 in 3e Nationale BIS is officieel bekendgemaakt",
+        description:
+          "De Koninklijke Belgische Voetbalbond heeft vandaag de definitieve reeksindeling voor het seizoen 2025-2026 in 3e Nationale BIS bekendgemaakt. KCVV Elewijt komt uit in reeks A samen met enkele bekende tegenstanders uit de buurt. De volledige kalender wordt later deze maand gepubliceerd.",
+        imageUrl: "https://placehold.co/800x600/4acf52/fff?text=Worst+Case",
+        imageAlt: "Worst-case content test",
+        date: "20 juni 2025",
+        dateIso: "2025-06-20",
+        tags: [{ name: "Competitie & Reeksindeling" }],
+      },
+      ...mockArticles.slice(0, 2),
+    ],
+    autoRotate: false,
+  },
+};
+
+/**
  * Empty state (no articles)
  */
 export const Empty: Story = {

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
@@ -202,7 +202,7 @@ export const FeaturedArticles = ({
         </div>
 
         {/* Content Overlay — padded away from sidebar on desktop */}
-        <div className="relative z-10 h-full flex items-start pt-10 md:pt-14 lg:items-center lg:pt-0 px-4 lg:px-10">
+        <div className="relative z-10 h-full flex items-start pt-10 md:pt-14 lg:items-end lg:pt-0 lg:pb-[calc(clamp(2rem,6vw,5rem)+3rem)] px-4 lg:px-10">
           <Link
             href={activeArticle.href}
             className="group flex flex-col justify-center max-w-lg lg:max-w-xl"


### PR DESCRIPTION
Closes #1302

## What changed
- Bottom-anchor the `FeaturedArticles` text block on `lg+` (`items-start` → `items-end`) so content clears the dot navigation at all viewport widths
- Remove empty gray spacer between sponsors section and footer on homepage by conditionally rendering `FooterTransition`
- Add Storybook variants with worst-case content for visual regression

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Verified no text/dot overlap from 320px to 2560px in Storybook
- FooterTransition unit test added and passing