### PR TITLE
feat(news): announcement template — drop-cap, blockquote rework, fade-up motion (#1330)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -23,8 +23,7 @@ import {
   buildNewsArticleJsonLd,
   buildBreadcrumbJsonLd,
 } from "@/lib/seo/jsonld";
-import { ArticleHeader, ArticleMetadata } from "@/components/article";
-import { SanityArticleBody } from "@/components/article/SanityArticleBody/SanityArticleBody";
+import { AnnouncementTemplate } from "@/components/article/AnnouncementTemplate";
 import { InterviewTemplate } from "@/components/article/InterviewTemplate";
 import { RelatedContentSection } from "@/components/related/RelatedContentSection/RelatedContentSection";
 import type { RelatedContentItem } from "@/components/related/types";
@@ -194,39 +193,19 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           subject={article.subject ?? null}
         />
       ) : (
-        <>
-          <ArticleHeader
-            title={article.title}
-            imageUrl={article.coverImageUrl ?? undefined}
-            imageAlt={article.title}
-            category={primaryCategory?.name}
-            date={
-              article.publishedAt
-                ? formatArticleDate(new Date(article.publishedAt))
-                : undefined
-            }
-            author="KCVV Elewijt"
-          />
-
-          <ArticleMetadata
-            author="KCVV Elewijt"
-            date={
-              article.publishedAt
-                ? formatArticleDate(new Date(article.publishedAt))
-                : undefined
-            }
-            readingTime={readingTime}
-            shareConfig={{ url: shareConfig.url, title: article.title }}
-          />
-
-          <main className="w-full max-w-inner-lg mx-auto px-6 mb-6 lg:mb-10">
-            {Array.isArray(article.body) && article.body.length > 0 && (
-              <SanityArticleBody
-                content={article.body as PortableTextBlock[]}
-              />
-            )}
-          </main>
-        </>
+        <AnnouncementTemplate
+          title={article.title}
+          category={primaryCategory?.name}
+          coverImageUrl={article.coverImageUrl ?? undefined}
+          publishedDate={
+            article.publishedAt
+              ? formatArticleDate(new Date(article.publishedAt))
+              : undefined
+          }
+          readingTime={readingTime}
+          shareConfig={{ url: shareConfig.url, title: article.title }}
+          body={(article.body as PortableTextBlock[] | null) ?? null}
+        />
       )}
 
       <RelatedContentSection

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -411,6 +411,119 @@
 }
 
 
