### PR TITLE
feat(news): videoBlock embed URL escape hatch + XOR validation (#1364)

### DIFF
--- a/apps/web/src/components/article/VideoBlock/VideoBlock.stories.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.stories.tsx
@@ -95,11 +95,12 @@ export const EmbedYoutube: Story = {
   args: {
     value: {
       _type: "videoBlock",
-      // Google's "Chrome Dino" short — a stable, club-unrelated public
-      // video good enough to demonstrate the iframe path. Editors will
-      // paste their own URL; this fixture just proves the parser maps
-      // watch URLs to the youtube-nocookie.com/embed/<id> iframe.
-      embedUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      // "Me at the zoo" (jNQXAC9IVRw) — the first video ever uploaded to
+      // YouTube (2005, by co-founder Jawed Karim). A stable, club-
+      // unrelated public fixture used here to demonstrate that the
+      // parser maps watch URLs to the youtube-nocookie.com/embed/<id>
+      // iframe.
+      embedUrl: "https://www.youtube.com/watch?v=jNQXAC9IVRw",
     },
   },
   parameters: {
@@ -117,7 +118,7 @@ export const EmbedYoutubeShort: Story = {
   args: {
     value: {
       _type: "videoBlock",
-      embedUrl: "https://youtu.be/dQw4w9WgXcQ?t=30",
+      embedUrl: "https://youtu.be/jNQXAC9IVRw?t=30",
     },
   },
   parameters: {

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.stories.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.stories.tsx
@@ -87,3 +87,82 @@ export const MissingAsset: Story = {
     },
   },
 };
+
+// ─── Phase 2 — embed URL stories (#1364) ──────────────────────────────────
+
+export const EmbedYoutube: Story = {
+  name: "Embed — YouTube",
+  args: {
+    value: {
+      _type: "videoBlock",
+      // Google's "Chrome Dino" short — a stable, club-unrelated public
+      // video good enough to demonstrate the iframe path. Editors will
+      // paste their own URL; this fixture just proves the parser maps
+      // watch URLs to the youtube-nocookie.com/embed/<id> iframe.
+      embedUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the privacy-enhanced YouTube iframe (`youtube-nocookie.com/embed/<id>`) inside a 16:9 container. The serializer pulls the video ID from the `v=` query param via `parseEmbedUrl`.",
+      },
+    },
+  },
+};
+
+export const EmbedYoutubeShort: Story = {
+  name: "Embed — YouTube (youtu.be)",
+  args: {
+    value: {
+      _type: "videoBlock",
+      embedUrl: "https://youtu.be/dQw4w9WgXcQ?t=30",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Short-form `youtu.be/<id>` URLs resolve to the same iframe as their watch-URL equivalents. Trailing query params (`t=...`, `feature=...`) are ignored.",
+      },
+    },
+  },
+};
+
+export const EmbedVimeo: Story = {
+  name: "Embed — Vimeo",
+  args: {
+    value: {
+      _type: "videoBlock",
+      // Vimeo staff-picks short — public, ad-free, with a stable ID.
+      embedUrl: "https://vimeo.com/824804225",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the `player.vimeo.com/video/<id>` iframe inside a 16:9 container. Vimeo URLs are recognised via the numeric first path segment.",
+      },
+    },
+  },
+};
+
+export const EmbedUnknownProvider: Story = {
+  name: "Embed — unknown provider (fallback)",
+  args: {
+    value: {
+      _type: "videoBlock",
+      embedUrl: "https://dailymotion.com/video/x1234abcd",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`parseEmbedUrl` rejects anything outside the YouTube/Vimeo allowlist. The serializer logs a `console.warn` (visible in the browser console) and renders a neutral Dutch-language fallback. The raw URL is **never** injected into the DOM, guarding against XSS and open-redirect risks.",
+      },
+    },
+  },
+};

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.test.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { VideoBlock, type VideoBlockValue } from "./VideoBlock";
 
