### PR TITLE
docs(ui): lock phase 2 track b design checkpoint (direction D)

### DIFF
--- a/docs/design/mockups/phase-2-track-b/compare.md
+++ b/docs/design/mockups/phase-2-track-b/compare.md
@@ -1,0 +1,140 @@
+# Phase 2 — Track B Design Checkpoint
+
+> **Status:** ✅ **LOCKED — Direction D chosen.**
+> **Date:** 2026-04-30.
+> **Worktree:** `design/phase-2-track-b`.
+> **Master design:** [`docs/plans/2026-04-27-redesign-master-design.md`](../../../plans/2026-04-27-redesign-master-design.md) §6.5.
+> **PRD:** [`docs/prd/redesign-phase-2.md`](../../../prd/redesign-phase-2.md) §6.5.
+> **Tracking issues:** [#1524](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1524) (umbrella), [#1575](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1575) (Spinner), [#1576](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1576) (BrandedTabs), [#1577](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1577) (FilterTabs), [#1578](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1578) (HorizontalSlider + ScrollHint arrows).
+
+---
+
+## Decision
+
+**Direction D — "Paper chrome, ink emphasis"** is the chosen direction. Canonical visual reference: [`option-d-paper-chrome-ink-emphasis.html`](option-d-paper-chrome-ink-emphasis.html).
+
+Direction D is a synthesis derived from owner feedback on the three exploratory directions. Its threads:
+
+- **Paper-card foundation everywhere on chrome:** `border-2 ink` + `shadow-paper-sm` + cream bg.
+- **Ink-invert active states**, never jersey-fill. Jersey reserved for *content* (live match strip, KCVV name, scoring) — not chrome.
+- **No tape on chrome.** Tape stays for editorial primitives (TapedCard hero artefacts).
+- **Sharp corners** everywhere — no `border-radius`.
+- **No leading glyphs** on filter tabs.
+- **Typographic `←` / `→`** over Lucide where the glyph reads.
+- **One canonical form per atom**, no sub-variants shipped.
+- **All slider cards equally treated** — no "active" variant for the live match. Live status signalled via kicker text alone.
+- **New token `--shadow-paper-sm-soft`** (4×4 ink-muted gray) for ink-bg active states + chrome on dark panels, where the standard ink shadow would vanish.
+
+### Provisional caveat
+
+Owner sign-off was conditional ("not 200% convinced, but let's go with it for now"). The dark-shadow soft variant and the slider's "all cards equally treated" decision are the two areas most likely to need refinement during implementation. If issues #1575–#1578 surface real-use friction, the implementation PRD can revise — this checkpoint is the source-of-record, not a hard freeze.
+
+---
+
+## Locked specifications
+
+### Spinner ([#1575](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1575))
+
+**Primary motif:** scarf barber-pole. Diagonal jersey/cream/ink/cream stripes scrolling infinitely inside a paper bar. Implementation note: stripes rendered as a 90° gradient on a `::before` pseudo-element, statically `transform: rotate(-45deg)`, with `background-position-x` animating by clean-integer 80 px per cycle to avoid sub-pixel rasterisation seams (see `option-d` source for the canonical CSS technique).
+
+**Variants:**
+
+- `primary` — jersey · cream · ink · cream stripes. Default loading on cream surfaces.
+- `secondary` — ink · cream · ink-muted · cream (no jersey). Non-brand loading (form save, admin save, background sync).
+- `white` — palette flip: cream · ink · jersey-bright · ink stripes on `bg-ink-soft`. Border `paper-edge`, shadow `--shadow-paper-sm-soft`. Used on dark interlude bg.
+- `compact` — three jersey-deep dots pulsing in sequence. Inline next to text where a 96 px barber-pole bar is too heavy.
+- `logo` — **RETIRED.** `SpinnerVariant` becomes `"primary" | "secondary" | "white" | "compact"`.
+
+**Sizes (sm/md/lg/xl):** 96 × 16 / 180 × 28 / 240 × 36 / 360 × 56. Logo variant removal lets `Spinner.tsx` drop the `Image` import path entirely.
+
+### BrandedTabs ([#1576](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1576))
+
+Each tab: `border-2 ink` + `shadow-paper-sm` + `bg-cream`, mono caps label, sharp corners, no rotation, no tape.
+
+**Active state:** invert to `bg-ink text-cream` + `--shadow-paper-sm-soft` (so the ink tab body and shadow remain distinguishable instead of merging into one solid block).
+
+**Hover (inactive):** shadow → 3 × 3 + `translate(1px, 1px)` (paper press idiom).
+
+Prop surface: unchanged from current (`tabs`, `activeTabId`, `onTabChange`, `ariaLabel?`).
+
+### FilterTabs ([#1577](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1577))
+
+Each chip: `border-2 ink` + `shadow-paper-sm` + `bg-cream-soft`, mono caps label, sharp corners.
+
+**Active state:** invert to `bg-ink text-cream` + `--shadow-paper-sm-soft` (matches BrandedTabs).
+
+**Count:** inline mono after a 1 px ink-muted hairline pipe — `LIVE | 1`. No pill stamp, no badge.
+
+**Sizes (sm/md/lg):** padding + font-size only.
+
+**Prop change:** **drop `FilterTab.icon` entirely** (no leading glyphs anywhere). This **closes #1573 with no UI work** — what would have been a Lucide → Phosphor type swap becomes a prop removal. `FilterTabsProps` and the `icon?` field on each tab go away.
+
+### ScrollArrowButton ([#1578](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1578) — part 1)
+
+Single canonical button. 48 × 48: `border-2 ink` + `shadow-paper-sm` + `bg-cream`. Glyph: typographic `←` / `→` in Freight Display italic. Press: shadow → 3 × 3 + `translate(1px, 1px)`.
+
+**Prop change:** **drop `variant: "light" | "dark"` entirely.** The same cream-on-ink-bordered button reads correctly on both light cream panels (full shadow visible) and dark ink panels (shadow vanishes into ink, but cream-on-ink contrast carries elevation). On `panel--dusk` contexts, a CSS descendant rule swaps shadow to `--shadow-paper-sm-soft` so the gray offset still reads.
+
+`ScrollArrowButtonProps` becomes `{ direction, onClick, className? }`.
+
+### HorizontalSlider ([#1578](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1578) — part 2)
+
+**Match card structure (top-to-bottom):**
+
+1. Mono kicker row: competition tag · date OR live status. `1STE PROV. · ZA 02 MEI` or `1STE PROV. · ★ LIVE · 67'` (live word in `--color-alert`).
+2. Teams row: each team has crest (~24 × 24) + name. **KCVV always rendered as `Elewijt` in italic Freight Display + `--color-jersey-deep`**; opponent in body sans `--color-ink`.
+3. Score row: mono, large. `2 — 1` for played; `20:00` (italic Freight Display, ink-muted) for upcoming.
+4. Venue + CTA row: mono caps, `--color-ink-muted`. `DRIESSTRAAT · TICKETS →`.
+
+**Card rotation:** sub-degree pool `--rotate-tape-a..d` cycling per `nth-child(4n+1..4)`, matching `<TapedCardGrid>`.
+
+**All cards equally treated** — no live-card surface variant. Live status comes only from the kicker text and the score field.
+
+**Prop surface:** unchanged. `theme: "light" | "dark"` stays (homepage `MatchesSliderSection` consumes dark).
+
+**Dark theme:** panel bg flips to ink-soft. Cards remain identical to light theme (`bg-cream` + `border-2 ink`), but their box-shadow swaps to `--shadow-paper-sm-soft` via a `.panel--dusk` descendant rule so the offset depth stays readable. No green borders, no green shadows, no neon. Arrows on dusk panels get the same treatment.
+
+### New token
+
+```css
+/* Append to the existing @theme block in apps/web/src/styles/globals.css */
+--shadow-paper-sm-soft: 4px 4px 0 0 var(--color-ink-muted);
+```
+
+Used wherever `--shadow-paper-sm` (ink) would vanish: ink-bg active states (BrandedTab + FilterTab) and any chrome surface on a dark panel (arrows, cards, white-variant spinner).
+
+---
+
+## Historical exploration (preserved for reference)
+
+The three original directional explorations led to the synthesis. Each is preserved for context:
+
+| File | Direction | Status |
+| --- | --- | --- |
+| [`option-a-paper-and-tape.html`](option-a-paper-and-tape.html) | Paper &amp; Tape — paper feel everywhere on chrome | Historical — not chosen |
+| [`option-b-mono-and-ink.html`](option-b-mono-and-ink.html) | Mono &amp; Ink — flat chrome, restrained | Historical — not chosen |
+| [`option-c-matchday-programme.html`](option-c-matchday-programme.html) | Matchday Programme — programme vocabulary, sub-variants | Historical — not chosen |
+| [`option-d-paper-chrome-ink-emphasis.html`](option-d-paper-chrome-ink-emphasis.html) | **Paper chrome, ink emphasis** | ✅ **Chosen** |
+
+Owner feedback that drove the synthesis:
+
+- BrandedTabs: liked Direction A's paper-card body, dropped the tape strip.
+- FilterTabs: liked the paper-chip body but rejected jersey-fill active (too loud) and the green-border outline (too subtle); picked ink-invert for cohesion with BrandedTabs.
+- Spinner: liked Direction C's barber-pole exclusively. Retired the logo variant.
+- ScrollArrowButton: liked Direction A's paper button, dropped the tape strip and the dark-variant green styling.
+- HorizontalSlider: rejected the live-card jersey-fill (no "active" state — all matches equally important); rejected the original dusk theme (cream-soft cards + jersey-deep border + green shadow read as visual noise on dark).
+
+The new `--shadow-paper-sm-soft` token emerged from owner-flagged shadow visibility issues on dark/ink contexts: ink shadow on ink panel = invisible, ink shadow under ink active tab = merges into one solid block. Soft (ink-muted) shadow restores depth in both cases.
+
+---
+
+## Next step
+
+The atom contracts above are the source-of-record for issues #1575–#1578. Each implementation issue:
+
+1. Reads this `compare.md` + the canonical `option-d-paper-chrome-ink-emphasis.html`.
+2. Ships its component reskin with a real Storybook story (`tags: ["autodocs", "vr"]`) per existing Phase 1 convention.
+3. Captures VR baselines via `pnpm vr:update:story "<AtomName>"`.
+4. Lists VR baselines updated in the PR description.
+
+Issue #1573 (FilterTabs icon prop type swap) is closed by #1577 — the prop is removed entirely instead of being type-swapped.

--- a/docs/design/mockups/phase-2-track-b/option-a-paper-and-tape.html
+++ b/docs/design/mockups/phase-2-track-b/option-a-paper-and-tape.html
@@ -1,0 +1,1360 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Direction A — Paper &amp; Tape · Phase 2 · Track B · KCVV Elewijt</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #4acf52;
+        --color-jersey-deep: #008755;
+        --color-jersey-bright: #22c55e;
+        --color-paper-edge: #d9d2bd;
+        --color-alert: #b84a3a;
+        --color-warning: #c68b2c;
+        --shadow-paper-sm: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-md: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+        --rotate-tape-a: -0.5deg;
+        --rotate-tape-b: -0.25deg;
+        --rotate-tape-c: 0.25deg;
+        --rotate-tape-d: 0.5deg;
+        --font-display: "Playfair Display", "Freight Display Pro", Georgia, serif;
+        --font-body: "Inter", "Quasimoda", -apple-system, sans-serif;
+        --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: var(--font-body);
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-size: 16px;
+        line-height: 1.6;
+        /* Paper-grain texture: layered low-opacity radial gradients */
+        background-image:
+          radial-gradient(circle at 12% 20%, rgba(10, 10, 10, 0.025) 0 1px, transparent 1px),
+          radial-gradient(circle at 78% 65%, rgba(10, 10, 10, 0.018) 0 1px, transparent 1px),
+          radial-gradient(circle at 45% 90%, rgba(10, 10, 10, 0.02) 0 1px, transparent 1px);
+        background-size: 240px 240px, 180px 180px, 320px 320px;
+      }
+
+      main {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 64px 32px 96px;
+      }
+
+      .mono-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+        color: var(--color-ink);
+      }
+
+      .mono-label--muted {
+        color: var(--color-ink-muted);
+      }
+
+      .display {
+        font-family: var(--font-display);
+        font-weight: 900;
+        line-height: 1.05;
+        letter-spacing: -0.01em;
+      }
+
+      .display em {
+        font-style: italic;
+        color: var(--color-jersey-deep);
+      }
+
+      h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 900;
+        font-size: clamp(48px, 6vw, 72px);
+        line-height: 1.05;
+        margin: 16px 0 12px;
+      }
+
+      h2 {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: clamp(28px, 3vw, 40px);
+        line-height: 1.1;
+        margin: 0 0 6px;
+      }
+
+      h2 em {
+        font-style: italic;
+        color: var(--color-jersey-deep);
+      }
+
+      h3 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-style: italic;
+        font-size: 22px;
+        margin: 0 0 4px;
+        color: var(--color-ink);
+      }
+
+      .lead {
+        max-width: 680px;
+        font-size: 17px;
+        color: var(--color-ink-soft);
+        margin: 0 0 24px;
+      }
+
+      .section {
+        margin: 80px 0;
+        padding-top: 32px;
+        border-top: 1px solid var(--color-paper-edge);
+      }
+
+      .section-meta {
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+        margin-bottom: 16px;
+      }
+
+      .section-meta .star {
+        color: var(--color-jersey-deep);
+        font-family: var(--font-display);
+      }
+
+      .panel {
+        background: var(--color-cream);
+        padding: 32px;
+        border: 1px solid var(--color-paper-edge);
+        margin-top: 24px;
+      }
+
+      .panel--soft {
+        background: var(--color-cream-soft);
+      }
+
+      .panel--ink {
+        background: var(--color-ink-soft);
+        color: var(--color-cream);
+        border-color: var(--color-ink);
+      }
+
+      .panel--ink h3,
+      .panel--ink .mono-label {
+        color: var(--color-cream);
+      }
+
+      .stack {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .tradeoffs {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin-top: 24px;
+        padding: 20px;
+        background: rgba(255, 255, 255, 0.4);
+        border: 1px dashed var(--color-paper-edge);
+      }
+
+      .tradeoffs h4 {
+        margin: 0 0 6px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+      }
+
+      .tradeoffs h4.for {
+        color: var(--color-jersey-deep);
+      }
+
+      .tradeoffs h4.against {
+        color: var(--color-alert);
+      }
+
+      .tradeoffs p {
+        margin: 0;
+        font-size: 14px;
+        color: var(--color-ink-soft);
+      }
+
+      .primitive-note {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--color-ink-muted);
+        margin-top: 8px;
+      }
+
+      /* ============================================================
+         HEADER
+         ============================================================ */
+
+      .hero {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        padding: 40px 48px;
+        position: relative;
+        transform: rotate(var(--rotate-tape-b));
+      }
+
+      .hero::before {
+        /* Tape strip on top-left corner — visually matches <TapeStrip> primitive */
+        content: "";
+        position: absolute;
+        top: -14px;
+        left: 28px;
+        width: 84px;
+        height: 28px;
+        background: repeating-linear-gradient(
+          135deg,
+          var(--color-jersey) 0 6px,
+          var(--color-jersey-deep) 6px 8px
+        );
+        transform: rotate(-8deg);
+        border: 1px solid rgba(0, 0, 0, 0.1);
+        opacity: 0.95;
+      }
+
+      .hero-meta {
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+      }
+
+      .hero h1 .em {
+        font-style: italic;
+        color: var(--color-jersey-deep);
+      }
+
+      .hero p {
+        max-width: 720px;
+        color: var(--color-ink-soft);
+        font-size: 17px;
+        margin: 16px 0 0;
+      }
+
+      /* ============================================================
+         SPINNER
+         ============================================================ */
+
+      .spinner-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 32px;
+        margin-top: 24px;
+      }
+
+      .spinner-cell {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 12px;
+        min-height: 180px;
+      }
+
+      .spinner-cell .size-tag {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+
+      /* Halftone-dot spinner — 8 dots in a circle, sequential fade */
+      .halftone {
+        position: relative;
+        display: inline-block;
+      }
+
+      .halftone .dot {
+        position: absolute;
+        background: var(--color-jersey-deep);
+        border-radius: 50%;
+        animation: halftone-pulse 1.2s linear infinite;
+        opacity: 0;
+      }
+
+      @keyframes halftone-pulse {
+        0%, 100% { opacity: 0.15; transform: scale(0.85); }
+        15% { opacity: 1; transform: scale(1); }
+      }
+
+      .halftone--sm { width: 16px; height: 16px; }
+      .halftone--md { width: 32px; height: 32px; }
+      .halftone--lg { width: 48px; height: 48px; }
+      .halftone--xl { width: 64px; height: 64px; }
+
+      .halftone--sm .dot { width: 3px; height: 3px; }
+      .halftone--md .dot { width: 5px; height: 5px; }
+      .halftone--lg .dot { width: 7px; height: 7px; }
+      .halftone--xl .dot { width: 9px; height: 9px; }
+
+      /* 8 dots positioned around a circle */
+      .halftone .dot:nth-child(1) { top: 0; left: 50%; transform: translate(-50%, 0); animation-delay: 0s; }
+      .halftone .dot:nth-child(2) { top: 14.6%; right: 14.6%; animation-delay: 0.15s; }
+      .halftone .dot:nth-child(3) { top: 50%; right: 0; transform: translate(0, -50%); animation-delay: 0.3s; }
+      .halftone .dot:nth-child(4) { bottom: 14.6%; right: 14.6%; animation-delay: 0.45s; }
+      .halftone .dot:nth-child(5) { bottom: 0; left: 50%; transform: translate(-50%, 0); animation-delay: 0.6s; }
+      .halftone .dot:nth-child(6) { bottom: 14.6%; left: 14.6%; animation-delay: 0.75s; }
+      .halftone .dot:nth-child(7) { top: 50%; left: 0; transform: translate(0, -50%); animation-delay: 0.9s; }
+      .halftone .dot:nth-child(8) { top: 14.6%; left: 14.6%; animation-delay: 1.05s; }
+
+      /* Torn-ticket spinner sub-variant — composes <TicketStub> vocabulary */
+      .torn-ticket {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 8px 16px 8px 8px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        position: relative;
+        animation: ticket-tilt 2.2s ease-in-out infinite;
+      }
+
+      @keyframes ticket-tilt {
+        0%, 100% { transform: rotate(-0.5deg); }
+        50% { transform: rotate(0.5deg); }
+      }
+
+      .torn-ticket::before {
+        /* Perforated edge — mirrors <TicketStub> dot column */
+        content: "";
+        position: absolute;
+        left: 32px;
+        top: 4px;
+        bottom: 4px;
+        width: 1px;
+        background-image: radial-gradient(circle, var(--color-ink) 1px, transparent 1px);
+        background-size: 1px 6px;
+        background-repeat: repeat-y;
+      }
+
+      .torn-ticket .stamp {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 4px 8px;
+        margin-right: 12px;
+      }
+
+      .torn-ticket .ellipsis::after {
+        content: "...";
+        animation: ellipsis-cycle 1.4s steps(4) infinite;
+      }
+
+      @keyframes ellipsis-cycle {
+        0% { content: "."; }
+        25% { content: ".."; }
+        50% { content: "..."; }
+        75% { content: ""; }
+      }
+
+      /* Logo placeholder */
+      .logo-placeholder {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 56px;
+        height: 56px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.02em;
+        color: var(--color-jersey-deep);
+        animation: logo-y-spin 2.4s linear infinite;
+      }
+
+      @keyframes logo-y-spin {
+        0% { transform: rotateY(0deg); }
+        100% { transform: rotateY(360deg); }
+      }
+
+      /* ============================================================
+         BRANDED TABS — taped paper-card strip
+         ============================================================ */
+
+      .branded-tabs {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: stretch;
+      }
+
+      .b-tab {
+        position: relative;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        padding: 12px 18px;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+      }
+
+      .b-tab:hover {
+        transform: translate(1px, 1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+
+      .b-tab--active {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      .b-tab--active::before {
+        /* Tape strip — explicit <TapeStrip color="jersey" position="tl" rotation="-8"> */
+        content: "";
+        position: absolute;
+        top: -10px;
+        left: -8px;
+        width: 50px;
+        height: 18px;
+        background: repeating-linear-gradient(
+          135deg,
+          var(--color-jersey) 0 4px,
+          var(--color-jersey-deep) 4px 6px
+        );
+        transform: rotate(-8deg);
+        border: 1px solid rgba(0, 0, 0, 0.18);
+      }
+
+      .scroll-arrow-overlay {
+        position: relative;
+      }
+
+      .scroll-arrow-overlay::after {
+        content: "→";
+        position: absolute;
+        right: -16px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 36px;
+        height: 36px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 16px;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         FILTER TABS — paper chips
+         ============================================================ */
+
+      .filter-tabs {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      .f-chip {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--color-cream-soft);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        padding: 8px 12px;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+      }
+
+      .f-chip:hover {
+        transform: translate(1px, 1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+
+      .f-chip--active {
+        background: var(--color-jersey);
+        color: var(--color-ink);
+      }
+
+      .f-chip .count {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 2px 6px;
+        font-size: 10px;
+        font-weight: 700;
+      }
+
+      .f-chip--active .count {
+        background: var(--color-ink);
+        color: var(--color-jersey);
+      }
+
+      .f-chip .glyph {
+        font-family: var(--font-display);
+        font-style: italic;
+        color: var(--color-jersey-deep);
+      }
+
+      /* Sizes */
+      .f-chip--sm {
+        font-size: 10px;
+        padding: 5px 9px;
+      }
+
+      .f-chip--sm .count {
+        padding: 1px 4px;
+        font-size: 9px;
+      }
+
+      .f-chip--lg {
+        font-size: 12px;
+        padding: 11px 16px;
+      }
+
+      .f-chip--lg .count {
+        padding: 3px 8px;
+        font-size: 11px;
+      }
+
+      .filter-row {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+        padding: 12px 0;
+      }
+
+      .filter-row .size-tag {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-ink-muted);
+        min-width: 32px;
+      }
+
+      /* ============================================================
+         HORIZONTAL SLIDER + arrow buttons
+         ============================================================ */
+
+      .slider-wrap {
+        position: relative;
+        margin: 24px 0;
+        padding: 0 28px;
+      }
+
+      .slider-track {
+        display: flex;
+        gap: 16px;
+        overflow: hidden;
+      }
+
+      .match-card {
+        flex: 0 0 220px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 16px;
+        font-family: var(--font-body);
+        font-size: 13px;
+      }
+
+      .match-card .meta {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-ink-muted);
+        margin-bottom: 8px;
+      }
+
+      .match-card .teams {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 18px;
+        margin-bottom: 8px;
+      }
+
+      .match-card .score {
+        font-family: var(--font-mono);
+        font-size: 16px;
+        font-weight: 700;
+        color: var(--color-jersey-deep);
+      }
+
+      .match-card:nth-child(4n+1) { transform: rotate(var(--rotate-tape-a)); }
+      .match-card:nth-child(4n+2) { transform: rotate(var(--rotate-tape-c)); }
+      .match-card:nth-child(4n+3) { transform: rotate(var(--rotate-tape-b)); }
+      .match-card:nth-child(4n+4) { transform: rotate(var(--rotate-tape-d)); }
+
+      .arrow-btn {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 48px;
+        height: 48px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        color: var(--color-ink);
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+        z-index: 2;
+      }
+
+      .arrow-btn:hover {
+        transform: translateY(calc(-50% + 1px)) translateX(1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+
+      .arrow-btn::before {
+        /* Tape strip — <TapeStrip color="jersey" position="tl" rotation="-10"> */
+        content: "";
+        position: absolute;
+        top: -8px;
+        left: -6px;
+        width: 28px;
+        height: 12px;
+        background: repeating-linear-gradient(
+          135deg,
+          var(--color-jersey) 0 4px,
+          var(--color-jersey-deep) 4px 6px
+        );
+        transform: rotate(-10deg);
+        border: 1px solid rgba(0, 0, 0, 0.15);
+      }
+
+      .arrow-btn--left { left: -20px; }
+      .arrow-btn--right { right: -20px; }
+
+      .arrow-btn--dark {
+        background: var(--color-cream);
+        color: var(--color-ink);
+      }
+
+      .arrow-btn--dark::before {
+        background: repeating-linear-gradient(
+          135deg,
+          var(--color-jersey-bright) 0 4px,
+          var(--color-jersey) 4px 6px
+        );
+      }
+
+      /* ============================================================
+         COHESION mini-mockup — "matches page"
+         ============================================================ */
+
+      .cohesion {
+        background: var(--color-cream);
+        padding: 40px;
+        border: 1px solid var(--color-paper-edge);
+      }
+
+      .cohesion-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 24px;
+      }
+
+      .cohesion-head h2 {
+        font-style: italic;
+        margin: 0;
+      }
+
+      .cohesion-loading {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-ink-muted);
+      }
+
+      /* ============================================================
+         FOOTER notes
+         ============================================================ */
+
+      footer {
+        margin-top: 80px;
+        padding-top: 32px;
+        border-top: 2px solid var(--color-ink);
+      }
+
+      .map-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+        margin-top: 16px;
+      }
+
+      .map-grid h4 {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin: 0 0 8px;
+        color: var(--color-ink);
+      }
+
+      .map-grid ul {
+        margin: 0;
+        padding-left: 18px;
+        font-size: 14px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+      }
+
+      .map-grid code,
+      footer code {
+        font-family: var(--font-mono);
+        font-size: 13px;
+        background: var(--color-cream-soft);
+        padding: 1px 6px;
+        border: 1px solid var(--color-paper-edge);
+      }
+
+      /* Scroll-hint overflow indicator */
+      .scroll-hint {
+        background: var(--color-cream);
+        padding: 16px;
+        border: 1px solid var(--color-paper-edge);
+        position: relative;
+        overflow: hidden;
+      }
+
+      /* Dark-theme slider panel */
+      .slider-dark {
+        background: var(--color-ink-soft);
+        padding: 32px 16px;
+        margin-top: 16px;
+      }
+
+      .slider-dark .match-card {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        border-color: var(--color-jersey-bright);
+      }
+
+      .slider-dark .match-card .meta {
+        color: var(--color-ink-muted);
+      }
+
+      .slider-dark .match-card .teams {
+        color: var(--color-cream);
+      }
+
+      .slider-dark .match-card .score {
+        color: var(--color-jersey-bright);
+      }
+
+      .star-mark {
+        font-family: var(--font-display);
+        color: var(--color-jersey-deep);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <!-- ===========================================================
+           HEADER
+           =========================================================== -->
+      <header class="hero">
+        <div class="hero-meta">
+          <span class="mono-label mono-label--muted">PHASE 2 · TRACK B · DIRECTION A</span>
+          <span class="mono-label mono-label--muted">★ KCVV ELEWIJT</span>
+          <span class="mono-label mono-label--muted">2026-04-30</span>
+        </div>
+        <h1>Paper &amp; <span class="em">tape.</span></h1>
+        <p>
+          Tests the hypothesis that even functional UI chrome adopts the editorial
+          paper feel — cream surfaces, hard offset shadows, sub-degree rotation,
+          tape accents, mono caps. Atoms read as physical paper artefacts even
+          when they are functional controls. <em>Argument FOR:</em> visual
+          consistency with TapedCard, EditorialHeading, and PullQuote.
+          <em>Argument AGAINST:</em> chrome wants to disappear, not draw editorial
+          weight; risk of competing with editorial primitives for attention.
+        </p>
+      </header>
+
+      <!-- ===========================================================
+           SPINNER — halftone dots + torn ticket sub-variant + logo
+           =========================================================== -->
+      <section class="section" id="spinner">
+        <div class="section-meta">
+          <span class="mono-label">★ 01 · SPINNER</span>
+          <span class="mono-label mono-label--muted">— halftone-dot cycle + torn-ticket ephemera</span>
+        </div>
+        <h2>Halftone <em>kringloop.</em></h2>
+        <p class="lead">
+          Eight ink-stamp dots arranged around a paper circle, each fading
+          sequentially at 0.15s offsets. Reads as silkscreen / risograph print
+          texture. Composes the same dot vocabulary as the perforation column on
+          <code>&lt;TicketStub&gt;</code>.
+        </p>
+
+        <div class="panel">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">A.1 · HALFTONE DOTS — sm / md / lg / xl</div>
+          <div class="spinner-grid">
+            <div class="spinner-cell">
+              <div class="halftone halftone--sm">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+              </div>
+              <span class="size-tag">SM · 16px</span>
+            </div>
+            <div class="spinner-cell">
+              <div class="halftone halftone--md">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+              </div>
+              <span class="size-tag">MD · 32px</span>
+            </div>
+            <div class="spinner-cell">
+              <div class="halftone halftone--lg">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+              </div>
+              <span class="size-tag">LG · 48px</span>
+            </div>
+            <div class="spinner-cell">
+              <div class="halftone halftone--xl">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+              </div>
+              <span class="size-tag">XL · 64px</span>
+            </div>
+          </div>
+          <p class="primitive-note">
+            ↪ Composes: paper-card frame for each cell uses <code>&lt;TapedCard&gt;</code> vocabulary
+            (border-2 ink + shadow-paper-sm). Dots use <code>--color-jersey-deep</code> (text-readable
+            green on cream).
+          </p>
+        </div>
+
+        <div class="panel panel--soft" style="margin-top: 16px">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">A.2 · TORN TICKET — inline ephemera variant</div>
+          <div class="torn-ticket">
+            <span class="stamp">★ LAADT</span>
+            <span>LADEN<span class="ellipsis"></span></span>
+          </div>
+          <p class="primitive-note">
+            ↪ Composes: <code>&lt;TicketStub&gt;</code> (perforated edge + ink-stamp label) +
+            <code>--rotate-tape-a..d</code> sub-degree tilt animation. For inline
+            "loading…" contexts where a whole-cell halftone reads as too heavy.
+          </p>
+        </div>
+
+        <div class="panel" style="margin-top: 16px">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">A.3 · LOGO VARIANT — retained as-is</div>
+          <div class="row">
+            <div class="logo-placeholder">KCVV</div>
+            <div>
+              <div class="mono-label">VARIANT="logo" — KCVV mark, 3D Y-axis spin (existing animate-kcvv-logo-spin retained)</div>
+              <p style="margin: 6px 0 0; font-size: 14px; color: var(--color-ink-soft)">
+                Already brand-character; no change required. Sized by the existing
+                sm/md/lg/xl prop (48 / 56 / 80 / 96 px).
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>
+              Halftone dots match the silkscreen / programme-print aesthetic of
+              the redesign. Ticket-stub sub-variant integrates a beloved primitive
+              (<code>&lt;TicketStub&gt;</code>) at micro-scale. Both stay calm —
+              never aggressive UX-loader material.
+            </p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>
+              Halftone dots may read as decorative-not-functional at sm sizes
+              (16 px) — ambiguity around "what's loading?". Torn-ticket form is
+              novel and may cost a few seconds of recognition the first time a
+              user encounters it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           BRANDED TABS — taped paper-card strip
+           =========================================================== -->
+      <section class="section" id="branded-tabs">
+        <div class="section-meta">
+          <span class="mono-label">★ 02 · BRANDED TABS</span>
+          <span class="mono-label mono-label--muted">— paper-card strip, jersey tape on active</span>
+        </div>
+        <h2>Geplakte <em>tabbladen.</em></h2>
+        <p class="lead">
+          Each tab is a flat paper card (<code>&lt;TapedCard&gt;</code> vocabulary —
+          <code>border-2 ink</code> + <code>shadow-paper-sm</code>, no rotation on
+          inactive — chrome stays straight to read as a row). Active tab inverts
+          to ink + cream and gets a jersey washi tape strip pinned to the
+          top-left corner at -8°.
+        </p>
+
+        <div class="panel">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">DEFAULT — on cream</div>
+          <div class="branded-tabs" role="tablist" aria-label="Ploeg selectie">
+            <button class="b-tab" type="button" role="tab" aria-selected="false">A-PLOEG</button>
+            <button class="b-tab b-tab--active" type="button" role="tab" aria-selected="true">B-PLOEG</button>
+            <button class="b-tab" type="button" role="tab" aria-selected="false">U21</button>
+            <button class="b-tab" type="button" role="tab" aria-selected="false">U17</button>
+            <button class="b-tab" type="button" role="tab" aria-selected="false">DAMES</button>
+          </div>
+        </div>
+
+        <div class="panel panel--soft" style="margin-top: 16px">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">OVERFLOW — scroll-arrow visible on right edge</div>
+          <div class="scroll-arrow-overlay">
+            <div class="branded-tabs" role="tablist" aria-label="Wedstrijden filter">
+              <button class="b-tab b-tab--active" type="button" role="tab">RECENT</button>
+              <button class="b-tab" type="button" role="tab">AANKOMEND</button>
+              <button class="b-tab" type="button" role="tab">UITSLAGEN</button>
+              <button class="b-tab" type="button" role="tab">COMPETITIE</button>
+              <button class="b-tab" type="button" role="tab">BEKER</button>
+              <button class="b-tab" type="button" role="tab">VRIENDSCHAPPELIJK</button>
+            </div>
+          </div>
+          <p class="primitive-note">↪ Right-edge arrow uses the same square-paper-button vocabulary as the slider arrows below.</p>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>
+              Tabs read as a printed programme's section dividers — physically
+              recognisable. The jersey tape strip on active is unmistakable
+              ("torn from the supporters' programme"). Reuses
+              <code>&lt;TapeStrip&gt;</code> + <code>&lt;TapedCard&gt;</code>
+              vocabulary.
+            </p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>
+              Five card-shadows + a tape strip = visual weight that may compete
+              with adjacent editorial content. Inactive tabs still carry full
+              border + shadow; reading them as "navigation chrome" rather than
+              "another row of cards" depends on context.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           FILTER TABS — paper chips with ink-stamp count
+           =========================================================== -->
+      <section class="section" id="filter-tabs">
+        <div class="section-meta">
+          <span class="mono-label">★ 03 · FILTER TABS</span>
+          <span class="mono-label mono-label--muted">— paper chips, ink-stamp count badges</span>
+        </div>
+        <h2>Stempel <em>chipjes.</em></h2>
+        <p class="lead">
+          Same paper-card vocabulary at chip scale — border + shadow + small
+          ink-stamp count. Active flips to a jersey fill (the only place jersey
+          appears on cream as full surface — earns its weight by signalling the
+          single active filter).
+        </p>
+
+        <div class="panel">
+          <div class="filter-row">
+            <span class="size-tag">LG</span>
+            <div class="filter-tabs">
+              <button class="f-chip f-chip--lg f-chip--active" type="button">LIVE <span class="count">1</span></button>
+              <button class="f-chip f-chip--lg" type="button">AANKOMEND <span class="count">6</span></button>
+              <button class="f-chip f-chip--lg" type="button">UITSLAGEN <span class="count">24</span></button>
+              <button class="f-chip f-chip--lg" type="button">THUIS <span class="count">12</span></button>
+              <button class="f-chip f-chip--lg" type="button">UIT <span class="count">13</span></button>
+            </div>
+          </div>
+
+          <div class="filter-row">
+            <span class="size-tag">MD</span>
+            <div class="filter-tabs">
+              <button class="f-chip" type="button">LIVE <span class="count">1</span></button>
+              <button class="f-chip f-chip--active" type="button">AANKOMEND <span class="count">6</span></button>
+              <button class="f-chip" type="button">UITSLAGEN <span class="count">24</span></button>
+              <button class="f-chip" type="button">THUIS <span class="count">12</span></button>
+              <button class="f-chip" type="button">UIT <span class="count">13</span></button>
+            </div>
+          </div>
+
+          <div class="filter-row">
+            <span class="size-tag">SM</span>
+            <div class="filter-tabs">
+              <button class="f-chip f-chip--sm" type="button">LIVE <span class="count">1</span></button>
+              <button class="f-chip f-chip--sm" type="button">AANKOMEND <span class="count">6</span></button>
+              <button class="f-chip f-chip--sm f-chip--active" type="button">UITSLAGEN <span class="count">24</span></button>
+              <button class="f-chip f-chip--sm" type="button">THUIS <span class="count">12</span></button>
+              <button class="f-chip f-chip--sm" type="button">UIT <span class="count">13</span></button>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel panel--soft" style="margin-top: 16px">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">WITH LEADING GLYPHS — typographic icons over Phosphor where possible</div>
+          <div class="filter-tabs">
+            <button class="f-chip" type="button"><span class="glyph">★</span> ALLES <span class="count">76</span></button>
+            <button class="f-chip f-chip--active" type="button"><span class="glyph">⌂</span> THUIS <span class="count">12</span></button>
+            <button class="f-chip" type="button"><span class="glyph">↗</span> UIT <span class="count">13</span></button>
+            <button class="f-chip" type="button"><span class="glyph">§</span> COMPETITIE <span class="count">22</span></button>
+            <button class="f-chip" type="button"><span class="glyph">¶</span> BEKER <span class="count">3</span></button>
+          </div>
+          <p class="primitive-note">↪ Glyphs in italic Freight Display where legible (★ ⌂ ↗ § ¶); fall back to Phosphor Fill via <code>icons.redesign.ts</code> when not.</p>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>
+              Active state is unambiguous — single jersey-filled chip in a row of
+              cream chips. Count badges read as physical ink-stamps, matching
+              programme-page typography. Sm/md/lg differ only in padding —
+              consistent visual rhythm across sizes.
+            </p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>
+              Five paper-shadow chips in a row create cumulative visual noise.
+              When chip rows appear in tight contexts (sidebars, dense headers),
+              the shadow stack-up makes the row feel "loud". May need a
+              <code>density="compact"</code> escape hatch in real usage.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           HORIZONTAL SLIDER + arrow buttons
+           =========================================================== -->
+      <section class="section" id="slider">
+        <div class="section-meta">
+          <span class="mono-label">★ 04 · HORIZONTAL SLIDER + SCROLL HINT</span>
+          <span class="mono-label mono-label--muted">— paper button arrows, jersey tape corner</span>
+        </div>
+        <h2>Papieren <em>pijlen.</em></h2>
+        <p class="lead">
+          Square paper buttons composing <code>&lt;TapedCard&gt;</code>: border 2 ink,
+          shadow-paper-sm, jersey washi tape strip on top-left at -10°. The arrow
+          glyph is a typographic <em>← / →</em> in Freight Display italic — never a
+          Phosphor arrow at this size (the glyph reads cleaner). Press collapses
+          the shadow + translates +1px on both axes.
+        </p>
+
+        <div class="panel">
+          <div class="mono-label mono-label--muted" style="margin-bottom: 16px">LIGHT THEME — cream bg, paper arrow buttons floating at edges</div>
+          <div class="slider-wrap">
+            <button class="arrow-btn arrow-btn--left" type="button" aria-label="Vorige"><span>←</span></button>
+            <div class="slider-track">
+              <div class="match-card">
+                <div class="meta">★ LIVE · 67' · 1STE PROV.</div>
+                <div class="teams">KCVV vs Tervuren</div>
+                <div class="score">2 — 1</div>
+              </div>
+              <div class="match-card">
+                <div class="meta">ZA 02 MEI · 20:00</div>
+                <div class="teams">Wezembeek vs KCVV</div>
+                <div class="score">VS</div>
+              </div>
+              <div class="match-card">
+                <div class="meta">WO 06 MEI · 19:30 · BEKER</div>
+                <div class="teams">KCVV vs Lebbeke</div>
+                <div class="score">VS</div>
+              </div>
+              <div class="match-card">
+                <div class="meta">ZA 09 MEI · 15:00</div>
+                <div class="teams">KCVV vs Vilvoorde</div>
+                <div class="score">VS</div>
+              </div>
+            </div>
+            <button class="arrow-btn arrow-btn--right" type="button" aria-label="Volgende"><span>→</span></button>
+          </div>
+        </div>
+
+        <div class="panel" style="margin-top: 16px; padding: 0">
+          <div class="mono-label mono-label--muted" style="padding: 16px 16px 0">DARK THEME — ink-soft bg, jersey-bright tape strip</div>
+          <div class="slider-dark">
+            <div class="slider-wrap">
+              <button class="arrow-btn arrow-btn--dark arrow-btn--left" type="button" aria-label="Vorige"><span>←</span></button>
+              <div class="slider-track">
+                <div class="match-card">
+                  <div class="meta">★ LIVE · 67' · 1STE PROV.</div>
+                  <div class="teams">KCVV vs Tervuren</div>
+                  <div class="score">2 — 1</div>
+                </div>
+                <div class="match-card">
+                  <div class="meta">ZA 02 MEI · 20:00</div>
+                  <div class="teams">Wezembeek vs KCVV</div>
+                  <div class="score">VS</div>
+                </div>
+                <div class="match-card">
+                  <div class="meta">WO 06 MEI · 19:30</div>
+                  <div class="teams">KCVV vs Lebbeke</div>
+                  <div class="score">VS</div>
+                </div>
+                <div class="match-card">
+                  <div class="meta">ZA 09 MEI · 15:00</div>
+                  <div class="teams">KCVV vs Vilvoorde</div>
+                  <div class="score">VS</div>
+                </div>
+              </div>
+              <button class="arrow-btn arrow-btn--dark arrow-btn--right" type="button" aria-label="Volgende"><span>→</span></button>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>
+              Arrows are visually unmistakable as "click me" — paper depth + tape
+              strip read as a tangible object. Press feedback (shadow collapse +
+              translate) is the same idiom as the rest of the redesign's button
+              vocabulary. Glyph instead of Phosphor arrow keeps the editorial
+              tone.
+            </p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>
+              Arrows visually weigh more than the cards they're navigating —
+              especially noticeable when only 4 cards fit and overflow is barely
+              there. May need a smaller "size: sm" variant for compact slider
+              contexts (single-card mobile, narrow sidebar).
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           COHESION mini-mockup
+           =========================================================== -->
+      <section class="section" id="cohesion">
+        <div class="section-meta">
+          <span class="mono-label">★ 05 · COHESION CHECK</span>
+          <span class="mono-label mono-label--muted">— all four atoms in a "matches" page fragment</span>
+        </div>
+        <h2>De <em>kruistest.</em></h2>
+        <p class="lead">
+          The real measure: do BrandedTabs, FilterTabs, the slider, and a spinner
+          read as one family on a page? Below: a single composite mock to
+          eyeball coherence vs. cumulative visual noise.
+        </p>
+
+        <div class="cohesion">
+          <div class="cohesion-head">
+            <div>
+              <div class="mono-label mono-label--muted" style="margin-bottom: 6px">★ MATCHDAG</div>
+              <h2 class="display"><em>Wedstrijden.</em></h2>
+            </div>
+            <div class="cohesion-loading">
+              <div class="halftone halftone--md">
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+                <span class="dot"></span><span class="dot"></span><span class="dot"></span><span class="dot"></span>
+              </div>
+              <span>BIJWERKEN<span class="ellipsis"></span></span>
+            </div>
+          </div>
+
+          <div class="branded-tabs" style="margin-bottom: 16px">
+            <button class="b-tab b-tab--active" type="button">A-PLOEG</button>
+            <button class="b-tab" type="button">B-PLOEG</button>
+            <button class="b-tab" type="button">U21</button>
+            <button class="b-tab" type="button">DAMES</button>
+          </div>
+
+          <div class="filter-tabs" style="margin-bottom: 24px">
+            <button class="f-chip" type="button">LIVE <span class="count">1</span></button>
+            <button class="f-chip f-chip--active" type="button">AANKOMEND <span class="count">6</span></button>
+            <button class="f-chip" type="button">UITSLAGEN <span class="count">24</span></button>
+            <button class="f-chip" type="button">THUIS <span class="count">12</span></button>
+          </div>
+
+          <div class="slider-wrap" style="padding: 0 28px 0 0">
+            <div class="slider-track">
+              <div class="match-card">
+                <div class="meta">★ LIVE · 67' · 1STE PROV.</div>
+                <div class="teams">KCVV vs Tervuren</div>
+                <div class="score">2 — 1</div>
+              </div>
+              <div class="match-card">
+                <div class="meta">ZA 02 MEI · 20:00</div>
+                <div class="teams">Wezembeek vs KCVV</div>
+                <div class="score">VS</div>
+              </div>
+              <div class="match-card">
+                <div class="meta">WO 06 MEI · 19:30</div>
+                <div class="teams">KCVV vs Lebbeke</div>
+                <div class="score">VS</div>
+              </div>
+            </div>
+            <button class="arrow-btn arrow-btn--right" type="button" aria-label="Volgende"><span>→</span></button>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           FOOTER NOTES
+           =========================================================== -->
+      <footer>
+        <div class="section-meta">
+          <span class="mono-label">★ NOTES</span>
+          <span class="mono-label mono-label--muted">— token map, primitive composition, prop preservation</span>
+        </div>
+
+        <h3>Token map</h3>
+        <div class="map-grid">
+          <div>
+            <h4>SURFACE / TEXT</h4>
+            <ul>
+              <li>Tab + chip body: <code>--color-cream</code> default, <code>--color-cream-soft</code> for variation</li>
+              <li>Active tab: <code>--color-ink</code> bg + <code>--color-cream</code> text</li>
+              <li>Active chip: <code>--color-jersey</code> bg + <code>--color-ink</code> text</li>
+              <li>Body text + count badges: <code>--color-ink</code> on cream</li>
+              <li>Spinner dots: <code>--color-jersey-deep</code></li>
+            </ul>
+          </div>
+          <div>
+            <h4>STRUCTURE / DEPTH</h4>
+            <ul>
+              <li>Every atom: <code>border: 2px solid var(--color-ink)</code></li>
+              <li>Every atom: <code>--shadow-paper-sm</code> (4×4 ink offset, no blur)</li>
+              <li>Press state: shadow collapses to 3×3 + translate +1/+1</li>
+              <li>Tape strips: <code>--color-jersey</code>/<code>jersey-deep</code> stripe pattern, -8° to -10°</li>
+              <li>Match card rotation: <code>--rotate-tape-a..d</code> (sub-degree pool)</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3 style="margin-top: 32px">Primitive composition map</h3>
+        <ul style="font-size: 14px; color: var(--color-ink-soft); padding-left: 18px">
+          <li><strong>Spinner cells</strong> compose <code>&lt;TapedCard&gt;</code> (border-2 ink + shadow-paper-sm + bg cream); halftone dots are the same dot vocabulary as <code>&lt;TicketStub&gt;</code> perforations.</li>
+          <li><strong>Spinner sub-variant A.2</strong> (torn ticket) directly composes <code>&lt;TicketStub&gt;</code> — perforated edge + ink-stamp label.</li>
+          <li><strong>BrandedTabs</strong> active state composes <code>&lt;TapedCard bg="ink"&gt;</code> (inverted) + <code>&lt;TapeStrip color="jersey" position="tl" rotation="-8"&gt;</code>.</li>
+          <li><strong>FilterTabs chips</strong> are <code>&lt;TapedCard&gt;</code> at chip scale (border + shadow); count badges use <code>&lt;MonoLabel variant="pill-ink"&gt;</code> sizing (11px / 0.08em / pill padding).</li>
+          <li><strong>HorizontalSlider arrows</strong> compose <code>&lt;TapedCard&gt;</code> (square 48px) + <code>&lt;TapeStrip color="jersey"&gt;</code> at -10°. Glyph is typographic Freight Display italic per the "no Lucide where the glyph reads" preference.</li>
+          <li><strong>Cohesion mini-mockup</strong> uses <code>&lt;EditorialHeading&gt;</code> period-terminated heading (<em>Wedstrijden.</em>) + <code>&lt;MonoLabelRow&gt;</code> kicker.</li>
+        </ul>
+
+        <h3 style="margin-top: 32px">Prop-surface preservation</h3>
+        <p style="font-size: 14px; color: var(--color-ink-soft)">
+          Every atom's TypeScript surface is preserved. Visual changes are
+          token + layout only. Specifically:
+        </p>
+        <ul style="font-size: 14px; color: var(--color-ink-soft); padding-left: 18px">
+          <li><code>Spinner</code>: <code>size: "sm" | "md" | "lg" | "xl"</code>, <code>variant: "primary" | "secondary" | "white" | "logo"</code>, <code>label</code>. Halftone implementation replaces the SVG circle for non-logo variants. Sizes 16/32/48/64 px unchanged.</li>
+          <li><code>BrandedTabs</code>: <code>tabs</code>, <code>activeTabId</code>, <code>onTabChange</code>, <code>ariaLabel?</code>. No new props.</li>
+          <li><code>FilterTabs</code>: <code>tabs</code>, <code>activeTab</code>, <code>onChange?</code>, <code>size</code>, <code>showCounts?</code>, <code>icon?</code>, <code>renderAsLinks?</code>. Icon prop type swap to Phosphor <code>Icon</code> per Phase 2.A.6 — Direction A is compatible with that swap.</li>
+          <li><code>HorizontalSlider</code>: <code>children</code>, <code>title?</code>, <code>theme: "light" | "dark"</code>. No new props.</li>
+          <li><code>ScrollArrowButton</code>: <code>direction</code>, <code>onClick</code>, <code>variant: "light" | "dark"</code>. May need <code>size?: "sm" | "md"</code> if compact slider contexts surface (see Slider trade-offs).</li>
+        </ul>
+
+        <h3 style="margin-top: 32px">Direction-level trade-offs</h3>
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ DIRECTION FOR</h4>
+            <p>
+              Maximum coherence with editorial primitives. The site reads as one
+              physical artefact — programme, scarf, ticket — without exception.
+              Every chrome decision reinforces the core thesis.
+            </p>
+          </div>
+          <div>
+            <h4 class="against">↓ DIRECTION AGAINST</h4>
+            <p>
+              Cumulative paper-shadow density on chrome-heavy surfaces (filter +
+              tab + slider arrow + spinner all in one viewport) may compete with
+              editorial cards for visual weight. Editorial primitives already
+              earn paper depth; chrome carrying it too can flatten the
+              hierarchy.
+            </p>
+          </div>
+        </div>
+
+        <p style="margin-top: 32px; font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-ink-muted)">
+          ★ END · DIRECTION A — PAPER &amp; TAPE · KCVV ELEWIJT · 2026-04-30
+        </p>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/design/mockups/phase-2-track-b/option-b-mono-and-ink.html
+++ b/docs/design/mockups/phase-2-track-b/option-b-mono-and-ink.html
@@ -1,0 +1,2121 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=1280, initial-scale=1" />
+    <title>KCVV Elewijt — Phase 2 · Track B · Direction B — Mono &amp; Ink</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,700;0,900;1,400&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ------------------------------------------------------------------
+         TOKENS — Direction B explicitly does NOT consume --shadow-paper-*
+         ------------------------------------------------------------------ */
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #4acf52;
+        --color-jersey-deep: #008755;
+        --color-jersey-bright: #22c55e;
+        --color-paper-edge: #d9d2bd;
+        --color-alert: #b84a3a;
+        --color-warning: #c68b2c;
+
+        --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.08);
+
+        --font-display: "Playfair Display", "Georgia", serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", "Menlo", monospace;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: var(--font-body);
+        font-size: 16px;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      ::selection {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      .page {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 64px 56px 96px;
+      }
+
+      /* ------------------------------------------------------------------
+         HELPERS
+         ------------------------------------------------------------------ */
+      .kicker {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 11px;
+        line-height: 1;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .kicker .dot {
+        width: 4px;
+        height: 4px;
+        background: var(--color-ink);
+        border-radius: 50%;
+        display: inline-block;
+      }
+
+      .kicker--ink {
+        color: var(--color-ink);
+      }
+
+      .hairline {
+        height: 1px;
+        background: var(--color-ink);
+        opacity: 0.18;
+        width: 100%;
+      }
+
+      h1.display,
+      h2.display,
+      h3.display {
+        font-family: var(--font-display);
+        font-weight: 900;
+        line-height: 0.95;
+        letter-spacing: -0.01em;
+        margin: 0;
+      }
+
+      h1.display {
+        font-size: 88px;
+        font-style: italic;
+        font-weight: 400;
+      }
+
+      h1.display .period {
+        color: var(--color-jersey-deep);
+        font-style: normal;
+      }
+
+      h2.display {
+        font-size: 52px;
+      }
+
+      h3.display {
+        font-size: 36px;
+        font-weight: 700;
+      }
+
+      .lede {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-ink-soft);
+        line-height: 1.35;
+        max-width: 60ch;
+        margin: 18px 0 0;
+      }
+
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.9em;
+        background: rgba(10, 10, 10, 0.06);
+        padding: 1px 5px;
+        color: var(--color-ink);
+      }
+
+      /* ------------------------------------------------------------------
+         HEADER
+         ------------------------------------------------------------------ */
+      .doc-header {
+        padding-bottom: 48px;
+        margin-bottom: 56px;
+        border-bottom: 1px solid var(--color-ink);
+        position: relative;
+      }
+
+      .doc-header .kicker-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 28px;
+      }
+
+      .doc-header h1 {
+        max-width: 14ch;
+      }
+
+      .doc-header .meta {
+        margin-top: 36px;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 28px;
+        padding-top: 24px;
+        border-top: 1px solid var(--color-ink);
+      }
+
+      .meta dt {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-bottom: 6px;
+      }
+
+      .meta dd {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        color: var(--color-ink);
+      }
+
+      /* ------------------------------------------------------------------
+         SECTION
+         ------------------------------------------------------------------ */
+      section.atom {
+        padding: 56px 0 64px;
+        border-bottom: 1px solid rgba(10, 10, 10, 0.18);
+      }
+
+      section.atom:last-of-type {
+        border-bottom: none;
+      }
+
+      .atom-head {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: end;
+        gap: 32px;
+        margin-bottom: 36px;
+      }
+
+      .atom-head .copy {
+        max-width: 60ch;
+      }
+
+      .atom-head h2 {
+        margin: 14px 0 0;
+      }
+
+      .atom-head p {
+        margin: 14px 0 0;
+        color: var(--color-ink-soft);
+        font-size: 16px;
+        line-height: 1.6;
+      }
+
+      .atom-head .index {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 96px;
+        line-height: 0.85;
+        color: var(--color-ink);
+        opacity: 0.12;
+      }
+
+      .demo-card {
+        background: var(--color-cream);
+        border: 1px solid var(--color-ink);
+        padding: 36px 32px 32px;
+        position: relative;
+      }
+
+      .demo-card .demo-label {
+        position: absolute;
+        top: 0;
+        left: 24px;
+        transform: translateY(-50%);
+        background: var(--color-cream);
+        padding: 0 10px;
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 11px;
+        line-height: 1;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+
+      .demo-card--soft {
+        background: var(--color-cream-soft);
+      }
+
+      .demo-card--soft .demo-label {
+        background: var(--color-cream-soft);
+      }
+
+      .demo-card--ink {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        border-color: var(--color-ink);
+      }
+
+      .demo-card--ink .demo-label {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      /* ------------------------------------------------------------------
+         SPINNER — variant B.1: mono ellipsis + 2px arc
+         ------------------------------------------------------------------ */
+      .spinner-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 24px;
+        align-items: stretch;
+      }
+
+      .spinner-tile {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 18px;
+        padding: 36px 12px 18px;
+        border: 1px solid rgba(10, 10, 10, 0.18);
+        background: var(--color-cream);
+        min-height: 240px;
+      }
+
+      .spinner-tile__caption {
+        font-family: var(--font-mono);
+        font-weight: 500;
+        font-size: 10px;
+        line-height: 1.4;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        text-align: center;
+      }
+
+      .spinner-tile__caption strong {
+        display: block;
+        color: var(--color-ink);
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+
+      .spinner-b1 {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .spinner-b1__arc {
+        position: absolute;
+        inset: 0;
+        margin: auto;
+        border: 2px solid transparent;
+        border-top-color: var(--color-ink);
+        border-right-color: var(--color-ink);
+        border-radius: 50%;
+        animation: spin-quiet 1.6s linear infinite;
+      }
+
+      .spinner-b1__label {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        white-space: nowrap;
+        text-align: center;
+        position: relative;
+      }
+
+      .spinner-b1__label::after {
+        content: ".";
+        display: inline-block;
+        animation: ellipsis 1.6s steps(4, end) infinite;
+        margin-left: 1px;
+        position: relative;
+      }
+
+      .spinner-b1--sm {
+        width: 64px;
+        height: 64px;
+      }
+      .spinner-b1--sm .spinner-b1__label {
+        font-size: 8px;
+        letter-spacing: 0.14em;
+      }
+
+      .spinner-b1--md {
+        width: 96px;
+        height: 96px;
+      }
+      .spinner-b1--md .spinner-b1__label {
+        font-size: 10px;
+      }
+
+      .spinner-b1--lg {
+        width: 128px;
+        height: 128px;
+      }
+      .spinner-b1--lg .spinner-b1__label {
+        font-size: 12px;
+      }
+
+      .spinner-b1--xl {
+        width: 168px;
+        height: 168px;
+      }
+      .spinner-b1--xl .spinner-b1__arc {
+        border-width: 2.5px;
+      }
+      .spinner-b1--xl .spinner-b1__label {
+        font-size: 14px;
+      }
+
+      @keyframes spin-quiet {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @keyframes ellipsis {
+        0% {
+          content: ".";
+        }
+        25% {
+          content: "..";
+        }
+        50% {
+          content: "...";
+        }
+        75% {
+          content: "..";
+        }
+        100% {
+          content: ".";
+        }
+      }
+
+      /* B.2 — three-dot inline pulse */
+      .spinner-b2 {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 0 4px;
+      }
+
+      .spinner-b2 .pulse-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--color-ink);
+        opacity: 0.25;
+        animation: dot-pulse 1.2s ease-in-out infinite;
+      }
+
+      .spinner-b2 .pulse-dot:nth-child(1) {
+        animation-delay: 0s;
+      }
+      .spinner-b2 .pulse-dot:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+      .spinner-b2 .pulse-dot:nth-child(3) {
+        animation-delay: 0.4s;
+      }
+
+      .spinner-b2__label {
+        font-family: var(--font-mono);
+        font-weight: 500;
+        font-size: 12px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-left: 12px;
+      }
+
+      @keyframes dot-pulse {
+        0%,
+        100% {
+          opacity: 0.18;
+          transform: translateY(0) scale(0.92);
+        }
+        40% {
+          opacity: 1;
+          transform: translateY(-1px) scale(1);
+        }
+      }
+
+      .spinner-inline-row {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        padding: 18px 22px;
+        border: 1px solid rgba(10, 10, 10, 0.2);
+        background: var(--color-cream);
+      }
+
+      .spinner-inline-row + .spinner-inline-row {
+        margin-top: 12px;
+      }
+
+      .spinner-inline-row__copy {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .spinner-inline-row__copy strong {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+      }
+
+      .spinner-inline-row__copy span {
+        font-size: 13px;
+        color: var(--color-ink-muted);
+      }
+
+      /* logo variant placeholder */
+      .spinner-logo {
+        width: 96px;
+        height: 96px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+      }
+
+      .spinner-logo svg {
+        width: 100%;
+        height: 100%;
+        animation: logo-pulse 2.4s ease-in-out infinite;
+      }
+
+      @keyframes logo-pulse {
+        0%,
+        100% {
+          opacity: 0.55;
+        }
+        50% {
+          opacity: 1;
+        }
+      }
+
+      /* ------------------------------------------------------------------
+         BRANDED TABS
+         ------------------------------------------------------------------ */
+      .branded-tabs {
+        position: relative;
+        display: flex;
+        align-items: stretch;
+        gap: 48px;
+        padding: 6px 0 0;
+      }
+
+      .branded-tabs__hairline {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 1px;
+        background: var(--color-ink);
+        opacity: 0.22;
+      }
+
+      .branded-tab {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 14px 0 18px;
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 12px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        background: transparent;
+        border: 0;
+        cursor: pointer;
+        transition: color 160ms ease;
+      }
+
+      .branded-tab:hover {
+        color: var(--color-ink);
+      }
+
+      .branded-tab[aria-selected="true"] {
+        color: var(--color-ink);
+      }
+
+      .branded-tab[aria-selected="true"]::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: -1px;
+        height: 3px;
+        background: var(--color-jersey-deep);
+      }
+
+      .branded-tab:focus-visible {
+        outline: 1px dashed var(--color-ink);
+        outline-offset: 4px;
+      }
+
+      .branded-tabs--ink .branded-tab {
+        color: rgba(245, 241, 230, 0.55);
+      }
+      .branded-tabs--ink .branded-tab:hover,
+      .branded-tabs--ink .branded-tab[aria-selected="true"] {
+        color: var(--color-cream);
+      }
+      .branded-tabs--ink .branded-tabs__hairline {
+        background: var(--color-cream);
+        opacity: 0.25;
+      }
+      .branded-tabs--ink .branded-tab[aria-selected="true"]::after {
+        background: var(--color-jersey);
+      }
+
+      /* state preview row */
+      .state-row {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+        margin-top: 28px;
+      }
+
+      .state-card {
+        padding: 22px 22px 24px;
+        border: 1px solid rgba(10, 10, 10, 0.2);
+        background: var(--color-cream);
+      }
+
+      .state-card__caption {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 10px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-bottom: 14px;
+      }
+
+      .state-card .branded-tabs {
+        gap: 28px;
+      }
+
+      .state-card .branded-tab {
+        font-size: 11px;
+      }
+
+      /* ------------------------------------------------------------------
+         FILTER TABS
+         ------------------------------------------------------------------ */
+      .filter-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .filter-row + .filter-row {
+        margin-top: 16px;
+      }
+
+      .filter-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: var(--font-mono);
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        background: transparent;
+        border: 0;
+        cursor: pointer;
+        transition:
+          background-color 140ms ease,
+          color 140ms ease;
+        white-space: nowrap;
+      }
+
+      .filter-chip__count {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        color: var(--color-ink-muted);
+        font-weight: 500;
+      }
+
+      .filter-chip__count::before {
+        content: "";
+        display: inline-block;
+        width: 1px;
+        height: 10px;
+        background: currentColor;
+        opacity: 0.55;
+      }
+
+      .filter-chip[aria-pressed="true"] {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      .filter-chip[aria-pressed="true"] .filter-chip__count {
+        color: var(--color-cream);
+        opacity: 0.75;
+      }
+
+      .filter-chip:hover:not([aria-pressed="true"]) {
+        color: var(--color-ink-soft);
+        background: rgba(10, 10, 10, 0.05);
+      }
+
+      .filter-chip:focus-visible {
+        outline: 1px dashed var(--color-ink);
+        outline-offset: 3px;
+      }
+
+      .filter-chip__icon {
+        display: inline-flex;
+        font-family: var(--font-mono);
+        font-weight: 700;
+        font-size: 11px;
+        line-height: 1;
+        letter-spacing: 0;
+      }
+
+      .filter-chip--sm {
+        font-size: 11px;
+        padding: 6px 10px;
+      }
+
+      .filter-chip--md {
+        font-size: 12px;
+        padding: 9px 14px;
+      }
+
+      .filter-chip--lg {
+        font-size: 13px;
+        padding: 12px 18px;
+      }
+
+      .filter-row__label {
+        width: 64px;
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+
+      .live-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--color-alert);
+        display: inline-block;
+        animation: live-pulse 1.4s ease-in-out infinite;
+      }
+
+      .filter-chip[aria-pressed="true"] .live-dot {
+        background: var(--color-jersey);
+      }
+
+      @keyframes live-pulse {
+        0%,
+        100% {
+          opacity: 0.55;
+          transform: scale(0.85);
+        }
+        50% {
+          opacity: 1;
+          transform: scale(1.1);
+        }
+      }
+
+      /* ------------------------------------------------------------------
+         HORIZONTAL SLIDER
+         ------------------------------------------------------------------ */
+      .slider {
+        position: relative;
+        padding: 28px 0 4px;
+        background: var(--color-cream);
+      }
+
+      .slider--ink {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      .slider__head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        margin-bottom: 22px;
+      }
+
+      .slider__title {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 36px;
+        line-height: 1;
+        letter-spacing: -0.01em;
+      }
+
+      .slider__title .period {
+        color: var(--color-jersey-deep);
+      }
+
+      .slider--ink .slider__title .period {
+        color: var(--color-jersey);
+      }
+
+      .slider__controls {
+        display: inline-flex;
+        gap: 8px;
+      }
+
+      .scroll-arrow {
+        width: 40px;
+        height: 40px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: transparent;
+        border: 1px solid var(--color-ink);
+        cursor: pointer;
+        font-family: var(--font-mono);
+        font-size: 18px;
+        font-weight: 600;
+        line-height: 1;
+        color: var(--color-ink);
+        transition:
+          background-color 160ms ease,
+          color 160ms ease;
+        padding: 0;
+      }
+
+      .scroll-arrow:hover {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      .scroll-arrow:focus-visible {
+        outline: 1px dashed var(--color-ink);
+        outline-offset: 3px;
+      }
+
+      .scroll-arrow[disabled] {
+        opacity: 0.3;
+        cursor: not-allowed;
+      }
+
+      .slider--ink .scroll-arrow {
+        border-color: var(--color-cream);
+        color: var(--color-cream);
+      }
+
+      .slider--ink .scroll-arrow:hover {
+        background: var(--color-cream);
+        color: var(--color-ink);
+      }
+
+      .slider__track {
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(260px, 1fr);
+        gap: 16px;
+        overflow-x: hidden;
+        padding-bottom: 4px;
+      }
+
+      .match-card {
+        border: 1px solid var(--color-ink);
+        padding: 18px;
+        background: var(--color-cream);
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        min-height: 168px;
+      }
+
+      .slider--ink .match-card {
+        background: var(--color-ink);
+        border-color: rgba(245, 241, 230, 0.4);
+        color: var(--color-cream);
+      }
+
+      .match-card__meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+
+      .slider--ink .match-card__meta {
+        color: rgba(245, 241, 230, 0.65);
+      }
+
+      .match-card__teams {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .match-card__row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-weight: 600;
+        font-size: 15px;
+      }
+
+      .match-card__row .team {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .match-card__crest {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--color-cream-soft);
+        border: 1px solid var(--color-ink);
+        display: inline-block;
+        flex-shrink: 0;
+      }
+
+      .slider--ink .match-card__crest {
+        background: var(--color-ink-soft);
+        border-color: rgba(245, 241, 230, 0.5);
+      }
+
+      .match-card__crest--away {
+        background: var(--color-jersey);
+        border-color: var(--color-jersey-deep);
+      }
+
+      .match-card__score {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+      }
+
+      .match-card__footer {
+        margin-top: auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        padding-top: 10px;
+        border-top: 1px solid rgba(10, 10, 10, 0.18);
+      }
+
+      .slider--ink .match-card__footer {
+        color: rgba(245, 241, 230, 0.55);
+        border-top-color: rgba(245, 241, 230, 0.18);
+      }
+
+      .match-card .badge-final {
+        color: var(--color-ink);
+        font-weight: 700;
+      }
+
+      .slider--ink .match-card .badge-final {
+        color: var(--color-cream);
+      }
+
+      .slider__track--drift {
+        animation: drift 18s ease-in-out infinite alternate;
+      }
+
+      @keyframes drift {
+        0% {
+          transform: translateX(0);
+        }
+        100% {
+          transform: translateX(-32px);
+        }
+      }
+
+      /* ------------------------------------------------------------------
+         COHESION
+         ------------------------------------------------------------------ */
+      .cohesion {
+        background: var(--color-cream);
+        border: 1px solid var(--color-ink);
+        padding: 40px 36px 44px;
+      }
+
+      .cohesion__head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        margin-bottom: 24px;
+      }
+
+      .cohesion__title {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 64px;
+        letter-spacing: -0.01em;
+        line-height: 0.95;
+      }
+
+      .cohesion__title .period {
+        color: var(--color-jersey-deep);
+      }
+
+      .cohesion__sub {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 18px;
+        color: var(--color-ink-soft);
+        margin-top: 8px;
+        max-width: 38ch;
+      }
+
+      .cohesion__loading-slot {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 18px 22px;
+        margin-top: 24px;
+        border: 1px dashed rgba(10, 10, 10, 0.4);
+        background: var(--color-cream-soft);
+      }
+
+      .cohesion__loading-slot__copy {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .cohesion__loading-slot__copy strong {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .cohesion__loading-slot span {
+        font-size: 13px;
+        color: var(--color-ink-muted);
+      }
+
+      .cohesion__filters {
+        margin: 18px 0 24px;
+      }
+
+      /* ------------------------------------------------------------------
+         TRADE-OFFS / NOTES
+         ------------------------------------------------------------------ */
+      .tradeoffs {
+        margin-top: 28px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+
+      .tradeoff {
+        border-left: 2px solid var(--color-ink);
+        padding: 4px 0 4px 16px;
+      }
+
+      .tradeoff--for {
+        border-left-color: var(--color-jersey-deep);
+      }
+
+      .tradeoff--against {
+        border-left-color: var(--color-alert);
+      }
+
+      .tradeoff__label {
+        font-family: var(--font-mono);
+        font-weight: 700;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin-bottom: 6px;
+      }
+
+      .tradeoff--for .tradeoff__label {
+        color: var(--color-jersey-deep);
+      }
+
+      .tradeoff--against .tradeoff__label {
+        color: var(--color-alert);
+      }
+
+      .tradeoff p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.55;
+        color: var(--color-ink-soft);
+      }
+
+      /* token map */
+      .token-map {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 16px;
+        margin-top: 28px;
+      }
+
+      .token-card {
+        padding: 12px 14px;
+        border: 1px solid rgba(10, 10, 10, 0.18);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 1.4;
+        background: var(--color-cream);
+      }
+
+      .token-card .swatch {
+        width: 18px;
+        height: 18px;
+        display: inline-block;
+        vertical-align: middle;
+        margin-right: 8px;
+        border: 1px solid rgba(10, 10, 10, 0.25);
+      }
+
+      .token-card .swatch--cream {
+        background: var(--color-cream);
+      }
+      .token-card .swatch--cream-soft {
+        background: var(--color-cream-soft);
+      }
+      .token-card .swatch--ink {
+        background: var(--color-ink);
+        border-color: var(--color-ink);
+      }
+      .token-card .swatch--ink-muted {
+        background: var(--color-ink-muted);
+      }
+      .token-card .swatch--jersey-deep {
+        background: var(--color-jersey-deep);
+      }
+      .token-card .swatch--jersey {
+        background: var(--color-jersey);
+      }
+      .token-card .swatch--alert {
+        background: var(--color-alert);
+      }
+      .token-card .swatch--paper-edge {
+        background: var(--color-paper-edge);
+      }
+
+      .token-card strong {
+        display: block;
+        font-weight: 700;
+        margin-bottom: 4px;
+        color: var(--color-ink);
+      }
+
+      .token-card span {
+        color: var(--color-ink-muted);
+      }
+
+      .not-consumed {
+        margin-top: 20px;
+        padding: 16px 18px;
+        border: 1px dashed var(--color-ink-muted);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.6;
+        color: var(--color-ink-muted);
+      }
+
+      .not-consumed strong {
+        color: var(--color-ink);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 11px;
+        font-weight: 700;
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      footer.doc-footer {
+        margin-top: 64px;
+        padding-top: 32px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: var(--color-ink-muted);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      footer.doc-footer strong {
+        color: var(--color-ink);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 700;
+      }
+
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <!-- ============================================================
+           HEADER
+           ============================================================ -->
+      <header class="doc-header">
+        <div class="kicker-row">
+          <span class="kicker">
+            <span class="dot"></span>
+            PHASE 2 · TRACK B · DIRECTION B
+          </span>
+          <span class="kicker">
+            KCVV ELEWIJT · UI CHROME EXPLORATION · 2026
+          </span>
+        </div>
+
+        <h1 class="display">Mono <em>&amp;</em> Ink<span class="period">.</span></h1>
+
+        <p class="lede">
+          Functional restraint. Chrome stays flat — no rotation, no tape, no offset shadow.
+          The editorial primitives carry the weight; the atoms quietly hand the page back to
+          the writing.
+        </p>
+
+        <dl class="meta">
+          <div>
+            <dt>Direction</dt>
+            <dd>B — Mono &amp; Ink</dd>
+          </div>
+          <div>
+            <dt>Atoms covered</dt>
+            <dd>Spinner · BrandedTabs · FilterTabs · HorizontalSlider</dd>
+          </div>
+          <div>
+            <dt>Token posture</dt>
+            <dd>cream + ink + jersey-deep accent</dd>
+          </div>
+          <div>
+            <dt>Paper shadows</dt>
+            <dd>not consumed</dd>
+          </div>
+        </dl>
+      </header>
+
+      <!-- ============================================================
+           1 — SPINNER
+           ============================================================ -->
+      <section class="atom" id="spinner">
+        <div class="atom-head">
+          <div class="copy">
+            <span class="kicker"><span class="dot"></span>01 · ATOM · SPINNER</span>
+            <h2 class="display">Een rustige laad&shy;indicator<span class="period" style="color: var(--color-jersey-deep);">.</span></h2>
+            <p>
+              Two sub-variants share one identity. <strong>B.1</strong> is the canonical loading
+              state: a quietly rotating 2&nbsp;px ink arc behind a mono-caps <code>LADEN.</code>
+              ellipsis. <strong>B.2</strong> is a three-dot inline pulse for compact contexts —
+              row meta, list footers, micro-loading. No paper texture, no stripes, no rotation
+              of the label itself.
+            </p>
+          </div>
+          <div class="index">01.</div>
+        </div>
+
+        <div class="demo-card">
+          <span class="demo-label">B.1 — sm · md · lg · xl</span>
+          <div class="spinner-row">
+            <div class="spinner-tile">
+              <div class="spinner-b1 spinner-b1--sm" role="status" aria-label="Laden">
+                <div class="spinner-b1__arc"></div>
+                <span class="spinner-b1__label">LADEN</span>
+              </div>
+              <div class="spinner-tile__caption"><strong>SM · 64</strong>list rows · inline blocks</div>
+            </div>
+            <div class="spinner-tile">
+              <div class="spinner-b1 spinner-b1--md" role="status" aria-label="Laden">
+                <div class="spinner-b1__arc"></div>
+                <span class="spinner-b1__label">LADEN</span>
+              </div>
+              <div class="spinner-tile__caption"><strong>MD · 96</strong>panels · cards</div>
+            </div>
+            <div class="spinner-tile">
+              <div class="spinner-b1 spinner-b1--lg" role="status" aria-label="Laden">
+                <div class="spinner-b1__arc"></div>
+                <span class="spinner-b1__label">LADEN</span>
+              </div>
+              <div class="spinner-tile__caption"><strong>LG · 128</strong>page sections</div>
+            </div>
+            <div class="spinner-tile">
+              <div class="spinner-b1 spinner-b1--xl" role="status" aria-label="Laden">
+                <div class="spinner-b1__arc"></div>
+                <span class="spinner-b1__label">LADEN</span>
+              </div>
+              <div class="spinner-tile__caption"><strong>XL · 168</strong>full-page boundary</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid-2" style="margin-top: 24px;">
+          <div class="demo-card">
+            <span class="demo-label">B.2 — three-dot inline pulse</span>
+            <div class="spinner-inline-row">
+              <span class="spinner-b2" role="status" aria-label="Laden">
+                <span class="pulse-dot"></span>
+                <span class="pulse-dot"></span>
+                <span class="pulse-dot"></span>
+                <span class="spinner-b2__label">UITSLAGEN LADEN</span>
+              </span>
+            </div>
+            <div class="spinner-inline-row">
+              <span class="spinner-b2" role="status" aria-label="Laden" aria-hidden="false">
+                <span class="pulse-dot"></span>
+                <span class="pulse-dot"></span>
+                <span class="pulse-dot"></span>
+              </span>
+              <div class="spinner-inline-row__copy">
+                <strong>OPSTELLINGEN</strong>
+                <span>Aanvragen bij PSD…</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="demo-card">
+            <span class="demo-label">Variant: logo (placeholder)</span>
+            <div style="display: flex; align-items: center; gap: 28px; padding: 12px 0;">
+              <div class="spinner-logo" role="status" aria-label="Laden">
+                <svg viewBox="0 0 96 96" aria-hidden="true">
+                  <circle cx="48" cy="48" r="44" fill="none" stroke="#0A0A0A" stroke-width="1" />
+                  <text
+                    x="48"
+                    y="42"
+                    text-anchor="middle"
+                    font-family="Playfair Display, Georgia, serif"
+                    font-style="italic"
+                    font-weight="900"
+                    font-size="22"
+                    fill="#0A0A0A"
+                  >
+                    KCVV
+                  </text>
+                  <text
+                    x="48"
+                    y="62"
+                    text-anchor="middle"
+                    font-family="IBM Plex Mono, monospace"
+                    font-weight="600"
+                    font-size="8"
+                    letter-spacing="2"
+                    fill="#0A0A0A"
+                  >
+                    ELEWIJT
+                  </text>
+                  <line x1="20" y1="74" x2="76" y2="74" stroke="#008755" stroke-width="3" />
+                </svg>
+              </div>
+              <div>
+                <p style="margin: 0 0 4px; font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;">
+                  variant=&quot;logo&quot;
+                </p>
+                <p style="margin: 0; font-size: 13px; color: var(--color-ink-muted);">
+                  Reserved for the route loading boundary; opacity pulse only — no rotation,
+                  no tilt.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <div class="tradeoff__label">FOR</div>
+            <p>
+              Reads as quiet system feedback. The mono-caps label doubles as a status string,
+              accessible without relying on shape language. The inline sub-variant avoids the
+              awkward &quot;tiny spinning logo in a list row&quot; mismatch of monolithic
+              spinner systems.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <div class="tradeoff__label">AGAINST</div>
+            <p>
+              At a glance, almost identical to the React Suspense default. Loses the chance to
+              make &quot;waiting for KCVV data&quot; feel like a club moment.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           2 — BRANDED TABS
+           ============================================================ -->
+      <section class="atom" id="branded-tabs">
+        <div class="atom-head">
+          <div class="copy">
+            <span class="kicker"><span class="dot"></span>02 · ATOM · BRANDED TABS</span>
+            <h2 class="display">Eén lijn, één onderstreping<span class="period" style="color: var(--color-jersey-deep);">.</span></h2>
+            <p>
+              Mono caps labels, generous gap, a single 1&nbsp;px ink-muted hairline under the row.
+              The active tab is signalled by a 3&nbsp;px <strong>jersey-deep</strong> underline that
+              overlaps the hairline by one pixel — no badges, no shadows, no surrounding borders.
+              Hover lifts the muted label into full ink.
+            </p>
+          </div>
+          <div class="index">02.</div>
+        </div>
+
+        <div class="demo-card">
+          <span class="demo-label">on cream — default surface</span>
+          <div class="branded-tabs" role="tablist" aria-label="Ploegen">
+            <button class="branded-tab" role="tab" aria-selected="false">A-ploeg</button>
+            <button class="branded-tab" role="tab" aria-selected="true">B-ploeg</button>
+            <button class="branded-tab" role="tab" aria-selected="false">U21</button>
+            <button class="branded-tab" role="tab" aria-selected="false">U17</button>
+            <button class="branded-tab" role="tab" aria-selected="false">Dames</button>
+            <span class="branded-tabs__hairline"></span>
+          </div>
+        </div>
+
+        <div class="demo-card demo-card--soft" style="margin-top: 24px;">
+          <span class="demo-label">on cream-soft — section surface</span>
+          <div class="branded-tabs" role="tablist" aria-label="Ploegen">
+            <button class="branded-tab" role="tab" aria-selected="false">A-ploeg</button>
+            <button class="branded-tab" role="tab" aria-selected="true">B-ploeg</button>
+            <button class="branded-tab" role="tab" aria-selected="false">U21</button>
+            <button class="branded-tab" role="tab" aria-selected="false">U17</button>
+            <button class="branded-tab" role="tab" aria-selected="false">Dames</button>
+            <span class="branded-tabs__hairline"></span>
+          </div>
+        </div>
+
+        <div class="state-row">
+          <div class="state-card">
+            <div class="state-card__caption">DEFAULT</div>
+            <div class="branded-tabs" role="tablist">
+              <button class="branded-tab" role="tab" aria-selected="true">A-ploeg</button>
+              <button class="branded-tab" role="tab" aria-selected="false">B-ploeg</button>
+              <button class="branded-tab" role="tab" aria-selected="false">U21</button>
+              <span class="branded-tabs__hairline"></span>
+            </div>
+          </div>
+          <div class="state-card">
+            <div class="state-card__caption">HOVER (B-ploeg)</div>
+            <div class="branded-tabs" role="tablist">
+              <button class="branded-tab" role="tab" aria-selected="true">A-ploeg</button>
+              <button class="branded-tab" role="tab" aria-selected="false" style="color: var(--color-ink);">
+                B-ploeg
+              </button>
+              <button class="branded-tab" role="tab" aria-selected="false">U21</button>
+              <span class="branded-tabs__hairline"></span>
+            </div>
+          </div>
+          <div class="state-card">
+            <div class="state-card__caption">FOCUS-VISIBLE (U21)</div>
+            <div class="branded-tabs" role="tablist">
+              <button class="branded-tab" role="tab" aria-selected="true">A-ploeg</button>
+              <button class="branded-tab" role="tab" aria-selected="false">B-ploeg</button>
+              <button
+                class="branded-tab"
+                role="tab"
+                aria-selected="false"
+                style="outline: 1px dashed var(--color-ink); outline-offset: 4px;"
+              >
+                U21
+              </button>
+              <span class="branded-tabs__hairline"></span>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <div class="tradeoff__label">FOR</div>
+            <p>
+              The 3&nbsp;px jersey-deep stripe is the only club-coded mark on the row. It overlaps
+              the hairline so the underline reads as a continuous member of the same axis — not as
+              an applied decoration. Quiet, but unmistakable.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <div class="tradeoff__label">AGAINST</div>
+            <p>
+              Without a brand mark or kit motif, the row could live on any modern site. Compared
+              to Direction A&apos;s tape and Direction C&apos;s heavy underscore, B feels generic
+              at first glance.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           3 — FILTER TABS
+           ============================================================ -->
+      <section class="atom" id="filter-tabs">
+        <div class="atom-head">
+          <div class="copy">
+            <span class="kicker"><span class="dot"></span>03 · ATOM · FILTER TABS</span>
+            <h2 class="display">Sharp chips, no curves<span class="period" style="color: var(--color-jersey-deep);">.</span></h2>
+            <p>
+              Inactive chips render as transparent text-only — no border, no fill. Active chips
+              flip to <code>bg-ink text-cream</code> in a sharp rectangle (no rounded corners).
+              Counts sit inline behind a 1&nbsp;px hairline divider — never as pills or badges.
+            </p>
+          </div>
+          <div class="index">03.</div>
+        </div>
+
+        <div class="demo-card">
+          <span class="demo-label">size variants — sm · md · lg</span>
+
+          <div class="filter-row">
+            <span class="filter-row__label">SM</span>
+            <button class="filter-chip filter-chip--sm" aria-pressed="false">
+              <span class="live-dot"></span>
+              Live
+              <span class="filter-chip__count">1</span>
+            </button>
+            <button class="filter-chip filter-chip--sm" aria-pressed="true">
+              Aankomend
+              <span class="filter-chip__count">6</span>
+            </button>
+            <button class="filter-chip filter-chip--sm" aria-pressed="false">
+              Uitslagen
+              <span class="filter-chip__count">24</span>
+            </button>
+            <button class="filter-chip filter-chip--sm" aria-pressed="false">
+              Thuis
+              <span class="filter-chip__count">12</span>
+            </button>
+            <button class="filter-chip filter-chip--sm" aria-pressed="false">
+              Uit
+              <span class="filter-chip__count">13</span>
+            </button>
+          </div>
+
+          <div class="filter-row">
+            <span class="filter-row__label">MD</span>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              <span class="live-dot"></span>
+              Live
+              <span class="filter-chip__count">1</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              Aankomend
+              <span class="filter-chip__count">6</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="true">
+              Uitslagen
+              <span class="filter-chip__count">24</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              Thuis
+              <span class="filter-chip__count">12</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              Uit
+              <span class="filter-chip__count">13</span>
+            </button>
+          </div>
+
+          <div class="filter-row">
+            <span class="filter-row__label">LG</span>
+            <button class="filter-chip filter-chip--lg" aria-pressed="false">
+              <span class="live-dot"></span>
+              Live
+              <span class="filter-chip__count">1</span>
+            </button>
+            <button class="filter-chip filter-chip--lg" aria-pressed="false">
+              Aankomend
+              <span class="filter-chip__count">6</span>
+            </button>
+            <button class="filter-chip filter-chip--lg" aria-pressed="false">
+              Uitslagen
+              <span class="filter-chip__count">24</span>
+            </button>
+            <button class="filter-chip filter-chip--lg" aria-pressed="true">
+              Thuis
+              <span class="filter-chip__count">12</span>
+            </button>
+            <button class="filter-chip filter-chip--lg" aria-pressed="false">
+              Uit
+              <span class="filter-chip__count">13</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="demo-card" style="margin-top: 24px;">
+          <span class="demo-label">leading typographic glyph variant</span>
+          <div class="filter-row">
+            <span class="filter-row__label">MD</span>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              <span class="filter-chip__icon">●</span>
+              Live
+              <span class="filter-chip__count">1</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="true">
+              <span class="filter-chip__icon">»</span>
+              Aankomend
+              <span class="filter-chip__count">6</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              <span class="filter-chip__icon">§</span>
+              Uitslagen
+              <span class="filter-chip__count">24</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              <span class="filter-chip__icon">⌂</span>
+              Thuis
+              <span class="filter-chip__count">12</span>
+            </button>
+            <button class="filter-chip filter-chip--md" aria-pressed="false">
+              <span class="filter-chip__icon">↗</span>
+              Uit
+              <span class="filter-chip__count">13</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <div class="tradeoff__label">FOR</div>
+            <p>
+              The hairline-divided count is unique enough to feel typeset rather than UI-kit.
+              Sharp corners reinforce the broadsheet/fanzine surface. Active state needs zero
+              animation to read.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <div class="tradeoff__label">AGAINST</div>
+            <p>
+              Inactive chips have no resting border, so the row reads as a list of links until
+              you click. Density is high; we&apos;ll need to verify hit-target spacing at SM
+              still clears the 44&nbsp;px tap area on touch.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           4 — HORIZONTAL SLIDER
+           ============================================================ -->
+      <section class="atom" id="slider">
+        <div class="atom-head">
+          <div class="copy">
+            <span class="kicker"><span class="dot"></span>04 · ATOM · HORIZONTAL SLIDER</span>
+            <h2 class="display">Pijlen die niet schreeuwen<span class="period" style="color: var(--color-jersey-deep);">.</span></h2>
+            <p>
+              Two scroll arrows: 40&nbsp;×&nbsp;40&nbsp;px squares with a 1&nbsp;px ink border, a
+              typographic chevron (<code>‹</code>&nbsp;/&nbsp;<code>›</code>) in IBM Plex Mono,
+              no fill. Hover inverts to ink-fill / cream-glyph. Track gap matches body grid
+              (16&nbsp;px).
+            </p>
+          </div>
+          <div class="index">04.</div>
+        </div>
+
+        <div class="demo-card" style="padding: 24px; border: 1px solid var(--color-ink); background: var(--color-cream);">
+          <span class="demo-label" style="background: var(--color-cream);">theme · light</span>
+          <div class="slider">
+            <div class="slider__head">
+              <div>
+                <span class="kicker kicker--ink"><span class="dot"></span>BLOK · AANKOMEND</span>
+                <div class="slider__title" style="margin-top: 6px;">Aankomende wedstrijden<span class="period">.</span></div>
+              </div>
+              <div class="slider__controls">
+                <button class="scroll-arrow" aria-label="Vorige" disabled>‹</button>
+                <button class="scroll-arrow" aria-label="Volgende">›</button>
+              </div>
+            </div>
+            <div class="slider__track slider__track--drift">
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZA · 03 MEI · 15:00</span>
+                  <span>EERSTE PROV.</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>SK Halle</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span>THUIS</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZO · 04 MEI · 14:30</span>
+                  <span>U21</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>FC Vossem</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt U21</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>VOSSEM</span>
+                  <span>UIT</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZA · 10 MEI · 19:30</span>
+                  <span>BEKER</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>RC Mechelen</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span>THUIS</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZO · 11 MEI · 11:00</span>
+                  <span>U17</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt U17</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>KFC Boortmeerbeek</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span>THUIS</span>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
+
+        <div class="demo-card demo-card--ink" style="margin-top: 24px;">
+          <span class="demo-label">theme · dark</span>
+          <div class="slider slider--ink">
+            <div class="slider__head">
+              <div>
+                <span class="kicker" style="color: rgba(245, 241, 230, 0.6);">
+                  <span class="dot" style="background: var(--color-cream);"></span>BLOK · UITSLAGEN
+                </span>
+                <div class="slider__title" style="margin-top: 6px;">Recente uitslagen<span class="period">.</span></div>
+              </div>
+              <div class="slider__controls">
+                <button class="scroll-arrow" aria-label="Vorige">‹</button>
+                <button class="scroll-arrow" aria-label="Volgende">›</button>
+              </div>
+            </div>
+            <div class="slider__track slider__track--drift">
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZA · 26 APR · 15:00</span>
+                  <span>EERSTE PROV.</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt</span>
+                    <span class="match-card__score">3</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>VC Eppegem</span>
+                    <span class="match-card__score">1</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span class="badge-final">FINAAL</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZO · 20 APR · 14:30</span>
+                  <span>B-PLOEG</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>SK Lubbeek</span>
+                    <span class="match-card__score">0</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt B</span>
+                    <span class="match-card__score">2</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>LUBBEEK</span>
+                  <span class="badge-final">FINAAL</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZA · 19 APR · 18:00</span>
+                  <span>DAMES</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt Dames</span>
+                    <span class="match-card__score">2</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>KFC Heist</span>
+                    <span class="match-card__score">2</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span><span class="live-dot"></span>LIVE 78&apos;</span>
+                  <span class="badge-final">LIVE</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZO · 13 APR · 11:00</span>
+                  <span>U21</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt U21</span>
+                    <span class="match-card__score">4</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>FC Wespelaar</span>
+                    <span class="match-card__score">0</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span class="badge-final">FINAAL</span>
+                </div>
+              </article>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <div class="tradeoff__label">FOR</div>
+            <p>
+              The arrows are pure typographic primitives — they scale with the font and don&apos;t
+              fight the broadsheet rhythm. Disabled state is just opacity; no extra colour token
+              required.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <div class="tradeoff__label">AGAINST</div>
+            <p>
+              Mono chevrons are smaller in optical weight than ChevronLeft/Right SVGs at the same
+              box. We may need 44&nbsp;px boxes for touch, or a 700 glyph weight on dark theme so
+              the contrast holds at distance.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           5 — COHESION
+           ============================================================ -->
+      <section class="atom" id="cohesion">
+        <div class="atom-head">
+          <div class="copy">
+            <span class="kicker"><span class="dot"></span>05 · COHESION · WEDSTRIJDEN PAGE</span>
+            <h2 class="display">Restraint, in context<span class="period" style="color: var(--color-jersey-deep);">.</span></h2>
+            <p>
+              All four atoms in their natural habitat: a fragment of <code>/wedstrijden</code>.
+              The display heading carries the page; the chrome stays out of its way. A loading
+              slot at the bottom holds B.2 in case any panel suspends.
+            </p>
+          </div>
+          <div class="index">05.</div>
+        </div>
+
+        <div class="cohesion">
+          <div class="cohesion__head">
+            <div>
+              <span class="kicker"><span class="dot"></span>SECTIE · WEDSTRIJDEN</span>
+              <div class="cohesion__title" style="margin-top: 8px;">Wedstrijden<span class="period">.</span></div>
+              <p class="cohesion__sub">
+                <em>De volgende afspraken aan de Tervuursesteenweg, en wat we daarvoor hebben
+                gedaan.</em>
+              </p>
+            </div>
+            <div class="slider__controls">
+              <button class="scroll-arrow" aria-label="Vorige" disabled>‹</button>
+              <button class="scroll-arrow" aria-label="Volgende">›</button>
+            </div>
+          </div>
+
+          <div class="branded-tabs" role="tablist" aria-label="Ploegen">
+            <button class="branded-tab" role="tab" aria-selected="true">A-ploeg</button>
+            <button class="branded-tab" role="tab" aria-selected="false">B-ploeg</button>
+            <button class="branded-tab" role="tab" aria-selected="false">U21</button>
+            <button class="branded-tab" role="tab" aria-selected="false">U17</button>
+            <button class="branded-tab" role="tab" aria-selected="false">Dames</button>
+            <span class="branded-tabs__hairline"></span>
+          </div>
+
+          <div class="cohesion__filters">
+            <div class="filter-row" style="margin-top: 18px;">
+              <button class="filter-chip filter-chip--md" aria-pressed="false">
+                <span class="live-dot"></span>
+                Live
+                <span class="filter-chip__count">1</span>
+              </button>
+              <button class="filter-chip filter-chip--md" aria-pressed="true">
+                Aankomend
+                <span class="filter-chip__count">6</span>
+              </button>
+              <button class="filter-chip filter-chip--md" aria-pressed="false">
+                Uitslagen
+                <span class="filter-chip__count">24</span>
+              </button>
+              <button class="filter-chip filter-chip--md" aria-pressed="false">
+                Thuis
+                <span class="filter-chip__count">12</span>
+              </button>
+              <button class="filter-chip filter-chip--md" aria-pressed="false">
+                Uit
+                <span class="filter-chip__count">13</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="slider" style="padding: 0;">
+            <div class="slider__track">
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZA · 03 MEI · 15:00</span>
+                  <span>EERSTE PROV.</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>SK Halle</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span>THUIS</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZO · 04 MEI · 14:30</span>
+                  <span>RES. A</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>FC Vossem</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt B</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>VOSSEM</span>
+                  <span>UIT</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__meta">
+                  <span>ZA · 10 MEI · 19:30</span>
+                  <span>BEKER</span>
+                </div>
+                <div class="match-card__teams">
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest"></span>KCVV Elewijt</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                  <div class="match-card__row">
+                    <span class="team"><span class="match-card__crest match-card__crest--away"></span>RC Mechelen</span>
+                    <span class="match-card__score">—</span>
+                  </div>
+                </div>
+                <div class="match-card__footer">
+                  <span>SPORTPARK ELEWIJT</span>
+                  <span>THUIS</span>
+                </div>
+              </article>
+            </div>
+          </div>
+
+          <div class="cohesion__loading-slot" role="status" aria-live="polite">
+            <span class="spinner-b2" aria-hidden="true">
+              <span class="pulse-dot"></span>
+              <span class="pulse-dot"></span>
+              <span class="pulse-dot"></span>
+            </span>
+            <div class="cohesion__loading-slot__copy">
+              <strong>VERWANTE WEDSTRIJDEN</strong>
+              <span>Opstellingen en uitslagen worden uit PSD gehaald…</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================================================
+           6 — TOKEN MAP & FOOTER NOTES
+           ============================================================ -->
+      <section class="atom" id="tokens">
+        <div class="atom-head">
+          <div class="copy">
+            <span class="kicker"><span class="dot"></span>06 · TOKEN MAP</span>
+            <h2 class="display">Wat we wel en niet gebruiken<span class="period" style="color: var(--color-jersey-deep);">.</span></h2>
+            <p>
+              The full Phase&nbsp;2 token surface is available, but Direction&nbsp;B is deliberately
+              narrow: cream surfaces, ink type, ink-muted secondaries, jersey-deep accent. Paper
+              shadow tokens are not consumed.
+            </p>
+          </div>
+          <div class="index">06.</div>
+        </div>
+
+        <div class="token-map">
+          <div class="token-card">
+            <strong><span class="swatch swatch--cream"></span>--color-cream</strong>
+            <span>#F5F1E6 · default surface</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--cream-soft"></span>--color-cream-soft</strong>
+            <span>#EDE8DA · section surface</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--ink"></span>--color-ink</strong>
+            <span>#0A0A0A · type, hairline, active filter fill</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--ink-muted"></span>--color-ink-muted</strong>
+            <span>#6B6B6B · inactive labels, count meta</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--jersey-deep"></span>--color-jersey-deep</strong>
+            <span>#008755 · active tab underline (light)</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--jersey"></span>--color-jersey</strong>
+            <span>#4ACF52 · live dot, dark-theme accent</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--alert"></span>--color-alert</strong>
+            <span>#B84A3A · live status dot only</span>
+          </div>
+          <div class="token-card">
+            <strong><span class="swatch swatch--paper-edge"></span>--color-paper-edge</strong>
+            <span>#D9D2BD · reserved (unused here)</span>
+          </div>
+        </div>
+
+        <div class="not-consumed">
+          <strong>Tokens explicitly NOT consumed in Direction B</strong>
+          <code>--shadow-paper-sm</code> · <code>--shadow-paper-md</code> ·
+          <code>--shadow-paper-lg</code> · <code>--shadow-paper-tape</code> · all rotation
+          transforms · the sticker/tape decorative layer.<br />
+          Direction B&apos;s argument: chrome that doesn&apos;t cast a shadow lets editorial
+          primitives (TapedCard, EditorialHeading, PullQuote) keep ownership of the paper
+          metaphor. Atoms stay on the page surface.
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <div class="tradeoff__label">FOR — overall direction</div>
+            <p>
+              Cleanest typographic hierarchy of the three options. Editorial primitives have
+              maximum room to breathe. Accessibility passes trivially: every state is
+              colour-and-text, never shape-only.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <div class="tradeoff__label">AGAINST — overall direction</div>
+            <p>
+              Visually under-articulated. Without paper shadow, tape, or rotation, the atoms
+              don&apos;t telegraph &quot;KCVV fanzine&quot; on their own — they rely on neighbouring
+              editorial primitives to do that work. Risk: at small viewports, the page reads as
+              minimalist-default rather than club-coded.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <footer class="doc-footer">
+        <span><strong>KCVV ELEWIJT</strong> · Phase 2 · Track B · Direction B — Mono &amp; Ink</span>
+        <span>Er is maar één plezante compagnie.</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/design/mockups/phase-2-track-b/option-c-matchday-programme.html
+++ b/docs/design/mockups/phase-2-track-b/option-c-matchday-programme.html
@@ -1,0 +1,2388 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Direction C — Matchday Programme · Phase 2 Track B</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #4acf52;
+        --color-jersey-deep: #008755;
+        --color-jersey-bright: #22c55e;
+        --color-paper-edge: #d9d2bd;
+        --color-alert: #b84a3a;
+        --color-warning: #c68b2c;
+        --shadow-paper-sm: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-md: 6px 6px 0 0 var(--color-ink);
+        --rotate-tape-a: -0.5deg;
+        --rotate-tape-b: -0.25deg;
+        --rotate-tape-c: 0.25deg;
+        --rotate-tape-d: 0.5deg;
+        --rotate-ticket-active: 1deg;
+
+        --font-serif: "Playfair Display", Georgia, serif;
+        --font-sans: "Inter", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", "Courier New", monospace;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: var(--font-sans);
+        font-size: 16px;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      .page {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 64px 48px 120px;
+      }
+
+      /* ===== Typography helpers ===== */
+      .mono {
+        font-family: var(--font-mono);
+        font-weight: 500;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-ink);
+      }
+      .mono--muted {
+        color: var(--color-ink-muted);
+      }
+      .serif-italic {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 400;
+      }
+      .serif-display {
+        font-family: var(--font-serif);
+        font-weight: 900;
+        line-height: 0.95;
+        letter-spacing: -0.01em;
+      }
+
+      /* ===== Hairline divider ===== */
+      .rule-ink {
+        height: 1px;
+        background: var(--color-ink);
+        border: 0;
+        margin: 0;
+      }
+      .rule-edge {
+        height: 1px;
+        background: var(--color-paper-edge);
+        border: 0;
+        margin: 0;
+      }
+
+      /* ===== Header ===== */
+      .header__kicker {
+        display: inline-block;
+        margin-bottom: 24px;
+      }
+      .header__title {
+        font-size: 96px;
+        margin: 0 0 24px;
+      }
+      .header__lede {
+        max-width: 760px;
+        font-size: 18px;
+        line-height: 1.55;
+        color: var(--color-ink-soft);
+        margin: 0 0 20px;
+      }
+      .header__meta {
+        display: flex;
+        gap: 24px;
+        align-items: center;
+        flex-wrap: wrap;
+        padding-top: 20px;
+        border-top: 1px solid var(--color-paper-edge);
+      }
+      .header__meta-item {
+        display: flex;
+        gap: 8px;
+        align-items: baseline;
+      }
+      .header__meta-item strong {
+        font-family: var(--font-mono);
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--color-ink);
+      }
+
+      /* ===== Section frames ===== */
+      .section {
+        margin: 96px 0 0;
+      }
+      .section__head {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 24px;
+        margin-bottom: 32px;
+        flex-wrap: wrap;
+      }
+      .section__title {
+        font-size: 56px;
+        margin: 12px 0 0;
+      }
+      .section__head-meta {
+        max-width: 420px;
+        font-size: 14px;
+        color: var(--color-ink-muted);
+        line-height: 1.5;
+      }
+      .section__head-meta p {
+        margin: 0;
+      }
+
+      .subvariant {
+        margin-top: 56px;
+      }
+      .subvariant__head {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        margin-bottom: 20px;
+      }
+      .subvariant__num {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+      }
+      .subvariant__name {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 28px;
+      }
+      .recommended-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        padding: 4px 10px;
+        margin-left: 4px;
+      }
+      .recommended-badge::before {
+        content: "★";
+        color: var(--color-jersey);
+        font-size: 11px;
+      }
+      .subvariant__caption {
+        font-size: 14px;
+        color: var(--color-ink-muted);
+        line-height: 1.55;
+        max-width: 640px;
+        margin: 16px 0 0;
+      }
+
+      .stage {
+        position: relative;
+        background: var(--color-cream);
+        border: 1px solid var(--color-paper-edge);
+        padding: 56px 48px;
+      }
+      .stage--soft {
+        background: var(--color-cream-soft);
+      }
+
+      /* ===== SCARF SPINNER =====
+         Why this is structured the way it is: a diagonal repeating-gradient
+         (-45°) animated via background-position runs into sub-pixel rasterisation
+         issues — the gradient axis is at 45°, so any pure X or X+Y translation
+         resolves to a non-integer phase shift along the gradient axis and the
+         loop seam is visible.
+
+         Cleaner technique: render HORIZONTAL stripes (gradient angle 90°, clean
+         80px period along local x) inside a ::before pseudo-element, rotate the
+         pseudo-element statically by -45° to make the stripes appear diagonal,
+         and animate background-position-x by exactly 80px — one integer period
+         in the pseudo-element's local pre-transform frame. The browser quantises
+         the translation cleanly to pixel boundaries, the loop wraps without
+         phase mismatch, and the parent's overflow:hidden clips the rotated
+         child to the bar's rectangle. */
+      @keyframes scarf-scroll {
+        0% {
+          background-position: 0 0;
+        }
+        100% {
+          background-position: 80px 0;
+        }
+      }
+
+      .scarf-spinner {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+      }
+      .scarf-spinner__bar {
+        position: relative;
+        width: 240px;
+        height: 36px;
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        background: var(--color-cream);
+        overflow: hidden;
+      }
+      .scarf-spinner__bar::before {
+        content: "";
+        position: absolute;
+        inset: -200px;
+        background:
+          repeating-linear-gradient(
+            90deg,
+            var(--color-jersey) 0px,
+            var(--color-jersey) 20px,
+            var(--color-cream) 20px,
+            var(--color-cream) 40px,
+            var(--color-ink) 40px,
+            var(--color-ink) 60px,
+            var(--color-cream) 60px,
+            var(--color-cream) 80px
+          );
+        transform: rotate(-45deg);
+        animation: scarf-scroll 1.5s linear infinite;
+      }
+      .scarf-spinner__label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+
+      /* size variants */
+      .scarf-spinner--sm .scarf-spinner__bar {
+        width: 96px;
+        height: 16px;
+      }
+      .scarf-spinner--sm .scarf-spinner__label {
+        font-size: 9px;
+      }
+      .scarf-spinner--md .scarf-spinner__bar {
+        width: 180px;
+        height: 28px;
+      }
+      .scarf-spinner--md .scarf-spinner__label {
+        font-size: 10px;
+      }
+      .scarf-spinner--lg .scarf-spinner__bar {
+        width: 240px;
+        height: 36px;
+      }
+      .scarf-spinner--xl .scarf-spinner__bar {
+        width: 360px;
+        height: 56px;
+      }
+      .scarf-spinner--xl .scarf-spinner__label {
+        font-size: 13px;
+      }
+
+      .spinner-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 40px 24px;
+        align-items: end;
+      }
+      .spinner-grid__cell {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .spinner-grid__cell .mono {
+        color: var(--color-ink-muted);
+      }
+
+      .spinner-logo {
+        width: 56px;
+        height: 56px;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+        display: grid;
+        place-items: center;
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 900;
+        font-size: 28px;
+        position: relative;
+        animation: spin 1.4s ease-in-out infinite;
+      }
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      /* ===== BRANDED TABS — 01 SLICED RAIL ===== */
+      .sliced-rail {
+        position: relative;
+        padding-top: 28px;
+      }
+      .sliced-rail__rail {
+        height: 1px;
+        background: var(--color-ink);
+        margin-bottom: 0;
+      }
+      .sliced-rail__row {
+        display: flex;
+        gap: 56px;
+        align-items: flex-start;
+        padding: 28px 0 12px;
+      }
+      .sliced-rail__tab {
+        position: relative;
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
+        padding-bottom: 24px;
+        cursor: pointer;
+      }
+      .sliced-rail__tab--inactive {
+        color: var(--color-ink-muted);
+      }
+      .sliced-rail__num {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .sliced-rail__tab--active .sliced-rail__num {
+        color: var(--color-ink);
+        font-weight: 600;
+      }
+      .sliced-rail__label {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 22px;
+        line-height: 1;
+        color: inherit;
+      }
+      .sliced-rail__tab--active .sliced-rail__label {
+        color: var(--color-ink);
+      }
+      .sliced-rail__count {
+        display: inline-block;
+        background: var(--color-cream-soft);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.04em;
+        padding: 2px 6px;
+        line-height: 1.2;
+        color: var(--color-ink-muted);
+      }
+      .sliced-rail__tab--active .sliced-rail__count {
+        color: var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .sliced-rail__scribble {
+        position: absolute;
+        left: -4px;
+        right: -4px;
+        bottom: 4px;
+        height: 14px;
+        pointer-events: none;
+      }
+
+      /* ===== BRANDED TABS — 02 PASTED PILLS ===== */
+      .pasted-pills {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .pasted-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px 10px 16px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        border-radius: 6px;
+        box-shadow: 2px 2px 0 0 var(--color-ink);
+        cursor: pointer;
+        transition: transform 0.12s ease;
+      }
+      .pasted-pill:hover {
+        transform: translate(-1px, -1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+      .pasted-pill__label {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+      .pasted-pill__count {
+        display: inline-grid;
+        place-items: center;
+        min-width: 24px;
+        height: 18px;
+        padding: 0 5px;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+      }
+      .pasted-pill--active {
+        background: var(--color-ink);
+      }
+      .pasted-pill--active .pasted-pill__label {
+        color: var(--color-cream);
+      }
+      .pasted-pill--active .pasted-pill__count {
+        background: var(--color-jersey);
+        color: var(--color-ink);
+      }
+
+      /* ===== BRANDED TABS — 03 TICKET STUB ===== */
+      .ticket-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 18px;
+        align-items: stretch;
+      }
+      .ticket {
+        position: relative;
+        background: var(--color-cream-soft);
+        border: 2px solid var(--color-ink);
+        padding: 18px 32px 18px 18px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 14px;
+        cursor: pointer;
+        min-height: 120px;
+      }
+      .ticket__perf {
+        position: absolute;
+        top: 8px;
+        bottom: 8px;
+        right: 12px;
+        width: 4px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 2px;
+      }
+      .ticket__perf-dot {
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background: var(--color-ink-muted);
+      }
+      .ticket--inactive .ticket__perf-dot {
+        background: var(--color-paper-edge);
+      }
+      .ticket__kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .ticket__name {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 22px;
+        line-height: 1;
+        color: var(--color-ink);
+        margin: 0;
+      }
+      .ticket__sub {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .ticket--active {
+        background: var(--color-cream);
+        box-shadow: var(--shadow-paper-sm);
+        transform: rotate(var(--rotate-ticket-active));
+        z-index: 2;
+      }
+      .ticket--active .ticket__kicker {
+        color: var(--color-ink);
+      }
+      .ticket--active .ticket__perf-dot {
+        background: var(--color-ink);
+      }
+      .ticket__tape {
+        position: absolute;
+        top: -8px;
+        left: 14px;
+        background: var(--color-jersey);
+        color: var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        padding: 3px 10px;
+        transform: rotate(-10deg);
+        border: 1px solid var(--color-ink);
+        z-index: 3;
+      }
+      .ticket-seam {
+        margin-top: 24px;
+        position: relative;
+        height: 12px;
+      }
+      .ticket-seam__line {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 5px;
+        height: 2px;
+        background: var(--color-jersey-bright);
+      }
+      .ticket-seam__ticks {
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        height: 12px;
+        display: flex;
+        justify-content: space-between;
+      }
+      .ticket-seam__tick {
+        width: 2px;
+        height: 12px;
+        background: var(--color-jersey-deep);
+      }
+
+      /* ===== FILTERTABS — STAMP CHIPS ===== */
+      .stampchips {
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+      }
+      .stampchips__bar {
+        display: flex;
+        align-items: stretch;
+        gap: 20px;
+      }
+      .stampchips__heading {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding-right: 4px;
+        white-space: nowrap;
+      }
+      .stampchips__heading-star {
+        font-size: 13px;
+        color: var(--color-ink);
+      }
+      .stampchips__heading-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+      .stampchips__divider {
+        width: 1px;
+        background: var(--color-paper-edge);
+        align-self: stretch;
+      }
+      .stampchips__chips {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .stamp-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 8px 8px 12px;
+        border: 2px solid var(--color-ink);
+        border-radius: 6px;
+        background: transparent;
+        cursor: pointer;
+        transition: transform 0.1s;
+      }
+      .stamp-chip:hover {
+        transform: translate(-1px, -1px);
+      }
+      .stamp-chip__label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+      .stamp-chip__count {
+        display: inline-grid;
+        place-items: center;
+        min-width: 22px;
+        height: 16px;
+        padding: 0 5px;
+        background: var(--color-cream-soft);
+        color: var(--color-ink-muted);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+      }
+      .stamp-chip--active {
+        background: var(--color-jersey);
+      }
+      .stamp-chip--active .stamp-chip__label {
+        color: var(--color-ink);
+      }
+      .stamp-chip--active .stamp-chip__count {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      /* size variants */
+      .stampchips--sm .stamp-chip {
+        padding: 6px 6px 6px 10px;
+        border-width: 1.5px;
+      }
+      .stampchips--sm .stamp-chip__label {
+        font-size: 10px;
+      }
+      .stampchips--sm .stamp-chip__count {
+        min-width: 20px;
+        height: 14px;
+        font-size: 9px;
+      }
+      .stampchips--sm .stampchips__heading-label {
+        font-size: 10px;
+      }
+
+      .stampchips--lg .stamp-chip {
+        padding: 10px 10px 10px 14px;
+      }
+      .stampchips--lg .stamp-chip__label {
+        font-size: 12px;
+      }
+      .stampchips--lg .stamp-chip__count {
+        min-width: 24px;
+        height: 18px;
+        font-size: 11px;
+      }
+      .stampchips--lg .stampchips__heading-label {
+        font-size: 12px;
+      }
+
+      /* ===== HORIZONTAL SLIDER ===== */
+      .slider {
+        position: relative;
+      }
+      .slider__head {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: end;
+        gap: 32px;
+        margin-bottom: 32px;
+      }
+      .slider__head-left {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .slider__title {
+        font-size: 64px;
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 900;
+        line-height: 0.95;
+        margin: 0;
+      }
+      .slider__head-right {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+      }
+      .slider__pagination {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .slider__bullets {
+        display: flex;
+        gap: 6px;
+      }
+      .slider__bullet {
+        width: 10px;
+        height: 10px;
+        border: 1.5px solid var(--color-ink);
+        background: transparent;
+      }
+      .slider__bullet--active {
+        background: var(--color-ink);
+      }
+      .slider__counter {
+        font-family: var(--font-mono);
+        font-weight: 600;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        color: var(--color-ink);
+      }
+      .slider__arrows {
+        display: flex;
+        gap: 12px;
+      }
+      .slider__arrow {
+        width: 56px;
+        height: 56px;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        color: var(--color-ink);
+        display: grid;
+        place-items: center;
+        font-size: 24px;
+        font-weight: 700;
+        font-family: var(--font-mono);
+        cursor: pointer;
+        box-shadow: 4px 4px 0 0 var(--color-ink);
+        transition: transform 0.1s;
+      }
+      .slider__arrow:hover {
+        transform: translate(-1px, -1px);
+        box-shadow: 5px 5px 0 0 var(--color-ink);
+      }
+      .slider__arrow--active {
+        background: var(--color-ink);
+        color: var(--color-cream);
+      }
+
+      .slider__track {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 18px;
+        margin-bottom: 24px;
+      }
+
+      .match-card {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        min-height: 220px;
+      }
+      .match-card--rota {
+        transform: rotate(var(--rotate-tape-a));
+      }
+      .match-card:nth-of-type(2) {
+        transform: rotate(var(--rotate-tape-b));
+      }
+      .match-card:nth-of-type(3) {
+        transform: rotate(var(--rotate-tape-c));
+      }
+      .match-card:nth-of-type(4) {
+        transform: rotate(var(--rotate-tape-d));
+      }
+
+      .match-card__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .match-card__competition {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+      .match-card__date {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 500;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .match-card__body {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 22px;
+      }
+      .match-card__teams {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .crest {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 1.5px solid var(--color-ink);
+        background: var(--color-cream-soft);
+        display: grid;
+        place-items: center;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+      }
+      .crest--green {
+        background: var(--color-jersey);
+      }
+      .match-card__sub {
+        font-family: var(--font-sans);
+        font-size: 13px;
+        color: var(--color-ink-muted);
+      }
+      .match-card__foot {
+        margin-top: auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-top: 10px;
+        border-top: 1px solid var(--color-paper-edge);
+      }
+      .match-card__cta {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+
+      .match-card--live {
+        background: var(--color-jersey);
+        color: var(--color-ink-soft);
+        transform: rotate(0deg);
+      }
+      .match-card--live .match-card__date,
+      .match-card--live .match-card__sub,
+      .match-card--live .match-card__competition,
+      .match-card--live .match-card__cta {
+        color: var(--color-ink-soft);
+      }
+      .match-card--live .match-card__foot {
+        border-top-color: rgba(10, 10, 10, 0.25);
+      }
+      .match-card__live-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 2px 8px;
+        font-family: var(--font-mono);
+        font-size: 9px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+      }
+      .match-card__minute {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+      }
+      .match-card__score {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 900;
+        font-size: 40px;
+        letter-spacing: -0.02em;
+        line-height: 1;
+      }
+
+      .slider__rail {
+        position: relative;
+        height: 1px;
+        background: var(--color-paper-edge);
+        margin: 36px 0 12px;
+      }
+      .slider__rail-fill {
+        position: absolute;
+        left: 0;
+        top: -1px;
+        height: 3px;
+        width: 14%;
+        background: var(--color-jersey);
+      }
+      .slider__rail-marks {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 8px;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.1em;
+        color: var(--color-ink-muted);
+      }
+
+      .nav-variants {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 20px;
+        margin-top: 64px;
+      }
+      .nav-variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        position: relative;
+      }
+      .nav-variant__label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .nav-variant__title {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 24px;
+        line-height: 1.1;
+        margin: 0;
+      }
+      .nav-variant__desc {
+        font-size: 13px;
+        color: var(--color-ink-soft);
+        line-height: 1.5;
+      }
+      .nav-variant__rec {
+        position: absolute;
+        top: 18px;
+        right: 18px;
+      }
+
+      /* ===== COHESION MOCKUP ===== */
+      .cohesion {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        padding: 40px 36px;
+        position: relative;
+      }
+      .cohesion__corner {
+        position: absolute;
+        top: -16px;
+        right: -10px;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.16em;
+        padding: 6px 12px;
+        transform: rotate(2deg);
+      }
+      .cohesion__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      .cohesion__title {
+        font-size: 56px;
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 900;
+        line-height: 0.95;
+        margin: 8px 0 0;
+      }
+      .cohesion__head-right {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+      }
+
+      /* ===== FOOTER ===== */
+      .footer {
+        margin-top: 96px;
+        padding-top: 32px;
+        border-top: 2px solid var(--color-ink);
+      }
+      .tradeoffs {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 28px;
+        margin-top: 24px;
+      }
+      .tradeoff {
+        background: var(--color-cream-soft);
+        padding: 20px 22px;
+        border-left: 4px solid var(--color-ink);
+      }
+      .tradeoff--against {
+        border-left-color: var(--color-alert);
+      }
+      .tradeoff--for {
+        border-left-color: var(--color-jersey-deep);
+      }
+      .tradeoff h4 {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin: 0 0 8px;
+        color: var(--color-ink);
+      }
+      .tradeoff p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.55;
+        color: var(--color-ink-soft);
+      }
+
+      .token-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 14px;
+        margin-top: 24px;
+      }
+      .token {
+        background: var(--color-cream-soft);
+        padding: 12px 14px;
+        border-left: 4px solid var(--color-ink);
+      }
+      .token__sw {
+        height: 28px;
+        margin-bottom: 8px;
+        border: 1px solid var(--color-ink);
+      }
+      .token__name {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        color: var(--color-ink);
+      }
+      .token__hex {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        color: var(--color-ink-muted);
+      }
+
+      .recommendation-row {
+        margin-top: 32px;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 28px 32px;
+      }
+      .recommendation-row h4 {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin: 0 0 16px;
+        color: var(--color-cream);
+      }
+      .recommendation-row__grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 24px;
+      }
+      .recommendation {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .recommendation__atom {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(245, 241, 230, 0.6);
+      }
+      .recommendation__pick {
+        font-family: var(--font-serif);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 22px;
+        color: var(--color-jersey);
+      }
+      .recommendation__note {
+        font-size: 12px;
+        color: rgba(245, 241, 230, 0.75);
+        line-height: 1.4;
+      }
+
+      .surface-notes {
+        margin-top: 32px;
+        background: var(--color-cream-soft);
+        padding: 24px 28px;
+        border: 1px dashed var(--color-ink-muted);
+      }
+      .surface-notes h4 {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin: 0 0 12px;
+      }
+      .surface-notes ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      .surface-notes li {
+        font-size: 13px;
+        line-height: 1.55;
+        color: var(--color-ink-soft);
+        margin-bottom: 6px;
+      }
+      .surface-notes code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream);
+        padding: 1px 4px;
+        border-radius: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <!-- ============================ HEADER ============================ -->
+      <header>
+        <span class="mono header__kicker">★ Phase 2 · Track B · Direction C</span>
+        <h1 class="serif-display header__title" style="font-style: italic; font-weight: 900">
+          Matchday<br />programme.
+        </h1>
+        <p class="header__lede">
+          Een hybride richting tussen <em>Paper</em> en <em>Mono</em>. We lenen het
+          vocabulair van een gedrukt matchblad: getelde badges, genummerde secties,
+          sjaal-strepen voor laad-states en geperforeerde ticket-stubs voor actieve
+          tabbladen. Chrome blijft grotendeels plat — rotatie wordt zeldzaam ingezet
+          (alleen voor het actieve ticket-tabblad). Data wordt grafisch gecodeerd zodat
+          fans het herkennen vóór ze het lezen.
+        </p>
+        <div class="header__meta">
+          <div class="header__meta-item">
+            <span class="mono mono--muted">Direction</span>
+            <strong>C / 03</strong>
+          </div>
+          <div class="header__meta-item">
+            <span class="mono mono--muted">Aesthetic</span>
+            <strong>Programme · Hybrid</strong>
+          </div>
+          <div class="header__meta-item">
+            <span class="mono mono--muted">Atoms</span>
+            <strong>Spinner · BrandedTabs · FilterTabs · HorizontalSlider</strong>
+          </div>
+          <div class="header__meta-item">
+            <span class="mono mono--muted">Compared with</span>
+            <strong>Direction A (Paper) · Direction B (Mono)</strong>
+          </div>
+        </div>
+      </header>
+
+      <!-- ============================ SPINNER ============================ -->
+      <section class="section">
+        <div class="section__head">
+          <div>
+            <span class="mono">★ 01 · Spinner — scarf barber-pole</span>
+            <h2 class="serif-display section__title" style="font-style: italic">
+              Sjaal-strepen.
+            </h2>
+          </div>
+          <div class="section__head-meta">
+            <p>
+              Eén sub-variant. Diagonale strepen schuiven oneindig naar rechts in een
+              ingelijst rechthoek. Direct herkenbaar als sjaal — laad-states krijgen
+              een terras-stem in plaats van een steriele cirkel.
+            </p>
+          </div>
+        </div>
+
+        <div class="stage">
+          <div style="display: flex; flex-direction: column; gap: 36px">
+            <!-- Hero -->
+            <div style="display: flex; align-items: flex-end; gap: 56px; flex-wrap: wrap">
+              <div class="scarf-spinner scarf-spinner--lg">
+                <div class="scarf-spinner__bar"></div>
+                <span class="scarf-spinner__label">Laden…</span>
+              </div>
+              <div style="max-width: 420px">
+                <p style="margin: 0; font-size: 14px; color: var(--color-ink-muted); line-height: 1.55; font-style: italic">
+                  “Sjaal-strepen die oneindig schuiven. Hoort bij de retro look.”
+                </p>
+              </div>
+            </div>
+
+            <hr class="rule-edge" />
+
+            <!-- Sizes grid -->
+            <div>
+              <span class="mono mono--muted" style="display: block; margin-bottom: 24px">
+                Maten · sm · md · lg · xl · logo
+              </span>
+              <div class="spinner-grid">
+                <div class="spinner-grid__cell">
+                  <div class="scarf-spinner scarf-spinner--sm">
+                    <div class="scarf-spinner__bar"></div>
+                  </div>
+                  <span class="mono">sm · 96 × 16</span>
+                </div>
+                <div class="spinner-grid__cell">
+                  <div class="scarf-spinner scarf-spinner--md">
+                    <div class="scarf-spinner__bar"></div>
+                    <span class="scarf-spinner__label">Laden…</span>
+                  </div>
+                  <span class="mono">md · 180 × 28</span>
+                </div>
+                <div class="spinner-grid__cell">
+                  <div class="scarf-spinner scarf-spinner--lg">
+                    <div class="scarf-spinner__bar"></div>
+                    <span class="scarf-spinner__label">Laden…</span>
+                  </div>
+                  <span class="mono">lg · 240 × 36</span>
+                </div>
+                <div class="spinner-grid__cell">
+                  <div class="scarf-spinner scarf-spinner--xl">
+                    <div class="scarf-spinner__bar"></div>
+                    <span class="scarf-spinner__label">Laden…</span>
+                  </div>
+                  <span class="mono">xl · 360 × 56</span>
+                </div>
+              </div>
+              <div style="margin-top: 32px; display: flex; gap: 24px; align-items: center">
+                <div class="spinner-logo">K</div>
+                <div>
+                  <span class="mono" style="display: block">Logo variant</span>
+                  <span style="font-size: 13px; color: var(--color-ink-muted)">
+                    Geretourneerd uit Direction A (placeholder, draait 360°)
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <h4>+ Voor</h4>
+            <p>
+              Cultureel geladen: sjaal-strepen lezen als clubteken, niet als loader.
+              Compatibel met cream-ondergrond en jersey-groen — geen extra tokens nodig.
+              Animatie is licht (1 background-position keyframe).
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <h4>− Tegen</h4>
+            <p>
+              Op kleine maten (sm, 96×16) wordt de strepen-grain prominent en kan
+              hij visueel ruisen. Vereist een minimum-breedte regel of fallback naar
+              de logo-variant onder ~80px.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================ BRANDED TABS ============================ -->
+      <section class="section">
+        <div class="section__head">
+          <div>
+            <span class="mono">★ 02 · BrandedTabs — drie sub-varianten</span>
+            <h2 class="serif-display section__title" style="font-style: italic">
+              Genummerde<br />secties.
+            </h2>
+          </div>
+          <div class="section__head-meta">
+            <p>
+              Programme-pagina's nummeren altijd hun secties. We tonen drie aanpakken:
+              een hairline-rail met groene scribble-onderlijning, geplakte stempel-pills,
+              en een geperforeerd ticket-stub. Vergelijk en kies.
+            </p>
+          </div>
+        </div>
+
+        <!-- 01 SLICED RAIL -->
+        <div class="subvariant">
+          <div class="subvariant__head">
+            <span class="subvariant__num">★ 01 —</span>
+            <span class="subvariant__name">Sliced — hairline rail met groene scheur</span>
+          </div>
+          <div class="stage">
+            <div class="sliced-rail">
+              <div class="sliced-rail__rail"></div>
+              <div class="sliced-rail__row">
+                <div class="sliced-rail__tab sliced-rail__tab--active">
+                  <span class="sliced-rail__num">01</span>
+                  <span class="sliced-rail__label">A-PLOEG</span>
+                  <span class="sliced-rail__count">28</span>
+                  <svg
+                    class="sliced-rail__scribble"
+                    viewBox="0 0 200 14"
+                    preserveAspectRatio="none"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M2 9 C 18 4, 38 12, 58 7 S 96 11, 118 6 S 158 13, 198 7"
+                      stroke="var(--color-jersey-deep)"
+                      stroke-width="3"
+                      stroke-linecap="round"
+                      fill="none"
+                    />
+                  </svg>
+                </div>
+                <div class="sliced-rail__tab sliced-rail__tab--inactive">
+                  <span class="sliced-rail__num">02</span>
+                  <span class="sliced-rail__label">B-PLOEG</span>
+                  <span class="sliced-rail__count">24</span>
+                </div>
+                <div class="sliced-rail__tab sliced-rail__tab--inactive">
+                  <span class="sliced-rail__num">03</span>
+                  <span class="sliced-rail__label">U21</span>
+                  <span class="sliced-rail__count">22</span>
+                </div>
+                <div class="sliced-rail__tab sliced-rail__tab--inactive">
+                  <span class="sliced-rail__num">04</span>
+                  <span class="sliced-rail__label">U17</span>
+                  <span class="sliced-rail__count">19</span>
+                </div>
+                <div class="sliced-rail__tab sliced-rail__tab--inactive">
+                  <span class="sliced-rail__num">05</span>
+                  <span class="sliced-rail__label">DAMES</span>
+                  <span class="sliced-rail__count">21</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p class="subvariant__caption">
+            Eén hairline boven, één scribble onder de actieve tab. Lichtste optie qua
+            chrome — geen pills, geen rotatie. Sterke kandidaat voor secundaire tab-rijen
+            (bijvoorbeeld in een match-detail pagina).
+          </p>
+        </div>
+
+        <!-- 02 PASTED PILLS -->
+        <div class="subvariant">
+          <div class="subvariant__head">
+            <span class="subvariant__num">★ 02 —</span>
+            <span class="subvariant__name">Pasted pills — geplakte stempel-tabs</span>
+          </div>
+          <div class="stage">
+            <div class="pasted-pills">
+              <button class="pasted-pill" type="button">
+                <span class="pasted-pill__label">A-PLOEG</span>
+                <span class="pasted-pill__count">28</span>
+              </button>
+              <button class="pasted-pill pasted-pill--active" type="button">
+                <span class="pasted-pill__label">B-PLOEG</span>
+                <span class="pasted-pill__count">24</span>
+              </button>
+              <button class="pasted-pill" type="button">
+                <span class="pasted-pill__label">U21</span>
+                <span class="pasted-pill__count">22</span>
+              </button>
+              <button class="pasted-pill" type="button">
+                <span class="pasted-pill__label">U17</span>
+                <span class="pasted-pill__count">19</span>
+              </button>
+              <button class="pasted-pill" type="button">
+                <span class="pasted-pill__label">DAMES</span>
+                <span class="pasted-pill__count">21</span>
+              </button>
+            </div>
+          </div>
+          <p class="subvariant__caption">
+            Compact, click-target friendly, robuust. De count-badge zit binnen de pill —
+            één hit-area in plaats van twee. Visueel nauwer verwant aan de stamp-chips
+            uit de filter-toolbar — het hele systeem leest als één familie.
+          </p>
+        </div>
+
+        <!-- 03 TICKET STUB -->
+        <div class="subvariant">
+          <div class="subvariant__head">
+            <span class="subvariant__num">★ 03 —</span>
+            <span class="subvariant__name">Ticket stub — geperforeerd ticket per sectie</span>
+            <span class="recommended-badge">Aanbevolen</span>
+          </div>
+          <div class="stage">
+            <div class="ticket-row">
+              <div class="ticket ticket--active">
+                <div class="ticket__tape">PLAY</div>
+                <span class="ticket__kicker">★ Ticket 01</span>
+                <h3 class="ticket__name">A-ploeg</h3>
+                <span class="ticket__sub">1ste prov.</span>
+                <div class="ticket__perf" aria-hidden="true">
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                </div>
+              </div>
+              <div class="ticket ticket--inactive">
+                <span class="ticket__kicker">★ Ticket 02</span>
+                <h3 class="ticket__name">B-ploeg</h3>
+                <span class="ticket__sub">2de prov.</span>
+                <div class="ticket__perf" aria-hidden="true">
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                </div>
+              </div>
+              <div class="ticket ticket--inactive">
+                <span class="ticket__kicker">★ Ticket 03</span>
+                <h3 class="ticket__name">U21</h3>
+                <span class="ticket__sub">Provinciaal</span>
+                <div class="ticket__perf" aria-hidden="true">
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                </div>
+              </div>
+              <div class="ticket ticket--inactive">
+                <span class="ticket__kicker">★ Ticket 04</span>
+                <h3 class="ticket__name">Dames</h3>
+                <span class="ticket__sub">2de prov.</span>
+                <div class="ticket__perf" aria-hidden="true">
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                  <span class="ticket__perf-dot"></span>
+                </div>
+              </div>
+            </div>
+            <!-- jersey seam -->
+            <div class="ticket-seam" aria-hidden="true">
+              <div class="ticket-seam__line"></div>
+              <div class="ticket-seam__ticks">
+                <!-- 30 tick marks -->
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+                <span class="ticket-seam__tick"></span>
+              </div>
+            </div>
+          </div>
+          <p class="subvariant__caption">
+            Ticket-stub draagt de meeste programma-betekenis: perforatie + tape-strip
+            + +1° rotatie op het actieve item. Dit is dé moment waarop chrome zich kort
+            "vergeet" en als geprint object voelt — en dus precies waar Direction C zich
+            onderscheidt van Direction B.
+          </p>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <h4>+ Voor (sub-variant 03)</h4>
+            <p>
+              Het ticket-stub is direct leesbaar als programma-vocabulair. Tape-strip
+              op het actieve item geeft hiërarchie zonder kleurkracht in te zetten;
+              cream / jersey-tape / ink-perforatie zijn al token-aanwezig.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <h4>− Tegen</h4>
+            <p>
+              Surface-extensie: <code>subLabel?: string</code> moet als optionele prop
+              op <code>BrandedTabs</code> verschijnen. Mobile-portrait: 4 tickets in een
+              rij wordt te smal — vereist horizontaal-scroll behavior of vertical stack.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================ FILTERTABS — STAMP CHIPS ============================ -->
+      <section class="section">
+        <div class="section__head">
+          <div>
+            <span class="mono">★ 03 · FilterTabs — stamp chips</span>
+            <h2 class="serif-display section__title" style="font-style: italic">
+              Stempel-toolbar.
+            </h2>
+          </div>
+          <div class="section__head-meta">
+            <p>
+              Eén sub-variant, drie maten. Compacte chips boven slider-rijen, met
+              numerieke counts ingebed in elk chip. Statusfilters en venue-filters mengen
+              vrij — meerdere tegelijk actief is toegestaan.
+            </p>
+          </div>
+        </div>
+
+        <div class="stage">
+          <span class="mono mono--muted" style="display: block; margin-bottom: 18px">
+            ★ 02 · Stamp chips — compacte toolbar boven sliders
+          </span>
+
+          <div class="stampchips">
+            <!-- LG -->
+            <div class="stampchips--lg">
+              <div class="stampchips__bar">
+                <div class="stampchips__heading">
+                  <span class="stampchips__heading-star">★</span>
+                  <span class="stampchips__heading-label">Wedstrijden</span>
+                </div>
+                <div class="stampchips__divider"></div>
+                <div class="stampchips__chips">
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Live</span>
+                    <span class="stamp-chip__count">1</span>
+                  </button>
+                  <button class="stamp-chip stamp-chip--active" type="button">
+                    <span class="stamp-chip__label">Aankomend</span>
+                    <span class="stamp-chip__count">6</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Uitslagen</span>
+                    <span class="stamp-chip__count">24</span>
+                  </button>
+                  <button class="stamp-chip stamp-chip--active" type="button">
+                    <span class="stamp-chip__label">Thuis</span>
+                    <span class="stamp-chip__count">12</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Uit</span>
+                    <span class="stamp-chip__count">13</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Competitie</span>
+                    <span class="stamp-chip__count">22</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Beker</span>
+                    <span class="stamp-chip__count">3</span>
+                  </button>
+                </div>
+              </div>
+              <span class="mono mono--muted" style="display: block; margin-top: 10px">
+                Maat lg — desktop primair
+              </span>
+            </div>
+
+            <hr class="rule-edge" />
+
+            <!-- MD -->
+            <div>
+              <div class="stampchips__bar">
+                <div class="stampchips__heading">
+                  <span class="stampchips__heading-star">★</span>
+                  <span class="stampchips__heading-label">Wedstrijden</span>
+                </div>
+                <div class="stampchips__divider"></div>
+                <div class="stampchips__chips">
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Live</span>
+                    <span class="stamp-chip__count">1</span>
+                  </button>
+                  <button class="stamp-chip stamp-chip--active" type="button">
+                    <span class="stamp-chip__label">Aankomend</span>
+                    <span class="stamp-chip__count">6</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Uitslagen</span>
+                    <span class="stamp-chip__count">24</span>
+                  </button>
+                  <button class="stamp-chip stamp-chip--active" type="button">
+                    <span class="stamp-chip__label">Thuis</span>
+                    <span class="stamp-chip__count">12</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Uit</span>
+                    <span class="stamp-chip__count">13</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Competitie</span>
+                    <span class="stamp-chip__count">22</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Beker</span>
+                    <span class="stamp-chip__count">3</span>
+                  </button>
+                </div>
+              </div>
+              <span class="mono mono--muted" style="display: block; margin-top: 10px">
+                Maat md — standaard
+              </span>
+            </div>
+
+            <hr class="rule-edge" />
+
+            <!-- SM -->
+            <div class="stampchips--sm">
+              <div class="stampchips__bar">
+                <div class="stampchips__heading">
+                  <span class="stampchips__heading-star">★</span>
+                  <span class="stampchips__heading-label">Wedstrijden</span>
+                </div>
+                <div class="stampchips__divider"></div>
+                <div class="stampchips__chips">
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Live</span>
+                    <span class="stamp-chip__count">1</span>
+                  </button>
+                  <button class="stamp-chip stamp-chip--active" type="button">
+                    <span class="stamp-chip__label">Aankomend</span>
+                    <span class="stamp-chip__count">6</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Uitslagen</span>
+                    <span class="stamp-chip__count">24</span>
+                  </button>
+                  <button class="stamp-chip stamp-chip--active" type="button">
+                    <span class="stamp-chip__label">Thuis</span>
+                    <span class="stamp-chip__count">12</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Uit</span>
+                    <span class="stamp-chip__count">13</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Competitie</span>
+                    <span class="stamp-chip__count">22</span>
+                  </button>
+                  <button class="stamp-chip" type="button">
+                    <span class="stamp-chip__label">Beker</span>
+                    <span class="stamp-chip__count">3</span>
+                  </button>
+                </div>
+              </div>
+              <span class="mono mono--muted" style="display: block; margin-top: 10px">
+                Maat sm — mobile / dense
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <h4>+ Voor</h4>
+            <p>
+              Past in de bestaande <code>FilterTabs</code> prop-surface — count is al
+              gemodelleerd. Visueel nauw verwant aan pasted-pills uit BrandedTabs:
+              één design-familie.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <h4>− Tegen</h4>
+            <p>
+              Met 7 chips + heading + divider wordt de toolbar lang op tablet-portrait.
+              Vereist horizontale-scroll wrap of een “meer”-overflow knop op &lt;640px.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================ HORIZONTAL SLIDER ============================ -->
+      <section class="section">
+        <div class="section__head">
+          <div>
+            <span class="mono">★ 04 · HorizontalSlider — drie navigatie-varianten</span>
+            <h2 class="serif-display section__title" style="font-style: italic">
+              Bladwijzers.
+            </h2>
+          </div>
+          <div class="section__head-meta">
+            <p>
+              Een voorbeeld-slider boven, drie navigatie-aanpakken eronder. Header-counter,
+              hairline progress rail, en zwevende pasted-card pijlen. Elk verschilt in
+              wat het toevoegt aan de prop-surface van <code>HorizontalSlider</code>.
+            </p>
+          </div>
+        </div>
+
+        <div class="stage">
+          <!-- Example slider -->
+          <div class="slider">
+            <div class="slider__head">
+              <div class="slider__head-left">
+                <span class="mono">★ Matchdag</span>
+                <h3 class="slider__title">Wedstrijden</h3>
+              </div>
+              <div class="slider__head-right">
+                <div class="slider__pagination">
+                  <div class="slider__bullets">
+                    <span class="slider__bullet slider__bullet--active"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                  </div>
+                  <span class="slider__counter">01 / 07</span>
+                </div>
+                <div class="slider__arrows">
+                  <button class="slider__arrow" type="button" aria-label="Vorige">←</button>
+                  <button class="slider__arrow slider__arrow--active" type="button" aria-label="Volgende">→</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="slider__track">
+              <!-- LIVE card -->
+              <article class="match-card match-card--live">
+                <div class="match-card__head">
+                  <span class="match-card__competition">1ste prov.</span>
+                  <span class="match-card__live-pill">★ Live · 67'</span>
+                </div>
+                <div class="match-card__body" style="display: flex; flex-direction: column; align-items: flex-start; gap: 8px">
+                  <div class="match-card__teams" style="font-size: 16px">
+                    <span class="crest crest--green">EL</span>
+                    <span style="font-style: italic; font-weight: 700">Elewijt</span>
+                  </div>
+                  <span class="match-card__score">2 — 1</span>
+                  <div class="match-card__teams" style="font-size: 16px">
+                    <span class="crest">TE</span>
+                    <span style="font-style: italic; font-weight: 700">Tervuren</span>
+                  </div>
+                </div>
+                <span class="match-card__sub">Driesstraat</span>
+                <div class="match-card__foot">
+                  <span class="match-card__cta">Volg live →</span>
+                </div>
+              </article>
+
+              <!-- Upcoming 1 -->
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">1ste prov.</span>
+                  <span class="match-card__date">Za 02 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest">WB</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest crest--green">KC</span>
+                </div>
+                <span class="match-card__sub">Wezembeek vs Elewijt · 20:00</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Uit</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+
+              <!-- Upcoming 2 -->
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">1ste prov.</span>
+                  <span class="match-card__date">Zo 10 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest crest--green">KC</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest">SW</span>
+                </div>
+                <span class="match-card__sub">Elewijt vs Schriek · 15:00</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Thuis</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+
+              <!-- Upcoming 3 -->
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">Beker</span>
+                  <span class="match-card__date">Wo 13 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest">PE</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest crest--green">KC</span>
+                </div>
+                <span class="match-card__sub">Perk vs Elewijt · 20:30</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Uit</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+            </div>
+
+            <!-- Progress rail -->
+            <div class="slider__rail">
+              <div class="slider__rail-fill"></div>
+            </div>
+            <div class="slider__rail-marks">
+              <span>01</span>
+              <span>07</span>
+            </div>
+          </div>
+
+          <!-- Three nav variants -->
+          <div class="nav-variants">
+            <div class="nav-variant">
+              <span class="recommended-badge nav-variant__rec">Aanbevolen</span>
+              <span class="nav-variant__label">Variant A</span>
+              <h4 class="nav-variant__title">Header counter + arrows</h4>
+              <p class="nav-variant__desc">
+                Bullets, 01/07 teller, twee chunky pijlen. Bovenaan.
+              </p>
+            </div>
+            <div class="nav-variant">
+              <span class="nav-variant__label">Variant B</span>
+              <h4 class="nav-variant__title">Hairline progress rail</h4>
+              <p class="nav-variant__desc">
+                Klikbare scrubber met groene fill. Onderaan.
+              </p>
+            </div>
+            <div class="nav-variant">
+              <span class="nav-variant__label">Variant C</span>
+              <h4 class="nav-variant__title">Floating arrows</h4>
+              <p class="nav-variant__desc">
+                Twee pasted-card knoppen, lichtjes geroteerd, naast de slider.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <h4>+ Voor (Variant A)</h4>
+            <p>
+              Header-counter geeft fans direct aantal en positie — programma-page logic.
+              De chunky shadow-paper pijlen voelen als knoppen op een matchblad. Goede
+              hiërarchie zonder rail-clutter.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <h4>− Tegen</h4>
+            <p>
+              Surface-impact: <code>total?</code> en <code>current?</code> als nieuwe
+              optionele props. Op mobile-portrait verbergt de header-row de pijlen onder
+              de title — vereist een breakpoint waar arrows naar onderaan migreren.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================ COHESION MOCKUP ============================ -->
+      <section class="section">
+        <div class="section__head">
+          <div>
+            <span class="mono">★ 05 · Cohesion — aanbevolen combinatie</span>
+            <h2 class="serif-display section__title" style="font-style: italic">
+              Alles<br />samen.
+            </h2>
+          </div>
+          <div class="section__head-meta">
+            <p>
+              Mini-mockup van een “Wedstrijden”-pagina met de aanbevolen sub-varianten:
+              ticket-stub tabs, stamp chip filters, header counter slider, en sjaal-strepen
+              als loader. Dit is wat we voorstellen als de finale Direction C combinatie.
+            </p>
+          </div>
+        </div>
+
+        <div class="cohesion">
+          <span class="cohesion__corner">★ Recommended combo</span>
+
+          <!-- Tickets -->
+          <div class="ticket-row">
+            <div class="ticket ticket--active">
+              <div class="ticket__tape">PLAY</div>
+              <span class="ticket__kicker">★ Ticket 01</span>
+              <h3 class="ticket__name">A-ploeg</h3>
+              <span class="ticket__sub">1ste prov.</span>
+              <div class="ticket__perf" aria-hidden="true">
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+              </div>
+            </div>
+            <div class="ticket ticket--inactive">
+              <span class="ticket__kicker">★ Ticket 02</span>
+              <h3 class="ticket__name">B-ploeg</h3>
+              <span class="ticket__sub">2de prov.</span>
+              <div class="ticket__perf" aria-hidden="true">
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+              </div>
+            </div>
+            <div class="ticket ticket--inactive">
+              <span class="ticket__kicker">★ Ticket 03</span>
+              <h3 class="ticket__name">U21</h3>
+              <span class="ticket__sub">Provinciaal</span>
+              <div class="ticket__perf" aria-hidden="true">
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+              </div>
+            </div>
+            <div class="ticket ticket--inactive">
+              <span class="ticket__kicker">★ Ticket 04</span>
+              <h3 class="ticket__name">Dames</h3>
+              <span class="ticket__sub">2de prov.</span>
+              <div class="ticket__perf" aria-hidden="true">
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+                <span class="ticket__perf-dot"></span>
+              </div>
+            </div>
+          </div>
+          <div class="ticket-seam" aria-hidden="true" style="margin-top: 18px">
+            <div class="ticket-seam__line"></div>
+            <div class="ticket-seam__ticks">
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+              <span class="ticket-seam__tick"></span>
+            </div>
+          </div>
+
+          <!-- Stamp chips toolbar -->
+          <div style="margin-top: 36px">
+            <div class="stampchips__bar">
+              <div class="stampchips__heading">
+                <span class="stampchips__heading-star">★</span>
+                <span class="stampchips__heading-label">Wedstrijden</span>
+              </div>
+              <div class="stampchips__divider"></div>
+              <div class="stampchips__chips">
+                <button class="stamp-chip" type="button">
+                  <span class="stamp-chip__label">Live</span>
+                  <span class="stamp-chip__count">1</span>
+                </button>
+                <button class="stamp-chip stamp-chip--active" type="button">
+                  <span class="stamp-chip__label">Aankomend</span>
+                  <span class="stamp-chip__count">6</span>
+                </button>
+                <button class="stamp-chip" type="button">
+                  <span class="stamp-chip__label">Uitslagen</span>
+                  <span class="stamp-chip__count">24</span>
+                </button>
+                <button class="stamp-chip stamp-chip--active" type="button">
+                  <span class="stamp-chip__label">Thuis</span>
+                  <span class="stamp-chip__count">12</span>
+                </button>
+                <button class="stamp-chip" type="button">
+                  <span class="stamp-chip__label">Uit</span>
+                  <span class="stamp-chip__count">13</span>
+                </button>
+                <button class="stamp-chip" type="button">
+                  <span class="stamp-chip__label">Competitie</span>
+                  <span class="stamp-chip__count">22</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Slider -->
+          <div class="slider" style="margin-top: 36px">
+            <div class="slider__head">
+              <div class="slider__head-left">
+                <span class="mono">★ Matchdag</span>
+                <h3 class="slider__title" style="font-size: 48px">Aankomend</h3>
+              </div>
+              <div class="slider__head-right">
+                <div class="slider__pagination">
+                  <div class="slider__bullets">
+                    <span class="slider__bullet slider__bullet--active"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                    <span class="slider__bullet"></span>
+                  </div>
+                  <span class="slider__counter">01 / 06</span>
+                </div>
+                <div class="slider__arrows">
+                  <button class="slider__arrow" type="button" aria-label="Vorige">←</button>
+                  <button class="slider__arrow slider__arrow--active" type="button" aria-label="Volgende">→</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="slider__track">
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">1ste prov.</span>
+                  <span class="match-card__date">Za 02 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest">WB</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest crest--green">KC</span>
+                </div>
+                <span class="match-card__sub">Wezembeek vs Elewijt · 20:00</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Uit</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">1ste prov.</span>
+                  <span class="match-card__date">Zo 10 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest crest--green">KC</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest">SW</span>
+                </div>
+                <span class="match-card__sub">Elewijt vs Schriek · 15:00</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Thuis</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">Beker</span>
+                  <span class="match-card__date">Wo 13 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest">PE</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest crest--green">KC</span>
+                </div>
+                <span class="match-card__sub">Perk vs Elewijt · 20:30</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Uit</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+              <article class="match-card">
+                <div class="match-card__head">
+                  <span class="match-card__competition">1ste prov.</span>
+                  <span class="match-card__date">Za 16 mei</span>
+                </div>
+                <div class="match-card__teams">
+                  <span class="crest crest--green">KC</span>
+                  <span class="serif-italic" style="font-weight: 700">vs</span>
+                  <span class="crest">TE</span>
+                </div>
+                <span class="match-card__sub">Elewijt vs Tervuren · 19:30</span>
+                <div class="match-card__foot">
+                  <span class="match-card__date">Thuis</span>
+                  <span class="match-card__cta">Tickets →</span>
+                </div>
+              </article>
+            </div>
+          </div>
+
+          <!-- Loading state demonstration -->
+          <div style="margin-top: 36px; padding-top: 24px; border-top: 1px dashed var(--color-paper-edge); display: flex; gap: 32px; align-items: center; flex-wrap: wrap">
+            <div class="scarf-spinner scarf-spinner--md">
+              <div class="scarf-spinner__bar"></div>
+              <span class="scarf-spinner__label">Resultaten laden…</span>
+            </div>
+            <span class="mono mono--muted" style="max-width: 360px; line-height: 1.6">
+              Wanneer de pagina nieuwe matches ophaalt, verschijnt de sjaal-spinner
+              boven de slider — niet onder, niet erin. Eén consistente plek per pagina.
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============================ FOOTER ============================ -->
+      <footer class="footer">
+        <span class="mono">★ 06 · Notes</span>
+        <h2 class="serif-display section__title" style="font-style: italic; font-size: 40px; margin-top: 12px">
+          Token map &amp; trade-offs.
+        </h2>
+
+        <h4 class="mono" style="margin-top: 32px">Color tokens used</h4>
+        <div class="token-grid">
+          <div class="token">
+            <div class="token__sw" style="background: #f5f1e6"></div>
+            <div class="token__name">--color-cream</div>
+            <div class="token__hex">#F5F1E6</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #ede8da"></div>
+            <div class="token__name">--color-cream-soft</div>
+            <div class="token__hex">#EDE8DA</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #0a0a0a"></div>
+            <div class="token__name">--color-ink</div>
+            <div class="token__hex">#0A0A0A</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #6b6b6b"></div>
+            <div class="token__name">--color-ink-muted</div>
+            <div class="token__hex">#6B6B6B</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #4acf52"></div>
+            <div class="token__name">--color-jersey</div>
+            <div class="token__hex">#4ACF52</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #008755"></div>
+            <div class="token__name">--color-jersey-deep</div>
+            <div class="token__hex">#008755</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #d9d2bd"></div>
+            <div class="token__name">--color-paper-edge</div>
+            <div class="token__hex">#D9D2BD</div>
+          </div>
+          <div class="token">
+            <div class="token__sw" style="background: #b84a3a"></div>
+            <div class="token__name">--color-alert</div>
+            <div class="token__hex">#B84A3A</div>
+          </div>
+        </div>
+
+        <h4 class="mono" style="margin-top: 32px">Direction-level trade-offs</h4>
+        <div class="tradeoffs">
+          <div class="tradeoff tradeoff--for">
+            <h4>+ Argument FOR Direction C</h4>
+            <p>
+              Voetbalfans herkennen programme-vocabulair direct: counts, genummerde
+              secties, sjaal-strepen, ticket-stubs zijn cultureel beladen. Dit is een
+              toegankelijke hybride die data graphisch codeert zonder Direction-A's
+              over-rotation, en zonder Direction-B's restraint te zwaar in te zetten.
+            </p>
+          </div>
+          <div class="tradeoff tradeoff--against">
+            <h4>− Argument AGAINST Direction C</h4>
+            <p>
+              Meer visuele complexiteit dan restraint. Risico: chrome kan concurreren
+              met editorial primitives (interview-spreads, photo-essays) als ticket-stubs
+              en stamp-chips overal opduiken. Discipline rond plaatsing is essentieel —
+              programma-elementen mogen alleen op dataschermen verschijnen, niet op
+              redactionele pagina's.
+            </p>
+          </div>
+        </div>
+
+        <!-- Surface notes -->
+        <div class="surface-notes">
+          <h4>Atom prop-surface impact</h4>
+          <ul>
+            <li>
+              <code>Spinner</code> — geen surface-wijziging. <code>variant: "logo"</code>
+              blijft beschikbaar als fallback voor &lt;80px.
+            </li>
+            <li>
+              <code>BrandedTabs</code> — sub-variant 01 (sliced) leidt tab-nummer af van
+              index, geen nieuwe prop. Sub-variant 03 (ticket) vereist
+              <code>subLabel?: string</code> per tab. Voorkeur voor 03 → flag dit als
+              kleine surface-extensie.
+            </li>
+            <li>
+              <code>FilterTabs</code> — past binnen huidige surface;
+              <code>count</code> is al gemodelleerd. Geen wijziging.
+            </li>
+            <li>
+              <code>HorizontalSlider</code> — variant A (header counter+arrows) vereist
+              optionele <code>total?: number</code> + <code>current?: number</code>; en
+              een title-row layout-shift. Variant B en C vereisen geen nieuwe props.
+            </li>
+            <li>
+              <code>ScrollArrowButton</code> — variant A (chunky) vraagt
+              <code>size?: "sm" | "md" | "lg"</code> — bestaande styling kan worden
+              behouden voor <code>sm</code>; <code>lg</code> wordt de 56×56 chunky.
+            </li>
+          </ul>
+        </div>
+
+        <!-- Recommendation row -->
+        <div class="recommendation-row">
+          <h4>★ Aanbevolen sub-variant per atoom</h4>
+          <div class="recommendation-row__grid">
+            <div class="recommendation">
+              <span class="recommendation__atom">Spinner</span>
+              <span class="recommendation__pick">Scarf barber-pole</span>
+              <span class="recommendation__note">Enige sub-variant. Logo als fallback voor &lt;80px.</span>
+            </div>
+            <div class="recommendation">
+              <span class="recommendation__atom">BrandedTabs</span>
+              <span class="recommendation__pick">03 — Ticket stub</span>
+              <span class="recommendation__note">Programma-vocabulair op zijn sterkst; vereist <code>subLabel?</code>.</span>
+            </div>
+            <div class="recommendation">
+              <span class="recommendation__atom">FilterTabs</span>
+              <span class="recommendation__pick">Stamp chips</span>
+              <span class="recommendation__note">Past op huidige surface. Familie met pasted-pills.</span>
+            </div>
+            <div class="recommendation">
+              <span class="recommendation__atom">Slider arrows</span>
+              <span class="recommendation__pick">Variant A — Header counter + arrows</span>
+              <span class="recommendation__note">Programma-page logic; vereist <code>total?</code> + <code>current?</code>.</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bottom signature -->
+        <div style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--color-paper-edge); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px">
+          <span class="mono mono--muted">★ KCVV Elewijt — Phase 2 Track B — Direction C — Matchday Programme</span>
+          <span class="mono mono--muted">Compare: A (Paper) · B (Mono) · <strong style="color: var(--color-ink)">C (Programme)</strong></span>
+        </div>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html
+++ b/docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html
@@ -1,0 +1,1096 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Direction D — Paper chrome, ink emphasis · Phase 2 · Track B</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #4acf52;
+        --color-jersey-deep: #008755;
+        --color-jersey-bright: #22c55e;
+        --color-paper-edge: #d9d2bd;
+        --color-alert: #b84a3a;
+        --shadow-paper-sm: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-sm-soft: 4px 4px 0 0 var(--color-ink-muted);
+        --shadow-paper-md: 6px 6px 0 0 var(--color-ink);
+        --rotate-tape-a: -0.5deg;
+        --rotate-tape-b: -0.25deg;
+        --rotate-tape-c: 0.25deg;
+        --rotate-tape-d: 0.5deg;
+        --font-display: "Playfair Display", "Freight Display Pro", Georgia, serif;
+        --font-body: "Inter", "Quasimoda", -apple-system, sans-serif;
+        --font-mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        font-family: var(--font-body);
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-size: 16px;
+        line-height: 1.6;
+        background-image:
+          radial-gradient(circle at 12% 20%, rgba(10, 10, 10, 0.022) 0 1px, transparent 1px),
+          radial-gradient(circle at 78% 65%, rgba(10, 10, 10, 0.018) 0 1px, transparent 1px),
+          radial-gradient(circle at 45% 90%, rgba(10, 10, 10, 0.02) 0 1px, transparent 1px);
+        background-size: 240px 240px, 180px 180px, 320px 320px;
+      }
+      main { max-width: 1200px; margin: 0 auto; padding: 64px 32px 96px; }
+
+      .mono { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 500; }
+      .mono--muted { color: var(--color-ink-muted); }
+      .display { font-family: var(--font-display); font-weight: 900; line-height: 1.05; }
+      .display em { font-style: italic; color: var(--color-jersey-deep); }
+
+      h1 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(48px, 6vw, 72px); line-height: 1.05; margin: 16px 0 12px; }
+      h2 { font-family: var(--font-display); font-weight: 900; font-size: clamp(28px, 3vw, 40px); line-height: 1.1; margin: 0 0 6px; }
+      h2 em { font-style: italic; color: var(--color-jersey-deep); }
+      h3 { font-family: var(--font-display); font-weight: 700; font-style: italic; font-size: 22px; margin: 0 0 4px; }
+      .lead { max-width: 720px; font-size: 17px; color: var(--color-ink-soft); margin: 0 0 24px; }
+
+      .hero {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        padding: 40px 48px;
+      }
+      .hero-meta { display: flex; gap: 16px; align-items: baseline; flex-wrap: wrap; }
+
+      .section { margin: 80px 0; padding-top: 32px; border-top: 1px solid var(--color-paper-edge); }
+      .section-meta { display: flex; gap: 16px; align-items: baseline; flex-wrap: wrap; margin-bottom: 16px; }
+
+      .panel { background: var(--color-cream); padding: 32px; border: 1px solid var(--color-paper-edge); margin-top: 24px; }
+      .panel--soft { background: var(--color-cream-soft); }
+      .panel--dusk { background: var(--color-ink-soft); border-color: var(--color-ink); color: var(--color-cream); }
+      .panel--dusk h3, .panel--dusk .mono { color: var(--color-cream); }
+      /* Chrome inside dusk panels: ink offset shadow disappears against ink-soft bg.
+         Lift to the soft (ink-muted) shadow so the offset depth stays readable. */
+      .panel--dusk .arrow-btn,
+      .panel--dusk .match-card {
+        box-shadow: var(--shadow-paper-sm-soft);
+      }
+      .panel--dusk .arrow-btn:hover { box-shadow: 3px 3px 0 0 var(--color-ink-muted); }
+
+      .row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+      .stack { display: flex; flex-direction: column; gap: 16px; }
+
+      .tradeoffs { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 24px; padding: 20px; background: rgba(255, 255, 255, 0.4); border: 1px dashed var(--color-paper-edge); }
+      .tradeoffs h4 { margin: 0 0 6px; font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
+      .tradeoffs h4.for { color: var(--color-jersey-deep); }
+      .tradeoffs h4.against { color: var(--color-alert); }
+      .tradeoffs p { margin: 0; font-size: 14px; color: var(--color-ink-soft); }
+
+      .recommend-pick {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--color-jersey);
+        color: var(--color-ink);
+        padding: 4px 10px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+      }
+
+      .label-row { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; min-height: 28px; }
+      .label-row .row-label { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-ink-muted); min-width: 96px; }
+
+      /* ============================================================
+         SPINNER — scarf barber-pole (primary/secondary/white) + compact pulse
+         ============================================================ */
+
+      @keyframes scarf-scroll {
+        0% { background-position: 0 0; }
+        100% { background-position: 80px 0; }
+      }
+
+      .scarf {
+        position: relative;
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        background: var(--color-cream);
+        overflow: hidden;
+        display: inline-block;
+      }
+      .scarf::before {
+        content: "";
+        position: absolute;
+        inset: -200px;
+        animation: scarf-scroll 1.5s linear infinite;
+      }
+
+      .scarf--primary::before {
+        background: repeating-linear-gradient(90deg,
+          var(--color-jersey) 0px, var(--color-jersey) 20px,
+          var(--color-cream) 20px, var(--color-cream) 40px,
+          var(--color-ink) 40px, var(--color-ink) 60px,
+          var(--color-cream) 60px, var(--color-cream) 80px);
+        transform: rotate(-45deg);
+      }
+      .scarf--secondary::before {
+        background: repeating-linear-gradient(90deg,
+          var(--color-ink) 0px, var(--color-ink) 20px,
+          var(--color-cream) 20px, var(--color-cream) 40px,
+          var(--color-ink-muted) 40px, var(--color-ink-muted) 60px,
+          var(--color-cream) 60px, var(--color-cream) 80px);
+        transform: rotate(-45deg);
+      }
+      .scarf--white {
+        background: var(--color-ink-soft);
+        border-color: var(--color-paper-edge);
+        box-shadow: var(--shadow-paper-sm-soft);
+      }
+      .scarf--white::before {
+        background: repeating-linear-gradient(90deg,
+          var(--color-cream) 0px, var(--color-cream) 20px,
+          var(--color-ink) 20px, var(--color-ink) 40px,
+          var(--color-jersey-bright) 40px, var(--color-jersey-bright) 60px,
+          var(--color-ink) 60px, var(--color-ink) 80px);
+        transform: rotate(-45deg);
+      }
+
+      .scarf--sm { width: 96px; height: 16px; }
+      .scarf--md { width: 180px; height: 28px; }
+      .scarf--lg { width: 240px; height: 36px; }
+      .scarf--xl { width: 360px; height: 56px; }
+
+      .scarf-cell {
+        display: inline-flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+      }
+      .scarf-cell .scarf-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+      }
+      .scarf-cell--white .scarf-label { color: var(--color-cream); }
+
+      /* Compact three-dot pulse */
+      @keyframes dot-pulse {
+        0%, 80%, 100% { opacity: 0.2; transform: scale(0.85); }
+        40% { opacity: 1; transform: scale(1); }
+      }
+      .dot-pulse {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .dot-pulse__dots { display: inline-flex; gap: 4px; align-items: center; }
+      .dot-pulse__dots span {
+        width: 6px;
+        height: 6px;
+        background: var(--color-jersey-deep);
+        border-radius: 50%;
+        animation: dot-pulse 1.2s ease-in-out infinite;
+      }
+      .dot-pulse__dots span:nth-child(2) { animation-delay: 0.15s; }
+      .dot-pulse__dots span:nth-child(3) { animation-delay: 0.3s; }
+
+      .spinner-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 32px;
+        margin-top: 24px;
+      }
+      .spinner-cell {
+        background: var(--color-cream);
+        border: 1px solid var(--color-paper-edge);
+        padding: 24px 16px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+        min-height: 140px;
+        justify-content: center;
+      }
+      .spinner-cell .size-tag { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-ink-muted); }
+
+      /* ============================================================
+         BRANDED TABS — paper-card, ink-invert active, NO TAPE
+         ============================================================ */
+
+      .b-tab-row { display: flex; gap: 12px; flex-wrap: wrap; align-items: stretch; }
+
+      .b-tab {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        padding: 12px 18px;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+        border-radius: 0; /* sharp corners — confirmed */
+      }
+      .b-tab:hover {
+        transform: translate(1px, 1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+      .b-tab--active {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        box-shadow: var(--shadow-paper-sm-soft);
+      }
+      .b-tab--active:hover { box-shadow: 3px 3px 0 0 var(--color-ink-muted); }
+
+      /* ============================================================
+         FILTER TABS — paper-chip body, THREE active states for comparison
+         ============================================================ */
+
+      .f-row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+
+      .f-chip {
+        background: var(--color-cream-soft);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        padding: 8px 12px;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+        border-radius: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .f-chip:hover {
+        transform: translate(1px, 1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+      .f-chip__count {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--color-ink-muted);
+        padding-left: 8px;
+        border-left: 1px solid var(--color-ink-muted);
+      }
+
+      /* Variant 1 — jersey fill (from Direction A) */
+      .f-chip--jersey-fill.f-chip--active {
+        background: var(--color-jersey);
+        color: var(--color-ink);
+      }
+      .f-chip--jersey-fill.f-chip--active .f-chip__count {
+        color: var(--color-ink);
+        border-left-color: var(--color-ink);
+      }
+
+      /* Variant 2 — ink invert (synthesis proposal) */
+      .f-chip--ink-invert.f-chip--active {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        box-shadow: var(--shadow-paper-sm-soft);
+      }
+      .f-chip--ink-invert.f-chip--active .f-chip__count {
+        color: var(--color-cream);
+        border-left-color: var(--color-cream);
+      }
+
+      /* Variant 3 — green-border outline (from C reference image) */
+      .f-chip--green-outline.f-chip--active {
+        background: var(--color-cream-soft);
+        border-color: var(--color-jersey-deep);
+        color: var(--color-ink);
+      }
+      .f-chip--green-outline.f-chip--active .f-chip__count {
+        color: var(--color-jersey-deep);
+        border-left-color: var(--color-jersey-deep);
+      }
+
+      /* Sizes */
+      .f-chip--sm { font-size: 10px; padding: 5px 9px; }
+      .f-chip--lg { font-size: 12px; padding: 11px 16px; }
+
+      /* ============================================================
+         SCROLL ARROW BUTTONS — paper card, no tape
+         ============================================================ */
+
+      .arrow-btn {
+        width: 48px;
+        height: 48px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        color: var(--color-ink);
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+        border-radius: 0;
+      }
+      .arrow-btn:hover {
+        transform: translate(1px, 1px);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+      /* No `arrow-btn--dark` variant — a single canonical cream-on-ink arrow
+         renders correctly on both light and dark panel bgs. The shadow vanishes
+         into an ink panel; cream contrast against ink already shows elevation. */
+
+      /* ============================================================
+         HORIZONTAL SLIDER — match cards, KCVV-prominent typography
+         ============================================================ */
+
+      .slider-wrap { position: relative; padding: 0 32px; }
+      .slider-track { display: flex; gap: 20px; overflow: hidden; padding: 12px 0; }
+
+      .match-card {
+        flex: 0 0 280px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 16px 18px;
+      }
+      .match-card:nth-child(4n+1) { transform: rotate(var(--rotate-tape-a)); }
+      .match-card:nth-child(4n+2) { transform: rotate(var(--rotate-tape-c)); }
+      .match-card:nth-child(4n+3) { transform: rotate(var(--rotate-tape-b)); }
+      .match-card:nth-child(4n+4) { transform: rotate(var(--rotate-tape-d)); }
+
+      .match-card__kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--color-ink-muted);
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+        align-items: baseline;
+      }
+      .match-card__kicker .live {
+        color: var(--color-alert);
+        font-weight: 700;
+      }
+
+      .match-card__teams {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 10px;
+      }
+      .match-card__team {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex: 1;
+        min-width: 0;
+      }
+      .match-card__crest {
+        width: 28px;
+        height: 28px;
+        flex-shrink: 0;
+        border: 1.5px solid var(--color-ink);
+        background: var(--color-cream-soft);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 900;
+        font-size: 11px;
+        color: var(--color-ink);
+      }
+      .match-card__name {
+        font-family: var(--font-body);
+        font-weight: 600;
+        font-size: 15px;
+        color: var(--color-ink);
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+      .match-card__name--kcvv {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 700;
+        font-size: 17px;
+        color: var(--color-jersey-deep);
+      }
+      .match-card__vs {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--color-ink-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .match-card__score {
+        font-family: var(--font-mono);
+        font-size: 28px;
+        font-weight: 700;
+        color: var(--color-ink);
+        margin: 8px 0 12px;
+        text-align: center;
+        letter-spacing: -0.01em;
+      }
+      .match-card__score--upcoming {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        font-weight: 400;
+        color: var(--color-ink-muted);
+      }
+
+      .match-card__footer {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding-top: 8px;
+        border-top: 1px dashed var(--color-paper-edge);
+      }
+      .match-card__venue { color: var(--color-ink-muted); }
+      .match-card__cta {
+        color: var(--color-jersey-deep);
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      /* All slider cards are equally treated — no live "active" variant.
+         A live match is signalled only through its kicker text (`★ LIVE · 67'`
+         in alert red) and through the score showing real numbers instead of a
+         time. The card surface itself stays identical to upcoming matches.
+
+         Dusk dark theme: the panel bg flips to ink, but the cards do not change.
+         Cream paper cards on ink panel pop via contrast alone; the ink offset
+         shadow becomes invisible against the ink bg, which is fine — the cream
+         surface carries the depth read on its own. No green borders, no green
+         shadows, no neon. */
+
+      /* ============================================================
+         COHESION mock
+         ============================================================ */
+
+      .cohesion { background: var(--color-cream); padding: 40px; border: 1px solid var(--color-paper-edge); }
+      .cohesion-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 24px; flex-wrap: wrap; gap: 16px; }
+
+      footer { margin-top: 80px; padding-top: 32px; border-top: 2px solid var(--color-ink); }
+      .map-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; margin-top: 16px; }
+      .map-grid h4 { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; margin: 0 0 8px; }
+      .map-grid ul { margin: 0; padding-left: 18px; font-size: 14px; line-height: 1.6; color: var(--color-ink-soft); }
+      footer code { font-family: var(--font-mono); font-size: 13px; background: var(--color-cream-soft); padding: 1px 6px; border: 1px solid var(--color-paper-edge); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <!-- ===========================================================
+           HEADER
+           =========================================================== -->
+      <header class="hero">
+        <div class="hero-meta">
+          <span class="mono mono--muted">PHASE 2 · TRACK B · DIRECTION D</span>
+          <span class="mono mono--muted">★ SYNTHESIS</span>
+          <span class="mono mono--muted">2026-04-30</span>
+        </div>
+        <h1>Paper chrome, <span class="display"><em>ink</em></span> emphasis.</h1>
+        <p class="lead" style="font-size: 17px; color: var(--color-ink-soft); margin: 16px 0 0">
+          One coherent direction synthesised from your A / B / C feedback. Paper-card
+          foundation everywhere (border-2 ink + shadow-paper-sm + cream bg). Active
+          states invert to ink + cream — never jersey-fill, except on the live match
+          card where jersey is the <em>content</em> moment, not chrome. No tape on
+          chrome. No leading glyphs on filter tabs. Sharp corners. Typographic
+          arrows over Lucide. One canonical form per atom.
+        </p>
+      </header>
+
+      <!-- ===========================================================
+           SPINNER
+           =========================================================== -->
+      <section class="section" id="spinner">
+        <div class="section-meta">
+          <span class="mono">★ 01 · SPINNER</span>
+          <span class="mono mono--muted">— scarf barber-pole (primary / secondary / white) + compact pulse</span>
+        </div>
+        <h2>Sjaal-strepen <em>oneindig.</em></h2>
+        <p class="lead">
+          Diagonal scarf stripes scrolling infinitely — strongest KCVV cultural
+          signal of the three directions. Three palette variants cover all spinner
+          contexts; compact pulse handles inline use.
+        </p>
+
+        <div class="panel">
+          <div class="mono mono--muted" style="margin-bottom: 16px">PRIMARY · jersey · cream · ink — default loading on cream surfaces</div>
+          <div class="spinner-grid">
+            <div class="spinner-cell"><div class="scarf scarf--primary scarf--sm"></div><span class="size-tag">SM · 96×16</span></div>
+            <div class="spinner-cell"><div class="scarf scarf--primary scarf--md"></div><span class="size-tag">MD · 180×28</span></div>
+            <div class="spinner-cell"><div class="scarf scarf--primary scarf--lg"></div><span class="size-tag">LG · 240×36</span></div>
+            <div class="spinner-cell"><div class="scarf scarf--primary scarf--xl"></div><span class="size-tag">XL · 360×56</span></div>
+          </div>
+        </div>
+
+        <div class="panel panel--soft" style="margin-top: 16px">
+          <div class="mono mono--muted" style="margin-bottom: 16px">SECONDARY · ink · cream · ink-muted (no jersey) — non-brand loading</div>
+          <div class="row">
+            <div class="scarf-cell">
+              <div class="scarf scarf--secondary scarf--lg"></div>
+              <span class="scarf-label">Bezig met opslaan…</span>
+            </div>
+          </div>
+          <p class="mono mono--muted" style="margin-top: 16px; font-size: 12px; text-transform: none; letter-spacing: 0">
+            Used when the brand colour shouldn't pull attention — e.g. form
+            validation, admin-panel saves, background sync. Stripe palette swaps
+            jersey for ink-muted; everything else identical.
+          </p>
+        </div>
+
+        <div class="panel panel--dusk" style="margin-top: 16px">
+          <div class="mono mono--muted" style="margin-bottom: 16px; color: var(--color-cream)">WHITE · cream · ink · jersey-bright (palette flip) — on dark interlude bg</div>
+          <div class="row">
+            <div class="scarf-cell scarf-cell--white">
+              <div class="scarf scarf--white scarf--lg"></div>
+              <span class="scarf-label">Wedstrijden laden…</span>
+            </div>
+          </div>
+          <p class="mono mono--muted" style="margin-top: 16px; font-size: 12px; text-transform: none; letter-spacing: 0; color: var(--color-cream)">
+            Surface flips to ink-soft, stripes invert to cream-led. Border lifts
+            to <code style="color: var(--color-cream); background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.15)">paper-edge</code> (warm tan)
+            so it's visible against the ink panel; box-shadow lifts to
+            <code style="color: var(--color-cream); background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.15)">--shadow-paper-sm-soft</code>
+            (gray, ink-muted) so the offset depth stays readable. Jersey-bright
+            kept only because the cream stripes carry the contrast.
+          </p>
+        </div>
+
+        <div class="panel" style="margin-top: 16px">
+          <div class="mono mono--muted" style="margin-bottom: 16px">COMPACT · three jersey-deep dots — inline next to text</div>
+          <div class="dot-pulse">
+            <span>BIJWERKEN</span>
+            <span class="dot-pulse__dots"><span></span><span></span><span></span></span>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>Most KCVV-coded chrome of any direction. Three palette variants cover every loading context (default / non-brand / dark interlude). Compact pulse is the inline workhorse.</p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>Barber-pole bar requires a minimum width (~96px sm). For very-tight inline contexts (button-internal loading state), only `compact` works.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           BRANDED TABS
+           =========================================================== -->
+      <section class="section" id="branded-tabs">
+        <div class="section-meta">
+          <span class="mono">★ 02 · BRANDED TABS</span>
+          <span class="mono mono--muted">— paper-card, ink-invert active, no tape, no rotation</span>
+        </div>
+        <h2>Geplakte <em>tabbladen.</em></h2>
+        <p class="lead">
+          Paper-card vocabulary at tab scale — same border + shadow as TapedCard.
+          Active inverts to ink + cream. Tape removed per your A feedback.
+        </p>
+
+        <div class="panel">
+          <div class="mono mono--muted" style="margin-bottom: 16px">DEFAULT — five ploeg tabs, B-PLOEG active</div>
+          <div class="b-tab-row" role="tablist" aria-label="Ploeg selectie">
+            <button class="b-tab" type="button" role="tab" aria-selected="false">A-PLOEG</button>
+            <button class="b-tab b-tab--active" type="button" role="tab" aria-selected="true">B-PLOEG</button>
+            <button class="b-tab" type="button" role="tab" aria-selected="false">U21</button>
+            <button class="b-tab" type="button" role="tab" aria-selected="false">U17</button>
+            <button class="b-tab" type="button" role="tab" aria-selected="false">DAMES</button>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>Tabs read as physical paper sections. Clear active signal (full inversion). Hover idiom (shadow shift + translate) unifies with all other paper-card press states.</p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>Five paper shadows in a row carry visible weight — fine on a section header, possibly heavy in dense layouts.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           FILTER TABS — three active state variants
+           =========================================================== -->
+      <section class="section" id="filter-tabs">
+        <div class="section-meta">
+          <span class="mono">★ 03 · FILTER TABS</span>
+          <span class="mono mono--muted">— paper-chip body fixed, three active-state options to compare</span>
+        </div>
+        <h2>Drie <em>actieve</em> opties.</h2>
+        <p class="lead">
+          Chip body locked: paper-card vocabulary with `border-2 ink` + `shadow-paper-sm`,
+          mono caps label, count after a hairline pipe (`LIVE | 1`). Three options
+          for the active state below — pick one.
+        </p>
+
+        <div class="panel">
+          <div class="label-row">
+            <span class="row-label">VARIANT 1</span>
+            <span class="mono">JERSEY FILL — from Direction A</span>
+          </div>
+          <div class="f-row">
+            <button class="f-chip f-chip--jersey-fill" type="button">LIVE<span class="f-chip__count">1</span></button>
+            <button class="f-chip f-chip--jersey-fill f-chip--active" type="button">AANKOMEND<span class="f-chip__count">6</span></button>
+            <button class="f-chip f-chip--jersey-fill" type="button">UITSLAGEN<span class="f-chip__count">24</span></button>
+            <button class="f-chip f-chip--jersey-fill" type="button">THUIS<span class="f-chip__count">12</span></button>
+            <button class="f-chip f-chip--jersey-fill" type="button">UIT<span class="f-chip__count">13</span></button>
+          </div>
+          <p class="mono mono--muted" style="margin-top: 12px; font-size: 12px; text-transform: none; letter-spacing: 0">
+            Active chip flips to <code>bg-jersey text-ink</code>. Loud but unmistakable.
+            Owner concern: green active may pull attention away from editorial.
+          </p>
+        </div>
+
+        <div class="panel" style="margin-top: 16px">
+          <div class="label-row">
+            <span class="row-label">VARIANT 2</span>
+            <span class="mono">INK INVERT — synthesis proposal</span>
+            <span class="recommend-pick">★ GEKOZEN</span>
+          </div>
+          <div class="f-row">
+            <button class="f-chip f-chip--ink-invert" type="button">LIVE<span class="f-chip__count">1</span></button>
+            <button class="f-chip f-chip--ink-invert f-chip--active" type="button">AANKOMEND<span class="f-chip__count">6</span></button>
+            <button class="f-chip f-chip--ink-invert" type="button">UITSLAGEN<span class="f-chip__count">24</span></button>
+            <button class="f-chip f-chip--ink-invert" type="button">THUIS<span class="f-chip__count">12</span></button>
+            <button class="f-chip f-chip--ink-invert" type="button">UIT<span class="f-chip__count">13</span></button>
+          </div>
+          <p class="mono mono--muted" style="margin-top: 12px; font-size: 12px; text-transform: none; letter-spacing: 0">
+            Active flips to <code>bg-ink text-cream</code> (matches BrandedTabs).
+            Strongest readable contrast, doesn't compete with editorial jersey moments.
+            Multi-active works (each active chip independently inverted).
+          </p>
+        </div>
+
+        <div class="panel" style="margin-top: 16px">
+          <div class="label-row">
+            <span class="row-label">VARIANT 3</span>
+            <span class="mono">GREEN OUTLINE — from your reference image</span>
+          </div>
+          <div class="f-row">
+            <button class="f-chip f-chip--green-outline" type="button">LIVE<span class="f-chip__count">1</span></button>
+            <button class="f-chip f-chip--green-outline f-chip--active" type="button">AANKOMEND<span class="f-chip__count">6</span></button>
+            <button class="f-chip f-chip--green-outline" type="button">UITSLAGEN<span class="f-chip__count">24</span></button>
+            <button class="f-chip f-chip--green-outline f-chip--active" type="button">THUIS<span class="f-chip__count">12</span></button>
+            <button class="f-chip f-chip--green-outline" type="button">UIT<span class="f-chip__count">13</span></button>
+          </div>
+          <p class="mono mono--muted" style="margin-top: 12px; font-size: 12px; text-transform: none; letter-spacing: 0">
+            Border + count digit flip to jersey-deep, body stays cream. Most restrained.
+            Multi-active reads cleanly. Risk: subtler than other two — at quick glance
+            the active state may not pop on a busy page. Test in cohesion mock to verify.
+          </p>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR (across all three)</h4>
+            <p>Paper-card chip body reads as filters at a glance — addresses your B concern. Hairline pipe count divider keeps things readable without a pill stamp. No leading glyphs.</p>
+          </div>
+          <div>
+            <h4 class="against">↓ RESOLVED</h4>
+            <p>Variant 2 (ink-invert) chosen. Chrome states are uniformly ink-coded across BrandedTabs + FilterTabs; jersey stays reserved for content moments only. Variants 1 + 3 retained above as historical reference, will not ship.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           SCROLL ARROW BUTTONS
+           =========================================================== -->
+      <section class="section" id="scroll-arrows">
+        <div class="section-meta">
+          <span class="mono">★ 04 · SCROLL ARROW BUTTON</span>
+          <span class="mono mono--muted">— paper card, no tape, typographic glyph</span>
+        </div>
+        <h2>Pijlen <em>op papier.</em></h2>
+
+        <p class="lead">
+          One canonical arrow — cream paper button with ink border and offset
+          shadow. Same rendering on both light and dark panel bgs. The hard-offset
+          shadow vanishes when the panel itself is ink (visible only at very close
+          inspection where the shadow's bottom-right edge clips the ink panel),
+          and the cream button still reads as obviously elevated thanks to the
+          cream-on-ink contrast.
+        </p>
+
+        <div class="panel">
+          <div class="mono mono--muted" style="margin-bottom: 16px">ON CREAM PANEL — default light context</div>
+          <div class="row">
+            <button class="arrow-btn" type="button" aria-label="Vorige">←</button>
+            <button class="arrow-btn" type="button" aria-label="Volgende">→</button>
+            <span class="mono mono--muted" style="margin-left: 16px">Hover any arrow — shadow shifts to 3×3, translate +1/+1.</span>
+          </div>
+        </div>
+
+        <div class="panel panel--dusk" style="margin-top: 16px">
+          <div class="mono mono--muted" style="margin-bottom: 16px; color: var(--color-cream)">ON INK PANEL — dusk dark context</div>
+          <div class="row">
+            <button class="arrow-btn" type="button" aria-label="Vorige">←</button>
+            <button class="arrow-btn" type="button" aria-label="Volgende">→</button>
+            <span class="mono mono--muted" style="margin-left: 16px; color: var(--color-cream)">Same button, different bg. No green styling — cream-on-ink contrast does the elevation work.</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           HORIZONTAL SLIDER
+           =========================================================== -->
+      <section class="section" id="slider">
+        <div class="section-meta">
+          <span class="mono">★ 05 · HORIZONTAL SLIDER</span>
+          <span class="mono mono--muted">— match cards with KCVV-prominent typography, dusk dark theme</span>
+        </div>
+        <h2>De <em>kalender.</em></h2>
+        <p class="lead">
+          Match card structure: mono kicker · teams (KCVV always rendered as italic
+          Freight Display in jersey-deep, opponent in body sans) · big mono score ·
+          venue + CTA. Sub-degree rotation per <code>nth-child(4n+1..4)</code>, same as
+          <code>&lt;TapedCardGrid&gt;</code>. <strong>All cards are equally treated</strong> —
+          no live "active" variant; live status comes from the kicker text only
+          (<code>★ LIVE · 67'</code> in alert-red). Dark theme keeps the same paper
+          cards on an ink panel — no green borders, no green shadows.
+        </p>
+
+        <div class="panel">
+          <div class="mono mono--muted" style="margin-bottom: 16px">LIGHT THEME · cream bg · paper match cards</div>
+          <div class="slider-wrap">
+            <button class="arrow-btn" type="button" aria-label="Vorige" style="position: absolute; left: -8px; top: 50%; transform: translateY(-50%); z-index: 2">←</button>
+            <div class="slider-track">
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span class="live">★ LIVE · 67'</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">KC</span>
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name">Tervuren</span>
+                    <span class="match-card__crest">TV</span>
+                  </div>
+                </div>
+                <div class="match-card__score">2 — 1</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">VOLG LIVE →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span>ZA 02 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">WB</span>
+                    <span class="match-card__name">Wezembeek</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                    <span class="match-card__crest">KC</span>
+                  </div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">20:00</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">WEZEMBEEK-OPPEM</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>BEKER · 1/8</span><span>WO 06 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">KC</span>
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name">Lebbeke</span>
+                    <span class="match-card__crest">LB</span>
+                  </div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">19:30</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span>ZA 09 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">KC</span>
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name">Vilvoorde</span>
+                    <span class="match-card__crest">VV</span>
+                  </div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">15:00</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+            </div>
+            <button class="arrow-btn" type="button" aria-label="Volgende" style="position: absolute; right: -8px; top: 50%; transform: translateY(-50%); z-index: 2">→</button>
+          </div>
+        </div>
+
+        <div class="panel panel--dusk" style="margin-top: 16px">
+          <div class="mono mono--muted" style="margin-bottom: 16px; color: var(--color-cream)">DARK THEME · ink panel · cream paper cards (identical to light) · cream-on-ink contrast carries elevation</div>
+          <div class="slider-wrap">
+            <button class="arrow-btn" type="button" aria-label="Vorige" style="position: absolute; left: -8px; top: 50%; transform: translateY(-50%); z-index: 2">←</button>
+            <div class="slider-track">
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span class="live">★ LIVE · 67'</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">KC</span>
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name">Tervuren</span>
+                    <span class="match-card__crest">TV</span>
+                  </div>
+                </div>
+                <div class="match-card__score">2 — 1</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">VOLG LIVE →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span>ZA 02 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">WB</span>
+                    <span class="match-card__name">Wezembeek</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                    <span class="match-card__crest">KC</span>
+                  </div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">20:00</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">WEZEMBEEK-OPPEM</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>BEKER · 1/8</span><span>WO 06 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team">
+                    <span class="match-card__crest">KC</span>
+                    <span class="match-card__name match-card__name--kcvv">Elewijt</span>
+                  </div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end">
+                    <span class="match-card__name">Lebbeke</span>
+                    <span class="match-card__crest">LB</span>
+                  </div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">19:30</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+            </div>
+            <button class="arrow-btn" type="button" aria-label="Volgende" style="position: absolute; right: -8px; top: 50%; transform: translateY(-50%); z-index: 2">→</button>
+          </div>
+        </div>
+
+        <div class="tradeoffs">
+          <div>
+            <h4 class="for">↑ FOR</h4>
+            <p>KCVV (always rendered as <em>Elewijt</em> in italic Freight Display jersey-deep) is unambiguously the visual centre of every card. All cards equally treated — no special-casing. Dark theme is just "cream paper on ink", no green chrome.</p>
+          </div>
+          <div>
+            <h4 class="against">↓ AGAINST</h4>
+            <p>Match card width (~280px) means ~3–4 cards visible per viewport on desktop — fewer than a dense slider. Sub-degree rotation through 4 cards is satisfying; on uneven counts the rhythm interrupts. Live status reads only via kicker text — fine for at-a-glance, but a viewer scrolling fast may not register "this one's playing now" without scanning the kicker.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           COHESION mock
+           =========================================================== -->
+      <section class="section" id="cohesion">
+        <div class="section-meta">
+          <span class="mono">★ 06 · COHESION CHECK</span>
+          <span class="mono mono--muted">— matches page fragment, all four atoms together</span>
+        </div>
+
+        <div class="cohesion">
+          <div class="cohesion-head">
+            <div>
+              <div class="mono mono--muted" style="margin-bottom: 6px">★ MATCHDAG</div>
+              <h2 class="display"><em>Wedstrijden.</em></h2>
+            </div>
+            <div class="dot-pulse">
+              <span>BIJWERKEN</span>
+              <span class="dot-pulse__dots"><span></span><span></span><span></span></span>
+            </div>
+          </div>
+
+          <div class="b-tab-row" style="margin-bottom: 16px">
+            <button class="b-tab b-tab--active" type="button">A-PLOEG</button>
+            <button class="b-tab" type="button">B-PLOEG</button>
+            <button class="b-tab" type="button">U21</button>
+            <button class="b-tab" type="button">DAMES</button>
+          </div>
+
+          <div class="f-row" style="margin-bottom: 24px">
+            <button class="f-chip f-chip--ink-invert" type="button">LIVE<span class="f-chip__count">1</span></button>
+            <button class="f-chip f-chip--ink-invert f-chip--active" type="button">AANKOMEND<span class="f-chip__count">6</span></button>
+            <button class="f-chip f-chip--ink-invert" type="button">UITSLAGEN<span class="f-chip__count">24</span></button>
+            <button class="f-chip f-chip--ink-invert" type="button">THUIS<span class="f-chip__count">12</span></button>
+          </div>
+
+          <div class="slider-wrap">
+            <div class="slider-track">
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span class="live">★ LIVE · 67'</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team"><span class="match-card__crest">KC</span><span class="match-card__name match-card__name--kcvv">Elewijt</span></div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end"><span class="match-card__name">Tervuren</span><span class="match-card__crest">TV</span></div>
+                </div>
+                <div class="match-card__score">2 — 1</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">VOLG LIVE →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>1STE PROV.</span><span>ZA 02 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team"><span class="match-card__crest">WB</span><span class="match-card__name">Wezembeek</span></div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end"><span class="match-card__name match-card__name--kcvv">Elewijt</span><span class="match-card__crest">KC</span></div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">20:00</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">WEZEMBEEK-OPPEM</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+              <div class="match-card">
+                <div class="match-card__kicker"><span>BEKER · 1/8</span><span>WO 06 MEI</span></div>
+                <div class="match-card__teams">
+                  <div class="match-card__team"><span class="match-card__crest">KC</span><span class="match-card__name match-card__name--kcvv">Elewijt</span></div>
+                  <span class="match-card__vs">VS</span>
+                  <div class="match-card__team" style="justify-content: flex-end"><span class="match-card__name">Lebbeke</span><span class="match-card__crest">LB</span></div>
+                </div>
+                <div class="match-card__score match-card__score--upcoming">19:30</div>
+                <div class="match-card__footer">
+                  <span class="match-card__venue">DRIESSTRAAT</span>
+                  <a href="#" class="match-card__cta">TICKETS →</a>
+                </div>
+              </div>
+            </div>
+            <button class="arrow-btn" type="button" aria-label="Volgende" style="position: absolute; right: -8px; top: 50%; transform: translateY(-50%); z-index: 2">→</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===========================================================
+           FOOTER
+           =========================================================== -->
+      <footer>
+        <div class="section-meta">
+          <span class="mono">★ NOTES</span>
+          <span class="mono mono--muted">— token map, decisions resolved, decisions remaining</span>
+        </div>
+
+        <h3>Resolved</h3>
+        <ul style="font-size: 14px; color: var(--color-ink-soft); padding-left: 18px; margin: 12px 0">
+          <li>Spinner: barber-pole primary / secondary / white + compact three-dot pulse. <code>variant="logo"</code> retired</li>
+          <li>BrandedTabs: paper-card, no tape, no rotation, ink-invert active</li>
+          <li>FilterTabs: paper-chip body + hairline pipe count divider. <strong>Active state: variant 2 (ink invert)</strong> — cohesive with BrandedTabs, jersey reserved for content</li>
+          <li><code>FilterTab.icon</code> prop retired entirely (no leading glyphs anywhere → closes #1573 with no UI work)</li>
+          <li>ScrollArrowButton: single canonical cream-on-ink-bordered paper button with italic Freight Display glyph + <code>shadow-paper-sm</code>. <strong>No <code>variant: "light" | "dark"</code></strong> — same arrow on both panel bgs</li>
+          <li>HorizontalSlider: match card layout (kicker / teams / score / venue+CTA), KCVV always italic Freight Display jersey-deep, sub-degree rotation per <code>nth-child(4n+1..4)</code></li>
+          <li><strong>All slider cards equally treated</strong> — no live "active" variant. Live status signalled only via the kicker text (<code>★ LIVE · 67'</code> in alert-red)</li>
+          <li>Slider <code>theme: "light" | "dark"</code> stays (homepage MatchesSliderSection consumes dark). Dark theme is "cream paper cards on ink panel" — no green borders, no green shadows, no neon</li>
+          <li><strong>New token <code>--shadow-paper-sm-soft: 4px 4px 0 var(--color-ink-muted)</code></strong> — the gray-shadow sibling of <code>--shadow-paper-sm</code>, used wherever ink would vanish: ink-bg active states (BrandedTab + FilterTab) and any chrome on a dark panel (arrows, cards, white-variant spinner). White-variant spinner border also lifts to <code>paper-edge</code> for visibility on ink panels</li>
+        </ul>
+
+        <h3>Open</h3>
+        <p style="font-size: 14px; color: var(--color-ink-soft); margin: 8px 0">
+          None. The synthesis is locked pending owner sign-off.
+        </p>
+
+        <h3 style="margin-top: 32px">Token map</h3>
+        <div class="map-grid">
+          <div>
+            <h4>SURFACE / TEXT</h4>
+            <ul>
+              <li>Chrome surfaces: <code>--color-cream</code> default, <code>--color-cream-soft</code> for chips</li>
+              <li>Active chrome: <code>--color-ink</code> bg + <code>--color-cream</code> text</li>
+              <li>Live match card: <code>--color-jersey</code> bg + <code>--color-ink</code> text</li>
+              <li>KCVV name typography: italic Freight Display + <code>--color-jersey-deep</code></li>
+              <li>Dusk dark theme: <code>--color-ink-soft</code> bg + <code>--color-cream-soft</code> cards + <code>--color-jersey-deep</code> accents</li>
+            </ul>
+          </div>
+          <div>
+            <h4>STRUCTURE / DEPTH</h4>
+            <ul>
+              <li>Chrome border: <code>2px solid var(--color-ink)</code> (default), <code>paper-edge</code> on white-variant spinner (visibility on ink panel)</li>
+              <li>Chrome shadow: <code>--shadow-paper-sm</code> (4×4 ink) — default</li>
+              <li>Soft shadow sibling: <code>--shadow-paper-sm-soft</code> (4×4 ink-muted gray) — for ink-bg active states + any chrome on dark panel where ink would vanish</li>
+              <li>Press: shadow → 3×3 + <code>translate(1px, 1px)</code></li>
+              <li>Match card rotation: <code>--rotate-tape-a..d</code> via nth-child cycle</li>
+              <li>Sharp corners: no <code>border-radius</code> anywhere</li>
+            </ul>
+          </div>
+        </div>
+
+        <p style="margin-top: 32px" class="mono mono--muted">
+          ★ END · DIRECTION D — PAPER CHROME, INK EMPHASIS · KCVV ELEWIJT · 2026-04-30
+        </p>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html
+++ b/docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html
@@ -359,8 +359,11 @@
         box-shadow: 3px 3px 0 0 var(--color-ink);
       }
       /* No `arrow-btn--dark` variant — a single canonical cream-on-ink arrow
-         renders correctly on both light and dark panel bgs. The shadow vanishes
-         into an ink panel; cream contrast against ink already shows elevation. */
+         renders correctly on both light and dark panel bgs. On a dusk panel the
+         standard ink offset shadow would lose contrast, so the `.panel--dusk`
+         descendant rule above swaps the arrow's box-shadow to
+         --shadow-paper-sm-soft (4×4 ink-muted). The cream button keeps a
+         visible, softened gray offset against the ink panel. */
 
       /* ============================================================
          HORIZONTAL SLIDER — match cards, KCVV-prominent typography
@@ -490,11 +493,12 @@
          in alert red) and through the score showing real numbers instead of a
          time. The card surface itself stays identical to upcoming matches.
 
-         Dusk dark theme: the panel bg flips to ink, but the cards do not change.
-         Cream paper cards on ink panel pop via contrast alone; the ink offset
-         shadow becomes invisible against the ink bg, which is fine — the cream
-         surface carries the depth read on its own. No green borders, no green
-         shadows, no neon. */
+         Dusk dark theme: the panel bg flips to ink, but the cards themselves
+         keep their light-theme paper-card vocabulary. The chrome shadow is
+         swapped to --shadow-paper-sm-soft (4×4 ink-muted) via the
+         `.panel--dusk .match-card` descendant rule above, so the cream paper
+         card retains a visible softened gray offset against the ink bg —
+         depth without green borders, green shadows, or neon. */
 
       /* ============================================================
          COHESION mock
@@ -742,12 +746,13 @@
         <h2>Pijlen <em>op papier.</em></h2>
 
         <p class="lead">
-          One canonical arrow — cream paper button with ink border and offset
-          shadow. Same rendering on both light and dark panel bgs. The hard-offset
-          shadow vanishes when the panel itself is ink (visible only at very close
-          inspection where the shadow's bottom-right edge clips the ink panel),
-          and the cream button still reads as obviously elevated thanks to the
-          cream-on-ink contrast.
+          One canonical arrow — cream paper button with ink border and a hard
+          offset shadow. On cream panels the shadow is the standard
+          <code>--shadow-paper-sm</code> (4×4 ink). On dusk panels a
+          <code>.panel--dusk</code> descendant rule swaps the shadow to
+          <code>--shadow-paper-sm-soft</code> (4×4 ink-muted gray) so the offset
+          depth remains visible against the ink bg. Same button across both
+          contexts; only the shadow colour adapts.
         </p>
 
         <div class="panel">

--- a/docs/prd/redesign-phase-2.md
+++ b/docs/prd/redesign-phase-2.md
@@ -67,7 +67,7 @@ Phase 2.0 — Tracer bullet (tokens + vr:update:story + Button.primary + Phospho
    │       2.A.3  Button rework completion (inverted, secondary, ghost; retire link)       → #1570
    │       2.A.4  Form atoms reskin (Input, Select, Textarea, Label)                       → #1571
    │       2.A.5  Alert reskin (drop info; success/warning/error)                          → #1572
-   │       2.A.6  FilterTabs icon prop type swap (Lucide → Phosphor Icon)                  → #1573
+   │       2.A.6  Remove FilterTab.icon prop entirely (no leading glyphs)                 → #1573
    │
    └──── Track B — design checkpoint via /design-an-interface (cohesive across atoms, per-atom variation)
            2.B.1  Spinner — design + reskin                                                → #1575
@@ -100,7 +100,7 @@ Phase 2.0 — Tracer bullet (tokens + vr:update:story + Button.primary + Phospho
 - [ ] **2.A.3 Button:** `ButtonVariant` type is `"primary" | "inverted" | "secondary" | "ghost"` (no `link`). `withArrow` renders typographic `→` glyph (`<span aria-hidden>→</span>`), not a Phosphor icon. Focus ring uses `ring-jersey-deep`. Disabled stays `opacity-50 cursor-not-allowed`. Zero non-test consumers of the removed `link` variant (verified by grep at PR time).
 - [ ] **2.A.4 Form atoms:** All four atoms render `bg-white` with `border border-ink/20`, focus state uses `border-jersey-deep` + `ring-jersey-deep/20`. Error state on Input/Select/Textarea uses `--color-alert`. Label required asterisk uses `--color-alert`. `kcvv-alert` no longer referenced from these four files.
 - [ ] **2.A.5 Alert:** `AlertVariant` type is `"success" | "warning" | "error"` (no `info`). Each variant matches the colour map in §6.5. Dismiss button renders Phosphor Fill `X`.
-- [ ] **2.A.6 FilterTabs prop type:** `FilterTab.icon` typed as Phosphor `Icon` from `@phosphor-icons/react`. Type-check passes (no current consumers verified to break).
+- [ ] **2.A.6 FilterTab.icon removal:** `FilterTab.icon` field removed from the `FilterTab` interface; the `<FilterTabs>` rendering path no longer accepts or renders any leading icon. Locked at the Track B design checkpoint (2026-04-30) — supersedes the original Lucide → Phosphor type-swap plan. Acceptance: zero non-test references to `FilterTab.icon` after the PR; consumers that previously passed an `icon` stop doing so; type-check passes.
 
 ### 5.B Track B acceptance (per child issue)
 
@@ -111,10 +111,10 @@ Each Track B child issue has two phases internally:
 
 Per atom:
 
-- [ ] **2.B.1 Spinner:** Approved design (likely _not_ the circular SVG default). Reskinned. `SpinnerVariant` updated if needed (e.g., `white` → `cream` rename). Story + baseline.
+- [ ] **2.B.1 Spinner:** Approved design (scarf barber-pole + compact three-dot pulse, per locked design checkpoint). Reskinned. `SpinnerVariant` becomes `"primary" | "secondary" | "white" | "compact"` — the `"white"` member is **retained** (it's the dark-interlude palette flip; no rename). `"logo"` is **removed**. Story + baseline.
 - [ ] **2.B.2 BrandedTabs:** Approved design. Bottom-border tabs reinterpreted in retro vocabulary. Token swap (`kcvv-green-bright` → `jersey-deep`, etc.). Story + baseline.
 - [ ] **2.B.3 FilterTabs:** Approved design. Pill toggle group reinterpreted. Story + baseline.
-- [ ] **2.B.4 HorizontalSlider + ScrollHint arrows:** Approved design. Arrow buttons reskinned. Phosphor Fill `CaretLeft` / `CaretRight` consumed via `icons.redesign.ts`. Story + baseline.
+- [ ] **2.B.4 HorizontalSlider + ScrollHint arrows:** Approved design (per locked design checkpoint). Arrow buttons reskinned as a single canonical 48 × 48 paper button with typographic `←` / `→` in Freight Display italic — **no Phosphor `CaretLeft` / `CaretRight` consumed; the typographic glyph is hardcoded** per the "typographic glyphs over Lucide where the glyph reads" preference. `ScrollArrowButtonProps.variant` removed. HorizontalSlider match-card layout shipped per `docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html`. Story + baseline.
 
 ### Cross-cutting acceptance
 

--- a/docs/prd/redesign-phase-2.md
+++ b/docs/prd/redesign-phase-2.md
@@ -207,16 +207,25 @@ Border radius (`rounded-[0.25em]`) unchanged. Sizes (sm/md/lg) unchanged.
 - `info` variant removed entirely. Any consumer using it migrates to `success` (the closest visual semantic).
 - Verify zero `<Alert variant="info">` consumers at PR time; if any exist, migrate them in the same PR.
 
-### 6.5 Track B atoms (designs to be produced)
+### 6.5 Track B atoms — locked design contract
 
-The following atoms have **no specified visual contract in this PRD** — design checkpoints via `/design-an-interface` produce that contract before implementation begins.
+The Track B design checkpoint completed 2026-04-30. Owner picked **Direction D — "Paper chrome, ink emphasis"**, a synthesis derived from feedback on three exploratory directions (A — Paper &amp; Tape, B — Mono &amp; Ink, C — Matchday Programme).
 
-- **`<Spinner>`** — circular SVG default is the digital-loader trope. Explore retro-fanzine alternatives: spinning football glyph, halftone dot cycle, barber-pole stripe, animated mono-cycling dots. Constraint: still works at every Spinner size (sm/md/lg/xl) and renders correctly inline + standalone. Logo variant (`/images/logo-flat.png` rotation) likely retained as-is — it's already brand-character.
-- **`<BrandedTabs>`** — bottom-border tab pattern. Token swap is trivial; the open question is whether the bottom-border _pattern itself_ survives in the retro vocabulary or gets reinterpreted (e.g., taped corner accent, mono-stamp underline, ink ribbon).
-- **`<FilterTabs>`** — pill toggle group. Open question: pills survive (with new fills), or replaced with a stamped-card grid, button-row, or other retro-coherent toggle pattern.
-- **`<HorizontalSlider>` + `<ScrollHint>` arrow buttons** — arrow button shape, fill, hover treatment. Should match whatever toggle/button vocabulary settles in BrandedTabs/FilterTabs for visual cohesion.
+**Source-of-record:**
 
-**Design exploration brief for Track B:** produce _cohesive directional options_ (e.g., direction A = "stamped paper buttons", direction B = "ink ribbon underlines") so the four atoms read as one family, AND _per-atom variations_ within each direction so each atom can be evaluated on its own merits. Owner picks direction → per-atom mockups → implementation.
+- Canonical visual: `docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html`.
+- Per-atom locked specifications, historical exploration trail, and provisional caveats: `docs/design/mockups/phase-2-track-b/compare.md`.
+
+**Locked atom contracts (summary; see compare.md for full detail):**
+
+- **`<Spinner>`** — primary motif: scarf barber-pole (diagonal jersey/cream/ink stripes scrolling at 90° via a rotated `::before` for seam-free integer-pixel translation). Variants: `primary` (full brand stripes), `secondary` (no jersey, ink/cream/ink-muted only), `white` (palette flip on dark interlude bg, with `paper-edge` border + `--shadow-paper-sm-soft`), `compact` (three jersey-deep dots pulsing in sequence, inline). Sizes sm/md/lg/xl: 96 × 16 / 180 × 28 / 240 × 36 / 360 × 56. **`variant="logo"` retired** — `SpinnerVariant` becomes `"primary" | "secondary" | "white" | "compact"`.
+- **`<BrandedTabs>`** — paper-card vocabulary at tab scale: `border-2 ink` + `shadow-paper-sm` + `bg-cream`, mono caps, sharp corners, no rotation, no tape. Active: `bg-ink text-cream` + `--shadow-paper-sm-soft` (so the ink tab body and shadow remain distinguishable). Hover: shadow → 3 × 3 + `translate(1px, 1px)`. Prop surface unchanged.
+- **`<FilterTabs>`** — paper-chip vocabulary: `border-2 ink` + `shadow-paper-sm` + `bg-cream-soft`, mono caps, sharp corners. Active: `bg-ink text-cream` + `--shadow-paper-sm-soft` (matches BrandedTabs). Count rendered inline after a 1 px ink-muted hairline pipe — no pill, no badge. Sizes sm/md/lg differ in padding + font-size only. **`FilterTab.icon` prop dropped entirely** — closes #1573 with no UI work (the type swap becomes a removal). `renderAsLinks?`, `showCounts?`, `size`, `tabs`, `activeTab`, `onChange?`, `ariaLabel?`, `className?` retained.
+- **`<HorizontalSlider>` + `<ScrollHint>` arrows.** Arrow: single canonical 48 × 48 paper button (`border-2 ink` + `shadow-paper-sm` + `bg-cream` + italic Freight Display `←` / `→` glyph). On `panel--dusk`, shadow swaps to `--shadow-paper-sm-soft` via descendant rule. **`ScrollArrowButtonProps.variant` dropped** — `{ direction, onClick, className? }` is the full surface. Slider match-card structure (top-to-bottom): mono kicker · teams (KCVV always italic Freight Display + jersey-deep, opponent in body sans) · big mono score · venue + CTA. Sub-degree rotation per `nth-child(4n+1..4)` matching `<TapedCardGrid>`. **No live-card surface variant** — all cards equally treated; live status signalled only via kicker text (`★ LIVE` in alert-red) and score field. `theme: "light" | "dark"` retained (homepage `MatchesSliderSection` consumes dark); dark theme keeps the same paper cards on an ink panel + soft shadow via descendant rule. No green borders, no green shadows.
+
+**Provisional caveats** (from compare.md):
+
+- Owner sign-off was conditional ("not 200% convinced, but let's go with it for now"). The dark-shadow `--shadow-paper-sm-soft` decision and the slider's "all cards equally treated" rule are the two areas most likely to need refinement during implementation. If issues #1575–#1578 surface real-use friction, the per-issue PRDs may revise — this checkpoint is the source-of-record, not a hard freeze.
 
 ### 6.6 Phosphor migration — `apps/web/src/lib/icons.redesign.ts`
 
@@ -266,6 +275,13 @@ Append to the existing `@theme` block alongside other redesign tokens (cream/ink
 --color-alert-soft: #e8d5cf;
 --color-warning: #c68b2c;
 --color-warning-soft: #ecddb8;
+
+/* Soft offset-shadow sibling — used wherever the standard --shadow-paper-sm
+   (ink) would vanish: ink-bg active states (BrandedTab + FilterTab) and any
+   chrome surface on a dark / ink panel (arrows, match cards, white-variant
+   scarf spinner). Ink-muted (#6b6b6b) gives the offset visible depth without
+   adding a third primary shadow weight. */
+--shadow-paper-sm-soft: 4px 4px 0 0 var(--color-ink-muted);
 ```
 
 `--color-success` is not added — `--color-jersey-deep` covers success semantics.
@@ -305,12 +321,12 @@ Full `pnpm vr:update` (~25–41 minutes) runs only when a token file change demo
 
 These are NOT blockers for writing the PRD. Each one is genuinely unknown right now and will be resolved at the indicated point:
 
-- [ ] **Spinner direction.** Retro alternatives explored — which one wins? → resolved by `/design-an-interface` for #2.B.1
-- [ ] **BrandedTabs pattern survival.** Bottom-border underline preserved or reinterpreted (taped accent, mono-stamp, ink ribbon)? → resolved by `/design-an-interface` for #2.B.2
-- [ ] **FilterTabs pattern survival.** Pill toggle preserved (new fills) or replaced with a stamped-card grid? → resolved by `/design-an-interface` for #2.B.3
-- [ ] **Arrow button shape.** Should follow whatever toggle vocabulary settles in BrandedTabs/FilterTabs. → resolved by `/design-an-interface` for #2.B.4
+- [x] **Spinner direction.** ✅ Resolved 2026-04-30 — scarf barber-pole + compact three-dot pulse. See `docs/design/mockups/phase-2-track-b/compare.md`.
+- [x] **BrandedTabs pattern survival.** ✅ Resolved 2026-04-30 — paper-card body, ink-invert active, no tape, no rotation. See compare.md.
+- [x] **FilterTabs pattern survival.** ✅ Resolved 2026-04-30 — paper-chip body, ink-invert active, hairline pipe count. See compare.md.
+- [x] **Arrow button shape.** ✅ Resolved 2026-04-30 — single canonical 48 × 48 paper button, italic Freight Display `←` / `→`. See compare.md.
 - [ ] **`<Alert variant="info">` migration.** Are there existing consumers? If yes, do they all map cleanly to `success`, or do some need a different variant? → resolved by grep at PR time for #2.A.5
-- [ ] **Phosphor `Spinner` compatibility.** Phosphor Fill ships a `Spinner` icon — does it work as a CSS-spun loading indicator, or does the design checkpoint settle on something else? → resolved by `/design-an-interface` for #2.B.1
+- [x] **Phosphor `Spinner` compatibility.** ✅ Resolved 2026-04-30 — not used. The barber-pole motif replaces the SVG spinner entirely. Phosphor `Spinner` icon was never adopted.
 - [ ] **`disabled` cream-soft on Form atoms.** Master design has no explicit guidance for disabled form chrome; cream-soft is a guess that unifies with surrounding page. May need to be lighter (`cream-soft/50`) if it reads as too prominent. → resolved during implementation of #2.A.4
 - [ ] **EditorialLink `inline` arrow opt-in.** Is there a use case for inline links that _do_ want a trailing arrow? Default is `false` for `inline` but `withArrow` accepts override. May discover none and remove the prop. → resolved during implementation of #2.A.1
 - [ ] **VR baselines for legacy consumers.** When an atom changes, its appearance inside legacy consumer stories also changes. Should those baselines be updated too (consumer is unchanged but renders the new atom), or marked `vr-skip` until the consumer's own phase? → resolved during tracer bullet (#2.0); set the precedent there.


### PR DESCRIPTION
## Summary

- Lock the Phase 2 Track B design checkpoint to **Direction D — "Paper chrome, ink emphasis"**, a synthesis of three exploratory directions following owner feedback.
- Establishes per-atom visual contracts for Spinner, BrandedTabs, FilterTabs, HorizontalSlider, and ScrollArrowButton — the four child issues (#1575–#1578) now ship from a locked source-of-record.
- Drops three props as a clean side-effect: `SpinnerVariant.logo`, `FilterTab.icon`, `ScrollArrowButtonProps.variant` — and **closes #1573 with no UI work** (the planned Lucide → Phosphor type swap becomes a prop removal).
- Adds one new token to `apps/web/src/styles/globals.css`: `--shadow-paper-sm-soft` (4×4 ink-muted gray) — the gray-shadow sibling of `--shadow-paper-sm`, used wherever the standard ink shadow would vanish (ink-bg active states + chrome on dark panels).

Refs #1524 (umbrella) and #1575 / #1576 / #1577 / #1578 (child implementation issues). Closes #1573.

## What's in this PR

| Path | What |
| --- | --- |
| `docs/design/mockups/phase-2-track-b/option-a-paper-and-tape.html` | Historical exploration — Direction A |
| `docs/design/mockups/phase-2-track-b/option-b-mono-and-ink.html` | Historical exploration — Direction B |
| `docs/design/mockups/phase-2-track-b/option-c-matchday-programme.html` | Historical exploration — Direction C |
| `docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html` | ✅ **Canonical visual reference** for the chosen direction |
| `docs/design/mockups/phase-2-track-b/compare.md` | Synthesis doc — locked specs, owner-feedback trail, provisional caveats |
| `docs/prd/redesign-phase-2.md` | §6.5 (Track B contract), §6.7 (token append), §9 (questions resolved) |

## Test plan

- [ ] Open each `option-*.html` in a browser at 1280 px viewport. Confirm option-d animations run on load (scarf barber-pole stripes, three-dot pulse, ellipsis cycle) and the seamless-loop fix on the C scarf-pole spinner is intact.
- [ ] Read `compare.md` and confirm per-atom locked specs match the visual in `option-d-paper-chrome-ink-emphasis.html`.
- [ ] Confirm `docs/prd/redesign-phase-2.md` §6.5 reads as a contract (not a brief), §6.7 includes `--shadow-paper-sm-soft`, §9 marks Track B questions as resolved.
- [ ] No code touched — no lint / type-check / VR run required.

## Provisional caveat

Owner sign-off was conditional ("not 200% convinced, but let's go with it for now"). The dark-shadow soft variant and the slider's "all cards equally treated" rule are the two areas most likely to need refinement during implementation. If issues #1575–#1578 surface real-use friction, the per-issue PRDs may revise — this checkpoint is the source-of-record, not a hard freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed Phase 2 design specifications with the "Paper chrome, ink emphasis" visual direction finalized and locked.
  * Added comprehensive design mockups and component visual guidelines establishing standardized design patterns.
  * Updated product roadmap with resolved design decisions for the upcoming release phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->