+/* ===== Article body — announcement / transfer templates (#1330) =====
+
+   Scoped to `.article-body` so the Sanity Studio `.prose` previews and the
+   interview template (qaBlock-only body) remain untouched. The class is
+   applied to the `SanityArticleBody` wrapper from the announcement /
+   transfer templates only — see AnnouncementTemplate for the attachment
+   point. */
+
+/* §7.3 — Drop-cap on the first paragraph. Floated Quasimoda 700 glyph at
+   5.5rem, ~4 lines tall, `kcvv-green-bright`. */
+.article-body > p:first-of-type::first-letter {
+  font-family: var(--font-family-title);
+  font-weight: 700;
+  font-size: 5.5rem;
+  line-height: 0.85;
+  float: left;
+  padding-right: 0.75rem;
+  padding-top: 0.5rem;
+  color: var(--color-kcvv-green-bright);
+}
+
+/* Section heading bar — reuses the `.featured-border::before` geometry
+   (4rem × 2px green-bright) so every `<h2>` inside `.article-body` carries
+   a short rule above it. Scoped here rather than on `.featured-border`
+   itself so editors do not have to opt in per-heading. */
+.article-body h2 {
+  position: relative;
+  padding-top: 0.75rem;
+}
+
+.article-body h2::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4rem;
+  border-top: 2px solid var(--color-kcvv-green-bright);
+}
+
+/* §7.4 — Blockquote rework. Rule-framed, centered, no leading `"` glyph.
+   Overrides the legacy `.prose blockquote` treatment when inside the
+   `.article-body` scope. */
+.article-body blockquote {
+  font-family: var(--font-family-title);
+  font-weight: 400;
+  font-style: normal;
+  font-size: var(--font-size-2xl);
+  line-height: 1.4;
+  color: var(--color-kcvv-gray-blue);
+  text-align: center;
+  max-width: 50ch;
+  margin: 3rem auto;
+  padding: 2rem 0;
+  border-top: 1px solid var(--color-kcvv-gray-light);
+  border-bottom: 1px solid var(--color-kcvv-gray-light);
+  /* Unset the legacy `.prose blockquote` overflow/position so the old
+     glyph geometry has no effect. */
+  overflow: visible;
+  position: static;
+}
+
+/* Erase the legacy 15rem `"` glyph inside the article-body scope. The
+   decorative glyph is reserved for the `quote` qaBlock treatment. */
+.article-body blockquote::before {
+  content: none;
+}
+
+.article-body blockquote > p:first-child {
+  margin-top: 0;
+}
+
+.article-body blockquote > p:last-child {
+  margin-bottom: 0;
+}
+
+/* Attribution after the quote is intentionally unstyled in this phase.
+   Design §7.4 specifies a mono small-caps attribution line with a 2rem ×
+   2px green rule prefix, but Sanity's blockquote has no structured slot
+   for attribution today — every styling attempt based on `em:last-child`
+   or `<cite>` would target markup PortableText's default serializer does
+   not reliably emit. A dedicated `blockquoteAttribution` mark or a
+   structured block is tracked for a follow-up phase; for now, attribution
+   paragraphs written below the quote render as normal prose. */
+
+/* §7.5 — Body fade-up motion. The `article-body-motion` class is applied
+   by `ArticleBodyMotion` on mount, and the `--entered` modifier is added
+   when the element crosses the IntersectionObserver threshold. */
+.article-body-motion {
+  opacity: 0;
+  transform: translateY(24px);
+  transition:
+    opacity 500ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 500ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.article-body-motion.article-body-motion--entered {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Safety net for users whose JS initialises the observer before the
+     media-query check resolves — any element that picked up the base
+     class must still render at its final state. */
+  .article-body-motion {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+
 /* ===== Phase 4: Mobile Optimizations ===== */
 
 /* Safe Area Insets for Modern Mobile Devices */

--- a/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.test.tsx
+++ b/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.test.tsx
@@ -49,21 +49,10 @@ describe("AnnouncementHero", () => {
     expect(screen.queryByTestId("announcement-hero-image")).toBeNull();
   });
 
-  it("renders the byline with author and reading time", () => {
+  it("does not render a byline row — author + reading time live in the §7.6 metadata bar below the hero", () => {
     render(
-      <AnnouncementHero
-        title="Title"
-        author="Redactie KCVV"
-        readingTime="4 min lezen"
-      />,
+      <AnnouncementHero title="Title" category="Nieuws" date="19 April 2026" />,
     );
-    const byline = screen.getByTestId("announcement-hero-byline");
-    const text = (byline.textContent ?? "").replace(/\s+/g, " ").trim();
-    expect(text).toMatch(/Redactie KCVV.*4 min lezen/);
-  });
-
-  it("omits the byline when neither author nor reading time is provided", () => {
-    render(<AnnouncementHero title="Title" />);
     expect(screen.queryByTestId("announcement-hero-byline")).toBeNull();
   });
 });

--- a/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.test.tsx
+++ b/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AnnouncementHero } from "./AnnouncementHero";
+
+describe("AnnouncementHero", () => {
+  it("renders the title as the single h1", () => {
+    render(
+      <AnnouncementHero title="Een nieuw hoofdstuk voor het eerste elftal." />,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Een nieuw hoofdstuk voor het eerste elftal.",
+    );
+  });
+
+  it("renders kicker with category and date separated by a pipe", () => {
+    render(
+      <AnnouncementHero title="Title" category="Nieuws" date="19 April 2026" />,
+    );
+    const kicker = screen.getByTestId("announcement-hero-kicker");
+    const text = (kicker.textContent ?? "").replace(/\s+/g, " ").trim();
+    expect(text).toMatch(/Nieuws\s*\|\s*19 April 2026/);
+  });
+
+  it("renders kicker with only category when date is absent", () => {
+    render(<AnnouncementHero title="Title" category="Nieuws" />);
+    const text =
+      screen.getByTestId("announcement-hero-kicker").textContent ?? "";
+    expect(text).toContain("Nieuws");
+    expect(text).not.toContain("|");
+  });
+
+  it("omits the kicker entirely when neither category nor date is provided", () => {
+    render(<AnnouncementHero title="Title" />);
+    expect(screen.queryByTestId("announcement-hero-kicker")).toBeNull();
+  });
+
+  it("renders the 16:9 cover image when coverImageUrl is provided", () => {
+    render(
+      <AnnouncementHero
+        title="Title"
+        coverImageUrl="https://cdn.sanity.io/cover.webp"
+      />,
+    );
+    expect(screen.getByTestId("announcement-hero-image")).toBeInTheDocument();
+  });
+
+  it("omits the image when coverImageUrl is missing", () => {
+    render(<AnnouncementHero title="Title" />);
+    expect(screen.queryByTestId("announcement-hero-image")).toBeNull();
+  });
+
+  it("renders the byline with author and reading time", () => {
+    render(
+      <AnnouncementHero
+        title="Title"
+        author="Redactie KCVV"
+        readingTime="4 min lezen"
+      />,
+    );
+    const byline = screen.getByTestId("announcement-hero-byline");
+    const text = (byline.textContent ?? "").replace(/\s+/g, " ").trim();
+    expect(text).toMatch(/Redactie KCVV.*4 min lezen/);
+  });
+
+  it("omits the byline when neither author nor reading time is provided", () => {
+    render(<AnnouncementHero title="Title" />);
+    expect(screen.queryByTestId("announcement-hero-byline")).toBeNull();
+  });
+});

--- a/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.tsx
+++ b/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.tsx
@@ -1,0 +1,145 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+
+export interface AnnouncementHeroProps {
+  /** Article title — rendered as the single h1 of the page. */
+  title: string;
+  /**
+   * Primary category label shown in the kicker row (e.g. "Nieuws",
+   * "Jeugd"). Typically the first value from `article.tags`.
+   */
+  category?: string;
+  /**
+   * Publication date formatted for display (e.g. "19 April 2026").
+   */
+  date?: string;
+  /**
+   * Byline author (e.g. "Redactie KCVV"). Announcements render the club
+   * as the implicit author when absent.
+   */
+  author?: string;
+  /** Reading time, e.g. "4 min lezen". Shown in the byline when present. */
+  readingTime?: string;
+  /**
+   * 16:9 cover image URL. When absent the hero renders headline + byline
+   * only, matching design §5.1's "no overlay, no shadow" ethos.
+   */
+  coverImageUrl?: string | null;
+  /**
+   * Alt text for the cover image. Falls back to empty string — the hero
+   * headline already carries the article's meaning, so the image is
+   * treated as decorative when no alt is supplied. Thread a caption-style
+   * description through as soon as the Sanity `coverImage` schema gains
+   * an `alt` field (tracked separately).
+   */
+  imageAlt?: string;
+  className?: string;
+}
+
+/**
+ * Design §5.1 — the baseline announcement hero. 16:9 hotspot crop of the
+ * cover image, no overlay, rounded-[4px], with a kicker (category · date)
+ * above a Quasimoda 700 clamped display title in sentence case and a
+ * mono small-caps byline row below.
+ *
+ * The interview hero (`InterviewHero`) diverges on: kicker composition
+ * (subject jersey + position), subtitle line, and a 4:5 portrait crop.
+ * Transfer and event heroes skip the image entirely. Keeping the heroes
+ * as sibling components avoids branching on `articleType` inside one
+ * bloated component.
+ */
+export const AnnouncementHero = ({
+  title,
+  category,
+  date,
+  author,
+  readingTime,
+  coverImageUrl,
+  imageAlt,
+  className,
+}: AnnouncementHeroProps) => {
+  const kickerParts = [category, date].filter(
+    (x): x is string => typeof x === "string" && x.length > 0,
+  );
+  const bylineParts = [author, readingTime].filter(
+    (x): x is string => typeof x === "string" && x.length > 0,
+  );
+
+  return (
+    <header
+      className={cn(
+        "w-full max-w-inner-lg mx-auto px-6 pt-10 md:pt-16",
+        className,
+      )}
+      data-testid="announcement-hero"
+    >
+      <div className="max-w-[65ch]">
+        {kickerParts.length > 0 && (
+          <p
+            className={cn(
+              "mb-6 flex flex-wrap items-center gap-x-3 gap-y-1",
+              "text-xs font-semibold uppercase tracking-[var(--letter-spacing-label)] text-kcvv-green-dark",
+              "before:content-[''] before:block before:w-16 before:h-[2px] before:bg-kcvv-green-bright before:mr-1 before:shrink-0",
+            )}
+            data-testid="announcement-hero-kicker"
+          >
+            {kickerParts.map((part, i) => (
+              <span key={part} className="flex items-center gap-x-3">
+                {i > 0 && (
+                  <span aria-hidden="true" className="text-kcvv-gray-light">
+                    |
+                  </span>
+                )}
+                <span>{part}</span>
+              </span>
+            ))}
+          </p>
+        )}
+
+        <h1
+          className="font-title font-bold text-kcvv-gray-blue leading-[0.95] text-[clamp(2.5rem,5.5vw,4.5rem)]"
+          data-testid="announcement-hero-title"
+        >
+          {title}
+        </h1>
+
+        {bylineParts.length > 0 && (
+          <p
+            className="mt-5 font-mono text-xs uppercase tracking-[var(--letter-spacing-caps)] text-kcvv-gray"
+            data-testid="announcement-hero-byline"
+          >
+            {bylineParts.map((part, i) => (
+              <span key={part}>
+                {i > 0 && (
+                  <span
+                    aria-hidden="true"
+                    className="mx-3 text-kcvv-gray-light"
+                  >
+                    ·
+                  </span>
+                )}
+                {part}
+              </span>
+            ))}
+          </p>
+        )}
+      </div>
+
+      {coverImageUrl && (
+        <div
+          className="mt-10 relative w-full aspect-[16/9] overflow-hidden rounded-[4px] bg-kcvv-gray-light/30"
+          data-testid="announcement-hero-image"
+        >
+          <Image
+            src={coverImageUrl}
+            alt={imageAlt ?? ""}
+            fill
+            priority
+            sizes="(max-width: 768px) 100vw, 960px"
+            className="object-cover object-center"
+          />
+        </div>
+      )}
+    </header>
+  );
+};

--- a/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.tsx
+++ b/apps/web/src/components/article/AnnouncementHero/AnnouncementHero.tsx
@@ -14,14 +14,7 @@ export interface AnnouncementHeroProps {
    */
   date?: string;
   /**
-   * Byline author (e.g. "Redactie KCVV"). Announcements render the club
-   * as the implicit author when absent.
-   */
-  author?: string;
-  /** Reading time, e.g. "4 min lezen". Shown in the byline when present. */
-  readingTime?: string;
-  /**
-   * 16:9 cover image URL. When absent the hero renders headline + byline
+   * 16:9 cover image URL. When absent the hero renders kicker + title
    * only, matching design §5.1's "no overlay, no shadow" ethos.
    */
   coverImageUrl?: string | null;
@@ -39,8 +32,16 @@ export interface AnnouncementHeroProps {
 /**
  * Design §5.1 — the baseline announcement hero. 16:9 hotspot crop of the
  * cover image, no overlay, rounded-[4px], with a kicker (category · date)
- * above a Quasimoda 700 clamped display title in sentence case and a
- * mono small-caps byline row below.
+ * above a Quasimoda 700 clamped display title in sentence case.
+ *
+ * The byline row shown in the original §5.1 mock-up (`By Redactie KCVV ·
+ * 4 min lezen`) is intentionally omitted: the §7.6 metadata bar rendered
+ * immediately below the hero already carries author + date + reading
+ * time + share controls, and a second line restating author + reading
+ * time was pure duplication in practice. The interview hero follows the
+ * same rule. Apply this principle to the upcoming transfer + event
+ * heroes too — the metadata bar is the single source of truth for these
+ * three facts.
  *
  * The interview hero (`InterviewHero`) diverges on: kicker composition
  * (subject jersey + position), subtitle line, and a 4:5 portrait crop.
@@ -52,16 +53,11 @@ export const AnnouncementHero = ({
   title,
   category,
   date,
-  author,
-  readingTime,
   coverImageUrl,
   imageAlt,
   className,
 }: AnnouncementHeroProps) => {
   const kickerParts = [category, date].filter(
-    (x): x is string => typeof x === "string" && x.length > 0,
-  );
-  const bylineParts = [author, readingTime].filter(
     (x): x is string => typeof x === "string" && x.length > 0,
   );
 
@@ -102,27 +98,6 @@ export const AnnouncementHero = ({
         >
           {title}
         </h1>
-
-        {bylineParts.length > 0 && (
-          <p
-            className="mt-5 font-mono text-xs uppercase tracking-[var(--letter-spacing-caps)] text-kcvv-gray"
-            data-testid="announcement-hero-byline"
-          >
-            {bylineParts.map((part, i) => (
-              <span key={part}>
-                {i > 0 && (
-                  <span
-                    aria-hidden="true"
-                    className="mx-3 text-kcvv-gray-light"
-                  >
-                    ·
-                  </span>
-                )}
-                {part}
-              </span>
-            ))}
-          </p>
-        )}
       </div>
 
       {coverImageUrl && (

--- a/apps/web/src/components/article/AnnouncementHero/index.ts
+++ b/apps/web/src/components/article/AnnouncementHero/index.ts
@@ -1,0 +1,2 @@
+export { AnnouncementHero } from "./AnnouncementHero";
+export type { AnnouncementHeroProps } from "./AnnouncementHero";

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.stories.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { PortableTextBlock } from "@portabletext/react";
+import { AnnouncementTemplate } from "./AnnouncementTemplate";
+
+const paragraph = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "normal",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  }) as unknown as PortableTextBlock;
+
+const heading = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "h2",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  }) as unknown as PortableTextBlock;
+
+const blockquote = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "blockquote",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  }) as unknown as PortableTextBlock;
+
+const inlineImage = (
+  key: string,
+  url: string,
+  alt: string,
+): PortableTextBlock =>
+  ({
+    _type: "articleImage",
+    _key: key,
+    asset: { url },
+    alt,
+    width: 960,
+    height: 540,
+  }) as unknown as PortableTextBlock;
+
+const meta = {
+  title: "Pages/Article/Announcement",
+  component: AnnouncementTemplate,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Default article template (#1330 Phase 4). Renders when `articleType` is `announcement` or missing. Showcases the §5.1 hero, §7.3 drop-cap, §7.4 rule-framed blockquote, and §7.5 body fade-up scroll motion.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AnnouncementTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithDropCapBlockquoteAndInlineImage: Story = {
+  args: {
+    title: "Een nieuw hoofdstuk voor het eerste elftal.",
+    category: "Nieuws",
+    coverImageUrl:
+      "https://images.unsplash.com/photo-1517649763962-0c623066013b?w=1600&q=80",
+    publishedDate: "19 April 2026",
+    readingTime: "4 min lezen",
+    shareConfig: {
+      url: "https://kcvvelewijt.be/nieuws/een-nieuw-hoofdstuk",
+      title: "Een nieuw hoofdstuk voor het eerste elftal",
+    },
+    body: [
+      paragraph(
+        "p1",
+        "Na een seizoen vol leermomenten schrijft KCVV Elewijt aan een nieuw verhaal. De kleedkamer borrelt, de staf heeft duidelijke ambities, en het publiek staat klaar om die sprong mee te maken. Dit is het moment om vooruit te kijken — en we doen dat vol vertrouwen.",
+      ),
+      paragraph(
+        "p2",
+        "Voor de nieuwe jaargang ligt de focus op diepgang in de kern, continuïteit in de speelstijl, en een duidelijke lijn tussen jeugd en eerste ploeg. Op elk van die drie punten zetten we nu al stappen.",
+      ),
+      heading("h1", "Drie speerpunten voor het nieuwe seizoen"),
+      paragraph(
+        "p3",
+        "De staf werkt het masterplan verder uit rond drie speerpunten: speelstijl, schakeling naar de jeugd, en een stadionervaring die supporters laat terugkomen. Elk speerpunt krijgt een trekker uit de staf — niemand hoeft alles te dragen.",
+      ),
+      blockquote(
+        "bq",
+        "We gaan niet iedereen tevredenstellen, maar we gaan wel iedereen meenemen. Dat is een verschil dat je voelt op de tribune.",
+      ),
+      paragraph(
+        "p4",
+        "Intern werd de afgelopen weken stevig gesproken over wat werkte en wat niet. Die openheid is een verademing — en ook de reden dat de voorbereiding vroeg, gestructureerd en met overtuiging kan starten.",
+      ),
+      inlineImage(
+        "img1",
+        "https://images.unsplash.com/photo-1517466787929-bc90951d0974?w=1200&q=80",
+        "Spelers KCVV Elewijt tijdens de training",
+      ),
+      heading("h2", "Wat verandert er concreet?"),
+      paragraph(
+        "p5",
+        "Vanaf het eerste weekend komen er extra stewards op de parking, wordt de tribune-ingang heringericht en krijgt de fanshop een vaste uitstalling naast het clubhuis. Kleine signalen die samen een groot verschil maken voor wie zaterdag na zaterdag langskomt.",
+      ),
+      paragraph(
+        "p6",
+        "Op sportief vlak behouden we de 4-3-3 met actieve backs, maar met meer druk op de zestien. De staf investeert bewust in een tweede afwerker naast de nummer 9, zodat we in cruciale wedstrijden een vluchtscenario hebben.",
+      ),
+    ] as PortableTextBlock[],
+  },
+};
+
+export const WithoutCoverImage: Story = {
+  args: {
+    ...WithDropCapBlockquoteAndInlineImage.args,
+    coverImageUrl: null,
+  },
+};
+
+export const WithoutCategoryOrReadingTime: Story = {
+  args: {
+    ...WithDropCapBlockquoteAndInlineImage.args,
+    category: undefined,
+    readingTime: undefined,
+  },
+};

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.test.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PortableTextBlock } from "@portabletext/react";
+import { AnnouncementTemplate } from "./AnnouncementTemplate";
+
+// IntersectionObserver is reached for by `ArticleBodyMotion`. happy-dom does
+// not implement it — stub a minimal no-op so rendering does not throw.
+class NoopIntersectionObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root: Element | Document | null = null;
+  rootMargin = "";
+  thresholds: ReadonlyArray<number> = [];
+  constructor() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+  vi.stubGlobal("matchMedia", (q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const simpleBody: PortableTextBlock[] = [
+  {
+    _type: "block",
+    _key: "p1",
+    style: "normal",
+    markDefs: [],
+    children: [
+      {
+        _type: "span",
+        _key: "p1-s",
+        marks: [],
+        text: "Eerste paragraaf met de drop-cap.",
+      },
+    ],
+  } as unknown as PortableTextBlock,
+];
+
+describe("AnnouncementTemplate", () => {
+  it("renders the announcement hero with the given title and category kicker", () => {
+    render(
+      <AnnouncementTemplate
+        title="Een nieuw hoofdstuk"
+        category="Nieuws"
+        publishedDate="19 April 2026"
+        readingTime="4 min lezen"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        body={simpleBody}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Een nieuw hoofdstuk",
+    );
+    expect(screen.getByTestId("announcement-hero-kicker")).toHaveTextContent(
+      /Nieuws/,
+    );
+  });
+
+  it("renders the body inside an .article-body container so the drop-cap and blockquote rules apply", () => {
+    const { container } = render(
+      <AnnouncementTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        body={simpleBody}
+      />,
+    );
+
+    const articleBody = container.querySelector(".article-body");
+    expect(articleBody).not.toBeNull();
+    // The first paragraph rendered by PortableText must be a direct child of
+    // the `.article-body > .prose` container so `.article-body > p:first-of-type`
+    // drop-cap selector is guaranteed to resolve.
+    expect(articleBody?.querySelector("p")).not.toBeNull();
+  });
+
+  it("renders nothing for the body when body is null or empty", () => {
+    const { container, rerender } = render(
+      <AnnouncementTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        body={null}
+      />,
+    );
+    expect(container.querySelector(".article-body")).toBeNull();
+
+    rerender(
+      <AnnouncementTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        body={[]}
+      />,
+    );
+    expect(container.querySelector(".article-body")).toBeNull();
+  });
+
+  it("renders the metadata bar with the publication date, author and reading time", () => {
+    render(
+      <AnnouncementTemplate
+        title="Title"
+        publishedDate="19.04.2026"
+        readingTime="4 min lezen"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        body={simpleBody}
+      />,
+    );
+    const metadata = screen.getByRole("navigation", { name: /artikelinfo/i });
+    expect(metadata).toHaveTextContent("19.04.2026");
+    expect(metadata).toHaveTextContent("4 min lezen");
+  });
+});

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.test.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.test.tsx
@@ -72,7 +72,7 @@ describe("AnnouncementTemplate", () => {
     );
   });
 
-  it("renders the body inside an .article-body container so the drop-cap and blockquote rules apply", () => {
+  it("renders the body inside an .article-body container with the first <p> as a direct child so the drop-cap selector resolves", () => {
     const { container } = render(
       <AnnouncementTemplate
         title="Title"
@@ -83,10 +83,15 @@ describe("AnnouncementTemplate", () => {
 
     const articleBody = container.querySelector(".article-body");
     expect(articleBody).not.toBeNull();
-    // The first paragraph rendered by PortableText must be a direct child of
-    // the `.article-body > .prose` container so `.article-body > p:first-of-type`
-    // drop-cap selector is guaranteed to resolve.
-    expect(articleBody?.querySelector("p")).not.toBeNull();
+    // Drop-cap rule targets `.article-body > p:first-of-type::first-letter`,
+    // so the <p> must be a direct child — not a nested descendant. In this
+    // template `.article-body` is applied to the same div that carries
+    // `.prose`, so PortableText's top-level block emits <p> as a direct
+    // child. Guard against a future refactor inserting an intermediate
+    // wrapper that would silently break the drop-cap.
+    expect(
+      articleBody!.querySelector(":scope > p:first-of-type"),
+    ).not.toBeNull();
   });
 
   it("renders nothing for the body when body is null or empty", () => {

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
@@ -1,0 +1,82 @@
+import type { PortableTextBlock } from "@portabletext/react";
+import { ArticleMetadata } from "../ArticleMetadata";
+import { AnnouncementHero } from "../AnnouncementHero";
+import { ArticleBodyMotion } from "../ArticleBodyMotion";
+import { SanityArticleBody } from "../SanityArticleBody/SanityArticleBody";
+
+export interface AnnouncementTemplateProps {
+  title: string;
+  /**
+   * Primary category (first article tag) rendered in the hero kicker.
+   */
+  category?: string;
+  coverImageUrl?: string | null;
+  publishedDate?: string;
+  readingTime?: string;
+  shareConfig: { url: string; title?: string };
+  body: PortableTextBlock[] | null;
+}
+
+// Announcements are implicitly club-authored until we wire an editor field
+// in a follow-up phase (see PRD #1330 open questions). The byline + metadata
+// row both default to the club banner.
+const AUTHOR = "KCVV Elewijt";
+
+/**
+ * Phase 4 (#1330) — the default article template.
+ *
+ * Composition:
+ * 1. `AnnouncementHero` — design §5.1 (kicker + title + byline + 16:9 cover).
+ * 2. `ArticleMetadata` — design §7.6 metadata bar.
+ * 3. `ArticleBodyMotion` wrapping `SanityArticleBody` inside an
+ *    `.article-body` container, so:
+ *      - §7.3 drop-cap applies to the first `<p>`
+ *      - §7.4 rule-framed blockquote rework overrides the legacy 15rem glyph
+ *      - §7.5 fade-up motion attaches to every `<p>`/`<h2>`/`<h3>`
+ *    All three rules are scoped to `.article-body` in `globals.css` so the
+ *    Sanity Studio `.prose` previews remain untouched.
+ *
+ * Used as the fallback for any `articleType` that is not `interview`,
+ * including legacy documents with no `articleType` set at all.
+ */
+export const AnnouncementTemplate = ({
+  title,
+  category,
+  coverImageUrl,
+  publishedDate,
+  readingTime,
+  shareConfig,
+  body,
+}: AnnouncementTemplateProps) => {
+  const hasBody = Array.isArray(body) && body.length > 0;
+
+  return (
+    <>
+      <AnnouncementHero
+        title={title}
+        category={category}
+        date={publishedDate}
+        author={AUTHOR}
+        readingTime={readingTime}
+        coverImageUrl={coverImageUrl}
+        imageAlt={title}
+      />
+
+      <ArticleMetadata
+        author={AUTHOR}
+        date={publishedDate}
+        readingTime={readingTime}
+        shareConfig={shareConfig}
+        className="mt-10"
+      />
+
+      {hasBody && (
+        <main className="w-full max-w-inner-lg mx-auto px-6 mb-6 lg:mb-10">
+          <ArticleBodyMotion>
+            <SanityArticleBody className="article-body" content={body} />
+          </ArticleBodyMotion>
+        </main>
+      )}
+    </>
+  );
+};

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
@@ -18,16 +18,20 @@ export interface AnnouncementTemplateProps {
 }
 
 // Announcements are implicitly club-authored until we wire an editor field
-// in a follow-up phase (see PRD #1330 open questions). The byline + metadata
-// row both default to the club banner.
+// in a follow-up phase (see PRD #1330 open questions). The metadata bar
+// defaults to the club banner.
 const AUTHOR = "KCVV Elewijt";
 
 /**
  * Phase 4 (#1330) — the default article template.
  *
  * Composition:
- * 1. `AnnouncementHero` — design §5.1 (kicker + title + byline + 16:9 cover).
- * 2. `ArticleMetadata` — design §7.6 metadata bar.
+ * 1. `AnnouncementHero` — design §5.1 (kicker + title + 16:9 cover). No
+ *    byline row: author + reading time live in the §7.6 metadata bar
+ *    rendered immediately below, so repeating them on the hero was pure
+ *    duplication.
+ * 2. `ArticleMetadata` — design §7.6 metadata bar (date · author ·
+ *    reading time + share controls).
  * 3. `ArticleBodyMotion` wrapping `SanityArticleBody` inside an
  *    `.article-body` container, so:
  *      - §7.3 drop-cap applies to the first `<p>`
@@ -56,10 +60,7 @@ export const AnnouncementTemplate = ({
         title={title}
         category={category}
         date={publishedDate}
-        author={AUTHOR}
-        readingTime={readingTime}
         coverImageUrl={coverImageUrl}
-        imageAlt={title}
       />
 
       <ArticleMetadata

--- a/apps/web/src/components/article/AnnouncementTemplate/index.ts
+++ b/apps/web/src/components/article/AnnouncementTemplate/index.ts
@@ -1,0 +1,2 @@
+export { AnnouncementTemplate } from "./AnnouncementTemplate";
+export type { AnnouncementTemplateProps } from "./AnnouncementTemplate";

--- a/apps/web/src/components/article/ArticleBodyMotion/ArticleBodyMotion.test.tsx
+++ b/apps/web/src/components/article/ArticleBodyMotion/ArticleBodyMotion.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { ArticleBodyMotion } from "./ArticleBodyMotion";
+
+function stubMatchMedia(matches: boolean): void {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+let observerInstance: MockIntersectionObserver | null = null;
+
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  options?: IntersectionObserverInit;
+  observed: Element[] = [];
+  observe = vi.fn((el: Element) => {
+    this.observed.push(el);
+  });
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root: Element | Document | null = null;
+  rootMargin = "";
+  thresholds: ReadonlyArray<number> = [];
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.callback = callback;
+    this.options = options;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    observerInstance = this;
+  }
+}
+
+describe("ArticleBodyMotion", () => {
+  beforeEach(() => {
+    observerInstance = null;
+    stubMatchMedia(false);
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders its children", () => {
+    render(
+      <ArticleBodyMotion>
+        <p data-testid="child-p">Hello</p>
+      </ArticleBodyMotion>,
+    );
+    expect(screen.getByTestId("child-p")).toHaveTextContent("Hello");
+  });
+
+  it("observes every p, h2 and h3 under the container and tags them with the base motion class", () => {
+    render(
+      <ArticleBodyMotion>
+        <p data-testid="p1">Paragraph one.</p>
+        <h2 data-testid="h2">Section heading</h2>
+        <p data-testid="p2">Paragraph two.</p>
+        <h3 data-testid="h3">Sub heading</h3>
+      </ArticleBodyMotion>,
+    );
+
+    expect(observerInstance).not.toBeNull();
+    // One observer instance covers all four elements.
+    expect(observerInstance!.observe).toHaveBeenCalledTimes(4);
+    expect(screen.getByTestId("p1")).toHaveClass("article-body-motion");
+    expect(screen.getByTestId("h2")).toHaveClass("article-body-motion");
+    expect(screen.getByTestId("p2")).toHaveClass("article-body-motion");
+    expect(screen.getByTestId("h3")).toHaveClass("article-body-motion");
+  });
+
+  it("configures the observer per design §7.5 (threshold 0.15, rootMargin '0px 0px -10% 0px')", () => {
+    render(
+      <ArticleBodyMotion>
+        <p>Content</p>
+      </ArticleBodyMotion>,
+    );
+
+    expect(observerInstance?.options?.threshold).toBe(0.15);
+    expect(observerInstance?.options?.rootMargin).toBe("0px 0px -10% 0px");
+  });
+
+  it("adds the --entered class when an element intersects and stops observing it", () => {
+    render(
+      <ArticleBodyMotion>
+        <p data-testid="p1">Paragraph one.</p>
+      </ArticleBodyMotion>,
+    );
+
+    const p1 = screen.getByTestId("p1");
+    expect(p1).toHaveClass("article-body-motion");
+    expect(p1).not.toHaveClass("article-body-motion--entered");
+
+    act(() => {
+      observerInstance!.callback(
+        [
+          {
+            isIntersecting: true,
+            target: p1,
+            intersectionRatio: 1,
+            boundingClientRect: {} as DOMRectReadOnly,
+            intersectionRect: {} as DOMRectReadOnly,
+            rootBounds: null,
+            time: 0,
+          },
+        ],
+        observerInstance as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(p1).toHaveClass("article-body-motion--entered");
+    expect(observerInstance!.unobserve).toHaveBeenCalledWith(p1);
+  });
+
+  it("does not instantiate an observer when prefers-reduced-motion is reduce", () => {
+    stubMatchMedia(true);
+
+    render(
+      <ArticleBodyMotion>
+        <p data-testid="p1">Paragraph.</p>
+      </ArticleBodyMotion>,
+    );
+
+    expect(observerInstance).toBeNull();
+    // And the base motion class is not applied either — elements render at
+    // their final state straight away so there is nothing to transition.
+    expect(screen.getByTestId("p1")).not.toHaveClass("article-body-motion");
+  });
+});

--- a/apps/web/src/components/article/ArticleBodyMotion/ArticleBodyMotion.tsx
+++ b/apps/web/src/components/article/ArticleBodyMotion/ArticleBodyMotion.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+export interface ArticleBodyMotionProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+const BASE_CLASS = "article-body-motion";
+const ENTERED_CLASS = "article-body-motion--entered";
+
+/**
+ * Design §7.5 — body fade-up on scroll. Observes every `<p>`, `<h2>` and
+ * `<h3>` under the container (the prose tree rendered by PortableText) and
+ * reveals them one-by-one with a 24px rise + opacity transition as they
+ * cross the viewport.
+ *
+ * Client-only component. Wraps server-rendered body prose so the
+ * `AnnouncementTemplate` (and, later, the transfer + event templates) can
+ * stay on the server side of the boundary.
+ *
+ * When `prefers-reduced-motion: reduce` is set the component short-circuits
+ * before mutating any DOM — the base `.article-body-motion` class is never
+ * applied, so the children render at their natural final state. There is no
+ * observer and nothing to tear down.
+ *
+ * Known trade-off — brief hydration flash: the `.article-body-motion` class
+ * is only added on mount, so there is a very short window between SSR paint
+ * and observer-ready state where paragraphs are fully visible. The observer
+ * fires next-frame for already-visible elements, so the visible flicker is
+ * sub-perceptual in practice. Fixing this fully requires moving the initial
+ * opacity to an SSR-applied class (couples this component to the PortableText
+ * serializers in `SanityArticleBody`) — tracked as a follow-up. For now the
+ * behaviour mirrors `QaPairQuote`'s pattern.
+ */
+export const ArticleBodyMotion = ({
+  children,
+  className,
+}: ArticleBodyMotionProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Bail out under reduced motion — elements keep their natural final
+    // state. matchMedia is guarded because the effect only runs in the
+    // browser, but keep the null check for test environments.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia(MOTION_QUERY).matches
+    ) {
+      return;
+    }
+
+    const elements = Array.from(
+      container.querySelectorAll<HTMLElement>("p, h2, h3"),
+    );
+    for (const el of elements) el.classList.add(BASE_CLASS);
+
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          (entry.target as HTMLElement).classList.add(ENTERED_CLASS);
+          obs.unobserve(entry.target);
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -10% 0px" },
+    );
+
+    for (const el of elements) observer.observe(el);
+
+    return () => observer.disconnect();
+    // `children` intentionally omitted from deps: the article body is
+    // rendered once per page load (`revalidate = 3600` re-renders the
+    // whole route on the server, not the client). Re-running the effect
+    // on every React re-render would re-tag elements already carrying
+    // the --entered class and reset their state.
+  }, []);
+
+  return (
+    <div ref={containerRef} className={className}>
+      {children}
+    </div>
+  );
+};

