### PR TITLE
chore(news): cross-template polish for article-detail-redesign (#1361)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -415,13 +415,13 @@
 }
 
 
-/* ===== Article body — announcement / transfer templates (#1330) =====
+/* ===== Article body — announcement / interview / transfer / event templates =====
 
-   Scoped to `.article-body` so the Sanity Studio `.prose` previews and the
-   interview template (qaBlock-only body) remain untouched. The class is
-   applied to the `SanityArticleBody` wrapper from the announcement /
-   transfer templates only — see AnnouncementTemplate for the attachment
-   point. */
+   Scoped to `.article-body` so the Sanity Studio `.prose` previews remain
+   untouched. The class is applied to the `SanityArticleBody` wrapper from
+   every article template — see each `*Template` for the attachment point.
+   Originally introduced for announcement/transfer in #1330; extended to
+   interview + event as part of the cross-template polish pass in #1361. */
 
 /* §7.3 — Drop-cap on the first paragraph. Floated Quasimoda 700 glyph at
    5.5rem, ~4 lines tall, `kcvv-green-bright`. */

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
@@ -1,8 +1,8 @@
 import type { PortableTextBlock } from "@portabletext/react";
 import { ArticleMetadata } from "../ArticleMetadata";
-import { AnnouncementHero } from "../AnnouncementHero";
 import { ArticleBodyMotion } from "../ArticleBodyMotion";
 import { SanityArticleBody } from "../SanityArticleBody/SanityArticleBody";