@@ -68,5 +68,113 @@ describe("VideoBlock", () => {
     };
     const { container } = render(<VideoBlock value={value} />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("VideoBlock — embed path (Phase 2)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a privacy-enhanced YouTube iframe when embedUrl is a YouTube URL", () => {
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        }}
+      />,
+    );
+    const iframe = screen.getByTestId(
+      "video-block-iframe",
+    ) as HTMLIFrameElement;
+    expect(iframe.getAttribute("src")).toBe(
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+    );
+    const wrapper = screen.getByTestId("video-block");
+    expect(wrapper.dataset.source).toBe("embed");
+    expect(wrapper.dataset.provider).toBe("youtube");
+  });
+
+  it("renders the player.vimeo.com iframe when embedUrl is a Vimeo URL", () => {
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://vimeo.com/123456789",
+        }}
+      />,
+    );
+    const iframe = screen.getByTestId(
+      "video-block-iframe",
+    ) as HTMLIFrameElement;
+    expect(iframe.getAttribute("src")).toBe(
+      "https://player.vimeo.com/video/123456789",
+    );
+    expect(screen.getByTestId("video-block").dataset.provider).toBe("vimeo");
+  });
+
+  it("forwards loading=lazy + referrerPolicy on the iframe", () => {
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://youtu.be/dQw4w9WgXcQ",
+        }}
+      />,
+    );
+    const iframe = screen.getByTestId("video-block-iframe");
+    expect(iframe.getAttribute("loading")).toBe("lazy");
+    expect(iframe.getAttribute("referrerpolicy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("renders a neutral fallback (no iframe) for an unsupported host", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://dailymotion.com/video/x1234abcd",
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("video-block-iframe")).toBeNull();
+    const wrapper = screen.getByTestId("video-block");
+    expect(wrapper.dataset.source).toBe("embed-unknown");
+    expect(screen.getByText(/provider niet ondersteund/i)).toBeTruthy();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT interpolate the raw URL into the DOM for an unsupported host (XSS guard)", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const suspicious = "https://evil.example.com/watch?v=dQw4w9WgXcQ";
+    const { container } = render(
+      <VideoBlock value={{ _type: "videoBlock", embedUrl: suspicious }} />,
+    );
+    expect(container.innerHTML).not.toContain(suspicious);
+    expect(container.innerHTML).not.toContain("evil.example.com");
+  });
+
+  it("prefers embedUrl over videoAsset when both are populated (defensive)", () => {
+    // Normally the Sanity XOR validator makes this state unreachable,
+    // but the runtime must still pick a single deterministic path.
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          videoAsset: {
+            url: "https://cdn.sanity.io/files/vhb33jaz/staging/other.mp4",
+            size: 1_000_000,
+            mimeType: "video/mp4",
+            originalFilename: "other.mp4",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByTestId("video-block").dataset.source).toBe("embed");
+    expect(screen.queryByTestId("video-block-video")).toBeNull();
   });
 });

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
@@ -68,6 +68,10 @@ function renderUpload(value: VideoBlockValue, className: string | undefined) {
 
 // ─── Embed path (Phase 2) ────────────────────────────────────────────────
 
+const assertNever = (value: never): never => {
+  throw new Error(`Unhandled VideoProvider: ${JSON.stringify(value)}`);
+};
+
 function embedSrc(provider: VideoProvider, videoId: string): string {
   switch (provider) {
     case "youtube":
@@ -76,6 +80,8 @@ function embedSrc(provider: VideoProvider, videoId: string): string {
       return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}`;
     case "vimeo":
       return `https://player.vimeo.com/video/${encodeURIComponent(videoId)}`;
+    default:
+      return assertNever(provider);
   }
 }
 
@@ -85,6 +91,8 @@ function embedTitle(provider: VideoProvider): string {
       return "YouTube-video";
     case "vimeo":
       return "Vimeo-video";
+    default:
+      return assertNever(provider);
   }
 }
 

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils/cn";
+import { parseEmbedUrl, type VideoProvider } from "./parseEmbedUrl";
 
 export interface VideoBlockValue {
   _type: "videoBlock";
@@ -8,6 +9,7 @@ export interface VideoBlockValue {
     mimeType?: string | null;
     originalFilename?: string | null;
   } | null;
+  embedUrl?: string | null;
 }
 
 export interface VideoBlockProps {
@@ -16,31 +18,40 @@ export interface VideoBlockProps {
 }
 
 /**
- * Phase 1 tracer (#1363). Renders a bare HTML5 `<video controls>` pointing
- * at the Sanity asset URL. Returns `null` when no asset resolves — the
- * page shouldn't crash on a block that slipped through publishing without
- * a file attached.
+ * Phase 1 (#1363) shipped the upload path. Phase 2 (#1364) adds the
+ * embed path: YouTube and Vimeo URLs render in privacy-enhanced iframes
+ * (`youtube-nocookie.com`, `player.vimeo.com`) inside a 16:9 container.
+ * Exactly one of `videoAsset` / `embedUrl` is ever populated (enforced
+ * by the Sanity XOR validator) — `embedUrl` takes precedence if both
+ * happened to arrive somehow, since an explicit editor-authored link is
+ * the most recent signal of intent.
  *
- * Phase 2 will layer on provider iframes (YouTube/Vimeo) via an optional
- * `embedUrl` field; Phase 3 adds poster, caption, lazy-load and
- * fullBleed. This file will grow — keep each phase's additions under
- * its own commit so the tracer stays reviewable in isolation.
+ * Unknown-host guard: `parseEmbedUrl` returns `null` for anything outside
+ * the YouTube/Vimeo allowlist. We log a dev-only `console.warn` and
+ * render a neutral DOM fallback — never inject a raw URL into an
+ * iframe/src attribute.
  */
 export function VideoBlock({ value, className }: VideoBlockProps) {
+  const embed =
+    typeof value.embedUrl === "string" && value.embedUrl.length > 0
+      ? value.embedUrl
+      : null;
+  if (embed !== null) return renderEmbed(embed, className);
+  return renderUpload(value, className);
+}
+
+// ─── Upload path (Phase 1 tracer, unchanged) ─────────────────────────────
+
+function renderUpload(value: VideoBlockValue, className: string | undefined) {
   const src = value.videoAsset?.url;
   if (typeof src !== "string" || src.length === 0) return null;
-
   const mimeType = value.videoAsset?.mimeType ?? undefined;
-
   return (
     <figure
       className={cn("my-8 overflow-hidden rounded-lg bg-black", className)}
       data-testid="video-block"
+      data-source="upload"
     >
-      {/* `controls` gives the reader start/stop without custom UI in the
-          tracer. `preload="metadata"` mirrors the HTML default — Phase 3
-          will switch to `"none"` with a poster so MP4 bytes only download
-          on interaction. */}
       <video
         controls
         preload="metadata"
@@ -51,6 +62,84 @@ export function VideoBlock({ value, className }: VideoBlockProps) {
         Je browser ondersteunt geen HTML5-video. Download het bestand via de
         link.
       </video>
+    </figure>
+  );
+}
+
+// ─── Embed path (Phase 2) ────────────────────────────────────────────────
+
+function embedSrc(provider: VideoProvider, videoId: string): string {
+  switch (provider) {
+    case "youtube":
+      // Privacy-enhanced variant: doesn't set cookies until the reader
+      // actually plays the video.
+      return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}`;
+    case "vimeo":
+      return `https://player.vimeo.com/video/${encodeURIComponent(videoId)}`;
+  }
+}
+
+function embedTitle(provider: VideoProvider): string {
+  switch (provider) {
+    case "youtube":
+      return "YouTube-video";
+    case "vimeo":
+      return "Vimeo-video";
+  }
+}
+
+function renderEmbed(url: string, className: string | undefined) {
+  const parsed = parseEmbedUrl(url);
+  if (parsed === null) {
+    // Log for editor visibility, render a neutral fallback. Crucially —
+    // we never interpolate `url` into an iframe/src or an anchor href
+    // without provider-matching, to avoid open-redirect / mixed-content
+    // / javascript: URL risks.
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "[VideoBlock] Unknown embed URL provider — refusing to render an iframe. Allowed: YouTube, Vimeo.",
+      );
+    }
+    return (
+      <figure
+        className={cn(
+          "bg-kcvv-gray-light my-8 rounded-lg p-6 text-center",
+          className,
+        )}
+        data-testid="video-block"
+        data-source="embed-unknown"
+      >
+        <p className="text-kcvv-gray-dark text-sm">
+          Video-embed (provider niet ondersteund). Controleer of de link van
+          YouTube of Vimeo komt.
+        </p>
+      </figure>
+    );
+  }
+
+  const src = embedSrc(parsed.provider, parsed.videoId);
+  return (
+    <figure
+      className={cn("my-8 overflow-hidden rounded-lg bg-black", className)}
+      data-testid="video-block"
+      data-source="embed"
+      data-provider={parsed.provider}
+    >
+      {/* 16:9 responsive container — aspect-video + absolute-positioned
+          iframe covers the full box. allow="…" enables in-frame
+          fullscreen + picture-in-picture on providers that support it. */}
+      <div className="relative aspect-video w-full">
+        <iframe
+          src={src}
+          title={embedTitle(parsed.provider)}
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          referrerPolicy="strict-origin-when-cross-origin"
+          className="absolute inset-0 h-full w-full border-0"
+          data-testid="video-block-iframe"
+        />
+      </div>
     </figure>
   );
 }