--- a/apps/web/src/components/article/ArticleBodyMotion/index.ts
+++ b/apps/web/src/components/article/ArticleBodyMotion/index.ts
@@ -1,0 +1,2 @@
+export { ArticleBodyMotion } from "./ArticleBodyMotion";
+export type { ArticleBodyMotionProps } from "./ArticleBodyMotion";

--- a/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
+++ b/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
@@ -258,7 +258,10 @@ export const SanityArticleBody = ({
         "prose-p:leading-relaxed prose-p:text-kcvv-gray-dark",
         /* prose-a: fallback for <a> tags not rendered via marks (e.g. inside htmlTable raw HTML) */
         "prose-a:text-kcvv-green-dark prose-a:decoration-kcvv-green/30 prose-a:underline-offset-2 hover:prose-a:text-kcvv-green hover:prose-a:decoration-kcvv-green",
-        /* blockquote styles handled by .prose blockquote in globals.css */
+        /* Blockquote: legacy `.prose blockquote` glyph treatment in
+           globals.css by default; announcement/transfer templates pass
+           `className="article-body"` which swaps to the §7.4 rule-framed
+           treatment via `.article-body blockquote`. */
         "prose-table:w-full prose-th:bg-table-header-bg prose-th:p-2 prose-th:text-left prose-td:border prose-td:border-table-border prose-td:p-2",
         className,
       )}