+import { AnnouncementHero } from "../AnnouncementHero";
 
 export interface AnnouncementTemplateProps {
   title: string;
@@ -20,11 +20,6 @@ export interface AnnouncementTemplateProps {
   /** Article type (for analytics param `article_type`). */
   articleType?: string | null;
 }
-
-// Announcements are implicitly club-authored until we wire an editor field
-// in a follow-up phase (see PRD #1330 open questions). The metadata bar
-// defaults to the club banner.
-const AUTHOR = "KCVV Elewijt";
 
 /**
  * Phase 4 (#1330) — the default article template.
@@ -70,7 +65,6 @@ export const AnnouncementTemplate = ({
       />
 
       <ArticleMetadata
-        author={AUTHOR}
         date={publishedDate}
         readingTime={readingTime}
         shareConfig={shareConfig}

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
@@ -73,4 +73,20 @@ describe("ArticleMetadata", () => {
     );
     expect(container.querySelector("nav")).toHaveClass("custom-metadata");
   });
+
+  it("falls back to the club default author when none is supplied", () => {
+    // The four article templates all render the same implicit club author
+    // until an editor-authored byline field lands. Defaulting inside
+    // ArticleMetadata removes per-template `const AUTHOR = "KCVV Elewijt"`
+    // duplication. See #1361 cross-template polish.
+    render(
+      <ArticleMetadata
+        date="19.04.2026"
+        readingTime="6 min lezen"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+      />,
+    );
+    const nav = screen.getByRole("navigation", { name: "Artikelinfo" });
+    expect(nav).toHaveTextContent("KCVV Elewijt");
+  });
 });

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
@@ -6,8 +6,13 @@ import { cn } from "@/lib/utils/cn";
 import { useArticleAnalytics } from "@/hooks/useArticleAnalytics";
 
 export interface ArticleMetadataProps {
-  /** Article author name (e.g. "Redactie KCVV"). */
-  author: string;
+  /**
+   * Article author name (e.g. "Redactie KCVV"). Defaults to the club
+   * banner `"KCVV Elewijt"` — every article template renders this implicit
+   * club author until an editor-authored byline field lands. Pass
+   * explicitly to override (e.g. ghost-written articles).
+   */
+  author?: string;
   /** Publication date formatted for display (e.g. "19.04.2026"). */
   date?: string;
   /** Reading time, e.g. "4 min lezen". Optional — omitted when empty. */
@@ -32,6 +37,8 @@ export interface ArticleMetadataProps {
 
 const FACEBOOK_SHARER = "https://www.facebook.com/sharer/sharer.php?u=";
 
+const DEFAULT_AUTHOR = "KCVV Elewijt";
+
 /**
  * Design §7.6 — article metadata bar. Single row with 1px `kcvv-gray-light`
  * rules above and below. Left cluster: date · author · reading time, mono
@@ -43,7 +50,7 @@ const FACEBOOK_SHARER = "https://www.facebook.com/sharer/sharer.php?u=";
  * Instagram is not a URL-share target either, so the cluster stays at Share2 + Facebook.
  */
 export const ArticleMetadata = ({
-  author,
+  author = DEFAULT_AUTHOR,
   date,
   readingTime,
   shareConfig,

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
@@ -24,11 +24,6 @@ export interface EventTemplateProps {
   articleType?: string | null;
 }
 
-// Event articles are implicitly club-authored — same pattern the other
-// templates use. The §7.6 metadata bar is the single source of truth for
-// author + date + reading time.
-const AUTHOR = "KCVV Elewijt";
-
 const isEventFact = (
   block: PortableTextBlock,
 ): block is PortableTextBlock & EventFactValue =>
@@ -86,7 +81,6 @@ export const EventTemplate = ({
       />
 
       <ArticleMetadata
-        author={AUTHOR}
         date={publishedDate}
         readingTime={readingTime}
         shareConfig={shareConfig}

--- a/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.test.tsx
+++ b/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { PortableTextBlock } from "@portabletext/react";
+import { InterviewTemplate } from "./InterviewTemplate";
+import type { IndexedSubject } from "@/components/article/SubjectAttribution";
+
+// IntersectionObserver is reached for by `ArticleBodyMotion`. happy-dom does
+// not implement it — stub a minimal no-op so rendering does not throw.
+class NoopIntersectionObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root: Element | Document | null = null;
+  rootMargin = "";
+  thresholds: ReadonlyArray<number> = [];
+  constructor() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IntersectionObserver", NoopIntersectionObserver);
+  vi.stubGlobal("matchMedia", (q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const MAXIM: IndexedSubject = {
+  _key: "maxim-k",
+  kind: "player",
+  playerRef: {
+    firstName: "Maxim",
+    lastName: "Breugelmans",
+    jerseyNumber: 9,
+    position: "Middenvelder",
+    transparentImageUrl: null,
+    psdImageUrl: "https://example.com/maxim.jpg",
+  },
+};
+
+const intro = (key: string, text: string): PortableTextBlock =>
+  ({
+    _type: "block",
+    _key: key,
+    style: "normal",
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, marks: [], text }],
+  }) as unknown as PortableTextBlock;
+
+const simpleBody: PortableTextBlock[] = [
+  intro("p1", "Een korte inleiding boven het eerste qaBlock."),
+];
+
+describe("InterviewTemplate", () => {
+  it("renders the interview hero with the title and a subject-driven subtitle", () => {
+    render(
+      <InterviewTemplate
+        title="Drive, passie, doorzettingsvermogen"
+        publishedDate="19.04.2026"
+        readingTime="6 min lezen"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        subjects={[MAXIM]}
+        body={simpleBody}
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Drive, passie, doorzettingsvermogen",
+    );
+    expect(screen.getByTestId("interview-hero-subtitle")).toHaveTextContent(
+      "Maxim Breugelmans",
+    );
+  });
+
+  it("renders the body inside an .article-body container so the §7.3/§7.4 scoped styles apply, with first <p> as a direct child for the drop-cap selector", () => {
+    const { container } = render(
+      <InterviewTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        subjects={[MAXIM]}
+        body={simpleBody}
+      />,
+    );
+
+    const articleBody = container.querySelector(".article-body");
+    expect(articleBody).not.toBeNull();
+    // §7.3 drop-cap rule targets `.article-body > p:first-of-type::first-letter`,
+    // so when an interview opens with a prose intro the <p> must be a direct
+    // child. Mirrors the AnnouncementTemplate guard against a future
+    // SanityArticleBody refactor inserting an intermediate wrapper.
+    expect(
+      articleBody!.querySelector(":scope > p:first-of-type"),
+    ).not.toBeNull();
+  });
+
+  it("wraps the body in ArticleBodyMotion so descendant <p>/<h2>/<h3> gain the fade-up base class", () => {
+    const { container } = render(
+      <InterviewTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        subjects={[MAXIM]}
+        body={simpleBody}
+      />,
+    );
+
+    // ArticleBodyMotion's useEffect tags every <p>, <h2>, <h3> beneath the
+    // wrapper with `article-body-motion`. Without the wrapper, no element
+    // gains the class — so a non-zero count proves the wrapper is wired
+    // around the body.
+    const motionEls = container.querySelectorAll(".article-body-motion");
+    expect(motionEls.length).toBeGreaterThan(0);
+  });
+
+  it("renders nothing for the body when body is null or empty", () => {
+    const { container, rerender } = render(
+      <InterviewTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        subjects={[MAXIM]}
+        body={null}
+      />,
+    );
+    expect(container.querySelector(".article-body")).toBeNull();
+
+    rerender(
+      <InterviewTemplate
+        title="Title"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        subjects={[MAXIM]}
+        body={[]}
+      />,
+    );
+    expect(container.querySelector(".article-body")).toBeNull();
+  });
+
+  it("renders the metadata bar with the publication date and reading time", () => {
+    render(
+      <InterviewTemplate
+        title="Title"
+        publishedDate="19.04.2026"
+        readingTime="6 min lezen"
+        shareConfig={{ url: "https://kcvvelewijt.be/nieuws/test" }}
+        subjects={[MAXIM]}
+        body={simpleBody}
+      />,
+    );
+    const metadata = screen.getByRole("navigation", { name: /artikelinfo/i });
+    expect(metadata).toHaveTextContent("19.04.2026");
+    expect(metadata).toHaveTextContent("6 min lezen");
+    // Implicit club-author default supplied by ArticleMetadata — guards the
+    // dedupe of the per-template `const AUTHOR = "KCVV Elewijt"` (#1361).
+    expect(metadata).toHaveTextContent("KCVV Elewijt");
+  });
+});

--- a/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
+++ b/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
@@ -1,5 +1,6 @@
 import type { PortableTextBlock } from "@portabletext/react";
 import { ArticleMetadata } from "../ArticleMetadata";
+import { ArticleBodyMotion } from "../ArticleBodyMotion";
 import { InterviewHero } from "../InterviewHero";
 import { SanityArticleBody } from "../SanityArticleBody/SanityArticleBody";
 import type { IndexedSubject } from "@/components/article/SubjectAttribution";
@@ -25,19 +26,23 @@ export interface InterviewTemplateProps {
   articleType?: string | null;
 }
 
-// Byline — Phase 4 (#1330) may wire this to an editor-authored field when
-// ghost-written articles are introduced. For interviews the club is the
-// implicit author.
-const AUTHOR = "KCVV Elewijt";
-
 /**
  * Phase 3 (#1329): full interview template.
  * - `InterviewHero` — subject-driven kicker, subtitle (full name), title
  *   `clamp(2rem,4.5vw,3.5rem)`, 4:5 portrait crop of the cover image.
  * - `ArticleMetadata` — design §7.6 (mono small-caps facts + Share2 +
  *   Facebook share icons).
- * - `SanityArticleBody` — body with subject threaded down so the
- *   `key`/`quote` qaBlock pairs can render attribution + photo.
+ * - `ArticleBodyMotion` wrapping `SanityArticleBody` inside an
+ *   `.article-body` container — same scope the announcement / transfer /
+ *   event templates use. Design §7.4 blockquote rework and §7.5 fade-up
+ *   motion apply uniformly; §7.3 drop-cap only triggers when the body
+ *   leads with a prose `<p>` (interviews that open with a `qaBlock`
+ *   skip the drop-cap by selector design — `.article-body > p:first-of-type`
+ *   has no match). Q&A pair `<p>` and answer paragraphs gain the
+ *   staggered fade-up reveal as they cross the viewport. Wired in #1361
+ *   as part of the cross-template polish pass. Subjects are threaded
+ *   down so the `key`/`quote` qaBlock pairs can render attribution +
+ *   photo.
  */
 export const InterviewTemplate = ({
   title,
@@ -50,6 +55,8 @@ export const InterviewTemplate = ({
   articleId,
   articleType,
 }: InterviewTemplateProps) => {
+  const hasBody = Array.isArray(body) && body.length > 0;
+
   return (
     <>
       <InterviewHero
@@ -59,7 +66,6 @@ export const InterviewTemplate = ({
       />
 
       <ArticleMetadata
-        author={AUTHOR}
         date={publishedDate}
         readingTime={readingTime}
         shareConfig={shareConfig}
@@ -68,11 +74,17 @@ export const InterviewTemplate = ({
         className="mt-10"
       />
 
-      <div className="max-w-inner-lg mx-auto mb-6 w-full px-6 lg:mb-10">
-        {Array.isArray(body) && body.length > 0 && (
-          <SanityArticleBody content={body} subjects={subjects} />
-        )}
-      </div>
+      {hasBody && (
+        <div className="max-w-inner-lg mx-auto mb-6 w-full px-6 lg:mb-10">
+          <ArticleBodyMotion>
+            <SanityArticleBody
+              className="article-body"
+              content={body}
+              subjects={subjects}
+            />
+          </ArticleBodyMotion>
+        </div>
+      )}
     </>
   );
 };

--- a/apps/web/src/components/article/TransferTemplate/TransferTemplate.tsx
+++ b/apps/web/src/components/article/TransferTemplate/TransferTemplate.tsx
@@ -28,10 +28,6 @@ export interface TransferTemplateProps {
   articleType?: string | null;
 }
 
-// Transfer articles are implicitly club-authored — same pattern the
-// announcement + interview templates use.
-const AUTHOR = "KCVV Elewijt";
-
 const isTransferFact = (
   block: PortableTextBlock,
 ): block is PortableTextBlock & TransferFactValue =>
@@ -88,7 +84,6 @@ export const TransferTemplate = ({
       />
 
       <ArticleMetadata
-        author={AUTHOR}
         date={publishedDate}
         readingTime={readingTime}
         shareConfig={shareConfig}


### PR DESCRIPTION
Closes #1361.

## Changes

- **InterviewTemplate gains the `<ArticleBodyMotion>` wrapper + `className="article-body"`** — interview was the only template missing both. Design §7.4 blockquote rework and §7.5 fade-up motion now apply uniformly across all four templates. Q&A pair `<p>` and answer paragraphs participate in the staggered scroll reveal as the issue body called out (_"Q&A blocks and pull-quotes staggered into view reads very well"_).
- **Default the implicit club author `"KCVV Elewijt"` inside `<ArticleMetadata>`** and remove the duplicated `const AUTHOR` from each of the four templates. Per AC #1: prefer extracting shared values into a shared sub-component over per-template duplication. The `author` prop becomes optional with a documented default; existing explicit callers (Storybook stories, isolation tests) continue to work unchanged.
- **Add `InterviewTemplate.test.tsx`** (none existed before — only stories) covering: hero + subject-driven subtitle render, `.article-body` scope present with first `<p>` as a direct child (drop-cap selector guard, mirroring `AnnouncementTemplate.test.tsx`), `<ArticleBodyMotion>` wired (verified via the `article-body-motion` class added by `useEffect`), body section collapses on null/empty body, metadata bar renders date + reading time + implicit author.
- **Add `ArticleMetadata` default-author test.**
- **Reorder `AnnouncementTemplate` imports** to match the canonical order shared by Interview / Transfer / Event (`ArticleMetadata → ArticleBodyMotion → SanityArticleBody → Hero`).
- **Refresh the `.article-body` `globals.css` block-comment header** to reflect that all four templates now use the scope (previous comment said the interview template was intentionally untouched).

## Cross-template audit findings

| Aspect | Status |
|---|---|
| Outer hero `<header>` container | identical across all four (modulo Tailwind class order — Prettier-managed) |
| Body container `max-w-inner-lg mx-auto mb-6 w-full px-6 lg:mb-10` | identical |
| `<ArticleMetadata className="mt-10" />` placement | identical |
| `ArticleBodyMotion` wrapper | now present on all four (was missing on interview) |
| `.article-body` scope on body | now present on all four (was missing on interview) |
| `AUTHOR` constant | dedupe → default in `<ArticleMetadata>` |
| Interview h1 size `clamp(2rem,4.5vw,3.5rem)` | intentionally smaller per #1358 design — left alone |
| Per-hero composition (16:9 vs 4:5 vs portrait+facts) | intentionally per template — left alone |

## Testing

- `pnpm --filter @kcvv/web check-all` — lint + type-check + 304 article-related tests + production build all green
- New `InterviewTemplate.test.tsx` — 5 tests, all green
- `ArticleMetadata.test.tsx` — added default-author test, 8 tests total, all green

## Manual visual check requested

The new `<ArticleBodyMotion>` wrapper around interview body means the inner `<p>` of `QaPairQuote` (cream-band pull-quote) now also receives the §7.5 fade-up motion in addition to QaPairQuote's own glyph scale-in. Both have similar 0.15 IntersectionObserver thresholds and ~500–700 ms easings. The issue text predicted this would read well — please verify on the staging interview page (e.g. `/nieuws/<recent-interview-slug>`) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)