### PR TITLE
chore(deps): adopt @typescript/native-preview (tsgo) as primary type-checker

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,10 @@ Before the final commit on any branch, re-read every plan/doc file touched and v
 
 - **Always add language identifiers to fenced code blocks** in plan/doc/markdown files (e.g. ` ```typescript `, ` ```json `, ` ```bash `, ` ```text `). Bare ` ``` ` blocks fail MD040 and are consistently flagged in code review.
 
+### TypeScript Compiler — Dual-Install (tsgo + tsc)
+
+`@typescript/native-preview` (`tsgo`) is the primary type-checker and runs every workspace's `type-check` script (and `packages/api-contract`'s `build`). Classic `typescript` (`tsc`) stays installed in every workspace because `typescript-eslint`, `knip`, `@sanity/cli` typegen, and Next.js's `next build` all resolve the `typescript` package name and consume its (unstable) compiler API. **Do not remove `typescript` from any workspace.** Revisit this split after TypeScript 7.0 GA (est. July 2026).
+
 ## Issue Tracking
 
 Current work lives in GitHub Issues. Check status: `gh issue list --label in-progress`

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "deploy:staging": "wrangler deploy --env staging",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20260425.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@vitest/coverage-v8": "4.1.5",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,6 +65,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/sanitize-html": "2.16.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@vitejs/plugin-react": "6.0.1",
     "@vitest/coverage-v8": "4.1.5",
     "@vitest/ui": "4.1.5",

--- a/docs/plans/2026-04-24-typescript-7-migration-design.md
+++ b/docs/plans/2026-04-24-typescript-7-migration-design.md
@@ -1,0 +1,111 @@
+# TypeScript 7.0 Beta Migration — Design
+
+**Date:** 2026-04-24
+**Status:** Approved (design phase)
+**Owner:** @climacon
+
+## Problem
+
+TypeScript 7.0 Beta shipped 2026-04-21. Its Go-based compiler (`tsgo`) is ~10× faster than classic `tsc` while preserving TypeScript 6.0 type-checking semantics byte-for-byte. Our monorepo already upgraded to TypeScript 6.0.3 on main (PR #1430), so the 5.x → 6.0 breaking-change cliff is already behind us.
+
+This design covers swapping our type-check pipeline from `tsc` to `tsgo` to get the 10× speedup where it matters (lint-staged, CI, local dev loop) while accepting zero additional risk from the unstable 7.x compiler API.
+
+## Non-Goals
+
+- Migrating to `tsgo` for Next.js's internal `next build` type-check (blocked by Next's typed-routes generation dependency — revisit after 7.0 stable in July 2026).
+- Replacing the classic `typescript` package (needed for `typescript-eslint`, `knip`, Sanity typegen, and Next's internal type-check).
+- Adopting any 7.x-only compiler API features in our own code.
+
+## Current State
+
+| Concern | Status |
+| --- | --- |
+| TS version | `typescript@6.0.3` in all 7 workspaces |
+| `tsconfig.json` hard-error fields | Clean — no `baseUrl`, no `downlevelIteration`, no deprecated `target`/`module`/`moduleResolution` values |
+| Direct compiler-API imports in app code | None (grepped) |
+| Type-check script pattern | `tsc --noEmit` in every workspace |
+| Declaration build | `tsc --build` in `packages/api-contract` (composite + root project refs) |
+| Tooling depending on classic TS | `typescript-eslint` 8.59, `knip` 6.6, `@sanity/cli` typegen |
+
+## Decision
+
+Adopt **Approach #2 (dual-install, tsgo as primary)** with Next's internal type-check left untouched.
+
+- Install `@typescript/native-preview@beta` as a dev dependency.
+- Keep `typescript@6.0.3` installed for tooling.
+- Rewrite every workspace's `type-check` script from `tsc --noEmit` to `tsgo --noEmit`.
+- Rewrite `packages/api-contract`'s `build` script from `tsc --build` to `tsgo --build`.
+- Leave `apps/web/next.config.ts` unchanged; Next continues to run its classic type-check during `next build` (correctness-first for typed routes).
+
+## Rejected Alternatives
+
+### Full swap (uninstall `typescript`, alias `@typescript/native-preview` as `typescript`)
+
+Rejected. `typescript-eslint`, `knip`, Sanity typegen, and Next's build-time type-checker all resolve the `typescript` package name at runtime and consume its compiler API — which is explicitly **not stable until 7.1**, several months after 7.0 stable. Aliasing risks subtle tool breakage with hard-to-diagnose symptoms.
+
+### Dual-install, `tsc` as primary + parallel `tsgo` preflight
+
+Rejected. Users pay install cost of two compilers but only see the 10× in a non-blocking side channel; the blocking path (lint-staged + CI `type-check` job + local `pnpm check-all`) stays on classic `tsc`. All cost, most of the user-visible latency.
+
+### Disable Next's internal type-check + gate with `tsgo --noEmit` on CI only (Option B)
+
+Rejected. Next auto-generates typed-route declarations into `.next/types/**` **during** `next build`. Running `tsgo --noEmit` before build on a clean CI runner produces false negatives (stale/missing generated types) or false positives (missing imports). Correct sequencing requires a double build or an undocumented "types-only" Next step. Fragility isn't worth the Vercel-only speedup.
+
+## Architecture / Pipeline Changes
+
+### Before
+
+```text
+lint-staged  →  eslint + prettier
+CI type-check job  →  turbo run type-check  →  tsc --noEmit (per workspace)
+CI build job      →  turbo run build  →  next build | wrangler deploy | tsc --build
+local check-all  →  lint → type-check (tsc) → test → build
+```
+
+### After
+
+```text
+lint-staged  →  eslint + prettier                        (unchanged)
+CI type-check job  →  turbo run type-check  →  tsgo --noEmit (per workspace)
+CI build job      →  turbo run build  →  next build     (still runs classic tsc internally, by design)
+                                       |  wrangler deploy
+                                       |  tsgo --build   (api-contract declarations)
+local check-all  →  lint → type-check (tsgo) → test → build
+```
+
+### File touch list
+
+- Root `package.json` — add `@typescript/native-preview` as root dev dep (so `tsgo` is on PATH everywhere turbo spawns).
+- Every workspace `package.json` with a `type-check` or `build` script invoking `tsc`: `apps/web`, `apps/api`, `apps/studio`, `apps/studio-staging`, `packages/api-contract`, `packages/sanity-schemas`, `packages/sanity-studio` — rewrite `tsc` → `tsgo` in those scripts only.
+- `turbo.json` — verify cache keys still hash correctly after script change; no structural change expected.
+- `.github/workflows/ci.yml` — no change needed if CI invokes `pnpm type-check` (which delegates to turbo); verify.
+- `packages/api-contract/package.json` — `build: tsgo --build` (composite + project refs are the one area to pressure-test).
+
+## Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| `tsgo --build` mishandles composite/project refs in api-contract | Medium | High (blocks declarations consumed by web + api) | Pressure-test early in implementation plan; fallback is to keep `tsc --build` in this one workspace |
+| Divergent error output between `tsc` and `tsgo` on edge cases | Low | Low | TS 7 type-checking is structurally identical to TS 6.0; run both against a known-clean tree as a diff check |
+| Lint-staged or CI hits a cached `tsc` binary | Low | Low | Explicitly call `tsgo` by name in scripts |
+| `typescript-eslint` parser confusion if both packages present | Very Low | Medium | `typescript-eslint` only resolves the `typescript` package; `@typescript/native-preview` is a separate package name — no conflict |
+| TS 7.0 stable ships a flag change between beta and stable | Medium | Low | Beta-to-stable deltas are typically small; pin to `@beta` tag, revisit at GA |
+
+## Success Criteria
+
+1. All 7 workspace `type-check` scripts pass using `tsgo` with zero warnings or errors.
+2. `packages/api-contract/dist/**` declaration files produced by `tsgo --build` are byte-equivalent (or semantically equivalent) to those produced by `tsc --build`.
+3. `pnpm check-all` in `apps/web` completes in measurably less wall-clock time than on `main`.
+4. CI `type-check` job wall-clock time drops ≥ 5× (10× is the theoretical ceiling; real-world often 5–10× because of workspace overhead).
+5. `next build` on Vercel still succeeds without code or config changes.
+6. No regressions in `eslint`, `knip`, or Sanity typegen.
+
+## Rollback Plan
+
+Single commit revert restores the baseline. The design is intentionally additive-on-top-of-existing (classic `typescript` stays installed), so rollback is `git revert <merge-commit>` + `pnpm install`. No schema, data, or infra changes to undo.
+
+## Follow-Up Work
+
+- After TS 7.0 stable GA (target: late June / early July 2026): re-evaluate whether to disable Next's internal type-check and promote `tsgo` to sole type-checker.
+- Track `@typescript/native-preview` beta release cadence; bump as needed.
+- Track ecosystem milestones: `typescript-eslint` native-7 support, `knip` native-7 support — likely unblock a full swap.

--- a/docs/plans/2026-04-24-typescript-7-migration-timings.md
+++ b/docs/plans/2026-04-24-typescript-7-migration-timings.md
@@ -1,0 +1,40 @@
+# TypeScript 7 Migration — Measured Timings
+
+Wall-clock seconds, all runs on macOS arm64 with pnpm 10.33.2 + Node 24.15. Per-workspace numbers are best-of-3 (cold first run, then 2 warm runs — best taken).
+
+## Per-workspace type-check (vs `tsc --noEmit` 6.0.3 baseline)
+
+| Workspace              | tsc baseline | tsgo (this branch) | Speedup |
+| ---------------------- | -----------: | -----------------: | ------: |
+| `@kcvv/api-contract`   |        2.87s |              0.44s |    6.5× |
+| `@kcvv/sanity-schemas` |        5.30s |              0.56s |    9.4× |
+| `@kcvv/sanity-studio`  |        6.34s |              0.56s |   11.4× |
+| `@kcvv/api`            |        6.63s |              0.86s |    7.7× |
+| `@kcvv/web`            |        8.73s |              1.56s |    5.6× |
+
+## api-contract declaration build (`tsc --build` → `tsgo --build`)
+
+| Run                      | Wall-clock | Speedup |
+| ------------------------ | ---------: | ------: |
+| `tsc --build` (baseline) |      4.31s |       — |
+| `tsgo --build`           |      0.39s |   11.0× |
+
+Output diff: 81 dist files emitted, all `.js` byte-identical, all `.d.ts` semantically equivalent (only alphabetical reordering of union/intersection/literal-union members; same types). 1 `.d.ts.map` differs in `mappings` VLQ as a downstream consequence. `tsconfig.tsbuildinfo` differs (internal build state, not part of public output).
+
+## Root-level (cold turbo cache, parallel)
+
+| Command                  |                                Wall-clock |
+| ------------------------ | ----------------------------------------: |
+| `pnpm type-check` (root) |                                     ~2.4s |
+| `pnpm build` (root)      |          ~38s (dominated by `next build`) |
+| `pnpm lint` (root)       |                                    ~12.6s |
+| `pnpm test` (root)       | ~38s (2672 vitest tests across 213 files) |
+| `pnpm knip`              |                                     ~2.1s |
+
+## Headline
+
+The honest single number is **per-workspace tsgo type-check is 5.6× to 11.4× faster than classic tsc** depending on the workspace. The headline ratio for serial sum-of-baselines (29.87s) vs root parallel cold turbo (~2.4s) is ~12×, but mixes per-package compiler speedup with turbo's parallelism — not directly comparable.
+
+## Tooling unaffected
+
+`pnpm knip` zero new warnings. Classic `typescript@6.0.3` remains installed in every workspace and is consumed by `typescript-eslint`, `knip`, `@sanity/cli` typegen, and Next.js's `next build` internal type-check.

--- a/docs/plans/2026-04-24-typescript-7-migration.md
+++ b/docs/plans/2026-04-24-typescript-7-migration.md
@@ -1,0 +1,476 @@
+# TypeScript 7.0 Beta Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Swap our monorepo's type-check pipeline from classic `tsc` to the Go-based `tsgo` compiler (`@typescript/native-preview@beta`) to cut wall-clock type-check time ~10× on lint-staged, CI, and the local dev loop.
+
+**Architecture:** Dual-install pattern. Keep classic `typescript@6.0.3` installed in every workspace (required by `typescript-eslint`, `knip`, Sanity typegen, Next's internal build-time check). Add `@typescript/native-preview` as a dev dep only in the 5 workspaces whose `type-check`/`build` scripts we are rewriting to call `tsgo`. Leave `apps/web/next.config.ts` untouched so `next build` still runs its classic `tsc` pass for typed-route safety.
+
+**Tech Stack:** Node 22 / pnpm 10.33 / Turborepo 2.9 / TypeScript 6.0.3 / `@typescript/native-preview` (tsgo) / Vitest 4 / Next 16 / Wrangler 4
+
+**Design Reference:** `docs/plans/2026-04-24-typescript-7-migration-design.md`
+
+---
+
+## Ground Rules for Every Task
+
+- Work in the worktree at `/Users/kevinvanransbeeck/Sites/KCVV/kcvv-typescript-7-beta/` on branch `chore/typescript-7-beta`.
+- One workspace per commit. Conventional commit type = `chore`, scope = `deps` (or `config` for CI/turbo touches).
+- After every workspace switch, run that workspace's `type-check` (and `build` where applicable) and paste the exit status + wall-clock into the task completion notes.
+- If `tsgo` produces a different error set than `tsc` on the same tree, STOP and escalate — semantics must match TS 6.0 exactly.
+- Never commit directly to `main`.
+
+---
+
+### Task 0: Baseline timing capture (no code change)
+
+**Why:** We need "before" numbers to validate the 10× claim and to include in the PR body.
+
+**Files:** None.
+
+**Step 0.1: Verify worktree baseline is clean**
+
+```bash
+cd /Users/kevinvanransbeeck/Sites/KCVV/kcvv-typescript-7-beta
+git status
+git log --oneline -3
+```
+
+Expected: working tree clean; HEAD on `chore/typescript-7-beta` with the design-doc commit on top of `526d1e86`.
+
+**Step 0.2: Install baseline dependencies**
+
+```bash
+pnpm install
+```
+
+Expected: "Done" with no errors. (pnpm store is shared so should be near-instant.)
+
+**Step 0.3: Time classic `tsc --noEmit` per workspace**
+
+```bash
+for W in @kcvv/api-contract @kcvv/sanity-schemas @kcvv/sanity-studio @kcvv/api @kcvv/web; do
+  echo "=== $W ==="
+  time pnpm --filter "$W" type-check
+done
+```
+
+Record each wall-clock time. Paste the block into the PR scratchpad (`docs/plans/2026-04-24-typescript-7-migration-timings.md` — created at Task 9).
+
+**Step 0.4: Time `tsc --build` for api-contract**
+
+```bash
+rm -rf packages/api-contract/dist packages/api-contract/tsconfig.tsbuildinfo
+time pnpm --filter @kcvv/api-contract build
+ls packages/api-contract/dist | head
+```
+
+Record timing. Capture the file list — we'll diff it against the `tsgo --build` output in Task 2.
+
+**Step 0.5: Snapshot the classic dist for diff**
+
+```bash
+cp -r packages/api-contract/dist /tmp/api-contract-dist-tsc
+```
+
+No commit.
+
+---
+
+### Task 1: Install `@typescript/native-preview` and verify `tsgo` binary
+
+**Files:**
+- Modify: `apps/web/package.json` (devDependencies)
+- Modify: `apps/api/package.json` (devDependencies)
+- Modify: `packages/api-contract/package.json` (devDependencies)
+- Modify: `packages/sanity-schemas/package.json` (devDependencies)
+- Modify: `packages/sanity-studio/package.json` (devDependencies)
+- Modify: `pnpm-lock.yaml` (auto)
+
+**Step 1.1: Add the beta package to each target workspace**
+
+```bash
+pnpm --filter @kcvv/api-contract add -D @typescript/native-preview@beta
+pnpm --filter @kcvv/sanity-schemas add -D @typescript/native-preview@beta
+pnpm --filter @kcvv/sanity-studio add -D @typescript/native-preview@beta
+pnpm --filter @kcvv/api add -D @typescript/native-preview@beta
+pnpm --filter @kcvv/web add -D @typescript/native-preview@beta
+```
+
+Expected: each `package.json` now shows a pinned version (e.g. `"@typescript/native-preview": "7.0.0-beta.N"`).
+
+**Step 1.2: Verify the `tsgo` binary resolves in every target workspace**
+
+```bash
+for W in @kcvv/api-contract @kcvv/sanity-schemas @kcvv/sanity-studio @kcvv/api @kcvv/web; do
+  echo "=== $W ==="
+  pnpm --filter "$W" exec tsgo --version
+done
+```
+
+Expected: prints a `7.0.0-beta.*` version in every workspace. If any workspace prints "command not found", pnpm did not hoist the bin — add `@typescript/native-preview` to that workspace's `devDependencies` explicitly and re-run.
+
+**Step 1.3: Verify classic `typescript` is still resolvable**
+
+```bash
+pnpm --filter @kcvv/web exec tsc --version
+```
+
+Expected: `Version 6.0.3`. (Dual-install sanity check.)
+
+**Step 1.4: Commit**
+
+```bash
+git add apps/web/package.json apps/api/package.json packages/api-contract/package.json packages/sanity-schemas/package.json packages/sanity-studio/package.json pnpm-lock.yaml
+git commit -m "chore(deps): add @typescript/native-preview (tsgo) beta
+
+Installs the Go-based TypeScript compiler alongside classic tsc.
+No scripts switched yet — this commit is additive.
+"
+```
+
+---
+
+### Task 2: Switch `packages/api-contract` (composite + project-refs pressure test)
+
+**Why first:** This is the only workspace using `tsc --build` and the only one exercising composite project references. If `tsgo --build` breaks here, the entire plan needs reconsidering.
+
+**Files:**
+- Modify: `packages/api-contract/package.json:11-17` (scripts block)
+
+**Step 2.1: Rewrite the scripts**
+
+In `packages/api-contract/package.json`, change the `scripts` block to:
+
+```json
+"scripts": {
+  "type-check": "tsgo --noEmit",
+  "build": "tsgo --build",
+  "test": "vitest run",
+  "test:watch": "vitest"
+}
+```
+
+**Step 2.2: Run type-check**
+
+```bash
+cd /Users/kevinvanransbeeck/Sites/KCVV/kcvv-typescript-7-beta
+time pnpm --filter @kcvv/api-contract type-check
+```
+
+Expected: exit 0, no diagnostics. Record wall-clock.
+
+**Step 2.3: Clean + run build, diff against baseline**
+
+```bash
+rm -rf packages/api-contract/dist packages/api-contract/tsconfig.tsbuildinfo
+time pnpm --filter @kcvv/api-contract build
+diff -r /tmp/api-contract-dist-tsc packages/api-contract/dist
+```
+
+Expected: `diff` prints nothing, OR only whitespace/sourcemap `file` field differences (acceptable). Record wall-clock.
+
+**If the diff shows declaration-content differences:** STOP. This would mean tsgo emits different `.d.ts` than tsc — a regression consumers would notice. Escalate.
+
+**Step 2.4: Sanity-check the consumers still type-check against the new dist**
+
+```bash
+time pnpm --filter @kcvv/web type-check  # still on tsc in this task
+time pnpm --filter @kcvv/api type-check  # still on tsc in this task
+```
+
+Expected: both exit 0.
+
+**Step 2.5: Commit**
+
+```bash
+git add packages/api-contract/package.json
+git commit -m "chore(deps): switch api-contract type-check + build to tsgo
+
+Composite project references and declaration emit verified byte-equivalent
+to tsc --build (see docs/plans/2026-04-24-typescript-7-migration-timings.md).
+"
+```
+
+---
+
+### Task 3: Switch `packages/sanity-schemas`
+
+**Files:**
+- Modify: `packages/sanity-schemas/package.json:12-15` (scripts block, `type-check` + `build`)
+
+**Step 3.1: Rewrite**
+
+```json
+"scripts": {
+  "type-check": "tsgo --noEmit",
+  "build": "tsgo --noEmit"
+}
+```
+
+(Keeps the existing `build = type-check` aliasing — Turbo task has `"outputs": []` so no artifact drift.)
+
+**Step 3.2: Verify**
+
+```bash
+time pnpm --filter @kcvv/sanity-schemas type-check
+time pnpm --filter @kcvv/sanity-schemas build
+```
+
+Expected: both exit 0. Record wall-clock.
+
+**Step 3.3: Commit**
+
+```bash
+git add packages/sanity-schemas/package.json
+git commit -m "chore(deps): switch sanity-schemas type-check to tsgo"
+```
+
+---
+
+### Task 4: Switch `packages/sanity-studio`
+
+**Files:**
+- Modify: `packages/sanity-studio/package.json:17` (`type-check` line)
+
+**Step 4.1: Rewrite**
+
+Change `"type-check": "tsc --noEmit"` → `"type-check": "tsgo --noEmit"`. The `build` script delegates via `pnpm type-check` (unchanged).
+
+**Step 4.2: Verify**
+
+```bash
+time pnpm --filter @kcvv/sanity-studio type-check
+time pnpm --filter @kcvv/sanity-studio build
+time pnpm --filter @kcvv/sanity-studio check-all
+```
+
+Expected: each exits 0. Record wall-clock.
+
+**Step 4.3: Commit**
+
+```bash
+git add packages/sanity-studio/package.json
+git commit -m "chore(deps): switch sanity-studio type-check to tsgo"
+```
+
+---
+
+### Task 5: Switch `apps/api`
+
+**Files:**
+- Modify: `apps/api/package.json:10` (`type-check` line)
+
+**Step 5.1: Rewrite**
+
+Change `"type-check": "tsc --noEmit"` → `"type-check": "tsgo --noEmit"`.
+
+**Step 5.2: Verify**
+
+```bash
+time pnpm --filter @kcvv/api type-check
+time pnpm --filter @kcvv/api test
+```
+
+Expected: both exit 0. Record wall-clock.
+
+**Step 5.3: Commit**
+
+```bash
+git add apps/api/package.json
+git commit -m "chore(deps): switch api type-check to tsgo"
+```
+
+---
+
+### Task 6: Switch `apps/web` (the big one — includes `.next/types/**` includes)
+
+**Files:**
+- Modify: `apps/web/package.json:11` (`type-check` line)
+
+**Step 6.1: Prime Next's generated types**
+
+`apps/web/tsconfig.json` `include`s `.next/types/**/*.ts` and `.next/dev/types/**/*.ts`. On a fresh worktree these do not exist yet — tsgo will complain about missing typed-route imports. Prime them once:
+
+```bash
+cd /Users/kevinvanransbeeck/Sites/KCVV/kcvv-typescript-7-beta
+pnpm --filter @kcvv/web exec next build  # generates .next/types
+```
+
+Expected: `next build` succeeds. (Slow — this is the one-time priming cost.)
+
+**Step 6.2: Rewrite the script**
+
+Change `"type-check": "tsc --noEmit"` → `"type-check": "tsgo --noEmit"`.
+
+**Step 6.3: Verify**
+
+```bash
+time pnpm --filter @kcvv/web type-check
+```
+
+Expected: exit 0. Record wall-clock. If tsgo reports typed-route errors that `tsc` did not, the `.next/types` priming is stale — rerun `next build` and retry. If errors persist, STOP and escalate — this is the documented Next.js interaction we chose not to work around.
+
+**Step 6.4: Run the full check-all chain**
+
+```bash
+time pnpm --filter @kcvv/web check-all
+```
+
+Expected: lint → type-check → test → build all pass. This is the canonical pre-PR verification.
+
+**Step 6.5: Commit**
+
+```bash
+git add apps/web/package.json
+git commit -m "chore(deps): switch web type-check to tsgo
+
+Next.js keeps its internal tsc pass during next build — tsgo runs as
+the standalone type-check gate. .next/types/** is primed by next build
+before tsgo runs (as it already is in CI and on Vercel).
+"
+```
+
+---
+
+### Task 7: Full-monorepo verification
+
+**Files:** None.
+
+**Step 7.1: Root `type-check`**
+
+```bash
+time pnpm type-check
+```
+
+Expected: all 5 workspaces exit 0. Record wall-clock.
+
+**Step 7.2: Root `build`**
+
+```bash
+time pnpm build
+```
+
+Expected: all workspaces build. Record wall-clock.
+
+**Step 7.3: Lint + tests**
+
+```bash
+pnpm lint
+pnpm test
+```
+
+Expected: both green.
+
+**Step 7.4: Knip sanity check (compiler-API tool)**
+
+```bash
+pnpm knip 2>&1 | tail -20
+```
+
+Expected: exits 0 or with the same warnings it had on main (no *new* unresolved imports).
+
+No commit — data only.
+
+---
+
+### Task 8: Update `.claude/CLAUDE.md`
+
+**Why:** The in-repo rule says "CLAUDE.md Is a Required Deliverable" when the architecture description changes. The type-check toolchain is exactly that.
+
+**Files:**
+- Modify: `.claude/CLAUDE.md` (add a short note under "Development Guidelines")
+
+**Step 8.1: Add this block under "Development Guidelines"**
+
+````markdown
+### TypeScript Compiler — Dual-Install (tsgo + tsc)
+
+`@typescript/native-preview` (`tsgo`) is the primary type-checker and runs every `type-check` and `apps/api-contract` `build` script. Classic `typescript` (`tsc`) stays installed because `typescript-eslint`, `knip`, `@sanity/cli` typegen, and Next.js's `next build` all resolve the `typescript` package name and consume its (unstable) compiler API. Do not remove `typescript` from any workspace. Revisit this split after TypeScript 7.0 GA (est. July 2026).
+````
+
+**Step 8.2: Commit**
+
+```bash
+git add .claude/CLAUDE.md
+git commit -m "docs(config): document tsgo + tsc dual-install in CLAUDE.md"
+```
+
+---
+
+### Task 9: Timings scratchpad + PR
+
+**Files:**
+- Create: `docs/plans/2026-04-24-typescript-7-migration-timings.md`
+
+**Step 9.1: Record timings**
+
+Fill in the table from data collected in Tasks 0 and 2–7:
+
+```markdown
+# TS 7 Migration — Measured Timings
+
+| Command | Classic tsc (baseline) | tsgo (this branch) | Speedup |
+| --- | --- | --- | --- |
+| pnpm --filter @kcvv/api-contract type-check | <0.3> | <0.3> | |
+| pnpm --filter @kcvv/api-contract build      | <0.4> | <2.3> | |
+| pnpm --filter @kcvv/sanity-schemas type-check | ... | ... | |
+| pnpm --filter @kcvv/sanity-studio type-check  | ... | ... | |
+| pnpm --filter @kcvv/api type-check           | ... | ... | |
+| pnpm --filter @kcvv/web type-check           | ... | ... | |
+| pnpm --filter @kcvv/web check-all            | ... | ... | |
+| pnpm type-check (root)                       | ... | ... | |
+```
+
+**Step 9.2: Commit**
+
+```bash
+git add docs/plans/2026-04-24-typescript-7-migration-timings.md
+git commit -m "docs(deps): record tsgo vs tsc timings"
+```
+
+**Step 9.3: Push + open PR**
+
+```bash
+git push -u origin chore/typescript-7-beta
+gh pr create --title "chore(deps): adopt @typescript/native-preview (tsgo) as primary type-checker" --body "$(cat <<'EOF'
+## Summary
+- Swaps every workspace's `type-check` script (and `packages/api-contract`'s `build`) from classic `tsc` to `tsgo` (Go-based, ~10× faster).
+- Keeps classic `typescript@6.0.3` installed in every workspace — `typescript-eslint`, `knip`, Sanity typegen, and Next's internal `next build` all depend on the `typescript` package name.
+- Next.js's internal type-check during `next build` intentionally stays on classic `tsc` until TypeScript 7.0 GA (est. July 2026) — typed-route generation into `.next/types/**` makes a pre-build `tsgo` gate fragile.
+
+## Design doc
+`docs/plans/2026-04-24-typescript-7-migration-design.md`
+
+## Timings
+See `docs/plans/2026-04-24-typescript-7-migration-timings.md`.
+
+## Test plan
+- [ ] `pnpm type-check` exits 0
+- [ ] `pnpm build` exits 0
+- [ ] `pnpm lint` exits 0
+- [ ] `pnpm test` exits 0
+- [ ] `pnpm --filter @kcvv/web check-all` exits 0
+- [ ] Vercel preview deployment succeeds
+- [ ] CI `type-check` jobs for web, api, studio all green
+- [ ] `pnpm knip` shows no *new* unresolved-import warnings vs main
+
+## Rollback
+`git revert` the merge commit + `pnpm install`. No schema/data/infra changes.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Return it to the user.
+
+---
+
+## Done definition
+
+- [ ] All 10 tasks committed on branch `chore/typescript-7-beta`.
+- [ ] Root `pnpm type-check`, `pnpm build`, `pnpm lint`, `pnpm test` all pass.
+- [ ] Timings table shows measurable speedup on the main paths.
+- [ ] PR opened against `main`, CI green.
+- [ ] `.claude/CLAUDE.md` updated.

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -10,8 +10,8 @@
     }
   },
   "scripts": {
-    "type-check": "tsc --noEmit",
-    "build": "tsc --build",
+    "type-check": "tsgo --noEmit",
+    "build": "tsgo --build",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -20,6 +20,7 @@
     "effect": "3.21.2"
   },
   "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   }

--- a/packages/sanity-schemas/package.json
+++ b/packages/sanity-schemas/package.json
@@ -10,8 +10,8 @@
     }
   },
   "scripts": {
-    "type-check": "tsc --noEmit",
-    "build": "tsc --noEmit"
+    "type-check": "tsgo --noEmit",
+    "build": "tsgo --noEmit"
   },
   "peerDependencies": {
     "@sanity/icons": "3.7.4",

--- a/packages/sanity-schemas/package.json
+++ b/packages/sanity-schemas/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@sanity/icons": "3.7.4",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "sanity": "5.22.0",
     "typescript": "6.0.3"
   }

--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -36,6 +36,7 @@
     "@sanity/ui": "3.1.14",
     "@testing-library/react": "16.3.2",
     "@types/react": "19.2.14",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@vitejs/plugin-react": "6.0.1",
     "eslint": "9.39.4",
     "happy-dom": "20.9.0",

--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "type-check": "tsc --noEmit",
+    "type-check": "tsgo --noEmit",
     "build": "pnpm type-check",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 4.20260425.1
         version: 4.20260425.1
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       '@vitest/coverage-v8':
         specifier: 4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -270,6 +273,9 @@ importers:
       '@types/sanitize-html':
         specifier: 2.16.1
         version: 2.16.1
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -331,6 +337,9 @@ importers:
         specifier: 3.21.2
         version: 3.21.2
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -343,6 +352,9 @@ importers:
       '@sanity/icons':
         specifier: 3.7.4
         version: 3.7.4(react@19.2.5)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       sanity:
         specifier: 5.22.0
         version: 5.22.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.1(@noble/hashes@2.2.0)(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(ts-toolbelt@9.6.0)(typescript@6.0.3)
@@ -371,6 +383,9 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       '@vitejs/plugin-react':
         specifier: 6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -4027,6 +4042,45 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.0':
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+    hasBin: true
 
   '@uiw/codemirror-extensions-basic-setup@4.25.9':
     resolution: {integrity: sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==}
@@ -12205,6 +12259,37 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
+
   '@uiw/codemirror-extensions-basic-setup@4.25.9(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.5)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/view@6.41.1)':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -13431,7 +13516,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -13464,7 +13549,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13478,7 +13563,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

- Swaps every workspace's `type-check` script (and `packages/api-contract`'s `build`) from classic `tsc` to `tsgo` (Go-based, ~5–11× faster per workspace).
- Keeps classic `typescript@6.0.3` installed in every workspace — `typescript-eslint`, `knip`, Sanity typegen, and Next.js's `next build` all depend on the `typescript` package name and consume its (still-unstable in 7.x) compiler API.
- Next.js's internal type-check during `next build` intentionally stays on classic `tsc` until TypeScript 7.0 GA (est. July 2026) — typed-route generation into `.next/types/**` makes a pre-build `tsgo` gate fragile.
- `.claude/CLAUDE.md` updated so future Claude sessions don't try to remove the classic `typescript` package.

## Measured speedups (best-of-3, wall-clock)

| Workspace | tsc baseline | tsgo (this branch) | Speedup |
| --- | ---: | ---: | ---: |
| `@kcvv/api-contract` type-check | 2.87s | 0.44s | 6.5× |
| `@kcvv/api-contract` build (`tsc --build`) | 4.31s | 0.39s | 11.0× |
| `@kcvv/sanity-schemas` type-check | 5.30s | 0.56s | 9.4× |
| `@kcvv/sanity-studio` type-check | 6.34s | 0.56s | 11.4× |
| `@kcvv/api` type-check | 6.63s | 0.86s | 7.7× |
| `@kcvv/web` type-check | 8.73s | 1.56s | 5.6× |

## Design + plan

- Design: `docs/plans/2026-04-24-typescript-7-migration-design.md`
- Plan: `docs/plans/2026-04-24-typescript-7-migration.md`
- Timings: `docs/plans/2026-04-24-typescript-7-migration-timings.md`

## api-contract declaration-emit equivalence

`tsc --build` and `tsgo --build` produce 81 dist files. All `.js` files byte-identical. All `.d.ts` files semantically equivalent — the only differences are alphabetical reordering of union/intersection/literal-union members, which TypeScript treats as identical types (`A | B ≡ B | A`). Verified by running `apps/api` type-check against the new dist (passes).

## Test plan

- [x] `pnpm type-check` exits 0 (cold turbo: ~5.4s)
- [x] `pnpm build` exits 0 (~50.7s, includes `next build` of 225 static pages)
- [x] `pnpm lint` exits 0 (~11.2s)
- [x] `pnpm test` exits 0 (2672 vitest tests across 213 files)
- [x] `pnpm --filter @kcvv/web check-all` exits 0 locally
- [x] `pnpm knip` shows no new unresolved-import warnings
- [ ] CI `type-check` jobs for web, api, studio all green
- [ ] Vercel preview deployment succeeds (Next's internal `tsc` pass still runs during `next build`)

## Rollback

Single revert. Dual-install pattern means the classic `typescript` toolchain was never removed — `git revert` of the merge commit + `pnpm install` restores baseline. No schema/data/infra changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)