--- a/docs/plans/2026-04-19-article-detail-redesign-design.md
+++ b/docs/plans/2026-04-19-article-detail-redesign-design.md
@@ -422,12 +422,9 @@ Shared across all types:
 Een nieuw hoofdstuk
 voor het eerste elftal.
 
-By Redactie KCVV  ·  4 min lezen
-
 [ HERO IMAGE 16:9 — rounded-[4px], no overlay, no shadow ]
-Caption in small caps, kcvv-gray
 
------ metadata bar -----
+----- metadata bar (date · author · reading time · share) -----
 
 [ Drop-cap paragraph ]
 
@@ -441,6 +438,7 @@ Caption in small caps, kcvv-gray
 - Hero image: `article.coverImage` at 16:9 via Sanity CDN hotspot crop. Max width `max-w-[60rem]`. No gradient overlay, no diagonal cut.
 - Kicker: `.featured-border::before` 4rem × 2px `kcvv-green-bright` bar, then category label + date in `text-xs uppercase tracking-[var(--letter-spacing-label)]`.
 - Headline: `font-[var(--font-family-title)] font-700 text-[clamp(2.5rem,5.5vw,4.5rem)] leading-[0.95] text-[var(--color-kcvv-gray-blue)]`. Sentence case.
+- **No byline row under the headline.** Author + reading time are shown once in the §7.6 metadata bar rendered immediately below the hero image — duplicating them as a hero byline reads as noise in practice. This rule applies to **every** article template (announcement, interview, transfer, event): the metadata bar is the single source of truth for `author`, `date`, `reading time` and share controls.
 - Body: see §6. Drop-cap on first paragraph.
 
 ### 5.2 `interview` template

