### PR TITLE
test(ui): cover Phosphor Fill icon wrapper shim (#1569)

### DIFF
--- a/apps/web/src/lib/icons.redesign.test.tsx
+++ b/apps/web/src/lib/icons.redesign.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { createElement, type ComponentType } from "react";
+
+vi.mock("@phosphor-icons/react", () => {
+  const makeIcon = (name: string) =>
+    vi.fn(
+      (props: {
+        weight?: string;
+        size?: number;
+        className?: string;
+        [key: string]: unknown;
+      }) =>
+        createElement("span", {
+          "data-icon": name,
+          "data-weight": props.weight,
+          "data-size": props.size,
+          "data-classname": props.className,
+        }),
+    );
+
+  return {
+    ArrowRight: makeIcon("ArrowRight"),
+    CaretDown: makeIcon("CaretDown"),
+    CaretLeft: makeIcon("CaretLeft"),
+    CaretRight: makeIcon("CaretRight"),
+    CheckCircle: makeIcon("CheckCircle"),
+    Warning: makeIcon("Warning"),
+    WarningCircle: makeIcon("WarningCircle"),
+    X: makeIcon("X"),
+  };
+});
+
+import {
+  ArrowRight,
+  CaretDown,
+  CaretLeft,
+  CaretRight,
+  CheckCircle,
+  Warning,
+  WarningCircle,
+  X,
+} from "./icons.redesign";
+
+const wrappers: Array<
+  [string, ComponentType<{ size?: number; className?: string }>]
+> = [
+  ["ArrowRight", ArrowRight],
+  ["CaretDown", CaretDown],
+  ["CaretLeft", CaretLeft],
+  ["CaretRight", CaretRight],
+  ["CheckCircle", CheckCircle],
+  ["Warning", Warning],
+  ["WarningCircle", WarningCircle],
+  ["X", X],
+];
+
+describe("icons.redesign — Phosphor Fill wrapper shim", () => {
+  it.each(wrappers)(
+    "%s wrapper forces weight='fill' on the underlying Phosphor icon",
+    (name, Wrapper) => {
+      const { container } = render(<Wrapper />);
+      const el = container.querySelector(`[data-icon="${name}"]`);
+      expect(el).not.toBeNull();
+      expect(el?.getAttribute("data-weight")).toBe("fill");
+    },
+  );
+
+  it("forwards user-supplied props (size, className) through to the underlying icon", () => {
+    const { container } = render(
+      <ArrowRight size={32} className="custom-icon" />,
+    );
+    const el = container.querySelector('[data-icon="ArrowRight"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute("data-weight")).toBe("fill");
+    expect(el?.getAttribute("data-size")).toBe("32");
+    expect(el?.getAttribute("data-classname")).toBe("custom-icon");
+  });
+
+  it("ignores any runtime weight override passed by a consumer that bypasses the type", () => {
+    // TypeScript prevents this at compile time because RedesignIconProps =
+    // Omit<IconProps, "weight">. The runtime spread order (`{ ...props, weight: "fill" }`)
+    // is the defence-in-depth guarantee that verifies the contract holds even when
+    // a caller force-casts past the type, ensuring the visual contract cannot drift.
+    const Escaped = ArrowRight as unknown as ComponentType<{ weight: string }>;
+    const { container } = render(<Escaped weight="thin" />);
+    const el = container.querySelector('[data-icon="ArrowRight"]');
+    expect(el?.getAttribute("data-weight")).toBe("fill");
+  });
+});


### PR DESCRIPTION
Closes #1569.

## Summary

The tracer bullet PR #1568 already shipped the full set of Phosphor Fill icon wrappers in `apps/web/src/lib/icons.redesign.ts` (`ArrowRight`, `CaretDown`, `CaretLeft`, `CaretRight`, `CheckCircle`, `Warning`, `WarningCircle`, `X`) plus the `Icon` type re-export. The only outstanding acceptance criterion for #1569 was the missing Vitest unit test that verifies each wrapper forces `weight="fill"`.

This PR adds that single test file. No production-code changes.

## Changes

- **New file:** `apps/web/src/lib/icons.redesign.test.tsx` — 10 tests covering:
  - Each of the 8 wrappers forcing `weight="fill"` (parameterised `it.each`).
  - User-supplied props (`size`, `className`) flowing through unchanged.
  - Defence-in-depth: a runtime-bypassed `weight` override is ignored — the wrapper's spread order `{ ...props, weight: "fill" }` always wins. Locks the contract against a future refactor that flips spread order.

The test mocks `@phosphor-icons/react` so each Phosphor icon stub mirrors `weight` onto a data attribute (Phosphor's path-based weight rendering isn't DOM-observable otherwise).

## Acceptance criteria from #1569

- [x] `apps/web/src/lib/icons.redesign.ts` exports `weight="fill"` wrappers for all 8 icons (already shipped in #1568).
- [x] Re-exports the `Icon` type from `@phosphor-icons/react` (already shipped in #1568).
- [x] All wrappers use `fillWrapper(IconComponent)` per PRD §6.6 (already shipped in #1568).
- [x] **Vitest unit test verifies each wrapper renders with fill weight forced** (this PR).
- [x] No Phase 2 atom imports raw `@phosphor-icons/react` (verified by `grep`).
- [x] Legacy `apps/web/src/lib/icons.ts` (Lucide) untouched.
- [x] `pnpm --filter @kcvv/web check-all` passes.

## Test plan

- [x] `pnpm --filter @kcvv/web exec vitest run src/lib/icons.redesign.test.tsx` — 10/10 pass.
- [x] `pnpm --filter @kcvv/web check-all` — lint, type-check, full test suite, build all green.
- [x] Pre-commit hooks (lint-staged + monorepo type-check) green.

## VR baselines

None — this PR is test-only and touches no rendered surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for icon components to validate styling properties and props forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->