### PR TITLE
feat(news): articleType dispatch + qaBlock standard rendering (#1327)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/seo/jsonld";
 import { ArticleHeader, ArticleMetadata } from "@/components/article";
 import { SanityArticleBody } from "@/components/article/SanityArticleBody/SanityArticleBody";
+import { InterviewTemplate } from "@/components/article/InterviewTemplate";
 import { RelatedContentSection } from "@/components/related/RelatedContentSection/RelatedContentSection";
 import type { RelatedContentItem } from "@/components/related/types";
 import type { PortableTextBlock } from "@portabletext/react";
@@ -175,35 +176,54 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           })}
         />
       )}
-      <ArticleHeader
-        title={article.title}
-        imageUrl={article.coverImageUrl ?? undefined}
-        imageAlt={article.title}
-        category={primaryCategory?.name}
-        date={
-          article.publishedAt
-            ? formatArticleDate(new Date(article.publishedAt))
-            : undefined
-        }
-        author="KCVV Elewijt"
-      />
+      {article.articleType === "interview" ? (
+        <InterviewTemplate
+          title={article.title}
+          coverImageUrl={article.coverImageUrl}
+          publishedDate={
+            article.publishedAt
+              ? formatArticleDate(new Date(article.publishedAt))
+              : undefined
+          }
+          category={primaryCategory}
+          shareConfig={shareConfig}
+          body={(article.body as PortableTextBlock[] | null) ?? null}
+        />
+      ) : (
+        <>
+          <ArticleHeader
+            title={article.title}
+            imageUrl={article.coverImageUrl ?? undefined}
+            imageAlt={article.title}
+            category={primaryCategory?.name}
+            date={
+              article.publishedAt
+                ? formatArticleDate(new Date(article.publishedAt))
+                : undefined
+            }
+            author="KCVV Elewijt"
+          />
 
-      <ArticleMetadata
-        author="KCVV Elewijt"
-        date={
-          article.publishedAt
-            ? formatArticleDate(new Date(article.publishedAt))
-            : undefined
-        }
-        category={primaryCategory}
-        shareConfig={shareConfig}
-      />
+          <ArticleMetadata
+            author="KCVV Elewijt"
+            date={
+              article.publishedAt
+                ? formatArticleDate(new Date(article.publishedAt))
+                : undefined
+            }
+            category={primaryCategory}
+            shareConfig={shareConfig}
+          />
 
-      <main className="w-full max-w-inner-lg mx-auto px-6 mb-6 lg:mb-10">
-        {Array.isArray(article.body) && article.body.length > 0 && (
-          <SanityArticleBody content={article.body as PortableTextBlock[]} />
-        )}
-      </main>
+          <main className="w-full max-w-inner-lg mx-auto px-6 mb-6 lg:mb-10">
+            {Array.isArray(article.body) && article.body.length > 0 && (
+              <SanityArticleBody
+                content={article.body as PortableTextBlock[]}
+              />
+            )}
+          </main>
+        </>
+      )}
 
       <RelatedContentSection
         items={relatedItems}

--- a/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
+++ b/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
@@ -1,0 +1,56 @@
+import type { PortableTextBlock } from "@portabletext/react";
+import { ArticleHeader } from "../ArticleHeader";
+import { ArticleMetadata } from "../ArticleMetadata";
+import { SanityArticleBody } from "../SanityArticleBody/SanityArticleBody";
+
+export interface InterviewTemplateProps {
+  title: string;
+  coverImageUrl?: string | null;
+  publishedDate?: string;
+  category?: { name: string; href: string };
+  shareConfig: { url: string };
+  body: PortableTextBlock[] | null;
+}
+
+/**
+ * Phase 1 tracer for the interview template. Structurally identical to the
+ * legacy renderer (header + metadata + body) — the unique 4:5 portrait hero,
+ * subject kicker, and related-slider integration ship in Phase 3 (#1329).
+ *
+ * Its value at this phase is proving the `articleType` dispatch end-to-end
+ * and giving the Phase 3 work a stable landing site.
+ */
+export const InterviewTemplate = ({
+  title,
+  coverImageUrl,
+  publishedDate,
+  category,
+  shareConfig,
+  body,
+}: InterviewTemplateProps) => {
+  return (
+    <>
+      <ArticleHeader
+        title={title}
+        imageUrl={coverImageUrl ?? undefined}
+        imageAlt={title}
+        category={category?.name}
+        date={publishedDate}
+        author="KCVV Elewijt"
+      />
+
+      <ArticleMetadata
+        author="KCVV Elewijt"
+        date={publishedDate}
+        category={category}
+        shareConfig={shareConfig}
+      />
+
+      <main className="w-full max-w-inner-lg mx-auto px-6 mb-6 lg:mb-10">
+        {Array.isArray(body) && body.length > 0 && (
+          <SanityArticleBody content={body} />
+        )}
+      </main>
+    </>
+  );
+};