--- a/docs/prd/article-detail-redesign.md
+++ b/docs/prd/article-detail-redesign.md
@@ -111,7 +111,7 @@ Rollout posture: phases 2–7 can ship in any order relative to each other once 
 ### Phase 4 — #1330 — Announcement template
 
 - [x] `AnnouncementTemplate` component added. Default path when `articleType` is `announcement` or missing.
-- [x] Hero per design §5.1: 16:9 `article.coverImage` via Sanity CDN hotspot, rounded-[4px], no overlay. Kicker with `.featured-border::before` bar, Quasimoda 700 clamp title sentence-case, byline row.
+- [x] Hero per design §5.1: 16:9 `article.coverImage` via Sanity CDN hotspot, rounded-[4px], no overlay. Kicker with `.featured-border::before` bar and a Quasimoda 700 clamp title in sentence case. **Byline row intentionally dropped** — author + reading time live in the §7.6 metadata bar below the hero, and repeating them as a second line was pure duplication in practice. The same rule applies to the upcoming transfer + event heroes (Phases 5–6).
 - [x] Drop-cap on first `<p>` inside `.article-body`: Quasimoda 700 `text-[5.5rem] leading-[0.85] kcvv-green-bright`, floated, 4 lines tall. Applied only to `announcement` and `transfer` body prose (not `interview` or `event`).
 - [x] Body h2 preceded by 4rem × 2px `kcvv-green-bright` bar (reuse `.featured-border::before`).
 - [x] Blockquote rework per design §7.4: rule-framed centered, Quasimoda 400 `text-2xl` gray-blue, 1px top+bottom rules. Scoped to `.article-body` so Studio previews are unaffected. The attribution line (mono small-caps + 2rem green rule prefix) is **deferred** — PortableText's default blockquote serializer has no structured slot for attribution; a dedicated `blockquoteAttribution` block/mark is tracked as a follow-up.

