### PR TITLE
chore(schema): sync studio-staging structure.ts with production + add appId (#1462)

### DIFF
--- a/apps/studio-staging/.env.example
+++ b/apps/studio-staging/.env.example
@@ -1,0 +1,1 @@
+SANITY_STUDIO_DATASET=staging

--- a/apps/studio-staging/sanity.cli.ts
+++ b/apps/studio-staging/sanity.cli.ts
@@ -6,10 +6,7 @@ export default defineCliConfig({
     dataset: 'production'
   },
   deployment: {
-    /**
-     * Enable auto-updates for studios.
-     * Learn more at https://www.sanity.io/docs/studio/latest-version-of-sanity#k47faf43faf56
-     */
+    appId: 'jkabcua9cn3yjd8wvcyfybyz',
     autoUpdates: true,
   }
 })

--- a/apps/studio-staging/structure.ts
+++ b/apps/studio-staging/structure.ts
@@ -46,5 +46,58 @@ export const structure: StructureResolver = (S) =>
         .title('Pages')
         .child(S.documentTypeList('page').title('Pages')),
       S.divider(),
+      S.listItem()
+        .title('Banners')
+        .child(S.documentTypeList('banner').title('Banners')),
+      S.listItem()
+        .title('Homepage')
+        .child(
+          S.document()
+            .schemaType('homePage')
+            .documentId('homePage')
+            .title('Homepage configuratie'),
+        ),
+      S.listItem()
+        .title('Jeugd landing page')
+        .child(
+          S.document()
+            .schemaType('jeugdLandingPage')
+            .documentId('jeugdLandingPage')
+            .title('Jeugd landing page configuratie'),
+        ),
+      S.divider(),
       responsibilityStructure(S),
+      S.divider(),
+      S.listItem()
+        .title('📊 Feedback')
+        .child(
+          S.list()
+            .title('Feedback')
+            .items([
+              S.listItem()
+                .title('Alle feedback')
+                .child(
+                  S.documentList()
+                    .title('Alle feedback')
+                    .filter('_type == "searchFeedback"')
+                    .defaultOrdering([{field: '_createdAt', direction: 'desc'}]),
+                ),
+              S.listItem()
+                .title('👍 Positief')
+                .child(
+                  S.documentList()
+                    .title('Positief')
+                    .filter('_type == "searchFeedback" && vote == "up"')
+                    .defaultOrdering([{field: '_createdAt', direction: 'desc'}]),
+                ),
+              S.listItem()
+                .title('👎 Negatief')
+                .child(
+                  S.documentList()
+                    .title('Negatief')
+                    .filter('_type == "searchFeedback" && vote == "down"')
+                    .defaultOrdering([{field: '_createdAt', direction: 'desc'}]),
+                ),
+            ]),
+        ),
     ])


### PR DESCRIPTION
Closes #1462

## Changes

- **`structure.ts`**: adds the missing Banners, Homepage, Jeugd landing page, and Feedback sections to `apps/studio-staging/structure.ts` — now 1:1 with production
- **`sanity.cli.ts`**: adds `appId: 'jkabcua9cn3yjd8wvcyfybyz'` (staging Studio deployed at `kcvv-elewijt-staging.sanity.studio`, first deployed 2026-04-26)
- **`.env.example`**: documents the required `SANITY_STUDIO_DATASET=staging` variable

## Manual step

Create `apps/studio-staging/.env.local` (gitignored) with:

```env
SANITY_STUDIO_DATASET=staging
```

## Testing

- Lint, type-check, and all 2771 tests pass
- `diff apps/studio/structure.ts apps/studio-staging/structure.ts` → no diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin interface sections for managing banner documents and configuration settings for homepage and landing pages.
  * Introduced a new feedback management section with organized feedback lists filtered by user sentiment (positive/negative votes), sorted by creation date.

* **Chores**
  * Updated staging environment configuration and deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->