### PR TITLE
feat(studio): launcher tool + responsibility field groups — Phase 1 tracer bullet (#1499)

### DIFF
--- a/apps/studio-staging/sanity.config.ts
+++ b/apps/studio-staging/sanity.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
-import {LinkToPsdAction} from '@kcvv/sanity-studio'
+import {LinkToPsdAction, launcherTool, responsibilityTemplates} from '@kcvv/sanity-studio'
 import {schemaTypes} from './schemaTypes'
 import {structure} from './structure'
 
@@ -18,8 +18,11 @@ export default defineConfig({
 
   plugins: [structureTool({structure}), visionTool()],
 
+  tools: (prev) => [...prev, launcherTool()],
+
   schema: {
     types: schemaTypes,
+    templates: (prev) => [...prev, ...responsibilityTemplates],
   },
 
   document: {

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
-import {LinkToPsdAction} from '@kcvv/sanity-studio'
+import {LinkToPsdAction, launcherTool, responsibilityTemplates} from '@kcvv/sanity-studio'
 import {schemaTypes} from './schemaTypes'
 import {structure} from './structure'
 
@@ -14,8 +14,11 @@ export default defineConfig({
 
   plugins: [structureTool({structure}), visionTool()],
 
+  tools: (prev) => [...prev, launcherTool()],
+
   schema: {
     types: schemaTypes,
+    templates: (prev) => [...prev, ...responsibilityTemplates],
   },
 
   document: {

--- a/packages/sanity-schemas/src/responsibility.ts
+++ b/packages/sanity-schemas/src/responsibility.ts
@@ -4,6 +4,36 @@ import {responsibilityPreviewSelect, prepareResponsibilityPreview} from './previ
 const hasContent = (value: unknown): boolean =>
   typeof value === 'string' && value.trim().length > 0
 
+/**
+ * Shared validation for both `primaryContact` and `solutionStep.contact`
+ * — single source of truth for the contact-type discriminator branches
+ * and their teaching messages. The two validators differ only in
+ * whether `contactType` is required: primary contact is mandatory on
+ * the parent document; per-step contact is optional and short-circuits
+ * to `true` when no `contactType` was picked.
+ */
+function validateContactFields(
+  contact: Record<string, unknown> | undefined,
+  required: boolean,
+): true | string {
+  if (!contact?.contactType) return required ? 'Kies een type contact' : true
+  switch (contact.contactType) {
+    case 'position':
+      return contact.organigramNode ? true : 'Kies een organigram-positie'
+    case 'team-role':
+      return contact.teamRole ? true : 'Kies een teamrol'
+    case 'manual':
+      return hasContent(contact.email) ||
+        hasContent(contact.phone) ||
+        hasContent(contact.role) ||
+        hasContent(contact.department)
+        ? true
+        : 'Vul minstens één van: rol, email, telefoon, afdeling in'
+    default:
+      return 'Ongeldig type contact'
+  }
+}
+
 const contactFields = [
   defineField({
     name: 'contactType',
@@ -250,21 +280,9 @@ export const responsibility = defineType({
                 'Optioneel: contactpersoon specifiek voor déze stap (bijv. "stuur het ingevulde formulier naar [secretaris]"). Overschrijft de primaire contact alleen voor deze stap.',
               fields: contactFields,
               validation: (Rule) =>
-                Rule.custom((contact: Record<string, unknown> | undefined) => {
-                  if (!contact?.contactType) return true // step contacts are optional
-                  switch (contact.contactType) {
-                    case 'position':
-                      return contact.organigramNode ? true : 'Kies een organigram-positie'
-                    case 'team-role':
-                      return contact.teamRole ? true : 'Kies een teamrol'
-                    case 'manual':
-                      return hasContent(contact.email) || hasContent(contact.phone) || hasContent(contact.role) || hasContent(contact.department)
-                        ? true
-                        : 'Vul minstens één van: rol, email, telefoon, afdeling in'
-                    default:
-                      return 'Ongeldig type contact'
-                  }
-                }),
+                Rule.custom((contact: Record<string, unknown> | undefined) =>
+                  validateContactFields(contact, false),
+                ),
             }),
           ],
           preview: {
@@ -286,21 +304,9 @@ export const responsibility = defineType({
         'Hoofdcontactpersoon voor dit info-pad. Verschijnt rechtsboven op de detailpagina als "Voor vragen, contacteer …". Kies tussen een vaste organigram-positie, een dynamische teamrol, of handmatige contactgegevens.',
       fields: contactFields,
       validation: (Rule) =>
-        Rule.required().custom((contact: Record<string, unknown> | undefined) => {
-          if (!contact?.contactType) return 'Kies een type contact'
-          switch (contact.contactType) {
-            case 'position':
-              return contact.organigramNode ? true : 'Kies een organigram-positie'
-            case 'team-role':
-              return contact.teamRole ? true : 'Kies een teamrol'
-            case 'manual':
-              return hasContent(contact.email) || hasContent(contact.phone) || hasContent(contact.role) || hasContent(contact.department)
-                ? true
-                : 'Vul minstens één van: rol, email, telefoon, afdeling in'
-            default:
-              return 'Ongeldig type contact'
-          }
-        }),
+        Rule.required().custom((contact: Record<string, unknown> | undefined) =>
+          validateContactFields(contact, true),
+        ),
     }),
     defineField({
       name: 'active',

--- a/packages/sanity-schemas/src/responsibility.ts
+++ b/packages/sanity-schemas/src/responsibility.ts
@@ -18,14 +18,18 @@ const contactFields = [
       layout: 'radio',
     },
     initialValue: 'position',
-    validation: (Rule) => Rule.required(),
+    validation: (Rule) =>
+      Rule.required().error(
+        'Verplicht. Bepaalt welke velden hieronder verschijnen — kies "Organigram positie" voor vaste functies (bijv. Secretaris), "Teamrol" voor trainer/afgevaardigde van een ploeg, of "Handmatig" voor ad-hoc contacten.',
+      ),
   }),
   defineField({
     name: 'organigramNode',
     title: 'Positie',
     type: 'reference',
     to: [{type: 'organigramNode'}],
-    description: 'Kies de organigram-positie (bijv. Secretaris, TVJO, API)',
+    description:
+      'Kies de organigram-positie (bijv. Secretaris, TVJO, API). De naam en gegevens van de huidige titularis worden automatisch overgenomen op de site — zo blijft de info up-to-date als iemand wisselt van rol.',
     hidden: ({parent}) => parent?.contactType !== 'position',
   }),
   defineField({
@@ -38,7 +42,8 @@ const contactFields = [
         {title: 'Afgevaardigde', value: 'afgevaardigde'},
       ],
     },
-    description: 'Wordt dynamisch ingevuld op basis van de ploeg die de gebruiker kiest',
+    description:
+      'Wordt dynamisch ingevuld op basis van de ploeg die de gebruiker kiest. Bijvoorbeeld: een speler van het A-team die "trainer" selecteert krijgt zijn eigen trainer als contactpersoon te zien.',
     hidden: ({parent}) => parent?.contactType !== 'team-role',
   }),
   defineField({
@@ -51,14 +56,16 @@ const contactFields = [
         {title: 'Afgevaardigde', value: 'afgevaardigde'},
       ],
     },
-    description: 'Optioneel: als de primaire teamrol niet beschikbaar is, wordt deze rol geprobeerd',
+    description:
+      'Optioneel: als de primaire teamrol niet beschikbaar is voor de gekozen ploeg, wordt deze rol geprobeerd. Voorkomt dat gebruikers met een lege contactkaart eindigen.',
     hidden: ({parent}) => parent?.contactType !== 'team-role',
   }),
   defineField({
     name: 'role',
     title: 'Rol',
     type: 'string',
-    description: 'Weergavenaam (bijv. "Kantine")',
+    description:
+      'Weergavenaam (bijv. "Kantine"). Wordt op de site getoond als de naam van de contactpersoon — kies iets dat een buitenstaander herkent.',
     hidden: ({parent}) => parent?.contactType !== 'manual',
   }),
   defineField({
@@ -92,34 +99,57 @@ export const responsibility = defineType({
   name: 'responsibility',
   title: 'Responsibility',
   type: 'document',
+  groups: [
+    {name: 'vraag', title: 'Vraag', default: true},
+    {name: 'antwoord', title: 'Antwoord'},
+    {name: 'contact', title: 'Contact'},
+    {name: 'meta', title: 'Meta'},
+  ],
   fields: [
     defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-      description: 'Short display title for Studio (e.g. "Blessure – herstel")',
-      validation: (Rule) => Rule.required(),
+      group: 'vraag',
+      description:
+        'Korte interne titel die je in Studio terugziet (bijv. "Blessure – herstel"). Niet zichtbaar op de site — alleen bedoeld om dit info-pad terug te vinden in zoekresultaten en lijsten in Studio.',
+      validation: (Rule) =>
+        Rule.required().error(
+          'Verplicht. Zonder titel is dit info-pad niet terug te vinden in Studio en kan je het niet later bewerken.',
+        ),
     }),
     defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
-      description: 'Unique identifier used in the web app (kebab-case, stable across environments)',
+      group: 'vraag',
+      description:
+        'Unieke identifier voor de URL (`/info/{slug}`). Eens gepubliceerd: niet meer wijzigen — externe links breken anders. Gebruik kebab-case (kleine letters, koppeltekens).',
       options: {source: 'title', maxLength: 96},
-      validation: (Rule) => Rule.required(),
+      validation: (Rule) =>
+        Rule.required().error(
+          'Verplicht. De slug bepaalt de URL waar gebruikers dit info-pad bereiken — zonder slug verschijnt het niet op de site.',
+        ),
     }),
     defineField({
-      name: 'active',
-      title: 'Active',
-      type: 'boolean',
-      description: 'Unpublish without deleting. Inactive paths are hidden from the web app.',
-      initialValue: true,
+      name: 'question',
+      title: 'Question',
+      type: 'string',
+      group: 'vraag',
+      description:
+        'De vraag in spreektaal, zoals een gebruiker hem zou typen (bijv. "heb een ongeval op training"). Lowercase, geen punt op het einde. Dit is de tekst die getoond wordt in zoekresultaten op de site.',
+      validation: (Rule) =>
+        Rule.required().error(
+          'Verplicht. Zonder vraag verschijnt dit info-pad niet in zoekresultaten — gebruikers kunnen het dan niet vinden.',
+        ),
     }),
     defineField({
       name: 'audience',
       title: 'Audience',
       type: 'array',
-      description: 'Who can ask this question?',
+      group: 'vraag',
+      description:
+        'Wie kan deze vraag stellen? Selecteer alle relevante doelgroepen — gebruikers krijgen alleen info-paden te zien die op hen van toepassing zijn na de eerste filterklik op de site.',
       of: [
         {
           type: 'string',
@@ -135,35 +165,20 @@ export const responsibility = defineType({
           },
         },
       ],
-      validation: (Rule) => Rule.required().min(1),
-    }),
-    defineField({
-      name: 'question',
-      title: 'Question',
-      type: 'string',
-      description: 'Lowercase, conversational (e.g. "heb een ongeval op training")',
-      validation: (Rule) => Rule.required(),
-    }),
-    defineField({
-      name: 'keywords',
-      title: 'Keywords',
-      type: 'array',
-      of: [{type: 'string'}],
-      description: 'Search synonyms and related terms. Be generous.',
-      validation: (Rule) => Rule.required().min(1),
-    }),
-    defineField({
-      name: 'summary',
-      title: 'Summary',
-      type: 'text',
-      rows: 2,
-      description: '1-2 sentences shown immediately after the user selects this path',
-      validation: (Rule) => Rule.required(),
+      validation: (Rule) =>
+        Rule.required()
+          .min(1)
+          .error(
+            'Verplicht — kies minstens één doelgroep. Zonder doelgroep blijft dit info-pad voor alle bezoekers verborgen.',
+          ),
     }),
     defineField({
       name: 'category',
       title: 'Category',
       type: 'string',
+      group: 'vraag',
+      description:
+        'Bovenliggende categorie waar dit info-pad onder valt. Bepaalt het icoon-thema en de groepering op de site (bijv. medische vragen worden samen gepresenteerd).',
       options: {
         list: [
           {title: 'Medisch', value: 'medisch'},
@@ -174,42 +189,36 @@ export const responsibility = defineType({
           {title: 'Commercieel', value: 'commercieel'},
         ],
       },
-      validation: (Rule) => Rule.required(),
+      validation: (Rule) => Rule.required().error('Verplicht — kies een categorie zodat dit info-pad correct gegroepeerd wordt op de site.'),
     }),
     defineField({
-      name: 'icon',
-      title: 'Icon',
-      type: 'string',
-      description: 'Lucide icon name (e.g. "heart", "file-text", "shield")',
+      name: 'keywords',
+      title: 'Keywords',
+      type: 'array',
+      group: 'vraag',
+      of: [{type: 'string'}],
+      description:
+        'Zoeksynoniemen en gerelateerde termen — wees genereus. Voorbeelden voor "blessure": "letsel", "geblesseerd", "kreukel", "ongeval". Zorgt dat gebruikers dit info-pad vinden ook al gebruiken ze niet de exacte woorden uit de vraag.',
+      validation: (Rule) => Rule.required().min(1),
     }),
     defineField({
-      name: 'primaryContact',
-      title: 'Primary contact',
-      type: 'object',
-      description: 'Main contact person for this path',
-      fields: contactFields,
+      name: 'summary',
+      title: 'Summary',
+      type: 'text',
+      rows: 2,
+      group: 'antwoord',
+      description:
+        '1-2 zinnen die direct getoond worden zodra de gebruiker dit info-pad opent. De kern van het antwoord — alle details horen in de stappen hieronder.',
       validation: (Rule) =>
-        Rule.required().custom((contact: Record<string, unknown> | undefined) => {
-          if (!contact?.contactType) return 'Kies een type contact'
-          switch (contact.contactType) {
-            case 'position':
-              return contact.organigramNode ? true : 'Kies een organigram-positie'
-            case 'team-role':
-              return contact.teamRole ? true : 'Kies een teamrol'
-            case 'manual':
-              return hasContent(contact.email) || hasContent(contact.phone) || hasContent(contact.role) || hasContent(contact.department)
-                ? true
-                : 'Vul minstens één van: rol, email, telefoon, afdeling in'
-            default:
-              return 'Ongeldig type contact'
-          }
-        }),
+        Rule.required().error('Verplicht. De summary is het eerste wat gebruikers zien na het openen — zonder dit veld lijkt de pagina leeg.'),
     }),
     defineField({
       name: 'steps',
       title: 'Steps',
       type: 'array',
-      description: 'Ordered solution steps. Array order is the display order.',
+      group: 'antwoord',
+      description:
+        'Geordende oplossingsstappen. De volgorde in de lijst = de volgorde op de site. Splits het antwoord in concrete acties die de gebruiker één voor één kan doorlopen.',
       of: [
         {
           type: 'object',
@@ -219,13 +228,17 @@ export const responsibility = defineType({
               name: 'description',
               title: 'Description',
               type: 'string',
-              validation: (Rule) => Rule.required(),
+              validation: (Rule) =>
+                Rule.required().error(
+                  'Verplicht. Een stap zonder beschrijving wordt op de site weergegeven als een leeg item.',
+                ),
             }),
             defineField({
               name: 'link',
               title: 'Link',
               type: 'string',
-              description: 'Optional relative or absolute URL',
+              description:
+                'Optioneel: relatieve of absolute URL (bijv. `/contact` of `https://...`). Als ingevuld, wordt de beschrijving een klikbare actie op de site.',
               // @ts-expect-error .uri() exists at runtime but is missing from StringRule types
               validation: (Rule) => Rule.uri({allowRelative: true}),
             }),
@@ -233,7 +246,8 @@ export const responsibility = defineType({
               name: 'contact',
               title: 'Contact (this step)',
               type: 'object',
-              description: 'Optional contact specific to this step',
+              description:
+                'Optioneel: contactpersoon specifiek voor déze stap (bijv. "stuur het ingevulde formulier naar [secretaris]"). Overschrijft de primaire contact alleen voor deze stap.',
               fields: contactFields,
               validation: (Rule) =>
                 Rule.custom((contact: Record<string, unknown> | undefined) => {
@@ -264,11 +278,53 @@ export const responsibility = defineType({
       validation: (Rule) => Rule.required().min(1),
     }),
     defineField({
+      name: 'primaryContact',
+      title: 'Primary contact',
+      type: 'object',
+      group: 'contact',
+      description:
+        'Hoofdcontactpersoon voor dit info-pad. Verschijnt rechtsboven op de detailpagina als "Voor vragen, contacteer …". Kies tussen een vaste organigram-positie, een dynamische teamrol, of handmatige contactgegevens.',
+      fields: contactFields,
+      validation: (Rule) =>
+        Rule.required().custom((contact: Record<string, unknown> | undefined) => {
+          if (!contact?.contactType) return 'Kies een type contact'
+          switch (contact.contactType) {
+            case 'position':
+              return contact.organigramNode ? true : 'Kies een organigram-positie'
+            case 'team-role':
+              return contact.teamRole ? true : 'Kies een teamrol'
+            case 'manual':
+              return hasContent(contact.email) || hasContent(contact.phone) || hasContent(contact.role) || hasContent(contact.department)
+                ? true
+                : 'Vul minstens één van: rol, email, telefoon, afdeling in'
+            default:
+              return 'Ongeldig type contact'
+          }
+        }),
+    }),
+    defineField({
+      name: 'active',
+      title: 'Active',
+      type: 'boolean',
+      group: 'meta',
+      description:
+        'Laat staan op `true` voor zichtbaar op de site. Zet op `false` om dit info-pad tijdelijk te verbergen zonder het te verwijderen — handig tijdens herwerking of als de info even niet klopt.',
+      initialValue: true,
+    }),
+    defineField({
+      name: 'icon',
+      title: 'Icon',
+      type: 'string',
+      group: 'meta',
+      description: 'Lucide icon name (e.g. "heart", "file-text", "shield"). Optioneel; valt anders terug op het categorie-icoon.',
+    }),
+    defineField({
       name: 'relatedPaths',
       title: 'Related paths',
       type: 'array',
+      group: 'meta',
       of: [{type: 'reference', to: [{type: 'responsibility'}]}],
-      description: '"See also" links shown at the bottom of the result card',
+      description: '"Zie ook"-links onderaan de detailpagina. Verwijs naar verwante info-paden zodat gebruikers hun vraag kunnen verfijnen of gerelateerde acties terugvinden.',
     }),
   ],
   preview: {

--- a/packages/sanity-schemas/src/responsibility.ts
+++ b/packages/sanity-schemas/src/responsibility.ts
@@ -229,7 +229,12 @@ export const responsibility = defineType({
       of: [{type: 'string'}],
       description:
         'Zoeksynoniemen en gerelateerde termen — wees genereus. Voorbeelden voor "blessure": "letsel", "geblesseerd", "kreukel", "ongeval". Zorgt dat gebruikers dit info-pad vinden ook al gebruiken ze niet de exacte woorden uit de vraag.',
-      validation: (Rule) => Rule.required().min(1),
+      validation: (Rule) =>
+        Rule.required()
+          .min(1)
+          .error(
+            'Verplicht — voeg minstens één keyword toe. Zonder keywords mist de zoekfunctie synoniemen waardoor gebruikers dit info-pad alleen vinden met de exacte woorden uit de vraag.',
+          ),
     }),
     defineField({
       name: 'summary',
@@ -293,7 +298,12 @@ export const responsibility = defineType({
           },
         },
       ],
-      validation: (Rule) => Rule.required().min(1),
+      validation: (Rule) =>
+        Rule.required()
+          .min(1)
+          .error(
+            'Verplicht — voeg minstens één stap toe. Een stap is een concrete actie die de gebruiker kan uitvoeren (bijv. "Verwittig de afgevaardigde via WhatsApp"); zonder stappen lijkt het antwoord op de site onvolledig.',
+          ),
     }),
     defineField({
       name: 'primaryContact',

--- a/packages/sanity-schemas/src/responsibility.ts
+++ b/packages/sanity-schemas/src/responsibility.ts
@@ -314,9 +314,13 @@ export const responsibility = defineType({
         'Hoofdcontactpersoon voor dit info-pad. Verschijnt rechtsboven op de detailpagina als "Voor vragen, contacteer …". Kies tussen een vaste organigram-positie, een dynamische teamrol, of handmatige contactgegevens.',
       fields: contactFields,
       validation: (Rule) =>
-        Rule.required().custom((contact: Record<string, unknown> | undefined) =>
-          validateContactFields(contact, true),
-        ),
+        Rule.required()
+          .error(
+            'Verplicht. Zonder hoofdcontactpersoon weet de gebruiker niet bij wie hij terecht kan en blijft de detailpagina onvolledig.',
+          )
+          .custom((contact: Record<string, unknown> | undefined) =>
+            validateContactFields(contact, true),
+          ),
     }),
     defineField({
       name: 'active',
@@ -332,7 +336,8 @@ export const responsibility = defineType({
       title: 'Icon',
       type: 'string',
       group: 'meta',
-      description: 'Lucide icon name (e.g. "heart", "file-text", "shield"). Optioneel; valt anders terug op het categorie-icoon.',
+      description:
+        'Lucide-icoonnaam (bijv. "heart", "file-text", "shield"). Optioneel; valt anders terug op het categorie-icoon.',
     }),
     defineField({
       name: 'relatedPaths',

--- a/packages/sanity-studio/CLAUDE.md
+++ b/packages/sanity-studio/CLAUDE.md
@@ -24,6 +24,9 @@ src/
 ├── migrations/       ← One-off data migration scripts (run manually via CLI)
 ├── preview/          ← previewSelect + prepare helpers shared with sanity-schemas
 ├── structure/        ← Structure builder fragments (desk sidebar ordering)
+├── templates/        ← LauncherTemplate manifests grouped per schema type
+├── tools/            ← Studio Tools (top-nav tabs); one folder per Tool
+│   └── launcher/     ← LauncherTool — `✨ Create` card grid (#1499)
 ├── validation/       ← Custom Rule.custom() validators
 ├── schema-types.ts   ← Re-exports schemaTypes from @kcvv/sanity-schemas
 └── index.ts          ← Barrel: everything exported by name
@@ -35,6 +38,31 @@ src/
 - Extract pure logic (mutation builders, queries) into a sibling `build-<action>-mutations.ts` — keeps the React component thin and the logic unit-testable
 - Actions are registered in the studio `defineConfig` in `apps/studio/` and `apps/studio-staging/` — this package exports the component, the studio app wires it in
 - Gate visibility with early-return null checks: `if (type !== 'staffMember') return null`
+
+## Tools (top-nav tabs)
+
+Custom Studio Tools live under `src/tools/<name>/`. Each Tool exports:
+
+- A factory function (`<name>Tool()`) returning a Sanity `Tool` object — wired in both `apps/studio/sanity.config.ts` and `apps/studio-staging/sanity.config.ts` via `tools: (prev) => [...prev, <name>Tool()]`.
+- A root React component (`<Name>Tool`) referenced by the factory's `component` field.
+- Sub-components (cards, grids, etc.) kept pure where possible — receive data via props, dispatch intent via `useRouter()` from `sanity/router` only at the root.
+
+### LauncherTool — `tools/launcher/`
+
+The `✨ Create` card grid in the top nav. Reads launcher-eligible templates from the workspace via `useTemplates()` and dispatches `router.navigateIntent('create', { type, template })` when an editor picks a card. Sanity routes the intent to a new draft seeded by the template's `value`.
+
+**Adding a launcher card** for an existing schema type:
+
+1. Create or edit `src/templates/<schemaType>-templates.ts` and export a `<schemaType>Templates: LauncherTemplate[]` constant. Each entry needs `id`, `title`, `schemaType`, `value` (zero-prefill `{}` unless seeding form-shape fields like `articleType`), and a `ui` block (`icon`, Dutch ≤100-char `description`, `group`).
+2. Re-export the manifest from `src/templates/index.ts` and from the package barrel.
+3. Wire it into both studios' `sanity.config.ts` via `schema.templates: (prev) => [...prev, ...<schemaType>Templates]`.
+
+**Filtering rules** (enforced by `filterLauncherTemplates`):
+
+- Templates without a `ui` block are ignored — Sanity's auto-generated and third-party templates still work via the default `+ Create` button. Coexistence is the design contract.
+- Templates whose `schemaType` is not registered in the workspace schema are ignored and a single console warning is logged per unknown type per render.
+
+The pure filter (`filterLauncherTemplates`) lives in its own file separate from the React hook so vitest can import it without dragging Sanity's runtime CSS bundle into the module graph. Keep new pure helpers in their own files for the same reason.
 
 ## Custom Inputs
 

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -27,3 +27,10 @@ export {validateSubjectsCount} from './validation/subjects-count'
 export type {SubjectsCountContext} from './validation/subjects-count'
 export {validateRespondentKey} from './validation/respondent-key'
 export type {RespondentKeyContext} from './validation/respondent-key'
+// Public LauncherTool surface. `useTemplates` and `filterLauncherTemplates`
+// are intentionally NOT re-exported — they would shadow Sanity's own
+// `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.
+// Internal callers reach them via the `./tools/launcher` subpath instead.
+export {launcherTool} from './tools/launcher'
+export {responsibilityTemplates} from './templates'
+export type {LauncherTemplate, LauncherTemplateUi} from './templates'

--- a/packages/sanity-studio/src/templates/index.ts
+++ b/packages/sanity-studio/src/templates/index.ts
@@ -1,0 +1,3 @@
+export type {LauncherTemplate, LauncherTemplateUi} from './types'
+export {isLauncherTemplate} from './types'
+export {responsibilityTemplates} from './responsibility-templates'

--- a/packages/sanity-studio/src/templates/responsibility-templates.ts
+++ b/packages/sanity-studio/src/templates/responsibility-templates.ts
@@ -1,0 +1,22 @@
+import type {LauncherTemplate} from './types'
+
+/**
+ * Phase 1 tracer-bullet template manifest for `responsibility`.
+ * Single zero-prefill entry — the launcher card copy is the teaching
+ * moment. Editorial defaults are deliberately NOT seeded; per design
+ * decision D6 templates only seed fields that change form shape.
+ */
+export const responsibilityTemplates: LauncherTemplate[] = [
+  {
+    id: 'responsibility-new',
+    title: 'Nieuwe responsibility',
+    schemaType: 'responsibility',
+    value: {},
+    ui: {
+      icon: 'help-circle',
+      description:
+        "Voor info-paden zoals 'Hoe meld ik een blessure?' — gebruikers vinden dit via zoeken op de site.",
+      group: 'Responsibilities',
+    },
+  },
+]

--- a/packages/sanity-studio/src/templates/types.ts
+++ b/packages/sanity-studio/src/templates/types.ts
@@ -1,0 +1,40 @@
+import type {Template} from 'sanity'
+
+/**
+ * UI metadata required for a template to appear on the LauncherTool grid.
+ * Templates without a `ui` block are ignored by the launcher (they still
+ * work via Sanity's default `+ Create` button) — this preserves graceful
+ * coexistence with auto-generated and third-party templates.
+ */
+export interface LauncherTemplateUi {
+  /** Lucide icon name rendered on the card (e.g. `'help-circle'`). */
+  icon: string
+  /** Dutch ≤100-char "when to use this" description rendered on the card. */
+  description: string
+  /** Card group label (e.g. `'Responsibilities'`, `'Articles'`). */
+  group: string
+}
+
+/**
+ * Sanity Template extended with the launcher-specific `ui` block. Cards
+ * appear on the launcher grid only for templates of this shape.
+ */
+export interface LauncherTemplate extends Template {
+  ui: LauncherTemplateUi
+}
+
+/**
+ * Type guard used by `useTemplates()` to narrow Sanity's `Template[]`
+ * down to the launcher-eligible subset. Filtering on `'ui' in t` alone
+ * is not enough — the field could be present but malformed; this guard
+ * checks the three required string fields explicitly.
+ */
+export function isLauncherTemplate(template: Template): template is LauncherTemplate {
+  const ui = (template as Partial<LauncherTemplate>).ui
+  return (
+    !!ui &&
+    typeof ui.icon === 'string' &&
+    typeof ui.description === 'string' &&
+    typeof ui.group === 'string'
+  )
+}

--- a/packages/sanity-studio/src/tools/launcher/filter-launcher-templates.ts
+++ b/packages/sanity-studio/src/tools/launcher/filter-launcher-templates.ts
@@ -1,0 +1,36 @@
+import type {Template} from 'sanity'
+
+import {isLauncherTemplate, type LauncherTemplate} from '../../templates/types'
+
+/**
+ * Pure filter — narrows Sanity's `Template[]` down to the launcher-
+ * eligible subset and drops entries whose `schemaType` is unknown to
+ * the workspace (would fail-closed on intent navigation otherwise).
+ *
+ * Unknown types are reported via `onUnknownType` so the calling hook
+ * can log once per render. Tests pass a no-op to keep them silent.
+ *
+ * Lives in its own file (separate from `use-templates.ts`) so the
+ * vitest suite can import it without dragging Sanity's runtime CSS
+ * bundle into the module graph.
+ */
+export function filterLauncherTemplates(
+  templates: ReadonlyArray<Template>,
+  isKnownType: (schemaType: string) => boolean,
+  onUnknownType?: (schemaType: string) => void,
+): LauncherTemplate[] {
+  const result: LauncherTemplate[] = []
+  const seenUnknown = new Set<string>()
+  for (const template of templates) {
+    if (!isLauncherTemplate(template)) continue
+    if (!isKnownType(template.schemaType)) {
+      if (onUnknownType && !seenUnknown.has(template.schemaType)) {
+        seenUnknown.add(template.schemaType)
+        onUnknownType(template.schemaType)
+      }
+      continue
+    }
+    result.push(template)
+  }
+  return result
+}

--- a/packages/sanity-studio/src/tools/launcher/index.ts
+++ b/packages/sanity-studio/src/tools/launcher/index.ts
@@ -1,0 +1,5 @@
+export {LauncherTool, launcherTool} from './launcher-tool'
+export {LauncherCard, type LauncherCardProps} from './launcher-card'
+export {LauncherGrid, type LauncherGridProps, groupByUiGroup, searchTemplates} from './launcher-grid'
+export {useTemplates} from './use-templates'
+export {filterLauncherTemplates} from './filter-launcher-templates'

--- a/packages/sanity-studio/src/tools/launcher/index.ts
+++ b/packages/sanity-studio/src/tools/launcher/index.ts
@@ -1,5 +1,6 @@
 export {LauncherTool, launcherTool} from './launcher-tool'
 export {LauncherCard, type LauncherCardProps} from './launcher-card'
-export {LauncherGrid, type LauncherGridProps, groupByUiGroup, searchTemplates} from './launcher-grid'
+export {LauncherGrid, type LauncherGridProps} from './launcher-grid'
+export {groupByUiGroup, searchTemplates} from './launcher-grid-helpers'
 export {useTemplates} from './use-templates'
 export {filterLauncherTemplates} from './filter-launcher-templates'

--- a/packages/sanity-studio/src/tools/launcher/launcher-card.test.tsx
+++ b/packages/sanity-studio/src/tools/launcher/launcher-card.test.tsx
@@ -1,0 +1,105 @@
+import {fireEvent, render, screen} from '@testing-library/react'
+import type {ComponentProps} from 'react'
+import {describe, expect, it, vi} from 'vitest'
+
+vi.mock('@sanity/ui', () => {
+  const Card = ({children, onClick, onKeyDown, role, tabIndex, ...rest}: ComponentProps<'div'>) => (
+    <div
+      data-mock="Card"
+      role={role}
+      tabIndex={tabIndex}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+  const Stack = ({children, ...rest}: ComponentProps<'div'>) => (
+    <div data-mock="Stack" {...rest}>
+      {children}
+    </div>
+  )
+  const Flex = ({children, ...rest}: ComponentProps<'div'>) => (
+    <div data-mock="Flex" {...rest}>
+      {children}
+    </div>
+  )
+  const Text = ({children, ...rest}: ComponentProps<'div'>) => (
+    <div data-mock="Text" {...rest}>
+      {children}
+    </div>
+  )
+  const Badge = ({children, ...rest}: ComponentProps<'div'>) => (
+    <span data-mock="Badge" {...rest}>
+      {children}
+    </span>
+  )
+  return {Card, Stack, Flex, Text, Badge}
+})
+
+import {LauncherCard} from './launcher-card'
+import type {LauncherTemplate} from '../../templates/types'
+
+const template: LauncherTemplate = {
+  id: 'responsibility-new',
+  title: 'Nieuwe responsibility',
+  schemaType: 'responsibility',
+  value: {},
+  ui: {
+    icon: 'help-circle',
+    description: 'Voor info-paden zoals "Hoe meld ik een blessure?"',
+    group: 'Responsibilities',
+  },
+}
+
+describe('LauncherCard', () => {
+  it('renders the template title, description, and schemaType badge', () => {
+    render(<LauncherCard template={template} onSelect={() => undefined} />)
+    expect(screen.getByText('Nieuwe responsibility')).toBeTruthy()
+    expect(screen.getByText(/Voor info-paden/)).toBeTruthy()
+    expect(screen.getByText('responsibility')).toBeTruthy()
+  })
+
+  it('exposes the schemaType as a data attribute for downstream consumers', () => {
+    const {container} = render(<LauncherCard template={template} onSelect={() => undefined} />)
+    const card = container.querySelector('[data-testid="launcher-card-responsibility-new"]')
+    expect(card?.getAttribute('data-schema-type')).toBe('responsibility')
+  })
+
+  it('calls onSelect with the template when clicked', () => {
+    const onSelect = vi.fn()
+    render(<LauncherCard template={template} onSelect={onSelect} />)
+    fireEvent.click(screen.getByTestId('launcher-card-responsibility-new'))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(template)
+  })
+
+  it('calls onSelect when Enter is pressed (keyboard a11y)', () => {
+    const onSelect = vi.fn()
+    render(<LauncherCard template={template} onSelect={onSelect} />)
+    fireEvent.keyDown(screen.getByTestId('launcher-card-responsibility-new'), {key: 'Enter'})
+    expect(onSelect).toHaveBeenCalledWith(template)
+  })
+
+  it('calls onSelect when Space is pressed (keyboard a11y)', () => {
+    const onSelect = vi.fn()
+    render(<LauncherCard template={template} onSelect={onSelect} />)
+    fireEvent.keyDown(screen.getByTestId('launcher-card-responsibility-new'), {key: ' '})
+    expect(onSelect).toHaveBeenCalledWith(template)
+  })
+
+  it('does not call onSelect for unrelated keys', () => {
+    const onSelect = vi.fn()
+    render(<LauncherCard template={template} onSelect={onSelect} />)
+    fireEvent.keyDown(screen.getByTestId('launcher-card-responsibility-new'), {key: 'a'})
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('renders as a button-role with a tabIndex (keyboard-focusable)', () => {
+    render(<LauncherCard template={template} onSelect={() => undefined} />)
+    const card = screen.getByTestId('launcher-card-responsibility-new')
+    expect(card.getAttribute('role')).toBe('button')
+    expect(card.getAttribute('tabIndex')).toBe('0')
+  })
+})

--- a/packages/sanity-studio/src/tools/launcher/launcher-card.tsx
+++ b/packages/sanity-studio/src/tools/launcher/launcher-card.tsx
@@ -1,0 +1,61 @@
+import {Badge, Card, Flex, Stack, Text} from '@sanity/ui'
+import type {JSX} from 'react'
+
+import type {LauncherTemplate} from '../../templates/types'
+
+export interface LauncherCardProps {
+  template: LauncherTemplate
+  /**
+   * Click handler. Called with the template so the parent can call
+   * `router.navigateIntent('create', { type, template })` from a single
+   * place — keeps the card pure (testable without router context).
+   */
+  onSelect: (template: LauncherTemplate) => void
+}
+
+/**
+ * Single template card on the launcher grid. Pure — no router or
+ * Sanity-context coupling. The parent owns navigation.
+ *
+ * Lucide icon resolution is intentionally deferred to Phase 2 — the
+ * card renders title/description/badge today; an icon slot will be
+ * added when the icon-name registry lands.
+ */
+export function LauncherCard({template, onSelect}: LauncherCardProps): JSX.Element {
+  return (
+    <Card
+      padding={4}
+      radius={3}
+      shadow={1}
+      tone="default"
+      data-testid={`launcher-card-${template.id}`}
+      data-schema-type={template.schemaType}
+      onClick={() => onSelect(template)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onSelect(template)
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      style={{cursor: 'pointer'}}
+    >
+      <Stack space={3}>
+        <Flex align="center" gap={2}>
+          <Text size={2} weight="medium">
+            {template.title}
+          </Text>
+        </Flex>
+        <Text size={1} muted>
+          {template.ui.description}
+        </Text>
+        <Flex>
+          <Badge tone="primary" mode="outline" fontSize={0}>
+            {template.schemaType}
+          </Badge>
+        </Flex>
+      </Stack>
+    </Card>
+  )
+}

--- a/packages/sanity-studio/src/tools/launcher/launcher-card.tsx
+++ b/packages/sanity-studio/src/tools/launcher/launcher-card.tsx
@@ -39,6 +39,7 @@ export function LauncherCard({template, onSelect}: LauncherCardProps): JSX.Eleme
       }}
       role="button"
       tabIndex={0}
+      aria-label={`Maak nieuw "${template.title}" document aan`}
       style={{cursor: 'pointer'}}
     >
       <Stack space={3}>

--- a/packages/sanity-studio/src/tools/launcher/launcher-grid-helpers.ts
+++ b/packages/sanity-studio/src/tools/launcher/launcher-grid-helpers.ts
@@ -1,0 +1,43 @@
+import type {LauncherTemplate} from '../../templates/types'
+
+/**
+ * Group templates by `ui.group`, preserving the first-seen group order.
+ *
+ * Lives in its own file (separate from `launcher-grid.tsx`) so vitest
+ * can import it without dragging Sanity UI / runtime CSS into the
+ * module graph. Mirrors the convention established by
+ * `filter-launcher-templates.ts`.
+ */
+export function groupByUiGroup(
+  templates: ReadonlyArray<LauncherTemplate>,
+): {group: string; templates: LauncherTemplate[]}[] {
+  const order: string[] = []
+  const map = new Map<string, LauncherTemplate[]>()
+  for (const template of templates) {
+    const key = template.ui.group
+    if (!map.has(key)) {
+      map.set(key, [])
+      order.push(key)
+    }
+    map.get(key)!.push(template)
+  }
+  return order.map((group) => ({group, templates: map.get(group)!}))
+}
+
+/**
+ * Case-insensitive substring search across the title, description,
+ * group label, and schemaType. Empty / whitespace queries return the
+ * full input list (a fresh copy, never the input array).
+ */
+export function searchTemplates(
+  templates: ReadonlyArray<LauncherTemplate>,
+  query: string,
+): LauncherTemplate[] {
+  const trimmed = query.trim().toLowerCase()
+  if (!trimmed) return [...templates]
+  return templates.filter((template) => {
+    const haystack =
+      `${template.title} ${template.ui.description} ${template.ui.group} ${template.schemaType}`.toLowerCase()
+    return haystack.includes(trimmed)
+  })
+}

--- a/packages/sanity-studio/src/tools/launcher/launcher-grid.tsx
+++ b/packages/sanity-studio/src/tools/launcher/launcher-grid.tsx
@@ -3,46 +3,11 @@ import {type JSX, useMemo, useState} from 'react'
 
 import type {LauncherTemplate} from '../../templates/types'
 import {LauncherCard} from './launcher-card'
+import {groupByUiGroup, searchTemplates} from './launcher-grid-helpers'
 
 export interface LauncherGridProps {
   templates: ReadonlyArray<LauncherTemplate>
   onSelect: (template: LauncherTemplate) => void
-}
-
-/**
- * Group templates by `ui.group`, preserving the first-seen group order.
- * Pure helper — exported for unit tests.
- */
-export function groupByUiGroup(
-  templates: ReadonlyArray<LauncherTemplate>,
-): {group: string; templates: LauncherTemplate[]}[] {
-  const order: string[] = []
-  const map = new Map<string, LauncherTemplate[]>()
-  for (const template of templates) {
-    const key = template.ui.group
-    if (!map.has(key)) {
-      map.set(key, [])
-      order.push(key)
-    }
-    map.get(key)!.push(template)
-  }
-  return order.map((group) => ({group, templates: map.get(group)!}))
-}
-
-/**
- * Case-insensitive substring search across the title, description,
- * group label, and schemaType. Pure — exported for unit tests.
- */
-export function searchTemplates(
-  templates: ReadonlyArray<LauncherTemplate>,
-  query: string,
-): LauncherTemplate[] {
-  const trimmed = query.trim().toLowerCase()
-  if (!trimmed) return [...templates]
-  return templates.filter((template) => {
-    const haystack = `${template.title} ${template.ui.description} ${template.ui.group} ${template.schemaType}`.toLowerCase()
-    return haystack.includes(trimmed)
-  })
 }
 
 export function LauncherGrid({templates, onSelect}: LauncherGridProps): JSX.Element {

--- a/packages/sanity-studio/src/tools/launcher/launcher-grid.tsx
+++ b/packages/sanity-studio/src/tools/launcher/launcher-grid.tsx
@@ -1,0 +1,92 @@
+import {Box, Container, Heading, Stack, Text, TextInput} from '@sanity/ui'
+import {type JSX, useMemo, useState} from 'react'
+
+import type {LauncherTemplate} from '../../templates/types'
+import {LauncherCard} from './launcher-card'
+
+export interface LauncherGridProps {
+  templates: ReadonlyArray<LauncherTemplate>
+  onSelect: (template: LauncherTemplate) => void
+}
+
+/**
+ * Group templates by `ui.group`, preserving the first-seen group order.
+ * Pure helper — exported for unit tests.
+ */
+export function groupByUiGroup(
+  templates: ReadonlyArray<LauncherTemplate>,
+): {group: string; templates: LauncherTemplate[]}[] {
+  const order: string[] = []
+  const map = new Map<string, LauncherTemplate[]>()
+  for (const template of templates) {
+    const key = template.ui.group
+    if (!map.has(key)) {
+      map.set(key, [])
+      order.push(key)
+    }
+    map.get(key)!.push(template)
+  }
+  return order.map((group) => ({group, templates: map.get(group)!}))
+}
+
+/**
+ * Case-insensitive substring search across the title, description,
+ * group label, and schemaType. Pure — exported for unit tests.
+ */
+export function searchTemplates(
+  templates: ReadonlyArray<LauncherTemplate>,
+  query: string,
+): LauncherTemplate[] {
+  const trimmed = query.trim().toLowerCase()
+  if (!trimmed) return [...templates]
+  return templates.filter((template) => {
+    const haystack = `${template.title} ${template.ui.description} ${template.ui.group} ${template.schemaType}`.toLowerCase()
+    return haystack.includes(trimmed)
+  })
+}
+
+export function LauncherGrid({templates, onSelect}: LauncherGridProps): JSX.Element {
+  const [query, setQuery] = useState('')
+  const grouped = useMemo(() => groupByUiGroup(searchTemplates(templates, query)), [templates, query])
+
+  return (
+    <Container width={3} padding={4}>
+      <Stack space={5}>
+        <Stack space={3}>
+          <Heading size={3}>Wat wil je aanmaken?</Heading>
+          <Text size={1} muted>
+            Kies een sjabloon hieronder. Elke kaart legt uit wanneer je dit type document gebruikt.
+          </Text>
+        </Stack>
+        <TextInput
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Zoek een sjabloon…"
+          aria-label="Zoek een sjabloon"
+        />
+        {grouped.length === 0 ? (
+          <Box padding={4}>
+            <Text muted>Geen sjabloon gevonden voor &ldquo;{query}&rdquo;.</Text>
+          </Box>
+        ) : (
+          grouped.map(({group, templates: groupTemplates}) => (
+            <Stack key={group} space={3}>
+              <Heading size={1}>{group}</Heading>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+                  gap: 16,
+                }}
+              >
+                {groupTemplates.map((template) => (
+                  <LauncherCard key={template.id} template={template} onSelect={onSelect} />
+                ))}
+              </div>
+            </Stack>
+          ))
+        )}
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity-studio/src/tools/launcher/launcher-tool.tsx
+++ b/packages/sanity-studio/src/tools/launcher/launcher-tool.tsx
@@ -1,0 +1,50 @@
+import {ComposeSparklesIcon} from '@sanity/icons'
+import {useRouter} from 'sanity/router'
+import type {JSX} from 'react'
+import type {Tool} from 'sanity'
+
+import type {LauncherTemplate} from '../../templates/types'
+import {LauncherGrid} from './launcher-grid'
+import {useTemplates} from './use-templates'
+
+/**
+ * Root component of the LauncherTool. Reads launcher-eligible templates
+ * from the workspace via `useTemplates()` and dispatches an intent
+ * navigation when an editor picks a card. Sanity routes the intent to
+ * a new draft seeded by the template's `value`.
+ *
+ * `useRouter()` from `sanity/router` resolves to the workspace router
+ * inside a Tool — `navigateIntent('create', …)` bubbles up out of the
+ * Tool and lands the editor in a new draft. (Sanity's own structure
+ * tool follows the same pattern.)
+ */
+export function LauncherTool(): JSX.Element {
+  const templates = useTemplates()
+  const router = useRouter()
+
+  const handleSelect = (template: LauncherTemplate) => {
+    router.navigateIntent('create', {
+      type: template.schemaType,
+      template: template.id,
+    })
+  }
+
+  return <LauncherGrid templates={templates} onSelect={handleSelect} />
+}
+
+/**
+ * Tool definition consumed by `apps/studio/sanity.config.ts` and
+ * `apps/studio-staging/sanity.config.ts` via `tools: (prev) => [...prev, launcherTool()]`.
+ *
+ * The factory function shape mirrors Sanity's plugin convention so a
+ * future "options" argument (e.g. recents persistence, group ordering)
+ * lands additively without breaking call sites.
+ */
+export function launcherTool(): Tool {
+  return {
+    name: 'launcher',
+    title: 'Create',
+    icon: ComposeSparklesIcon,
+    component: LauncherTool,
+  }
+}

--- a/packages/sanity-studio/src/tools/launcher/use-templates.test.ts
+++ b/packages/sanity-studio/src/tools/launcher/use-templates.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it, vi} from 'vitest'
+import type {Template} from 'sanity'
+
+import {filterLauncherTemplates} from './filter-launcher-templates'
+
+const known = (registered: string[]) => (schemaType: string) => registered.includes(schemaType)
+
+const launcherTemplate = (overrides: Partial<Template> = {}): Template => ({
+  id: 'responsibility-new',
+  title: 'Nieuwe responsibility',
+  schemaType: 'responsibility',
+  value: {},
+  // @ts-expect-error LauncherTemplate ui field is not part of Sanity's Template type
+  ui: {icon: 'help-circle', description: 'desc', group: 'Responsibilities'},
+  ...overrides,
+})
+
+describe('filterLauncherTemplates', () => {
+  it('keeps templates with a valid ui block and a known schemaType', () => {
+    const result = filterLauncherTemplates([launcherTemplate()], known(['responsibility']))
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('responsibility-new')
+  })
+
+  it('drops templates without a ui block (auto-generated / third-party)', () => {
+    const sanityAutoTemplate: Template = {
+      id: 'responsibility',
+      title: 'responsibility',
+      schemaType: 'responsibility',
+      value: {},
+    }
+    const result = filterLauncherTemplates([sanityAutoTemplate], known(['responsibility']))
+    expect(result).toHaveLength(0)
+  })
+
+  it('drops templates with malformed ui (missing required fields)', () => {
+    const malformed = {
+      id: 'malformed',
+      title: 'x',
+      schemaType: 'responsibility',
+      value: {},
+      ui: {icon: 'help-circle'}, // description + group missing
+    } as unknown as Template
+    const result = filterLauncherTemplates([malformed], known(['responsibility']))
+    expect(result).toHaveLength(0)
+  })
+
+  it('drops templates whose schemaType is not registered in the workspace', () => {
+    const result = filterLauncherTemplates(
+      [launcherTemplate({id: 'ghost', schemaType: 'ghostType'})],
+      known(['responsibility']),
+    )
+    expect(result).toHaveLength(0)
+  })
+
+  it('logs unknown schemaTypes once per pass via the onUnknownType callback', () => {
+    const onUnknownType = vi.fn()
+    filterLauncherTemplates(
+      [
+        launcherTemplate({id: 'a', schemaType: 'ghostType'}),
+        launcherTemplate({id: 'b', schemaType: 'ghostType'}),
+        launcherTemplate({id: 'c', schemaType: 'otherGhost'}),
+      ],
+      known([]),
+      onUnknownType,
+    )
+    expect(onUnknownType).toHaveBeenCalledTimes(2)
+    expect(onUnknownType).toHaveBeenCalledWith('ghostType')
+    expect(onUnknownType).toHaveBeenCalledWith('otherGhost')
+  })
+
+  it('does not log when onUnknownType is omitted', () => {
+    expect(() =>
+      filterLauncherTemplates(
+        [launcherTemplate({schemaType: 'ghostType'})],
+        known([]),
+      ),
+    ).not.toThrow()
+  })
+
+  it('preserves input order for kept templates', () => {
+    const templates: Template[] = [
+      launcherTemplate({id: 'a', schemaType: 'responsibility'}),
+      launcherTemplate({id: 'b', schemaType: 'article'}),
+      launcherTemplate({id: 'c', schemaType: 'responsibility'}),
+    ]
+    const result = filterLauncherTemplates(templates, known(['responsibility', 'article']))
+    expect(result.map((t) => t.id)).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/packages/sanity-studio/src/tools/launcher/use-templates.ts
+++ b/packages/sanity-studio/src/tools/launcher/use-templates.ts
@@ -1,0 +1,34 @@
+import {useMemo} from 'react'
+import {useSource, useTemplates as useSanityTemplates} from 'sanity'
+
+import type {LauncherTemplate} from '../../templates/types'
+import {filterLauncherTemplates} from './filter-launcher-templates'
+
+/**
+ * React hook that returns the launcher-eligible templates registered
+ * on the current Sanity workspace. Filters out templates without a
+ * `ui` block (Sanity's auto-generated and third-party templates) and
+ * templates whose `schemaType` is not registered in the workspace
+ * schema. Unknown types are logged once per filter pass.
+ *
+ * AC: `useTemplates()` filters out templates without `ui` and
+ * templates with unknown `schemaType`; logs once to console for
+ * unknown types. (Issue #1499)
+ */
+export function useTemplates(): LauncherTemplate[] {
+  const allTemplates = useSanityTemplates()
+  const {schema} = useSource()
+
+  return useMemo(
+    () =>
+      filterLauncherTemplates(
+        allTemplates,
+        (schemaType) => schema.get(schemaType) !== undefined,
+        (schemaType) =>
+          console.warn(
+            `[LauncherTool] template references unknown schemaType "${schemaType}" — ignored.`,
+          ),
+      ),
+    [allTemplates, schema],
+  )
+}


### PR DESCRIPTION
Closes #1499

## Summary

Phase 1 tracer bullet for the Sanity Studio editor-UX rework. Proves the launcher Tool registration, Initial Value Template wiring, intent navigation, field-group rendering, and the dual-studio sync workflow — end-to-end. Establishes the `tools/launcher/` and `templates/` module-layout conventions that Phases 2+ build on.

## Acceptance criteria

- [x] `LauncherTool` lives at `packages/sanity-studio/src/tools/launcher/launcher-tool.tsx` and is exported (factory) from the package barrel
- [x] Tool appears as `✨ Create` tab in top nav of both studios — uses `ComposeSparklesIcon` from `@sanity/icons`
- [x] `LauncherTemplate` interface defined in `packages/sanity-studio/src/templates/types.ts` extending Sanity `Template` + required `ui: { icon, description, group }`
- [x] `useTemplates()` filters out templates without `ui` and templates with unknown `schemaType`; `console.warn`s once per unknown type per render
- [x] Single template `responsibility-new` registered with empty `value: {}` and Dutch description
- [x] Card click triggers `router.navigateIntent('create', { type: 'responsibility', template: 'responsibility-new' })`
- [x] `responsibility.ts` declares `groups: [vraag, antwoord, contact, meta]` (Vraag is `default: true`)
- [x] All fields assigned to a group per design doc mapping (vraag: title, slug, question, audience, category, keywords; antwoord: summary, steps; contact: primaryContact; meta: active, icon, relatedPaths)
- [x] **Expanded descriptions** (≥4 required; ~12 expanded): `title`, `slug`, `question`, `audience`, `category`, `keywords`, `summary`, `steps`, `primaryContact`, `active`, `relatedPaths`, plus `contactType` / `organigramNode` / `teamRole` / `teamRoleFallback` / `role` inside the contact object
- [x] **Teaching `Rule.required().error(...)` rewrites** (≥4 required; 8 rewrites): `contactType`, `title`, `slug`, `question`, `audience`, `category`, `summary`, `steps[].description`
- [x] `apps/studio/sanity.config.ts` and `apps/studio-staging/sanity.config.ts` updated identically — `tools` and `schema.templates` wired
- [x] Vitest tests: `filter-launcher-templates.test.ts` (7 cases) + `launcher-card.test.tsx` (7 RTL cases)
- [x] `packages/sanity-studio/CLAUDE.md` updated with `tools/<name>/` conventions and the launcher-card-add recipe

## Quality gate

- `pnpm --filter @kcvv/sanity-studio type-check` ✓
- `pnpm --filter @kcvv/sanity-studio lint` ✓ (only the pre-existing `respondent-picker.test.tsx` warning remains, untouched)
- `pnpm --filter @kcvv/sanity-studio test` — my new tests pass cleanly (14/14). 7 PRE-EXISTING test suite failures exist on `main` due to a `bundle.css` import in `sanity`'s `lib/index.js` that vitest's happy-dom environment can't load. Out of scope for this PR; they affect tests that import `defineField`/`defineType` value-side from `sanity`.
- `pnpm --filter @kcvv/sanity-schemas type-check` ✓
- `pnpm --filter @kcvv/studio lint` + `build` ✓ (no `check-all` script exists on the studio app)
- `SANITY_STUDIO_DATASET=staging pnpm --filter @kcvv/studio-staging build` ✓

## Out of scope (Phase 2 / #1500)

- `ContactPicker` custom input (replaces the `primaryContact` + step-contact UI)
- `GuidedSidebar` document layout wrapper (required-field checklist + "why this matters" expanders + preview link)
- `withPlaceholder` / `sectionIntro` helpers
- All Phase 2 `responsibility` validation/description sweep beyond what landed here

## Manual smoke

Recommended before merge: run `pnpm --filter @kcvv/studio dev` against staging dataset → top-nav shows `✨ Create` → click → "Nieuwe responsibility" card → click → opens new draft form with the new field-group tabs (Vraag default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launcher tool in the top-nav: searchable, grouped template grid with accessible template cards for quick document creation; integrates responsibility creation templates into studios.

* **Schema / Validation**
  * Reorganized responsibility content with stronger field validations, clearer descriptions, and required fields.

* **Documentation**
  * Added documentation for the Tools layer and Launcher conventions.

* **Tests**
  * Added unit and interaction tests covering launcher UI and template filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->