--- a/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
+++ b/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
@@ -12,6 +12,10 @@ export interface InterviewTemplateProps {
   body: PortableTextBlock[] | null;
 }
 
+// Byline for Phase 1 — Phase 3 (#1329) replaces this with the author
+// resolved from the article's `subject` field.
+const AUTHOR = "KCVV Elewijt";
+
 /**
  * Phase 1 tracer for the interview template. Structurally identical to the
  * legacy renderer (header + metadata + body) — the unique 4:5 portrait hero,
@@ -36,11 +40,11 @@ export const InterviewTemplate = ({
         imageAlt={title}
         category={category?.name}
         date={publishedDate}
-        author="KCVV Elewijt"
+        author={AUTHOR}
       />
 
       <ArticleMetadata
-        author="KCVV Elewijt"
+        author={AUTHOR}
         date={publishedDate}
         category={category}
         shareConfig={shareConfig}

--- a/apps/web/src/components/article/InterviewTemplate/index.ts
+++ b/apps/web/src/components/article/InterviewTemplate/index.ts
@@ -1,0 +1,2 @@
+export { InterviewTemplate } from "./InterviewTemplate";
+export type { InterviewTemplateProps } from "./InterviewTemplate";

--- a/apps/web/src/components/article/QaBlock/QaBlock.stories.tsx
+++ b/apps/web/src/components/article/QaBlock/QaBlock.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { PortableTextBlock } from "@portabletext/react";
+import { QaBlock } from "./QaBlock";
+
+const answer = (text: string): PortableTextBlock[] => [
+  {
+    _type: "block",
+    _key: `block-${text.slice(0, 8)}`,
+    style: "normal",
+    children: [
+      {
+        _type: "span",
+        _key: `span-${text.slice(0, 8)}`,
+        text,
+        marks: [],
+      },
+    ],
+    markDefs: [],
+  },
+];
+
+const meta = {
+  title: "Features/Articles/QaBlock",
+  component: QaBlock,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Phase 1 tracer rendering of the interview qaBlock. Only the `standard` tag is implemented; `key`, `quote`, and `rapid-fire` ship in Phase 2.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  render: (args) => (
+    <div className="max-w-[65ch] mx-auto">
+      <QaBlock {...args} />
+    </div>
+  ),
+} satisfies Meta<typeof QaBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TwoStandardPairs: Story = {
+  args: {
+    value: {
+      pairs: [
+        {
+          _key: "pair-1",
+          tag: "standard",
+          question: "Wat is je eerste herinnering aan KCVV?",
+          answer: answer(
+            "Als U9 spelen op het A-terrein, nog met mijn grote broer in de dug-out. Ik weet nog dat het regende en dat ik dacht: ik wil hier nooit meer weg.",
+          ),
+        },
+        {
+          _key: "pair-2",
+          tag: "standard",
+          question:
+            "En wat maakt KCVV anders dan de andere clubs waar je speelde?",
+          answer: answer(
+            "De mensen. Je speelt niet voor de voorzitter of de sponsor — je speelt voor de cafébaas die na de match weet dat je een mislukte pass gaf. Dat is de plezante compagnie.",
+          ),
+        },
+      ],
+    },
+  },
+};
+
+export const SinglePair: Story = {
+  args: {
+    value: {
+      pairs: [
+        {
+          _key: "pair-1",
+          tag: "standard",
+          question: "Eén vraag, één antwoord — zonder rule eronder.",
+          answer: answer(
+            "Precies. Het 1 px `kcvv-gray-light` lijntje valt weg na de laatste pair.",
+          ),
+        },
+      ],
+    },
+  },
+};

--- a/apps/web/src/components/article/QaBlock/QaBlock.test.tsx
+++ b/apps/web/src/components/article/QaBlock/QaBlock.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PortableTextBlock } from "@portabletext/react";
+import { QaBlock } from "./QaBlock";
+
+const makeAnswer = (text: string): PortableTextBlock[] => [
+  {
+    _type: "block",
+    _key: `block-${text}`,
+    style: "normal",
+    children: [{ _type: "span", _key: `span-${text}`, text, marks: [] }],
+    markDefs: [],
+  },
+];
+
+describe("QaBlock", () => {
+  it("renders two standard-tagged pairs in document order with 01./02. numerals", () => {
+    render(
+      <QaBlock
+        value={{
+          pairs: [
+            {
+              _key: "pair-1",
+              tag: "standard",
+              question: "Wat is je eerste herinnering aan KCVV?",
+              answer: makeAnswer("Spelen op het A-terrein als U9."),
+            },
+            {
+              _key: "pair-2",
+              tag: "standard",
+              question: "En je beste match?",
+              answer: makeAnswer("De 4-3 tegen Duffel, vorig seizoen."),
+            },
+          ],
+        }}
+      />,
+    );
+
+    const pairs = screen.getAllByTestId("qa-pair-standard");
+    expect(pairs).toHaveLength(2);
+
+    const numerals = screen.getAllByTestId("qa-pair-numeral");
+    expect(numerals[0]).toHaveTextContent("01.");
+    expect(numerals[1]).toHaveTextContent("02.");
+
+    expect(
+      screen.getByText("Wat is je eerste herinnering aan KCVV?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("En je beste match?")).toBeInTheDocument();
+    expect(
+      screen.getByText("Spelen op het A-terrein als U9."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("De 4-3 tegen Duffel, vorig seizoen."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 1px rule between pairs but not after the last pair", () => {
+    render(
+      <QaBlock
+        value={{
+          pairs: [
+            {
+              _key: "pair-1",
+              tag: "standard",
+              question: "Eerste?",
+              answer: makeAnswer("A."),
+            },
+            {
+              _key: "pair-2",
+              tag: "standard",
+              question: "Tweede?",
+              answer: makeAnswer("B."),
+            },
+            {
+              _key: "pair-3",
+              tag: "standard",
+              question: "Derde?",
+              answer: makeAnswer("C."),
+            },
+          ],
+        }}
+      />,
+    );
+
+    // Three pairs → exactly two separators between consecutive pairs. The
+    // separators are aria-hidden for visual-only decoration, so the hidden
+    // option is required to find them through the a11y tree.
+    expect(screen.getAllByRole("separator", { hidden: true })).toHaveLength(2);
+  });
+
+  it("returns null when pairs is empty", () => {
+    const { container } = render(<QaBlock value={{ pairs: [] }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when pairs is missing", () => {
+    const { container } = render(<QaBlock value={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("falls back to QaPairStandard for unknown tag values", () => {
+    render(
+      <QaBlock
+        value={{
+          pairs: [
+            {
+              _key: "pair-1",
+              tag: "some-future-tag-we-have-not-implemented-yet",
+              question: "Onbekende tag?",
+              answer: makeAnswer("Valt terug op standard."),
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByTestId("qa-pair-standard")).toBeInTheDocument();
+    expect(screen.getByText("Onbekende tag?")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/article/QaBlock/QaBlock.tsx
+++ b/apps/web/src/components/article/QaBlock/QaBlock.tsx
@@ -1,0 +1,47 @@
+import { Fragment } from "react";
+import type { PortableTextBlock } from "@portabletext/react";
+import { QaPairStandard } from "./QaPairStandard";
+
+export interface QaPairValue {
+  _key?: string;
+  question?: string;
+  answer?: PortableTextBlock[];
+  tag?: string;
+}
+
+export interface QaBlockValue {
+  pairs?: QaPairValue[];
+}
+
+/**
+ * Phase 1 tracer: only the `standard` tag is implemented.
+ * Unknown or missing tags fall back to `QaPairStandard` — Phase 2 will add
+ * `key`, `quote`, and `rapid-fire` variants via a dispatch map here.
+ */
+export const QaBlock = ({ value }: { value: QaBlockValue }) => {
+  const pairs = value.pairs ?? [];
+  if (pairs.length === 0) return null;
+
+  return (
+    <div className="my-12" data-testid="qa-block">
+      {pairs.map((pair, i) => {
+        const isLast = i === pairs.length - 1;
+        return (
+          <Fragment key={pair._key ?? i}>
+            <QaPairStandard
+              index={i + 1}
+              question={pair.question ?? ""}
+              answer={pair.answer ?? []}
+            />
+            {!isLast && (
+              <hr
+                className="my-10 border-t border-kcvv-gray-light"
+                aria-hidden="true"
+              />
+            )}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/web/src/components/article/QaBlock/QaBlock.tsx
+++ b/apps/web/src/components/article/QaBlock/QaBlock.tsx
@@ -23,7 +23,11 @@ export const QaBlock = ({ value }: { value: QaBlockValue }) => {
   if (pairs.length === 0) return null;
 
   return (
-    <div className="my-12" data-testid="qa-block">
+    // `not-prose` opts out of the parent `.prose prose-lg` cascade in
+    // SanityArticleBody. Without it, descendant `<p>` tags inherit prose-p
+    // margins/colors and blow the pair rhythm past the design's 40 px above
+    // + 40 px below rule spacing.
+    <div className="not-prose my-12" data-testid="qa-block">
       {pairs.map((pair, i) => {
         const isLast = i === pairs.length - 1;
         return (

--- a/apps/web/src/components/article/QaBlock/QaPairStandard.tsx
+++ b/apps/web/src/components/article/QaBlock/QaPairStandard.tsx
@@ -1,0 +1,38 @@
+import { PortableText, type PortableTextBlock } from "@portabletext/react";
+
+export interface QaPairStandardProps {
+  index: number;
+  question: string;
+  answer: PortableTextBlock[];
+}
+
+const formatNumeral = (n: number) => `${n.toString().padStart(2, "0")}.`;
+
+export const QaPairStandard = ({
+  index,
+  question,
+  answer,
+}: QaPairStandardProps) => {
+  return (
+    <div
+      className="grid gap-3 md:grid-cols-[4rem_1fr] md:gap-x-16 md:gap-y-0"
+      data-testid="qa-pair-standard"
+    >
+      <div
+        aria-hidden="true"
+        data-testid="qa-pair-numeral"
+        className="font-title font-bold text-5xl leading-[0.9] text-kcvv-green-bright"
+      >
+        {formatNumeral(index)}
+      </div>
+      <div>
+        <p className="font-title font-bold text-xl leading-[1.3] text-kcvv-gray-blue mb-3">
+          {question}
+        </p>
+        <div className="text-lg leading-[1.6] text-kcvv-gray-dark [&>p+p]:mt-4">
+          <PortableText value={answer} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/article/QaBlock/QaPairStandard.tsx
+++ b/apps/web/src/components/article/QaBlock/QaPairStandard.tsx
@@ -15,7 +15,9 @@ export const QaPairStandard = ({
 }: QaPairStandardProps) => {
   return (
     <div
-      className="grid gap-3 md:grid-cols-[4rem_1fr] md:gap-x-16 md:gap-y-0"
+      // Baseline-align the numeral to the question per design §6.1 so the
+      // "01." descender line sits on the same baseline as the question text.
+      className="grid gap-3 md:grid-cols-[4rem_1fr] md:gap-x-16 md:gap-y-0 md:items-baseline"
       data-testid="qa-pair-standard"
     >
       <div

--- a/apps/web/src/components/article/QaBlock/QaPairStandard.tsx
+++ b/apps/web/src/components/article/QaBlock/QaPairStandard.tsx
@@ -15,9 +15,7 @@ export const QaPairStandard = ({
 }: QaPairStandardProps) => {
   return (
     <div
-      // Baseline-align the numeral to the question per design §6.1 so the
-      // "01." descender line sits on the same baseline as the question text.
-      className="grid gap-3 md:grid-cols-[4rem_1fr] md:gap-x-16 md:gap-y-0 md:items-baseline"
+      className="grid gap-3 md:grid-cols-[4rem_1fr] md:gap-x-16 md:gap-y-0"
       data-testid="qa-pair-standard"
     >
       <div

--- a/apps/web/src/components/article/QaBlock/index.ts
+++ b/apps/web/src/components/article/QaBlock/index.ts
@@ -1,0 +1,4 @@
+export { QaBlock } from "./QaBlock";
+export type { QaBlockValue, QaPairValue } from "./QaBlock";
+export { QaPairStandard } from "./QaPairStandard";
+export type { QaPairStandardProps } from "./QaPairStandard";

--- a/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
+++ b/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
@@ -13,6 +13,7 @@ import { ExternalLink as ExternalLinkIcon } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { DownloadButton } from "@/components/design-system/DownloadButton";
 import { useScrollHint } from "@/components/design-system/ScrollHint/useScrollHint";
+import { QaBlock, type QaBlockValue } from "@/components/article/QaBlock";
 
 const TABLE_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: [
@@ -165,6 +166,7 @@ const components: PortableTextComponents = {
     htmlTable: HtmlTableBlock,
     image: ArticleImageBlock,
     articleImage: ArticleImageBlock,
+    qaBlock: ({ value }: { value: QaBlockValue }) => <QaBlock value={value} />,
   },
   block: {
     blockquote: ({ children }) => (

--- a/apps/web/src/lib/repositories/article.repository.test.ts
+++ b/apps/web/src/lib/repositories/article.repository.test.ts
@@ -48,6 +48,7 @@ function makeArticleDetailRow(
     publishedAt: "2026-03-20T10:00:00Z",
     featured: true,
     tags: ["Eerste ploeg"],
+    articleType: "announcement",
     coverImageUrl: "https://cdn.sanity.io/cover.webp",
     body: [
       {

--- a/apps/web/src/lib/repositories/article.repository.test.ts
+++ b/apps/web/src/lib/repositories/article.repository.test.ts
@@ -251,8 +251,29 @@ describe("ArticleRepository", () => {
       expect(a.publishedAt).toBe("2026-03-20T10:00:00Z");
       expect(a.featured).toBe(true);
       expect(a.tags).toEqual(["Eerste ploeg"]);
+      expect(a.articleType).toBe("announcement");
       expect(a.coverImageUrl).toBe("https://cdn.sanity.io/cover.webp");
       expect(a.body).toEqual(row.body);
+    });
+
+    it("passes through every articleType enum value and null without transformation", async () => {
+      for (const value of [
+        "interview",
+        "announcement",
+        "transfer",
+        "event",
+        null,
+      ] as const) {
+        const row = makeArticleDetailRow({ articleType: value });
+        mockFetch.mockResolvedValueOnce(row);
+        const result = await runWithRepo(
+          Effect.gen(function* () {
+            const repo = yield* ArticleRepository;
+            return yield* repo.findBySlug("test-article-detail");
+          }),
+        );
+        expect(result!.articleType).toBe(value);
+      }
     });
 
     it("maps related articles on detail VM", async () => {

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -37,7 +37,7 @@ export const RELATED_ARTICLES_QUERY =
 
 export const ARTICLE_BY_SLUG_QUERY =
   defineQuery(`*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {
-  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
+  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []), articleType,
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },
   relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -192,6 +192,39 @@ export type Sponsor = {
   active?: boolean;
 };
 
+export type QaPair = {
+  _type: "qaPair";
+  question?: string;
+  answer?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal";
+    listItem?: never;
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+  tag?: "standard" | "key" | "quote" | "rapid-fire";
+};
+
+export type QaBlock = {
+  _type: "qaBlock";
+  pairs?: Array<
+    {
+      _key: string;
+    } & QaPair
+  >;
+};
+
 export type ArticleImage = {
   _type: "articleImage";
   image?: {
@@ -246,6 +279,7 @@ export type Article = {
   _createdAt: string;
   _updatedAt: string;
   _rev: string;
+  articleType?: "interview" | "announcement" | "transfer" | "event";
   title?: string;
   slug?: Slug;
   publishAt?: string;
@@ -307,6 +341,9 @@ export type Article = {
     | ({
         _key: string;
       } & HtmlTable)
+    | ({
+        _key: string;
+      } & QaBlock)
   >;
   relatedArticles?: Array<
     {
@@ -774,6 +811,8 @@ export type AllSanitySchemaTypes =
   | FileAttachment
   | Event
   | Sponsor
+  | QaPair
+  | QaBlock
   | ArticleImage
   | PlayerReference
   | StaffMemberReference
@@ -924,6 +963,21 @@ export type ARTICLES_QUERY_RESULT = Array<{
         asset: null;
         markDefs: null;
       }
+    | {
+        _key: string;
+        _type: "qaBlock";
+        pairs?: Array<
+          {
+            _key: string;
+          } & QaPair
+        >;
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: null;
+        markDefs: null;
+      }
   > | null;
 }>;
 
@@ -960,7 +1014,7 @@ export type RELATED_ARTICLES_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLE_BY_SLUG_QUERY
-// Query: *[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {    _id, firstName, lastName, position,    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    psdId  },  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {    _id, name,    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "slug": slug.current  },  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {    _id, firstName, lastName,    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"  }}
+// Query: *[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []), articleType,  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {    _id, firstName, lastName, position,    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    psdId  },  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {    _id, name,    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "slug": slug.current  },  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {    _id, firstName, lastName,    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"  }}
 export type ARTICLE_BY_SLUG_QUERY_RESULT = {
   id: string;
   updatedAt: string;
@@ -969,6 +1023,7 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
   publishedAt: string | null;
   featured: boolean | false;
   tags: Array<string> | Array<never>;
+  articleType: "announcement" | "event" | "interview" | "transfer" | null;
   coverImageUrl: string | null;
   body: Array<
     | {
@@ -1076,6 +1131,21 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
         _key: string;
         _type: "htmlTable";
         html?: string;
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "qaBlock";
+        pairs?: Array<
+          {
+            _key: string;
+          } & QaPair
+        >;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1743,7 +1813,7 @@ declare module "@sanity/client" {
     'array::unique(*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])': ARTICLE_TAGS_QUERY_RESULT;
     '*[_type == "article" && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishAt desc) [$offset...$end] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
     '*[_type == "article" && references($documentId) && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishAt desc) {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;
-    '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
+    '*[_type == "article" && slug.current == $slug && publishAt <= now() && (!defined(unpublishAt) || unpublishAt > now())][0] {\n  "id": _id, "updatedAt": _updatedAt, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []), articleType,\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } },\n  relatedArticles[]-> { "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""), "publishedAt": publishAt, unpublishAt, "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max" },\n  "mentionedPlayers": body[].markDefs[_type == "internalLink" && reference->_type == "player"].reference-> {\n    _id, firstName, lastName, position,\n    "imageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    psdId\n  },\n  "mentionedTeams": body[].markDefs[_type == "internalLink" && reference->_type == "team"].reference-> {\n    _id, name,\n    "imageUrl": teamImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "slug": slug.current\n  },\n  "mentionedStaffMembers": body[].markDefs[_type == "internalLink" && reference->_type == "staffMember"].reference-> {\n    _id, firstName, lastName,\n    "imageUrl": photo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n  }\n}': ARTICLE_BY_SLUG_QUERY_RESULT;
     '*[_type == "event"] | order(dateStart asc) {\n  "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": false,\n  "href": coalesce(externalLink.url, "#"),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': EVENTS_QUERY_RESULT;
     '\n  coalesce(\n    *[_type == "event" && featuredOnHome == true && dateStart > $now] | order(dateStart asc) [0] {\n      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),\n      "href": coalesce(externalLink.url, "#"),\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    },\n    *[_type == "event" && dateStart > $now] | order(dateStart asc) [0] {\n      "id": _id, "title": coalesce(title, ""), "dateStart": coalesce(dateStart, ""), dateEnd, "featuredOnHome": coalesce(featuredOnHome, false),\n      "href": coalesce(externalLink.url, "#"),\n      "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n    }\n  )\n': NEXT_FEATURED_EVENT_QUERY_RESULT;
     '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;

--- a/packages/sanity-schemas/src/article.ts
+++ b/packages/sanity-schemas/src/article.ts
@@ -19,6 +19,22 @@ export const article = defineType({
   ],
   fields: [
     defineField({
+      name: "articleType",
+      title: "Article type",
+      type: "string",
+      options: {
+        list: [
+          { title: "Interview", value: "interview" },
+          { title: "Announcement", value: "announcement" },
+          { title: "Transfer", value: "transfer" },
+          { title: "Event", value: "event" },
+        ],
+        layout: "radio",
+      },
+      initialValue: "announcement",
+      validation: (r) => r.required(),
+    }),
+    defineField({
       name: "title",
       title: "Title",
       type: "string",
@@ -114,6 +130,7 @@ export const article = defineType({
         { type: "articleImage" },
         { type: "fileAttachment" },
         { type: "htmlTable" },
+        { type: "qaBlock" },
       ],
     }),
     defineField({

--- a/packages/sanity-schemas/src/index.ts
+++ b/packages/sanity-schemas/src/index.ts
@@ -8,6 +8,7 @@ export {responsibilityPreviewSelect, prepareResponsibilityPreview} from './previ
 export {validateOrganigramMember} from './validation/organigram-members'
 export {article} from './article'
 export {articleImage} from './articleImage'
+export {qaBlock, qaPair} from './qaBlock'
 export {sponsor} from './sponsor'
 export {event} from './event'
 export {page} from './page'
@@ -26,6 +27,7 @@ import {organigramNode} from './organigramNode'
 import {responsibility} from './responsibility'
 import {article} from './article'
 import {articleImage} from './articleImage'
+import {qaBlock, qaPair} from './qaBlock'
 import {sponsor} from './sponsor'
 import {event} from './event'
 import {page} from './page'
@@ -46,6 +48,8 @@ export const schemaTypes = [
   responsibility,
   article,
   articleImage,
+  qaBlock,
+  qaPair,
   sponsor,
   event,
   page,

--- a/packages/sanity-schemas/src/qaBlock.ts
+++ b/packages/sanity-schemas/src/qaBlock.ts
@@ -1,0 +1,79 @@
+import {defineField, defineType} from 'sanity'
+
+export const qaPair = defineType({
+  name: 'qaPair',
+  title: 'Q&A pair',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'question',
+      title: 'Question',
+      type: 'string',
+      validation: (r) => r.required().max(240),
+    }),
+    defineField({
+      name: 'answer',
+      title: 'Answer',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          // Design §6.1: answer is flat prose — no headings, no lists, no
+          // images. Default marks (bold, italic, underline, code, link) are
+          // retained to support emphasis and inline links.
+          styles: [{title: 'Normal', value: 'normal'}],
+          lists: [],
+        },
+      ],
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: 'tag',
+      title: 'Tag',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Standard', value: 'standard'},
+          {title: 'Key quote', value: 'key'},
+          {title: 'Standalone quote', value: 'quote'},
+          {title: 'Rapid-fire', value: 'rapid-fire'},
+        ],
+      },
+      initialValue: 'standard',
+    }),
+  ],
+  preview: {
+    select: {question: 'question', tag: 'tag'},
+    prepare({question, tag}) {
+      return {
+        title: question ?? 'Untitled Q&A pair',
+        subtitle: tag ? `Tag: ${tag}` : 'Tag: standard',
+      }
+    },
+  },
+})
+
+export const qaBlock = defineType({
+  name: 'qaBlock',
+  title: 'Q&A',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'pairs',
+      title: 'Pairs',
+      type: 'array',
+      of: [{type: 'qaPair'}],
+      validation: (r) => r.min(1).error('At least one Q&A pair required.'),
+    }),
+  ],
+  preview: {
+    select: {pairs: 'pairs'},
+    prepare({pairs}) {
+      const count = Array.isArray(pairs) ? pairs.length : 0
+      return {
+        title: 'Q&A block',
+        subtitle: `${count} pair${count === 1 ? '' : 's'}`,
+      }
+    },
+  },
+})

--- a/packages/sanity-schemas/src/qaBlock.ts
+++ b/packages/sanity-schemas/src/qaBlock.ts
@@ -47,7 +47,9 @@ export const qaPair = defineType({
     prepare({question, tag}) {
       return {
         title: question ?? 'Untitled Q&A pair',
-        subtitle: tag ? `Tag: ${tag}` : 'Tag: standard',
+        // Distinguish an explicitly-set `standard` from an unset tag so
+        // editors can see at a glance whether the field has been touched.
+        subtitle: tag ? `Tag: ${tag}` : 'Tag: — (defaults to standard)',
       }
     },
   },


### PR DESCRIPTION
Closes #1327 — Phase 1 tracer-bullet for the article-detail redesign.

## Summary

Proves end-to-end that the article-detail redesign's moving pieces fit together: schema change lands in both studios, `qaBlock` body block is authorable, GROQ returns the shape, PortableText dispatches to a custom renderer, and `/nieuws/[slug]` swaps template on `article.articleType`. Styling polish, the other three tag treatments, other article types, analytics, and migration are deliberately out of scope for this phase (Phases 2–8 in the PRD).

## Changes

**Schema — `packages/sanity-schemas`**
- `article.ts` adds `articleType` enum (`interview | announcement | transfer | event`, radio layout, required, default `announcement`). `body` array now accepts `{type: 'qaBlock'}`.
- New `qaBlock.ts` exports `qaBlock` (pairs array, min 1) + `qaPair` (`question: string max 240`, `answer: array of normal blocks with no lists and default marks`, `tag: standard | key | quote | rapid-fire`, default `standard`). Both studios pick this up through `@kcvv/sanity-schemas`.

**Web — `apps/web`**
- GROQ: `ARTICLE_BY_SLUG_QUERY` projects `articleType`; the existing `body[]{...}` spread already picks up qaBlock shape.
- New `QaBlock` + `QaPairStandard` components under `components/article/QaBlock/` matching design §6.1 (4rem left gutter, Quasimoda 700 `text-5xl` `kcvv-green-bright` numeral, Quasimoda 700 `text-xl` `kcvv-gray-blue` question, `text-lg` `kcvv-gray-dark` answer, 1px `kcvv-gray-light` separator between pairs). Unknown tags fall back to `QaPairStandard`.
- `SanityArticleBody` gains a `qaBlock` PortableText renderer — all articles that embed a qaBlock render correctly regardless of `articleType`.
- New `InterviewTemplate` — thin wrapper rendering the existing `ArticleHeader` + `ArticleMetadata` + `SanityArticleBody`. Structurally identical to the legacy path in this phase; Phase 3 (#1329) replaces it with the 4:5 portrait hero per design §5.2.
- `app/(main)/nieuws/[slug]/page.tsx` dispatches: `articleType === 'interview'` → `InterviewTemplate`, else → legacy JSX (unchanged). JSON-LD and RelatedContentSection remain at page level, shared by both branches.

## Testing

- `pnpm --filter @kcvv/web check-all` — lint, type-check (all 8 workspaces), 2434 vitest tests (5 new), Next.js build: all green
- `pnpm --filter @kcvv/web build-storybook` — passes
- `sanity schema extract` on both `@kcvv/studio` and `@kcvv/studio-staging` — both produce a schema containing `qaBlock` + `qaPair`
- `QaBlock.test.tsx` covers: two standard pairs render in order with 01./02. numerals; exactly N-1 separators between N pairs; empty-pairs returns null; missing-pairs returns null; unknown tag values fall back to `QaPairStandard`
- Storybook `Features/Articles/QaBlock` renders `TwoStandardPairs` + `SinglePair`

## Manual verification to perform before merge

Per the issue's two manual-only AC bullets:
- [ ] Create a staging article with `articleType='interview'` + one `qaBlock` with two standard pairs → confirm `/nieuws/<slug>` renders through `InterviewTemplate` with both pairs visible
- [ ] Open three existing `/nieuws/<slug>` pages (without `articleType` in the document) → confirm they render unchanged through the legacy path (dispatch falls through when `articleType` is null/undefined)

## Follow-ups carried to Phase 2+

- Promote `components/article/QaBlock/` to `components/article/blocks/QaBlock/` alongside `QaPairKey`, `QaPairQuote`, `QaGroupRapidFire`, and `SubjectAttribution` (design §10) — do this as one atomic rename in #1328.
- Replace the implicit "always render standard" fallback with a real `{standard, key, quote, 'rapid-fire'} → Component` dispatch map — #1328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)