### PR TITLE
chore(config): vr CI memory parity + worker anti-pattern docs (#1548)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -285,6 +285,11 @@ produces `page.goto: Page crashed` failures on `Features/*` and `Pages/*` storie
 If your machine allocates less than 8 GB, use the `vr:update:single` script
 (see "Single-worker fallback" below).
 
+**CI / local parity contract:** GitHub-hosted `ubuntu-latest` runners provide
+16 GB RAM — 2× the 8 GB local floor, satisfying the ≥ 25 % headroom requirement.
+If either the runner spec or the local floor changes, re-verify the other before
+merging.
+
 **Node.js heap:** `docker-compose.vr.yml` sets `NODE_OPTIONS=--max-old-space-size=4096`
 to raise the Node.js heap limit to 4 GB. Without this, the test runner OOMs
 after ~80 story visits regardless of Docker memory allocation (Node.js defaults
@@ -596,7 +601,10 @@ explicitly. A GitHub App is the cleaner long-term replacement.
 - **No `visual` label.** Triggering is path-based; never introduce a label gate.
 - **Do not run multi-worker `vr:update` on hosts under the 8 GB memory floor.**
   Chromium will crash mid-story inside the Docker container and produce phantom
-  `page.goto: Page crashed` failures. Use `vr:update:single` instead.
+  `page.goto: Page crashed` failures. Use `vr:run:single` / `vr:update:single`
+  instead (see "Single-worker fallback" above). CI runners have 16 GB and are
+  not affected, but contributor machines under the floor must use the single-worker
+  variants.
 - **Do not remove `NODE_OPTIONS=--max-old-space-size=4096` from `docker-compose.vr.yml`.**
   Node.js defaults to ~1.4 GB heap — the test runner OOMs after ~80 story visits
   regardless of Docker memory allocation.


### PR DESCRIPTION
Closes #1548

## Changes

- Added **CI/local parity contract** to `apps/web/CLAUDE.md`: GitHub-hosted `ubuntu-latest` runners provide 16 GB RAM — 2× the 8 GB local floor, satisfying the ≥ 25% headroom requirement. Documents that if either changes, the other must be re-verified.
- Expanded **anti-pattern bullet** to explicitly name `vr:run:single` / `vr:update:single` as the contributor escape hatch and note that CI runners (16 GB) are not affected.
- No changes to `.github/workflows/ci.yml` — `ubuntu-latest` already meets the headroom requirement.

## Testing

- `pnpm --filter @kcvv/web lint` ✅
- `pnpm --filter @kcvv/web type-check` ✅
- `pnpm --filter @kcvv/web test` ✅ (230 files, 2866 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VR testing documentation to establish clear memory parity expectations between local development and CI environments
  * Refined troubleshooting guidance for contributors encountering memory-related failures, directing them to specific mitigation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->