### PR TITLE
fix(news): deduplicate articles across featured and grid sections (#1303)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.test.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.test.tsx
@@ -121,6 +121,107 @@ describe("NewsListingClient", () => {
     });
   });
 
+  it("deduplicates articles returned by loadMore against featured and grid", async () => {
+    const featured = [
+      makeArticle({ id: "a1", title: "Article One" }),
+      makeArticle({ id: "a2", title: "Article Two" }),
+      makeArticle({ id: "a3", title: "Article Three" }),
+    ];
+    const grid = [
+      makeArticle({ id: "a4", title: "Article Four" }),
+      makeArticle({ id: "a5", title: "Article Five" }),
+      makeArticle({ id: "a6", title: "Article Six" }),
+    ];
+
+    // loadMore returns a mix of duplicates (a3, a6) and new articles (a7, a8)
+    mockFetchArticles.mockResolvedValue({
+      articles: [
+        makeArticle({ id: "a3", title: "Article Three" }),
+        makeArticle({ id: "a6", title: "Article Six" }),
+        makeArticle({ id: "a7", title: "Article Seven" }),
+        makeArticle({ id: "a8", title: "Article Eight" }),
+      ],
+      hasMore: false,
+    });
+
+    render(
+      <NewsListingClient
+        featuredArticles={featured}
+        initialArticles={grid}
+        categories={categories}
+        hasMore={true}
+        fetchArticles={mockFetchArticles}
+      />,
+    );
+
+    // Trigger the IntersectionObserver
+    if (intersectionCallback) {
+      intersectionCallback([{ isIntersecting: true }]);
+    }
+
+    // New articles should appear, duplicates should not create extra DOM nodes
+    await waitFor(() => {
+      expect(screen.getByText("Article Seven")).toBeInTheDocument();
+      expect(screen.getByText("Article Eight")).toBeInTheDocument();
+    });
+
+    // Verify no duplicate IDs in the rendered output
+    const allArticleTitles = [
+      "Article One",
+      "Article Two",
+      "Article Three",
+      "Article Four",
+      "Article Five",
+      "Article Six",
+      "Article Seven",
+      "Article Eight",
+    ];
+    for (const title of allArticleTitles) {
+      const elements = screen.getAllByText(title);
+      expect(elements).toHaveLength(1);
+    }
+  });
+
+  it("deduplicates articles after category change", async () => {
+    const featured = [
+      makeArticle({ id: "a1", title: "First Article" }),
+      makeArticle({ id: "a2", title: "Second Article" }),
+      makeArticle({ id: "a3", title: "Third Article" }),
+    ];
+    const grid = [makeArticle({ id: "a4", title: "Fourth Article" })];
+
+    // Category change returns results where article a1 appears again at position 4
+    mockFetchArticles.mockResolvedValue({
+      articles: [
+        makeArticle({ id: "c1", title: "Cat One" }),
+        makeArticle({ id: "c2", title: "Cat Two" }),
+        makeArticle({ id: "c3", title: "Cat Three" }),
+        makeArticle({ id: "c1", title: "Cat One" }), // duplicate
+        makeArticle({ id: "c4", title: "Cat Four" }),
+      ],
+      hasMore: false,
+    });
+
+    render(
+      <NewsListingClient
+        featuredArticles={featured}
+        initialArticles={grid}
+        categories={categories}
+        hasMore={false}
+        fetchArticles={mockFetchArticles}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Jeugd" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Cat Four")).toBeInTheDocument();
+    });
+
+    // Cat One should appear exactly once (featured), not also in the grid
+    expect(screen.getAllByText("Cat One")).toHaveLength(1);
+  });
+
   it("shows loading indicator while fetching", async () => {
     // Make fetchArticles hang
     let resolvePromise: (value: unknown) => void;

--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.test.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.test.tsx
@@ -190,13 +190,15 @@ describe("NewsListingClient", () => {
     ];
     const grid = [makeArticle({ id: "a4", title: "Fourth Article" })];
 
-    // Category change returns results where article a1 appears again at position 4
+    // Duplicate "c1" appears within the first three items so the pre-split
+    // dedup path (deduplicateById on the whole result before slicing into
+    // featured/grid) is exercised.
     mockFetchArticles.mockResolvedValue({
       articles: [
         makeArticle({ id: "c1", title: "Cat One" }),
+        makeArticle({ id: "c1", title: "Cat One" }), // duplicate within featured slice
         makeArticle({ id: "c2", title: "Cat Two" }),
         makeArticle({ id: "c3", title: "Cat Three" }),
-        makeArticle({ id: "c1", title: "Cat One" }), // duplicate
         makeArticle({ id: "c4", title: "Cat Four" }),
       ],
       hasMore: false,

--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
@@ -49,11 +49,10 @@ export function NewsListingClient({
   const categoryRequestId = useRef(0);
   const isLoadingRef = useRef(false);
   const featuredIdsRef = useRef(new Set(initialFeatured.map((a) => a.id)));
-  const featuredCountRef = useRef(initialFeatured.length);
+  const nextOffsetRef = useRef(initialFeatured.length + initialArticles.length);
 
   useEffect(() => {
     featuredIdsRef.current = new Set(featuredArticles.map((a) => a.id));
-    featuredCountRef.current = featuredArticles.length;
   }, [featuredArticles]);
 
   const loadMore = useCallback(async () => {
@@ -65,7 +64,7 @@ export function NewsListingClient({
 
     try {
       const category = activeCategory === "all" ? undefined : activeCategory;
-      const offset = featuredCountRef.current + gridArticles.length;
+      const offset = nextOffsetRef.current;
 
       const result = await fetchArticles({
         offset,
@@ -83,6 +82,7 @@ export function NewsListingClient({
         ]);
         return [...prev, ...deduplicateById(result.articles, existingIds)];
       });
+      nextOffsetRef.current += result.articles.length;
       setHasMore(result.hasMore);
     } catch (err) {
       if (requestId !== categoryRequestId.current) return;
@@ -100,7 +100,7 @@ export function NewsListingClient({
         setIsLoading(false);
       }
     }
-  }, [hasMore, activeCategory, gridArticles.length, fetchArticles]);
+  }, [hasMore, activeCategory, fetchArticles]);
 
   // Intersection Observer for infinite scroll
   useEffect(() => {
@@ -123,6 +123,7 @@ export function NewsListingClient({
   // Category change handler
   const handleCategoryChange = useCallback(
     async (category: string) => {
+      if (category === activeCategory) return;
       const prevCategory = activeCategory;
       const requestId = ++categoryRequestId.current;
       setActiveCategory(category);
@@ -148,6 +149,7 @@ export function NewsListingClient({
 
         setFeaturedArticles(featured);
         setGridArticles(grid);
+        nextOffsetRef.current = result.articles.length;
         setHasMore(result.hasMore);
 
         // Update URL and scroll only after successful fetch

--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
@@ -5,6 +5,7 @@ import type { ArticleVM } from "@/lib/repositories/article.repository";
 import { NewsCard, CategoryFilters } from "@/components/article";
 import { formatArticleDate } from "@/lib/utils/dates";
 import type { PaginatedArticles } from "./utils";
+import { deduplicateById } from "./utils";
 import { BATCH_SIZE, INITIAL_TOTAL } from "./constants";
 
 interface Category {
@@ -47,6 +48,13 @@ export function NewsListingClient({
   const sentinelRef = useRef<HTMLDivElement>(null);
   const categoryRequestId = useRef(0);
   const isLoadingRef = useRef(false);
+  const featuredIdsRef = useRef(new Set(initialFeatured.map((a) => a.id)));
+  const featuredCountRef = useRef(initialFeatured.length);
+
+  useEffect(() => {
+    featuredIdsRef.current = new Set(featuredArticles.map((a) => a.id));
+    featuredCountRef.current = featuredArticles.length;
+  }, [featuredArticles]);
 
   const loadMore = useCallback(async () => {
     if (!hasMore || isLoadingRef.current) return;
@@ -57,7 +65,7 @@ export function NewsListingClient({
 
     try {
       const category = activeCategory === "all" ? undefined : activeCategory;
-      const offset = featuredArticles.length + gridArticles.length;
+      const offset = featuredCountRef.current + gridArticles.length;
 
       const result = await fetchArticles({
         offset,
@@ -68,7 +76,13 @@ export function NewsListingClient({
       // Discard if a category switch happened while loading
       if (requestId !== categoryRequestId.current) return;
 
-      setGridArticles((prev) => [...prev, ...result.articles]);
+      setGridArticles((prev) => {
+        const existingIds = new Set([
+          ...featuredIdsRef.current,
+          ...prev.map((a) => a.id),
+        ]);
+        return [...prev, ...deduplicateById(result.articles, existingIds)];
+      });
       setHasMore(result.hasMore);
     } catch (err) {
       if (requestId !== categoryRequestId.current) return;
@@ -86,13 +100,7 @@ export function NewsListingClient({
         setIsLoading(false);
       }
     }
-  }, [
-    hasMore,
-    activeCategory,
-    featuredArticles.length,
-    gridArticles.length,
-    fetchArticles,
-  ]);
+  }, [hasMore, activeCategory, gridArticles.length, fetchArticles]);
 
   // Intersection Observer for infinite scroll
   useEffect(() => {
@@ -133,8 +141,10 @@ export function NewsListingClient({
         // Ignore stale responses from superseded category switches
         if (requestId !== categoryRequestId.current) return;
 
-        const featured = result.articles.slice(0, 3);
-        const grid = result.articles.slice(3);
+        const uniqueArticles = deduplicateById(result.articles, new Set());
+        const featured = uniqueArticles.slice(0, 3);
+        const featuredIds = new Set(featured.map((a) => a.id));
+        const grid = deduplicateById(uniqueArticles.slice(3), featuredIds);
 
         setFeaturedArticles(featured);
         setGridArticles(grid);

--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
@@ -45,7 +45,7 @@ export function NewsListingClient({
     message: string;
     retry: () => void;
   } | null>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [sentinelNode, setSentinelNode] = useState<HTMLDivElement | null>(null);
   const categoryRequestId = useRef(0);
   const isLoadingRef = useRef(false);
   const featuredIdsRef = useRef(new Set(initialFeatured.map((a) => a.id)));
@@ -102,10 +102,10 @@ export function NewsListingClient({
     }
   }, [hasMore, activeCategory, fetchArticles]);
 
-  // Intersection Observer for infinite scroll
+  // Intersection Observer for infinite scroll — reattaches whenever the
+  // sentinel DOM node changes (remount via hasMore/isLoading/error toggling).
   useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
+    if (!sentinelNode) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -116,9 +116,9 @@ export function NewsListingClient({
       { rootMargin: "200px" },
     );
 
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadMore]);
+    observer.observe(sentinelNode);
+    return () => observer.unobserve(sentinelNode);
+  }, [sentinelNode, loadMore]);
 
   // Category change handler
   const handleCategoryChange = useCallback(
@@ -277,7 +277,7 @@ export function NewsListingClient({
 
         {/* Intersection Observer sentinel */}
         {hasMore && !isLoading && !error && (
-          <div ref={sentinelRef} className="h-4" aria-hidden="true" />
+          <div ref={setSentinelNode} className="h-4" aria-hidden="true" />
         )}
       </div>
     </div>

--- a/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
+++ b/apps/web/src/app/(main)/nieuws/NewsListingClient.tsx
@@ -144,8 +144,7 @@ export function NewsListingClient({
 
         const uniqueArticles = deduplicateById(result.articles, new Set());
         const featured = uniqueArticles.slice(0, 3);
-        const featuredIds = new Set(featured.map((a) => a.id));
-        const grid = deduplicateById(uniqueArticles.slice(3), featuredIds);
+        const grid = uniqueArticles.slice(3);
 
         setFeaturedArticles(featured);
         setGridArticles(grid);

--- a/apps/web/src/app/(main)/nieuws/utils.test.ts
+++ b/apps/web/src/app/(main)/nieuws/utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { ArticleVM } from "@/lib/repositories/article.repository";
+import { deduplicateById } from "./utils";
+
+function makeArticle(id: string): ArticleVM {
+  return {
+    id,
+    title: `Article ${id}`,
+    slug: `article-${id}`,
+    publishedAt: "2026-03-15T10:00:00Z",
+    featured: false,
+    coverImageUrl: null,
+    tags: [],
+  };
+}
+
+describe("deduplicateById", () => {
+  it("returns all articles when there are no duplicates", () => {
+    const articles = [makeArticle("1"), makeArticle("2"), makeArticle("3")];
+    const result = deduplicateById(articles, new Set());
+    expect(result).toHaveLength(3);
+    expect(result.map((a) => a.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("removes articles whose IDs are in existingIds", () => {
+    const articles = [makeArticle("1"), makeArticle("2"), makeArticle("3")];
+    const result = deduplicateById(articles, new Set(["1", "3"]));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("2");
+  });
+
+  it("removes within-batch duplicates", () => {
+    const articles = [
+      makeArticle("1"),
+      makeArticle("2"),
+      makeArticle("1"),
+      makeArticle("2"),
+    ];
+    const result = deduplicateById(articles, new Set());
+    expect(result).toHaveLength(2);
+    expect(result.map((a) => a.id)).toEqual(["1", "2"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(deduplicateById([], new Set())).toEqual([]);
+    expect(deduplicateById([], new Set(["1", "2"]))).toEqual([]);
+  });
+
+  it("returns empty array when all articles are duplicates", () => {
+    const articles = [makeArticle("1"), makeArticle("2")];
+    const result = deduplicateById(articles, new Set(["1", "2"]));
+    expect(result).toEqual([]);
+  });
+
+  it("does not mutate the existingIds set", () => {
+    const existingIds = new Set(["1"]);
+    deduplicateById([makeArticle("2"), makeArticle("3")], existingIds);
+    expect(existingIds.size).toBe(1);
+  });
+});

--- a/apps/web/src/app/(main)/nieuws/utils.ts
+++ b/apps/web/src/app/(main)/nieuws/utils.ts
@@ -5,6 +5,18 @@ export interface PaginatedArticles {
   hasMore: boolean;
 }
 
+export function deduplicateById(
+  articles: ArticleVM[],
+  existingIds: ReadonlySet<string>,
+): ArticleVM[] {
+  const seen = new Set(existingIds);
+  return articles.filter((a) => {
+    if (seen.has(a.id)) return false;
+    seen.add(a.id);
+    return true;
+  });
+}
+
 export function paginateResults(
   articles: ArticleVM[],
   limit: number,


### PR DESCRIPTION
Closes #1303

## What changed

- Extracted a `deduplicateById` utility to filter articles already shown in the featured section from the paginated grid
- Applied deduplication in `NewsListingClient` when splitting articles into featured vs. grid, and after each infinite-scroll fetch
- Added regression tests for both the utility and the component-level deduplication logic

## Root cause

The featured section (main 2fr card + right-hand 1fr stack) is carved from the same paginated query results as the grid below. The first N articles were displayed in featured slots **and** left in the grid array, causing the latest article to appear twice. The fix filters featured article IDs from the grid before rendering.

## Testing

- All checks pass: `pnpm --filter @kcvv/web check-all`
- Unit tests: `deduplicateById` utility + `NewsListingClient` dedup integration
- Manual: verified no duplicates on default view, category filters, and after infinite-scroll loads