### PR TITLE
chore(schema): backfill articleType migration + editorial guide (#1334)

### DIFF
--- a/apps/studio-staging/migrations/backfill-article-type/index.ts
+++ b/apps/studio-staging/migrations/backfill-article-type/index.ts
@@ -1,0 +1,40 @@
+import {defineMigration, at, set} from 'sanity/migrate'
+
+/**
+ * Backfill `articleType = "announcement"` on legacy article documents that
+ * predate the field. Part of #1334 — final phase of the article-detail
+ * redesign milestone.
+ *
+ * The schema declares `articleType` as required with an initialValue of
+ * "announcement", but existing documents created before the field landed
+ * don't carry it. Downstream the `page.tsx` renderTemplate default
+ * branch already treats missing articleType as announcement (PRD §3), so
+ * this migration is a correctness pass, not a behaviour change — editors
+ * want the value explicit in Studio so it shows in list/grouping views
+ * and validates on subsequent edits.
+ *
+ * Skips any article that already has articleType set. Tag-signalled
+ * interview auto-promotion is NOT done here — it requires editor
+ * review per the issue spec. See `apps/web/scripts/audit-interview-
+ * candidates.mjs` for the report-only companion.
+ *
+ * Dry-run first:
+ *   npx sanity@latest migration run backfill-article-type --project vhb33jaz --dataset staging --dry-run
+ *
+ * Apply:
+ *   npx sanity@latest migration run backfill-article-type --project vhb33jaz --dataset staging
+ *   npx sanity@latest migration run backfill-article-type --project vhb33jaz --dataset production
+ */
+export default defineMigration({
+  title: 'Backfill articleType="announcement" on legacy articles',
+  documentTypes: ['article'],
+
+  migrate: {
+    document(doc) {
+      if (typeof doc.articleType === 'string' && doc.articleType.length > 0) {
+        return undefined
+      }
+      return [at('articleType', set('announcement'))]
+    },
+  },
+})

--- a/apps/studio/migrations/backfill-article-type/index.ts
+++ b/apps/studio/migrations/backfill-article-type/index.ts
@@ -1,0 +1,40 @@
+import {defineMigration, at, set} from 'sanity/migrate'
+
+/**
+ * Backfill `articleType = "announcement"` on legacy article documents that
+ * predate the field. Part of #1334 — final phase of the article-detail
+ * redesign milestone.
+ *
+ * The schema declares `articleType` as required with an initialValue of
+ * "announcement", but existing documents created before the field landed
+ * don't carry it. Downstream the `page.tsx` renderTemplate default
+ * branch already treats missing articleType as announcement (PRD §3), so
+ * this migration is a correctness pass, not a behaviour change — editors
+ * want the value explicit in Studio so it shows in list/grouping views
+ * and validates on subsequent edits.
+ *
+ * Skips any article that already has articleType set. Tag-signalled
+ * interview auto-promotion is NOT done here — it requires editor
+ * review per the issue spec. See `apps/web/scripts/audit-interview-
+ * candidates.mjs` for the report-only companion.
+ *
+ * Dry-run first:
+ *   npx sanity@latest migration run backfill-article-type --project vhb33jaz --dataset staging --dry-run
+ *
+ * Apply:
+ *   npx sanity@latest migration run backfill-article-type --project vhb33jaz --dataset staging
+ *   npx sanity@latest migration run backfill-article-type --project vhb33jaz --dataset production
+ */
+export default defineMigration({
+  title: 'Backfill articleType="announcement" on legacy articles',
+  documentTypes: ['article'],
+
+  migrate: {
+    document(doc) {
+      if (typeof doc.articleType === 'string' && doc.articleType.length > 0) {
+        return undefined
+      }
+      return [at('articleType', set('announcement'))]
+    },
+  },
+})

--- a/apps/web/scripts/audit-interview-candidates.mjs
+++ b/apps/web/scripts/audit-interview-candidates.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/*
+ * apps/web/scripts/audit-interview-candidates.mjs
+ *
+ * Read-only companion to the `backfill-article-type` Sanity migration
+ * (#1334). Scans articles whose tags suggest an interview and prints a
+ * candidate report for editors to review in Studio. Nothing is written
+ * — editors decide which candidates get their `articleType` flipped.
+ *
+ * The migration backfills "announcement" on every legacy article. Tag-
+ * signalled interview promotion is intentionally manual: auto-rewriting
+ * would lose subject attribution (no way to pick the right player ref)
+ * and body structure (bold/italic Q&A needs human re-entry into the
+ * `qaBlock` editor). See `docs/editorial/restructuring-legacy-
+ * interviews.md` for the one-pager editors follow.
+ *
+ * Usage (from `apps/web` so @sanity/client resolves via the workspace):
+ *
+ *   SANITY_DATASET=staging node scripts/audit-interview-candidates.mjs
+ *   SANITY_DATASET=production node scripts/audit-interview-candidates.mjs
+ *
+ * No token required — uses the public Sanity dataset (articles are
+ * public documents). A token is still honoured if SANITY_API_TOKEN is
+ * set, which is useful for draft-inclusive queries.
+ */
+
+import { createClient } from "@sanity/client";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const PROJECT_ID = "vhb33jaz";
+const DATASET = process.env.SANITY_DATASET ?? "staging";
+if (!process.env.SANITY_DATASET) {
+  console.warn(
+    "⚠️  SANITY_DATASET not set — defaulting to 'staging'. Set it " +
+      "explicitly to avoid surprises (especially before running against " +
+      "production).",
+  );
+}
+
+// Patterns (case-insensitive) that signal "this is probably an
+// interview". Keep these lists narrow — false positives here create
+// editor-review noise. Refine by running the audit and listening to
+// editor feedback. Nederlands + English spellings covered because the
+// historical dataset has both.
+const INTERVIEW_TAG_PATTERNS = [
+  /^interview$/i,
+  /^intervieuw$/i,
+  /^vraaggesprek$/i,
+  /^gesprek met/i,
+  /^q&a$/i,
+  /^q & a$/i,
+];
+
+const INTERVIEW_TITLE_PATTERNS = [
+  /\binterview\b/i,
+  /\bvraaggesprek\b/i,
+  /\bgesprek met\b/i,
+];
+
+const INTERVIEW_SLUG_PATTERNS = [/interview/i, /gesprek/i, /vraaggesprek/i];
+
+function resolveToken() {
+  if (process.env.SANITY_API_TOKEN) return process.env.SANITY_API_TOKEN;
+  try {
+    const configPath = join(homedir(), ".config", "sanity", "config.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (config.authToken) return config.authToken;
+  } catch (err) {
+    // ENOENT = no `sanity login` yet → public reads still work. Other
+    // errors (malformed JSON, permission denied) should surface loudly.
+    if (err?.code !== "ENOENT") {
+      console.warn(`⚠️  Could not read Sanity config: ${err.message}`);
+    }
+  }
+  return undefined;
+}
+
+const client = createClient({
+  projectId: PROJECT_ID,
+  dataset: DATASET,
+  apiVersion: "2024-01-01",
+  token: resolveToken(),
+  useCdn: false,
+});
+
+function isInterviewTag(tag) {
+  if (typeof tag !== "string") return false;
+  return INTERVIEW_TAG_PATTERNS.some((re) => re.test(tag.trim()));
+}
+
+function matchesTitle(title) {
+  if (typeof title !== "string") return false;
+  return INTERVIEW_TITLE_PATTERNS.some((re) => re.test(title));
+}
+
+function matchesSlug(slug) {
+  if (typeof slug !== "string") return false;
+  return INTERVIEW_SLUG_PATTERNS.some((re) => re.test(slug));
+}
+
+function classifySignal(article) {
+  if (Array.isArray(article.tags) && article.tags.some(isInterviewTag)) {
+    return "tag";
+  }
+  if (matchesTitle(article.title)) return "title";
+  if (matchesSlug(article.slug)) return "slug";
+  return null;
+}
+
+async function main() {
+  // Filter out drafts at the GROQ layer — with a write token, the client
+  // returns both published + drafts.* duplicates otherwise.
+  const articles = await client.fetch(
+    `*[_type == "article" && !(_id in path("drafts.**"))]{
+       _id,
+       "title": coalesce(title, "(no title)"),
+       "slug": slug.current,
+       articleType,
+       tags,
+       publishAt
+     } | order(coalesce(publishAt, _createdAt) desc)`,
+  );
+
+  const candidates = articles
+    .filter((a) => a.articleType !== "interview")
+    .map((a) => ({ ...a, signal: classifySignal(a) }))
+    .filter((a) => a.signal !== null);
+
+  console.log("━".repeat(72));
+  console.log(`Dataset: ${DATASET}`);
+  console.log(`Total articles scanned: ${articles.length}`);
+  console.log(`Interview candidates (not yet tagged as 'interview'): ${candidates.length}`);
+  console.log("━".repeat(72));
+
+  if (candidates.length === 0) {
+    console.log("\nNothing to review. ✓\n");
+    return;
+  }
+
+  console.log(
+    "\nReview each candidate in Studio. If it's genuinely an interview,\n" +
+      "follow docs/editorial/restructuring-legacy-interviews.md to set\n" +
+      "articleType='interview', link the subject, and restructure the\n" +
+      "Q&A paragraphs into qaBlock pairs.\n",
+  );
+
+  for (const a of candidates) {
+    const currentType =
+      a.articleType ?? "(unset — will be 'announcement' after migration)";
+    const signalDetail =
+      a.signal === "tag"
+        ? `tag: ${(a.tags ?? []).filter(isInterviewTag).join(", ")}`
+        : a.signal === "title"
+          ? `title matches interview pattern`
+          : `slug matches interview pattern`;
+    console.log(`• ${a.title}`);
+    console.log(`    slug:         ${a.slug ?? "(no slug)"}`);
+    console.log(`    _id:          ${a._id}`);
+    console.log(`    current type: ${currentType}`);
+    console.log(`    signal:       ${signalDetail}`);
+    console.log(`    all tags:     ${(a.tags ?? []).join(", ") || "(none)"}`);
+    console.log("");
+  }
+}
+
+main().catch((err) => {
+  console.error("audit-interview-candidates failed:", err);
+  process.exit(1);
+});

--- a/docs/editorial/restructuring-legacy-interviews.md
+++ b/docs/editorial/restructuring-legacy-interviews.md
@@ -1,0 +1,99 @@
+# Restructuring legacy interviews
+
+**Audience:** Sanity editors with write access to the article collection.
+**Prerequisite:** An existing article you recognise as an interview — currently stored as plain prose with bold questions and italic answers.
+
+## Why this exists
+
+The article editor now supports four types: `announcement`, `interview`, `transfer`, `event`. Legacy articles predate this field and were all backfilled to `announcement`. Articles that are actually interviews should be manually promoted so the site renders the interview hero + attribution, and search engines see the correct `NewsArticle` + `about: Person` structured data.
+
+The `Interview`-style tagged articles surfaced by `audit-interview-candidates` are the candidates. Run the audit from `apps/web/`:
+
+```bash
+SANITY_DATASET=staging node scripts/audit-interview-candidates.mjs
+```
+
+The report prints each candidate's slug, title, and matched tags. Open them in Studio one at a time and follow the steps below.
+
+---
+
+## Before / after
+
+### Before — legacy interview
+
+The body is a Portable Text array of plain blocks, with questions emphasised via **bold** and answers in regular prose (sometimes also _italic_):
+
+```text
+Body:
+
+  [Paragraph, bold]  Hoe kijk je terug op het seizoen?
+
+  [Paragraph]        Met een dubbel gevoel. We zijn vijfde geëindigd
+                     terwijl we naar promotie speelden.
+
+  [Paragraph, bold]  En de match tegen Wezemaal?
+
+  [Paragraph]        Die mag ik voor geen geld ooit nog eens spelen.
+                     Zeven spelers ziek de week ervoor.
+
+  …
+```
+
+### After — interview with `qaBlock`
+
+```text
+Article type:  interview
+Subject:       ►  Kind: player
+                  Player: Max Breugelmans (#9, Middenvelder)
+
+Body:
+
+  [Q&A]   Hoe kijk je terug op het seizoen?
+          Tag: standard
+          ► Met een dubbel gevoel. We zijn vijfde geëindigd terwijl we
+            naar promotie speelden.
+
+  [Q&A]   En de match tegen Wezemaal?
+          Tag: quote             ← isolates a pull quote in the body
+          ► Die mag ik voor geen geld ooit nog eens spelen. Zeven
+            spelers ziek de week ervoor.
+
+  …
+```
+
+The interview hero now shows the article-type kicker (`INTERVIEW | #9 · MIDDENVELDER` for players with a jersey + position; just `INTERVIEW` for staff / custom subjects or players without those fields), the subject name as subtitle, and the cover image as a 4:5 portrait. Each `quote`/`key`-tagged Q&A pair renders with a decorative glyph + attribution from `article.subject`.
+
+---
+
+## Step-by-step in Studio
+
+1. **Open the article** in Studio (staging first; repeat on production once happy).
+2. **Set Article type** to `Interview`.
+3. **Fill Subject**:
+   - **Kind** → `player`, `staff`, or `custom`.
+   - For `player`: link to the player document by name/number.
+   - For `staff`: link to the staff member document.
+   - For `custom` (external guest): type the name + role; upload a photo.
+     The subject drives the hero kicker (jersey + position), subtitle, and the pull-quote attribution on `key`/`quote` Q&A pairs.
+4. **Rebuild the body with Q&A pairs**. For each legacy paragraph pair (bold question → plain answer):
+   - Delete the two legacy paragraphs.
+   - Insert a **Q&A pair** block.
+   - Paste the question (short, ends with a question mark).
+   - Paste the answer into the answer field. Keep it flat prose — no headings, no lists (the schema enforces that). Bold, italic, underline, and inline links are all kept.
+   - Set the **Tag** intentionally:
+     - `standard` — default. Regular Q&A flow.
+     - `key` — highlighted Q&A pair (boxed, attributed).
+     - `quote` — standalone pull quote with decorative glyph; use sparingly, once per article.
+     - `rapid-fire` — short back-and-forth; consecutive rapid-fire pairs are visually grouped in the renderer.
+5. **Keep** any paragraphs that are editorial framing (intro, outro, scene-setting) as plain Portable Text blocks above/below/between the Q&A pairs. Not everything has to become a `qaBlock`.
+6. **Save as draft, preview, then publish**.
+
+## Don'ts
+
+- **Don't auto-parse**. Bold-first / italic-second is a convention, not structure — bolded callouts mid-answer would be mis-detected as questions. Manual re-entry is the only safe option.
+- **Don't leave `articleType` as `announcement`** on the theory that "it still renders". The announcement template doesn't show the subject or qaBlock treatments, and the JSON-LD `about: Person` branch only fires for interviews.
+- **Don't skip the subject field**. Without it, the hero collapses to `INTERVIEW` + title only, and all `key`/`quote` pairs render without attribution.
+
+## Questions
+
+Post in `#website-editors` on Slack or tag Kevin on the article document in Studio.


### PR DESCRIPTION
Closes #1334

Final phase of the \`article-detail-redesign\` milestone. Backfills \`articleType\` on legacy articles + publishes an editorial guide for restructuring legacy interviews.

## Summary

- Sanity migration \`backfill-article-type\` mirrored across both studios (\`apps/studio\` + \`apps/studio-staging\`). Sets \`articleType="announcement"\` on every legacy article; skips already-typed articles.
- Read-only audit companion at \`apps/web/scripts/audit-interview-candidates.mjs\` — flags articles whose tag, title, or slug signals an interview. Editors promote manually in Studio.
- Editorial one-pager at \`docs/editorial/restructuring-legacy-interviews.md\` — before/after example, step-by-step in Studio, and do-nots.

## Migrations already applied

Staging (126 articles scanned, 122 backfilled):
\`\`\`text
announcement: 122   transfer: 1   event: 1   interview: 2
\`\`\`

Production (122 articles scanned, 122 backfilled):
\`\`\`text
announcement: 122
\`\`\`

Audit returned **0 candidates** on both datasets — historical editors haven't been using explicit interview signals. The script stays as ongoing tooling.

## Re-run commands (idempotent)

\`\`\`bash
# Dry-run first
cd apps/studio-staging && npx sanity@latest migration run backfill-article-type \\
  --project vhb33jaz --dataset staging --dry-run

# Apply
cd apps/studio-staging && npx sanity@latest migration run backfill-article-type \\
  --project vhb33jaz --dataset staging --no-dry-run --no-confirm
cd apps/studio && npx sanity@latest migration run backfill-article-type \\
  --project vhb33jaz --dataset production --no-dry-run --no-confirm

# Audit report
cd apps/web && SANITY_DATASET=staging    node scripts/audit-interview-candidates.mjs
cd apps/web && SANITY_DATASET=production node scripts/audit-interview-candidates.mjs
\`\`\`

## Test plan

- [x] Dual-studio parity (\`apps/studio\` + \`apps/studio-staging\` byte-identical)
- [x] Staging migration dry-run inspected (122 articles flagged)
- [x] Staging migration applied; post-tally verified (announcement=122, transfer=1, event=1, interview=2)
- [x] Production migration applied; post-tally verified (announcement=122)
- [x] Audit script runs clean on both datasets (0 candidates, no script errors)
- [x] \`pnpm --filter @kcvv/web check-all\` passes (210 files / 2631 tests)
- [ ] Editorial guide reviewed by at least one non-technical editor before handing it off