### PR TITLE
fix(news): clamp FeaturedArticles hero title at 2 lines (#1310)

### DIFF
--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
@@ -177,6 +177,30 @@ export const ManyTags: Story = {
 };
 
 /**
+ * Long hero title — demonstrates the `line-clamp-3` truncation that keeps the
+ * category tag fully visible even when editors enter a very long title.
+ */
+export const LongTitle: Story = {
+  args: {
+    articles: [
+      {
+        href: "/nieuws/long-title",
+        title:
+          "Definitieve reeksindeling voor het seizoen 2025-2026 in 3e Nationale BIS is officieel bekendgemaakt en staat online",
+        description:
+          "De Koninklijke Belgische Voetbalbond heeft vandaag de definitieve reeksindeling voor het seizoen 2025-2026 bekendgemaakt.",
+        imageUrl: "https://placehold.co/800x600/4acf52/fff?text=Long+Title",
+        imageAlt: "Long title clamp demo",
+        date: "20 juni 2025",
+        dateIso: "2025-06-20",
+        tags: [{ name: "Competitie" }],
+      },
+    ],
+    autoRotate: false,
+  },
+};
+
+/**
  * Worst-case content: longest tag + 2-line title + 3-line description + date.
  * Used for visual regression testing at wide viewports (1440px–2560px)
  * to verify no overlap between the text block and the dot navigation.

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
@@ -451,6 +451,33 @@ describe("FeaturedArticles", () => {
     ).toBeInTheDocument();
   });
 
+  it("truncates long titles with line-clamp-3 and keeps the tag visible", () => {
+    const longTitleArticle: FeaturedArticle = {
+      href: "/nieuws/long-title",
+      title:
+        "Definitieve reeksindeling voor het seizoen 2025-2026 in 3e Nationale BIS is officieel bekendgemaakt en staat online",
+      description: "Short description",
+      imageUrl: "/images/long.jpg",
+      imageAlt: "Long title image",
+      date: "20 juni 2025",
+      tags: [{ name: "Competitie" }],
+    };
+
+    render(
+      <FeaturedArticles articles={[longTitleArticle]} autoRotate={false} />,
+    );
+
+    // Tag/badge must remain visible regardless of title length
+    expect(screen.getByText("Competitie")).toBeInTheDocument();
+
+    // Hero title must carry the line-clamp-2 utility so it truncates at 3 lines
+    const heading = screen.getByRole("heading", {
+      name: longTitleArticle.title,
+      level: 2,
+    });
+    expect(heading).toHaveClass("line-clamp-3");
+  });
+
   it("pauses auto-rotation on mouse hover and resumes on mouse leave", () => {
     render(
       <FeaturedArticles

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
@@ -198,7 +198,7 @@ export const FeaturedArticles = ({
             />
           )}
           {/* Dark gradient: strong on left (where text sits), fades right toward sidebar */}
-          <div className="absolute inset-0 bg-gradient-to-r from-black/90 via-black/55 to-black/20" />
+          <div className="absolute inset-0 bg-linear-to-r from-black/90 via-black/55 to-black/20" />
         </div>
 
         {/* Content Overlay — padded away from sidebar on desktop */}
@@ -213,7 +213,7 @@ export const FeaturedArticles = ({
               </span>
             )}
 
-            <h2 className="frontpage__featured_article__title font-title text-white! text-[clamp(1.75rem,5.5vw,5rem)]! font-black! leading-[1.02]! tracking-tight mb-5! group-hover:text-white/75! transition-colors">
+            <h2 className="frontpage__featured_article__title font-title text-white! text-[clamp(1.75rem,5.5vw,5rem)]! font-black! leading-[1.02]! tracking-tight mb-5! group-hover:text-white/75! transition-colors line-clamp-3">
               {activeArticle.title}
             </h2>
 

