### PR TITLE
chore(schema): add apps/studio-staging/CLAUDE.md (#1467)

### DIFF
--- a/apps/studio-staging/CLAUDE.md
+++ b/apps/studio-staging/CLAUDE.md
@@ -1,0 +1,63 @@
+# apps/studio-staging — Staging Sanity Studio
+
+Staging Sanity Studio deployed to sanity.io. Near-mirror of `apps/studio` (production) but pointed at the staging dataset. See the root `.claude/CLAUDE.md` — **Sanity Studio — Dual Environment** section — for the authoritative dual-environment policy.
+
+## Identity
+
+| Field                  | Value                                                     |
+| ---------------------- | --------------------------------------------------------- |
+| Project ID             | `vhb33jaz` (shared with production)                       |
+| Dataset                | Set via `SANITY_STUDIO_DATASET` env var — **no fallback** |
+| Production counterpart | `apps/studio`                                             |
+
+## Where Things Live
+
+- **Schemas** — defined in `packages/sanity-schemas`. Never add `defineType`/`defineField` here.
+- **Studio UI customizations** (Document Actions, custom inputs, structure fragments, validators) — defined in `packages/sanity-studio`. Never add React components here.
+- **App-level wiring** — `sanity.config.ts` and `structure.ts` assemble the above into a runnable Studio. This is the only place those packages are composed together.
+
+## sanity.config.ts — Strict Env Handling
+
+The staging config intentionally throws if `SANITY_STUDIO_DATASET` is not set:
+
+```typescript
+dataset: (() => {
+  const ds = process.env.SANITY_STUDIO_DATASET as string | undefined
+  if (!ds) throw new Error('SANITY_STUDIO_DATASET env var is required for the staging studio')
+  return ds
+})(),
+```
+
+Production uses a lenient fallback (`|| 'production'`). **Do not add a fallback here.** The strict guard prevents accidentally pointing the staging Studio at the production dataset when `.env.local` is missing.
+
+## structure.ts — Must Mirror Production
+
+`structure.ts` must stay identical to `apps/studio/structure.ts`. When editing either file, apply the equivalent change to the other in the same PR. Drift between the two is tracked in issue #1462.
+
+## .env.local
+
+Required variables:
+
+```env
+SANITY_STUDIO_DATASET=staging
+```
+
+`.env.local` is gitignored. The Studio will throw on startup if this is absent (see strict env handling above). Never commit secrets or dataset values.
+
+## Deploy Workflow
+
+```bash
+# Local dev server (hot-reload)
+pnpm --filter @kcvv/studio-staging dev
+
+# Deploy to sanity.io (staging)
+pnpm --filter @kcvv/studio-staging deploy
+```
+
+`deploy` pushes to the hosted Studio at sanity.io — it does **not** deploy schemas or datasets.
+
+Note: `sanity.cli.ts` currently has no `appId` — a deploy will prompt for one or create a new deployment. Align with production once a stable staging deployment ID is established.
+
+## No Duplication With Root CLAUDE.md
+
+This file covers app-local concerns. For monorepo-wide conventions (TypeScript compiler setup, commit style, PR workflow, Turborepo tasks), see `.claude/CLAUDE.md`.

--- a/apps/studio-staging/CLAUDE.md
+++ b/apps/studio-staging/CLAUDE.md
@@ -12,8 +12,8 @@ Staging Sanity Studio deployed to sanity.io. Near-mirror of `apps/studio` (produ
 
 ## Where Things Live
 
-- **Schemas** — defined in `packages/sanity-schemas`. Never add `defineType`/`defineField` here.
-- **Studio UI customizations** (Document Actions, custom inputs, structure fragments, validators) — defined in `packages/sanity-studio`. Never add React components here.
+- **Schemas and validation** — defined in `packages/sanity-schemas` (schema types in `packages/sanity-schemas/src/`, validation rules in `packages/sanity-schemas/src/validation/`). Never add `defineType`/`defineField` or validation logic here.
+- **Studio UI customizations** (Document Actions, custom inputs, structure fragments) — defined in `packages/sanity-studio`. Never add React components here.
 - **App-level wiring** — `sanity.config.ts` and `structure.ts` assemble the above into a runnable Studio. This is the only place those packages are composed together.
 
 ## sanity.config.ts — Strict Env Handling
@@ -56,7 +56,7 @@ pnpm --filter @kcvv/studio-staging deploy
 
 `deploy` pushes to the hosted Studio at sanity.io — it does **not** deploy schemas or datasets.
 
-Note: `sanity.cli.ts` currently has no `appId` — a deploy will prompt for one or create a new deployment. Align with production once a stable staging deployment ID is established.
+Note: when `sanity.cli.ts` does not declare an `appId`, `pnpm deploy` will prompt to create or supply one (a new hosted Studio deployment). Once an `appId` is set in `sanity.cli.ts`, subsequent deploys reuse that existing deployment. Align the staging `appId` with production once a stable staging deployment ID is established.
 
 ## No Duplication With Root CLAUDE.md
 


### PR DESCRIPTION
Closes #1467

## Changes

- Adds `apps/studio-staging/CLAUDE.md` with staging Studio conventions
- Documents staging identity, the strict `SANITY_STUDIO_DATASET` guard (and why a fallback must never be added), the `structure.ts` mirror rule vs production, `.env.local` format, deploy workflow, and the production sync requirement
- Self-contained — does not depend on the unmerged `apps/studio/CLAUDE.md` (#1466)
- Links to root `.claude/CLAUDE.md` — no duplication

## Testing

- Lint, type-check, and all 2771 tests pass