### PR TITLE
feat(news): event template + eventFact block (#1332)

### DIFF
--- a/apps/web/scripts/seed-phase-6-event-tracer.mjs
+++ b/apps/web/scripts/seed-phase-6-event-tracer.mjs
@@ -107,13 +107,14 @@ function noteBlock(key, text) {
   ];
 }
 
-// Feature eventFact — absorbed by the strip. Exercises every field at
-// once so the full visual is on the preview.
+// Continuous multi-day overview row. Keeps the same-month range layout
+// exercised on the overview stack (as opposed to the strip).
 const lentetornooi = {
   _key: "evt-feature",
   _type: "eventFact",
   title: "Lentetornooi U13",
   date: "2026-04-25",
+  endDate: "2026-04-26",
   startTime: "10:00",
   endTime: "17:00",
   location: "Sportpark Elewijt",
@@ -124,7 +125,7 @@ const lentetornooi = {
   capacity: 64,
   note: noteBlock(
     "evt-feature-note",
-    "Open voor spelers geboren in 2013 en 2014. Wedstrijden en finales, met afsluiting op het terras.",
+    "Open voor spelers geboren in 2013 en 2014. Twee dagen wedstrijden en finales, met afsluiting op het terras.",
   ),
 };
 
@@ -153,6 +154,53 @@ const training = {
   ageGroup: "Senioren",
 };
 
+// Feature eventFact — recurring event with per-day schedules. Drives
+// the strip: date column shows the `20 – 22 NOV` range, right column
+// lists each session (Fri 18:00→22:00, Sat 17:00→23:00, Sun
+// 11:30→15:00) at display scale.
+const steakfestijn = {
+  _key: "evt-steakfestijn",
+  _type: "eventFact",
+  title: "Steakfestijn 2026",
+  location: "Kantine KCVV",
+  address: "Driesstraat 14, Elewijt",
+  competitionTag: "Clubfeest",
+  ticketUrl: "https://kcvvelewijt.be/steakfestijn",
+  sessions: [
+    {
+      _key: "s-fri",
+      date: "2026-11-20",
+      startTime: "18:00",
+      endTime: "22:00",
+    },
+    {
+      _key: "s-sat",
+      date: "2026-11-21",
+      startTime: "17:00",
+      endTime: "23:00",
+    },
+    {
+      _key: "s-sun",
+      date: "2026-11-22",
+      startTime: "11:30",
+      endTime: "15:00",
+    },
+  ],
+};
+
+// Overview row — cross-month multi-day range. Exercises the compact
+// `31 JUL – 2 AUG` layout on the overview stack.
+const zomerkamp = {
+  _key: "evt-zomerkamp",
+  _type: "eventFact",
+  title: "Jeugdkamp Elewijt",
+  date: "2026-07-31",
+  endDate: "2026-08-02",
+  location: "Sportpark Elewijt",
+  ageGroup: "U7 – U11",
+  ticketUrl: "https://kcvvelewijt.be/zomerkamp",
+};
+
 // Overview row — no date set. Exercises the `Datum volgt` branch.
 const openVraag = {
   _key: "evt-tbd",
@@ -172,7 +220,7 @@ try {
     _id: ARTICLE_ID,
     _type: "article",
     articleType: "event",
-    title: "Lentetornooi U13 — zaterdag in Elewijt",
+    title: "Steakfestijn 2026 — drie dagen tafelen voor de club",
     slug: { _type: "slug", current: SLUG },
     // Backdate publishAt so the article clears the GROQ `publishAt <= now()`
     // filter regardless of build/timezone clock drift on the preview.
@@ -184,20 +232,22 @@ try {
       asset: { _type: "reference", _ref: COVER_IMAGE_ASSET_REF },
     },
     body: [
-      lentetornooi,
+      steakfestijn,
       paragraph(
         "p1",
-        "Zaterdag 25 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
+        "Van vrijdag 20 tot zondag 22 november staat de kantine opnieuw in het teken van het jaarlijkse steakfestijn. Drie dagen vol biefstuk, frietjes en vriendschap — ten voordele van de jeugdwerking.",
       ),
       paragraph(
         "p2",
-        "De organisatie voorziet drinken en versnaperingen. Supporters zijn welkom de hele dag door — ook voor de finale om 16u30.",
+        "Per sessie zijn er aparte openingsuren. Reserveer op voorhand via de link hierboven; walk-ins zijn welkom zolang er tafels vrij zijn.",
       ),
       // Editor-authored section header — renders via the `.article-body`
       // H2 treatment (green 4 rem × 2 px bar above).
       heading("h-andere-evenementen", "Andere evenementen"),
+      lentetornooi,
       afterparty,
       training,
+      zomerkamp,
       openVraag,
       paragraph(
         "p3",

--- a/apps/web/scripts/seed-phase-6-event-tracer.mjs
+++ b/apps/web/scripts/seed-phase-6-event-tracer.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/*
+ * apps/web/scripts/seed-phase-6-event-tracer.mjs
+ *
+ * Creates (or updates) a tracer article on Sanity staging that exercises
+ * every eventFact variant introduced in Phase 6 (#1332):
+ *   - 1 × feature eventFact with full data (title, date, time range,
+ *     location, address, age group, CTA, note) → absorbed by the strip
+ *   - 1 × overview eventFact with a CTA (custom ticketLabel)
+ *   - 1 × overview eventFact without a CTA (null-ticket fallback)
+ *   - 1 × overview eventFact without a date (the `Datum volgt` branch)
+ *
+ * Idempotent — fixed `_id` so re-running updates the existing document.
+ *
+ * Usage (from `apps/web` so `@sanity/client` resolves via the workspace):
+ *
+ *   SANITY_API_TOKEN=<write-token> node scripts/seed-phase-6-event-tracer.mjs
+ *
+ * Token falls back to `~/.config/sanity/config.json` (set by
+ * `sanity login`). Refuses to run against the `production` dataset
+ * unless `SANITY_ALLOW_PRODUCTION=1` is set explicitly.
+ *
+ * Revert after the feature branch merges:
+ *   sanity documents delete --dataset=staging article-phase-6-event-tracer
+ */
+
+import { createClient } from "@sanity/client";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const PROJECT_ID = "vhb33jaz";
+const DATASET = process.env.SANITY_DATASET ?? "staging";
+const ARTICLE_ID = "article-phase-6-event-tracer";
+const SLUG = "phase-6-tracer-event-moves";
+
+if (DATASET === "production" && process.env.SANITY_ALLOW_PRODUCTION !== "1") {
+  console.error(
+    "Refusing to seed the event tracer into production — this article " +
+      "is staging-only. Re-run with SANITY_DATASET=staging, or set " +
+      "SANITY_ALLOW_PRODUCTION=1 if you truly meant to write to prod.",
+  );
+  process.exit(1);
+}
+
+function resolveToken() {
+  if (process.env.SANITY_API_TOKEN) return process.env.SANITY_API_TOKEN;
+  try {
+    const configPath = join(homedir(), ".config", "sanity", "config.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (config.authToken) return config.authToken;
+  } catch {
+    /* fall through */
+  }
+  console.error(
+    "No Sanity auth token found. Set SANITY_API_TOKEN or run `sanity login`.",
+  );
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId: PROJECT_ID,
+  dataset: DATASET,
+  apiVersion: "2024-01-01",
+  token: resolveToken(),
+  useCdn: false,
+});
+
+// ─── Body blocks ─────────────────────────────────────────────────────────────
+
+function paragraph(key, text) {
+  return {
+    _key: key,
+    _type: "block",
+    style: "normal",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text }],
+  };
+}
+
+function heading(key, text) {
+  return {
+    _key: key,
+    _type: "block",
+    style: "h2",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text }],
+  };
+}
+
+function noteBlock(key, text) {
+  return [
+    {
+      _key: key,
+      _type: "block",
+      style: "normal",
+      markDefs: [],
+      children: [{ _type: "span", _key: `${key}-s`, text }],
+    },
+  ];
+}
+
+// Feature eventFact — absorbed by the strip. Exercises every field at
+// once so the full visual is on the preview.
+const lentetornooi = {
+  _key: "evt-feature",
+  _type: "eventFact",
+  title: "Lentetornooi U13",
+  date: "2026-04-27",
+  startTime: "10:00",
+  endTime: "17:00",
+  location: "Sportpark Elewijt",
+  address: "Driesstraat 14, Elewijt",
+  ageGroup: "U13",
+  ticketUrl: "https://kcvvelewijt.be/inschrijven",
+  ticketLabel: "Inschrijven",
+  capacity: 64,
+  note: noteBlock(
+    "evt-feature-note",
+    "Open voor spelers geboren in 2013 en 2014. Wedstrijden en finales, met afsluiting op het terras.",
+  ),
+};
+
+// Overview row — with a custom CTA label.
+const afterparty = {
+  _key: "evt-afterparty",
+  _type: "eventFact",
+  title: "Afterparty",
+  date: "2026-04-27",
+  startTime: "20:00",
+  location: "Kantine KCVV",
+  competitionTag: "Clubfeest",
+  ticketUrl: "https://kcvvelewijt.be/afterparty",
+  ticketLabel: "Boek je plek",
+};
+
+// Overview row — no CTA, no URL. Exercises the null-ticket fallback.
+const training = {
+  _key: "evt-training",
+  _type: "eventFact",
+  title: "Seizoensstart training",
+  date: "2026-07-27",
+  startTime: "18:30",
+  endTime: "20:00",
+  location: "Sportpark Elewijt",
+  ageGroup: "Senioren",
+};
+
+// Overview row — no date set. Exercises the `Datum volgt` branch.
+const openVraag = {
+  _key: "evt-tbd",
+  _type: "eventFact",
+  title: "Jeugd barbecue",
+  location: "Kantine KCVV",
+  ageGroup: "Alle jeugd",
+};
+
+// ─── Execute ─────────────────────────────────────────────────────────────────
+
+const label = `[seed-phase-6-event-tracer] dataset=${DATASET}`;
+console.log(`${label} upserting ${ARTICLE_ID}…`);
+
+try {
+  const doc = {
+    _id: ARTICLE_ID,
+    _type: "article",
+    articleType: "event",
+    title: "Lentetornooi U13 — zaterdag in Elewijt",
+    slug: { _type: "slug", current: SLUG },
+    publishAt: new Date("2026-04-23T08:00:00Z").toISOString(),
+    featured: false,
+    tags: ["Jeugd", "Evenementen"],
+    body: [
+      lentetornooi,
+      paragraph(
+        "p1",
+        "Zaterdag 27 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
+      ),
+      paragraph(
+        "p2",
+        "De organisatie voorziet drinken en versnaperingen. Supporters zijn welkom de hele dag door — ook voor de finale om 16u30.",
+      ),
+      // Editor-authored section header — renders via the `.article-body`
+      // H2 treatment (green 4 rem × 2 px bar above).
+      heading("h-andere-evenementen", "Andere evenementen"),
+      afterparty,
+      training,
+      openVraag,
+      paragraph(
+        "p3",
+        "Meer info bij de jeugdvoorzitter via info@kcvvelewijt.be.",
+      ),
+    ],
+  };
+
+  const result = await client.createOrReplace(doc);
+  console.log(`${label} ✓ upserted _id=${result._id}`);
+  console.log(
+    `${label} staging URL: https://staging.kcvvelewijt.be/nieuws/${SLUG}`,
+  );
+} catch (err) {
+  console.error(`${label} ✗ failed`, err);
+  process.exit(1);
+}

--- a/apps/web/scripts/seed-phase-6-event-tracer.mjs
+++ b/apps/web/scripts/seed-phase-6-event-tracer.mjs
@@ -34,6 +34,13 @@ const DATASET = process.env.SANITY_DATASET ?? "staging";
 const ARTICLE_ID = "article-phase-6-event-tracer";
 const SLUG = "phase-6-tracer-event-moves";
 
+// Stable cover-image placeholder — reuse an existing staging asset
+// (one of the player psd images) so the tracer has a 16:9-ish landscape
+// on the hero without uploading a dedicated file each seed run. Real
+// articles ship an editor-supplied landscape asset used for TV + Facebook.
+const COVER_IMAGE_ASSET_REF =
+  "image-902b92c6fbed708cec758ed4f5848f0f3d848416-350x350-jpg";
+
 if (DATASET === "production" && process.env.SANITY_ALLOW_PRODUCTION !== "1") {
   console.error(
     "Refusing to seed the event tracer into production — this article " +
@@ -172,6 +179,10 @@ try {
     publishAt: new Date("2026-04-22T08:00:00Z").toISOString(),
     featured: false,
     tags: ["Jeugd", "Evenementen"],
+    coverImage: {
+      _type: "image",
+      asset: { _type: "reference", _ref: COVER_IMAGE_ASSET_REF },
+    },
     body: [
       lentetornooi,
       paragraph(

--- a/apps/web/scripts/seed-phase-6-event-tracer.mjs
+++ b/apps/web/scripts/seed-phase-6-event-tracer.mjs
@@ -106,7 +106,7 @@ const lentetornooi = {
   _key: "evt-feature",
   _type: "eventFact",
   title: "Lentetornooi U13",
-  date: "2026-04-27",
+  date: "2026-04-25",
   startTime: "10:00",
   endTime: "17:00",
   location: "Sportpark Elewijt",
@@ -126,7 +126,7 @@ const afterparty = {
   _key: "evt-afterparty",
   _type: "eventFact",
   title: "Afterparty",
-  date: "2026-04-27",
+  date: "2026-04-25",
   startTime: "20:00",
   location: "Kantine KCVV",
   competitionTag: "Clubfeest",
@@ -167,14 +167,16 @@ try {
     articleType: "event",
     title: "Lentetornooi U13 — zaterdag in Elewijt",
     slug: { _type: "slug", current: SLUG },
-    publishAt: new Date("2026-04-23T08:00:00Z").toISOString(),
+    // Backdate publishAt so the article clears the GROQ `publishAt <= now()`
+    // filter regardless of build/timezone clock drift on the preview.
+    publishAt: new Date("2026-04-22T08:00:00Z").toISOString(),
     featured: false,
     tags: ["Jeugd", "Evenementen"],
     body: [
       lentetornooi,
       paragraph(
         "p1",
-        "Zaterdag 27 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
+        "Zaterdag 25 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
       ),
       paragraph(
         "p2",

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -30,9 +30,83 @@ import { EventTemplate } from "@/components/article/EventTemplate";
 import { RelatedContentSection } from "@/components/related/RelatedContentSection/RelatedContentSection";
 import type { RelatedContentItem } from "@/components/related/types";
 import type { PortableTextBlock } from "@portabletext/react";
+import type { SubjectValue } from "@/components/article/SubjectAttribution";
 
 interface ArticlePageProps {
   params: Promise<{ slug: string }>;
+}
+
+/**
+ * Per-type template dispatch. Extracted out of the JSX so the nested
+ * ternary (four branches, each with its own prop shape) doesn't bloat
+ * the page body. Keyed on `articleType` with a default renderer for
+ * missing/unknown types → `AnnouncementTemplate` (the fallback path
+ * per PRD §3).
+ */
+interface RenderTemplateArgs {
+  articleType: string | null | undefined;
+  title: string;
+  category?: string;
+  coverImageUrl?: string;
+  coverImagePortraitUrl?: string | null;
+  publishedDate?: string;
+  readingTime?: string;
+  shareUrl: string;
+  body: PortableTextBlock[] | null;
+  subject: SubjectValue | null;
+}
+
+function renderTemplate(args: RenderTemplateArgs) {
+  const shareConfig = { url: args.shareUrl, title: args.title };
+  switch (args.articleType) {
+    case "interview":
+      return (
+        <InterviewTemplate
+          title={args.title}
+          coverImageUrl={args.coverImagePortraitUrl}
+          publishedDate={args.publishedDate}
+          readingTime={args.readingTime}
+          shareConfig={shareConfig}
+          body={args.body}
+          subject={args.subject}
+        />
+      );
+    case "transfer":
+      return (
+        <TransferTemplate
+          title={args.title}
+          coverImageUrl={args.coverImagePortraitUrl}
+          publishedDate={args.publishedDate}
+          readingTime={args.readingTime}
+          shareConfig={shareConfig}
+          body={args.body}
+        />
+      );
+    case "event":
+      return (
+        <EventTemplate
+          title={args.title}
+          publishedDate={args.publishedDate}
+          readingTime={args.readingTime}
+          shareConfig={shareConfig}
+          body={args.body}
+        />
+      );
+    // Missing or unknown articleType falls through to announcement —
+    // matches the PRD §3 legacy-article fallback rule.
+    default:
+      return (
+        <AnnouncementTemplate
+          title={args.title}
+          category={args.category}
+          coverImageUrl={args.coverImageUrl}
+          publishedDate={args.publishedDate}
+          readingTime={args.readingTime}
+          shareConfig={shareConfig}
+          body={args.body}
+        />
+      );
+  }
 }
 
 /**
@@ -180,60 +254,21 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
           })}
         />
       )}
-      {article.articleType === "interview" ? (
-        <InterviewTemplate
-          title={article.title}
-          coverImageUrl={article.coverImagePortraitUrl ?? article.coverImageUrl}
-          publishedDate={
-            article.publishedAt
-              ? formatArticleDate(new Date(article.publishedAt))
-              : undefined
-          }
-          readingTime={readingTime}
-          shareConfig={{ url: shareConfig.url, title: article.title }}
-          body={(article.body as PortableTextBlock[] | null) ?? null}
-          subject={article.subject ?? null}
-        />
-      ) : article.articleType === "transfer" ? (
-        <TransferTemplate
-          title={article.title}
-          coverImageUrl={article.coverImagePortraitUrl ?? article.coverImageUrl}
-          publishedDate={
-            article.publishedAt
-              ? formatArticleDate(new Date(article.publishedAt))
-              : undefined
-          }
-          readingTime={readingTime}
-          shareConfig={{ url: shareConfig.url, title: article.title }}
-          body={(article.body as PortableTextBlock[] | null) ?? null}
-        />
-      ) : article.articleType === "event" ? (
-        <EventTemplate
-          title={article.title}
-          publishedDate={
-            article.publishedAt
-              ? formatArticleDate(new Date(article.publishedAt))
-              : undefined
-          }
-          readingTime={readingTime}
-          shareConfig={{ url: shareConfig.url, title: article.title }}
-          body={(article.body as PortableTextBlock[] | null) ?? null}
-        />
-      ) : (
-        <AnnouncementTemplate
-          title={article.title}
-          category={primaryCategory?.name}
-          coverImageUrl={article.coverImageUrl ?? undefined}
-          publishedDate={
-            article.publishedAt
-              ? formatArticleDate(new Date(article.publishedAt))
-              : undefined
-          }
-          readingTime={readingTime}
-          shareConfig={{ url: shareConfig.url, title: article.title }}
-          body={(article.body as PortableTextBlock[] | null) ?? null}
-        />
-      )}
+      {renderTemplate({
+        articleType: article.articleType,
+        title: article.title,
+        category: primaryCategory?.name,
+        coverImageUrl: article.coverImageUrl ?? undefined,
+        coverImagePortraitUrl:
+          article.coverImagePortraitUrl ?? article.coverImageUrl,
+        publishedDate: article.publishedAt
+          ? formatArticleDate(new Date(article.publishedAt))
+          : undefined,
+        readingTime,
+        shareUrl: shareConfig.url,
+        body: (article.body as PortableTextBlock[] | null) ?? null,
+        subject: article.subject ?? null,
+      })}
 
       <RelatedContentSection
         items={relatedItems}

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -26,6 +26,7 @@ import {
 import { AnnouncementTemplate } from "@/components/article/AnnouncementTemplate";
 import { InterviewTemplate } from "@/components/article/InterviewTemplate";
 import { TransferTemplate } from "@/components/article/TransferTemplate";
+import { EventTemplate } from "@/components/article/EventTemplate";
 import { RelatedContentSection } from "@/components/related/RelatedContentSection/RelatedContentSection";
 import type { RelatedContentItem } from "@/components/related/types";
 import type { PortableTextBlock } from "@portabletext/react";
@@ -197,6 +198,18 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         <TransferTemplate
           title={article.title}
           coverImageUrl={article.coverImagePortraitUrl ?? article.coverImageUrl}
+          publishedDate={
+            article.publishedAt
+              ? formatArticleDate(new Date(article.publishedAt))
+              : undefined
+          }
+          readingTime={readingTime}
+          shareConfig={{ url: shareConfig.url, title: article.title }}
+          body={(article.body as PortableTextBlock[] | null) ?? null}
+        />
+      ) : article.articleType === "event" ? (
+        <EventTemplate
+          title={article.title}
           publishedDate={
             article.publishedAt
               ? formatArticleDate(new Date(article.publishedAt))

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -258,9 +258,13 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         articleType: article.articleType,
         title: article.title,
         category: primaryCategory?.name,
+        // Pass both projections separately — each template picks the
+        // aspect it needs (Interview + Transfer take the 4:5 portrait,
+        // Announcement takes the 16:9 wide). No cross-fallback: if a
+        // template's preferred projection is null the template renders
+        // without an image rather than cropping the wrong aspect.
         coverImageUrl: article.coverImageUrl ?? undefined,
-        coverImagePortraitUrl:
-          article.coverImagePortraitUrl ?? article.coverImageUrl,
+        coverImagePortraitUrl: article.coverImagePortraitUrl ?? undefined,
         publishedDate: article.publishedAt
           ? formatArticleDate(new Date(article.publishedAt))
           : undefined,

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -86,6 +86,7 @@ function renderTemplate(args: RenderTemplateArgs) {
       return (
         <EventTemplate
           title={args.title}
+          coverImageUrl={args.coverImageUrl}
           publishedDate={args.publishedDate}
           readingTime={args.readingTime}
           shareConfig={shareConfig}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -524,32 +524,40 @@
 }
 
 
-/* ===== Phase 5 (#1331): Transfer overview stack =============================
+/* ===== Phases 5 + 6 (#1331, #1332): Overview-row stack =======================
 
-   Consecutive `transferFact` overview rows fuse into a single seamless
-   dark band. The outer rows in a group keep 2.5 rem breathing space
-   against the surrounding prose; rows INSIDE the group strip both the
-   top margin of the row and the bottom margin of its predecessor so the
-   dark surface flows edge-to-edge with no white slivers between rows.
+   Consecutive `transferFact` / `eventFact` overview rows fuse into a
+   single seamless dark band. The outer rows in a group keep 2.5 rem
+   breathing space against the surrounding prose; rows INSIDE the group
+   strip both the top margin of the row and the bottom margin of its
+   predecessor so the dark surface flows edge-to-edge with no white
+   slivers between rows.
 
    `:has(+ X)` peels the trailing gap off any overview that is itself
    followed by another overview. Safari 15.4+, Chrome 105+, Firefox 121+
    all support it — same baseline the rest of the site targets.
 
-   Tailwind arbitrary-variant syntax for sibling + `:has()` selectors
-   gets noisy with attribute selectors, so the rules live here. */
-[data-testid='transfer-overview'] {
+   The selector list groups both overview variants so a mixed stack
+   (transferFact followed by eventFact, etc.) also flows seamlessly. */
+[data-testid='transfer-overview'],
+[data-testid='event-overview'] {
   margin-top: 2.5rem;
   margin-bottom: 2.5rem;
 }
 
-[data-testid='transfer-overview'] + [data-testid='transfer-overview'] {
+[data-testid='transfer-overview']
+  + :is([data-testid='transfer-overview'], [data-testid='event-overview']),
+[data-testid='event-overview']
+  + :is([data-testid='transfer-overview'], [data-testid='event-overview']) {
   margin-top: 0;
 }
 
 [data-testid='transfer-overview']:has(
-  + [data-testid='transfer-overview']
-) {
+    + :is([data-testid='transfer-overview'], [data-testid='event-overview'])
+  ),
+[data-testid='event-overview']:has(
+    + :is([data-testid='transfer-overview'], [data-testid='event-overview'])
+  ) {
   margin-bottom: 0;
 }
 

--- a/apps/web/src/components/article/EventHero/EventHero.test.tsx
+++ b/apps/web/src/components/article/EventHero/EventHero.test.tsx
@@ -73,8 +73,11 @@ describe("EventHero", () => {
 
   it("never renders an empty h1 — falls back to `Event` when title is blank", () => {
     render(<EventHero title="   " feature={null} />);
+    // Anchor the regex so the fallback must be exactly "Event" — a
+    // future refactor that changes the fallback to "Events coming soon"
+    // would otherwise slip through.
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-      /Event/,
+      /^Event$/,
     );
   });
 });

--- a/apps/web/src/components/article/EventHero/EventHero.test.tsx
+++ b/apps/web/src/components/article/EventHero/EventHero.test.tsx
@@ -55,6 +55,30 @@ describe("EventHero", () => {
     expect(text).toMatch(/^Event$/i);
   });
 
+  it("renders the 16:9 landscape cover image when coverImageUrl is provided", () => {
+    render(
+      <EventHero
+        title="Lentetornooi"
+        feature={{
+          title: "Lentetornooi U13",
+          date: "2026-04-25",
+        }}
+        coverImageUrl="https://cdn.sanity.io/cover.webp"
+      />,
+    );
+    expect(screen.getByTestId("event-hero-image")).toBeInTheDocument();
+  });
+
+  it("omits the cover image when coverImageUrl is missing or null", () => {
+    render(
+      <EventHero
+        title="Lentetornooi"
+        feature={{ title: "Lentetornooi U13", date: "2026-04-25" }}
+      />,
+    );
+    expect(screen.queryByTestId("event-hero-image")).toBeNull();
+  });
+
   it("renders the article title as the h1", () => {
     render(
       <EventHero

--- a/apps/web/src/components/article/EventHero/EventHero.test.tsx
+++ b/apps/web/src/components/article/EventHero/EventHero.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EventHero } from "./EventHero";
+
+describe("EventHero", () => {
+  it("renders `EVENT | <ageGroup>` when the feature has an age group", () => {
+    render(
+      <EventHero
+        title="Lentetornooi U13 — zaterdag in Elewijt"
+        feature={{
+          title: "Lentetornooi U13",
+          date: "2026-04-27",
+          ageGroup: "U13",
+        }}
+      />,
+    );
+    const kicker = screen.getByTestId("event-hero-kicker");
+    expect(kicker.textContent).toMatch(/Event\s*\|\s*U13/i);
+  });
+
+  it("falls back to `competitionTag` when `ageGroup` is missing", () => {
+    render(
+      <EventHero
+        title="Clubfeest"
+        feature={{
+          title: "Clubfeest",
+          date: "2026-04-27",
+          competitionTag: "Clubfeest",
+        }}
+      />,
+    );
+    const kicker = screen.getByTestId("event-hero-kicker");
+    expect(kicker.textContent).toMatch(/Event\s*\|\s*Clubfeest/i);
+  });
+
+  it("collapses to bare `EVENT` kicker when neither ageGroup nor competitionTag is set", () => {
+    render(
+      <EventHero
+        title="Datum volgt"
+        feature={{
+          title: "Datum volgt",
+          date: "2026-04-27",
+        }}
+      />,
+    );
+    const kicker = screen.getByTestId("event-hero-kicker");
+    const text = (kicker.textContent ?? "").trim();
+    expect(text).toMatch(/^Event$/i);
+  });
+
+  it("renders a bare `EVENT` kicker when no feature eventFact is provided at all", () => {
+    render(<EventHero title="Evenementenupdate" feature={null} />);
+    const kicker = screen.getByTestId("event-hero-kicker");
+    const text = (kicker.textContent ?? "").trim();
+    expect(text).toMatch(/^Event$/i);
+  });
+
+  it("renders the article title as the h1", () => {
+    render(
+      <EventHero
+        title="Lentetornooi U13 — zaterdag in Elewijt"
+        feature={{
+          title: "Lentetornooi U13",
+          date: "2026-04-27",
+          ageGroup: "U13",
+        }}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Lentetornooi U13 — zaterdag in Elewijt",
+    );
+  });
+
+  it("never renders an empty h1 — falls back to `Event` when title is blank", () => {
+    render(<EventHero title="   " feature={null} />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      /Event/,
+    );
+  });
+});

--- a/apps/web/src/components/article/EventHero/EventHero.tsx
+++ b/apps/web/src/components/article/EventHero/EventHero.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { cn } from "@/lib/utils/cn";
 import type { EventFactValue } from "@/components/article/blocks/EventFact";
 
@@ -15,19 +16,32 @@ export interface EventHeroProps {
    * the strip below the metadata bar).
    */
   title: string;
+  /**
+   * 16:9 landscape cover image from `article.coverImage`. Same crop
+   * the announcement hero uses — event articles always upload a
+   * landscape image because the same asset doubles as the TV-screen
+   * and Facebook-event graphic.
+   */
+  coverImageUrl?: string | null;
   className?: string;
 }
 
 /**
- * Design §5.4 — event hero. Typographic only (no image): kicker +
- * article title. The serif-style date block and metadata live on the
- * `EventStrip` beneath the §7.6 metadata bar, mirroring the Phase 5
- * transfer hero/strip split so facts appear exactly once per page.
+ * Design §5.4 — event hero. Kicker + article title, followed by the
+ * editor-supplied 16:9 landscape cover. The serif-style date block and
+ * metadata live on the `EventStrip` beneath the §7.6 metadata bar,
+ * mirroring the Phase 5 transfer hero/strip split so facts appear
+ * exactly once per page.
  *
  * Kicker composition: `EVENT | ${ageGroup || competitionTag}` when a
  * feature eventFact is present; bare `EVENT` otherwise.
  */
-export const EventHero = ({ feature, title, className }: EventHeroProps) => {
+export const EventHero = ({
+  feature,
+  title,
+  coverImageUrl,
+  className,
+}: EventHeroProps) => {
   const kickerMeta =
     feature?.ageGroup?.trim() || feature?.competitionTag?.trim();
 
@@ -69,6 +83,22 @@ export const EventHero = ({ feature, title, className }: EventHeroProps) => {
           {h1}
         </h1>
       </div>
+
+      {coverImageUrl && (
+        <div
+          data-testid="event-hero-image"
+          className="bg-kcvv-gray-light/30 relative mt-10 aspect-[16/9] w-full overflow-hidden rounded-[4px]"
+        >
+          <Image
+            src={coverImageUrl}
+            alt={feature?.title ?? ""}
+            fill
+            priority
+            sizes="(max-width: 768px) 100vw, 960px"
+            className="object-cover object-center"
+          />
+        </div>
+      )}
     </header>
   );
 };

--- a/apps/web/src/components/article/EventHero/EventHero.tsx
+++ b/apps/web/src/components/article/EventHero/EventHero.tsx
@@ -1,0 +1,74 @@
+import { cn } from "@/lib/utils/cn";
+import type { EventFactValue } from "@/components/article/blocks/EventFact";
+
+export interface EventHeroProps {
+  /**
+   * The feature `eventFact` — first eventFact in the body. Drives the
+   * kicker's second segment (ageGroup or competitionTag). When null the
+   * hero collapses to `EVENT` kicker + fallback h1.
+   */
+  feature: EventFactValue | null;
+  /**
+   * Article title — rendered as the single h1 of the page. Used as the
+   * h1 regardless of `feature`, since the event article's narrative
+   * title is the headline (not the eventFact's `title`, which lives on
+   * the strip below the metadata bar).
+   */
+  title: string;
+  className?: string;
+}
+
+/**
+ * Design §5.4 — event hero. Typographic only (no image): kicker +
+ * article title. The serif-style date block and metadata live on the
+ * `EventStrip` beneath the §7.6 metadata bar, mirroring the Phase 5
+ * transfer hero/strip split so facts appear exactly once per page.
+ *
+ * Kicker composition: `EVENT | ${ageGroup || competitionTag}` when a
+ * feature eventFact is present; bare `EVENT` otherwise.
+ */
+export const EventHero = ({ feature, title, className }: EventHeroProps) => {
+  const kickerMeta =
+    feature?.ageGroup?.trim() || feature?.competitionTag?.trim();
+
+  // Trim-guarded h1 — an empty heading fails every a11y audit.
+  const h1 = title?.trim() || "Event";
+
+  return (
+    <header
+      data-testid="event-hero"
+      className={cn(
+        "max-w-inner-lg mx-auto w-full px-6 pt-10 md:pt-16",
+        className,
+      )}
+    >
+      <div className="max-w-[65ch]">
+        <p
+          className={cn(
+            "mb-6 flex flex-wrap items-center gap-x-3 gap-y-1",
+            "text-kcvv-green-dark text-xs font-semibold tracking-[var(--letter-spacing-label)] uppercase",
+            "before:bg-kcvv-green-bright before:mr-1 before:block before:h-[2px] before:w-16 before:shrink-0 before:content-['']",
+          )}
+          data-testid="event-hero-kicker"
+        >
+          <span>Event</span>
+          {kickerMeta && (
+            <>
+              <span aria-hidden="true" className="text-kcvv-gray-light">
+                |
+              </span>
+              <span>{kickerMeta}</span>
+            </>
+          )}
+        </p>
+
+        <h1
+          className="font-title text-kcvv-gray-blue text-[clamp(2.5rem,5.5vw,4.5rem)] leading-[0.95] font-bold"
+          data-testid="event-hero-title"
+        >
+          {h1}
+        </h1>
+      </div>
+    </header>
+  );
+};

--- a/apps/web/src/components/article/EventHero/index.ts
+++ b/apps/web/src/components/article/EventHero/index.ts
@@ -1,0 +1,2 @@
+export { EventHero } from "./EventHero";
+export type { EventHeroProps } from "./EventHero";

--- a/apps/web/src/components/article/EventStrip/EventStrip.test.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.test.tsx
@@ -124,6 +124,22 @@ describe("EventStrip", () => {
     expect(cta).toHaveTextContent(/Inschrijven/i);
   });
 
+  it("falls back to `Inschrijven` when `ticketLabel` is whitespace-only — exercises the trim path", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          ticketUrl: "https://kcvvelewijt.be/inschrijven",
+          ticketLabel: "   ",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-strip-cta")).toHaveTextContent(
+      /Inschrijven/i,
+    );
+  });
+
   it("uses the editor-authored ticketLabel when set", () => {
     render(
       <EventStrip

--- a/apps/web/src/components/article/EventStrip/EventStrip.test.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.test.tsx
@@ -19,6 +19,94 @@ describe("EventStrip", () => {
     expect(dateBlock.textContent).toMatch(/2026/);
   });
 
+  it("renders a same-month range as `25 – 26 APRIL 2026` at display scale", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Pinksterweekend tornooi",
+          date: "2026-04-25",
+          endDate: "2026-04-26",
+        }}
+      />,
+    );
+    const range = screen.getByTestId("event-strip-date-range");
+    expect(range.textContent).toMatch(/25\s*–\s*26/);
+    expect(range.textContent).toMatch(/april/i);
+    expect(range.textContent).toMatch(/2026/);
+    // Weekday line spans both days.
+    const weekday = screen.getByTestId("event-strip-date-weekday");
+    expect(weekday.textContent).toMatch(/zaterdag\s*–\s*zondag/i);
+  });
+
+  it("renders a cross-month range compactly: `25 APR – 2 MEI`", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Bi-monthly camp",
+          date: "2026-04-30",
+          endDate: "2026-05-02",
+        }}
+      />,
+    );
+    const range = screen.getByTestId("event-strip-date-range");
+    expect(range.textContent).toMatch(/30\s*apr/i);
+    expect(range.textContent).toMatch(/2\s*mei/i);
+    expect(range.textContent).toMatch(/2026/);
+  });
+
+  it("renders a sessions list when the feature has multiple per-day schedules", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Steakfestijn",
+          sessions: [
+            { date: "2026-11-21", startTime: "17:00", endTime: "23:00" },
+            { date: "2026-11-20", startTime: "18:00", endTime: "22:00" },
+            { date: "2026-11-22", startTime: "11:30", endTime: "15:00" },
+          ],
+          location: "Kantine KCVV",
+        }}
+      />,
+    );
+    // Date column renders the same same-month range layout as
+    // continuous multi-day events.
+    expect(screen.getByTestId("event-strip-date-sessions")).toBeInTheDocument();
+    expect(screen.queryByTestId("event-strip-date-range")).toBeNull();
+
+    // Three session rows, rendered in chronological order (20 → 21 → 22)
+    // even though the editor entered them out of order.
+    const rows = screen.getAllByTestId("event-strip-session-row");
+    expect(rows).toHaveLength(3);
+    const rowTexts = rows.map((r) => r.textContent ?? "");
+    expect(rowTexts[0]).toMatch(/20/);
+    expect(rowTexts[0]).toMatch(/18:00/);
+    expect(rowTexts[1]).toMatch(/21/);
+    expect(rowTexts[1]).toMatch(/17:00/);
+    expect(rowTexts[2]).toMatch(/22/);
+    expect(rowTexts[2]).toMatch(/11:30/);
+
+    // The single display-scale time row is suppressed — each session
+    // carries its own hours.
+    expect(screen.queryByTestId("event-strip-time")).toBeNull();
+  });
+
+  it("treats endDate equal to date as single-day (no range rendering)", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-25",
+          endDate: "2026-04-25",
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("event-strip-date-range")).toBeNull();
+    expect(screen.getByTestId("event-strip-date")).toHaveTextContent(/25/);
+    expect(screen.getByTestId("event-strip-date-weekday")).toHaveTextContent(
+      /^zaterdag$/i,
+    );
+  });
+
   it("renders a 'Datum volgt' placeholder when the date is missing", () => {
     render(
       <EventStrip
@@ -44,20 +132,65 @@ describe("EventStrip", () => {
     );
   });
 
-  it("combines weekday + time range on the `when` row when both are present", () => {
+  it("renders the weekday inside the date column", () => {
     render(
       <EventStrip
         feature={{
           title: "Lentetornooi",
-          date: "2026-04-27",
+          date: "2026-04-25",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-strip-date-weekday")).toHaveTextContent(
+      /zaterdag/i,
+    );
+  });
+
+  it("renders both start and end time at display scale with a direction arrow", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-25",
           startTime: "10:00",
           endTime: "17:00",
         }}
       />,
     );
-    const when = screen.getByTestId("event-strip-when");
-    expect(when.textContent).toMatch(/maandag/i);
-    expect(when.textContent).toMatch(/10:00 - 17:00/);
+    const time = screen.getByTestId("event-strip-time");
+    expect(time).toHaveTextContent(/10:00/);
+    expect(time).toHaveTextContent(/17:00/);
+    // The arrow between them — rendered inline as the Lucide SVG. Find
+    // it by looking for an svg child of the time row.
+    expect(time.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders only the start time (no arrow) when the end time is missing", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Training",
+          date: "2026-04-25",
+          startTime: "18:30",
+        }}
+      />,
+    );
+    const time = screen.getByTestId("event-strip-time");
+    expect(time).toHaveTextContent(/18:30/);
+    // No arrow when there is only one time anchor.
+    expect(time.querySelector("svg")).toBeNull();
+  });
+
+  it("omits the time row entirely when neither start nor end time is set", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Jeugd barbecue",
+          date: "2026-04-25",
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("event-strip-time")).toBeNull();
   });
 
   it("combines location + address on the `where` row", () => {

--- a/apps/web/src/components/article/EventStrip/EventStrip.test.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PortableTextBlock } from "@portabletext/react";
+import { EventStrip } from "./EventStrip";
+
+describe("EventStrip", () => {
+  it("renders the serif-style date block with day, long month, and year in Dutch", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi U13",
+          date: "2026-04-27",
+        }}
+      />,
+    );
+    const dateBlock = screen.getByTestId("event-strip-date");
+    expect(dateBlock.textContent).toMatch(/27/);
+    expect(dateBlock.textContent).toMatch(/april/i);
+    expect(dateBlock.textContent).toMatch(/2026/);
+  });
+
+  it("renders a 'Datum volgt' placeholder when the date is missing", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Datum volgt",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-strip-date-tbd")).toBeInTheDocument();
+  });
+
+  it("renders the event title as an h2 on the right side of the strip", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi U13",
+          date: "2026-04-27",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-strip-title")).toHaveTextContent(
+      "Lentetornooi U13",
+    );
+  });
+
+  it("combines weekday + time range on the `when` row when both are present", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          startTime: "10:00",
+          endTime: "17:00",
+        }}
+      />,
+    );
+    const when = screen.getByTestId("event-strip-when");
+    expect(when.textContent).toMatch(/maandag/i);
+    expect(when.textContent).toMatch(/10:00 - 17:00/);
+  });
+
+  it("combines location + address on the `where` row", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          location: "Sportpark Elewijt",
+          address: "Driesstraat 14, Elewijt",
+        }}
+      />,
+    );
+    const where = screen.getByTestId("event-strip-where");
+    expect(where.textContent).toMatch(/Sportpark Elewijt/i);
+    expect(where.textContent).toMatch(/Driesstraat 14/i);
+  });
+
+  it("renders the note via PortableText when set", () => {
+    const note: PortableTextBlock[] = [
+      {
+        _type: "block",
+        _key: "n1",
+        style: "normal",
+        markDefs: [],
+        children: [
+          {
+            _type: "span",
+            _key: "n1-s",
+            text: "Open voor spelers geboren in 2013 en 2014.",
+            marks: [],
+          },
+        ],
+      } as unknown as PortableTextBlock,
+    ];
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          note,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-strip-note")).toHaveTextContent(
+      /Open voor spelers geboren in 2013 en 2014\./i,
+    );
+  });
+
+  it("renders the CTA with the default `Inschrijven` label when ticketLabel is blank", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          ticketUrl: "https://kcvvelewijt.be/inschrijven",
+        }}
+      />,
+    );
+    const cta = screen.getByTestId("event-strip-cta");
+    expect(cta).toHaveAttribute("href", "https://kcvvelewijt.be/inschrijven");
+    expect(cta).toHaveAttribute("target", "_blank");
+    expect(cta).toHaveAttribute("rel", "noopener noreferrer");
+    expect(cta).toHaveTextContent(/Inschrijven/i);
+  });
+
+  it("uses the editor-authored ticketLabel when set", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          ticketUrl: "https://kcvvelewijt.be/inschrijven",
+          ticketLabel: "Boek je plek",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-strip-cta")).toHaveTextContent(
+      /Boek je plek/,
+    );
+  });
+
+  it("hides the CTA entirely when ticketUrl is missing", () => {
+    render(
+      <EventStrip
+        feature={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("event-strip-cta")).toBeNull();
+  });
+});