--- a/apps/web/src/components/article/VideoBlock/parseEmbedUrl.test.ts
+++ b/apps/web/src/components/article/VideoBlock/parseEmbedUrl.test.ts
@@ -45,6 +45,12 @@ describe("parseEmbedUrl", () => {
         provider: "youtube",
         videoId: "abc-DEF_123",
       });
+      expect(
+        parseEmbedUrl("https://www.youtube.com/live/Some_Live-ID123"),
+      ).toEqual({
+        provider: "youtube",
+        videoId: "Some_Live-ID123",
+      });
     });
 
     it("returns null when the v= param is missing or empty", () => {

--- a/apps/web/src/components/article/VideoBlock/parseEmbedUrl.test.ts
+++ b/apps/web/src/components/article/VideoBlock/parseEmbedUrl.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { parseEmbedUrl } from "./parseEmbedUrl";
+
+describe("parseEmbedUrl", () => {
+  describe("YouTube", () => {
+    it("parses a standard watch URL (youtube.com/watch?v=)", () => {
+      expect(
+        parseEmbedUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+      ).toEqual({
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ",
+      });
+    });
+
+    it("parses the bare-host variant (youtube.com/watch?v=)", () => {
+      expect(parseEmbedUrl("https://youtube.com/watch?v=dQw4w9WgXcQ")).toEqual({
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ",
+      });
+    });
+
+    it("parses the short URL form (youtu.be/<id>)", () => {
+      expect(parseEmbedUrl("https://youtu.be/dQw4w9WgXcQ")).toEqual({
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ",
+      });
+    });
+
+    it("tolerates trailing query parameters on youtu.be URLs", () => {
+      expect(
+        parseEmbedUrl("https://youtu.be/dQw4w9WgXcQ?t=120&feature=share"),
+      ).toEqual({ provider: "youtube", videoId: "dQw4w9WgXcQ" });
+    });
+
+    it("parses embed/shorts/live URLs", () => {
+      expect(
+        parseEmbedUrl("https://www.youtube.com/embed/dQw4w9WgXcQ"),
+      ).toEqual({
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ",
+      });
+      expect(
+        parseEmbedUrl("https://www.youtube.com/shorts/abc-DEF_123"),
+      ).toEqual({
+        provider: "youtube",
+        videoId: "abc-DEF_123",
+      });
+    });
+
+    it("returns null when the v= param is missing or empty", () => {
+      expect(parseEmbedUrl("https://www.youtube.com/watch")).toBeNull();
+      expect(parseEmbedUrl("https://www.youtube.com/watch?v=")).toBeNull();
+    });
+
+    it("returns null when the v= param is malformed", () => {
+      expect(
+        parseEmbedUrl("https://www.youtube.com/watch?v=has spaces"),
+      ).toBeNull();
+    });
+  });
+
+  describe("Vimeo", () => {
+    it("parses a numeric-ID URL (vimeo.com/<id>)", () => {
+      expect(parseEmbedUrl("https://vimeo.com/123456789")).toEqual({
+        provider: "vimeo",
+        videoId: "123456789",
+      });
+    });
+
+    it("parses the www.vimeo.com host variant", () => {
+      expect(parseEmbedUrl("https://www.vimeo.com/987654321")).toEqual({
+        provider: "vimeo",
+        videoId: "987654321",
+      });
+    });
+
+    it("ignores trailing segments (album slug, review hash)", () => {
+      expect(parseEmbedUrl("https://vimeo.com/123456789/abc123def")).toEqual({
+        provider: "vimeo",
+        videoId: "123456789",
+      });
+    });
+
+    it("returns null for non-numeric Vimeo paths (channels/staffpicks)", () => {
+      expect(parseEmbedUrl("https://vimeo.com/channels/staffpicks")).toBeNull();
+    });
+
+    it("returns null when the first path segment is empty", () => {
+      expect(parseEmbedUrl("https://vimeo.com/")).toBeNull();
+      expect(parseEmbedUrl("https://vimeo.com")).toBeNull();
+    });
+  });
+
+  describe("rejection", () => {
+    it("returns null for unsupported hosts", () => {
+      expect(parseEmbedUrl("https://dailymotion.com/video/x123abc")).toBeNull();
+      expect(
+        parseEmbedUrl("https://evil.example.com/watch?v=dQw4w9WgXcQ"),
+      ).toBeNull();
+    });
+
+    it("returns null for non-HTTPS schemes", () => {
+      expect(
+        parseEmbedUrl("http://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+      ).toBeNull();
+    });
+
+    it("returns null for malformed input", () => {
+      expect(parseEmbedUrl("not a url")).toBeNull();
+      expect(parseEmbedUrl("")).toBeNull();
+      expect(parseEmbedUrl("   ")).toBeNull();
+    });
+
+    it("returns null for non-string inputs (defensive)", () => {
+      // @ts-expect-error -- runtime guard against GROQ returning unexpected shapes
+      expect(parseEmbedUrl(null)).toBeNull();
+      // @ts-expect-error -- runtime guard against GROQ returning unexpected shapes
+      expect(parseEmbedUrl(undefined)).toBeNull();
+      // @ts-expect-error -- runtime guard against GROQ returning unexpected shapes
+      expect(parseEmbedUrl(42)).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/components/article/VideoBlock/parseEmbedUrl.ts
+++ b/apps/web/src/components/article/VideoBlock/parseEmbedUrl.ts
@@ -1,0 +1,74 @@
+/**
+ * Parse a YouTube / Vimeo URL into `{ provider, videoId }`.
+ *
+ * Returns `null` for:
+ * - Non-HTTPS schemes (http, ftp, javascript, data, etc.)
+ * - Unknown hosts (anything outside YouTube / Vimeo)
+ * - Malformed URLs (unparseable via `URL()`)
+ * - URLs with the right host but no extractable video ID
+ *
+ * Locked to YouTube + Vimeo per the article-video-support PRD Phase 2
+ * scope (#1364). Extending to other providers needs: a new branch here,
+ * a corresponding iframe host on the serializer, an updated Storybook
+ * story, and a CSP review.
+ */
+export type VideoProvider = "youtube" | "vimeo";
+
+export interface ParsedEmbed {
+  provider: VideoProvider;
+  videoId: string;
+}
+
+const YOUTUBE_ID_RE = /^[A-Za-z0-9_-]{6,32}$/;
+const VIMEO_ID_RE = /^\d{5,15}$/;
+
+function parseYoutube(url: URL): ParsedEmbed | null {
+  const host = url.hostname.toLowerCase();
+  // youtu.be/<id>
+  if (host === "youtu.be") {
+    const id = url.pathname.replace(/^\//, "").split("/")[0];
+    return YOUTUBE_ID_RE.test(id) ? { provider: "youtube", videoId: id } : null;
+  }
+  // youtube.com/watch?v=<id>, www.youtube.com/watch?v=<id>
+  if (host === "youtube.com" || host === "www.youtube.com") {
+    // /watch?v=<id>
+    if (url.pathname === "/watch") {
+      const id = url.searchParams.get("v") ?? "";
+      return YOUTUBE_ID_RE.test(id)
+        ? { provider: "youtube", videoId: id }
+        : null;
+    }
+    // /embed/<id>, /shorts/<id>, /live/<id>
+    const embedMatch = /^\/(embed|shorts|live)\/([A-Za-z0-9_-]+)/.exec(
+      url.pathname,
+    );
+    if (embedMatch) {
+      const id = embedMatch[2];
+      return YOUTUBE_ID_RE.test(id)
+        ? { provider: "youtube", videoId: id }
+        : null;
+    }
+  }
+  return null;
+}
+
+function parseVimeo(url: URL): ParsedEmbed | null {
+  const host = url.hostname.toLowerCase();
+  if (host !== "vimeo.com" && host !== "www.vimeo.com") return null;
+  // vimeo.com/<numericId> — the first path segment must be all digits.
+  // Ignore trailing segments (album slugs, review hashes, etc.).
+  const first = url.pathname.replace(/^\//, "").split("/")[0];
+  return VIMEO_ID_RE.test(first) ? { provider: "vimeo", videoId: first } : null;
+}
+
+export function parseEmbedUrl(raw: string): ParsedEmbed | null {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:") return null;
+  return parseYoutube(url) ?? parseVimeo(url);
+}

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -325,6 +325,7 @@ export type VideoBlock = {
     media?: unknown;
     _type: "file";
   };
+  embedUrl?: string;
 };
 
 export type ArticleImage = {
@@ -1173,6 +1174,7 @@ export type ARTICLES_QUERY_RESULT = Array<{
           media?: unknown;
           _type: "file";
         };
+        embedUrl?: string;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1488,6 +1490,7 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
           media?: unknown;
           _type: "file";
         };
+        embedUrl?: string;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;

--- a/packages/sanity-schemas/src/videoBlock.ts
+++ b/packages/sanity-schemas/src/videoBlock.ts
@@ -1,13 +1,41 @@
 import {defineField, defineType} from 'sanity'
 
 /**
- * Phase 1 tracer (#1363) for article-video-support. Single field:
- * `uploadedFile` — a Sanity file asset restricted to MP4/WebM. Renders
- * in `apps/web` as a bare `<video controls src={asset.url}>`.
- *
- * Phases 2–3 will layer on an embed URL, poster, caption, fullBleed and
- * lazy-load controls. Keep this schema minimal until those phases ship —
- * the PRD's explicit "thinnest possible slice" guidance applies.
+ * Allowed hosts for `embedUrl` — locked to YouTube + Vimeo per the
+ * article-video-support PRD. Expanding the list requires updating the
+ * parser (`parseEmbedUrl`), iframe allow-list on the serializer, and
+ * any relevant CSP; don't add hosts ad-hoc without the parser work.
+ */
+const ALLOWED_EMBED_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'youtu.be',
+  'vimeo.com',
+  'www.vimeo.com',
+])
+
+// Matches `https://<host>[/...]` where <host> is any valid hostname.
+// Deliberately avoids `new URL()` so the schema package can stay on the
+// ES2017 lib without pulling in the DOM types.
+const HTTPS_URL_RE = /^https:\/\/([^/?#]+)(?:[/?#]|$)/i
+
+function isAllowedEmbedUrl(raw: string): boolean {
+  const match = HTTPS_URL_RE.exec(raw)
+  if (!match) return false
+  return ALLOWED_EMBED_HOSTS.has(match[1].toLowerCase())
+}
+
+function extractHost(raw: string): string | null {
+  const match = HTTPS_URL_RE.exec(raw)
+  return match ? match[1].toLowerCase() : null
+}
+
+/**
+ * Phase 1 tracer (#1363) introduced `uploadedFile`. Phase 2 (#1364) adds
+ * the `embedUrl` escape hatch for YouTube/Vimeo links — exactly one of
+ * the two must be set, enforced via a Rule.custom on the object. The
+ * preview falls back to whichever is populated. Phase 3 will layer on
+ * poster/caption/lazy-load/fullBleed.
  */
 export const videoBlock = defineType({
   name: 'videoBlock',
@@ -22,24 +50,67 @@ export const videoBlock = defineType({
         accept: 'video/mp4,video/webm',
       },
       description:
-        'Upload een MP4 of WebM (H.264 1080p ~2–3 Mbps aanbevolen). Geen YouTube/Vimeo link — die komt in fase 2.',
-      validation: (r) => r.required(),
+        'Upload een MP4 of WebM (H.264 1080p ~2–3 Mbps aanbevolen). Gebruik dit OF "Embed URL" — niet beide.',
+    }),
+    defineField({
+      name: 'embedUrl',
+      title: 'Embed URL',
+      type: 'url',
+      description:
+        'Plak een YouTube of Vimeo link. Gebruik dit OF "Video file" — niet beide. Toegestaan: youtube.com, youtu.be, vimeo.com (altijd https).',
+      validation: (r) =>
+        r.uri({
+          scheme: ['https'],
+          allowRelative: false,
+        }).custom((value) => {
+          if (typeof value !== 'string' || value.length === 0) return true
+          return isAllowedEmbedUrl(value)
+            ? true
+            : 'Alleen YouTube of Vimeo links zijn toegestaan (https://youtube.com, https://youtu.be, https://vimeo.com).'
+        }),
     }),
   ],
+  // Object-level XOR: exactly one of uploadedFile / embedUrl must be set.
+  // Ran as a Rule.custom on the parent object so the error surfaces on
+  // the block as a whole rather than on either field individually.
+  validation: (r) =>
+    r.custom((value) => {
+      const parent = value as
+        | {uploadedFile?: unknown; embedUrl?: unknown}
+        | undefined
+      const hasUpload =
+        !!parent?.uploadedFile &&
+        typeof parent.uploadedFile === 'object' &&
+        (parent.uploadedFile as {asset?: unknown}).asset != null
+      const hasEmbed =
+        typeof parent?.embedUrl === 'string' && parent.embedUrl.length > 0
+      if (hasUpload && hasEmbed) {
+        return 'Upload een bestand of plak een embed-URL — niet allebei.'
+      }
+      if (!hasUpload && !hasEmbed) {
+        return 'Upload een bestand of plak een embed-URL.'
+      }
+      return true
+    }),
   preview: {
     select: {
       originalFilename: 'uploadedFile.asset.originalFilename',
       size: 'uploadedFile.asset.size',
+      embedUrl: 'embedUrl',
     },
-    prepare({originalFilename, size}) {
+    prepare({originalFilename, size, embedUrl}) {
+      if (typeof embedUrl === 'string' && embedUrl.length > 0) {
+        const host = (extractHost(embedUrl) ?? 'embed').replace(/^www\./, '')
+        return {title: embedUrl, subtitle: `Video — embed (${host})`}
+      }
       const title =
         typeof originalFilename === 'string' && originalFilename.length > 0
           ? originalFilename
           : 'Video (geen bestand geüpload)'
       const subtitle =
         typeof size === 'number' && size > 0
-          ? `Video — ${(size / 1024 / 1024).toFixed(1)} MB`
-          : 'Video'
+          ? `Video — upload · ${(size / 1024 / 1024).toFixed(1)} MB`
+          : 'Video — upload'
       return {title, subtitle}
     },
   },


### PR DESCRIPTION
## Summary

Phase 2 of [`article-video-support`](../../../docs/prd/article-video-support.md) (closes #1364). Adds the YouTube/Vimeo link path as an alternative to Phase 1's upload — editors can now paste a link when a full Sanity upload isn't desired (league-provided clip, partner content, etc.).

- **Schema:** new optional `embedUrl` field (`type: url`, https-only, host allowlist on `youtube.com` / `youtu.be` / `vimeo.com` via regex so the React-free schema package stays on the ES2017 lib). Object-level `Rule.custom` enforces exactly-one-of `{uploadedFile, embedUrl}`.
- **Parser:** pure `parseEmbedUrl(url) → { provider, videoId } | null` colocated with the serializer. Handles watch URLs, `youtu.be/…`, `embed/shorts/live/…`, and Vimeo numeric-ID URLs; rejects non-HTTPS, unknown hosts, malformed input, and non-string inputs.
- **Serializer:** embed path renders a privacy-enhanced iframe (`www.youtube-nocookie.com/embed/<id>` or `player.vimeo.com/video/<id>`) in a 16:9 container with `loading="lazy"` and `referrerpolicy="strict-origin-when-cross-origin"`. Unknown-host branch logs a dev `console.warn` and renders a neutral Dutch fallback — **never** interpolates the raw URL into the DOM.
- **Studio preview:** uses the URL hostname when `embedUrl` is set, falls back to filename when it's an upload.
- **Storybook:** four new stories under `Features/Articles/VideoBlock` — `EmbedYoutube`, `EmbedYoutubeShort` (youtu.be + query params), `EmbedVimeo`, `EmbedUnknownProvider`.

## Test plan

- [ ] Studio: paste a YouTube watch URL into a new videoBlock, save — publish succeeds
- [ ] Studio: try to populate both `uploadedFile` and `embedUrl` — block-level validation blocks publish with the Dutch XOR copy
- [ ] Studio: paste `https://dailymotion.com/…` — field-level validation rejects with the allowlist copy
- [ ] Preview: confirm YouTube URL → `youtube-nocookie.com/embed/…` iframe
- [ ] Preview: confirm Vimeo URL → `player.vimeo.com/video/…` iframe
- [ ] Preview: confirm unsupported host → neutral fallback, no iframe, no URL in DOM (open devtools, search for the raw URL in rendered HTML — should not be present)
- [ ] 22 new vitest cases pass (6 VideoBlock embed + 16 parseEmbedUrl) — **2667/2667 total**
- [ ] Storybook builds — 4 new embed stories render
- [ ] `pnpm --filter @kcvv/web check-all` passes

## Out of scope (explicit, per PRD)

Poster image, caption, lazy-load toggle for uploads, fullBleed, size-guard warning — all #1365. Analytics instrumentation (`article_video_play` / `_complete`) — #1366 (blocked by this + #1365).

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)