### PR TITLE
fix(schema): drop migrations re-export from @kcvv/sanity-studio root barrel

### DIFF
--- a/packages/sanity-studio/CLAUDE.md
+++ b/packages/sanity-studio/CLAUDE.md
@@ -61,7 +61,8 @@ src/
 
 - One script per migration in `src/migrations/`
 - Migrations are one-off: run manually via `sanity exec` against the target dataset, then archived (not deleted)
-- Export a default function and any helper types from the migration file; list it in the barrel so consumers can import it programmatically if needed
+- Export a default function and any helper types from the migration file
+- **Never re-export migrations from the root `src/index.ts` barrel.** Migrations import `sanity/migrate`, a Node/CLI-only entry point. With `autoUpdates: true`, the deployed Studio resolves it via `modules.sanity-cdn.com/.../bare/migrate.mjs`, which 404s and crashes both deployed studios with a black screen. Surface migrations through the dedicated `src/migrations/index.ts` sub-barrel and consume them via `@kcvv/sanity-studio/migrations` (the CLI entry points in `apps/studio/migrations/*` already do this)
 
 ## Barrel Export Pattern (`index.ts`)
 
@@ -70,6 +71,7 @@ Everything public is exported by name from `src/index.ts`. Rules:
 - Export the component and its registration helper separately (`ArticleTagsInput` + `applyArticleTagsInput`)
 - Export types with `export type { ... }` to avoid runtime leakage
 - No default exports from the barrel — named only
+- **Migrations are an exception**: they live in the separate `src/migrations/index.ts` sub-barrel (consumed as `@kcvv/sanity-studio/migrations`). See the **Migrations** section below for why mixing them into the root barrel breaks the deployed Studio
 
 ## No Duplication With Root CLAUDE.md
 

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -8,11 +8,10 @@ export {
   applyRespondentPicker,
 } from './inputs'
 export {schemaTypes} from './schema-types'
-export {
-  default as interviewSubjectToSubjectsMigration,
-  migrateInterviewSubjectToSubjects,
-} from './migrations/interview-subject-to-subjects'
-export type {InterviewArticleDoc} from './migrations/interview-subject-to-subjects'
+// Migrations are intentionally NOT re-exported from this barrel: they import
+// `sanity/migrate`, a Node/CLI-only entry point that 404s on the Studio CDN
+// (`modules.sanity-cdn.com/.../bare/migrate.mjs`) and crashes the deployed
+// Studio at module load. Import migrations via `@kcvv/sanity-studio/migrations`.
 export {staffStructure} from './structure/staff'
 export {responsibilityStructure} from './structure/responsibility'
 export {


### PR DESCRIPTION
## Summary

- **Production incident fix.** Both deployed studios (production + staging) showed black screens; console errored on `GET https://modules.sanity-cdn.com/modules/v1/sanity/5.22.0/bare/migrate.mjs 404 (Not Found)`.
- Root cause: `packages/sanity-studio/src/index.ts` re-exported `interviewSubjectToSubjectsMigration` from `./migrations/interview-subject-to-subjects`. That migration file's first line is `import {…} from 'sanity/migrate'` — a Node/CLI-only entry point that is not shipped to the browser CDN. With `autoUpdates: true` on both studios, the Studio runtime tried to resolve `sanity/migrate` against `modules.sanity-cdn.com`, hit 404, and crashed the bundle at module init.
- Fix: remove the migration re-exports from the root barrel. Migrations remain available via the existing `@kcvv/sanity-studio/migrations` sub-export, which the CLI entry points in `apps/studio/migrations/*` and `apps/studio-staging/migrations/*` already use. No consumer of the root barrel referenced the removed symbols.
- Doc: updated `packages/sanity-studio/CLAUDE.md` to forbid root-barrel migration re-exports and document the failure mode so this can't recur silently.

## Test plan

- [x] `pnpm --filter @kcvv/sanity-studio check-all` (type-check, lint, 104 tests) passes
- [x] `pnpm --filter @kcvv/studio build` succeeds
- [x] `SANITY_STUDIO_DATASET=staging pnpm --filter @kcvv/studio-staging build` succeeds
- [x] Resulting bundles contain zero references to `sanity/migrate` / `bare/migrate.mjs` (verified via `grep -rl` over `apps/studio{,-staging}/dist`)
- [x] Repo-wide pre-commit type-check passes (8/8 turbo tasks)
- [ ] After merge: `sanity deploy` from `apps/studio-staging`, then `apps/studio`. Verify both studios load (no black screen) in incognito.

## Follow-up (separate PR, optional)

Consider flipping `autoUpdates: false` in both `sanity.cli.ts` files to pin a known-good runtime — auto-updates are what made this latent leak go critical without any code change on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Migration imports have been restructured. Import migrations from `@kcvv/sanity-studio/migrations` instead of the root package to prevent runtime failures in deployed Sanity Studios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->