### PR TITLE
chore(schema): rename-publish-at migration applied to staging + production (#1490)

### DIFF
--- a/apps/studio/migrations/rename-publish-at/index.ts
+++ b/apps/studio/migrations/rename-publish-at/index.ts
@@ -2,29 +2,29 @@
  * Migration: rename article.publishAt → article.publishedAt
  *
  * Run on staging first, then production:
- *   npx sanity@latest migration run rename-publish-at --dataset=staging
- *   npx sanity@latest migration run rename-publish-at --dataset=production
+ *   npx sanity@latest migration run rename-publish-at --project=vhb33jaz --dataset=staging --no-dry-run --no-confirm
+ *   npx sanity@latest migration run rename-publish-at --project=vhb33jaz --dataset=production --no-dry-run --no-confirm
  *
- * Idempotent: documents that already have publishedAt set are skipped.
+ * Idempotent: documents whose `publishAt` is already absent are skipped, and
+ * `publishedAt` is only set when missing — re-running is a no-op.
  */
-import {defineMigration, patch, unset} from 'sanity/migrate'
+import {defineMigration, at, set, unset} from 'sanity/migrate'
 
 export default defineMigration({
   title: 'Rename article.publishAt to article.publishedAt',
   documentTypes: ['article'],
 
   migrate: {
-    document(doc, _context) {
+    document(doc) {
       const d = doc as Record<string, unknown>
+      if (d.publishAt === undefined) return undefined
 
-      if (!('publishAt' in d)) return undefined
-
-      return [
-        patch(doc._id, [
-          {setIfMissing: {publishedAt: d.publishAt}},
-          unset(['publishAt']),
-        ]),
-      ]
+      const ops = []
+      if (d.publishedAt === undefined) {
+        ops.push(at('publishedAt', set(d.publishAt)))
+      }
+      ops.push(at('publishAt', unset()))
+      return ops
     },
   },
 })


### PR DESCRIPTION
Closes #1490

## Summary

Migration #1489 renames `article.publishAt` → `article.publishedAt`. Ran the migration against both datasets and adapted the script to a CLI form that doesn't trip a known formatter bug.

### Migration runs

| Dataset    | Docs processed | Transactions committed | Article patched                                            |
| ---------- | -------------: | ---------------------: | ---------------------------------------------------------- |
| staging    |            132 |                      1 | `article-phase-1317-curated-team-and-staff`                |
| production |            122 |                      1 | `article-drupal-d457dfb1-00d2-4ad8-a65f-35b8d46898d3`      |

The remaining 131 staging / 121 production articles were already on `publishedAt` (the field has been written by the Studio since #1489 merged), so the migration was a no-op for them — confirming idempotence.

### Migration script change

The script as shipped used the raw `patch(_id, [...])` mutation form. With current `@sanity/migrate`, that path crashes the CLI in `prettyMutationFormatter` → `tree.js:228 (node.path.length)` and aborts with **0 transactions committed** before any data is touched.

Rewrote `migrate.document` to the `at(field, set/unset)` operation-tree form already used by `apps/studio/migrations/rename-staff-position-fields/index.ts` — same end result, no CLI bug. Updated the runbook in the file header to include the `--project`, `--no-dry-run`, `--no-confirm` flags the CLI requires.

### Typegen

`pnpm --filter @kcvv/studio typegen` is a **no-op** — PR #1489 already aligned the schema and generated types in `apps/web/src/lib/sanity/sanity.types.ts`. The data migration brings stored documents into compliance with the already-correct schema; it doesn't change generated types.

## Test plan

- [x] Staging migration: 132 processed, 1 committed, articles render correctly in Staging Studio.
- [x] Production migration: 122 processed, 1 committed, articles render correctly in production Studio.
- [x] `pnpm --filter @kcvv/web check-all`: 216 unit-test files green, type-check + lint + build green, exit 0.
- [x] `pnpm --filter @kcvv/studio typegen`: regenerated, no diff (expected — schema already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated migration CLI guidance with explicit project targeting and deployment flags for staging and production environments
  * Improved migration logic for enhanced robustness and idempotency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->