### PR TITLE
fix(config): ignore kcvv-vr-bot comments in vr-baseline-update trigger

### DIFF
--- a/.github/workflows/vr-baseline-update.yml
+++ b/.github/workflows/vr-baseline-update.yml
@@ -27,7 +27,8 @@ jobs:
     name: Verify trigger
     if: |
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@kcvv-bot update-vr-baselines')
+      contains(github.event.comment.body, '@kcvv-bot update-vr-baselines') &&
+      github.event.comment.user.login != 'kcvv-vr-bot'
     runs-on: ubuntu-latest
     # Cheap gate (one API call + one reaction). 5 min is generous; anything
     # longer almost certainly means GitHub API itself is degraded.


### PR DESCRIPTION
## Root cause

The sticky PR comment posted by `ci.yml` (`vr-diff-comment` job) contains the literal text \`@kcvv-bot update-vr-baselines\`. When `kcvv-vr-bot` creates or updates that comment, GitHub fires an `issue_comment: created` event that passes the existing `trigger-check` condition — causing two parallel baseline-update runs every time the command is used.

## Fix

Add `github.event.comment.user.login != 'kcvv-vr-bot'` to the `trigger-check` `if` condition so the bot's own comments are ignored.

## Test plan

- [ ] Comment `@kcvv-bot update-vr-baselines` on a PR — only one VR Baseline Update run should appear in Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual regression baseline update workflow to prevent self-triggering loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->