### PR TITLE
refactor(ui): migrate YouthSection to SectionStack backdrop API (#1350)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -23,6 +23,7 @@ import {
   BannerSlot,
   MatchesSliderSection,
   YouthSection,
+  YouthBackdrop,
   WebshopSection,
   SponsorsSection,
 } from "@/components/home";
@@ -279,17 +280,15 @@ export default async function HomePage() {
         placeholder={matchesSliderPlaceholder}
       />
     ),
-    // The heading's cap-height makes the default pt-20/pb-20 read bottom-tight.
-    // Bump the bottom so the cards don't crash into the diagonal.
-    paddingBottom: "pb-32",
+    transition: { type: "diagonal", direction: "right" },
   };
 
   const youthSection: SectionConfig = {
     key: "youth",
     bg: "kcvv-green-dark",
-    content: <YouthSection prevBg="kcvv-black" nextBg="gray-100" />,
-    paddingTop: "pt-0",
-    paddingBottom: "pb-0",
+    content: <YouthSection />,
+    backdrop: <YouthBackdrop />,
+    transition: { type: "diagonal", direction: "left" },
   };
 
   const bannerSlotCSection: SectionConfig | null = banners.bannerSlotC

--- a/apps/web/src/components/home/Homepage.stories.tsx
+++ b/apps/web/src/components/home/Homepage.stories.tsx
@@ -5,7 +5,7 @@ import type { FeaturedEventStub } from "./NewsGrid";
 import { MatchWidget } from "./MatchWidget";
 import { BannerSlot } from "./BannerSlot";
 import { MatchesSliderSection } from "./MatchesSliderSection";
-import { YouthSection } from "./YouthSection";
+import { YouthSection, YouthBackdrop } from "./YouthSection";
 import { PageFooter } from "@/components/layout/PageFooter";
 import { Sponsors } from "@/components/sponsors/Sponsors";
 import { mockSponsors } from "@/components/sponsors/Sponsors.mocks";