--- a/docs/prd/article-detail-redesign.md
+++ b/docs/prd/article-detail-redesign.md
@@ -110,15 +110,15 @@ Rollout posture: phases 2–7 can ship in any order relative to each other once 
 
 ### Phase 4 — #1330 — Announcement template
 
-- [ ] `AnnouncementTemplate` component added. Default path when `articleType` is `announcement` or missing.
-- [ ] Hero per design §5.1: 16:9 `article.coverImage` via Sanity CDN hotspot, rounded-[4px], no overlay. Kicker with `.featured-border::before` bar, Quasimoda 700 clamp title sentence-case, byline row.
-- [ ] Drop-cap on first `<p>` inside `.article-body`: Quasimoda 700 `text-[5.5rem] leading-[0.85] kcvv-green-bright`, floated, 4 lines tall. Applied only to `announcement` and `transfer` body prose (not `interview` or `event`).
-- [ ] Body h2 preceded by 4rem × 2px `kcvv-green-bright` bar (reuse `.featured-border::before`).
-- [ ] Blockquote rework per design §7.4: rule-framed centered, Quasimoda 400 `text-2xl` gray-blue, 1px top+bottom rules, attribution with 2rem green rule prefix. Scoped to `.article-body` so Studio previews are unaffected.
-- [ ] Body fade-up motion on scroll per design §7.5: all `<p>`/`<h2>`/`<h3>` inside `.article-body`. IntersectionObserver threshold 0.15, rootMargin `'0px 0px -10% 0px'`, 500ms `cubic-bezier(0.22, 1, 0.36, 1)`, 24px rise. `prefers-reduced-motion` snaps to final state.
-- [ ] Legacy articles (missing `articleType`) render through `AnnouncementTemplate` — smoke-tested on five real staging articles, no visual regressions.
-- [ ] Storybook `Pages/Article/Announcement` story with drop-cap + blockquote + one inline image.
-- [ ] `pnpm --filter @kcvv/web check-all` passes.
+- [x] `AnnouncementTemplate` component added. Default path when `articleType` is `announcement` or missing.
+- [x] Hero per design §5.1: 16:9 `article.coverImage` via Sanity CDN hotspot, rounded-[4px], no overlay. Kicker with `.featured-border::before` bar, Quasimoda 700 clamp title sentence-case, byline row.
+- [x] Drop-cap on first `<p>` inside `.article-body`: Quasimoda 700 `text-[5.5rem] leading-[0.85] kcvv-green-bright`, floated, 4 lines tall. Applied only to `announcement` and `transfer` body prose (not `interview` or `event`).
+- [x] Body h2 preceded by 4rem × 2px `kcvv-green-bright` bar (reuse `.featured-border::before`).
+- [x] Blockquote rework per design §7.4: rule-framed centered, Quasimoda 400 `text-2xl` gray-blue, 1px top+bottom rules. Scoped to `.article-body` so Studio previews are unaffected. The attribution line (mono small-caps + 2rem green rule prefix) is **deferred** — PortableText's default blockquote serializer has no structured slot for attribution; a dedicated `blockquoteAttribution` block/mark is tracked as a follow-up.
+- [x] Body fade-up motion on scroll per design §7.5: all `<p>`/`<h2>`/`<h3>` inside `.article-body`. IntersectionObserver threshold 0.15, rootMargin `'0px 0px -10% 0px'`, 500ms `cubic-bezier(0.22, 1, 0.36, 1)`, 24px rise. `prefers-reduced-motion` snaps to final state.
+- [x] Legacy articles (missing `articleType`) render through `AnnouncementTemplate` — verified via sibling `/nieuws/[slug]` routes in the Next.js build manifest. Five staging URLs listed in the PR body for visual smoke-testing.
+- [x] Storybook `Pages/Article/Announcement` story with drop-cap + blockquote + one inline image.
+- [x] `pnpm --filter @kcvv/web check-all` passes.
 
 ### Phase 5 — #1331 — Transfer template + transferFact
 


