### PR TITLE
feat(matches): empty-state placeholder for homepage matches slider (#1323)

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -44,7 +44,7 @@ De officiële website van KCVV Elewijt: https://www.kcvvelewijt.be
 - Adres: Driesstraat 32, 1982 Elewijt, België
 - Website: https://www.kcvvelewijt.be
 - Facebook: https://www.facebook.com/KCVVElewijt
-- Twitter/X: @kcvve
+- Instagram: https://www.instagram.com/kcvve
 
 ## Wat deze website NIET bevat
 

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -119,8 +119,6 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 
   const shareConfig = {
     url: `${SITE_CONFIG.siteUrl}/nieuws/${article.slug}`,
-    title: article.title,
-    hashtags: tags,
   };
 
   const hasEditorialArticles =

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -45,11 +45,6 @@ export const metadata: Metadata = {
   openGraph: {
     images: [DEFAULT_OG_IMAGE],
   },
-  twitter: {
-    card: "summary_large_image",
-    site: `@${SITE_CONFIG.twitterHandle}`,
-    creator: `@${SITE_CONFIG.twitterHandle}`,
-  },
 };
 
 // Phase 4: Mobile viewport configuration with safe area support

--- a/apps/web/src/app/metadata.test.ts
+++ b/apps/web/src/app/metadata.test.ts
@@ -8,10 +8,6 @@ describe("root layout metadata", () => {
     expect(url.href).toBe("https://www.kcvvelewijt.be/");
   });
 
-  it("SITE_CONFIG.twitterHandle is configured for twitter cards", () => {
-    expect(SITE_CONFIG.twitterHandle).toBe("kcvve");
-  });
-
   it("includes openGraph.images matching DEFAULT_OG_IMAGE in root metadata", () => {
     const og = metadata.openGraph as { images?: unknown[] };
     expect(og.images).toBeDefined();

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -279,6 +279,10 @@ export default async function HomePage() {
         placeholder={matchesSliderPlaceholder}
       />
     ),
+    // SectionHeader contributes mb-10 on top, so the visual top gap reads
+    // larger than the default pt-20/pb-20 symmetry would suggest. Trim the
+    // bottom to compensate.
+    paddingBottom: "pb-16",
   };
 
   const youthSection: SectionConfig = {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -281,7 +281,7 @@ export default async function HomePage() {
     ),
     // The heading's cap-height makes the default pt-20/pb-20 read bottom-tight.
     // Bump the bottom so the cards don't crash into the diagonal.
-    paddingBottom: "pb-24",
+    paddingBottom: "pb-32",
   };
 
   const youthSection: SectionConfig = {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -100,51 +100,63 @@ function buildFeaturedEventStub(event: EventVM): FeaturedEventStub {
 }
 
 export default async function HomePage() {
-  const [articlesResult, matchesResult, eventResult, bannersResult] =
-    await Promise.all([
-      runPromise(
-        Effect.gen(function* () {
-          const repo = yield* ArticleRepository;
-          const all = yield* repo.findAll();
-          return all.slice(0, 9);
-        }).pipe(Effect.catchAll(() => Effect.succeed([]))),
+  const [
+    articlesResult,
+    matchesResult,
+    eventResult,
+    bannersResult,
+    matchesSliderPlaceholderResult,
+  ] = await Promise.all([
+    runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ArticleRepository;
+        const all = yield* repo.findAll();
+        return all.slice(0, 9);
+      }).pipe(Effect.catchAll(() => Effect.succeed([]))),
+    ),
+    runPromise(
+      Effect.gen(function* () {
+        const bff = yield* BffService;
+        return yield* bff.getNextMatches();
+      }).pipe(
+        Effect.catchAll((error) => {
+          console.error("[HomePage] Failed to fetch matches:", error);
+          return Effect.succeed([]);
+        }),
       ),
-      runPromise(
-        Effect.gen(function* () {
-          const bff = yield* BffService;
-          return yield* bff.getNextMatches();
-        }).pipe(
-          Effect.catchAll((error) => {
-            console.error("[HomePage] Failed to fetch matches:", error);
-            return Effect.succeed([]);
+    ),
+    runPromise(
+      Effect.gen(function* () {
+        const repo = yield* EventRepository;
+        return yield* repo.findNextFeatured();
+      }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+    ),
+    runPromise(
+      Effect.gen(function* () {
+        const repo = yield* HomepageRepository;
+        return yield* repo.getBanners();
+      }).pipe(
+        Effect.catchAll(() =>
+          Effect.succeed({
+            bannerSlotA: null,
+            bannerSlotB: null,
+            bannerSlotC: null,
           }),
         ),
       ),
-      runPromise(
-        Effect.gen(function* () {
-          const repo = yield* EventRepository;
-          return yield* repo.findNextFeatured();
-        }).pipe(Effect.catchAll(() => Effect.succeed(null))),
-      ),
-      runPromise(
-        Effect.gen(function* () {
-          const repo = yield* HomepageRepository;
-          return yield* repo.getBanners();
-        }).pipe(
-          Effect.catchAll(() =>
-            Effect.succeed({
-              bannerSlotA: null,
-              bannerSlotB: null,
-              bannerSlotC: null,
-            }),
-          ),
-        ),
-      ),
-    ]);
+    ),
+    runPromise(
+      Effect.gen(function* () {
+        const repo = yield* HomepageRepository;
+        return yield* repo.getPlaceholder();
+      }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+    ),
+  ]);
 
   const articles = articlesResult;
   const matches = matchesResult;
   const banners = bannersResult;
+  const matchesSliderPlaceholder = matchesSliderPlaceholderResult;
 
   const featuredArticles = toHomepageArticles(articles.slice(0, 3));
   const newsGridArticles = toHomepageArticles(articles.slice(3, 9));
@@ -261,7 +273,11 @@ export default async function HomePage() {
     key: "matches-slider",
     bg: "kcvv-black",
     content: (
-      <MatchesSliderSection matches={sliderMatches} highlightTeamId={1235} />
+      <MatchesSliderSection
+        matches={sliderMatches}
+        highlightTeamId={1235}
+        placeholder={matchesSliderPlaceholder}
+      />
     ),
   };
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -279,10 +279,9 @@ export default async function HomePage() {
         placeholder={matchesSliderPlaceholder}
       />
     ),
-    // SectionHeader contributes mb-10 on top, so the visual top gap reads
-    // larger than the default pt-20/pb-20 symmetry would suggest. Trim the
-    // bottom to compensate.
-    paddingBottom: "pb-16",
+    // The heading's cap-height makes the default pt-20/pb-20 read bottom-tight.
+    // Bump the bottom so the cards don't crash into the diagonal.
+    paddingBottom: "pb-24",
   };
 
   const youthSection: SectionConfig = {

--- a/apps/web/src/components/article/Article.stories.tsx
+++ b/apps/web/src/components/article/Article.stories.tsx
@@ -152,8 +152,6 @@ export const Default: Story = {
         category={{ name: "A-Ploeg", href: "/nieuws?categorie=a-ploeg" }}
         shareConfig={{
           url: "https://kcvvelewijt.be/nieuws/overwinning-derby",
-          title: "KCVV Elewijt wint met 3-1 in spannende derby",
-          hashtags: ["kcvv", "derby"],
         }}
       />
 
@@ -207,7 +205,6 @@ export const WithoutImage: Story = {
         category={{ name: "Training", href: "/nieuws?categorie=training" }}
         shareConfig={{
           url: "https://kcvvelewijt.be/nieuws/trainingsschema",
-          title: "Trainingsschema aangepast voor winterstop",
         }}
       />
 
@@ -251,8 +248,6 @@ export const LongArticle: Story = {
         category={{ name: "A-Ploeg", href: "/nieuws?categorie=a-ploeg" }}
         shareConfig={{
           url: "https://kcvvelewijt.be/nieuws/seizoensoverzicht",
-          title: "Seizoensoverzicht 2024-2025: Een analyse van onze prestaties",
-          hashtags: ["kcvv", "analyse", "seizoen"],
         }}
       />
 

--- a/apps/web/src/components/article/ArticleHeader/ArticleHeader.stories.tsx
+++ b/apps/web/src/components/article/ArticleHeader/ArticleHeader.stories.tsx
@@ -68,7 +68,6 @@ export const WithContent: Story = {
         category={{ name: "Transfers", href: "/nieuws?categorie=Transfers" }}
         shareConfig={{
           url: "https://kcvvelewijt.be/nieuws/transfers",
-          title: args.title,
         }}
       />
       <div className="max-w-inner-lg mx-auto px-6 py-8">

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.stories.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.stories.tsx
@@ -46,7 +46,6 @@ export const Default: Story = {
     shareConfig: {
       url: "https://kcvvelewijt.be/nieuws/belangrijke-overwinning",
       title: "KCVV Elewijt behaalt belangrijke overwinning",
-      twitterHandle: "@kcvve",
       hashtags: ["voetbal", "kcvv"],
     },
   },
@@ -98,7 +97,6 @@ export const InContext: Story = {
     shareConfig: {
       url: "https://kcvvelewijt.be/nieuws/nieuwe-speler",
       title: "Nieuwe speler aangekondigd",
-      twitterHandle: "@kcvve",
       hashtags: ["transfer", "kcvv"],
     },
   },

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.stories.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.stories.tsx
@@ -45,8 +45,6 @@ export const Default: Story = {
     category: { name: "Eerste ploeg", href: "/nieuws?categorie=eerste-ploeg" },
     shareConfig: {
       url: "https://kcvvelewijt.be/nieuws/belangrijke-overwinning",
-      title: "KCVV Elewijt behaalt belangrijke overwinning",
-      hashtags: ["voetbal", "kcvv"],
     },
   },
 };
@@ -60,7 +58,6 @@ export const WithoutCategory: Story = {
     date: "12/01/2025",
     shareConfig: {
       url: "https://kcvvelewijt.be/nieuws/test",
-      title: "Test Article",
     },
   },
 };
@@ -96,8 +93,6 @@ export const InContext: Story = {
     category: { name: "Transfer", href: "/nieuws?categorie=transfer" },
     shareConfig: {
       url: "https://kcvvelewijt.be/nieuws/nieuwe-speler",
-      title: "Nieuwe speler aangekondigd",
-      hashtags: ["transfer", "kcvv"],
     },
   },
   render: (args) => (

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
@@ -48,9 +48,15 @@ describe("ArticleMetadata", () => {
 
   it("renders share buttons as icon-only (no text labels)", () => {
     render(<ArticleMetadata {...defaultProps} />);
-    // Should NOT have "Facebook" or "Twitter" text labels
+    // Should NOT have "Facebook" text label
     expect(screen.queryByText("Facebook")).not.toBeInTheDocument();
-    expect(screen.queryByText("Twitter")).not.toBeInTheDocument();
+  });
+
+  it("renders a Facebook share button inside the share section", () => {
+    render(<ArticleMetadata {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: "Delen op Facebook" }),
+    ).toBeInTheDocument();
   });
 
   it("renders share label visible on tablet+ (sr-only on mobile)", () => {

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
@@ -9,7 +9,6 @@ describe("ArticleMetadata", () => {
     category: { name: "Eerste ploeg", href: "/nieuws?categorie=eerste-ploeg" },
     shareConfig: {
       url: "https://kcvvelewijt.be/nieuws/test",
-      title: "Test Article",
     },
   };
 

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
@@ -7,8 +7,8 @@
 
 import Link from "next/link";
 import { Icon } from "@/components/design-system";
-import { Facebook, Twitter } from "@/lib/icons";
-import { FacebookShareButton, TwitterShareButton } from "react-share";
+import { Facebook } from "@/lib/icons";
+import { FacebookShareButton } from "react-share";
 import { cn } from "@/lib/utils/cn";
 
 export interface ArticleMetadataProps {
@@ -25,7 +25,6 @@ export interface ArticleMetadataProps {
   shareConfig?: {
     url: string;
     title: string;
-    twitterHandle?: string;
     hashtags?: string[];
   };
   /** Additional CSS classes */
@@ -93,16 +92,6 @@ export const ArticleMetadata = ({
               >
                 <Icon icon={Facebook} size="xs" />
               </FacebookShareButton>
-              <TwitterShareButton
-                url={shareConfig.url}
-                title={shareConfig.title}
-                via={shareConfig.twitterHandle?.replace("@", "")}
-                hashtags={shareConfig.hashtags}
-                aria-label="Delen op X"
-                className="text-gray-400 hover:text-kcvv-black transition-colors"
-              >
-                <Icon icon={Twitter} size="xs" />
-              </TwitterShareButton>
             </div>
           )}
         </div>

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
@@ -24,8 +24,6 @@ export interface ArticleMetadataProps {
   /** Share configuration */
   shareConfig?: {
     url: string;
-    title: string;
-    hashtags?: string[];
   };
   /** Additional CSS classes */
   className?: string;

--- a/apps/web/src/components/design-system/Icon/Icon.stories.tsx
+++ b/apps/web/src/components/design-system/Icon/Icon.stories.tsx
@@ -14,7 +14,6 @@ import {
   Phone,
   Mail,
   Facebook,
-  Twitter,
   Instagram,
   ArrowRight,
   Search,
@@ -201,7 +200,6 @@ export const SocialIcons: Story = {
   render: () => (
     <div className="flex gap-4">
       <Icon icon={Facebook} size="lg" color="muted" />
-      <Icon icon={Twitter} size="lg" color="muted" />
       <Icon icon={Instagram} size="lg" color="muted" />
     </div>
   ),

--- a/apps/web/src/components/design-system/SocialLinks/SocialLinks.test.tsx
+++ b/apps/web/src/components/design-system/SocialLinks/SocialLinks.test.tsx
@@ -3,10 +3,9 @@ import { render, screen } from "@testing-library/react";
 import { SocialLinks } from "./SocialLinks";
 
 describe("SocialLinks", () => {
-  it("renders all three social links", () => {
+  it("renders Facebook and Instagram social links", () => {
     render(<SocialLinks />);
     expect(screen.getByLabelText("Facebook")).toBeInTheDocument();
-    expect(screen.getByLabelText("Twitter")).toBeInTheDocument();
     expect(screen.getByLabelText("Instagram")).toBeInTheDocument();
   });
 
@@ -25,7 +24,7 @@ describe("SocialLinks", () => {
   it("inline variant has ≥44×44 tap area on each social link", () => {
     render(<SocialLinks variant="inline" />);
     const links = screen.getAllByRole("link");
-    expect(links.length).toBeGreaterThanOrEqual(3);
+    expect(links.length).toBeGreaterThanOrEqual(2);
     for (const link of links) {
       expect(link).toHaveClass("min-h-11", "min-w-11");
     }
@@ -60,14 +59,6 @@ describe("SocialLinks", () => {
     expect(screen.getByLabelText("Facebook")).toHaveAttribute(
       "href",
       "https://facebook.com/KCVVElewijt/",
-    );
-  });
-
-  it("has correct Twitter URL", () => {
-    render(<SocialLinks />);
-    expect(screen.getByLabelText("Twitter")).toHaveAttribute(
-      "href",
-      "https://twitter.com/kcvve",
     );
   });
 

--- a/apps/web/src/components/design-system/SocialLinks/SocialLinks.test.tsx
+++ b/apps/web/src/components/design-system/SocialLinks/SocialLinks.test.tsx
@@ -24,7 +24,7 @@ describe("SocialLinks", () => {
   it("inline variant has ≥44×44 tap area on each social link", () => {
     render(<SocialLinks variant="inline" />);
     const links = screen.getAllByRole("link");
-    expect(links.length).toBeGreaterThanOrEqual(2);
+    expect(links).toHaveLength(2);
     for (const link of links) {
       expect(link).toHaveClass("min-h-11", "min-w-11");
     }

--- a/apps/web/src/components/design-system/SocialLinks/SocialLinks.tsx
+++ b/apps/web/src/components/design-system/SocialLinks/SocialLinks.tsx
@@ -7,7 +7,7 @@
  */
 
 import { Icon } from "@/components/design-system";
-import { Facebook, Twitter, Instagram } from "@/lib/icons";
+import { Facebook, Instagram } from "@/lib/icons";
 import { cn } from "@/lib/utils/cn";
 
 export interface SocialLinksProps {
@@ -36,11 +36,6 @@ const socialLinks = [
     name: "Facebook",
     url: "https://facebook.com/KCVVElewijt/",
     icon: Facebook,
-  },
-  {
-    name: "Twitter",
-    url: "https://twitter.com/kcvve",
-    icon: Twitter,
   },
   {
     name: "Instagram",

--- a/apps/web/src/components/design-system/SocialLinks/SocialLinks.tsx
+++ b/apps/web/src/components/design-system/SocialLinks/SocialLinks.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Icon } from "@/components/design-system";
+import { EXTERNAL_LINKS } from "@/lib/constants";
 import { Facebook, Instagram } from "@/lib/icons";
 import { cn } from "@/lib/utils/cn";
 
@@ -32,16 +33,8 @@ export interface SocialLinksProps {
 }
 
 const socialLinks = [
-  {
-    name: "Facebook",
-    url: "https://facebook.com/KCVVElewijt/",
-    icon: Facebook,
-  },
-  {
-    name: "Instagram",
-    url: "https://www.instagram.com/kcvve",
-    icon: Instagram,
-  },
+  { name: "Facebook", url: EXTERNAL_LINKS.facebook, icon: Facebook },
+  { name: "Instagram", url: EXTERNAL_LINKS.instagram, icon: Instagram },
 ];
 
 /**

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.stories.tsx
@@ -177,6 +177,30 @@ export const ManyTags: Story = {
 };
 
 /**
+ * Long hero title — demonstrates the `line-clamp-3` truncation that keeps the
+ * category tag fully visible even when editors enter a very long title.
+ */
+export const LongTitle: Story = {
+  args: {
+    articles: [
+      {
+        href: "/nieuws/long-title",
+        title:
+          "Definitieve reeksindeling voor het seizoen 2025-2026 in 3e Nationale BIS is officieel bekendgemaakt en staat online",
+        description:
+          "De Koninklijke Belgische Voetbalbond heeft vandaag de definitieve reeksindeling voor het seizoen 2025-2026 bekendgemaakt.",
+        imageUrl: "https://placehold.co/800x600/4acf52/fff?text=Long+Title",
+        imageAlt: "Long title clamp demo",
+        date: "20 juni 2025",
+        dateIso: "2025-06-20",
+        tags: [{ name: "Competitie" }],
+      },
+    ],
+    autoRotate: false,
+  },
+};
+
+/**
  * Worst-case content: longest tag + 2-line title + 3-line description + date.
  * Used for visual regression testing at wide viewports (1440px–2560px)
  * to verify no overlap between the text block and the dot navigation.

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
@@ -470,7 +470,7 @@ describe("FeaturedArticles", () => {
     // Tag/badge must remain visible regardless of title length
     expect(screen.getByText("Competitie")).toBeInTheDocument();
 
-    // Hero title must carry the line-clamp-2 utility so it truncates at 3 lines
+    // Hero title must carry the line-clamp-3 utility so it truncates at 3 lines
     const heading = screen.getByRole("heading", {
       name: longTitleArticle.title,
       level: 2,

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.test.tsx
@@ -451,6 +451,33 @@ describe("FeaturedArticles", () => {
     ).toBeInTheDocument();
   });
 
+  it("truncates long titles with line-clamp-3 and keeps the tag visible", () => {
+    const longTitleArticle: FeaturedArticle = {
+      href: "/nieuws/long-title",
+      title:
+        "Definitieve reeksindeling voor het seizoen 2025-2026 in 3e Nationale BIS is officieel bekendgemaakt en staat online",
+      description: "Short description",
+      imageUrl: "/images/long.jpg",
+      imageAlt: "Long title image",
+      date: "20 juni 2025",
+      tags: [{ name: "Competitie" }],
+    };
+
+    render(
+      <FeaturedArticles articles={[longTitleArticle]} autoRotate={false} />,
+    );
+
+    // Tag/badge must remain visible regardless of title length
+    expect(screen.getByText("Competitie")).toBeInTheDocument();
+
+    // Hero title must carry the line-clamp-2 utility so it truncates at 3 lines
+    const heading = screen.getByRole("heading", {
+      name: longTitleArticle.title,
+      level: 2,
+    });
+    expect(heading).toHaveClass("line-clamp-3");
+  });
+
   it("pauses auto-rotation on mouse hover and resumes on mouse leave", () => {
     render(
       <FeaturedArticles

--- a/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
+++ b/apps/web/src/components/home/FeaturedArticles/FeaturedArticles.tsx
@@ -198,7 +198,7 @@ export const FeaturedArticles = ({
             />
           )}
           {/* Dark gradient: strong on left (where text sits), fades right toward sidebar */}
-          <div className="absolute inset-0 bg-gradient-to-r from-black/90 via-black/55 to-black/20" />
+          <div className="absolute inset-0 bg-linear-to-r from-black/90 via-black/55 to-black/20" />
         </div>
 
         {/* Content Overlay — padded away from sidebar on desktop */}
@@ -213,7 +213,7 @@ export const FeaturedArticles = ({
               </span>
             )}
 
-            <h2 className="frontpage__featured_article__title font-title text-white! text-[clamp(1.75rem,5.5vw,5rem)]! font-black! leading-[1.02]! tracking-tight mb-5! group-hover:text-white/75! transition-colors">
+            <h2 className="frontpage__featured_article__title font-title text-white! text-[clamp(1.75rem,5.5vw,5rem)]! font-black! leading-[1.02]! tracking-tight mb-5! group-hover:text-white/75! transition-colors line-clamp-3">
               {activeArticle.title}
             </h2>
 

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { MatchesSliderEmptyState } from "./MatchesSliderEmptyState";
 
 const meta = {
-  title: "Features/Home/MatchesSliderEmptyState",
+  title: "Features/Homepage/MatchesSliderEmptyState",
   component: MatchesSliderEmptyState,
   tags: ["autodocs"],
   parameters: {
@@ -23,14 +23,4 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SplitBaseline: Story = {
-  args: {
-    layout: "split",
-  },
-};
-
-export const CenteredBaseline: Story = {
-  args: {
-    layout: "centered",
-  },
-};
+export const Baseline: Story = {};

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
@@ -61,11 +61,20 @@ export const Announcement: Story = {
   },
 };
 
-export const AnnouncementWithLink: Story = {
+export const AnnouncementWithExternalLink: Story = {
   args: {
     placeholder: {
       announcementText: "Kalender 25-26 volgende week online",
       announcementHref: "https://www.kcvvelewijt.be/kalender",
+    },
+  },
+};
+
+export const AnnouncementWithInternalLink: Story = {
+  args: {
+    placeholder: {
+      announcementText: "Kalender 25-26 volgende week online",
+      announcementHref: "/kalender",
     },
   },
 };

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { MatchesSliderEmptyState } from "./MatchesSliderEmptyState";
+
+const meta = {
+  title: "Features/Home/MatchesSliderEmptyState",
+  component: MatchesSliderEmptyState,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <section className="bg-kcvv-black py-16">
+        <div className="mx-auto max-w-7xl px-4 md:px-8">
+          <Story />
+        </div>
+      </section>
+    ),
+  ],
+} satisfies Meta<typeof MatchesSliderEmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SplitBaseline: Story = {
+  args: {
+    layout: "split",
+  },
+};
+
+export const CenteredBaseline: Story = {
+  args: {
+    layout: "centered",
+  },
+};

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.stories.tsx
@@ -23,4 +23,84 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const inDays = (n: number) =>
+  new Date(new Date().setUTCHours(0, 0, 0, 0) + n * MS_PER_DAY);
+
 export const Baseline: Story = {};
+
+export const Countdown: Story = {
+  args: {
+    placeholder: {
+      nextSeasonKickoff: inDays(70),
+    },
+  },
+};
+
+export const CountdownOneDay: Story = {
+  args: {
+    placeholder: {
+      nextSeasonKickoff: inDays(1),
+    },
+  },
+};
+
+export const CountdownToday: Story = {
+  args: {
+    placeholder: {
+      nextSeasonKickoff: inDays(0),
+    },
+  },
+};
+
+export const Announcement: Story = {
+  args: {
+    placeholder: {
+      announcementText: "Kalender 25-26 volgende week online",
+    },
+  },
+};
+
+export const AnnouncementWithLink: Story = {
+  args: {
+    placeholder: {
+      announcementText: "Kalender 25-26 volgende week online",
+      announcementHref: "https://www.kcvvelewijt.be/kalender",
+    },
+  },
+};
+
+export const CountdownAndAnnouncement: Story = {
+  args: {
+    placeholder: {
+      nextSeasonKickoff: inDays(70),
+      announcementText: "Abonnementen nu verkrijgbaar in het secretariaat",
+    },
+  },
+};
+
+export const CustomImage: Story = {
+  args: {
+    placeholder: {
+      nextSeasonKickoff: inDays(45),
+      highlightImage: {
+        alt: "Supporters juichen langs de lijn",
+        url: "/images/youth-trainers.jpg",
+      },
+    },
+  },
+};
+
+export const AllFieldsPopulated: Story = {
+  args: {
+    placeholder: {
+      nextSeasonKickoff: inDays(45),
+      announcementText: "Abonnementen nu verkrijgbaar in het secretariaat",
+      announcementHref: "https://www.kcvvelewijt.be/tickets",
+      highlightImage: {
+        alt: "Supporters juichen langs de lijn",
+        url: "/images/youth-trainers.jpg",
+      },
+    },
+  },
+};

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
@@ -2,10 +2,13 @@ import Image from "next/image";
 import { getButtonClasses } from "@/components/design-system/Button/button-styles";
 import { ExternalLink, Facebook } from "@/lib/icons";
 import { EXTERNAL_LINKS } from "@/lib/constants";
+import { formatMatchDate } from "@/lib/utils/dates";
 import { cn } from "@/lib/utils/cn";
 import type { MatchesSliderPlaceholderVM } from "@/lib/repositories/homepage.repository";
+import { resolveContent, type ResolvedContent } from "./decisionRule";
 
 const DEFAULT_IMAGE_SRC = "/images/youth-trainers.jpg";
+const MOTTO = "Er is maar één plezante compagnie";
 
 export interface MatchesSliderEmptyStateProps {
   placeholder?: MatchesSliderPlaceholderVM | null;
@@ -13,10 +16,13 @@ export interface MatchesSliderEmptyStateProps {
 }
 
 export const MatchesSliderEmptyState = ({
+  placeholder,
   className,
 }: MatchesSliderEmptyStateProps) => {
-  // TODO(Task 11): decision rule (countdown/announcement/baseline)
-  // TODO(Task 12): render countdown + announcement modes + custom image override
+  const content = resolveContent(placeholder);
+  const image = placeholder?.highlightImage;
+  const imageSrc = image?.url ?? DEFAULT_IMAGE_SRC;
+  const imageAlt = image?.alt ?? "";
 
   return (
     <div
@@ -27,8 +33,8 @@ export const MatchesSliderEmptyState = ({
     >
       <div className="relative aspect-video w-full max-w-sm overflow-hidden rounded-xl">
         <Image
-          src={DEFAULT_IMAGE_SRC}
-          alt=""
+          src={imageSrc}
+          alt={imageAlt}
           fill
           sizes="(max-width: 768px) 100vw, 640px"
           className="object-cover"
@@ -36,43 +42,131 @@ export const MatchesSliderEmptyState = ({
       </div>
 
       <span className="text-xs font-semibold uppercase tracking-[0.15em] text-kcvv-green-bright md:text-sm">
-        TUSSENSEIZOEN
+        {content.eyebrow}
       </span>
-      <p className="font-title text-3xl font-black leading-tight tracking-tight text-white md:text-5xl lg:text-6xl">
-        Er is maar één plezante compagnie
-      </p>
-      <p className="text-base leading-relaxed text-white/70 md:text-lg">
-        We zijn terug in juli!
-      </p>
 
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <a
-          href={EXTERNAL_LINKS.psdDashboard}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cn(
-            getButtonClasses({ variant: "primary" }),
-            "whitespace-nowrap",
-          )}
-          aria-label="Bekijk op PSD (opent in nieuw tabblad)"
-        >
-          Bekijk op PSD
-          <ExternalLink size={16} aria-hidden="true" />
-        </a>
-        <a
-          href={EXTERNAL_LINKS.facebook}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={cn(
-            getButtonClasses({ variant: "ghost" }),
-            "whitespace-nowrap",
-          )}
-          aria-label="Volg ons op Facebook (opent in nieuw tabblad)"
-        >
-          <Facebook size={16} aria-hidden="true" />
-          Volg ons op Facebook
-        </a>
-      </div>
+      <MainLines content={content} />
+
+      <CTAButtons />
     </div>
   );
 };
+
+const MainLines = ({ content }: { content: ResolvedContent }) => {
+  switch (content.mode) {
+    case "baseline":
+      return (
+        <>
+          <Title>{MOTTO}</Title>
+          <Secondary>We zijn terug in juli!</Secondary>
+        </>
+      );
+    case "countdown": {
+      const dayWord = content.daysUntil === 1 ? "dag" : "dagen";
+      const dateLabel = formatMatchDate(content.kickoffDate);
+      return (
+        <>
+          <Title
+            aria-label={`Nog ${content.daysUntil} ${dayWord} tot het nieuwe seizoen, aftrap op ${dateLabel}`}
+          >
+            Nog{" "}
+            <strong className="text-kcvv-green-bright">
+              {content.daysUntil} {dayWord}
+            </strong>{" "}
+            tot het nieuwe seizoen
+          </Title>
+          <Secondary>Aftrap op {dateLabel}</Secondary>
+          {content.secondary && <AnnouncementNote text={content.secondary} />}
+        </>
+      );
+    }
+    case "today": {
+      const dateLabel = formatMatchDate(content.kickoffDate);
+      return (
+        <>
+          <Title
+            aria-label={`Het seizoen start vandaag, aftrap op ${dateLabel}`}
+          >
+            Het seizoen start{" "}
+            <strong className="text-kcvv-green-bright">vandaag!</strong>
+          </Title>
+          <Secondary>Aftrap op {dateLabel}</Secondary>
+          {content.secondary && <AnnouncementNote text={content.secondary} />}
+        </>
+      );
+    }
+    case "announcement":
+      return (
+        <>
+          <Title>{content.text}</Title>
+          <Secondary>{MOTTO}</Secondary>
+          {content.href && (
+            <a
+              href={content.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-semibold text-kcvv-green-bright underline-offset-4 hover:underline"
+            >
+              Meer info
+            </a>
+          )}
+        </>
+      );
+  }
+};
+
+const Title = ({
+  children,
+  "aria-label": ariaLabel,
+}: {
+  children: React.ReactNode;
+  "aria-label"?: string;
+}) => (
+  <p
+    className="font-title text-3xl font-black leading-tight tracking-tight text-white md:text-5xl lg:text-6xl"
+    aria-label={ariaLabel}
+  >
+    {children}
+  </p>
+);
+
+const Secondary = ({ children }: { children: React.ReactNode }) => (
+  <p className="text-base leading-relaxed text-white/70 md:text-lg">
+    {children}
+  </p>
+);
+
+const AnnouncementNote = ({ text }: { text: string }) => (
+  <p className="text-sm text-white/60 md:text-base">{text}</p>
+);
+
+const CTAButtons = () => (
+  <div className="flex flex-col gap-3 sm:flex-row">
+    <a
+      href={EXTERNAL_LINKS.psdDashboard}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        getButtonClasses({ variant: "primary" }),
+        "whitespace-nowrap",
+      )}
+      aria-label="Bekijk op PSD (opent in nieuw tabblad)"
+    >
+      Bekijk op PSD
+      <ExternalLink size={16} aria-hidden="true" />
+    </a>
+    <a
+      href={EXTERNAL_LINKS.facebook}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        getButtonClasses({ variant: "ghost" }),
+        "whitespace-nowrap",
+      )}
+      aria-label="Volg ons op Facebook (opent in nieuw tabblad)"
+    >
+      <Facebook size={16} aria-hidden="true" />
+      Volg ons op Facebook
+    </a>
+  </div>
+);

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
@@ -112,8 +112,16 @@ const MainLines = ({ content }: { content: ResolvedContent }) => {
           )}
         </>
       );
+    default:
+      return assertUnreachable(content);
   }
 };
+
+function assertUnreachable(x: never): never {
+  throw new Error(
+    `Unhandled MatchesSliderEmptyState mode: ${JSON.stringify(x)}`,
+  );
+}
 
 const Title = ({
   children,
@@ -122,12 +130,14 @@ const Title = ({
   children: React.ReactNode;
   "aria-label"?: string;
 }) => (
-  <p
+  // h3 sits under the SectionHeader's h2 ("Wedstrijden"), giving the empty
+  // state a proper outline entry without duplicating the section heading.
+  <h3
     className="font-title text-3xl font-black leading-tight tracking-tight text-white md:text-5xl lg:text-6xl"
     aria-label={ariaLabel}
   >
     {children}
-  </p>
+  </h3>
 );
 
 const Secondary = ({ children }: { children: React.ReactNode }) => (

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
@@ -1,0 +1,133 @@
+import Image from "next/image";
+import { getButtonClasses } from "@/components/design-system/Button/button-styles";
+import { ExternalLink, Facebook } from "@/lib/icons";
+import { EXTERNAL_LINKS } from "@/lib/constants";
+import { cn } from "@/lib/utils/cn";
+import type { MatchesSliderPlaceholderVM } from "@/lib/repositories/homepage.repository";
+
+const DEFAULT_IMAGE_SRC = "/images/youth-trainers.jpg";
+
+export type MatchesSliderEmptyStateLayout = "split" | "centered";
+
+export interface MatchesSliderEmptyStateProps {
+  placeholder?: MatchesSliderPlaceholderVM | null;
+  layout?: MatchesSliderEmptyStateLayout;
+  className?: string;
+}
+
+export const MatchesSliderEmptyState = ({
+  layout = "split",
+  className,
+}: MatchesSliderEmptyStateProps) => {
+  // TODO(Task 11): decision rule (countdown/announcement/baseline)
+  // TODO(Task 12): render countdown + announcement modes + custom image override
+
+  return layout === "split" ? (
+    <SplitLayout className={className} />
+  ) : (
+    <CenteredLayout className={className} />
+  );
+};
+
+const SplitLayout = ({ className }: { className?: string }) => (
+  <div
+    className={cn("grid grid-cols-1 gap-6 md:grid-cols-3 md:gap-8", className)}
+  >
+    <div className="relative aspect-video overflow-hidden rounded-xl md:col-span-2">
+      <Image
+        src={DEFAULT_IMAGE_SRC}
+        alt=""
+        fill
+        sizes="(max-width: 768px) 100vw, 66vw"
+        className="object-cover"
+      />
+    </div>
+
+    <div className="flex flex-col justify-center gap-4 md:col-span-1">
+      <EmptyStateContent />
+      <CTAButtons />
+    </div>
+  </div>
+);
+
+const CenteredLayout = ({ className }: { className?: string }) => (
+  <div
+    className={cn(
+      "mx-auto flex max-w-2xl flex-col gap-6 py-8 text-center",
+      className,
+    )}
+  >
+    <div className="relative mx-auto aspect-video w-full max-w-sm overflow-hidden rounded-xl">
+      <Image
+        src={DEFAULT_IMAGE_SRC}
+        alt=""
+        fill
+        sizes="(max-width: 768px) 100vw, 640px"
+        className="object-cover"
+      />
+    </div>
+
+    <div className="flex flex-col items-center gap-4">
+      <EmptyStateContent centered />
+      <CTAButtons centered />
+    </div>
+  </div>
+);
+
+const EmptyStateContent = ({ centered = false }: { centered?: boolean }) => (
+  <>
+    <span
+      className={cn(
+        "text-xs font-semibold uppercase tracking-[0.15em] text-kcvv-green-bright md:text-sm",
+      )}
+    >
+      TUSSENSEIZOEN
+    </span>
+    <p
+      className={cn(
+        "text-2xl font-bold leading-tight text-white md:text-4xl lg:text-5xl",
+        centered && "text-center",
+      )}
+    >
+      Er is maar één plezante compagnie
+    </p>
+    <p
+      className={cn(
+        "text-base leading-relaxed text-white/70 md:text-lg",
+        centered && "text-center",
+      )}
+    >
+      We zijn terug in juli!
+    </p>
+  </>
+);
+
+const CTAButtons = ({ centered = false }: { centered?: boolean }) => (
+  <div
+    className={cn(
+      "flex flex-col gap-3 sm:flex-row",
+      centered && "justify-center",
+    )}
+  >
+    <a
+      href={EXTERNAL_LINKS.psdDashboard}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={getButtonClasses({ variant: "primary" })}
+      aria-label="Bekijk op PSD (opent in nieuw tabblad)"
+    >
+      Bekijk op PSD
+      <ExternalLink size={16} aria-hidden="true" />
+    </a>
+    <a
+      href={EXTERNAL_LINKS.facebook}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={getButtonClasses({ variant: "ghost" })}
+      aria-label="Volg ons op Facebook (opent in nieuw tabblad)"
+    >
+      <Facebook size={16} aria-hidden="true" />
+      Volg ons op Facebook
+    </a>
+  </div>
+);

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { getButtonClasses } from "@/components/design-system/Button/button-styles";
 import { ExternalLink, Facebook } from "@/lib/icons";
 import { EXTERNAL_LINKS } from "@/lib/constants";
@@ -100,16 +101,7 @@ const MainLines = ({ content }: { content: ResolvedContent }) => {
         <>
           <Title>{content.text}</Title>
           <Secondary>{MOTTO}</Secondary>
-          {content.href && (
-            <a
-              href={content.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm font-semibold text-kcvv-green-bright underline-offset-4 hover:underline"
-            >
-              Meer info
-            </a>
-          )}
+          {content.href && <AnnouncementLink href={content.href} />}
         </>
       );
     default:
@@ -149,6 +141,33 @@ const Secondary = ({ children }: { children: React.ReactNode }) => (
 const AnnouncementNote = ({ text }: { text: string }) => (
   <p className="text-sm text-white/60 md:text-base">{text}</p>
 );
+
+// Sanity's announcementHref allows relative URLs (allowRelative: true).
+// Render internal paths via next/link for client-side navigation +
+// prefetching; external URLs get the standard new-tab anchor.
+const AnnouncementLink = ({ href }: { href: string }) => {
+  const linkClasses =
+    "text-sm font-semibold text-kcvv-green-bright underline-offset-4 hover:underline";
+
+  if (href.startsWith("/")) {
+    return (
+      <Link href={href} className={linkClasses}>
+        Meer info
+      </Link>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={linkClasses}
+    >
+      Meer info
+    </a>
+  );
+};
 
 const CTAButtons = () => (
   <div className="flex flex-col gap-3 sm:flex-row">

--- a/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/MatchesSliderEmptyState.tsx
@@ -7,127 +7,72 @@ import type { MatchesSliderPlaceholderVM } from "@/lib/repositories/homepage.rep
 
 const DEFAULT_IMAGE_SRC = "/images/youth-trainers.jpg";
 
-export type MatchesSliderEmptyStateLayout = "split" | "centered";
-
 export interface MatchesSliderEmptyStateProps {
   placeholder?: MatchesSliderPlaceholderVM | null;
-  layout?: MatchesSliderEmptyStateLayout;
   className?: string;
 }
 
 export const MatchesSliderEmptyState = ({
-  layout = "split",
   className,
 }: MatchesSliderEmptyStateProps) => {
   // TODO(Task 11): decision rule (countdown/announcement/baseline)
   // TODO(Task 12): render countdown + announcement modes + custom image override
 
-  return layout === "split" ? (
-    <SplitLayout className={className} />
-  ) : (
-    <CenteredLayout className={className} />
+  return (
+    <div
+      className={cn(
+        "mx-auto flex max-w-2xl flex-col items-center gap-6 py-8 text-center",
+        className,
+      )}
+    >
+      <div className="relative aspect-video w-full max-w-sm overflow-hidden rounded-xl">
+        <Image
+          src={DEFAULT_IMAGE_SRC}
+          alt=""
+          fill
+          sizes="(max-width: 768px) 100vw, 640px"
+          className="object-cover"
+        />
+      </div>
+
+      <span className="text-xs font-semibold uppercase tracking-[0.15em] text-kcvv-green-bright md:text-sm">
+        TUSSENSEIZOEN
+      </span>
+      <p className="font-title text-3xl font-black leading-tight tracking-tight text-white md:text-5xl lg:text-6xl">
+        Er is maar één plezante compagnie
+      </p>
+      <p className="text-base leading-relaxed text-white/70 md:text-lg">
+        We zijn terug in juli!
+      </p>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <a
+          href={EXTERNAL_LINKS.psdDashboard}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            getButtonClasses({ variant: "primary" }),
+            "whitespace-nowrap",
+          )}
+          aria-label="Bekijk op PSD (opent in nieuw tabblad)"
+        >
+          Bekijk op PSD
+          <ExternalLink size={16} aria-hidden="true" />
+        </a>
+        <a
+          href={EXTERNAL_LINKS.facebook}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            getButtonClasses({ variant: "ghost" }),
+            "whitespace-nowrap",
+          )}
+          aria-label="Volg ons op Facebook (opent in nieuw tabblad)"
+        >
+          <Facebook size={16} aria-hidden="true" />
+          Volg ons op Facebook
+        </a>
+      </div>
+    </div>
   );
 };
-
-const SplitLayout = ({ className }: { className?: string }) => (
-  <div
-    className={cn("grid grid-cols-1 gap-6 md:grid-cols-3 md:gap-8", className)}
-  >
-    <div className="relative aspect-video overflow-hidden rounded-xl md:col-span-2">
-      <Image
-        src={DEFAULT_IMAGE_SRC}
-        alt=""
-        fill
-        sizes="(max-width: 768px) 100vw, 66vw"
-        className="object-cover"
-      />
-    </div>
-
-    <div className="flex flex-col justify-center gap-4 md:col-span-1">
-      <EmptyStateContent />
-      <CTAButtons />
-    </div>
-  </div>
-);
-
-const CenteredLayout = ({ className }: { className?: string }) => (
-  <div
-    className={cn(
-      "mx-auto flex max-w-2xl flex-col gap-6 py-8 text-center",
-      className,
-    )}
-  >
-    <div className="relative mx-auto aspect-video w-full max-w-sm overflow-hidden rounded-xl">
-      <Image
-        src={DEFAULT_IMAGE_SRC}
-        alt=""
-        fill
-        sizes="(max-width: 768px) 100vw, 640px"
-        className="object-cover"
-      />
-    </div>
-
-    <div className="flex flex-col items-center gap-4">
-      <EmptyStateContent centered />
-      <CTAButtons centered />
-    </div>
-  </div>
-);
-
-const EmptyStateContent = ({ centered = false }: { centered?: boolean }) => (
-  <>
-    <span
-      className={cn(
-        "text-xs font-semibold uppercase tracking-[0.15em] text-kcvv-green-bright md:text-sm",
-      )}
-    >
-      TUSSENSEIZOEN
-    </span>
-    <p
-      className={cn(
-        "text-2xl font-bold leading-tight text-white md:text-4xl lg:text-5xl",
-        centered && "text-center",
-      )}
-    >
-      Er is maar één plezante compagnie
-    </p>
-    <p
-      className={cn(
-        "text-base leading-relaxed text-white/70 md:text-lg",
-        centered && "text-center",
-      )}
-    >
-      We zijn terug in juli!
-    </p>
-  </>
-);
-
-const CTAButtons = ({ centered = false }: { centered?: boolean }) => (
-  <div
-    className={cn(
-      "flex flex-col gap-3 sm:flex-row",
-      centered && "justify-center",
-    )}
-  >
-    <a
-      href={EXTERNAL_LINKS.psdDashboard}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={getButtonClasses({ variant: "primary" })}
-      aria-label="Bekijk op PSD (opent in nieuw tabblad)"
-    >
-      Bekijk op PSD
-      <ExternalLink size={16} aria-hidden="true" />
-    </a>
-    <a
-      href={EXTERNAL_LINKS.facebook}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={getButtonClasses({ variant: "ghost" })}
-      aria-label="Volg ons op Facebook (opent in nieuw tabblad)"
-    >
-      <Facebook size={16} aria-hidden="true" />
-      Volg ons op Facebook
-    </a>
-  </div>
-);

--- a/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.test.ts
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { resolveContent } from "./decisionRule";
+
+describe("resolveContent", () => {
+  const now = new Date("2026-06-01T12:00:00Z");
+
+  it("returns motto baseline when no placeholder data", () => {
+    const result = resolveContent(undefined, now);
+    expect(result).toEqual({
+      mode: "baseline",
+      eyebrow: "TUSSENSEIZOEN",
+    });
+  });
+
+  it("returns motto baseline when placeholder has no actionable fields", () => {
+    const result = resolveContent({}, now);
+    expect(result.mode).toBe("baseline");
+  });
+
+  it("returns countdown when future kickoff date is set", () => {
+    const result = resolveContent(
+      { nextSeasonKickoff: new Date("2026-08-10T00:00:00Z") },
+      now,
+    );
+    expect(result.mode).toBe("countdown");
+    if (result.mode !== "countdown") return;
+    expect(result.eyebrow).toBe("NIEUW SEIZOEN");
+    expect(result.daysUntil).toBe(70);
+  });
+
+  it("treats past kickoff date as unset (falls back to baseline)", () => {
+    const result = resolveContent(
+      { nextSeasonKickoff: new Date("2026-05-01T00:00:00Z") },
+      now,
+    );
+    expect(result.mode).toBe("baseline");
+  });
+
+  it("countdown with daysUntil === 1 is still countdown mode", () => {
+    const result = resolveContent(
+      { nextSeasonKickoff: new Date("2026-06-02T00:00:00Z") },
+      now,
+    );
+    expect(result.mode).toBe("countdown");
+    if (result.mode !== "countdown") return;
+    expect(result.daysUntil).toBe(1);
+  });
+
+  it("daysUntil === 0 switches to 'today' mode", () => {
+    const result = resolveContent(
+      { nextSeasonKickoff: new Date("2026-06-01T00:00:00Z") },
+      now,
+    );
+    expect(result.mode).toBe("today");
+  });
+
+  it("returns announcement when only announcementText is set", () => {
+    const result = resolveContent(
+      { announcementText: "Kalender volgende week online" },
+      now,
+    );
+    expect(result.mode).toBe("announcement");
+    if (result.mode !== "announcement") return;
+    expect(result.eyebrow).toBe("MEDEDELING");
+    expect(result.text).toBe("Kalender volgende week online");
+  });
+
+  it("announcement preserves optional href", () => {
+    const result = resolveContent(
+      {
+        announcementText: "Kalender",
+        announcementHref: "https://example.com",
+      },
+      now,
+    );
+    if (result.mode !== "announcement")
+      throw new Error("expected announcement");
+    expect(result.href).toBe("https://example.com");
+  });
+
+  it("countdown takes precedence over announcement", () => {
+    const result = resolveContent(
+      {
+        nextSeasonKickoff: new Date("2026-08-10T00:00:00Z"),
+        announcementText: "Kalender volgende week online",
+      },
+      now,
+    );
+    expect(result.mode).toBe("countdown");
+    if (result.mode !== "countdown") return;
+    expect(result.secondary).toBe("Kalender volgende week online");
+  });
+
+  it("today mode carries announcement as secondary when both set", () => {
+    const result = resolveContent(
+      {
+        nextSeasonKickoff: new Date("2026-06-01T00:00:00Z"),
+        announcementText: "Succes!",
+      },
+      now,
+    );
+    expect(result.mode).toBe("today");
+    if (result.mode !== "today") return;
+    expect(result.secondary).toBe("Succes!");
+  });
+});

--- a/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.test.ts
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.test.ts
@@ -91,6 +91,17 @@ describe("resolveContent", () => {
     expect(result.secondary).toBe("Kalender volgende week online");
   });
 
+  it("anchors the day diff to Europe/Brussels, not UTC", () => {
+    // 22:30 UTC on 2026-08-09 is already 00:30 Brussels on 2026-08-10 (CEST, UTC+2).
+    // A Brussels user sees "seizoen start vandaag" rather than "Nog 1 dag".
+    const lateNightNow = new Date("2026-08-09T22:30:00Z");
+    const result = resolveContent(
+      { nextSeasonKickoff: new Date("2026-08-10T00:00:00Z") },
+      lateNightNow,
+    );
+    expect(result.mode).toBe("today");
+  });
+
   it("today mode carries announcement as secondary when both set", () => {
     const result = resolveContent(
       {

--- a/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.ts
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.ts
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import type { MatchesSliderPlaceholderVM } from "@/lib/repositories/homepage.repository";
 
 export type ResolvedContent =
@@ -22,20 +23,14 @@ export type ResolvedContent =
       href?: string;
     };
 
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const CLUB_ZONE = "Europe/Brussels";
 
-function calendarDaysBetween(from: Date, to: Date): number {
-  const fromUtc = Date.UTC(
-    from.getUTCFullYear(),
-    from.getUTCMonth(),
-    from.getUTCDate(),
-  );
-  const toUtc = Date.UTC(
-    to.getUTCFullYear(),
-    to.getUTCMonth(),
-    to.getUTCDate(),
-  );
-  return Math.round((toUtc - fromUtc) / MS_PER_DAY);
+// Calendar-days diff anchored to the club's local zone so a 23:30 UTC "now"
+// (00:30 Brussels) reads the same calendar date as 01:30 UTC the next day.
+function clubCalendarDaysBetween(from: Date, to: Date): number {
+  const fromDay = DateTime.fromJSDate(from, { zone: CLUB_ZONE }).startOf("day");
+  const toDay = DateTime.fromJSDate(to, { zone: CLUB_ZONE }).startOf("day");
+  return Math.round(toDay.diff(fromDay, "days").days);
 }
 
 export function resolveContent(
@@ -47,7 +42,7 @@ export function resolveContent(
   const href = placeholder?.announcementHref;
 
   if (kickoff) {
-    const daysUntil = calendarDaysBetween(now, kickoff);
+    const daysUntil = clubCalendarDaysBetween(now, kickoff);
     if (daysUntil === 0) {
       return {
         mode: "today",

--- a/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.ts
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/decisionRule.ts
@@ -1,0 +1,81 @@
+import type { MatchesSliderPlaceholderVM } from "@/lib/repositories/homepage.repository";
+
+export type ResolvedContent =
+  | { mode: "baseline"; eyebrow: "TUSSENSEIZOEN" }
+  | {
+      mode: "countdown";
+      eyebrow: "NIEUW SEIZOEN";
+      daysUntil: number;
+      kickoffDate: Date;
+      secondary?: string;
+    }
+  | {
+      mode: "today";
+      eyebrow: "NIEUW SEIZOEN";
+      kickoffDate: Date;
+      secondary?: string;
+    }
+  | {
+      mode: "announcement";
+      eyebrow: "MEDEDELING";
+      text: string;
+      href?: string;
+    };
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function calendarDaysBetween(from: Date, to: Date): number {
+  const fromUtc = Date.UTC(
+    from.getUTCFullYear(),
+    from.getUTCMonth(),
+    from.getUTCDate(),
+  );
+  const toUtc = Date.UTC(
+    to.getUTCFullYear(),
+    to.getUTCMonth(),
+    to.getUTCDate(),
+  );
+  return Math.round((toUtc - fromUtc) / MS_PER_DAY);
+}
+
+export function resolveContent(
+  placeholder?: MatchesSliderPlaceholderVM | null,
+  now: Date = new Date(),
+): ResolvedContent {
+  const kickoff = placeholder?.nextSeasonKickoff;
+  const text = placeholder?.announcementText;
+  const href = placeholder?.announcementHref;
+
+  if (kickoff) {
+    const daysUntil = calendarDaysBetween(now, kickoff);
+    if (daysUntil === 0) {
+      return {
+        mode: "today",
+        eyebrow: "NIEUW SEIZOEN",
+        kickoffDate: kickoff,
+        secondary: text || undefined,
+      };
+    }
+    if (daysUntil > 0) {
+      return {
+        mode: "countdown",
+        eyebrow: "NIEUW SEIZOEN",
+        daysUntil,
+        kickoffDate: kickoff,
+        secondary: text || undefined,
+      };
+    }
+    // Past kickoff → fall through to other modes or baseline.
+  }
+
+  if (text) {
+    return {
+      mode: "announcement",
+      eyebrow: "MEDEDELING",
+      text,
+      href: href || undefined,
+    };
+  }
+
+  return { mode: "baseline", eyebrow: "TUSSENSEIZOEN" };
+}

--- a/apps/web/src/components/home/MatchesSliderEmptyState/index.ts
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/index.ts
@@ -1,0 +1,5 @@
+export { MatchesSliderEmptyState } from "./MatchesSliderEmptyState";
+export type {
+  MatchesSliderEmptyStateProps,
+  MatchesSliderEmptyStateLayout,
+} from "./MatchesSliderEmptyState";

--- a/apps/web/src/components/home/MatchesSliderEmptyState/index.ts
+++ b/apps/web/src/components/home/MatchesSliderEmptyState/index.ts
@@ -1,5 +1,2 @@
 export { MatchesSliderEmptyState } from "./MatchesSliderEmptyState";
-export type {
-  MatchesSliderEmptyStateProps,
-  MatchesSliderEmptyStateLayout,
-} from "./MatchesSliderEmptyState";
+export type { MatchesSliderEmptyStateProps } from "./MatchesSliderEmptyState";

--- a/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.stories.tsx
+++ b/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.stories.tsx
@@ -7,10 +7,21 @@ const meta = {
   component: MatchesSliderSection,
   tags: ["autodocs"],
   parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <section className="bg-kcvv-black py-16">
+        <Story />
+      </section>
+    ),
+  ],
 } satisfies Meta<typeof MatchesSliderSection>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const inDays = (n: number) =>
+  new Date(new Date().setUTCHours(0, 0, 0, 0) + n * MS_PER_DAY);
 
 export const Default: Story = {
   args: {
@@ -19,6 +30,25 @@ export const Default: Story = {
       teamLabel: i < 3 ? "A-Ploeg" : "U17",
     })),
     highlightTeamId: 1235,
+  },
+  parameters: { backgrounds: { default: "dark" } },
+};
+
+export const EmptyWithoutPlaceholder: Story = {
+  args: {
+    matches: [],
+    highlightTeamId: 1235,
+  },
+  parameters: { backgrounds: { default: "dark" } },
+};
+
+export const EmptyWithCountdown: Story = {
+  args: {
+    matches: [],
+    highlightTeamId: 1235,
+    placeholder: {
+      nextSeasonKickoff: inDays(70),
+    },
   },
   parameters: { backgrounds: { default: "dark" } },
 };

--- a/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
+++ b/apps/web/src/components/home/MatchesSliderSection/MatchesSliderSection.tsx
@@ -1,20 +1,22 @@
 import { MatchesSlider } from "@/components/match/MatchesSlider/MatchesSlider";
 import { SectionHeader } from "@/components/design-system";
+import { MatchesSliderEmptyState } from "@/components/home/MatchesSliderEmptyState";
 import type { UpcomingMatch } from "@/components/match/types";
+import type { MatchesSliderPlaceholderVM } from "@/lib/repositories/homepage.repository";
 
 export interface MatchesSliderSectionProps {
   matches: UpcomingMatch[];
   highlightTeamId?: number;
+  placeholder?: MatchesSliderPlaceholderVM | null;
   className?: string;
 }
 
 export const MatchesSliderSection = ({
   matches,
   highlightTeamId,
+  placeholder,
   className,
 }: MatchesSliderSectionProps) => {
-  if (matches.length === 0) return null;
-
   return (
     <section className={className}>
       <div className="max-w-7xl mx-auto px-4 md:px-8">
@@ -25,11 +27,15 @@ export const MatchesSliderSection = ({
           variant="dark"
         />
 
-        <MatchesSlider
-          matches={matches}
-          highlightTeamId={highlightTeamId}
-          theme="dark"
-        />
+        {matches.length === 0 ? (
+          <MatchesSliderEmptyState placeholder={placeholder} />
+        ) : (
+          <MatchesSlider
+            matches={matches}
+            highlightTeamId={highlightTeamId}
+            theme="dark"
+          />
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -28,9 +28,6 @@ export const YouthSection = ({
       className={cn("relative bg-kcvv-green-dark text-left", className)}
       style={{
         marginTop: `calc(-1 * ${DIAGONAL_HEIGHT})`,
-        // -1px seam guard — mirrors SectionTransition.tsx; without it a
-        // sub-pixel hairline shows between the bottom diagonal and next section.
-        marginBottom: "-1px",
         paddingBottom: DIAGONAL_HEIGHT,
       }}
     >

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -28,6 +28,9 @@ export const YouthSection = ({
       className={cn("relative bg-kcvv-green-dark text-left", className)}
       style={{
         marginTop: `calc(-1 * ${DIAGONAL_HEIGHT})`,
+        // -1px seam guard — mirrors SectionTransition.tsx; without it a
+        // sub-pixel hairline shows between the bottom diagonal and next section.
+        marginBottom: "-1px",
         paddingBottom: DIAGONAL_HEIGHT,
       }}
     >

--- a/apps/web/src/components/layout/PageFooter/PageFooter.tsx
+++ b/apps/web/src/components/layout/PageFooter/PageFooter.tsx
@@ -112,7 +112,7 @@ export const PageFooter = ({ className }: PageFooterProps) => {
             </a>
             <div className="flex gap-2.5 mt-5 max-md:justify-center">
               <a
-                href="https://facebook.com/KCVVElewijt/"
+                href={EXTERNAL_LINKS.facebook}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="KCVV Elewijt op Facebook"
@@ -121,7 +121,7 @@ export const PageFooter = ({ className }: PageFooterProps) => {
                 <Facebook className="w-[18px] h-[18px]" />
               </a>
               <a
-                href="https://www.instagram.com/kcvve"
+                href={EXTERNAL_LINKS.instagram}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="KCVV Elewijt op Instagram"

--- a/apps/web/src/components/player/PlayerShare/PlayerShare.stories.tsx
+++ b/apps/web/src/components/player/PlayerShare/PlayerShare.stories.tsx
@@ -21,7 +21,7 @@ Share component for player profiles with QR code generation.
 Features:
 - QR code linking to player profile
 - Copy profile URL to clipboard
-- Social share buttons (Facebook, X/Twitter)
+- Social share button (Facebook)
 - Download QR code as image
 - Print-optimized layout option
         `,

--- a/apps/web/src/components/player/PlayerShare/PlayerShare.test.tsx
+++ b/apps/web/src/components/player/PlayerShare/PlayerShare.test.tsx
@@ -99,6 +99,14 @@ describe("PlayerShare", () => {
       ).toBeInTheDocument();
     });
 
+    it("does not render a Twitter/X share button", () => {
+      render(<PlayerShare {...defaultProps} />);
+
+      expect(
+        screen.queryByRole("button", { name: /twitter|x|delen op x/i }),
+      ).not.toBeInTheDocument();
+    });
+
     it("renders download QR button when QR is shown", () => {
       render(<PlayerShare {...defaultProps} showQR />);
 

--- a/apps/web/src/components/player/PlayerShare/PlayerShare.test.tsx
+++ b/apps/web/src/components/player/PlayerShare/PlayerShare.test.tsx
@@ -91,13 +91,12 @@ describe("PlayerShare", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders social share buttons", () => {
+    it("renders Facebook share button", () => {
       render(<PlayerShare {...defaultProps} />);
 
       expect(
         screen.getByRole("button", { name: /facebook/i }),
       ).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /x/i })).toBeInTheDocument();
     });
 
     it("renders download QR button when QR is shown", () => {
@@ -165,32 +164,6 @@ describe("PlayerShare", () => {
         "noopener,noreferrer,width=600,height=400",
       );
     });
-
-    it("opens Twitter share dialog when clicked", () => {
-      render(<PlayerShare {...defaultProps} />);
-
-      const twitterButton = screen.getByRole("button", { name: /x/i });
-      fireEvent.click(twitterButton);
-
-      expect(mockWindowOpen).toHaveBeenCalledWith(
-        expect.stringContaining("twitter.com/intent/tweet"),
-        "_blank",
-        "noopener,noreferrer,width=600,height=400",
-      );
-    });
-
-    it("includes player name in Twitter share text", () => {
-      render(<PlayerShare {...defaultProps} />);
-
-      const twitterButton = screen.getByRole("button", { name: /x/i });
-      fireEvent.click(twitterButton);
-
-      expect(mockWindowOpen).toHaveBeenCalledWith(
-        expect.stringContaining("Chiel%20Bertens"),
-        "_blank",
-        "noopener,noreferrer,width=600,height=400",
-      );
-    });
   });
 
   describe("compact variant", () => {
@@ -246,19 +219,6 @@ describe("PlayerShare", () => {
 
       expect(mockWindowOpen).toHaveBeenCalledWith(
         expect.stringContaining("facebook.com/sharer"),
-        "_blank",
-        "noopener,noreferrer,width=600,height=400",
-      );
-    });
-
-    it("opens Twitter share dialog in compact variant", () => {
-      render(<PlayerShare {...defaultProps} variant="compact" />);
-
-      const twitterButton = screen.getByRole("button", { name: /x/i });
-      fireEvent.click(twitterButton);
-
-      expect(mockWindowOpen).toHaveBeenCalledWith(
-        expect.stringContaining("twitter.com/intent/tweet"),
         "_blank",
         "noopener,noreferrer,width=600,height=400",
       );

--- a/apps/web/src/components/player/PlayerShare/PlayerShare.tsx
+++ b/apps/web/src/components/player/PlayerShare/PlayerShare.tsx
@@ -6,7 +6,7 @@
  * Features:
  * - QR code generation linking to player profile
  * - Copy profile URL to clipboard
- * - Social share buttons (Facebook, X/Twitter)
+ * - Social share button (Facebook)
  * - Download QR code as image
  * - Multiple display variants (default, compact, printable)
  */
@@ -89,12 +89,6 @@ export const PlayerShare = forwardRef<HTMLDivElement, PlayerShareProps>(
       const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(profileUrl)}`;
       window.open(url, "_blank", "noopener,noreferrer,width=600,height=400");
     }, [profileUrl]);
-
-    const handleShareTwitter = useCallback(() => {
-      const text = `Bekijk het spelersprofiel van ${playerName} bij ${teamName}`;
-      const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(profileUrl)}`;
-      window.open(url, "_blank", "noopener,noreferrer,width=600,height=400");
-    }, [profileUrl, playerName, teamName]);
 
     const handleDownloadQR = useCallback(() => {
       if (!qrRef.current) return;
@@ -257,21 +251,6 @@ export const PlayerShare = forwardRef<HTMLDivElement, PlayerShareProps>(
                 <path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z" />
               </svg>
             </button>
-
-            <button
-              onClick={handleShareTwitter}
-              className="p-2 rounded-md bg-black text-white hover:bg-gray-800 transition-colors"
-              aria-label="Delen op X"
-            >
-              <svg
-                className="w-5 h-5"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-            </button>
           </div>
         </div>
       );
@@ -358,40 +337,22 @@ export const PlayerShare = forwardRef<HTMLDivElement, PlayerShareProps>(
             )}
           </button>
 
-          {/* Social share buttons */}
-          <div className="flex gap-2">
-            <button
-              onClick={handleShareFacebook}
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-md bg-[#1877f2] text-white hover:bg-[#166fe5] transition-colors"
-              aria-label="Delen op Facebook"
+          {/* Social share button */}
+          <button
+            onClick={handleShareFacebook}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-md bg-[#1877f2] text-white hover:bg-[#166fe5] transition-colors"
+            aria-label="Delen op Facebook"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
             >
-              <svg
-                className="w-4 h-4"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z" />
-              </svg>
-              Facebook
-            </button>
-
-            <button
-              onClick={handleShareTwitter}
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium rounded-md bg-black text-white hover:bg-gray-800 transition-colors"
-              aria-label="Delen op X"
-            >
-              <svg
-                className="w-4 h-4"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-              X
-            </button>
-          </div>
+              <path d="M18.77 7.46H14.5v-1.9c0-.9.6-1.1 1-1.1h3V.5h-4.33C10.24.5 9.5 3.44 9.5 5.32v2.15h-3v4h3v12h5v-12h3.85l.42-4z" />
+            </svg>
+            Facebook
+          </button>
 
           {/* Download QR button */}
           {showQR && (

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -51,6 +51,9 @@ export const KCVV_FIRST_TEAM_CLUB_ID = 1235;
 // External Links
 export const EXTERNAL_LINKS = {
   webshop: "https://www.brandsfit.com/kcvvelewijt/nl-eu",
+  psdDashboard: "https://kcvv.prosoccerdata.com/dashboard",
+  facebook: "https://facebook.com/KCVVElewijt/",
+  instagram: "https://www.instagram.com/kcvve",
 } as const;
 
 // Image Aspect Ratios

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -16,7 +16,6 @@ export const SITE_CONFIG = {
   description:
     "KCVV Elewijt voetbalclub met stamnummer 55 - Er is maar één plezante compagnie",
   siteUrl: "https://www.kcvvelewijt.be",
-  twitterHandle: "kcvve",
   fbAppId: "679332239478086",
   stamnummer: 55,
 } as const;

--- a/apps/web/src/lib/icons.ts
+++ b/apps/web/src/lib/icons.ts
@@ -31,7 +31,6 @@ import {
 
   // Social
   Facebook,
-  Twitter,
   Instagram,
 
   // Content & Document
@@ -134,7 +133,6 @@ export const icons = {
 
   // Social
   facebook: Facebook,
-  twitter: Twitter,
   instagram: Instagram,
 
   // Content & Document
@@ -286,7 +284,6 @@ export {
 
   // Social
   Facebook,
-  Twitter,
   Instagram,
 
   // Content & Document

--- a/apps/web/src/lib/repositories/homepage.repository.test.ts
+++ b/apps/web/src/lib/repositories/homepage.repository.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { Effect } from "effect";
-import type { HOMEPAGE_BANNERS_QUERY_RESULT } from "../sanity/sanity.types";
+import type {
+  HOMEPAGE_BANNERS_QUERY_RESULT,
+  HOMEPAGE_PLACEHOLDER_QUERY_RESULT,
+} from "../sanity/sanity.types";
 
 // Mock the sanity client before importing the repository
 vi.mock("../sanity/client", () => ({
@@ -14,8 +17,10 @@ import {
   HOMEPAGE_BANNERS_QUERY,
   HomepageRepository,
   HomepageRepositoryLive,
+  toPlaceholderVM,
   type HomepageBannersVM,
   type BannerSlotVM,
+  type MatchesSliderPlaceholderVM,
 } from "./homepage.repository";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -144,6 +149,121 @@ describe("HomepageRepository", () => {
       );
 
       expect(banners.bannerSlotA).toBeNull();
+    });
+  });
+
+  describe("getPlaceholder", () => {
+    it("returns null when homepage document is missing", async () => {
+      mockFetch.mockResolvedValueOnce(null);
+
+      const placeholder = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* HomepageRepository;
+          return yield* repo.getPlaceholder();
+        }),
+      );
+
+      expect(placeholder).toBeNull();
+    });
+
+    it("returns null when matchesSliderPlaceholder is not set", async () => {
+      mockFetch.mockResolvedValueOnce({ matchesSliderPlaceholder: null });
+
+      const placeholder = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* HomepageRepository;
+          return yield* repo.getPlaceholder();
+        }),
+      );
+
+      expect(placeholder).toBeNull();
+    });
+
+    it("maps all fields correctly when fully populated", async () => {
+      mockFetch.mockResolvedValueOnce({
+        matchesSliderPlaceholder: {
+          nextSeasonKickoff: "2026-08-10",
+          announcementText: "Kalender 25-26 volgende week online",
+          announcementHref: "https://example.com/kalender",
+          highlightImage: {
+            alt: "Supporters op de Driesstraat",
+            asset: {
+              _id: "image-abc",
+              url: "https://cdn.sanity.io/images/abc.jpg",
+              lqip: "data:image/jpeg;base64,/9j...",
+              dimensions: { width: 1920, height: 1080 },
+            },
+          },
+        },
+      });
+
+      const placeholder = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* HomepageRepository;
+          return yield* repo.getPlaceholder();
+        }),
+      );
+
+      expect(placeholder).toEqual<MatchesSliderPlaceholderVM>({
+        nextSeasonKickoff: new Date("2026-08-10"),
+        announcementText: "Kalender 25-26 volgende week online",
+        announcementHref: "https://example.com/kalender",
+        highlightImage: {
+          alt: "Supporters op de Driesstraat",
+          url: "https://cdn.sanity.io/images/abc.jpg",
+          lqip: "data:image/jpeg;base64,/9j...",
+          width: 1920,
+          height: 1080,
+        },
+      });
+    });
+
+    it("omits highlightImage when alt is missing", () => {
+      const result = toPlaceholderVM({
+        matchesSliderPlaceholder: {
+          nextSeasonKickoff: null,
+          announcementText: null,
+          announcementHref: null,
+          highlightImage: {
+            alt: null,
+            asset: {
+              _id: "image-x",
+              url: "https://cdn.sanity.io/images/x.jpg",
+              lqip: null,
+              dimensions: null,
+            },
+          },
+        },
+      } as HOMEPAGE_PLACEHOLDER_QUERY_RESULT);
+
+      expect(result?.highlightImage).toBeUndefined();
+    });
+
+    it("omits nextSeasonKickoff when not set", () => {
+      const result = toPlaceholderVM({
+        matchesSliderPlaceholder: {
+          nextSeasonKickoff: null,
+          announcementText: "Later meer info",
+          announcementHref: null,
+          highlightImage: null,
+        },
+      } as HOMEPAGE_PLACEHOLDER_QUERY_RESULT);
+
+      expect(result?.nextSeasonKickoff).toBeUndefined();
+      expect(result?.announcementText).toBe("Later meer info");
+    });
+
+    it("accepts past kickoff dates (business logic filters, not the decoder)", () => {
+      const result = toPlaceholderVM({
+        matchesSliderPlaceholder: {
+          nextSeasonKickoff: "2024-08-10",
+          announcementText: null,
+          announcementHref: null,
+          highlightImage: null,
+        },
+      } as HOMEPAGE_PLACEHOLDER_QUERY_RESULT);
+
+      expect(result?.nextSeasonKickoff).toEqual(new Date("2024-08-10"));
     });
   });
 });

--- a/apps/web/src/lib/repositories/homepage.repository.ts
+++ b/apps/web/src/lib/repositories/homepage.repository.ts
@@ -1,7 +1,10 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
-import type { HOMEPAGE_BANNERS_QUERY_RESULT } from "../sanity/sanity.types";
+import type {
+  HOMEPAGE_BANNERS_QUERY_RESULT,
+  HOMEPAGE_PLACEHOLDER_QUERY_RESULT,
+} from "../sanity/sanity.types";
 
 // ─── GROQ Queries ────────────────────────────────────────────────────────────
 
@@ -20,6 +23,24 @@ export const HOMEPAGE_BANNERS_QUERY = defineQuery(`*[_type == "homePage"][0] {
       "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",
       alt,
       href
+    }
+  }`);
+
+export const HOMEPAGE_PLACEHOLDER_QUERY =
+  defineQuery(`*[_type == "homePage"][0] {
+    "matchesSliderPlaceholder": matchesSliderPlaceholder {
+      nextSeasonKickoff,
+      announcementText,
+      announcementHref,
+      "highlightImage": highlightImage {
+        alt,
+        "asset": asset->{
+          _id,
+          url,
+          "lqip": metadata.lqip,
+          "dimensions": metadata.dimensions
+        }
+      }
     }
   }`);
 
@@ -59,8 +80,49 @@ export function toBannersVM(
   };
 }
 
+export interface MatchesSliderPlaceholderVM {
+  nextSeasonKickoff?: Date;
+  announcementText?: string;
+  announcementHref?: string;
+  highlightImage?: {
+    alt: string;
+    url: string;
+    lqip?: string;
+    width?: number;
+    height?: number;
+  };
+}
+
+export function toPlaceholderVM(
+  data: HOMEPAGE_PLACEHOLDER_QUERY_RESULT,
+): MatchesSliderPlaceholderVM | null {
+  const placeholder = data?.matchesSliderPlaceholder;
+  if (!placeholder) return null;
+
+  const image = placeholder.highlightImage;
+  const hasImage = image?.alt && image.asset?.url;
+
+  return {
+    nextSeasonKickoff: placeholder.nextSeasonKickoff
+      ? new Date(placeholder.nextSeasonKickoff)
+      : undefined,
+    announcementText: placeholder.announcementText ?? undefined,
+    announcementHref: placeholder.announcementHref ?? undefined,
+    highlightImage: hasImage
+      ? {
+          alt: image.alt!,
+          url: image.asset!.url!,
+          lqip: image.asset!.lqip ?? undefined,
+          width: image.asset!.dimensions?.width ?? undefined,
+          height: image.asset!.dimensions?.height ?? undefined,
+        }
+      : undefined,
+  };
+}
+
 export interface HomepageRepositoryInterface {
   readonly getBanners: () => Effect.Effect<HomepageBannersVM>;
+  readonly getPlaceholder: () => Effect.Effect<MatchesSliderPlaceholderVM | null>;
 }
 
 export class HomepageRepository extends Context.Tag("HomepageRepository")<
@@ -73,4 +135,8 @@ export const HomepageRepositoryLive = Layer.succeed(HomepageRepository, {
     fetchGroq<HOMEPAGE_BANNERS_QUERY_RESULT>(HOMEPAGE_BANNERS_QUERY).pipe(
       Effect.map(toBannersVM),
     ),
+  getPlaceholder: () =>
+    fetchGroq<HOMEPAGE_PLACEHOLDER_QUERY_RESULT>(
+      HOMEPAGE_PLACEHOLDER_QUERY,
+    ).pipe(Effect.map(toPlaceholderVM)),
 });

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -22,6 +22,21 @@ export type SanityImageAssetReference = {
   [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
 };
 
+export type MatchesSliderPlaceholder = {
+  _type: "matchesSliderPlaceholder";
+  nextSeasonKickoff?: string;
+  announcementText?: string;
+  announcementHref?: string;
+  highlightImage?: {
+    asset?: SanityImageAssetReference;
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    alt?: string;
+    _type: "image";
+  };
+};
+
 export type JeugdLandingPage = {
   _id: string;
   _type: "jeugdLandingPage";
@@ -79,6 +94,7 @@ export type HomePage = {
   bannerSlotA?: BannerReference;
   bannerSlotB?: BannerReference;
   bannerSlotC?: BannerReference;
+  matchesSliderPlaceholder?: MatchesSliderPlaceholder;
 };
 
 export type Banner = {
@@ -745,6 +761,7 @@ export type Geopoint = {
 
 export type AllSanitySchemaTypes =
   | SanityImageAssetReference
+  | MatchesSliderPlaceholder
   | JeugdLandingPage
   | SanityImageCrop
   | SanityImageHotspot
@@ -1204,6 +1221,26 @@ export type HOMEPAGE_BANNERS_QUERY_RESULT = {
     imageUrl: string | null;
     alt: string | null;
     href: string | null;
+  } | null;
+} | null;
+
+// Source: ../web/src/lib/repositories/homepage.repository.ts
+// Variable: HOMEPAGE_PLACEHOLDER_QUERY
+// Query: *[_type == "homePage"][0] {    "matchesSliderPlaceholder": matchesSliderPlaceholder {      nextSeasonKickoff,      announcementText,      announcementHref,      "highlightImage": highlightImage {        alt,        "asset": asset->{          _id,          url,          "lqip": metadata.lqip,          "dimensions": metadata.dimensions        }      }    }  }
+export type HOMEPAGE_PLACEHOLDER_QUERY_RESULT = {
+  matchesSliderPlaceholder: {
+    nextSeasonKickoff: string | null;
+    announcementText: string | null;
+    announcementHref: string | null;
+    highlightImage: {
+      alt: string | null;
+      asset: {
+        _id: string;
+        url: string | null;
+        lqip: string | null;
+        dimensions: SanityImageDimensions | null;
+      } | null;
+    } | null;
   } | null;
 } | null;
 
@@ -1710,6 +1747,7 @@ declare module "@sanity/client" {
     '*[_type == "event"] | order(dateStart asc) {\n  "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": false,\n  "href": coalesce(externalLink.url, "#"),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': EVENTS_QUERY_RESULT;
     '\n  coalesce(\n    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {\n      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),\n      "href": coalesce(externalLink.url, "#"),\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    },\n    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {\n      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),\n      "href": coalesce(externalLink.url, "#"),\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    }\n  )\n': NEXT_FEATURED_EVENT_QUERY_RESULT;
     '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;
+    '*[_type == "homePage"][0] {\n    "matchesSliderPlaceholder": matchesSliderPlaceholder {\n      nextSeasonKickoff,\n      announcementText,\n      announcementHref,\n      "highlightImage": highlightImage {\n        alt,\n        "asset": asset->{\n          _id,\n          url,\n          "lqip": metadata.lqip,\n          "dimensions": metadata.dimensions\n        }\n      }\n    }\n  }': HOMEPAGE_PLACEHOLDER_QUERY_RESULT;
     '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
     '*[_type == "page" && slug.current == $slug][0] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;

--- a/apps/web/src/lib/seo/jsonld.ts
+++ b/apps/web/src/lib/seo/jsonld.ts
@@ -15,7 +15,7 @@ interface JsonLdDocument {
   [key: string]: unknown;
 }
 
-import { SITE_CONFIG } from "@/lib/constants";
+import { SITE_CONFIG, EXTERNAL_LINKS } from "@/lib/constants";
 
 const LOGO_URL = `${SITE_CONFIG.siteUrl}/icon.png`;
 
@@ -70,7 +70,7 @@ export function buildSportsClubJsonLd(): WithContext<SportsClubOrganization> {
     url: SITE_CONFIG.siteUrl,
     logo: LOGO_URL,
     foundingDate: "1924",
-    sameAs: ["https://www.facebook.com/KCVVElewijt"],
+    sameAs: [EXTERNAL_LINKS.facebook, EXTERNAL_LINKS.instagram],
     sport: "Soccer",
     address: {
       "@type": "PostalAddress",

--- a/apps/web/src/stories/foundation/SpacingAndIcons.mdx
+++ b/apps/web/src/stories/foundation/SpacingAndIcons.mdx
@@ -3,7 +3,7 @@ import {
   Menu, X, Search, ChevronDown, ChevronUp, ChevronLeft, ChevronRight,
   ArrowRight, ExternalLink, Check, CircleHelp,
   Info, CheckCircle, AlertTriangle, XCircle, ThumbsUp, ThumbsDown,
-  Facebook, Twitter, Instagram,
+  Facebook, Instagram,
   FileText, Clipboard, ClipboardList, Newspaper, Tag, Calendar, CalendarDays, Clock,
   Mail, Phone, Smartphone, MessageCircle,
   User, Users, UserPlus, GraduationCap,
@@ -147,7 +147,6 @@ Use the `<Icon>` component or import directly from `@/lib/icons`.
 
 <IconGrid label="Social" icons={[
   { Icon: Facebook, name: 'facebook' },
-  { Icon: Twitter, name: 'twitter' },
   { Icon: Instagram, name: 'instagram' },
 ]} />
 

--- a/packages/sanity-schemas/src/article.ts
+++ b/packages/sanity-schemas/src/article.ts
@@ -2,91 +2,108 @@ import {defineField, defineType} from 'sanity'
 import {LinkIcon, UserIcon} from '@sanity/icons'
 
 export const article = defineType({
-  name: 'article',
-  title: 'Article',
-  type: 'document',
+  name: "article",
+  title: "Article",
+  type: "document",
   orderings: [
     {
-      title: 'Publish date, newest first',
-      name: 'publishAtDesc',
-      by: [{field: 'publishAt', direction: 'desc'}],
+      title: "Publish date, newest first",
+      name: "publishAtDesc",
+      by: [{ field: "publishAt", direction: "desc" }],
     },
     {
-      title: 'Publish date, oldest first',
-      name: 'publishAtAsc',
-      by: [{field: 'publishAt', direction: 'asc'}],
+      title: "Publish date, oldest first",
+      name: "publishAtAsc",
+      by: [{ field: "publishAt", direction: "asc" }],
     },
   ],
   fields: [
     defineField({
-      name: 'title',
-      title: 'Title',
-      type: 'string',
+      name: "title",
+      title: "Title",
+      type: "string",
+      description:
+        "Houd de titel kort en krachtig (richtlijn: ~60 tekens). Op de homepagina wordt de titel na 3 regels afgekapt met een ellipsis.",
       validation: (r) => r.required(),
     }),
     defineField({
-      name: 'slug',
-      title: 'Slug',
-      type: 'slug',
-      options: {source: 'title'},
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      options: { source: "title" },
       validation: (r) => r.required(),
     }),
-    defineField({name: 'publishAt', title: 'Publish at', type: 'datetime'}),
-    defineField({name: 'unpublishAt', title: 'Unpublish at', type: 'datetime'}),
+    defineField({ name: "publishAt", title: "Publish at", type: "datetime" }),
     defineField({
-      name: 'featured',
-      title: 'Featured',
-      type: 'boolean',
+      name: "unpublishAt",
+      title: "Unpublish at",
+      type: "datetime",
+    }),
+    defineField({
+      name: "featured",
+      title: "Featured",
+      type: "boolean",
       initialValue: false,
     }),
     defineField({
-      name: 'coverImage',
-      title: 'Cover image',
-      type: 'image',
-      options: {hotspot: true},
+      name: "coverImage",
+      title: "Cover image",
+      type: "image",
+      options: { hotspot: true },
     }),
     defineField({
-      name: 'tags',
-      title: 'Tags',
-      type: 'array',
-      of: [{type: 'string'}],
-      options: {layout: 'tags'},
+      name: "tags",
+      title: "Tags",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { layout: "tags" },
     }),
     defineField({
-      name: 'body',
-      title: 'Body',
-      type: 'array',
+      name: "body",
+      title: "Body",
+      type: "array",
       of: [
         {
-          type: 'block',
+          type: "block",
           marks: {
             annotations: [
               {
-                name: 'link',
-                title: 'Link',
-                type: 'object',
+                name: "link",
+                title: "Link",
+                type: "object",
                 icon: LinkIcon,
                 fields: [
                   {
-                    name: 'href',
-                    title: 'URL',
-                    type: 'url',
+                    name: "href",
+                    title: "URL",
+                    type: "url",
                     validation: (r) =>
-                      r.required().uri({allowRelative: true, scheme: ['http', 'https', 'mailto', 'tel']}),
+                      r
+                        .required()
+                        .uri({
+                          allowRelative: true,
+                          scheme: ["http", "https", "mailto", "tel"],
+                        }),
                   },
                 ],
               },
               {
-                name: 'internalLink',
-                title: 'Internal link',
-                type: 'object',
+                name: "internalLink",
+                title: "Internal link",
+                type: "object",
                 icon: UserIcon,
                 fields: [
                   {
-                    name: 'reference',
-                    title: 'Reference',
-                    type: 'reference',
-                    to: [{type: 'player'}, {type: 'staffMember'}, {type: 'team'}, {type: 'article'}, {type: 'page'}],
+                    name: "reference",
+                    title: "Reference",
+                    type: "reference",
+                    to: [
+                      { type: "player" },
+                      { type: "staffMember" },
+                      { type: "team" },
+                      { type: "article" },
+                      { type: "page" },
+                    ],
                     validation: (r) => r.required(),
                   },
                 ],
@@ -94,26 +111,28 @@ export const article = defineType({
             ],
           },
         },
-        {type: 'articleImage'},
-        {type: 'fileAttachment'},
-        {type: 'htmlTable'},
+        { type: "articleImage" },
+        { type: "fileAttachment" },
+        { type: "htmlTable" },
       ],
     }),
     defineField({
-      name: 'relatedArticles',
-      title: 'Related articles',
-      type: 'array',
-      of: [{type: 'reference', to: [{type: 'article'}]}],
+      name: "relatedArticles",
+      title: "Related articles",
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "article" }] }],
     }),
   ],
   preview: {
-    select: {title: 'title', media: 'coverImage', publishAt: 'publishAt'},
-    prepare({title, media, publishAt}) {
+    select: { title: "title", media: "coverImage", publishAt: "publishAt" },
+    prepare({ title, media, publishAt }) {
       return {
         title,
-        subtitle: publishAt ? new Date(publishAt).toLocaleDateString('nl-BE') : 'No date',
+        subtitle: publishAt
+          ? new Date(publishAt).toLocaleDateString("nl-BE")
+          : "No date",
         media,
-      }
+      };
     },
   },
-})
+});

--- a/packages/sanity-schemas/src/homePage.ts
+++ b/packages/sanity-schemas/src/homePage.ts
@@ -25,6 +25,12 @@ export const homePage = defineType({
       type: 'reference',
       to: [{type: 'banner'}],
     }),
+    defineField({
+      name: 'matchesSliderPlaceholder',
+      title: 'Placeholder wedstrijdenblok',
+      type: 'matchesSliderPlaceholder',
+      description: 'Optioneel. Getoond wanneer er geen aankomende wedstrijden zijn.',
+    }),
   ],
   preview: {
     prepare() {

--- a/packages/sanity-schemas/src/index.ts
+++ b/packages/sanity-schemas/src/index.ts
@@ -17,6 +17,7 @@ export {searchFeedback} from './searchFeedback'
 export {banner} from './banner'
 export {homePage} from './homePage'
 export {jeugdLandingPage} from './jeugdLandingPage'
+export {matchesSliderPlaceholder} from './matchesSliderPlaceholder'
 
 import {player} from './player'
 import {team, trainingDay} from './team'
@@ -34,6 +35,7 @@ import {searchFeedback} from './searchFeedback'
 import {banner} from './banner'
 import {homePage} from './homePage'
 import {jeugdLandingPage} from './jeugdLandingPage'
+import {matchesSliderPlaceholder} from './matchesSliderPlaceholder'
 
 export const schemaTypes = [
   player,
@@ -53,4 +55,5 @@ export const schemaTypes = [
   banner,
   homePage,
   jeugdLandingPage,
+  matchesSliderPlaceholder,
 ]

--- a/packages/sanity-schemas/src/matchesSliderPlaceholder.ts
+++ b/packages/sanity-schemas/src/matchesSliderPlaceholder.ts
@@ -1,0 +1,51 @@
+import {defineField, defineType} from 'sanity'
+
+export const matchesSliderPlaceholder = defineType({
+  name: 'matchesSliderPlaceholder',
+  title: 'Placeholder wedstrijdenblok (tussenseizoen)',
+  type: 'object',
+  description:
+    'Optionele inhoud voor het wedstrijdenblok wanneer er geen aankomende wedstrijden zijn. Laat leeg voor de standaardweergave.',
+  fields: [
+    defineField({
+      name: 'nextSeasonKickoff',
+      title: 'Aftrap nieuw seizoen',
+      type: 'date',
+      description:
+        'Datum van de eerste wedstrijd. Wordt getoond als aftelling. Laat leeg als nog niet bekend.',
+      options: {dateFormat: 'DD-MM-YYYY'},
+    }),
+    defineField({
+      name: 'announcementText',
+      title: 'Mededeling',
+      type: 'string',
+      description:
+        "Korte tekst (max 80 tekens), bv. 'Kalender 25-26 volgende week online'.",
+      validation: (rule) => rule.max(80),
+    }),
+    defineField({
+      name: 'announcementHref',
+      title: 'Mededeling — link',
+      type: 'url',
+      description: 'Optionele link bij de mededeling.',
+      validation: (rule) => rule.uri({scheme: ['http', 'https'], allowRelative: true}),
+    }),
+    defineField({
+      name: 'highlightImage',
+      title: 'Afbeelding (overschrijft standaard)',
+      type: 'image',
+      description:
+        'Optionele afbeelding die de standaardfoto vervangt. Liefst horizontaal, min. 1280x720.',
+      options: {hotspot: true},
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Alt-tekst',
+          type: 'string',
+          validation: (rule) =>
+            rule.required().error('Alt-tekst is verplicht voor toegankelijkheid.'),
+        }),
+      ],
+    }),
+  ],
+})


### PR DESCRIPTION
Closes #1323

## Summary

- Designed empty-state placeholder for the homepage matches slider (shown ~2-3 months/year in off-season). Optional Sanity overlay with countdown / announcement / custom image; decision rule falls back to a motto baseline that requires no editorial input.
- Scoped `paddingBottom: "pb-16"` override on the matches-slider section to correct the top/bottom asymmetry (`SectionHeader.mb-10` biases the top spacing).
- Cleanup: Twitter removed everywhere (share buttons, `SITE_CONFIG.twitterHandle`, icon barrel, metadata, `llms.txt`); `EXTERNAL_LINKS` now owns PSD + social URLs.

## Deviations from the plan

- **Layout**: settled on the centered layout early (split discarded). Agreed during visual review after the initial split rendering looked awkward in its narrow column.
- **Photo**: reused existing `/images/youth-trainers.jpg` instead of downloading a new stock photo. The Sanity `highlightImage` override is the long-term answer; this is a stand-in.
- **Decoder shape**: Sanity placeholder flows through the existing `homepage.repository` pattern (typegen + VM) rather than a new Effect Schema file. Matches the existing Sanity/DDD boundary in this repo — Effect Schema is reserved for the PSD-facing `api-contract`.
- **Date math**: plain `Date.UTC(...)` + calendar-day diff rather than `date-fns` (already on Luxon for formatting; no new dep needed).

## Test plan

- [ ] Open Vercel preview homepage — matches are currently present, so slider should render normally; padding should read symmetric.
- [ ] In Sanity staging, edit the home-page document and set `matchesSliderPlaceholder.nextSeasonKickoff` to a date ~30 days out; verify countdown copy and ISR revalidation.
- [ ] Temporarily force `matches: []` locally (or wait for off-season) to eyeball the baseline empty state and verify the Youth diagonal transition still lands on `kcvv-black` correctly.
- [ ] Check both mobile and desktop.
- [ ] Storybook — `Features/Homepage/MatchesSliderEmptyState` has 9 variants covering baseline / countdown / today / announcement / combined / custom image / all fields.
- [ ] `pnpm --filter @kcvv/web check-all` passes locally (2435 tests).

## Follow-ups (not in this PR)

- Replace `/images/youth-trainers.jpg` with a proper single-frame stadium/atmosphere photo once one is available. Can be delivered via Sanity `highlightImage` without a redeploy.
- Visual review of `pb-16` override — may need to drop to `pb-14` or raise to `pb-18` once measured in-browser.
- Sanity Studio migration note: every new field is optional, no data migration required. Staging studio first per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)