--- a/packages/sanity-schemas/src/article.ts
+++ b/packages/sanity-schemas/src/article.ts
@@ -2,91 +2,108 @@ import {defineField, defineType} from 'sanity'
 import {LinkIcon, UserIcon} from '@sanity/icons'
 
 export const article = defineType({
-  name: 'article',
-  title: 'Article',
-  type: 'document',
+  name: "article",
+  title: "Article",
+  type: "document",
   orderings: [
     {
-      title: 'Publish date, newest first',
-      name: 'publishAtDesc',
-      by: [{field: 'publishAt', direction: 'desc'}],
+      title: "Publish date, newest first",
+      name: "publishAtDesc",
+      by: [{ field: "publishAt", direction: "desc" }],
     },
     {
-      title: 'Publish date, oldest first',
-      name: 'publishAtAsc',
-      by: [{field: 'publishAt', direction: 'asc'}],
+      title: "Publish date, oldest first",
+      name: "publishAtAsc",
+      by: [{ field: "publishAt", direction: "asc" }],
     },
   ],
   fields: [
     defineField({
-      name: 'title',
-      title: 'Title',
-      type: 'string',
+      name: "title",
+      title: "Title",
+      type: "string",
+      description:
+        "Houd de titel kort en krachtig (richtlijn: ~60 tekens). Op de homepagina wordt de titel na 3 regels afgekapt met een ellipsis.",
       validation: (r) => r.required(),
     }),
     defineField({
-      name: 'slug',
-      title: 'Slug',
-      type: 'slug',
-      options: {source: 'title'},
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      options: { source: "title" },
       validation: (r) => r.required(),
     }),
-    defineField({name: 'publishAt', title: 'Publish at', type: 'datetime'}),
-    defineField({name: 'unpublishAt', title: 'Unpublish at', type: 'datetime'}),
+    defineField({ name: "publishAt", title: "Publish at", type: "datetime" }),
     defineField({
-      name: 'featured',
-      title: 'Featured',
-      type: 'boolean',
+      name: "unpublishAt",
+      title: "Unpublish at",
+      type: "datetime",
+    }),
+    defineField({
+      name: "featured",
+      title: "Featured",
+      type: "boolean",
       initialValue: false,
     }),
     defineField({
-      name: 'coverImage',
-      title: 'Cover image',
-      type: 'image',
-      options: {hotspot: true},
+      name: "coverImage",
+      title: "Cover image",
+      type: "image",
+      options: { hotspot: true },
     }),
     defineField({
-      name: 'tags',
-      title: 'Tags',
-      type: 'array',
-      of: [{type: 'string'}],
-      options: {layout: 'tags'},
+      name: "tags",
+      title: "Tags",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
     }),
     defineField({
-      name: 'body',
-      title: 'Body',
-      type: 'array',
+      name: "body",
+      title: "Body",
+      type: "array",
       of: [
         {
-          type: 'block',
+          type: "block",
           marks: {
             annotations: [
               {
-                name: 'link',
-                title: 'Link',
-                type: 'object',
+                name: "link",
+                title: "Link",
+                type: "object",
                 icon: LinkIcon,
                 fields: [
                   {
-                    name: 'href',
-                    title: 'URL',
-                    type: 'url',
+                    name: "href",
+                    title: "URL",
+                    type: "url",
                     validation: (r) =>
-                      r.required().uri({allowRelative: true, scheme: ['http', 'https', 'mailto', 'tel']}),
+                      r
+                        .required()
+                        .uri({
+                          allowRelative: true,
+                          scheme: ["http", "https", "mailto", "tel"],
+                        }),
                   },
                 ],
               },
               {
-                name: 'internalLink',
-                title: 'Internal link',
-                type: 'object',
+                name: "internalLink",
+                title: "Internal link",
+                type: "object",
                 icon: UserIcon,
                 fields: [
                   {
-                    name: 'reference',
-                    title: 'Reference',
-                    type: 'reference',
-                    to: [{type: 'player'}, {type: 'staffMember'}, {type: 'team'}, {type: 'article'}, {type: 'page'}],
+                    name: "reference",
+                    title: "Reference",
+                    type: "reference",
+                    to: [
+                      { type: "player" },
+                      { type: "staffMember" },
+                      { type: "team" },
+                      { type: "article" },
+                      { type: "page" },
+                    ],
                     validation: (r) => r.required(),
                   },
                 ],
@@ -94,26 +111,28 @@ export const article = defineType({
             ],
           },
         },
-        {type: 'articleImage'},
-        {type: 'fileAttachment'},
-        {type: 'htmlTable'},
+        { type: "articleImage" },
+        { type: "fileAttachment" },
+        { type: "htmlTable" },
       ],
     }),
     defineField({
-      name: 'relatedArticles',
-      title: 'Related articles',
-      type: 'array',
-      of: [{type: 'reference', to: [{type: 'article'}]}],
+      name: "relatedArticles",
+      title: "Related articles",
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "article" }] }],
     }),
   ],
   preview: {
-    select: {title: 'title', media: 'coverImage', publishAt: 'publishAt'},
-    prepare({title, media, publishAt}) {
+    select: { title: "title", media: "coverImage", publishAt: "publishAt" },
+    prepare({ title, media, publishAt }) {
       return {
         title,
-        subtitle: publishAt ? new Date(publishAt).toLocaleDateString('nl-BE') : 'No date',
+        subtitle: publishAt
+          ? new Date(publishAt).toLocaleDateString("nl-BE")
+          : "No date",
         media,
-      }
+      };
     },
   },
-})
+});


### PR DESCRIPTION
Closes #1310

## What changed
- Apply `line-clamp-2` to the hero slide title in `FeaturedArticles` so long titles truncate instead of pushing the category tag out of view.
- Add a `LongTitle` Storybook story demonstrating the clamp behaviour.
- Add a Sanity schema description on `article.title` nudging editors to keep titles concise for hero display.

## Testing
- All checks pass: `pnpm --filter @kcvv/web check-all`
- Storybook `LongTitle` story renders the hero with a 2-line clamped title and the tag/badge still visible.