@@ -218,8 +218,7 @@ function buildSections(
       key: "youth",
       bg: "kcvv-green-dark",
       content: <YouthSection />,
-      paddingTop: "pt-0",
-      paddingBottom: "pb-0",
+      backdrop: <YouthBackdrop />,
       transition: { type: "diagonal", direction: "left" },
     },
     {

--- a/apps/web/src/components/home/YouthSection/YouthBackdrop.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthBackdrop.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+
+export const YouthBackdrop = () => (
+  <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
+    <div className="absolute -inset-4">
+      <Image
+        src="/images/youth-trainers.jpg"
+        alt=""
+        fill
+        className="object-cover object-top blur-[2px]"
+        sizes="100vw"
+      />
+    </div>
+    <div
+      className={cn(
+        "absolute inset-0",
+        "from-kcvv-green-dark/90 via-kcvv-green-dark/75 to-kcvv-green-dark/50",
+        "bg-gradient-to-b md:bg-gradient-to-r",
+      )}
+    />
+  </div>
+);

--- a/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { YouthSection } from "./YouthSection";
+import { YouthBackdrop } from "./YouthBackdrop";
 import { SectionStack } from "@/components/design-system/SectionStack/SectionStack";
 
 const meta = {
@@ -16,10 +17,11 @@ export const Default: Story = {
   args: {},
 };
 
-/** Shows the YouthSection sandwiched between sections. Both the top and bottom
- *  diagonals are rendered inside the component so the background image shows
- *  through the transparent triangles. No SectionTransition needed around it. */
-export const WithDiagonalTransitions: Story = {
+/** YouthSection sandwiched between sections — diagonals are owned by `SectionStack`
+ *  via `SectionTransition`. The photographic backdrop bleeds into both diagonal
+ *  bands because `revealFrom` / `revealTo` are auto-propagated from the
+ *  `backdrop` prop. */
+export const Sandwiched: Story = {
   render: () => (
     <SectionStack
       sections={[
@@ -31,13 +33,14 @@ export const WithDiagonalTransitions: Story = {
               Previous section (kcvv-black)
             </div>
           ),
+          transition: { type: "diagonal", direction: "right" },
         },
         {
           key: "youth",
           bg: "kcvv-green-dark",
-          content: <YouthSection prevBg="kcvv-black" nextBg="gray-100" />,
-          paddingTop: "pt-0",
-          paddingBottom: "pb-0",
+          content: <YouthSection />,
+          backdrop: <YouthBackdrop />,
+          transition: { type: "diagonal", direction: "left" },
         },
         {
           key: "after",

--- a/apps/web/src/components/home/YouthSection/YouthSection.test.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.test.tsx
@@ -1,6 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import type { ImageProps } from "next/image";
 import { YouthSection } from "./YouthSection";
+import { YouthBackdrop } from "./YouthBackdrop";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src, ...rest }: ImageProps) => (
+    <img alt={alt} src={typeof src === "string" ? src : ""} {...rest} />
+  ),
+}));
 
 describe("YouthSection", () => {
   it("renders the section label", () => {
@@ -31,9 +39,32 @@ describe("YouthSection", () => {
     expect(link).toHaveAttribute("href", "/jeugd");
   });
 
-  it("does not clip section overflow so background can bleed into diagonal transitions", () => {
+  it("renders no inline SVG diagonals (now owned by SectionTransition via SectionStack)", () => {
     const { container } = render(<YouthSection />);
-    const section = container.querySelector("section");
-    expect(section?.className).not.toContain("overflow-hidden");
+    expect(container.querySelectorAll("svg")).toHaveLength(0);
+  });
+
+  it("does not apply marginTop / paddingBottom positioning hacks (inline or pt-0/pb-0 classes)", () => {
+    const { container } = render(<YouthSection />);
+    const root = container.firstElementChild as HTMLElement | null;
+    expect(root?.style.marginTop).toBe("");
+    expect(root?.style.paddingBottom).toBe("");
+    expect(root?.className).not.toContain("pt-0");
+    expect(root?.className).not.toContain("pb-0");
+  });
+});
+
+describe("YouthBackdrop", () => {
+  it("renders the youth-trainers background image", () => {
+    const { container } = render(<YouthBackdrop />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toContain("youth-trainers");
+  });
+
+  it("marks itself decorative for assistive tech", () => {
+    const { container } = render(<YouthBackdrop />);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute("aria-hidden")).toBe("true");
   });
 });

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -1,152 +1,48 @@
-import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
-import {
-  DIAGONAL_HEIGHT,
-  BG_COLOR,
-  type SectionBg,
-} from "@/components/design-system/SectionTransition";
 
 export interface YouthSectionProps {
   className?: string;
-  /** Background key for the section above (top diagonal). */
-  prevBg?: SectionBg;
-  /** Background key for the section below (bottom diagonal). */
-  nextBg?: SectionBg;
 }
 
-export const YouthSection = ({
-  className,
-  prevBg = "kcvv-black",
-  nextBg = "gray-100",
-}: YouthSectionProps) => {
-  const prevBgColor = BG_COLOR[prevBg];
-  const nextBgColor = BG_COLOR[nextBg];
+export const YouthSection = ({ className }: YouthSectionProps) => (
+  <section className={cn("text-left", className)}>
+    <div className="mx-auto max-w-7xl px-4 md:px-8">
+      <p className="tracking-label mb-6 flex items-center gap-2 text-[11px] font-bold text-white/70 uppercase">
+        <span aria-hidden="true" className="block h-0.5 w-5 bg-white/50" />
+        Jeugdwerking
+      </p>
 
-  return (
-    <section
-      className={cn("bg-kcvv-green-dark relative text-left", className)}
-      style={{
-        marginTop: `calc(-1 * ${DIAGONAL_HEIGHT})`,
-        paddingBottom: DIAGONAL_HEIGHT,
-      }}
-    >
-      {/* Background image — covers the full section including both diagonal
-          areas. The diagonals' transparent triangles let the image show. */}
-      <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
-        <div className="absolute -inset-4">
-          <Image
-            src="/images/youth-trainers.jpg"
-            alt=""
-            fill
-            className="object-cover object-top blur-[2px]"
-            sizes="100vw"
-          />
-        </div>
-        {/* Directional gradient overlay — lets the photo breathe on the right
-            (desktop) or bottom (mobile) while keeping text readable. */}
-        <div
-          className={cn(
-            "absolute inset-0",
-            "from-kcvv-green-dark/90 via-kcvv-green-dark/75 to-kcvv-green-dark/50 bg-gradient-to-b",
-            "md:from-kcvv-green-dark/90 md:via-kcvv-green-dark/75 md:to-kcvv-green-dark/50 md:bg-gradient-to-r",
-          )}
-        />
-      </div>
-
-      {/* Top diagonal — previous section color in the upper-right triangle,
-          transparent lower-left so the image shows through (direction "right"). */}
-      <div
-        className="relative z-20"
-        style={{ height: DIAGONAL_HEIGHT }}
-        aria-hidden="true"
+      <h2
+        className="font-title mb-6 leading-[0.95] font-black text-white uppercase"
+        style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}
       >
-        <svg
-          viewBox="0 0 100 100"
-          preserveAspectRatio="none"
-          className="absolute inset-0 h-full w-full"
-        >
-          <polygon
-            points="0,0 100,0 100,100"
-            fill={prevBgColor}
-            shapeRendering="crispEdges"
-          />
-          <polygon
-            points="0,0 0,100 100,100"
-            fill="transparent"
-            shapeRendering="crispEdges"
-          />
-        </svg>
-      </div>
+        De toekomst
+        <br />
+        van Elewijt
+      </h2>
 
-      {/* Content — left-aligned editorial block */}
-      <div className="relative z-10 mx-auto max-w-7xl px-4 py-16 md:px-8 md:py-24">
-        {/* Section label */}
-        <p className="tracking-label mb-6 flex items-center gap-2 text-[11px] font-bold text-white/70 uppercase">
-          <span aria-hidden="true" className="block h-0.5 w-5 bg-white/50" />
-          Jeugdwerking
-        </p>
+      <p className="mb-6 max-w-lg text-base leading-relaxed text-white/90">
+        Meer dan 220 jonge spelers en 16 ploegen trainen elke week op Sportpark
+        Elewijt. Van de allerkleinsten tot de U21.
+      </p>
 
-        {/* Editorial title */}
-        <h2
-          className="font-title mb-6 leading-[0.95] font-black text-white uppercase"
-          style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}
-        >
-          De toekomst
-          <br />
-          van Elewijt
-        </h2>
+      <p className="mb-8 text-sm font-bold tracking-wider text-white uppercase">
+        220+ spelers · 16 ploegen
+      </p>
 
-        {/* Body text */}
-        <p className="mb-6 max-w-lg text-base leading-relaxed text-white/90">
-          Meer dan 220 jonge spelers en 16 ploegen trainen elke week op
-          Sportpark Elewijt. Van de allerkleinsten tot de U21.
-        </p>
-
-        {/* Stats line */}
-        <p className="mb-8 text-sm font-bold tracking-wider text-white uppercase">
-          220+ spelers · 16 ploegen
-        </p>
-
-        {/* CTA */}
-        <Link
-          href="/jeugd"
-          className="group text-kcvv-black hover:bg-kcvv-green inline-flex items-center gap-2 rounded-sm bg-white px-6 py-3 text-sm font-bold tracking-wider uppercase transition-colors"
-        >
-          Ontdek onze jeugd
-          <span
-            className="inline-block transition-transform group-hover:translate-x-1"
-            aria-hidden="true"
-          >
-            →
-          </span>
-        </Link>
-      </div>
-
-      {/* Bottom diagonal — absolutely positioned in the padding area so it
-          does not push the next section down with a negative margin. */}
-      <div
-        className="absolute inset-x-0 bottom-0 z-20"
-        style={{ height: DIAGONAL_HEIGHT }}
-        aria-hidden="true"
+      <Link
+        href="/jeugd"
+        className="group text-kcvv-black hover:bg-kcvv-green inline-flex items-center gap-2 rounded-sm bg-white px-6 py-3 text-sm font-bold tracking-wider uppercase transition-colors"
       >
-        <svg
-          viewBox="0 0 100 100"
-          preserveAspectRatio="none"
-          className="absolute inset-0 h-full w-full"
+        Ontdek onze jeugd
+        <span
+          className="inline-block transition-transform group-hover:translate-x-1"
+          aria-hidden="true"
         >
-          <polygon
-            points="0,0 100,0 0,100"
-            fill="transparent"
-            shapeRendering="crispEdges"
-          />
-          <polygon
-            points="100,0 100,100 0,100"
-            fill={nextBgColor}
-            shapeRendering="crispEdges"
-          />
-        </svg>
-      </div>
-    </section>
-  );
-};
+          →
+        </span>
+      </Link>
+    </div>
+  </section>
+);

--- a/apps/web/src/components/home/YouthSection/index.ts
+++ b/apps/web/src/components/home/YouthSection/index.ts
@@ -1,2 +1,4 @@
 export { YouthSection } from "./YouthSection";
 export type { YouthSectionProps } from "./YouthSection";
+
+export { YouthBackdrop } from "./YouthBackdrop";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -23,7 +23,7 @@ export type { BannerSlotProps } from "./BannerSlot";
 export { MatchesSliderSection } from "./MatchesSliderSection";
 export type { MatchesSliderSectionProps } from "./MatchesSliderSection";
 
-export { YouthSection } from "./YouthSection";
+export { YouthSection, YouthBackdrop } from "./YouthSection";
 export type { YouthSectionProps } from "./YouthSection";
 
 export { SponsorsSection } from "./SponsorsSection";


### PR DESCRIPTION
Closes #1350

## Summary

Consumer migration that lands on top of #1371. `YouthSection` no longer hand-rolls inline-SVG diagonals or the negative-margin/padding hack — `SectionStack` owns the geometry via the new `backdrop` API and auto-propagates `revealFrom` / `revealTo` onto the surrounding `SectionTransition`s.

## Changes

- `apps/web/src/components/home/YouthSection/YouthSection.tsx` — strip the two inline `<svg>` diagonals, the `marginTop: calc(-1 * DIAGONAL_HEIGHT)` / `paddingBottom: DIAGONAL_HEIGHT` hack, the `prevBg` / `nextBg` props, and the `DIAGONAL_HEIGHT` / `BG_COLOR` imports. `YouthSectionProps` is now `{ className?: string }` only.
- `apps/web/src/components/home/YouthSection/YouthBackdrop.tsx` (new) — co-located presentational layer rendering the blurred image + directional gradient overlay, exported via the `YouthSection` and home barrels.
- `apps/web/src/app/page.tsx` — `matchesSliderSection` gains `transition: { type: "diagonal", direction: "right" }` and drops `paddingBottom: "pb-32"`. `youthSection` gains `backdrop: <YouthBackdrop />` + `transition: { type: "diagonal", direction: "left" }`, and falls back to default `pt-20` / `pb-20` (the prior `pt-0` / `pb-0` was inline-diagonal compensation per PRD §7).
- `apps/web/src/components/home/YouthSection/YouthSection.stories.tsx` — `Sandwiched` story drives the new API: top neighbour declares its own `direction: "right"` transition; the youth entry declares `backdrop: <YouthBackdrop />` and `direction: "left"`. No manual `revealFrom` / `revealTo`.
- `apps/web/src/components/home/Homepage.stories.tsx` — youth entry drops `pt-0` / `pb-0` and adds `backdrop: <YouthBackdrop />` for parity with `page.tsx`.
- `apps/web/src/components/home/YouthSection/YouthSection.test.tsx` — drops the SVG-presence and overflow-hidden asserts, adds `YouthBackdrop` image + `aria-hidden` coverage, locks in the no-positioning-hack rule (inline styles + `pt-0` / `pb-0` classes).

## Acceptance criteria — all met

- [x] Zero `<svg>` in `YouthSection.tsx`.
- [x] No `DIAGONAL_HEIGHT` / `BG_COLOR` imports in `YouthSection.tsx`.
- [x] `YouthSectionProps` is `{ className?: string }`.
- [x] Co-located `YouthBackdrop.tsx` with visual parity (same `-inset-4` overscan, `blur-[2px]`, `object-cover object-top`, identical mobile/desktop gradient — direction utilities deduplicated since the colour stops cascade).
- [x] `page.tsx`: matches-slider transition + youth backdrop + youth transition declared; `pb-32` removed; youth uses default paddings.
- [x] `revealFrom` / `revealTo` are auto-propagated by `SectionStack` — verified, neither flag is set manually.
- [x] Top and bottom boundaries of YouthSection now flow through `SectionTransition` like every other section.
- [x] Stories and tests updated.
- [x] `pnpm --filter @kcvv/web check-all` passes (lint + type-check + 2710 tests + Next build).
- [x] `pnpm --filter @kcvv/web build-storybook` passes.

## Test plan

- [x] `pnpm --filter @kcvv/web check-all` — green
- [x] `pnpm --filter @kcvv/web build-storybook` — green
- [ ] Manual visual check on staging: side-by-side with production for hairline-seam absence at YouthSection ↔ matches-slider and YouthSection ↔ next-section, all viewport widths (desktop, tablet, mobile, retina). Confirm photo + gradient extends through both diagonal bands.
- [ ] If desktop reads tighter than today (mobile +16px / desktop −16px vs. prior `py-16 md:py-24`), follow-up tweak via `youthSection.paddingTop` / `paddingBottom` in `page.tsx` rather than reintroducing inner padding (PRD §3 step 3).

## References

- PRD: `docs/prd/section-backdrop-pattern.md` §7 (consumer-migration AC)
- Primitive: #1371 (now landed on `main`)
- Originating seam: surfaced during PR #1349 / issue #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)