### PR TITLE
chore(config): vr docker memory tuning + single-worker fallback (#1546)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -260,9 +260,15 @@ committed to the repo. Background and rationale: `docs/prd/visual-regression-tes
 
 ### Local workflow (Docker required)
 
-Prerequisite: Docker Desktop running. Local runs use the pinned
-`mcr.microsoft.com/playwright:v1.59.1-noble` image so font rendering matches CI
-exactly.
+Prerequisite: Docker Desktop running with **at least 8 GB of memory allocated**
+to the Docker VM. Local runs use the pinned `mcr.microsoft.com/playwright:v1.59.1-noble`
+image so font rendering matches CI exactly.
+
+**Minimum Docker Desktop memory:** 8 GB (measured against the full Phase 2+3
+story surface). Below this floor, Chromium runs out of memory mid-story and
+produces `page.goto: Page crashed` failures on `Features/*` and `Pages/*` stories.
+If your machine allocates less than 8 GB, use the `vr:update:single` script
+(see "Single-worker fallback" below).
 
 ```bash
 # Compare against committed baselines.
@@ -278,6 +284,24 @@ pnpm --filter @kcvv/web run vr:diff layout-pagefooter--standalone
 `vr:check` and `vr:update` rebuild Storybook first, then run the test-runner
 inside Docker. First run pulls the Playwright image (~1.3 GB). Steady-state run
 time on a warm cache is ~30 s for the Phase 1 tracer-bullet set.
+
+### Single-worker fallback
+
+If `vr:update` crashes mid-run with `page.goto: Page crashed` (Chromium OOM
+inside the Docker container), use the single-worker variants:
+
+```bash
+# Compare — single worker, lower peak memory.
+pnpm --filter @kcvv/web run vr:run:single
+
+# Update baselines — single worker, lower peak memory.
+pnpm --filter @kcvv/web run vr:update:single
+```
+
+These scripts pass `--maxWorkers=1` to `test-storybook`, serialising story
+visits instead of parallelising them. Run time roughly doubles, but peak RSS
+drops significantly, allowing the full suite to complete on hosts below the
+8 GB memory floor.
 
 ### Path-based triggering
 
@@ -547,3 +571,6 @@ explicitly. A GitHub App is the cleaner long-term replacement.
 - **No baselines committed from macOS or Windows hosts.** Only Docker-local
   (Linux-matched) or the CI bot.
 - **No `visual` label.** Triggering is path-based; never introduce a label gate.
+- **Do not run multi-worker `vr:update` on hosts under the 8 GB memory floor.**
+  Chromium will crash mid-story inside the Docker container and produce phantom
+  `page.goto: Page crashed` failures. Use `vr:update:single` instead.

--- a/apps/web/docker-compose.vr.yml
+++ b/apps/web/docker-compose.vr.yml
@@ -20,5 +20,6 @@ services:
       - ./storybook-static:/work/apps/web/storybook-static:ro
       # Read-write mount for baselines and diff artifacts.
       - ./test:/work/apps/web/test
+    mem_limit: 8g
     environment:
       - CI=true

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,8 +28,10 @@
     "vr:build-storybook": "rm -rf storybook-static && storybook build",
     "vr:run": "concurrently -k -s first --hide 0 \"http-server ./storybook-static -p 6006 -a 127.0.0.1 --silent --cors\" \"wait-on --timeout 60000 tcp:127.0.0.1:6006 && test-storybook --url http://127.0.0.1:6006 --index-json --testTimeout 30000 --includeTags vr --excludeTags vr-skip\"",
     "vr:run:update": "concurrently -k -s first --hide 0 \"http-server ./storybook-static -p 6006 -a 127.0.0.1 --silent --cors\" \"wait-on --timeout 60000 tcp:127.0.0.1:6006 && test-storybook --url http://127.0.0.1:6006 --index-json --testTimeout 30000 --includeTags vr --excludeTags vr-skip -u\"",
+    "vr:run:single": "concurrently -k -s first --hide 0 \"http-server ./storybook-static -p 6006 -a 127.0.0.1 --silent --cors\" \"wait-on --timeout 60000 tcp:127.0.0.1:6006 && test-storybook --url http://127.0.0.1:6006 --index-json --testTimeout 30000 --includeTags vr --excludeTags vr-skip --maxWorkers=1\"",
     "vr:check": "pnpm run vr:build-storybook && docker compose -f docker-compose.vr.yml run --rm vr",
     "vr:update": "pnpm run vr:build-storybook && docker compose -f docker-compose.vr.yml run --rm vr -u",
+    "vr:update:single": "pnpm run vr:build-storybook && docker compose -f docker-compose.vr.yml run --rm vr -u --maxWorkers=1",
     "vr:ci": "pnpm run vr:run",
     "vr:ci:update": "pnpm run vr:run:update",
     "vr:diff": "node scripts/vr-diff.mjs"


### PR DESCRIPTION
Closes #1546

## Changes

- **`apps/web/docker-compose.vr.yml`**: Add `mem_limit: 8g` to enforce the memory floor at the container level, producing a clear OOM error instead of a silent `page.goto: Page crashed`.
- **`apps/web/package.json`**: Add `vr:run:single` (direct test-storybook, no Docker) and `vr:update:single` (Docker + baseline update) scripts passing `--maxWorkers=1` to serialise story visits and reduce peak RSS.
- **`apps/web/CLAUDE.md`**: Document 8 GB minimum Docker Desktop memory requirement, add "Single-worker fallback" section explaining when and how to use the new scripts, add anti-pattern bullet: "Do not run multi-worker `vr:update` on hosts under the 8 GB memory floor."

## Testing

- All lint, type-check, and unit tests pass (`pnpm --filter @kcvv/web lint && type-check && test`).
- Build step has a pre-existing failure on `/staf/[slug]/opengraph-image` unrelated to this issue.
- New scripts are structurally identical to their parallel counterparts — only `--maxWorkers=1` differs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Visual Regression Testing documentation with Docker memory requirements.

* **New Features**
  * Added `vr:run:single` script for single-worker VR testing.
  * Added `vr:update:single` script for single-worker VR updates.

* **Configuration**
  * Set Docker memory limit to 8GB for VR testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->