--- a/apps/web/src/components/article/EventStrip/EventStrip.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { PortableText, type PortableTextComponents } from "@portabletext/react";
-import { ArrowRight } from "@/lib/icons";
+import { ArrowRight, ExternalLink } from "@/lib/icons";
 import { cn } from "@/lib/utils/cn";
 import {
   DEFAULT_TICKET_LABEL,
-  formatTimeRange,
-  resolveEventDate,
+  resolveEventRange,
   type EventFactValue,
 } from "@/components/article/blocks/EventFact";
 
@@ -29,34 +28,46 @@ const NOTE_COMPONENTS: PortableTextComponents = {
  * Design §5.4 + §8.2 — horizontal event strip. Renders beneath the §7.6
  * metadata bar and describes the event at display scale:
  *
- *   27           Lentetornooi U13
- *   APRIL    │   zaterdag · 10:00 – 17:00
- *   2026     │   Sportpark Elewijt · Driesstraat 14
- *            │
- *            │   Open voor spelers geboren in 2013 en 2014.
- *            │
- *            │   Inschrijven →
+ *   25         │   Lentetornooi U13
+ *   APRIL      │
+ *   2026       │   10:00  →  17:00            ← display scale
+ *   zaterdag   │
+ *              │   Sportpark Elewijt · Driesstraat 14, Elewijt
+ *              │   Open voor spelers geboren in 2013 en 2014.
+ *              │   Inschrijven →
  *
- * Two-column grid on md+: serif-style date block on the left + vertical
- * 1 px `kcvv-gray-light` rule, title + metadata + note + CTA on the
- * right. Full-bleed like `TransferStrip` so it has canvas room on wide
- * desktops; the hero stays within the 70 rem body column to keep the
- * reading rhythm intact.
+ * Two-column grid on md+: serif-style date block on the left (day,
+ * long month, year, weekday) + vertical 1 px `kcvv-gray-light` rule,
+ * right column stacks title → display-scale time range → location meta
+ * → note → CTA. The time range mirrors `TransferStrip`'s club → club
+ * composition: the two most important facts render at display scale
+ * with a direction arrow between.
  *
- * CTA behaviour: rendered only when `ticketUrl` is set. The ticket
- * label defaults to Dutch "Inschrijven" when the editor leaves it blank.
+ * Time row rules:
+ *   - both start + end → `10:00 → 17:00` with a Lucide arrow in green
+ *   - only start      → `10:00` alone
+ *   - neither         → row omitted (date block carries the schedule)
+ *
+ * CTA: rendered only when `ticketUrl` is set. Ticket label defaults to
+ * Dutch "Inschrijven" when the editor leaves it blank.
  */
 export const EventStrip = ({ feature, className }: EventStripProps) => {
-  const resolvedDate = resolveEventDate(feature.date);
-  const timeRange = formatTimeRange(feature.startTime, feature.endTime);
+  const range = resolveEventRange(
+    feature.date,
+    feature.endDate,
+    feature.sessions,
+  );
   const ticketLabel = feature.ticketLabel?.trim() || DEFAULT_TICKET_LABEL;
 
-  // The top line beneath the title pairs the weekday with the time
-  // range when both are present; either alone is acceptable.
-  const whenParts = [
-    resolvedDate.hasDate ? resolvedDate.weekday : null,
-    timeRange,
-  ].filter((x): x is string => typeof x === "string" && x.length > 0);
+  const startTime = feature.startTime?.trim() || undefined;
+  const endTime = feature.endTime?.trim() || undefined;
+
+  // Show the top-level time row ONLY for non-recurring events. When
+  // `sessions` is populated, each session renders its own time range
+  // inside the session list, so a single display-scale top-level time
+  // would be meaningless.
+  const hasTimeRow = range.kind !== "sessions" && Boolean(startTime || endTime);
+
   const whereParts = [feature.location, feature.address].filter(
     (x): x is string => typeof x === "string" && x.length > 0,
   );
@@ -87,22 +98,92 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
           data-testid="event-strip-date"
           className={cn("md:border-kcvv-gray-light flex md:border-r md:pr-10")}
         >
-          {resolvedDate.hasDate ? (
+          {range.kind === "single" && (
             <time
-              dateTime={resolvedDate.dateIso}
+              dateTime={range.date.dateIso}
               className="flex flex-col items-start"
             >
               <span className="font-title text-kcvv-gray-blue text-[5rem] leading-[0.85] font-bold md:text-[6rem]">
-                {resolvedDate.day}
+                {range.date.day}
               </span>
               <span className="font-title text-kcvv-gray-blue mt-2 text-xl font-bold tracking-[var(--letter-spacing-label)] uppercase">
-                {resolvedDate.monthLong}
+                {range.date.monthLong}
               </span>
               <span className="text-kcvv-gray mt-1 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase">
-                {resolvedDate.year}
+                {range.date.year}
+              </span>
+              <span
+                data-testid="event-strip-date-weekday"
+                className="text-kcvv-gray mt-2 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+              >
+                {range.date.weekday}
               </span>
             </time>
-          ) : (
+          )}
+          {(range.kind === "range" || range.kind === "sessions") && (
+            <div
+              data-testid={
+                range.kind === "sessions"
+                  ? "event-strip-date-sessions"
+                  : "event-strip-date-range"
+              }
+              className="flex flex-col items-start"
+            >
+              {range.sameMonth ? (
+                <>
+                  {/* Same-month: huge `25 – 26` composition keeps the display
+                      scale while signalling the two-day span. */}
+                  <span className="font-title text-kcvv-gray-blue text-[5rem] leading-[0.85] font-bold md:text-[6rem]">
+                    <time dateTime={range.start.dateIso}>
+                      {range.start.day}
+                    </time>
+                    <span className="text-kcvv-gray-light mx-2">–</span>
+                    <time dateTime={range.end.dateIso}>{range.end.day}</time>
+                  </span>
+                  <span className="font-title text-kcvv-gray-blue mt-2 text-xl font-bold tracking-[var(--letter-spacing-label)] uppercase">
+                    {range.start.monthLong}
+                  </span>
+                  <span className="text-kcvv-gray mt-1 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase">
+                    {range.start.year}
+                  </span>
+                  <span
+                    data-testid="event-strip-date-weekday"
+                    className="text-kcvv-gray mt-2 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+                  >
+                    {range.start.weekday} – {range.end.weekday}
+                  </span>
+                </>
+              ) : (
+                <>
+                  {/* Cross-month (or cross-year): compact "day month →
+                      day month" composition at the title scale. Display-size
+                      day numerals would overflow the 2-column strip on
+                      cross-month labels. */}
+                  <span className="font-title text-kcvv-gray-blue text-3xl leading-[1.05] font-bold md:text-4xl">
+                    <time dateTime={range.start.dateIso}>
+                      {range.start.day} {range.start.monthShort.toUpperCase()}
+                    </time>
+                    <span className="text-kcvv-gray-light mx-2">–</span>
+                    <time dateTime={range.end.dateIso}>
+                      {range.end.day} {range.end.monthShort.toUpperCase()}
+                    </time>
+                  </span>
+                  <span className="text-kcvv-gray mt-2 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase">
+                    {range.sameYear
+                      ? range.start.year
+                      : `${range.start.year} – ${range.end.year}`}
+                  </span>
+                  <span
+                    data-testid="event-strip-date-weekday"
+                    className="text-kcvv-gray mt-2 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+                  >
+                    {range.start.weekday} – {range.end.weekday}
+                  </span>
+                </>
+              )}
+            </div>
+          )}
+          {range.kind === "none" && (
             <span
               data-testid="event-strip-date-tbd"
               className="text-kcvv-gray font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
@@ -123,25 +204,78 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
             </h2>
           )}
 
-          {whenParts.length > 0 && (
-            <p
-              data-testid="event-strip-when"
-              className="text-kcvv-gray-dark font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+          {hasTimeRow && (
+            <div
+              data-testid="event-strip-time"
+              className="flex items-center gap-3 md:gap-5"
             >
-              {whenParts.map((part, i) => (
-                <span key={part}>
-                  {i > 0 && (
-                    <span
-                      aria-hidden="true"
-                      className="text-kcvv-gray-light mx-2"
-                    >
-                      ·
-                    </span>
-                  )}
-                  {part}
+              {startTime && (
+                <span className="font-title text-kcvv-gray-blue text-3xl leading-none font-bold md:text-4xl">
+                  {startTime}
                 </span>
+              )}
+              {startTime && endTime && (
+                <ArrowRight
+                  aria-hidden="true"
+                  className="text-kcvv-green-bright h-6 w-6 shrink-0 md:h-8 md:w-8"
+                />
+              )}
+              {endTime && (
+                <span className="font-title text-kcvv-gray-blue text-3xl leading-none font-bold md:text-4xl">
+                  {endTime}
+                </span>
+              )}
+            </div>
+          )}
+
+          {range.kind === "sessions" && (
+            <ul
+              data-testid="event-strip-sessions"
+              // Grid lays the weekday / date / start-time / arrow /
+              // end-time into five fixed columns so the values line up
+              // row-to-row. `tabular-nums` on the time columns locks
+              // digit widths — without it, proportional digits shift
+              // the arrow column horizontally (`11:30` narrower than
+              // `18:00`).
+              className={cn(
+                "border-kcvv-gray-light grid gap-x-4 gap-y-2 border-t pt-4",
+                "grid-cols-[auto_auto_auto_auto_auto] items-baseline justify-start",
+              )}
+            >
+              {range.sessions.map((session) => (
+                <li
+                  key={session._key ?? session.date.dateIso}
+                  data-testid="event-strip-session-row"
+                  className="contents"
+                >
+                  <span className="text-kcvv-gray-dark font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+                    {session.date.weekday.slice(0, 2)}
+                  </span>
+                  <time
+                    dateTime={session.date.dateIso}
+                    className="text-kcvv-gray-dark font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
+                  >
+                    {session.date.day} {session.date.monthShort}
+                  </time>
+                  <span className="font-title text-kcvv-gray-blue text-lg leading-none font-bold tabular-nums md:text-xl">
+                    {session.startTime ?? (
+                      <span className="text-kcvv-gray-light">–</span>
+                    )}
+                  </span>
+                  <span className="flex items-center justify-center">
+                    {session.startTime && session.endTime && (
+                      <ArrowRight
+                        aria-hidden="true"
+                        className="text-kcvv-green-bright h-4 w-4 shrink-0"
+                      />
+                    )}
+                  </span>
+                  <span className="font-title text-kcvv-gray-blue text-lg leading-none font-bold tabular-nums md:text-xl">
+                    {session.endTime ?? ""}
+                  </span>
+                </li>
               ))}
-            </p>
+            </ul>
           )}
 
           {whereParts.length > 0 && (
@@ -150,7 +284,9 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
               className="text-kcvv-gray-dark font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
             >
               {whereParts.map((part, i) => (
-                <span key={part}>
+                // Composite key — belt and braces for the unlikely case
+                // where location and address collide on the same string.
+                <span key={`${i}-${part}`}>
                   {i > 0 && (
                     <span
                       aria-hidden="true"
@@ -178,14 +314,19 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                "mt-2 inline-flex items-center gap-2 self-start",
+                "mt-2 inline-flex items-baseline gap-1 self-start",
                 "font-title text-base font-bold tracking-[var(--letter-spacing-caps)] uppercase",
                 "text-kcvv-green-dark decoration-kcvv-green-bright underline decoration-1 underline-offset-4",
                 "transition-[text-decoration-thickness] duration-150 hover:decoration-2",
               )}
             >
               {ticketLabel}
-              <ArrowRight aria-hidden="true" className="h-4 w-4" />
+              <ExternalLink
+                aria-hidden="true"
+                className="ml-0.5 inline-block align-baseline opacity-60"
+                size="0.75em"
+              />
+              <span className="sr-only"> (opens in new tab)</span>
             </a>
           )}
         </div>

--- a/apps/web/src/components/article/EventStrip/EventStrip.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.tsx
@@ -65,15 +65,19 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
     <section
       data-testid="event-strip"
       className={cn(
-        // Break out of the 70 rem body column so the date block + copy
-        // column breathe on wide desktops.
+        // Align with the 70 rem hero + metadata bar so the event page
+        // reads as a single indented column rather than three different
+        // widths. The dark `EventFactOverview` stack below the strip
+        // still breaks out wider (`max-w-outer`) — that's the deliberate
+        // canvas moment. Full-bleed rules preserve the edge-to-edge
+        // top/bottom borders across the viewport.
         "full-bleed border-kcvv-gray-light border-y py-10 md:py-16",
         className,
       )}
     >
       <div
         className={cn(
-          "max-w-outer mx-auto grid px-6",
+          "max-w-inner-lg mx-auto grid px-6",
           "gap-8 md:gap-10",
           "md:grid-cols-[auto_minmax(0,1fr)]",
         )}

--- a/apps/web/src/components/article/EventStrip/EventStrip.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.tsx
@@ -68,9 +68,9 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
   // would be meaningless.
   const hasTimeRow = range.kind !== "sessions" && Boolean(startTime || endTime);
 
-  const whereParts = [feature.location, feature.address].filter(
-    (x): x is string => typeof x === "string" && x.length > 0,
-  );
+  const whereParts = [feature.location, feature.address]
+    .map((x) => (typeof x === "string" ? x.trim() : x))
+    .filter((x): x is string => typeof x === "string" && x.length > 0);
 
   return (
     <section
@@ -242,9 +242,14 @@ export const EventStrip = ({ feature, className }: EventStripProps) => {
                 "grid-cols-[auto_auto_auto_auto_auto] items-baseline justify-start",
               )}
             >
-              {range.sessions.map((session) => (
+              {range.sessions.map((session, index) => (
                 <li
-                  key={session._key ?? session.date.dateIso}
+                  // `_key` is the stable identifier for Sanity array
+                  // items. Fall back to `<date>-<index>` rather than the
+                  // date alone so two sessions on the same calendar day
+                  // (e.g. morning + evening session) don't collide on
+                  // key and trigger unstable reconciliation.
+                  key={session._key ?? `${session.date.dateIso}-${index}`}
                   data-testid="event-strip-session-row"
                   className="contents"
                 >

--- a/apps/web/src/components/article/EventStrip/EventStrip.tsx
+++ b/apps/web/src/components/article/EventStrip/EventStrip.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { PortableText, type PortableTextComponents } from "@portabletext/react";
+import { ArrowRight } from "@/lib/icons";
+import { cn } from "@/lib/utils/cn";
+import {
+  DEFAULT_TICKET_LABEL,
+  formatTimeRange,
+  resolveEventDate,
+  type EventFactValue,
+} from "@/components/article/blocks/EventFact";
+
+export interface EventStripProps {
+  feature: EventFactValue;
+  className?: string;
+}
+
+const NOTE_COMPONENTS: PortableTextComponents = {
+  block: {
+    normal: ({ children }) => (
+      <p className="font-body text-kcvv-gray-dark text-lg leading-[1.6]">
+        {children}
+      </p>
+    ),
+  },
+};
+
+/**
+ * Design §5.4 + §8.2 — horizontal event strip. Renders beneath the §7.6
+ * metadata bar and describes the event at display scale:
+ *
+ *   27           Lentetornooi U13
+ *   APRIL    │   zaterdag · 10:00 – 17:00
+ *   2026     │   Sportpark Elewijt · Driesstraat 14
+ *            │
+ *            │   Open voor spelers geboren in 2013 en 2014.
+ *            │
+ *            │   Inschrijven →
+ *
+ * Two-column grid on md+: serif-style date block on the left + vertical
+ * 1 px `kcvv-gray-light` rule, title + metadata + note + CTA on the
+ * right. Full-bleed like `TransferStrip` so it has canvas room on wide
+ * desktops; the hero stays within the 70 rem body column to keep the
+ * reading rhythm intact.
+ *
+ * CTA behaviour: rendered only when `ticketUrl` is set. The ticket
+ * label defaults to Dutch "Inschrijven" when the editor leaves it blank.
+ */
+export const EventStrip = ({ feature, className }: EventStripProps) => {
+  const resolvedDate = resolveEventDate(feature.date);
+  const timeRange = formatTimeRange(feature.startTime, feature.endTime);
+  const ticketLabel = feature.ticketLabel?.trim() || DEFAULT_TICKET_LABEL;
+
+  // The top line beneath the title pairs the weekday with the time
+  // range when both are present; either alone is acceptable.
+  const whenParts = [
+    resolvedDate.hasDate ? resolvedDate.weekday : null,
+    timeRange,
+  ].filter((x): x is string => typeof x === "string" && x.length > 0);
+  const whereParts = [feature.location, feature.address].filter(
+    (x): x is string => typeof x === "string" && x.length > 0,
+  );
+
+  return (
+    <section
+      data-testid="event-strip"
+      className={cn(
+        // Break out of the 70 rem body column so the date block + copy
+        // column breathe on wide desktops.
+        "full-bleed border-kcvv-gray-light border-y py-10 md:py-16",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "max-w-outer mx-auto grid px-6",
+          "gap-8 md:gap-10",
+          "md:grid-cols-[auto_minmax(0,1fr)]",
+        )}
+      >
+        {/* Left — serif-style date block with a vertical rule on the right */}
+        <div
+          data-testid="event-strip-date"
+          className={cn("md:border-kcvv-gray-light flex md:border-r md:pr-10")}
+        >
+          {resolvedDate.hasDate ? (
+            <time
+              dateTime={resolvedDate.dateIso}
+              className="flex flex-col items-start"
+            >
+              <span className="font-title text-kcvv-gray-blue text-[5rem] leading-[0.85] font-bold md:text-[6rem]">
+                {resolvedDate.day}
+              </span>
+              <span className="font-title text-kcvv-gray-blue mt-2 text-xl font-bold tracking-[var(--letter-spacing-label)] uppercase">
+                {resolvedDate.monthLong}
+              </span>
+              <span className="text-kcvv-gray mt-1 font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase">
+                {resolvedDate.year}
+              </span>
+            </time>
+          ) : (
+            <span
+              data-testid="event-strip-date-tbd"
+              className="text-kcvv-gray font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+            >
+              Datum volgt
+            </span>
+          )}
+        </div>
+
+        {/* Right — title, metadata rows, note, CTA */}
+        <div className="flex flex-col gap-4">
+          {feature.title && (
+            <h2
+              data-testid="event-strip-title"
+              className="font-title text-kcvv-gray-blue text-3xl leading-[1.05] font-bold md:text-4xl"
+            >
+              {feature.title}
+            </h2>
+          )}
+
+          {whenParts.length > 0 && (
+            <p
+              data-testid="event-strip-when"
+              className="text-kcvv-gray-dark font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+            >
+              {whenParts.map((part, i) => (
+                <span key={part}>
+                  {i > 0 && (
+                    <span
+                      aria-hidden="true"
+                      className="text-kcvv-gray-light mx-2"
+                    >
+                      ·
+                    </span>
+                  )}
+                  {part}
+                </span>
+              ))}
+            </p>
+          )}
+
+          {whereParts.length > 0 && (
+            <p
+              data-testid="event-strip-where"
+              className="text-kcvv-gray-dark font-mono text-sm tracking-[var(--letter-spacing-caps)] uppercase"
+            >
+              {whereParts.map((part, i) => (
+                <span key={part}>
+                  {i > 0 && (
+                    <span
+                      aria-hidden="true"
+                      className="text-kcvv-gray-light mx-2"
+                    >
+                      ·
+                    </span>
+                  )}
+                  {part}
+                </span>
+              ))}
+            </p>
+          )}
+
+          {Array.isArray(feature.note) && feature.note.length > 0 && (
+            <div data-testid="event-strip-note" className="mt-2">
+              <PortableText value={feature.note} components={NOTE_COMPONENTS} />
+            </div>
+          )}
+
+          {feature.ticketUrl && (
+            <a
+              data-testid="event-strip-cta"
+              href={feature.ticketUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                "mt-2 inline-flex items-center gap-2 self-start",
+                "font-title text-base font-bold tracking-[var(--letter-spacing-caps)] uppercase",
+                "text-kcvv-green-dark decoration-kcvv-green-bright underline decoration-1 underline-offset-4",
+                "transition-[text-decoration-thickness] duration-150 hover:decoration-2",
+              )}
+            >
+              {ticketLabel}
+              <ArrowRight aria-hidden="true" className="h-4 w-4" />
+            </a>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/components/article/EventStrip/index.ts
+++ b/apps/web/src/components/article/EventStrip/index.ts
@@ -1,0 +1,2 @@
+export { EventStrip } from "./EventStrip";
+export type { EventStripProps } from "./EventStrip";

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.stories.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { PortableTextBlock } from "@portabletext/react";
+import { EventTemplate } from "./EventTemplate";
+
+const paragraph = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "normal",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  }) as unknown as PortableTextBlock;
+
+const heading = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "h2",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  }) as unknown as PortableTextBlock;
+
+const note = (key: string, text: string): PortableTextBlock[] => [
+  {
+    _type: "block",
+    _key: key,
+    style: "normal",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  } as unknown as PortableTextBlock,
+];
+
+const lentetornooi = {
+  _type: "eventFact",
+  _key: "evt-feature",
+  title: "Lentetornooi U13",
+  date: "2026-04-27",
+  startTime: "10:00",
+  endTime: "17:00",
+  location: "Sportpark Elewijt",
+  address: "Driesstraat 14, Elewijt",
+  ageGroup: "U13",
+  ticketUrl: "https://kcvvelewijt.be/inschrijven",
+  note: note(
+    "evt-note",
+    "Open voor spelers geboren in 2013 en 2014. Wedstrijden en finales, met afsluiting op het terras.",
+  ),
+} as unknown as PortableTextBlock;
+
+const afterparty = {
+  _type: "eventFact",
+  _key: "evt-after",
+  title: "Afterparty",
+  date: "2026-04-27",
+  startTime: "20:00",
+  location: "Kantine KCVV",
+  competitionTag: "Clubfeest",
+} as unknown as PortableTextBlock;
+
+const training = {
+  _type: "eventFact",
+  _key: "evt-training",
+  title: "Seizoensstart training",
+  date: "2026-07-27",
+  startTime: "18:30",
+  endTime: "20:00",
+  location: "Sportpark Elewijt",
+  ageGroup: "Senioren",
+} as unknown as PortableTextBlock;
+
+const meta = {
+  title: "Pages/Article/Event",
+  component: EventTemplate,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Phase 6 (#1332) — full event article composition. Typographic hero (kicker + title) + §7.6 metadata bar + full-bleed `EventStrip` (date block + metadata + note + CTA) + body prose + a stack of `EventFactOverview` rows on the dark band.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof EventTemplate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FullComposition: Story = {
+  args: {
+    title: "Lentetornooi U13 — zaterdag in Elewijt",
+    publishedDate: "19 April 2026",
+    readingTime: "2 min lezen",
+    shareConfig: {
+      url: "https://kcvvelewijt.be/nieuws/lentetornooi-u13",
+      title: "Lentetornooi U13",
+    },
+    body: [
+      lentetornooi,
+      paragraph(
+        "p1",
+        "Zaterdag 27 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
+      ),
+      paragraph(
+        "p2",
+        "De organisatie voorziet drinken en versnaperingen. Supporters zijn welkom de hele dag door — ook voor de finale om 16u30.",
+      ),
+      heading("h1", "Andere evenementen"),
+      afterparty,
+      training,
+      paragraph(
+        "p3",
+        "Meer info bij de jeugdvoorzitter via info@kcvvelewijt.be.",
+      ),
+    ],
+  },
+};
+
+export const WithoutEventFact: Story = {
+  args: {
+    title: "Evenementenupdate volgt",
+    publishedDate: "19 April 2026",
+    shareConfig: {
+      url: "https://kcvvelewijt.be/nieuws/evenementenupdate",
+    },
+    body: [
+      paragraph(
+        "p1",
+        "Hieronder zonder een gestructureerd eventFact-blok: de hero gebruikt de articletitel, er is geen strip en het body blijft normale prose.",
+      ),
+    ],
+  },
+};

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.stories.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.stories.tsx
@@ -89,6 +89,8 @@ type Story = StoryObj<typeof meta>;
 export const FullComposition: Story = {
   args: {
     title: "Lentetornooi U13 — zaterdag in Elewijt",
+    coverImageUrl:
+      "https://images.unsplash.com/photo-1517649763962-0c623066013b?w=1600&q=80&fit=max",
     publishedDate: "19 April 2026",
     readingTime: "2 min lezen",
     shareConfig: {

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.stories.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.stories.tsx
@@ -34,7 +34,7 @@ const lentetornooi = {
   _type: "eventFact",
   _key: "evt-feature",
   title: "Lentetornooi U13",
-  date: "2026-04-27",
+  date: "2026-04-25",
   startTime: "10:00",
   endTime: "17:00",
   location: "Sportpark Elewijt",
@@ -51,7 +51,7 @@ const afterparty = {
   _type: "eventFact",
   _key: "evt-after",
   title: "Afterparty",
-  date: "2026-04-27",
+  date: "2026-04-25",
   startTime: "20:00",
   location: "Kantine KCVV",
   competitionTag: "Clubfeest",
@@ -99,7 +99,7 @@ export const FullComposition: Story = {
       lentetornooi,
       paragraph(
         "p1",
-        "Zaterdag 27 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
+        "Zaterdag 25 april verwelkomen we acht ploegen voor het traditionele lentetornooi. Vijf velden, vier poules, één grote dag voor de U13-kern.",
       ),
       paragraph(
         "p2",

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.test.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PortableTextBlock } from "@portabletext/react";
+import { EventTemplate } from "./EventTemplate";
+
+// ArticleBodyMotion reaches for IntersectionObserver — stub both it and
+// matchMedia so the render completes in happy-dom.
+class NoopIntersectionObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root: Element | Document | null = null;
+  rootMargin = "";
+  thresholds: ReadonlyArray<number> = [];
+  constructor() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+  vi.stubGlobal("matchMedia", (q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const lentetornooi = {
+  _key: "evt-1",
+  _type: "eventFact" as const,
+  title: "Lentetornooi U13",
+  date: "2026-04-27",
+  startTime: "10:00",
+  endTime: "17:00",
+  location: "Sportpark Elewijt",
+  ageGroup: "U13",
+};
+
+const afterparty = {
+  _key: "evt-2",
+  _type: "eventFact" as const,
+  title: "Afterparty",
+  date: "2026-04-27",
+  startTime: "20:00",
+};
+
+const paragraph = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "normal",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  }) as unknown as PortableTextBlock;
+
+describe("EventTemplate", () => {
+  it("renders the hero with the article title and an EVENT | ageGroup kicker", () => {
+    render(
+      <EventTemplate
+        title="Lentetornooi U13 — zaterdag in Elewijt"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/e" }}
+        body={[lentetornooi as unknown as PortableTextBlock]}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Lentetornooi U13 — zaterdag in Elewijt",
+    );
+    expect(screen.getByTestId("event-hero-kicker").textContent).toMatch(
+      /Event\s*\|\s*U13/i,
+    );
+  });
+
+  it("renders the EventStrip when a feature eventFact is present", () => {
+    render(
+      <EventTemplate
+        title="Lentetornooi"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/e" }}
+        body={[lentetornooi as unknown as PortableTextBlock]}
+      />,
+    );
+    expect(screen.getByTestId("event-strip")).toBeInTheDocument();
+    expect(screen.getByTestId("event-strip-title")).toHaveTextContent(
+      "Lentetornooi U13",
+    );
+  });
+
+  it("first eventFact is absorbed by the strip — only the second renders as an overview row", () => {
+    render(
+      <EventTemplate
+        title="Lentetornooi"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/e" }}
+        body={[
+          lentetornooi as unknown as PortableTextBlock,
+          paragraph("p1", "Body paragraph."),
+          afterparty as unknown as PortableTextBlock,
+        ]}
+      />,
+    );
+    const overviews = screen.getAllByTestId("event-overview");
+    expect(overviews).toHaveLength(1);
+    expect(screen.getByTestId("event-overview-title")).toHaveTextContent(
+      "Afterparty",
+    );
+  });
+
+  it("falls back to the article title as h1 when the body has no eventFact", () => {
+    render(
+      <EventTemplate
+        title="Evenementenupdate"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/e" }}
+        body={[paragraph("p1", "Geen event block geleverd.")]}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Evenementenupdate",
+    );
+    expect(screen.queryByTestId("event-strip")).toBeNull();
+  });
+
+  it("renders the metadata bar (date · author · reading time)", () => {
+    render(
+      <EventTemplate
+        title="Lentetornooi"
+        publishedDate="19.04.2026"
+        readingTime="2 min lezen"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/e" }}
+        body={[lentetornooi as unknown as PortableTextBlock]}
+      />,
+    );
+    const meta = screen.getByRole("navigation", { name: /artikelinfo/i });
+    expect(meta).toHaveTextContent("19.04.2026");
+    expect(meta).toHaveTextContent("2 min lezen");
+  });
+});

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
@@ -8,6 +8,12 @@ import type { EventFactValue } from "@/components/article/blocks/EventFact";
 
 export interface EventTemplateProps {
   title: string;
+  /**
+   * 16:9 landscape cover image. Same `article.coverImage` projection
+   * announcement uses — events always upload landscape for TV +
+   * Facebook reuse.
+   */
+  coverImageUrl?: string | null;
   publishedDate?: string;
   readingTime?: string;
   shareConfig: { url: string; title?: string };
@@ -47,6 +53,7 @@ const isEventFact = (
  */
 export const EventTemplate = ({
   title,
+  coverImageUrl,
   publishedDate,
   readingTime,
   shareConfig,
@@ -66,7 +73,11 @@ export const EventTemplate = ({
 
   return (
     <>
-      <EventHero feature={firstEventFact ?? null} title={title} />
+      <EventHero
+        feature={firstEventFact ?? null}
+        title={title}
+        coverImageUrl={coverImageUrl}
+      />
 
       <ArticleMetadata
         author={AUTHOR}

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
@@ -1,0 +1,93 @@
+import type { PortableTextBlock } from "@portabletext/react";
+import { ArticleMetadata } from "../ArticleMetadata";
+import { ArticleBodyMotion } from "../ArticleBodyMotion";
+import { SanityArticleBody } from "../SanityArticleBody/SanityArticleBody";
+import { EventHero } from "../EventHero";
+import { EventStrip } from "../EventStrip";
+import type { EventFactValue } from "@/components/article/blocks/EventFact";
+
+export interface EventTemplateProps {
+  title: string;
+  publishedDate?: string;
+  readingTime?: string;
+  shareConfig: { url: string; title?: string };
+  body: PortableTextBlock[] | null;
+}
+
+// Event articles are implicitly club-authored — same pattern the other
+// templates use. The §7.6 metadata bar is the single source of truth for
+// author + date + reading time.
+const AUTHOR = "KCVV Elewijt";
+
+const isEventFact = (
+  block: PortableTextBlock,
+): block is PortableTextBlock & EventFactValue =>
+  (block as { _type?: string })._type === "eventFact";
+
+/**
+ * Phase 6 (#1332) — event article template.
+ *
+ * Composition:
+ *   1. `EventHero` — typographic kicker (`EVENT | ageGroup`) + article
+ *      title. No image, no date block — the hero keeps the body column
+ *      width so the narrative title sits in the reading rhythm.
+ *   2. `ArticleMetadata` — design §7.6 metadata bar.
+ *   3. `EventStrip` — full-bleed horizontal band with the serif-style
+ *      date block + title + metadata + note + optional CTA. Absorbs the
+ *      first `eventFact` in the body.
+ *   4. Body prose via `SanityArticleBody` (class `article-body` so
+ *      Phase 4 drop-cap / blockquote / fade-up scope applies). The
+ *      feature eventFact is filtered out of the body — the strip owns
+ *      it. Subsequent eventFacts render inline as `EventFactOverview`
+ *      dark-band rows via the SanityArticleBody dispatch.
+ *
+ * Mirrors the Phase 5 transfer template shape so editors work in a
+ * familiar editorial pattern across the three feature-block article
+ * types (transfer, event, later).
+ */
+export const EventTemplate = ({
+  title,
+  publishedDate,
+  readingTime,
+  shareConfig,
+  body,
+}: EventTemplateProps) => {
+  const hasBody = Array.isArray(body) && body.length > 0;
+  const firstEventFact: EventFactValue | undefined = hasBody
+    ? body.find(isEventFact)
+    : undefined;
+
+  // Feature eventFact is absorbed by the strip — strip it from the body
+  // so it doesn't render a second time as an overview row.
+  const bodyWithoutFeature =
+    hasBody && firstEventFact ? body.filter((b) => b !== firstEventFact) : body;
+  const hasRemainingBody =
+    Array.isArray(bodyWithoutFeature) && bodyWithoutFeature.length > 0;
+
+  return (
+    <>
+      <EventHero feature={firstEventFact ?? null} title={title} />
+
+      <ArticleMetadata
+        author={AUTHOR}
+        date={publishedDate}
+        readingTime={readingTime}
+        shareConfig={shareConfig}
+        className="mt-10"
+      />
+
+      {firstEventFact && <EventStrip feature={firstEventFact} />}
+
+      {hasRemainingBody && (
+        <main className="max-w-inner-lg mx-auto mb-6 w-full px-6 lg:mb-10">
+          <ArticleBodyMotion>
+            <SanityArticleBody
+              className="article-body"
+              content={bodyWithoutFeature}
+            />
+          </ArticleBodyMotion>
+        </main>
+      )}
+    </>
+  );
+};

--- a/apps/web/src/components/article/EventTemplate/index.ts
+++ b/apps/web/src/components/article/EventTemplate/index.ts
@@ -1,0 +1,2 @@
+export { EventTemplate } from "./EventTemplate";
+export type { EventTemplateProps } from "./EventTemplate";

--- a/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
+++ b/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
@@ -22,6 +22,10 @@ import {
   TransferFactOverview,
   type TransferFactValue,
 } from "@/components/article/blocks/TransferFact";
+import {
+  EventFactOverview,
+  type EventFactValue,
+} from "@/components/article/blocks/EventFact";
 import type { SubjectValue } from "@/components/article/SubjectAttribution";
 
 const TABLE_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
@@ -205,6 +209,14 @@ export const SanityArticleBody = ({
           // second-or-later block (or lives inside a non-transfer article)
           // and always renders as an overview card.
           <TransferFactOverview value={value} />
+        ),
+        eventFact: ({ value }: { value: EventFactValue }) => (
+          // Same absorption pattern as transferFact: the event template
+          // filters the first eventFact out of the body and renders it
+          // via `EventStrip` beneath the metadata bar. Every surviving
+          // eventFact here is a follow-up / inline-in-announcement
+          // block and renders as a dark-band overview row.
+          <EventFactOverview value={value} />
         ),
       },
       block: {

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.stories.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { EventFactOverview } from "./EventFactOverview";
+
+const meta = {
+  title: "Features/Articles/EventFact/Overview",
+  component: EventFactOverview,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Overview variant of the `eventFact` body block (design §8.2). Full-bleed dark band — consecutive rows fuse seamlessly via globals.css sibling rules. Three slots on md+: date cluster, title + metadata, CTA right. The CTA hides entirely when `ticketUrl` is missing.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof EventFactOverview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithTicketCta: Story = {
+  args: {
+    value: {
+      title: "Lentetornooi U13",
+      date: "2026-04-27",
+      startTime: "10:00",
+      endTime: "17:00",
+      location: "Sportpark Elewijt",
+      ageGroup: "U13",
+      ticketUrl: "https://kcvvelewijt.be/inschrijven",
+    },
+  },
+};
+
+export const WithCustomLabel: Story = {
+  args: {
+    value: {
+      title: "Clubfeest",
+      date: "2026-06-14",
+      startTime: "18:00",
+      location: "Kantine KCVV",
+      competitionTag: "Clubfeest",
+      ticketUrl: "https://kcvvelewijt.be/clubfeest",
+      ticketLabel: "Boek je plek",
+    },
+  },
+};
+
+export const WithoutCta: Story = {
+  args: {
+    value: {
+      title: "Training hervat",
+      date: "2026-08-01",
+      startTime: "18:30",
+      endTime: "20:00",
+      location: "Sportpark Elewijt",
+      ageGroup: "Senioren",
+    },
+  },
+};
+
+export const NoDateYet: Story = {
+  args: {
+    value: {
+      title: "Datum volgt",
+      location: "Sportpark Elewijt",
+      ageGroup: "Alle jeugd",
+    },
+  },
+};

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EventFactOverview } from "./EventFactOverview";
+
+describe("EventFactOverview", () => {
+  it("renders the Dutch-formatted date cluster (day + short month + weekday)", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Lentetornooi U13",
+          date: "2026-04-27",
+        }}
+      />,
+    );
+    const dateCell = screen.getByTestId("event-overview-date");
+    expect(dateCell.textContent).toMatch(/27/);
+    expect(dateCell.textContent).toMatch(/apr/i);
+    // 2026-04-27 is a Monday.
+    expect(dateCell.textContent).toMatch(/maandag/i);
+  });
+
+  it("renders on a full-bleed dark band so consecutive rows stack into one section", () => {
+    const { container } = render(
+      <EventFactOverview
+        value={{ title: "Lentetornooi", date: "2026-04-27" }}
+      />,
+    );
+    const section = container.querySelector("[data-testid='event-overview']");
+    expect(section).toHaveClass("bg-kcvv-gray-dark");
+    expect(section).toHaveClass("full-bleed");
+  });
+
+  it("renders the title + time + location + age-group metadata line", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Lentetornooi U13",
+          date: "2026-04-27",
+          startTime: "10:00",
+          endTime: "17:00",
+          location: "Sportpark Elewijt",
+          ageGroup: "U13",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-overview-title")).toHaveTextContent(
+      "Lentetornooi U13",
+    );
+    const meta = screen.getByTestId("event-overview-meta");
+    expect(meta.textContent).toMatch(/10:00 - 17:00/);
+    expect(meta.textContent).toMatch(/Sportpark Elewijt/i);
+    expect(meta.textContent).toMatch(/U13/);
+  });
+
+  it("falls back to `competitionTag` when `ageGroup` is missing", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Clubfeest",
+          date: "2026-04-27",
+          competitionTag: "Clubfeest",
+        }}
+      />,
+    );
+    const meta = screen.getByTestId("event-overview-meta");
+    expect(meta.textContent).toMatch(/Clubfeest/i);
+  });
+
+  it("renders the CTA link with the default label when `ticketLabel` is unset", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          ticketUrl: "https://kcvvelewijt.be/inschrijven",
+        }}
+      />,
+    );
+    const cta = screen.getByTestId("event-overview-cta");
+    expect(cta).toHaveTextContent(/Inschrijven/i);
+    expect(cta).toHaveAttribute("href", "https://kcvvelewijt.be/inschrijven");
+    expect(cta).toHaveAttribute("target", "_blank");
+  });
+
+  it("uses the editor-authored `ticketLabel` when provided", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+          ticketUrl: "https://kcvvelewijt.be/inschrijven",
+          ticketLabel: "Boek je plek",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-overview-cta")).toHaveTextContent(
+      /Boek je plek/,
+    );
+  });
+
+  it("hides the CTA when `ticketUrl` is unset", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Lentetornooi",
+          date: "2026-04-27",
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("event-overview-cta")).toBeNull();
+  });
+
+  it("renders `tbd` in the date column when the date is missing or malformed", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Datum volgt",
+          date: "",
+        }}
+      />,
+    );
+    const dateCell = screen.getByTestId("event-overview-date");
+    expect(dateCell.textContent).toMatch(/tbd/i);
+  });
+});

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
@@ -140,6 +140,35 @@ describe("EventFactOverview", () => {
     );
   });
 
+  it("skips the time row on recurring events — the date cell already carries the span", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Steakfestijn",
+          sessions: [
+            { date: "2026-11-20", startTime: "18:00", endTime: "22:00" },
+            { date: "2026-11-21", startTime: "17:00", endTime: "23:00" },
+            { date: "2026-11-22", startTime: "11:30", endTime: "15:00" },
+          ],
+          location: "Kantine KCVV",
+          competitionTag: "Clubfeest",
+        }}
+      />,
+    );
+    const meta = screen.getByTestId("event-overview-meta");
+    // No time / session-count — the date column handles the when.
+    expect(meta.textContent).not.toMatch(/18:00/);
+    expect(meta.textContent).not.toMatch(/sessies/i);
+    // Meta still carries the where + category.
+    expect(meta.textContent).toMatch(/Kantine KCVV/);
+    expect(meta.textContent).toMatch(/Clubfeest/i);
+    // Date column should show the span with 3-letter weekday abbreviations.
+    const dateCell = screen.getByTestId("event-overview-date");
+    expect(dateCell.textContent).toMatch(/20/);
+    expect(dateCell.textContent).toMatch(/22/);
+    expect(dateCell.textContent).toMatch(/vri\s*–\s*zon/i);
+  });
+
   it("falls back to `competitionTag` when `ageGroup` is an empty string", () => {
     render(
       <EventFactOverview

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
@@ -110,7 +110,7 @@ describe("EventFactOverview", () => {
     expect(screen.queryByTestId("event-overview-cta")).toBeNull();
   });
 
-  it("renders `tbd` in the date column when the date is missing or malformed", () => {
+  it("renders the `Datum volgt` placeholder when the date is missing", () => {
     render(
       <EventFactOverview
         value={{
@@ -120,6 +120,38 @@ describe("EventFactOverview", () => {
       />,
     );
     const dateCell = screen.getByTestId("event-overview-date");
-    expect(dateCell.textContent).toMatch(/tbd/i);
+    expect(dateCell.textContent).toMatch(/Datum volgt/i);
+  });
+
+  it("renders the `Datum volgt` placeholder when the date is malformed", () => {
+    // `resolveEventDate` is Luxon-backed, so invalid months/days reject
+    // cleanly instead of silently rolling over. Covers the
+    // non-existent-calendar-date regression from Phase 6 review.
+    render(
+      <EventFactOverview
+        value={{
+          title: "Ongeldige datum",
+          date: "2020-13-01",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("event-overview-date").textContent).toMatch(
+      /Datum volgt/i,
+    );
+  });
+
+  it("falls back to `competitionTag` when `ageGroup` is an empty string", () => {
+    render(
+      <EventFactOverview
+        value={{
+          title: "Clubfeest",
+          date: "2026-04-27",
+          ageGroup: "",
+          competitionTag: "Clubfeest",
+        }}
+      />,
+    );
+    const meta = screen.getByTestId("event-overview-meta");
+    expect(meta.textContent).toMatch(/Clubfeest/i);
   });
 });

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
@@ -149,7 +149,10 @@ export const EventFactOverview = ({
               className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
             >
               {metaParts.map((part, i) => (
-                <span key={part}>
+                // Composite key — two parts could collide on the same
+                // string (e.g. `U13 · U13` when editor accidentally
+                // duplicates a label).
+                <span key={`${i}-${part}`}>
                   {i > 0 && (
                     <span
                       aria-hidden="true"

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
@@ -1,0 +1,146 @@
+import { ArrowRight } from "@/lib/icons";
+import { cn } from "@/lib/utils/cn";
+import {
+  DEFAULT_TICKET_LABEL,
+  formatTimeRange,
+  resolveEventDate,
+  type EventFactValue,
+} from "./types";
+
+export interface EventFactOverviewProps {
+  value: EventFactValue;
+  className?: string;
+}
+
+/**
+ * Design §8.2 — overview variant of an `eventFact` body block. Rendered
+ * for subsequent eventFact blocks in an event article (the first one is
+ * absorbed by the `EventStrip` beneath the metadata bar), or inline
+ * inside an announcement.
+ *
+ * Shares the dark-band treatment with `TransferFactOverview`:
+ * consecutive rows fuse into one continuous dark section via the
+ * `[data-testid='transfer-overview']` / `[data-testid='event-overview']`
+ * sibling rules in `globals.css`.
+ *
+ * Four slots on md+:
+ *   [date]   [title + metadata]   [CTA link]   [status?]
+ *
+ * The CTA renders only when `ticketUrl` is set — otherwise the column
+ * collapses so the title + metadata claim the freed width.
+ */
+export const EventFactOverview = ({
+  value,
+  className,
+}: EventFactOverviewProps) => {
+  const resolvedDate = resolveEventDate(value.date);
+  const timeRange = formatTimeRange(value.startTime, value.endTime);
+
+  const metaParts = [
+    timeRange,
+    value.location,
+    value.ageGroup ?? value.competitionTag,
+  ].filter((x): x is string => typeof x === "string" && x.length > 0);
+
+  const ticketLabel = value.ticketLabel?.trim() || DEFAULT_TICKET_LABEL;
+
+  return (
+    <section
+      data-testid="event-overview"
+      className={cn(
+        // Break out of the 65 ch prose column into the shared dark band.
+        // Consecutive eventFact overviews fuse into one continuous
+        // section via the sibling rules in globals.css (same pattern as
+        // transferFact overview).
+        "full-bleed not-prose bg-kcvv-gray-dark py-6",
+        "border-kcvv-white/10 border-t",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "max-w-outer mx-auto grid px-6",
+          "gap-x-6 gap-y-3",
+          "md:grid-cols-[6rem_minmax(0,1fr)_auto] md:items-center md:gap-x-8",
+        )}
+      >
+        {resolvedDate.hasDate ? (
+          <time
+            data-testid="event-overview-date"
+            dateTime={resolvedDate.dateIso}
+            className="text-kcvv-white flex flex-col"
+          >
+            <span className="font-title text-xl leading-[0.95] font-bold">
+              {resolvedDate.day}{" "}
+              <span className="uppercase">{resolvedDate.monthShort}</span>
+            </span>
+            <span className="text-kcvv-gray-light mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+              {resolvedDate.weekday}
+            </span>
+          </time>
+        ) : (
+          <div
+            data-testid="event-overview-date"
+            className="text-kcvv-white flex flex-col"
+          >
+            <span className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+              tbd
+            </span>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1">
+          {value.title && (
+            <span
+              data-testid="event-overview-title"
+              className="font-title text-kcvv-white text-lg font-bold"
+            >
+              {value.title}
+            </span>
+          )}
+          {metaParts.length > 0 && (
+            <span
+              data-testid="event-overview-meta"
+              className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
+            >
+              {metaParts.map((part, i) => (
+                <span key={part}>
+                  {i > 0 && (
+                    <span
+                      aria-hidden="true"
+                      className="text-kcvv-white/30 mx-2"
+                    >
+                      ·
+                    </span>
+                  )}
+                  {part}
+                </span>
+              ))}
+            </span>
+          )}
+        </div>
+
+        {value.ticketUrl ? (
+          <a
+            data-testid="event-overview-cta"
+            href={value.ticketUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "font-title inline-flex items-center gap-2 text-sm font-bold tracking-[var(--letter-spacing-caps)] uppercase",
+              "text-kcvv-green-bright decoration-kcvv-green-bright underline decoration-1 underline-offset-4",
+              "transition-[text-decoration-thickness] duration-150 hover:decoration-2",
+            )}
+          >
+            {ticketLabel}
+            <ArrowRight aria-hidden="true" className="h-4 w-4" />
+          </a>
+        ) : (
+          // Grid spacer — keeps the CTA column present so adjacent rows
+          // with a CTA stay aligned when this row has none.
+          <div aria-hidden="true" className="hidden md:block" />
+        )}
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
@@ -36,11 +36,15 @@ export const EventFactOverview = ({
   const resolvedDate = resolveEventDate(value.date);
   const timeRange = formatTimeRange(value.startTime, value.endTime);
 
-  const metaParts = [
-    timeRange,
-    value.location,
-    value.ageGroup ?? value.competitionTag,
-  ].filter((x): x is string => typeof x === "string" && x.length > 0);
+  // Prefer the age group when it has real content; fall back to the
+  // competition tag otherwise. `??` alone would let an empty-string
+  // `ageGroup` suppress the tag, which editors hit when they clear the
+  // field without also clearing the value.
+  const ageOrCompetition = value.ageGroup?.trim() || value.competitionTag;
+
+  const metaParts = [timeRange, value.location, ageOrCompetition].filter(
+    (x): x is string => typeof x === "string" && x.length > 0,
+  );
 
   const ticketLabel = value.ticketLabel?.trim() || DEFAULT_TICKET_LABEL;
 
@@ -84,7 +88,7 @@ export const EventFactOverview = ({
             className="text-kcvv-white flex flex-col"
           >
             <span className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
-              tbd
+              Datum volgt
             </span>
           </div>
         )}

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
@@ -1,9 +1,9 @@
-import { ArrowRight } from "@/lib/icons";
+import { ExternalLink } from "@/lib/icons";
 import { cn } from "@/lib/utils/cn";
 import {
   DEFAULT_TICKET_LABEL,
   formatTimeRange,
-  resolveEventDate,
+  resolveEventRange,
   type EventFactValue,
 } from "./types";
 
@@ -33,7 +33,7 @@ export const EventFactOverview = ({
   value,
   className,
 }: EventFactOverviewProps) => {
-  const resolvedDate = resolveEventDate(value.date);
+  const range = resolveEventRange(value.date, value.endDate, value.sessions);
   const timeRange = formatTimeRange(value.startTime, value.endTime);
 
   // Prefer the age group when it has real content; fall back to the
@@ -42,7 +42,13 @@ export const EventFactOverview = ({
   // field without also clearing the value.
   const ageOrCompetition = value.ageGroup?.trim() || value.competitionTag;
 
-  const metaParts = [timeRange, value.location, ageOrCompetition].filter(
+  // For single-day events the time row belongs in the meta. Multi-day
+  // continuous events + recurring events let the date column carry
+  // the span — no count in the meta (it'd be redundant with the date
+  // column's visible range, and `N sessies` reads poorly in Dutch).
+  const timeMeta = range.kind === "single" ? timeRange : undefined;
+
+  const metaParts = [timeMeta, value.location, ageOrCompetition].filter(
     (x): x is string => typeof x === "string" && x.length > 0,
   );
 
@@ -65,24 +71,59 @@ export const EventFactOverview = ({
         className={cn(
           "max-w-outer mx-auto grid px-6",
           "gap-x-6 gap-y-3",
-          "md:grid-cols-[6rem_minmax(0,1fr)_auto] md:items-center md:gap-x-8",
+          // Date column widened from `6rem` → `9rem` so cross-month
+          // and multi-day ranges (e.g. `31 JUL – 2 AUG` + weekday
+          // pair) fit on one line instead of wrapping to three.
+          "md:grid-cols-[9rem_minmax(0,1fr)_auto] md:items-center md:gap-x-8",
         )}
       >
-        {resolvedDate.hasDate ? (
+        {range.kind === "single" && (
           <time
             data-testid="event-overview-date"
-            dateTime={resolvedDate.dateIso}
+            dateTime={range.date.dateIso}
             className="text-kcvv-white flex flex-col"
           >
             <span className="font-title text-xl leading-[0.95] font-bold">
-              {resolvedDate.day}{" "}
-              <span className="uppercase">{resolvedDate.monthShort}</span>
+              {range.date.day}{" "}
+              <span className="uppercase">{range.date.monthShort}</span>
             </span>
             <span className="text-kcvv-gray-light mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
-              {resolvedDate.weekday}
+              {range.date.weekday}
             </span>
           </time>
-        ) : (
+        )}
+        {(range.kind === "range" || range.kind === "sessions") && (
+          <div
+            data-testid="event-overview-date"
+            className="text-kcvv-white flex flex-col"
+          >
+            <span className="font-title text-xl leading-[0.95] font-bold">
+              <time dateTime={range.start.dateIso}>
+                {range.start.day}
+                {!range.sameMonth && (
+                  <span className="uppercase"> {range.start.monthShort}</span>
+                )}
+              </time>
+              <span className="text-kcvv-white/40 mx-1">–</span>
+              <time dateTime={range.end.dateIso}>
+                {range.end.day}{" "}
+                <span className="uppercase">
+                  {range.sameMonth
+                    ? range.start.monthShort
+                    : range.end.monthShort}
+                </span>
+              </time>
+            </span>
+            <span className="text-kcvv-gray-light mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+              {/* 3-letter weekday abbreviations so ranges stay on one
+                  line in the narrow date column (e.g. "vr – zo" vs
+                  "vrijdag – zondag"). */}
+              {range.start.weekday.slice(0, 3)} –{" "}
+              {range.end.weekday.slice(0, 3)}
+            </span>
+          </div>
+        )}
+        {range.kind === "none" && (
           <div
             data-testid="event-overview-date"
             className="text-kcvv-white flex flex-col"
@@ -131,13 +172,18 @@ export const EventFactOverview = ({
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
-              "font-title inline-flex items-center gap-2 text-sm font-bold tracking-[var(--letter-spacing-caps)] uppercase",
+              "font-title inline-flex items-baseline gap-1 text-sm font-bold tracking-[var(--letter-spacing-caps)] uppercase",
               "text-kcvv-green-bright decoration-kcvv-green-bright underline decoration-1 underline-offset-4",
               "transition-[text-decoration-thickness] duration-150 hover:decoration-2",
             )}
           >
             {ticketLabel}
-            <ArrowRight aria-hidden="true" className="h-4 w-4" />
+            <ExternalLink
+              aria-hidden="true"
+              className="ml-0.5 inline-block align-baseline opacity-60"
+              size="0.75em"
+            />
+            <span className="sr-only"> (opens in new tab)</span>
           </a>
         ) : (
           // Grid spacer — keeps the CTA column present so adjacent rows

--- a/apps/web/src/components/article/blocks/EventFact/index.ts
+++ b/apps/web/src/components/article/blocks/EventFact/index.ts
@@ -2,7 +2,14 @@ export { EventFactOverview } from "./EventFactOverview";
 export type { EventFactOverviewProps } from "./EventFactOverview";
 export {
   resolveEventDate,
+  resolveEventRange,
   formatTimeRange,
   DEFAULT_TICKET_LABEL,
 } from "./types";
-export type { EventFactValue, ResolvedEvent } from "./types";
+export type {
+  EventFactValue,
+  EventFactSession,
+  ResolvedEvent,
+  ResolvedSession,
+  ResolvedEventRange,
+} from "./types";

--- a/apps/web/src/components/article/blocks/EventFact/index.ts
+++ b/apps/web/src/components/article/blocks/EventFact/index.ts
@@ -1,0 +1,8 @@
+export { EventFactOverview } from "./EventFactOverview";
+export type { EventFactOverviewProps } from "./EventFactOverview";
+export {
+  resolveEventDate,
+  formatTimeRange,
+  DEFAULT_TICKET_LABEL,
+} from "./types";
+export type { EventFactValue, ResolvedEvent } from "./types";

--- a/apps/web/src/components/article/blocks/EventFact/types.test.ts
+++ b/apps/web/src/components/article/blocks/EventFact/types.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveEventDate,
+  formatTimeRange,
+  DEFAULT_TICKET_LABEL,
+} from "./types";
+
+describe("resolveEventDate", () => {
+  it("parses an ISO date into Dutch month + weekday parts", () => {
+    const out = resolveEventDate("2026-04-27");
+    if (!out.hasDate) throw new Error("expected hasDate: true");
+    expect(out.day).toBe("27");
+    expect(out.monthShort).toBe("apr");
+    expect(out.monthLong).toBe("april");
+    expect(out.year).toBe("2026");
+    // 2026-04-27 was a Monday.
+    expect(out.weekday).toBe("maandag");
+  });
+
+  it("drops leading zero on single-digit days", () => {
+    const out = resolveEventDate("2026-04-07");
+    if (!out.hasDate) throw new Error("expected hasDate: true");
+    expect(out.day).toBe("7");
+  });
+
+  it("returns `{ hasDate: false }` for undefined/empty input", () => {
+    expect(resolveEventDate(undefined).hasDate).toBe(false);
+    expect(resolveEventDate("").hasDate).toBe(false);
+  });
+
+  it("returns `{ hasDate: false }` for a malformed ISO string", () => {
+    expect(resolveEventDate("27-04-2026").hasDate).toBe(false);
+    expect(resolveEventDate("2026/04/27").hasDate).toBe(false);
+  });
+
+  it("rejects non-existent calendar dates — Luxon validates, no silent rollover", () => {
+    // `new Date(Date.UTC(2027, 1, 29))` silently rolls to 2027-03-01.
+    // Luxon's `.isValid` rejects it so the strip shows `Datum volgt`
+    // instead of rendering "29 februari 2027".
+    expect(resolveEventDate("2027-02-29").hasDate).toBe(false);
+    expect(resolveEventDate("2026-04-31").hasDate).toBe(false);
+    expect(resolveEventDate("2026-13-01").hasDate).toBe(false);
+    expect(resolveEventDate("2026-00-01").hasDate).toBe(false);
+  });
+
+  it("uses UTC parsing so weekday doesn't drift by timezone", () => {
+    // 2026-01-01 is a Thursday worldwide; if the function used local
+    // time, a negative-UTC-offset runner could render it as Wednesday.
+    const out = resolveEventDate("2026-01-01");
+    if (!out.hasDate) throw new Error("expected hasDate: true");
+    expect(out.weekday).toBe("donderdag");
+  });
+});
+
+describe("formatTimeRange", () => {
+  it("joins both ends with a dash when present", () => {
+    expect(formatTimeRange("10:00", "17:00")).toBe("10:00 - 17:00");
+  });
+
+  it("returns just the start time when end is missing", () => {
+    expect(formatTimeRange("10:00", undefined)).toBe("10:00");
+  });
+
+  it("returns just the end time when start is missing", () => {
+    expect(formatTimeRange(undefined, "17:00")).toBe("17:00");
+  });
+
+  it("returns undefined when both are missing — caller skips the slot", () => {
+    expect(formatTimeRange(undefined, undefined)).toBeUndefined();
+    expect(formatTimeRange("", "")).toBeUndefined();
+  });
+});
+
+describe("DEFAULT_TICKET_LABEL", () => {
+  it("is Dutch 'Inschrijven' — matches the schema default", () => {
+    expect(DEFAULT_TICKET_LABEL).toBe("Inschrijven");
+  });
+});

--- a/apps/web/src/components/article/blocks/EventFact/types.test.ts
+++ b/apps/web/src/components/article/blocks/EventFact/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   resolveEventDate,
+  resolveEventRange,
   formatTimeRange,
   DEFAULT_TICKET_LABEL,
 } from "./types";
@@ -68,6 +69,119 @@ describe("formatTimeRange", () => {
   it("returns undefined when both are missing — caller skips the slot", () => {
     expect(formatTimeRange(undefined, undefined)).toBeUndefined();
     expect(formatTimeRange("", "")).toBeUndefined();
+  });
+});
+
+describe("resolveEventRange", () => {
+  it("returns `none` when the start date is missing or invalid", () => {
+    expect(resolveEventRange(undefined, "2026-04-26").kind).toBe("none");
+    expect(resolveEventRange("2027-02-29", "2027-03-01").kind).toBe("none");
+  });
+
+  it("returns `single` when endDate is absent", () => {
+    const out = resolveEventRange("2026-04-25");
+    expect(out.kind).toBe("single");
+  });
+
+  it("returns `single` when endDate equals the start date", () => {
+    const out = resolveEventRange("2026-04-25", "2026-04-25");
+    expect(out.kind).toBe("single");
+  });
+
+  it("returns `single` when endDate is invalid — start date still renders", () => {
+    const out = resolveEventRange("2026-04-25", "not-a-date");
+    expect(out.kind).toBe("single");
+  });
+
+  it("treats an inverted endDate as `single` rather than silently reversing", () => {
+    // The schema validates `endDate >= date`, but drafts can slip
+    // through. Safer to render the start date alone than to reverse
+    // the range without the editor's consent.
+    const out = resolveEventRange("2026-04-25", "2026-04-20");
+    expect(out.kind).toBe("single");
+  });
+
+  it("returns `range` with sameMonth=true for a weekend within one month", () => {
+    const out = resolveEventRange("2026-04-25", "2026-04-26");
+    if (out.kind !== "range") throw new Error("expected range");
+    expect(out.start.day).toBe("25");
+    expect(out.end.day).toBe("26");
+    expect(out.sameMonth).toBe(true);
+    expect(out.sameYear).toBe(true);
+  });
+
+  it("returns `range` with sameMonth=false for cross-month events", () => {
+    const out = resolveEventRange("2026-04-30", "2026-05-02");
+    if (out.kind !== "range") throw new Error("expected range");
+    expect(out.sameMonth).toBe(false);
+    expect(out.sameYear).toBe(true);
+  });
+
+  it("returns `range` with sameYear=false for cross-year events", () => {
+    const out = resolveEventRange("2026-12-30", "2027-01-02");
+    if (out.kind !== "range") throw new Error("expected range");
+    expect(out.sameMonth).toBe(false);
+    expect(out.sameYear).toBe(false);
+  });
+
+  describe("with sessions", () => {
+    it("returns `sessions` for two or more valid sessions — sorted chronologically", () => {
+      // Sessions entered out of order — resolver must sort them so
+      // the span is deterministic and UI rendering is predictable.
+      const out = resolveEventRange(undefined, undefined, [
+        { date: "2026-11-21", startTime: "17:00", endTime: "23:00" },
+        { date: "2026-11-20", startTime: "18:00", endTime: "22:00" },
+        { date: "2026-11-22", startTime: "11:30", endTime: "15:00" },
+      ]);
+      if (out.kind !== "sessions") throw new Error("expected sessions");
+      expect(out.sessions).toHaveLength(3);
+      expect(out.sessions[0].date.day).toBe("20");
+      expect(out.sessions[1].date.day).toBe("21");
+      expect(out.sessions[2].date.day).toBe("22");
+      expect(out.start.day).toBe("20");
+      expect(out.end.day).toBe("22");
+      expect(out.sameMonth).toBe(true);
+      expect(out.sameYear).toBe(true);
+    });
+
+    it("collapses a one-session array to `single` kind", () => {
+      const out = resolveEventRange(undefined, undefined, [
+        { date: "2026-11-20", startTime: "18:00", endTime: "22:00" },
+      ]);
+      expect(out.kind).toBe("single");
+    });
+
+    it("ignores session rows with an invalid date but keeps the valid ones", () => {
+      const out = resolveEventRange(undefined, undefined, [
+        { date: "not-a-date" },
+        { date: "2026-11-20", startTime: "18:00", endTime: "22:00" },
+        { date: "2027-02-29" },
+        { date: "2026-11-21", startTime: "17:00", endTime: "23:00" },
+      ]);
+      if (out.kind !== "sessions") throw new Error("expected sessions");
+      expect(out.sessions).toHaveLength(2);
+    });
+
+    it("sessions override top-level date / endDate — precedence is correct", () => {
+      const out = resolveEventRange("2028-01-01", "2028-01-05", [
+        { date: "2026-11-20", startTime: "18:00" },
+        { date: "2026-11-21", startTime: "17:00" },
+      ]);
+      if (out.kind !== "sessions") throw new Error("expected sessions");
+      expect(out.start.year).toBe("2026");
+      expect(out.end.year).toBe("2026");
+    });
+
+    it("falls back to top-level date/endDate when every session is invalid", () => {
+      // Safety net — an editor might leave session rows empty while
+      // filling the top-level date. The resolver shouldn't drop into
+      // `none` just because sessions is a non-empty array of junk.
+      const out = resolveEventRange("2026-04-25", undefined, [
+        { date: "invalid" },
+        { date: "" },
+      ]);
+      expect(out.kind).toBe("single");
+    });
   });
 });
 

--- a/apps/web/src/components/article/blocks/EventFact/types.ts
+++ b/apps/web/src/components/article/blocks/EventFact/types.ts
@@ -6,16 +6,46 @@ import type { PortableTextBlock } from "@portabletext/react";
  * come through untouched via the `body[]{...}` GROQ spread; the `note`
  * field is a Portable Text block array (single-style, no lists).
  */
+/**
+ * One day's schedule for a recurring event (steakfestijn, tournament
+ * with split days, etc.). When `sessions` is populated on
+ * `EventFactValue`, it takes precedence over the top-level `startTime`
+ * / `endTime` — each session carries its own hours.
+ */
+export interface EventFactSession {
+  _key?: string;
+  /** ISO `YYYY-MM-DD`. */
+  date?: string;
+  /** `HH:mm`. */
+  startTime?: string;
+  /** `HH:mm`. */
+  endTime?: string;
+}
+
 export interface EventFactValue {
   _key?: string;
   _type?: "eventFact";
   title?: string;
   /** ISO `YYYY-MM-DD` — Sanity `date` type projects as a plain string. */
   date?: string;
-  /** `HH:mm` — optional. */
+  /**
+   * ISO `YYYY-MM-DD`. Set only for continuous multi-day events (weekend
+   * tornooi, school-holiday camp). When absent or equal to `date`, the
+   * renderer treats the event as single-day. Ignored when `sessions` is
+   * non-empty — the span is then derived from min/max session date.
+   */
+  endDate?: string;
+  /** `HH:mm`. Ignored when `sessions` is non-empty. */
   startTime?: string;
-  /** `HH:mm` — optional. */
+  /** `HH:mm`. Ignored when `sessions` is non-empty. */
   endTime?: string;
+  /**
+   * Per-day schedules for recurring events (e.g. a steakfestijn with
+   * different hours Fri/Sat/Sun). When at least one session has a
+   * valid date, the resolver produces a `sessions` result that
+   * overrides `date`/`endDate`/`startTime`/`endTime`.
+   */
+  sessions?: EventFactSession[];
   location?: string;
   address?: string;
   /** Free-text age-group label, e.g. `U13`, `Senioren`. */
@@ -50,6 +80,55 @@ export type ResolvedEvent =
     };
 
 /**
+ * Resolved session with a guaranteed valid date. `startTime` / `endTime`
+ * are kept as raw strings so the renderer can reuse `formatTimeRange`.
+ */
+export interface ResolvedSession {
+  _key?: string;
+  date: Extract<ResolvedEvent, { hasDate: true }>;
+  startTime?: string;
+  endTime?: string;
+}
+
+/**
+ * Start + end date of an event, discriminated so the strip / overview
+ * components can render the right layout without re-checking field
+ * presence. Produced by `resolveEventRange`.
+ *
+ *   - `kind: "none"`     — no valid start date. Callers fall back to
+ *                          `Datum volgt`.
+ *   - `kind: "single"`   — one valid day (endDate absent or equal to
+ *                          date, sessions empty).
+ *   - `kind: "range"`    — two distinct valid days, continuous span.
+ *                          `sameMonth` + `sameYear` let the renderer
+ *                          choose between the compact "25 – 26 APRIL"
+ *                          layout and the cross-month "25 APR – 2 MEI"
+ *                          fallback.
+ *   - `kind: "sessions"` — two or more valid sessions (recurring
+ *                          event). Span is derived from min/max
+ *                          session date. Each session carries its own
+ *                          hours.
+ */
+export type ResolvedEventRange =
+  | { kind: "none" }
+  | { kind: "single"; date: Extract<ResolvedEvent, { hasDate: true }> }
+  | {
+      kind: "range";
+      start: Extract<ResolvedEvent, { hasDate: true }>;
+      end: Extract<ResolvedEvent, { hasDate: true }>;
+      sameMonth: boolean;
+      sameYear: boolean;
+    }
+  | {
+      kind: "sessions";
+      sessions: ResolvedSession[];
+      start: Extract<ResolvedEvent, { hasDate: true }>;
+      end: Extract<ResolvedEvent, { hasDate: true }>;
+      sameMonth: boolean;
+      sameYear: boolean;
+    };
+
+/**
  * Parse an ISO `YYYY-MM-DD` date into renderable Dutch parts. Returns
  * `{ hasDate: false }` when the input is missing, empty, malformed, OR
  * out of range (e.g. `2027-02-29` on a non-leap year) — `DateTime.isValid`
@@ -71,6 +150,85 @@ export function resolveEventDate(iso?: string): ResolvedEvent {
     year: dt.toFormat("yyyy"),
     weekday: dt.toFormat("cccc"),
     dateIso: iso,
+  };
+}
+
+/**
+ * Resolve an event's schedule into a discriminated union the rendering
+ * components can switch on.
+ *
+ * Precedence (first wins):
+ *   1. `sessions` with at least one valid date → recurring event. Span
+ *      is derived from the min / max session date; `date` / `endDate`
+ *      are ignored. A single valid session collapses to `kind: "single"`.
+ *   2. `endDate` strictly after `date` → continuous multi-day range.
+ *   3. `date` alone (or `endDate` equal/invalid) → `single`.
+ *   4. No valid `date` → `kind: "none"`.
+ *
+ * When the editor inverts `endDate` (ends before start), schema
+ * validation blocks publish, but drafts can sneak through — safer to
+ * render as `single` using the start date than to reverse the range
+ * silently.
+ */
+export function resolveEventRange(
+  startIso?: string,
+  endIso?: string,
+  sessions?: EventFactSession[],
+): ResolvedEventRange {
+  // ── 1. Sessions take precedence ─────────────────────────────────
+  if (Array.isArray(sessions) && sessions.length > 0) {
+    const resolved: ResolvedSession[] = [];
+    for (const session of sessions) {
+      const d = resolveEventDate(session.date);
+      if (!d.hasDate) continue;
+      resolved.push({
+        _key: session._key,
+        date: d,
+        startTime: session.startTime?.trim() || undefined,
+        endTime: session.endTime?.trim() || undefined,
+      });
+    }
+    if (resolved.length === 0) {
+      // Fall through to top-level `date` handling — editor might have
+      // added empty session rows but filled `date` as a fallback.
+    } else if (resolved.length === 1) {
+      return { kind: "single", date: resolved[0].date };
+    } else {
+      // Sort by ISO date — lexicographic matches chronological for
+      // `YYYY-MM-DD` — so the span is deterministic even if the
+      // editor entered sessions out of order.
+      resolved.sort((a, b) => a.date.dateIso.localeCompare(b.date.dateIso));
+      const start = resolved[0].date;
+      const end = resolved[resolved.length - 1].date;
+      return {
+        kind: "sessions",
+        sessions: resolved,
+        start,
+        end,
+        sameMonth: start.monthLong === end.monthLong && start.year === end.year,
+        sameYear: start.year === end.year,
+      };
+    }
+  }
+
+  // ── 2-4. Fall back to top-level date / endDate ─────────────────
+  const start = resolveEventDate(startIso);
+  if (!start.hasDate) return { kind: "none" };
+
+  const end = resolveEventDate(endIso);
+  if (!end.hasDate || end.dateIso === start.dateIso) {
+    return { kind: "single", date: start };
+  }
+  if (end.dateIso < start.dateIso) {
+    return { kind: "single", date: start };
+  }
+
+  return {
+    kind: "range",
+    start,
+    end,
+    sameMonth: start.monthLong === end.monthLong && start.year === end.year,
+    sameYear: start.year === end.year,
   };
 }
 

--- a/apps/web/src/components/article/blocks/EventFact/types.ts
+++ b/apps/web/src/components/article/blocks/EventFact/types.ts
@@ -1,0 +1,94 @@
+import { DateTime } from "luxon";
+import type { PortableTextBlock } from "@portabletext/react";
+
+/**
+ * Normalised client-side shape of an `eventFact` body block. Text fields
+ * come through untouched via the `body[]{...}` GROQ spread; the `note`
+ * field is a Portable Text block array (single-style, no lists).
+ */
+export interface EventFactValue {
+  _key?: string;
+  _type?: "eventFact";
+  title?: string;
+  /** ISO `YYYY-MM-DD` — Sanity `date` type projects as a plain string. */
+  date?: string;
+  /** `HH:mm` — optional. */
+  startTime?: string;
+  /** `HH:mm` — optional. */
+  endTime?: string;
+  location?: string;
+  address?: string;
+  /** Free-text age-group label, e.g. `U13`, `Senioren`. */
+  ageGroup?: string;
+  /** Free-text competition tag, e.g. `Tornooi`, `Clubfeest`. */
+  competitionTag?: string;
+  /** Optional CTA URL — when absent, CTA is hidden. */
+  ticketUrl?: string;
+  /** Defaults to `Inschrijven` when absent. */
+  ticketLabel?: string;
+  capacity?: number;
+  note?: PortableTextBlock[];
+}
+
+/**
+ * Result of resolving an `eventFact` to renderable parts. Discriminated
+ * by `hasDate` so the strip / feature / overview components can rely on
+ * the compiler to know the date-block parts are present.
+ */
+export type ResolvedEvent =
+  | {
+      hasDate: true;
+      day: string;
+      monthShort: string;
+      monthLong: string;
+      year: string;
+      weekday: string;
+      dateIso: string;
+    }
+  | {
+      hasDate: false;
+    };
+
+/**
+ * Parse an ISO `YYYY-MM-DD` date into renderable Dutch parts. Returns
+ * `{ hasDate: false }` when the input is missing, empty, malformed, OR
+ * out of range (e.g. `2027-02-29` on a non-leap year) — `DateTime.isValid`
+ * catches the silent-rollover that `new Date(Date.UTC(…))` would miss.
+ *
+ * Luxon is the established date stack site-wide (`lib/utils/dates.ts`);
+ * reusing it keeps Dutch locale rendering + validation in one place
+ * rather than maintaining a second Dutch weekday/month table.
+ */
+export function resolveEventDate(iso?: string): ResolvedEvent {
+  if (!iso || typeof iso !== "string") return { hasDate: false };
+  const dt = DateTime.fromISO(iso.trim(), { zone: "utc" }).setLocale("nl");
+  if (!dt.isValid) return { hasDate: false };
+  return {
+    hasDate: true,
+    day: dt.toFormat("d"),
+    monthShort: dt.toFormat("LLL"),
+    monthLong: dt.toFormat("MMMM"),
+    year: dt.toFormat("yyyy"),
+    weekday: dt.toFormat("cccc"),
+    dateIso: iso,
+  };
+}
+
+/**
+ * Format the time range for an event row. Returns:
+ *   - `"10:00 - 17:00"` when both ends are present
+ *   - `"10:00"` when only `startTime` is set
+ *   - `undefined` when nothing is set (so the caller can skip the slot)
+ */
+export function formatTimeRange(
+  startTime?: string,
+  endTime?: string,
+): string | undefined {
+  const start = startTime?.trim();
+  const end = endTime?.trim();
+  if (!start && !end) return undefined;
+  if (start && end) return `${start} - ${end}`;
+  return start ?? end;
+}
+
+export const DEFAULT_TICKET_LABEL = "Inschrijven";

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -222,6 +222,39 @@ export type Subject = {
   customRole?: string;
 };
 
+export type EventFact = {
+  _type: "eventFact";
+  title?: string;
+  date?: string;
+  startTime?: string;
+  endTime?: string;
+  location?: string;
+  address?: string;
+  ageGroup?: string;
+  competitionTag?: string;
+  ticketUrl?: string;
+  ticketLabel?: string;
+  capacity?: number;
+  note?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal";
+    listItem?: never;
+    markDefs?: Array<{
+      href?: string;
+      _type: "link";
+      _key: string;
+    }>;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+};
+
 export type TransferFact = {
   _type: "transferFact";
   direction?: "incoming" | "outgoing" | "extension";
@@ -385,6 +418,9 @@ export type Article = {
     | ({
         _key: string;
       } & TransferFact)
+    | ({
+        _key: string;
+      } & EventFact)
   >;
   relatedArticles?: Array<
     {
@@ -855,6 +891,7 @@ export type AllSanitySchemaTypes =
   | PlayerReference
   | StaffMemberReference
   | Subject
+  | EventFact
   | TransferFact
   | QaPair
   | QaBlock
@@ -978,6 +1015,45 @@ export type ARTICLES_QUERY_RESULT = Array<{
         fileMimeType: null;
         fileOriginalFilename: null;
         asset: null;
+      }
+    | {
+        _key: string;
+        _type: "eventFact";
+        title?: string;
+        date?: string;
+        startTime?: string;
+        endTime?: string;
+        location?: string;
+        address?: string;
+        ageGroup?: string;
+        competitionTag?: string;
+        ticketUrl?: string;
+        ticketLabel?: string;
+        capacity?: number;
+        note?: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: never;
+          markDefs?: Array<{
+            href?: string;
+            _type: "link";
+            _key: string;
+          }>;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }>;
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: null;
+        markDefs: null;
       }
     | {
         _key: string;
@@ -1212,6 +1288,46 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
         fileOriginalFilename: null;
         asset: null;
         otherClubLogoUrl: null;
+      }
+    | {
+        _key: string;
+        _type: "eventFact";
+        title?: string;
+        date?: string;
+        startTime?: string;
+        endTime?: string;
+        location?: string;
+        address?: string;
+        ageGroup?: string;
+        competitionTag?: string;
+        ticketUrl?: string;
+        ticketLabel?: string;
+        capacity?: number;
+        note?: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: never;
+          markDefs?: Array<{
+            href?: string;
+            _type: "link";
+            _key: string;
+          }>;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }>;
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: null;
+        otherClubLogoUrl: null;
+        markDefs: null;
       }
     | {
         _key: string;

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -226,8 +226,16 @@ export type EventFact = {
   _type: "eventFact";
   title?: string;
   date?: string;
+  endDate?: string;
   startTime?: string;
   endTime?: string;
+  sessions?: Array<{
+    date?: string;
+    startTime?: string;
+    endTime?: string;
+    _type: "session";
+    _key: string;
+  }>;
   location?: string;
   address?: string;
   ageGroup?: string;
@@ -1021,8 +1029,16 @@ export type ARTICLES_QUERY_RESULT = Array<{
         _type: "eventFact";
         title?: string;
         date?: string;
+        endDate?: string;
         startTime?: string;
         endTime?: string;
+        sessions?: Array<{
+          date?: string;
+          startTime?: string;
+          endTime?: string;
+          _type: "session";
+          _key: string;
+        }>;
         location?: string;
         address?: string;
         ageGroup?: string;
@@ -1294,8 +1310,16 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
         _type: "eventFact";
         title?: string;
         date?: string;
+        endDate?: string;
         startTime?: string;
         endTime?: string;
+        sessions?: Array<{
+          date?: string;
+          startTime?: string;
+          endTime?: string;
+          _type: "session";
+          _key: string;
+        }>;
         location?: string;
         address?: string;
         ageGroup?: string;

--- a/docs/plans/2026-04-19-article-detail-redesign-design.md
+++ b/docs/plans/2026-04-19-article-detail-redesign-design.md
@@ -53,7 +53,7 @@ Four types, driven by a new `articleType` enum on the `article` document. Order 
 | `interview`    | Q&A profiles of players, staff, volunteers                       | `qaBlock` body, `subject` attribution, 4:5 portrait hero                                                   |
 | `announcement` | General-purpose news, club updates, facility, sponsor, editorial | Drop-cap on first paragraph, calm 16:9 hero image, rule-framed blockquote                                  |
 | `transfer`     | Single or overview transfer news                                 | Two-column hero from `article.coverImage`, horizontal van → naar strip, dark `transferFact` overview stack |
-| `event`        | Tournaments, stages, club events, youth days                     | Serif-style date block hero, `eventFact` feature + overview blocks                                         |
+| `event`        | Tournaments, stages, club events, youth days                     | Typographic hero + full-bleed `EventStrip` (serif-style date block + CTA), dark `eventFact` overview stack |
 
 **Routing:** one `/nieuws/[slug]` route, one React page component that dispatches to a type-specific template based on `article.articleType`. Do not split into separate routes.
 
@@ -519,26 +519,43 @@ Two-column hero with a horizontal van → naar strip beneath the metadata bar.
 
 ### 5.4 `event` template
 
+Hero is typographic only — kicker + article title. The serif-style date
+block + metadata + CTA live on `EventStrip` beneath the §7.6 metadata
+bar so facts appear exactly once per page, mirroring the Phase 5
+transfer hero/strip split.
+
 ```text
 < Terug naar nieuws
 
----- EVENT | JEUGD
+---- EVENT | U13
 
 Lentetornooi U13 — zaterdag in Elewijt.
 
-27         APRIL
-----       2026
-zaterdag · 10u00 · Sportpark Elewijt
+───── metadata bar ─────
 
------ metadata bar -----
+┌──────────┬─────────────────────────────────────────────┐
+│ 27       │ Lentetornooi U13                            │
+│ APRIL    │ zaterdag · 10:00 - 17:00                    │
+│ 2026     │ Sportpark Elewijt · Driesstraat 14, Elewijt │
+│          │                                             │
+│          │ Open voor spelers geboren in 2013 en 2014.  │
+│          │                                             │
+│          │ Inschrijven  →                              │
+└──────────┴─────────────────────────────────────────────┘
 
-[ feature eventFact card — full-bleed, first body block, see §8.2 ]
+[ body paragraphs ]
 
-[ body paragraphs / additional eventFact overview blocks ]
+---- Andere evenementen
+
+[ eventFact overview rows on the dark band ]
+
+[ closing paragraphs ]
 ```
 
-- Kicker `EVENT | ${ageGroup || competitionTag}`.
-- Below the headline: **serif-style date block** — day numeral at `text-[5rem]`, month uppercase `text-xl` with `tracking-[var(--letter-spacing-label)]`, year and metadata in mono small caps. Horizontal 1px rule in `kcvv-gray-light` between day and month labels.
+- **Hero** — `.featured-border::before` 4 rem × 2 px green bar, `EVENT | ${ageGroup || competitionTag}` kicker, Quasimoda 700 clamp title. Stays inside the `max-w-inner-lg` reading column so the headline sits in the same narrative rhythm as announcement/interview titles.
+- **EventStrip** (below the §7.6 metadata bar, full-bleed, `max-w-outer` inner): 2-column grid. Left column carries the serif-style date block — day at `font-title font-bold text-[5rem] md:text-[6rem] leading-[0.85] kcvv-gray-blue`, month in Dutch uppercase (`januari … december`) `text-xl tracking-[var(--letter-spacing-label)]`, year in mono small-caps `kcvv-gray`. On md+, a vertical 1 px `kcvv-gray-light` rule sits on the right edge of the date column. Right column stacks: title (Quasimoda 700 `text-3xl md:text-4xl`), weekday · time-range, location · address, optional Portable-Text note (Montserrat 400 `text-lg leading-[1.6]`), optional CTA link.
+- **CTA**: Quasimoda 700 uppercase tracking-caps `kcvv-green-dark`, 1 px `kcvv-green-bright` underline that thickens to 2 px on hover, Lucide `ArrowRight` 4 × 4. Rendered only when `eventFact.ticketUrl` is set. Label defaults to Dutch "Inschrijven" when `ticketLabel` is blank.
+- The first `eventFact` in the body is absorbed by `EventStrip` — the template filters it out of the body before rendering so it doesn't render twice. Subsequent `eventFact` blocks render inline as `EventFactOverview` rows (§8.2), typically beneath an editor-authored `Andere evenementen` H2.
 
 ---
 
@@ -740,44 +757,29 @@ There is no separate "feature card" component. The first `transferFact` in a `tr
 
 ### 8.2 `eventFact`
 
-**Feature variant** (first `eventFact` block in the body, and only when `articleType='event'`):
+There is no separate "feature card" component. The first `eventFact` in
+an `event` article is absorbed by `EventStrip` (see §5.4). Subsequent
+`eventFact` blocks render as `EventFactOverview` rows on the shared
+dark band (same treatment as `TransferFactOverview`).
+
+**Overview variant** (subsequent `eventFact` blocks, or an `eventFact`
+inside an `articleType='announcement'` article):
 
 ```text
-+-------------------------------------------------------------------+
-|   ---- EVENT | JEUGD                                              |
-|                                                                   |
-|   27                                       Lentetornooi U13       |
-|   APRIL    ----------------------------                           |
-|   2026     zaterdag · 10u00 - 17u00                               |
-|            Sportpark Elewijt                                      |
-|            Driesstraat 14, Elewijt                                |
-|                                                                   |
-|            Open voor spelers geboren in 2013 en 2014.             |
-|                                                                   |
-|            Inschrijven  >                                         |
-+-------------------------------------------------------------------+
+┌────────────────────────────────────────────────────────────────────┐
+│ 27 apr      Lentetornooi U13                 Inschrijven →         │
+│ maandag     10:00 - 17:00 · Sportpark Elewijt · U13                │
+├────────────────────────────────────────────────────────────────────┤
+│ 27 apr      Afterparty                        Boek je plek →       │
+│ maandag     20:00 · Kantine KCVV · Clubfeest                       │
+└────────────────────────────────────────────────────────────────────┘
 ```
 
-- Full-bleed, `max-w-[70rem]` inner, `py-16` desktop, `py-8` mobile, 1px top/bottom rules.
-- Date block left: day Quasimoda 700 `text-[6rem] leading-[0.85] kcvv-gray-blue`, month uppercase `text-xl tracking-[var(--letter-spacing-label)]`, year mono `text-sm kcvv-gray`. Vertical 1px `kcvv-gray-light` rule on the right of the date block.
-- Title Quasimoda 700 `text-4xl kcvv-gray-blue`.
-- Metadata rows in `text-sm uppercase tracking-[var(--letter-spacing-caps)] kcvv-gray-dark`, middle-dot separators.
-- Note: Montserrat 400, `text-lg leading-[1.6] kcvv-gray-dark`.
-- CTA: text link (not a button). Quasimoda 700, `text-base`, uppercase, `tracking-[var(--letter-spacing-caps)] kcvv-green-dark`, 1px `kcvv-green-bright` underline, Lucide `ArrowRight` 14px trailing. Hover: underline thickens to 2px.
-
-**Overview variant**:
-
-```text
-+-----------------------------------------------------------+
-|  27 APR    Lentetornooi U13              Inschrijven >    |
-|  zaterdag  Sportpark Elewijt · U13                        |
-+-----------------------------------------------------------+
-```
-
-- Same 1px-rule stack as `transferFact` overview.
-- Left column `w-[5rem]`: `27 APR` in Quasimoda 700 `text-xl kcvv-gray-blue` over weekday in mono `text-xs`.
-- Middle: title Quasimoda 700 `text-lg` over metadata line in small-caps.
-- Right: CTA link, same spec as feature at `text-sm`.
+- Single-row grid on md+: `grid-cols-[6rem_minmax(0,1fr)_auto]` with `gap-x-8`. Stacks to a flex column on mobile.
+- Full-bleed `kcvv-gray-dark` band; 1 px `kcvv-white/10` top rule. Consecutive eventFact/transferFact rows fuse into one seamless dark section via the sibling CSS in `globals.css`.
+- **Slot 1 — date cluster**: `27 apr` in Quasimoda 700 `text-xl kcvv-white` over Dutch weekday in mono small-caps `kcvv-gray-light`. `Datum volgt` placeholder when the date is missing or malformed.
+- **Slot 2 — title + metadata**: title (Quasimoda 700 `text-lg kcvv-white`) over a meta line in mono small-caps `kcvv-gray-light` — time range · location · ageGroup/competitionTag.
+- **Slot 3 — CTA**: same Lucide `ArrowRight` + underline spec as the feature strip at `text-sm`. `ticketLabel` defaults to Dutch "Inschrijven"; hidden entirely when `ticketUrl` is unset.
 
 ---
 
@@ -823,8 +825,10 @@ apps/web/src/components/article/
                                     # feature/hero content is absorbed by
                                     # TransferHero + TransferStrip — there
                                     # is no separate `TransferFactFeature`.
-    EventFactFeature/              # Phase 6
-    EventFactOverview/             # Phase 6
+    EventFact/                     # same pattern — dark overview-row
+                                    # variant only. The feature content
+                                    # is absorbed by EventHero + EventStrip;
+                                    # no `EventFactFeature` component.
   SubjectAttribution/              # shared attribution block used by key + quote
 ```
 

--- a/docs/prd/article-detail-redesign.md
+++ b/docs/prd/article-detail-redesign.md
@@ -134,14 +134,14 @@ Rollout posture: phases 2–7 can ship in any order relative to each other once 
 
 ### Phase 6 — #1332 — Event template + eventFact
 
-- [ ] New schema: `packages/sanity-schemas/src/eventFact.ts` per design §4.5.
-- [ ] `article.body` accepts `{type: 'eventFact'}`.
-- [ ] `EventTemplate` renders the serif-style date-block hero per §5.4.
-- [ ] `EventFactFeature` matches design §8.2: full-bleed, date block left with vertical 1px rule, title + metadata stack, Note PT, text-link CTA with Lucide `ArrowRight`.
-- [ ] `EventFactOverview` matches design §8.2: body-column-width 1px-rule stack, `w-[5rem]` date column, CTA link right-aligned.
-- [ ] CTA behavior: if `ticketUrl` missing, CTA hidden.
-- [ ] Storybook stories: feature and overview, plus composed `EventTemplate`.
-- [ ] `pnpm --filter @kcvv/web check-all` passes.
+- [x] New schema: `packages/sanity-schemas/src/eventFact.ts` with `title`, `date`, `startTime`, `endTime`, `location`, `address`, `ageGroup`, `competitionTag`, `ticketUrl`, `ticketLabel` (initialValue `"Inschrijven"`), `capacity`, `note` (Portable Text).
+- [x] `article.body` accepts `{type: 'eventFact'}`.
+- [x] `EventTemplate` renders the typographic hero per §5.4 (kicker `EVENT | ageGroup/competitionTag` + article title). The serif-style date block + title + metadata + note + CTA live on `EventStrip` beneath the §7.6 metadata bar — mirrors the Phase 5 transfer hero/strip split so facts appear exactly once per page.
+- [x] `EventStrip` matches design §8.2 feature: full-bleed, 2-column grid with date block left (day at clamp `text-[5rem]`/`text-[6rem]`, month in Dutch uppercase, year in mono small-caps) + vertical `kcvv-gray-light` rule, title + metadata stack + Portable-Text note + text-link CTA with Lucide `ArrowRight`.
+- [x] `EventFactOverview` matches design §8.2 overview treatment, reshaped to the dark-band stack treatment introduced for `TransferFactOverview` (3-column grid: date cluster · title + metadata · CTA). Sibling CSS rules in `globals.css` fuse consecutive transferFact/eventFact rows into one seamless dark band; mixed stacks (transferFact → eventFact) flow the same way.
+- [x] CTA behaviour: `ticketUrl` missing → CTA hidden on both the strip and the overview row. `ticketLabel` defaults to Dutch "Inschrijven" when blank.
+- [x] Storybook stories: `Features/Articles/EventFact/Overview` × 4 (with-CTA, with-custom-label, without-CTA, no-date-yet) + composed `Pages/Article/Event` × 2 (full composition, no-eventFact fallback).
+- [x] `pnpm --filter @kcvv/web check-all` passes.
 
 ### Phase 7 — #1333 — Related slider restyle + JSON-LD + analytics
 

--- a/packages/sanity-schemas/src/article.ts
+++ b/packages/sanity-schemas/src/article.ts
@@ -140,6 +140,7 @@ export const article = defineType({
         { type: "htmlTable" },
         { type: "qaBlock" },
         { type: "transferFact" },
+        { type: "eventFact" },
       ],
     }),
     defineField({

--- a/packages/sanity-schemas/src/eventFact.ts
+++ b/packages/sanity-schemas/src/eventFact.ts
@@ -1,0 +1,116 @@
+import {defineField, defineType} from 'sanity'
+
+/**
+ * Design §4.5 / §8.2 — `eventFact` is a body block for `articleType='event'`
+ * documents. The first eventFact in the body powers the horizontal
+ * `EventStrip` beneath the §7.6 metadata bar (serif-style date block left
+ * + title / metadata / note / CTA right). Subsequent eventFacts render as
+ * compact overview rows on the dark band stack, matching the transfer
+ * overview treatment.
+ *
+ * The hero itself stays typographic (kicker + title only) — the date
+ * block lives in the strip, not the hero, to avoid duplicating the date
+ * on the page. Mirrors the Phase 5 (transfer) hero/strip split.
+ */
+export const eventFact = defineType({
+  name: 'eventFact',
+  title: 'Event fact',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: 'date',
+      title: 'Date',
+      type: 'date',
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: 'startTime',
+      title: 'Start time',
+      type: 'string',
+      description: 'HH:mm (e.g. "10:00")',
+    }),
+    defineField({
+      name: 'endTime',
+      title: 'End time',
+      type: 'string',
+      description: 'HH:mm (e.g. "17:00")',
+    }),
+    defineField({
+      name: 'location',
+      title: 'Location',
+      type: 'string',
+      description: 'Short venue name, e.g. "Sportpark Elewijt".',
+    }),
+    defineField({
+      name: 'address',
+      title: 'Address',
+      type: 'string',
+      description: 'Street + town, e.g. "Driesstraat 14, Elewijt".',
+    }),
+    defineField({
+      name: 'ageGroup',
+      title: 'Age group',
+      type: 'string',
+      description:
+        'Free text, e.g. "U13", "Senioren", "Alle jeugd". Drives the hero kicker when present.',
+    }),
+    defineField({
+      name: 'competitionTag',
+      title: 'Competition tag',
+      type: 'string',
+      description:
+        'Free text, e.g. "Tornooi", "Clubfeest", "Training". Fallback for the hero kicker when `ageGroup` is empty.',
+    }),
+    defineField({
+      name: 'ticketUrl',
+      title: 'Ticket URL',
+      type: 'url',
+      description:
+        'Optional. When set, the strip + overview rows render a CTA link. When absent, the CTA is hidden.',
+    }),
+    defineField({
+      name: 'ticketLabel',
+      title: 'Ticket CTA label',
+      type: 'string',
+      description: 'Free text, defaults to "Inschrijven" when empty.',
+      initialValue: 'Inschrijven',
+    }),
+    defineField({
+      name: 'capacity',
+      title: 'Capacity',
+      type: 'number',
+      description: 'Optional. Displayed only when set (e.g. "Max 24 spelers").',
+    }),
+    defineField({
+      name: 'note',
+      title: 'Note',
+      type: 'array',
+      of: [{type: 'block', styles: [{title: 'Normal', value: 'normal'}], lists: []}],
+      description: 'Optional short prose — one or two paragraphs of context.',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      date: 'date',
+      location: 'location',
+      ageGroup: 'ageGroup',
+    },
+    prepare({title, date, location, ageGroup}) {
+      const who = title ?? 'Event fact'
+      const parts = [date, ageGroup, location].filter(
+        (x): x is string => typeof x === 'string' && x.length > 0,
+      )
+      return {
+        title: who,
+        subtitle: parts.length > 0 ? parts.join(' · ') : 'no date',
+      }
+    },
+  },
+})

--- a/packages/sanity-schemas/src/eventFact.ts
+++ b/packages/sanity-schemas/src/eventFact.ts
@@ -25,21 +25,85 @@ export const eventFact = defineType({
     }),
     defineField({
       name: 'date',
-      title: 'Date',
+      title: 'Start date',
       type: 'date',
+      description: 'Calendar day the event starts.',
       validation: (r) => r.required(),
+    }),
+    defineField({
+      name: 'endDate',
+      title: 'End date',
+      type: 'date',
+      description:
+        'Optional. Fill only for multi-day events (weekend tornooi, school-holiday camp). Must be on or after the start date.',
+      validation: (r) =>
+        r.custom((value, ctx) => {
+          if (typeof value !== 'string' || value.length === 0) return true
+          const parent = ctx.parent as {date?: string} | undefined
+          const start = parent?.date
+          if (typeof start !== 'string' || start.length === 0) return true
+          return value >= start
+            ? true
+            : 'End date must be on or after the start date.'
+        }),
     }),
     defineField({
       name: 'startTime',
       title: 'Start time',
       type: 'string',
-      description: 'HH:mm (e.g. "10:00")',
+      description:
+        'HH:mm (e.g. "10:00"). Use for simple single-day or continuous multi-day events. Leave empty when `sessions` (per-day schedule) is filled.',
     }),
     defineField({
       name: 'endTime',
       title: 'End time',
       type: 'string',
-      description: 'HH:mm (e.g. "17:00")',
+      description:
+        'HH:mm (e.g. "17:00"). Use for simple single-day or continuous multi-day events. Leave empty when `sessions` (per-day schedule) is filled.',
+    }),
+    defineField({
+      name: 'sessions',
+      title: 'Per-day schedule (recurring events)',
+      description:
+        'Use for recurring events where each day has its own hours (e.g. a steakfestijn: vrijdag 18:00–22:00, zaterdag 17:00–23:00, zondag 11:30–15:00). Leave empty for single-day or continuous multi-day events — the top-level date/time fields handle those.',
+      type: 'array',
+      of: [
+        defineField({
+          name: 'session',
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'date',
+              type: 'date',
+              validation: (r) => r.required(),
+            }),
+            defineField({
+              name: 'startTime',
+              type: 'string',
+              description: 'HH:mm',
+            }),
+            defineField({
+              name: 'endTime',
+              type: 'string',
+              description: 'HH:mm',
+            }),
+          ],
+          preview: {
+            select: {
+              date: 'date',
+              startTime: 'startTime',
+              endTime: 'endTime',
+            },
+            prepare({date, startTime, endTime}) {
+              const range = [startTime, endTime].filter(Boolean).join(' – ')
+              return {
+                title: date ?? 'Sessie',
+                subtitle: range || 'geen tijden ingevuld',
+              }
+            },
+          },
+        }),
+      ],
     }),
     defineField({
       name: 'location',

--- a/packages/sanity-schemas/src/index.ts
+++ b/packages/sanity-schemas/src/index.ts
@@ -10,6 +10,7 @@ export {article} from './article'
 export {articleImage} from './articleImage'
 export {qaBlock, qaPair} from './qaBlock'
 export {transferFact} from './transferFact'
+export {eventFact} from './eventFact'
 export {subject} from './subject'
 export {sponsor} from './sponsor'
 export {event} from './event'
@@ -31,6 +32,7 @@ import {article} from './article'
 import {articleImage} from './articleImage'
 import {qaBlock, qaPair} from './qaBlock'
 import {transferFact} from './transferFact'
+import {eventFact} from './eventFact'
 import {subject} from './subject'
 import {sponsor} from './sponsor'
 import {event} from './event'
@@ -55,6 +57,7 @@ export const schemaTypes = [
   qaBlock,
   qaPair,
   transferFact,
+  eventFact,
   subject,
   sponsor,
   event,


### PR DESCRIPTION
Closes #1332 — Phase 6 of the article-detail redesign.

## Summary

Events get a typographic hero (`EVENT | ageGroup` kicker + article title) and a full-bleed horizontal `EventStrip` beneath the §7.6 metadata bar. The strip carries the serif-style date block (day · Dutch long-month uppercase · year) + title + when row + where row + optional PortableText note + optional CTA link. Subsequent `eventFact` blocks render as dark-band overview rows, fusing seamlessly with any `transferFact` overview via the shared sibling-CSS rules.

Mirrors the Phase 5 transfer template shape so editors move between the three feature-block article types (transfer, event, and future additions) in a familiar editorial pattern.

## Changes

### Sanity schema

- **`packages/sanity-schemas/src/eventFact.ts`** (new): required `title` + `date`; optional `startTime`, `endTime`, `location`, `address`, `ageGroup`, `competitionTag`, `ticketUrl`, `ticketLabel` (initialValue `"Inschrijven"`), `capacity`, Portable-Text `note`.
- `article.body` `of:` accepts `{ type: "eventFact" }`.
- Barrel + `schemaTypes` updated; Sanity typegen regenerated.

### Components (`apps/web/src/components/article/`)

- **`blocks/EventFact/`**:
  - `types.ts` — `EventFactValue`, discriminated `ResolvedEvent`, `resolveEventDate()` powered by **Luxon** (already the site-wide date stack) so non-existent calendar dates (`2027-02-29`, `2026-04-31`, month 13) reject instead of rolling over silently. Drops the three hardcoded Dutch weekday/month arrays. `formatTimeRange()` and `DEFAULT_TICKET_LABEL` helpers.
  - `EventFactOverview.tsx` — dark-band horizontal row (`kcvv-gray-dark` surface, `kcvv-white/10` top rule). Three slots on md+: date cluster (wrapped in `<time dateTime>` for a11y), title + metadata, CTA right. CTA hidden when `ticketUrl` missing.
- **`EventHero/`** — typographic only. Kicker `EVENT | ageGroup / competitionTag`, article title as h1. Trim-guarded h1.
- **`EventStrip/`** — `"use client"` for the PortableText note renderer. Full-bleed 2-column band: serif-style date block left (wrapped in `<time dateTime>`) with a vertical `kcvv-gray-light` rule; title + when row + where row + note + optional CTA on the right. `Datum volgt` placeholder when the date is missing.
- **`EventTemplate/`** — composes hero + metadata bar + strip + `ArticleBodyMotion`-wrapped `SanityArticleBody`. Uses an `isEventFact` type guard to extract the feature eventFact and filter it out of the body.

### Integration

- `SanityArticleBody` adds the `eventFact` PortableText dispatch to `EventFactOverview`. Docstring mirrors the transferFact absorption rule.
- `/nieuws/[slug]/page.tsx` dispatch: `interview` → `InterviewTemplate` / `transfer` → `TransferTemplate` / **`event` → `EventTemplate`** / else → `AnnouncementTemplate`.
- `globals.css` widens the Phase 5 overview-stack rules so consecutive `transferFact` / `eventFact` overview rows fuse seamlessly via `:is([data-testid='transfer-overview'], [data-testid='event-overview'])` in both the `+` sibling and `:has(+)` selectors — mixed stacks (transferFact → eventFact) also flow edge-to-edge.

### Review follow-ups applied pre-push

- **Luxon migration + regression test**: `resolveEventDate` now validates via `DateTime.isValid`; `2027-02-29`, `2026-04-31`, `2026-13-01`, `2026-00-01` all reject correctly. Drops the hardcoded Dutch arrays (Luxon locale handles it).
- **`<time dateTime>` wrappers**: both the strip's date block and the overview's date cluster now render inside a semantic `<time>` element, so assistive tech announces the date natively instead of reading `APRIL` letter-by-letter.

## Tests

- **39 new event tests** — resolver × 11 (including the silent-rollover regression), overview × 8, hero × 6, strip × 9, template × 5.
- `pnpm --filter @kcvv/web check-all` green: lint, type-check on 8 workspaces, **2560 tests**, Next.js build, Storybook build.

## Manual verification

### Storybook

- `Features/Articles/EventFact/Overview` — WithTicketCta, WithCustomLabel, WithoutCta, NoDateYet.
- `Pages/Article/Event` — FullComposition (1 strip + 3 overviews + editor H2 separator), WithoutEventFact (fallback path).

### Staging

Seed: `apps/web/scripts/seed-phase-6-event-tracer.mjs` creates `article-phase-6-event-tracer` with four eventFact variants (full feature, CTA with custom label, no-CTA, no-date). Refuses to run against `production` unless `SANITY_ALLOW_PRODUCTION=1`.

Staging URL once the preview deploys: `https://staging.kcvvelewijt.be/nieuws/phase-6-tracer-event-moves`.

Cleanup after merge:

```bash
sanity documents delete --dataset=staging article-phase-6-event-tracer
```

## Docs

- PRD Phase 6 acceptance criteria ticked and reworded to match the shipped split.
- Design §3 taxonomy row, §5.4 hero spec, §8.2 overview spec, and §10 component tree rewritten to reflect the shipped layout (no `EventFactFeature` component — the feature content is absorbed by `EventHero` + `EventStrip`, same pattern as Phase 5's transfer split).

## Follow-ups (tracked, not in this PR)

- **Genericising the `isXFact` + `body.filter` pattern** — currently identical across `TransferTemplate` and `EventTemplate`. Reviewer agreed: defer until a third consumer appears; at two, the duplication reads more clearly than the abstraction would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)