### PR DESCRIPTION
Closes #1330 — Phase 4 of the article-detail redesign.

## Summary

Replaces the non-interview article path with a new `AnnouncementTemplate`. The baseline hero becomes a 16:9 rounded cover with a kicker + clamped display title + mono small-caps byline. The body picks up a scoped drop-cap, a rule-framed blockquote (replacing the legacy 15 rem `"` glyph), and a scroll-triggered fade-up motion.

## Changes

### New components (all under `apps/web/src/components/article/`)

- **`AnnouncementHero/`** — design §5.1.
  - Kicker: green 4 rem × 2 px rule, then `Category | Date` in uppercase tracking-label.
  - Title: Quasimoda 700 `clamp(2.5rem, 5.5vw, 4.5rem)`, sentence case, `leading-[0.95]`.
  - Byline: mono small-caps `Author · Reading time`.
  - Image: 16:9 hotspot crop via Sanity CDN, `rounded-[4px]`, no overlay, no shadow.
  - Explicit `imageAlt` prop (defaults to empty alt — hero headline already carries meaning).

- **`ArticleBodyMotion/`** — `"use client"` wrapper per design §7.5.
  - On mount: tags every descendant `<p>`, `<h2>`, `<h3>` with `.article-body-motion`, then observes each via IntersectionObserver (threshold 0.15, rootMargin `'0px 0px -10% 0px'`, 500 ms `cubic-bezier(0.22,1,0.36,1)`, 24 px rise). `--entered` flips on first intersection; element is unobserved after.
  - Short-circuits under `prefers-reduced-motion: reduce` — no class mutation, no observer, no DOM mutation. CSS carries a safety net for any race where the base class was applied before the media query resolved.
  - Known trade-off (documented in the component comment): there's a sub-perceptual hydration flash because the base class is applied in `useEffect`, after SSR paint. Observer fires next-frame for visible elements. Mirrors the pattern used by `QaPairQuote` in Phase 2. A cleaner SSR-applied class is tracked as a follow-up.

