### PR TITLE
fix(ci): re-register safe.directory before bot git push in container

### DIFF
--- a/.github/workflows/vr-baseline-update.yml
+++ b/.github/workflows/vr-baseline-update.yml
@@ -136,10 +136,14 @@ jobs:
         run: pnpm --filter @kcvv/web run vr:ci:update
 
       - name: Commit and push baselines
+        working-directory: ${{ github.workspace }}
         env:
           BOT_USER: kcvv-vr-bot
           BOT_EMAIL: kcvv-vr-bot@users.noreply.github.com
         run: |
+          # actions/checkout writes safe.directory under a temp HOME that is
+          # discarded after the step — re-register so git accepts the workspace.
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git config user.name "$BOT_USER"
           git config user.email "$BOT_EMAIL"
           git add apps/web/test/vr/__snapshots__


### PR DESCRIPTION
## Summary

- `actions/checkout@v6` writes `safe.directory` under a temporary `HOME` that is discarded when the step ends
- The subsequent **Commit and push baselines** step ran `git config --local`, which failed with `fatal: not in a git directory` because the workspace ownership check no longer had a valid config entry
- Fix: pin `working-directory` to `$GITHUB_WORKSPACE` and re-register `safe.directory` at the top of the push step

Discovered during #1545 end-to-end smoke test (bot identity fully working — this was the only remaining failure).

Closes #1550

## Test plan

- [ ] Merge this PR
- [ ] On PR #1537 (or any PR with a failing `visual-regression` check), comment `@kcvv-bot update-vr-baselines`
- [ ] Confirm :eyes: reaction appears (~30s), then :rocket: reaction (~5 min) with a new commit authored by `kcvv-vr-bot`
- [ ] Confirm `visual-regression` check goes green on the re-triggered CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved snapshot baseline update workflow reliability by configuring git settings to prevent directory-related conflicts during automated commits and pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->