### PR TITLE
fix(ui): prevent page jump to footer on first load (#1313)

### DIFF
--- a/apps/web/src/components/layout/CookieConsentBanner/CookieConsentBanner.tsx
+++ b/apps/web/src/components/layout/CookieConsentBanner/CookieConsentBanner.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect } from "react";
 import * as CookieConsent from "vanilla-cookieconsent";
+// Import the library CSS statically — do NOT switch to a dynamic `import()` inside the effect.
+// CookieConsent.run() injects the modal and focuses its accept button synchronously; if the CSS
+// has not yet resolved, the modal has no `position: fixed` and lives inline at the bottom of the
+// <body>, which causes the browser to scroll-into-view to the footer on first load (issue #1313).
+import "vanilla-cookieconsent/dist/cookieconsent.css";
 import { updateConsentState } from "@/lib/analytics/gtm-consent";
 
 // Tracks whether CookieConsent.run() has resolved; used by CookiePreferencesButton
@@ -16,9 +21,6 @@ function syncConsentState() {
 export function CookieConsentBanner() {
   useEffect(() => {
     let isMounted = true;
-
-    // Dynamically load library CSS — keeps it out of the critical path
-    import("vanilla-cookieconsent/dist/cookieconsent.css");
 
     CookieConsent.run({
       categories: {


### PR DESCRIPTION
## Summary

- Import `vanilla-cookieconsent` CSS statically instead of via dynamic `import()` inside `useEffect`
- Add an inline comment documenting why the static import must stay (prevents reintroduction of the race)

Closes #1313.

## Root cause

`CookieConsent.run()` synchronously injects the consent modal and focuses its accept button. The previous dynamic CSS import raced with that mount — if the CSS had not yet resolved, the modal rendered in normal flow at the bottom of `<body>` (no `position: fixed`), so the browser's scroll-into-view on the focused button jumped the page to the footer.

## Test plan

- [ ] Load a Vercel preview deploy of this branch in a clean browser session (no existing consent cookie) — page must stay at top, cookie banner appears fixed at bottom-right
- [ ] Reload several times to confirm the jump no longer happens intermittently
- [ ] Accept / decline cookies — analytics consent state updates as before
- [ ] Repeat on mobile viewport
- [x] `pnpm --filter @kcvv/web lint` passes
- [x] `pnpm --filter @kcvv/web type-check` passes
- [x] `pnpm --filter @kcvv/web test -- CookieConsentBanner` — 2422 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)