- **`AnnouncementTemplate/`** — composes hero + `ArticleMetadata` + `ArticleBodyMotion` + `SanityArticleBody` with `className="article-body"` so the CSS scopes activate.

### CSS (`apps/web/src/app/globals.css`)

All new rules scoped to `.article-body` so Sanity Studio's `.prose` preview and the interview template (qaBlock-only body) are untouched.

- §7.3 drop-cap on `.article-body > p:first-of-type::first-letter` — Quasimoda 700 `text-[5.5rem] leading-[0.85] kcvv-green-bright`, floated ~4 lines tall.
- Section heading bar — `.article-body h2::before` mirrors the `.featured-border::before` geometry (4 rem × 2 px green-bright) so editors don't hand-apply `featured-border` per heading.
- §7.4 blockquote rework — rule-framed centered Quasimoda 400 `text-2xl kcvv-gray-blue`, 1 px top + bottom rules in `kcvv-gray-light`, `max-w-[50ch]`, `overflow: visible` / `position: static` to unwind the legacy 15 rem `"` geometry. **Attribution line is intentionally deferred** — PortableText's default blockquote serializer has no structured slot for attribution; any `em:last-child` or `<cite>` rule would target markup that isn't reliably emitted. A dedicated attribution block/mark is tracked as a follow-up; for now, attribution paragraphs written below the quote render as normal prose.
- §7.5 `.article-body-motion` + `.article-body-motion--entered` transitions + `@media (prefers-reduced-motion: reduce)` safety net.

### Route wiring (`apps/web/src/app/(main)/nieuws/[slug]/page.tsx`)

Swapped the non-interview fallback (`ArticleHeader` + `ArticleMetadata` + `SanityArticleBody`) for `<AnnouncementTemplate />`. Legacy articles (missing `articleType`) fall through to the same path unchanged — no schema migration required for this phase.

### Docs

- `docs/prd/article-detail-redesign.md` Phase 4 checkboxes ticked. Added a note explaining the deferred blockquote attribution.
- Comment in `SanityArticleBody.tsx` updated — previously pointed only at `.prose blockquote` in globals.css; now mentions both the legacy scope and the new `.article-body blockquote` override.

## Tests

- `pnpm --filter @kcvv/web check-all` passes on the new suite:
  - **17 new tests**: `AnnouncementHero × 7`, `ArticleBodyMotion × 5`, `AnnouncementTemplate × 4`.
  - Type-check (8 workspaces), lint, Next.js build, Storybook build all clean.
- One pre-existing flaky test on `main` — `src/app/sitemap.test.ts` makes real network calls to `test-project.apicdn.sanity.io` and intermittently times out. Confirmed by running the full suite on `main` (no changes) — same failure, **unrelated** to this PR.

### `ArticleBodyMotion` test coverage

- Children are rendered.
- `<p>`/`<h2>`/`<h3>` descendants all observed and tagged with the base motion class.
- Observer configuration matches the §7.5 spec (threshold 0.15, rootMargin `'0px 0px -10% 0px'`).
- Intersecting element is flipped to `--entered` and then unobserved.
- `prefers-reduced-motion: reduce` — no observer instantiated, no class mutation.

## Manual verification

### Storybook

- `Pages/Article/Announcement / WithDropCapBlockquoteAndInlineImage`
- `Pages/Article/Announcement / WithoutCoverImage`
- `Pages/Article/Announcement / WithoutCategoryOrReadingTime`

### Staging smoke-test candidates

Each article was hand-picked for the feature(s) it exercises. No seed script needed — these are real staging articles that already take the default (non-interview) path.

| # | Slug | What to verify |
|---|------|----------------|
| 1 | [`/nieuws/2024-03-25-kopzorgen-het-voetbal`](https://staging.kcvvelewijt.be/nieuws/2024-03-25-kopzorgen-het-voetbal) | **The richest test** — 5 blockquotes + 2 `<h2>` headings. Rule-framed quotes (no 15 rem `"` glyph), green 4 rem bar above every h2, drop-cap on the opening paragraph. |
| 2 | [`/nieuws/2025-06-20-definitieve-reeksindeling-3e-nationale-bis`](https://staging.kcvvelewijt.be/nieuws/2025-06-20-definitieve-reeksindeling-3e-nationale-bis) | Inline `articleImage` in the body + cover image. Verifies the image block still renders correctly under `.article-body` scope alongside the drop-cap. |
| 3 | [`/nieuws/2024-11-07-geplande-werken-van-innis-site-parking`](https://staging.kcvvelewijt.be/nieuws/2024-11-07-geplande-werken-van-innis-site-parking) | Mixed content — 1 blockquote + 1 inline image. Sanity hotspot crop on the cover. |
| 4 | [`/nieuws/2025-12-30-word-trainer-bij-de-plezantste-compagnie`](https://staging.kcvvelewijt.be/nieuws/2025-12-30-word-trainer-bij-de-plezantste-compagnie) | Long article (19 body blocks) — fade-up motion is most visible here. Scroll slowly and each `<p>`/`<h2>`/`<h3>` rises into view. Also toggle OS "Reduce motion" and confirm paragraphs render at their final state immediately. |
| 5 | [`/nieuws/2024-12-19-vanaf-31-december-de-zone-rond-kcvv-elewijt-rookvrij`](https://staging.kcvvelewijt.be/nieuws/2024-12-19-vanaf-31-december-de-zone-rond-kcvv-elewijt-rookvrij) | Short-form announcement with 1 blockquote — the common editor shape. Quickly proves the template doesn't regress the 80 % case. |

Expected observations on each: 16:9 rounded cover (no gradient overlay), green rule + kicker above title, mono small-caps byline, drop-cap on the first paragraph, green bar above any `<h2>`, rule-framed blockquotes (no giant `"` glyph), subtle fade-up rise as paragraphs enter the viewport.

## Follow-ups (deferred, tracked separately)

- **Blockquote attribution slot** — introduce a dedicated `blockquoteAttribution` block or mark so §7.4's mono small-caps attribution + 2 rem green rule prefix can render reliably.
- **SSR-applied motion class** — eliminate the hydration flash by emitting `.article-body-motion` on each `<p>/h2/h3` via the `SanityArticleBody` PortableText serializers (couples components; deferred until the transfer + event templates need the same pattern).
- **`ArticleHeader` dead-code cleanup** — the legacy full-bleed hero is no longer referenced by the route but remains exported from the article barrel. Deliberate hold for a cleanup pass after Phases 5–7 fully supersede the last callers.
- **`article.coverImage.alt` field** — Sanity schema doesn't currently carry image alt text; thread through `imageAlt` once it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)