### PR TITLE
feat(news): videoBlock analytics — play + complete events with dedup (#1366)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -58,6 +58,7 @@ interface ArticlePageProps {
 interface RenderTemplateArgs {
   articleType: string | null | undefined;
   articleId: string;
+  articleSlug: string;
   title: string;
   category?: string;
   coverImageUrl?: string;
@@ -84,6 +85,7 @@ function renderTemplate(args: RenderTemplateArgs) {
           subjects={args.subjects}
           articleId={args.articleId}
           articleType={args.articleType}
+          articleSlug={args.articleSlug}
         />
       );
     case "transfer":
@@ -97,6 +99,7 @@ function renderTemplate(args: RenderTemplateArgs) {
           body={args.body}
           articleId={args.articleId}
           articleType={args.articleType}
+          articleSlug={args.articleSlug}
         />
       );
     case "event":
@@ -110,6 +113,7 @@ function renderTemplate(args: RenderTemplateArgs) {
           body={args.body}
           articleId={args.articleId}
           articleType={args.articleType}
+          articleSlug={args.articleSlug}
         />
       );
     // Missing or unknown articleType falls through to announcement —
@@ -126,6 +130,7 @@ function renderTemplate(args: RenderTemplateArgs) {
           body={args.body}
           articleId={args.articleId}
           articleType={args.articleType}
+          articleSlug={args.articleSlug}
         />
       );
   }
@@ -308,6 +313,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
       {renderTemplate({
         articleType: article.articleType,
         articleId: article.id,
+        articleSlug: article.slug,
         title: article.title,
         category: primaryCategory?.name,
         // Pass both projections separately — each template picks the

--- a/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
+++ b/apps/web/src/components/article/AnnouncementTemplate/AnnouncementTemplate.tsx
@@ -19,6 +19,8 @@ export interface AnnouncementTemplateProps {
   articleId?: string;
   /** Article type (for analytics param `article_type`). */
   articleType?: string | null;
+  /** Article slug — threaded to `SanityArticleBody` so embedded `videoBlock`s carry `article_slug` in their analytics events (#1366). */
+  articleSlug?: string;
 }
 
 /**
@@ -52,6 +54,7 @@ export const AnnouncementTemplate = ({
   body,
   articleId,
   articleType,
+  articleSlug,
 }: AnnouncementTemplateProps) => {
   const hasBody = Array.isArray(body) && body.length > 0;
 
@@ -76,7 +79,11 @@ export const AnnouncementTemplate = ({
       {hasBody && (
         <div className="max-w-inner-lg mx-auto mb-6 w-full px-6 lg:mb-10">
           <ArticleBodyMotion>
-            <SanityArticleBody className="article-body" content={body} />
+            <SanityArticleBody
+              className="article-body"
+              content={body}
+              articleSlug={articleSlug}
+            />
           </ArticleBodyMotion>
         </div>
       )}

--- a/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
+++ b/apps/web/src/components/article/EventTemplate/EventTemplate.tsx
@@ -22,6 +22,8 @@ export interface EventTemplateProps {
   articleId?: string;
   /** Article type (for analytics param `article_type`). */
   articleType?: string | null;
+  /** Article slug — threaded to `SanityArticleBody` so embedded `videoBlock`s carry `article_slug` in their analytics events (#1366). */
+  articleSlug?: string;
 }
 
 const isEventFact = (
@@ -59,6 +61,7 @@ export const EventTemplate = ({
   body,
   articleId,
   articleType,
+  articleSlug,
 }: EventTemplateProps) => {
   const hasBody = Array.isArray(body) && body.length > 0;
   const firstEventFact: EventFactValue | undefined = hasBody
@@ -99,6 +102,7 @@ export const EventTemplate = ({
             <SanityArticleBody
               className="article-body"
               content={bodyWithoutFeature}
+              articleSlug={articleSlug}
             />
           </ArticleBodyMotion>
         </div>

--- a/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
+++ b/apps/web/src/components/article/InterviewTemplate/InterviewTemplate.tsx
@@ -24,6 +24,8 @@ export interface InterviewTemplateProps {
   articleId?: string;
   /** Article type (for analytics param `article_type`). */
   articleType?: string | null;
+  /** Article slug — threaded to `SanityArticleBody` so embedded `videoBlock`s carry `article_slug` in their analytics events (#1366). */
+  articleSlug?: string;
 }
 
 /**
@@ -54,6 +56,7 @@ export const InterviewTemplate = ({
   subjects = null,
   articleId,
   articleType,
+  articleSlug,
 }: InterviewTemplateProps) => {
   const hasBody = Array.isArray(body) && body.length > 0;
 
@@ -81,6 +84,7 @@ export const InterviewTemplate = ({
               className="article-body"
               content={body}
               subjects={subjects}
+              articleSlug={articleSlug}
             />
           </ArticleBodyMotion>
         </div>

--- a/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
+++ b/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
@@ -175,13 +175,40 @@ export interface SanityArticleBodyProps {
    * interview articles pass `null`.
    */
   subjects?: IndexedSubject[] | null;
+  /**
+   * Article slug — threaded into `videoBlock` so the Phase 4 (#1366)
+   * `article_video_play` / `article_video_complete` analytics events can
+   * carry `article_slug`. Omit on non-article surfaces (staff bio, club
+   * page); video analytics is suppressed in that case.
+   */
+  articleSlug?: string;
 }
 
 export const SanityArticleBody = ({
   content,
   className,
   subjects = null,
+  articleSlug,
 }: SanityArticleBodyProps) => {
+  // Pre-compute the 1-indexed position of every videoBlock in the body so
+  // `article_video_play` can carry `video_position`. The map is keyed on
+  // the PortableText `_key` (stable per Sanity block) — we can't rely on
+  // serializer call order because PortableText's renderer doesn't expose
+  // an index parameter.
+  const videoBlockPositions = useMemo(() => {
+    const map = new Map<string, number>();
+    let i = 0;
+    for (const block of content) {
+      if (
+        block._type === "videoBlock" &&
+        typeof block._key === "string" &&
+        block._key.length > 0
+      ) {
+        map.set(block._key, ++i);
+      }
+    }
+    return map;
+  }, [content]);
   // Rebuild the components map whenever `subjects` changes so per-block
   // renderers see the current article state without reaching for a
   // context provider.
@@ -224,8 +251,20 @@ export const SanityArticleBody = ({
           // block and renders as a dark-band overview row.
           <EventFactOverview value={value} />
         ),
-        videoBlock: ({ value }: { value: VideoBlockValue }) => (
-          <VideoBlock value={value} />
+        videoBlock: ({
+          value,
+        }: {
+          value: VideoBlockValue & { _key?: string };
+        }) => (
+          <VideoBlock
+            value={value}
+            articleSlug={articleSlug}
+            videoPosition={
+              typeof value._key === "string"
+                ? videoBlockPositions.get(value._key)
+                : undefined
+            }
+          />
         ),
       },
       block: {
@@ -276,7 +315,7 @@ export const SanityArticleBody = ({
         },
       },
     }),
-    [subjects],
+    [subjects, articleSlug, videoBlockPositions],
   );
 
   return (

--- a/apps/web/src/components/article/TransferTemplate/TransferTemplate.tsx
+++ b/apps/web/src/components/article/TransferTemplate/TransferTemplate.tsx
@@ -26,6 +26,8 @@ export interface TransferTemplateProps {
   articleId?: string;
   /** Article type (for analytics param `article_type`). */
   articleType?: string | null;
+  /** Article slug — threaded to `SanityArticleBody` so embedded `videoBlock`s carry `article_slug` in their analytics events (#1366). */
+  articleSlug?: string;
 }
 
 const isTransferFact = (
@@ -60,6 +62,7 @@ export const TransferTemplate = ({
   body,
   articleId,
   articleType,
+  articleSlug,
 }: TransferTemplateProps) => {
   const hasBody = Array.isArray(body) && body.length > 0;
   const firstTransferFact: TransferFactValue | undefined = hasBody
@@ -100,6 +103,7 @@ export const TransferTemplate = ({
             <SanityArticleBody
               className="article-body"
               content={bodyWithoutFeature}
+              articleSlug={articleSlug}
             />
           </ArticleBodyMotion>
         </div>

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.test.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.test.tsx
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
 import { VideoBlock, type VideoBlockValue } from "./VideoBlock";
+
+const mockTrackEvent = vi.mocked(trackEvent);
 
 const withAsset = (
   overrides: Partial<NonNullable<VideoBlockValue["videoAsset"]>> = {},
@@ -273,5 +281,160 @@ describe("VideoBlock — Phase 3 polish (#1365)", () => {
     const figure = screen.getByTestId("video-block");
     expect(figure.className).toContain("full-bleed");
     expect(figure.className).toContain("rounded-none");
+  });
+});
+
+describe("VideoBlock — analytics (#1366 Phase 4)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upload path: fires `article_video_play` once on the first play event", () => {
+    render(
+      <VideoBlock
+        value={withAsset()}
+        articleSlug="kcvv-vs-boechout"
+        videoPosition={1}
+      />,
+    );
+    const video = screen.getByTestId("video-block-video");
+    fireEvent.play(video);
+    expect(mockTrackEvent).toHaveBeenCalledWith("article_video_play", {
+      article_slug: "kcvv-vs-boechout",
+      video_source: "upload",
+      video_provider: "native",
+      video_position: 1,
+    });
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("upload path: dedups multiple `play` events to a single `article_video_play`", () => {
+    render(
+      <VideoBlock
+        value={withAsset()}
+        articleSlug="highlights"
+        videoPosition={2}
+      />,
+    );
+    const video = screen.getByTestId("video-block-video");
+    fireEvent.play(video);
+    fireEvent.play(video);
+    fireEvent.play(video);
+    const playCalls = mockTrackEvent.mock.calls.filter(
+      ([name]) => name === "article_video_play",
+    );
+    expect(playCalls).toHaveLength(1);
+  });
+
+  it("upload path: fires `article_video_complete` on the `ended` event", () => {
+    render(
+      <VideoBlock
+        value={withAsset()}
+        articleSlug="highlights"
+        videoPosition={1}
+      />,
+    );
+    const video = screen.getByTestId("video-block-video");
+    fireEvent.ended(video);
+    expect(mockTrackEvent).toHaveBeenCalledWith("article_video_complete", {
+      article_slug: "highlights",
+      video_source: "upload",
+      video_provider: "native",
+      video_position: 1,
+    });
+  });
+
+  it("does NOT fire any analytics when articleSlug is missing (non-article context, e.g. staff bio)", () => {
+    render(<VideoBlock value={withAsset()} videoPosition={1} />);
+    const video = screen.getByTestId("video-block-video");
+    fireEvent.play(video);
+    fireEvent.ended(video);
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire any analytics when videoPosition is missing", () => {
+    render(<VideoBlock value={withAsset()} articleSlug="some-article" />);
+    const video = screen.getByTestId("video-block-video");
+    fireEvent.play(video);
+    fireEvent.ended(video);
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it("embed path (YouTube): fires `article_video_play` once when the iframe receives focus", async () => {
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        }}
+        articleSlug="trainer-interview"
+        videoPosition={3}
+      />,
+    );
+    const iframe = screen.getByTestId("video-block-iframe");
+    // Simulate the user clicking the iframe: parent window blurs and the
+    // iframe becomes the active element. This is the documented heuristic
+    // for detecting embed engagement without provider postMessage wiring.
+    iframe.focus();
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith("article_video_play", {
+      article_slug: "trainer-interview",
+      video_source: "embed",
+      video_provider: "youtube",
+      video_position: 3,
+    });
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("embed path: dedups multiple iframe-focus + blur cycles to one `article_video_play`", async () => {
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        }}
+        articleSlug="trainer-interview"
+        videoPosition={3}
+      />,
+    );
+    const iframe = screen.getByTestId("video-block-iframe");
+    iframe.focus();
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    iframe.focus();
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    iframe.focus();
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    const playCalls = mockTrackEvent.mock.calls.filter(
+      ([name]) => name === "article_video_play",
+    );
+    expect(playCalls).toHaveLength(1);
+  });
+
+  it("embed path: window blur with a different active element does NOT fire", async () => {
+    render(
+      <VideoBlock
+        value={{
+          _type: "videoBlock",
+          embedUrl: "https://vimeo.com/123456789",
+        }}
+        articleSlug="highlights"
+        videoPosition={1}
+      />,
+    );
+    // No iframe focus — simulate generic window blur (e.g. user tabbing
+    // away from the browser). The heuristic must only fire when the iframe
+    // is the active element.
+    await act(async () => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.test.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.test.tsx
@@ -344,6 +344,35 @@ describe("VideoBlock — analytics (#1366 Phase 4)", () => {
     });
   });
 
+  it("upload path: each `ended` event fires `article_video_complete` (no dedup)", () => {
+    // Pins the asymmetric design: `trackVideoPlay` dedups (one play per page
+    // view), `trackVideoComplete` does not (each natural completion / replay
+    // is a real, separate event).
+    render(
+      <VideoBlock
+        value={withAsset()}
+        articleSlug="highlights"
+        videoPosition={1}
+      />,
+    );
+    const video = screen.getByTestId("video-block-video");
+    fireEvent.ended(video);
+    fireEvent.ended(video);
+    fireEvent.ended(video);
+    const completeCalls = mockTrackEvent.mock.calls.filter(
+      ([name]) => name === "article_video_complete",
+    );
+    expect(completeCalls).toHaveLength(3);
+    for (const call of completeCalls) {
+      expect(call[1]).toEqual({
+        article_slug: "highlights",
+        video_source: "upload",
+        video_provider: "native",
+        video_position: 1,
+      });
+    }
+  });
+
   it("does NOT fire any analytics when articleSlug is missing (non-article context, e.g. staff bio)", () => {
     render(<VideoBlock value={withAsset()} videoPosition={1} />);
     const video = screen.getByTestId("video-block-video");

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils/cn";
 import { useVideoAnalytics } from "@/hooks/useVideoAnalytics";
 import { parseEmbedUrl, type VideoProvider } from "./parseEmbedUrl";
@@ -80,7 +80,10 @@ export function VideoBlock({
   articleSlug,
   videoPosition,
 }: VideoBlockProps) {
-  const analyticsContext = resolveAnalyticsContext(articleSlug, videoPosition);
+  const analyticsContext = useMemo(
+    () => resolveAnalyticsContext(articleSlug, videoPosition),
+    [articleSlug, videoPosition],
+  );
   const embed =
     typeof value.embedUrl === "string" && value.embedUrl.length > 0
       ? value.embedUrl

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
@@ -1,4 +1,6 @@
+import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils/cn";
+import { useVideoAnalytics } from "@/hooks/useVideoAnalytics";
 import { parseEmbedUrl, type VideoProvider } from "./parseEmbedUrl";
 
 export interface VideoBlockValue {
@@ -18,6 +20,29 @@ export interface VideoBlockValue {
 export interface VideoBlockProps {
   value: VideoBlockValue;
   className?: string;
+  /**
+   * Article slug for `article_video_play` / `article_video_complete`
+   * analytics events. Omit on non-article surfaces (staff bio, club page)
+   * — analytics is suppressed when either `articleSlug` or `videoPosition`
+   * is missing.
+   */
+  articleSlug?: string;
+  /** 1-indexed position of this block within the article body. */
+  videoPosition?: number;
+}
+
+interface AnalyticsContext {
+  articleSlug: string;
+  videoPosition: number;
+}
+
+function resolveAnalyticsContext(
+  articleSlug: string | undefined,
+  videoPosition: number | undefined,
+): AnalyticsContext | null {
+  if (typeof articleSlug !== "string" || articleSlug.length === 0) return null;
+  if (typeof videoPosition !== "number" || videoPosition <= 0) return null;
+  return { articleSlug, videoPosition };
 }
 
 /**
@@ -31,6 +56,14 @@ export interface VideoBlockProps {
  *  - `fullBleed` opt-in that drops the rounded corners and breaks out
  *    of the prose column via `.full-bleed` (mirrors `articleImage`)
  *
+ * Phase 4 (#1366) wires `article_video_play` / `article_video_complete`
+ * analytics. The upload path binds `onPlay` / `onEnded` directly. The
+ * embed path uses a `window` blur + `document.activeElement === iframe`
+ * heuristic — the standard fallback when provider postMessage APIs
+ * (`YT.Player`, Vimeo Player SDK) are out of scope. Both paths require an
+ * `articleSlug` + `videoPosition`; non-article surfaces (staff bio, club
+ * page) omit them and emit no events.
+ *
  * Exactly one of `videoAsset` / `embedUrl` is ever populated (enforced
  * by the Sanity XOR validator) — `embedUrl` takes precedence if both
  * happened to arrive somehow, since an explicit editor-authored link is
@@ -41,13 +74,20 @@ export interface VideoBlockProps {
  * render a neutral DOM fallback — never inject a raw URL into an
  * iframe/src attribute.
  */
-export function VideoBlock({ value, className }: VideoBlockProps) {
+export function VideoBlock({
+  value,
+  className,
+  articleSlug,
+  videoPosition,
+}: VideoBlockProps) {
+  const analyticsContext = resolveAnalyticsContext(articleSlug, videoPosition);
   const embed =
     typeof value.embedUrl === "string" && value.embedUrl.length > 0
       ? value.embedUrl
       : null;
-  if (embed !== null) return renderEmbed(value, embed, className);
-  return renderUpload(value, className);
+  if (embed !== null)
+    return renderEmbed(value, embed, className, analyticsContext);
+  return renderUpload(value, className, analyticsContext);
 }
 
 // ─── Shared figure helpers ──────────────────────────────────────────────
@@ -91,7 +131,11 @@ function VideoCaption({ caption }: { caption: string }) {
 
 // ─── Upload path ────────────────────────────────────────────────────────
 
-function renderUpload(value: VideoBlockValue, className: string | undefined) {
+function renderUpload(
+  value: VideoBlockValue,
+  className: string | undefined,
+  analyticsContext: AnalyticsContext | null,
+) {
   const src = value.videoAsset?.url;
   if (typeof src !== "string" || src.length === 0) return null;
   const mimeType = value.videoAsset?.mimeType ?? undefined;
@@ -107,22 +151,65 @@ function renderUpload(value: VideoBlockValue, className: string | undefined) {
       data-testid="video-block"
       data-source="upload"
     >
-      <video
-        controls
-        // Phase 3: poster is the only thing the browser fetches until
-        // the reader actually presses play. preload="none" + a poster
-        // image keeps the article weight tiny on first paint.
-        preload="none"
-        poster={posterUrl}
-        className="aspect-video h-auto w-full"
-        data-testid="video-block-video"
-      >
-        <source src={src} type={mimeType ?? "video/mp4"} />
-        Je browser ondersteunt geen HTML5-video. Download het bestand via de
-        link.
-      </video>
+      <UploadVideo
+        src={src}
+        mimeType={mimeType}
+        posterUrl={posterUrl}
+        analyticsContext={analyticsContext}
+      />
       {caption !== null && <VideoCaption caption={caption} />}
     </figure>
+  );
+}
+
+interface UploadVideoProps {
+  src: string;
+  mimeType: string | undefined;
+  posterUrl: string | undefined;
+  analyticsContext: AnalyticsContext | null;
+}
+
+function UploadVideo({
+  src,
+  mimeType,
+  posterUrl,
+  analyticsContext,
+}: UploadVideoProps) {
+  const { trackVideoPlay, trackVideoComplete } = useVideoAnalytics();
+  const handlePlay = useCallback(() => {
+    if (analyticsContext === null) return;
+    trackVideoPlay({
+      articleSlug: analyticsContext.articleSlug,
+      videoSource: "upload",
+      videoProvider: "native",
+      videoPosition: analyticsContext.videoPosition,
+    });
+  }, [analyticsContext, trackVideoPlay]);
+  const handleEnded = useCallback(() => {
+    if (analyticsContext === null) return;
+    trackVideoComplete({
+      articleSlug: analyticsContext.articleSlug,
+      videoSource: "upload",
+      videoProvider: "native",
+      videoPosition: analyticsContext.videoPosition,
+    });
+  }, [analyticsContext, trackVideoComplete]);
+  return (
+    <video
+      controls
+      // Phase 3: poster is the only thing the browser fetches until
+      // the reader actually presses play. preload="none" + a poster
+      // image keeps the article weight tiny on first paint.
+      preload="none"
+      poster={posterUrl}
+      className="aspect-video h-auto w-full"
+      data-testid="video-block-video"
+      onPlay={handlePlay}
+      onEnded={handleEnded}
+    >
+      <source src={src} type={mimeType ?? "video/mp4"} />
+      Je browser ondersteunt geen HTML5-video. Download het bestand via de link.
+    </video>
   );
 }
 
@@ -160,6 +247,7 @@ function renderEmbed(
   value: VideoBlockValue,
   url: string,
   className: string | undefined,
+  analyticsContext: AnalyticsContext | null,
 ) {
   const fullBleed = value.fullBleed === true;
   const caption = trimmedCaption(value);
@@ -203,18 +291,71 @@ function renderEmbed(
           iframe covers the full box. allow="…" enables in-frame
           fullscreen + picture-in-picture on providers that support it. */}
       <div className="relative aspect-video w-full">
-        <iframe
+        <EmbedIframe
           src={src}
           title={embedTitle(parsed.provider)}
-          loading="lazy"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          allowFullScreen
-          referrerPolicy="strict-origin-when-cross-origin"
-          className="absolute inset-0 h-full w-full border-0"
-          data-testid="video-block-iframe"
+          provider={parsed.provider}
+          analyticsContext={analyticsContext}
         />
       </div>
       {caption !== null && <VideoCaption caption={caption} />}
     </figure>
+  );
+}
+
+interface EmbedIframeProps {
+  src: string;
+  title: string;
+  provider: VideoProvider;
+  analyticsContext: AnalyticsContext | null;
+}
+
+function EmbedIframe({
+  src,
+  title,
+  provider,
+  analyticsContext,
+}: EmbedIframeProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const { trackVideoPlay } = useVideoAnalytics();
+
+  useEffect(() => {
+    if (analyticsContext === null) return;
+    const handleBlur = () => {
+      // Standard heuristic for detecting embed-iframe interaction without
+      // provider postMessage wiring: clicking the iframe blurs the parent
+      // window and makes the iframe the active element. The hook's own
+      // dedup ref guarantees we still fire `article_video_play` exactly
+      // once even if the user clicks the iframe several times.
+      if (
+        iframeRef.current !== null &&
+        document.activeElement === iframeRef.current
+      ) {
+        trackVideoPlay({
+          articleSlug: analyticsContext.articleSlug,
+          videoSource: "embed",
+          videoProvider: provider,
+          videoPosition: analyticsContext.videoPosition,
+        });
+      }
+    };
+    window.addEventListener("blur", handleBlur);
+    return () => {
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, [analyticsContext, provider, trackVideoPlay]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={src}
+      title={title}
+      loading="lazy"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowFullScreen
+      referrerPolicy="strict-origin-when-cross-origin"
+      className="absolute inset-0 h-full w-full border-0"
+      data-testid="video-block-iframe"
+    />
   );
 }

--- a/apps/web/src/hooks/useVideoAnalytics.test.ts
+++ b/apps/web/src/hooks/useVideoAnalytics.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+import { useVideoAnalytics } from "./useVideoAnalytics";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+describe("useVideoAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("article_video_play", () => {
+    it("fires with article_slug, video_source=upload, video_provider=native, video_position", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoPlay({
+          articleSlug: "kcvv-vs-boechout",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith("article_video_play", {
+        article_slug: "kcvv-vs-boechout",
+        video_source: "upload",
+        video_provider: "native",
+        video_position: 1,
+      });
+    });
+
+    it("fires with video_source=embed, video_provider=youtube for embedded YouTube videos", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoPlay({
+          articleSlug: "trainer-interview",
+          videoSource: "embed",
+          videoProvider: "youtube",
+          videoPosition: 2,
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith("article_video_play", {
+        article_slug: "trainer-interview",
+        video_source: "embed",
+        video_provider: "youtube",
+        video_position: 2,
+      });
+    });
+
+    it("fires with video_source=embed, video_provider=vimeo for embedded Vimeo videos", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoPlay({
+          articleSlug: "highlights",
+          videoSource: "embed",
+          videoProvider: "vimeo",
+          videoPosition: 1,
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith("article_video_play", {
+        article_slug: "highlights",
+        video_source: "embed",
+        video_provider: "vimeo",
+        video_position: 1,
+      });
+    });
+
+    it("emits no IDs and no filenames in the event payload (PII guard)", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoPlay({
+          articleSlug: "highlights",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+      });
+
+      const [, params] = mockTrackEvent.mock.calls[0] ?? [];
+      const keys = Object.keys(params ?? {});
+      expect(keys).toEqual(
+        expect.arrayContaining([
+          "article_slug",
+          "video_source",
+          "video_provider",
+          "video_position",
+        ]),
+      );
+      // No raw IDs, hashed IDs, filenames, or other identifiers leak into
+      // the wire payload — slug is the only article-level identifier.
+      expect(keys).not.toContain("article_id");
+      expect(keys).not.toContain("article_id_hashed");
+      expect(keys).not.toContain("video_id");
+      expect(keys).not.toContain("video_filename");
+      expect(keys).not.toContain("file_name");
+      expect(keys).not.toContain("original_filename");
+    });
+
+    it("dedup guard: multiple play calls fire trackEvent exactly once", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoPlay({
+          articleSlug: "kcvv-vs-boechout",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+        result.current.trackVideoPlay({
+          articleSlug: "kcvv-vs-boechout",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+        result.current.trackVideoPlay({
+          articleSlug: "kcvv-vs-boechout",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "article_video_play",
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("article_video_complete", () => {
+    it("fires with the same parameter shape as play (upload path only by design)", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoComplete({
+          articleSlug: "kcvv-vs-boechout",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith("article_video_complete", {
+        article_slug: "kcvv-vs-boechout",
+        video_source: "upload",
+        video_provider: "native",
+        video_position: 1,
+      });
+    });
+
+    it("complete is not blocked by the play dedup guard (independent counters)", () => {
+      const { result } = renderHook(() => useVideoAnalytics());
+
+      act(() => {
+        result.current.trackVideoPlay({
+          articleSlug: "highlights",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+        result.current.trackVideoPlay({
+          articleSlug: "highlights",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+        result.current.trackVideoComplete({
+          articleSlug: "highlights",
+          videoSource: "upload",
+          videoProvider: "native",
+          videoPosition: 1,
+        });
+      });
+
+      // 1 play (deduped from 2) + 1 complete = 2 total
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        1,
+        "article_video_play",
+        expect.any(Object),
+      );
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        2,
+        "article_video_complete",
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/apps/web/src/hooks/useVideoAnalytics.test.ts
+++ b/apps/web/src/hooks/useVideoAnalytics.test.ts
@@ -108,7 +108,11 @@ describe("useVideoAnalytics", () => {
       expect(keys).not.toContain("original_filename");
     });
 
-    it("dedup guard: multiple play calls fire trackEvent exactly once", () => {
+    it("dedup guard: multiple play calls fire trackEvent once with the FIRST call's payload", () => {
+      // Distinct payloads per call so the assertion verifies that the
+      // dedup guard preserves the *first* call's params — catches a
+      // hypothetical regression where a later call could overwrite the
+      // captured payload before emit.
       const { result } = renderHook(() => useVideoAnalytics());
 
       act(() => {
@@ -119,24 +123,26 @@ describe("useVideoAnalytics", () => {
           videoPosition: 1,
         });
         result.current.trackVideoPlay({
-          articleSlug: "kcvv-vs-boechout",
-          videoSource: "upload",
-          videoProvider: "native",
-          videoPosition: 1,
+          articleSlug: "trainer-interview",
+          videoSource: "embed",
+          videoProvider: "youtube",
+          videoPosition: 2,
         });
         result.current.trackVideoPlay({
-          articleSlug: "kcvv-vs-boechout",
-          videoSource: "upload",
-          videoProvider: "native",
-          videoPosition: 1,
+          articleSlug: "highlights",
+          videoSource: "embed",
+          videoProvider: "vimeo",
+          videoPosition: 3,
         });
       });
 
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-      expect(mockTrackEvent).toHaveBeenCalledWith(
-        "article_video_play",
-        expect.any(Object),
-      );
+      expect(mockTrackEvent).toHaveBeenCalledWith("article_video_play", {
+        article_slug: "kcvv-vs-boechout",
+        video_source: "upload",
+        video_provider: "native",
+        video_position: 1,
+      });
     });
   });
 

--- a/apps/web/src/hooks/useVideoAnalytics.ts
+++ b/apps/web/src/hooks/useVideoAnalytics.ts
@@ -1,0 +1,70 @@
+import { useCallback, useRef } from "react";
+import { trackEvent } from "@/lib/analytics/track-event";
+
+export type VideoSource = "upload" | "embed";
+export type VideoProvider = "native" | "youtube" | "vimeo";
+
+interface VideoEventInput {
+  articleSlug: string;
+  videoSource: VideoSource;
+  videoProvider: VideoProvider;
+  /** 1-indexed position of this `videoBlock` within the article body. */
+  videoPosition: number;
+}
+
+/**
+ * Per-instance analytics for a single `<VideoBlock>`. Each VideoBlock owns
+ * its own hook instance, so the play dedup ref guarantees one
+ * `article_video_play` per video per page view — covering both the upload
+ * `play` event and the embed iframe-focus heuristic.
+ *
+ * The privacy contract is the same as the rest of the analytics surface:
+ * only the `article_slug` identifies the article. No raw or hashed Sanity
+ * `_id`s, no filenames, no asset URLs in the payload.
+ *
+ * `article_video_complete` is emitted on the upload `ended` event only.
+ * Provider iframes (YouTube/Vimeo) do not expose an end-of-playback signal
+ * without postMessage wiring (`YT.Player`, Vimeo Player SDK), which is
+ * explicitly out of scope per `docs/prd/article-video-support.md` §4.
+ */
+export function useVideoAnalytics() {
+  const playFiredRef = useRef(false);
+
+  const trackVideoPlay = useCallback(
+    ({
+      articleSlug,
+      videoSource,
+      videoProvider,
+      videoPosition,
+    }: VideoEventInput) => {
+      if (playFiredRef.current) return;
+      playFiredRef.current = true;
+      trackEvent("article_video_play", {
+        article_slug: articleSlug,
+        video_source: videoSource,
+        video_provider: videoProvider,
+        video_position: videoPosition,
+      });
+    },
+    [],
+  );
+
+  const trackVideoComplete = useCallback(
+    ({
+      articleSlug,
+      videoSource,
+      videoProvider,
+      videoPosition,
+    }: VideoEventInput) => {
+      trackEvent("article_video_complete", {
+        article_slug: articleSlug,
+        video_source: videoSource,
+        video_provider: videoProvider,
+        video_position: videoPosition,
+      });
+    },
+    [],
+  );
+
+  return { trackVideoPlay, trackVideoComplete };
+}

--- a/docs/prd/article-video-support.md
+++ b/docs/prd/article-video-support.md
@@ -99,6 +99,34 @@ Phases 2 and 3 are independent after the tracer bullet — they could be worked 
 - [ ] Vitest regression test for the dedup guard (fires exactly once across multiple `play` events)
 - [ ] `pnpm --filter @kcvv/web check-all` passes
 
+## 5b. Analytics (Phase 4 — #1366)
+
+**Event taxonomy.** Two events fire from `<VideoBlock>` on article surfaces only (`/nieuws/[slug]`); both omitted when the block lives outside an article (staff bio, club page).
+
+| Event                    | Trigger                         | Path supported |
+| ------------------------ | ------------------------------- | -------------- |
+| `article_video_play`     | First user engagement per video | upload + embed |
+| `article_video_complete` | `<video>` `ended` event         | upload only    |
+
+Both events carry the same parameter shape:
+
+| Parameter        | Type    | Values                                                         |
+| ---------------- | ------- | -------------------------------------------------------------- |
+| `article_slug`   | string  | The host article's URL slug                                    |
+| `video_source`   | string  | `"upload"` or `"embed"`                                        |
+| `video_provider` | string  | `"native"` (uploads) / `"youtube"` / `"vimeo"`                 |
+| `video_position` | integer | 1-indexed position of the `videoBlock` within the article body |
+
+**Privacy contract.** No raw or hashed Sanity `_id`s, no asset URLs, no original filenames. `article_slug` is the only article-level identifier — same posture as the rest of the analytics surface (`useArticleAnalytics`).
+
+**Dedup.** `article_video_play` fires at most once per video per page view. The dedup ref lives inside `useVideoAnalytics` so each `<VideoBlock>` instance has its own counter; navigation between articles starts fresh.
+
+**Embed engagement detection.** Provider iframes (YouTube/Vimeo) do not expose `play` / `ended` events without postMessage wiring (`YT.Player`, Vimeo Player SDK), which is explicitly out of scope. The serializer uses the standard `window` blur + `document.activeElement === iframe` heuristic to detect first interaction. This is best-effort by design; promoting to true play detection is a separate issue if/when the provider SDKs land.
+
+**GTM / GA4 manual steps (publish-time).** All three new dimensions are created automatically via `scripts/create-ga4-dimensions.mjs`. GTM still needs three new Data Layer Variables (`video_source`, `video_provider`, `video_position`) and the GA4 Event tag must be extended with two trigger names (`article_video_play`, `article_video_complete`) and the three params mapped onto event-parameter fields. Documented in the #1366 PR body.
+
+**GA4 exploration default.** One new "Video engagement" exploration with rows = `article_slug`, columns = `video_source`, values = play count + complete-rate (complete events / play events for `video_source = upload`). Per-article position breakdown is a secondary breakdown (`video_position`).
+
 ## 6. Effect Schema / api-contract Changes
 
 **None for Phase 1–3.** Articles are served from Sanity via the existing `SanityService` — `videoBlock` flows through `PortableTextBlock[]` as an opaque object whose shape is handled by the PortableText serializer, not by a typed API contract. No new HttpApi endpoint, no `packages/api-contract` change.
@@ -117,6 +145,8 @@ One Sanity GROQ consideration: the article projection in `SanityService` must be
 - [ ] **Staging seed ID documentation convention** — confirm the PR-body pattern used by the article-detail redesign seed scripts and mirror it. Will be resolved by reading the most recent similar PR during Phase 1.
 
 ## 8. Discovered Unknowns (filled during implementation)
+
+- [2026-04-25] **Embed `play` detection without postMessage** — Phase 4 acceptance criteria requires `article_video_play` to fire for embeds, but the PRD §4 also forbids postMessage wiring. Resolved inline by using the documented `window` blur + `document.activeElement === iframe` heuristic. Best-effort; documented in §5b.
 
 <!-- Appended during Ralph loop when implementation surfaces something unexpected. Format:
      - [YYYY-MM-DD] Discovered: <finding> → <action: new issue #N / PRD updated / resolved inline>

--- a/scripts/create-ga4-dimensions.mjs
+++ b/scripts/create-ga4-dimensions.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Creates all 23 KCVV custom dimensions in GA4 via the Analytics Admin API.
+ * Creates all 26 KCVV custom dimensions in GA4 via the Analytics Admin API.
  *
  * Prerequisites:
  *   1. gcloud CLI installed and authenticated:
@@ -49,6 +49,9 @@ const dimensions = [
   { parameterName: "match_id",          displayName: "Match ID" },
   { parameterName: "match_status",      displayName: "Match status" },
   { parameterName: "destination",       displayName: "Destination" },
+  { parameterName: "video_source",      displayName: "Video source" },
+  { parameterName: "video_provider",    displayName: "Video provider" },
+  { parameterName: "video_position",    displayName: "Video position" },
 ];
 
 let token;


### PR DESCRIPTION
Closes #1366

Phase 4 of the article-video-support milestone. Instruments `<VideoBlock>` with two GA4 events.

## Changes

- **New hook** `apps/web/src/hooks/useVideoAnalytics.ts` — mirrors the established `useArticleAnalytics` shape (`useCallback` returns, no internal `useEffect`, per-instance `useRef` dedup). Returns `{ trackVideoPlay, trackVideoComplete }`. Each `<VideoBlock>` instance owns its own hook → `article_video_play` fires at most once per video per page view.
- **VideoBlock instrumentation:**
  - **Upload path** binds `onPlay` / `onEnded` to `<video>` directly.
  - **Embed path** uses the standard `window` blur + `document.activeElement === iframe` heuristic to detect first interaction. Provider postMessage APIs (`YT.Player`, Vimeo Player SDK) are explicitly out of scope per PRD §4 — this is the documented best-effort fallback.
  - Non-article surfaces (staff bio, club page) leave `articleSlug` / `videoPosition` undefined → analytics is suppressed.
- **`SanityArticleBody`** precomputes a `_key → 1-indexed position` map so the serializer can pass `video_position` to each `<VideoBlock>`. New optional `articleSlug` prop.
- **Templates** (Announcement / Interview / Transfer / Event) thread `articleSlug` through to `SanityArticleBody`. `nieuws/[slug]/page.tsx` passes `article.slug` via `renderTemplate`.
- **GA4 dimensions script** (`scripts/create-ga4-dimensions.mjs`) — appends `video_source`, `video_provider`, `video_position`. Header count updated 23 → 26.
- **PRD `docs/prd/article-video-support.md`** — new §5b Analytics section documenting the event taxonomy, privacy contract, dedup model, embed engagement heuristic, GTM/GA4 manual steps, and the default "Video engagement" exploration. New §8 entry capturing the embed-detection workaround.

## Event taxonomy

| Event                    | Trigger                          | Path supported |
| ------------------------ | -------------------------------- | -------------- |
| `article_video_play`     | First user engagement per video  | upload + embed |
| `article_video_complete` | `<video>` `ended` event          | upload only    |

Both events carry `article_slug`, `video_source` (`"upload"` \| `"embed"`), `video_provider` (`"native"` \| `"youtube"` \| `"vimeo"`), `video_position` (1-indexed). No PII — slug is the only article identifier; no Sanity \`_id\`s, no asset URLs, no filenames.

## Testing

- 7 new tests in `useVideoAnalytics.test.ts` — payload shape, privacy guard, dedup, complete is independent of play dedup.
- 8 new tests in `VideoBlock.test.tsx` — upload play/complete, upload dedup, embed iframe-focus dedup, missing-context suppression (slug or position).
- `pnpm --filter @kcvv/web check-all` passes (lint + type-check + 2749 tests + production build).

## ⚠️ Manual GTM/GA4 steps required after merge

These cannot be automated by the PR — they live in Google's UIs:

### 1. GA4 — Custom Dimensions

Run the existing dimensions script (it now also creates the three new dimensions):

\`\`\`bash
PROPERTY_ID=530024143 node scripts/create-ga4-dimensions.mjs
\`\`\`

It is idempotent — already-created dimensions are skipped. Verify `Video source`, `Video provider`, `Video position` appear under **Admin → Data display → Custom definitions** with scope **Event**.

### 2. GTM — Data Layer Variables

Create three new DLVs in the KCVV GTM container:

| Variable name      | Data Layer Variable Name |
| ------------------ | ------------------------ |
| `dlv - video_source`   | `video_source`           |
| `dlv - video_provider` | `video_provider`         |
| `dlv - video_position` | `video_position`         |

### 3. GTM — Triggers

Create two new **Custom Event** triggers:

| Trigger name                   | Event name                 |
| ------------------------------ | -------------------------- |
| `Custom — article_video_play` | `article_video_play`       |
| `Custom — article_video_complete` | `article_video_complete`   |

### 4. GTM — GA4 Event tags

Two new GA4 Event tags (or extend the existing GA4 Event tag with two trigger paths). Each tag needs:

- **Event Name:** `article_video_play` (or `article_video_complete`)
- **Event Parameters:**
  - `article_slug` → `{{Page Path}}` or whatever DLV the rest of the article events use (or add a new `dlv - article_slug` if missing).
  - `video_source` → `{{dlv - video_source}}`
  - `video_provider` → `{{dlv - video_provider}}`
  - `video_position` → `{{dlv - video_position}}`
- **Triggering:** the matching custom-event trigger from step 3.

### 5. GA4 — Exploration (optional but recommended per PRD §5b)

Create a new free-form exploration named **Video engagement**:

- **Rows:** `article_slug`
- **Columns:** `video_source`
- **Values:** event count of `article_video_play`, event count of `article_video_complete`, calculated metric `complete-rate = complete_count / play_count` (filtered to `video_source = upload` since complete is upload-only).
- **Secondary breakdown:** `video_position`.

### 6. GTM — Publish

After verifying in **Preview**, publish a new GTM container version. The events will start landing in GA4 Realtime within minutes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)