### PR TITLE
docs(redesign): phase 4 design checkpoint + PRD + plan

### DIFF
--- a/docs/design/mockups/phase-4-homepage/featuredeventband-locked.md
+++ b/docs/design/mockups/phase-4-homepage/featuredeventband-locked.md
@@ -1,0 +1,110 @@
+# Phase 4 · `<FeaturedEventBand>` — Locked
+
+**Locked 2026-05-07 across rounds 10, F.1.**
+**New component this phase.** Surfaced by Round 3 IA (E.2 — standalone band between hero and NewsGrid).
+
+## Composition
+
+```text
+<FeaturedEventBand>                       // server component
+  if (event === null) return null;        // drop-if-empty
+  <section className="jersey-deep-band">
+    <div className="grid 1fr 1.4fr">
+      <TapedFigure
+        aspect="landscape-16-9"
+        rotation="a"
+        tape={[{ color: "warm" }]}        // ← new "warm" tape variant per F.1 lock
+      >
+        <Image src={event.coverImage.url} alt={event.coverImage.alt} fill />
+      </TapedFigure>
+      <div className="text-block">
+        <span className="meta">AANSTAAND EVENEMENT</span>
+        <h2><EditorialHeading><span className="accent">{event.title.firstWord}</span> {event.title.rest}</EditorialHeading></h2>
+        <span className="when">{formatDateTime(event.dateStart, event.dateEnd)} · {event.location || "Kantine"}</span>
+        <a href={event.externalLink?.url ?? `/evenementen/${event.slug}`}>
+          {event.externalLink?.label ?? "Meer info →"}
+        </a>
+      </div>
+    </div>
+  </section>
+```
+
+## Spec
+
+| Aspect | Value |
+| --- | --- |
+| Section background | `var(--jersey-deep)` |
+| Layout | Image left 1fr + text right 1.4fr (desktop); stacks on mobile |
+| Image treatment | `<TapedFigure>` polaroid with `tape="warm"` variant (new — see Phase 0 task) |
+| Image aspect | `landscape-16-9` |
+| Polaroid rotation | `rotation="a"` (-0.5°) |
+| Text colour | `var(--cream)` |
+| Accent colour | `#f0c264` (warm yellow) on first noun in title |
+| Meta line | `AANSTAAND EVENEMENT` (uppercase mono, opacity 0.85) |
+| Headline | Event `title` rendered via `<EditorialHeading>` italic with optional accent decorator |
+| When line | `formatDateTime(dateStart, dateEnd)` + optional `location` (defaults to "Kantine") |
+| CTA copy | `event.externalLink.label` if present, else `"Meer info →"` |
+| CTA target | `event.externalLink.url` if present, else `/evenementen/${event.slug}` |
+| CTA hover | Canonical press-down |
+| Empty state | If 0 future events flagged `featuredOnHome === true`, return null |
+
+## Locked decisions
+
+| Round | Decision | Rationale |
+| --- | --- | --- |
+| 3 (IA) | **E.2 · Standalone band between hero and NewsGrid** | Surfaces the band; positions it after hero |
+| 10 | **L.1 · Image left (TapedFigure) + text right** | Reuses TapedFigure (consistent with NewsCard / EditorialHero cover) |
+| F.1 | **Warm/yellow tape variant on jersey-deep sections** | Default jersey-tape green disappears against jersey-deep section bg |
+
+## New `tape="warm"` variant
+
+The default `<TapeStrip>` colour is jersey-tape green (`rgba(31, 95, 63, 0.78)` per Phase 0).
+On jersey-deep sections (FeaturedEventBand here, potential others later), the green tape blends
+in. Phase 4 introduces a `warm` variant:
+
+- Token: `--tape-warm: rgba(240, 194, 100, 0.85)` (warm yellow at 85% opacity)
+- Usage rule: ANY TapedFigure or TapedCard placed on a jersey-deep section background uses
+  `tape="warm"`. On cream/cream-soft sections, default `tape="jersey"` stays.
+- This is a Phase 0/1 follow-up: extend `<TapeStrip>` and `<TapedFigure>`'s `tape` prop union
+  to accept `"warm"`. Add Storybook coverage. Capture VR baselines.
+
+## Data flow
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| `event` | `EventRepository.findNextFeatured()` (existing) | Returns next future event with `featuredOnHome === true` |
+| `title` | Sanity `event.title` (PortableText with optional accent decorator) | Rendered via `<EditorialHeading>` |
+| `dateStart` | Sanity `event.dateStart` (datetime) | Required |
+| `dateEnd` | Sanity `event.dateEnd` (datetime) | Optional; if present, format as range |
+| `coverImage` | Sanity `event.coverImage` | Required for FeaturedEventBand to show — if missing, treat as empty and return null |
+| `externalLink` | Sanity `event.externalLink {url, label}` | Optional; falls back to internal `/evenementen/{slug}` |
+| `location` | _NOT in schema today_ | Phase 4 hardcodes "Kantine" as default. Future schema field if location varies (Phase 6 events redesign). |
+
+## Reuse mandate
+
+FeaturedEventBand composes:
+- `<TapedFigure>` with new `tape="warm"` variant (extends Phase 1)
+- `<EditorialHeading>` with accent decorator (Phase 1)
+- `<MonoLabel>` (Phase 0) for the meta line
+- `<Button variant="primary">` (Phase 2) for the CTA
+
+One new primitive variant introduced (`tape="warm"`); no new primitive components.
+
+## Mobile
+
+- Grid collapses to single column at <880px
+- Image moves above text
+- TapedFigure rotation preserved
+
+## VR baseline contract
+
+- Story: `Home/FeaturedEventBand/Default` — typical event with all fields
+- Story: `Home/FeaturedEventBand/NoExternalLink` — internal `/evenementen/{slug}` fallback CTA
+- Story: `Home/FeaturedEventBand/MultiDay` — dateStart + dateEnd both set
+- Story: `Home/FeaturedEventBand/Empty` — returns null (deliberately empty viewport)
+
+## Out of scope
+
+- Spotlight section for `featured: true` events (events page, Phase 6)
+- Calendar integration (Phase 6 kalender redesign)
+- Event location field on schema (Phase 6 — events get richer schema)

--- a/docs/design/mockups/phase-4-homepage/ia-locked.md
+++ b/docs/design/mockups/phase-4-homepage/ia-locked.md
@@ -1,0 +1,89 @@
+# Phase 4 · Homepage IA — Locked
+
+**Locked 2026-05-07 across rounds 1, 1b, 2, 3, 4, 4b.**
+
+## Composition
+
+```text
+[Phase 3 chrome — locked]
+  <MatchStrip>          peek of next match
+  <SiteHeader>          sticky retro chrome + drawer
+
+[Phase 4 — hero region]
+  <EditorialHero placement="homepage" /> (D.1)
+                        carousel · 3 articles · auto-rotate every 5s
+                        strip-below thumbnails (active outlined jersey-yellow,
+                        inactives 60% opacity, click jumps the carousel)
+  <FeaturedEventBand>   (E.2 — new component this phase, see featuredeventband-locked.md)
+                        jersey-deep band; image left (TapedFigure with WARM tape) + text right
+                        sits between hero and NewsGrid; drop-if-empty
+
+[Phase 4 — body]
+  <BannerSlot a>        drop-if-empty
+  <NewsGrid>            6 article cards · NO event slot
+  <UpcomingMatches>  tabs: schedule | standings
+  <BannerSlot b>        drop-if-empty
+  <YouthBlock>          full-bleed jersey-deep interlude
+  <WebshopBanner>       single-CTA banner pointing to external supplier (renamed from
+                        <WebshopStrip>; ink palette to avoid green-on-green with YouthBlock —
+                        see webshopbanner-locked.md)
+  <BannerSlot c>        drop-if-empty
+  <SponsorsBlock>       newspaper grid · main + second tier only
+                        greyscale by default · colour on hover
+
+[Phase 3 chrome — locked]
+  <SiteFooter>          H3 wordmark replaces retired <PosterWordmark>
+```
+
+## Source-of-truth per surface
+
+| Surface | Source | Field | Fallback |
+| --- | --- | --- | --- |
+| EditorialHero carousel | Sanity `article` | `featured: boolean` (already in schema) | If < 3 flagged: fill remaining slots with most-recent published |
+| FeaturedEventBand | Sanity `event` | `featuredOnHome: boolean` (already in schema) | None — drop the band if no flagged event with `dateStart >= now()` |
+| bannerSlotA / B / C | Sanity `homePage` | `bannerSlotA / B / C: ref → banner` | None — drop the band if ref empty |
+| NewsGrid | Sanity `article` | `ARTICLES_QUERY[3..9]` (skip the 3 hero articles) | Drop the section if 0 |
+| UpcomingMatches | BFF | `getNextMatches()` (existing) — all KCVV teams, chronological | Return null if 0 upcoming. Standings dropped from homepage scope; live on `/ranking` only. See `upcoming-matches-locked.md` |
+| YouthBlock | Hardcoded | n/a | n/a |
+| WebshopStrip | Hardcoded thumbs + external link | n/a | n/a |
+| SponsorsBlock | Sanity `sponsor[]` | `tier in ["hoofdsponsor", "sponsor"]` only on homepage | Drop if 0 sponsors |
+
+## Round-by-round lock log
+
+- **Round 1 — Hero shape:** Variant **D · Carousel reskinned**. Auto-rotate preserved on the retro fanzine palette.
+- **Round 1b — Carousel thumbnails:** Variant **D.1 · Strip below**. All 3 thumbs in a horizontal row below the active hero; active outlined jersey-yellow, inactives 60% opacity.
+- **Round 2 — Hero source:** Variant **S.2 · `article.featured` boolean**. Field already exists. Query change only: `order(featured desc, publishedAt desc)`. Most-recent fallback if fewer than 3 are flagged.
+- **Round 3 — Featured event placement:** Variant **E.2 · Standalone band between hero and NewsGrid**. New `<FeaturedEventBand>` component, jersey-deep palette, drop-if-empty.
+- **Round 4 — Body spine:** Variant **A · NewsGrid → Schedule → Youth → Webshop → Sponsors**. Sponsors stays the commercial close.
+- **Round 4b — Banner slots:** Variant **BS.1 · Keep all 3 slots**. Positions: bannerSlotA between event and grid, bannerSlotB between schedule and youth, bannerSlotC between webshop and sponsors. All drop-if-empty.
+
+## Schema cost rolling total
+
+| Change | Type | Phase |
+| --- | --- | --- |
+| `article.featured` query usage in homepage hero | Query change only | Phase 4 |
+| `event.featuredOnHome` query usage on homepage | Query change only | Phase 4 |
+| `<FeaturedEventBand>` React component | New component | Phase 4 |
+| `<BannerSlot>` retains existing 3 refs on `homePage` | No change | Phase 4 |
+| **Sanity migrations required** | **0** | — |
+
+## Open questions deferred to per-section rounds
+
+- **NewsGrid card composition** — 4 aspect-ratio variants (16:9 / square / 3:4 / text-only), tape rotation rules per card position, kicker / byline / articleType MonoLabel placement. Round 5 (NewsGrid + NewsCard).
+- **ScheduleStandingsBlock layout** — tabs vs split, schedule depth (next 3? next 5? grouped by week?), standings shape (group only or full table), KCVV row highlight (psd_club_id 1235), empty-state. Round 6.
+- **SponsorsBlock tier rendering** — main (`hoofdsponsor`) vs second (`sponsor`) layout density per tier; missing-logo fallback (italic Freight Display name treatment). Round 7.
+- **YouthBlock copy + composition** — JerseyShirt placement, headline treatment, stat ("220+ spelers · 16 ploegen" — verify still accurate), CTA copy, divisions mention. Round 8.
+- **WebshopStrip** — 4-col jersey thumbs source (Sanity vs hardcoded), tape/rotation pattern, CTA copy, external-link indicator. Round 9.
+- **Cream / ink / jersey rhythm token map** — locks after all section internals. Round 10.
+- **Mobile compression rules** — single-column rules at <640px. Implementation-time, not design-time.
+
+## Reuse mandate
+
+Per `feedback_reuse_approved_primitives` and `feedback_editorial_hero_reuse_mandate`: every new
+sub-component built for Phase 4 must compose with the existing retro-fanzine vocabulary
+(`<TapedCard>`, `<TapeStrip>`, `<TicketStub>`, `<MonoLabel>`, `<EditorialHeading>`,
+`<EditorialKicker>`, `<EditorialLead>`, `<EditorialByline>`, `<HighlighterStroke>`,
+`<TapedFigure>`). The `<FeaturedEventBand>` introduced this phase will compose
+TapedFigure (cover) + MonoLabel (kicker) + EditorialHeading + a press-down CTA — no new primitive.
+
+The carousel motion logic (D.1) is the only "use client" component introduced in Phase 4.

--- a/docs/design/mockups/phase-4-homepage/ia-locked.md
+++ b/docs/design/mockups/phase-4-homepage/ia-locked.md
@@ -45,7 +45,7 @@
 | NewsGrid | Sanity `article` | `ARTICLES_QUERY[3..9]` (skip the 3 hero articles) | Drop the section if 0 |
 | UpcomingMatches | BFF | `getNextMatches()` (existing) — all KCVV teams, chronological | Return null if 0 upcoming. Standings dropped from homepage scope; live on `/ranking` only. See `upcoming-matches-locked.md` |
 | YouthBlock | Hardcoded | n/a | n/a |
-| WebshopStrip | Hardcoded thumbs + external link | n/a | n/a |
+| WebshopBanner | Hardcoded copy + external link | n/a | n/a |
 | SponsorsBlock | Sanity `sponsor[]` | `tier in ["hoofdsponsor", "sponsor"]` only on homepage | Drop if 0 sponsors |
 
 ## Round-by-round lock log
@@ -73,7 +73,7 @@
 - **ScheduleStandingsBlock layout** — tabs vs split, schedule depth (next 3? next 5? grouped by week?), standings shape (group only or full table), KCVV row highlight (psd_club_id 1235), empty-state. Round 6.
 - **SponsorsBlock tier rendering** — main (`hoofdsponsor`) vs second (`sponsor`) layout density per tier; missing-logo fallback (italic Freight Display name treatment). Round 7.
 - **YouthBlock copy + composition** — JerseyShirt placement, headline treatment, stat ("220+ spelers · 16 ploegen" — verify still accurate), CTA copy, divisions mention. Round 8.
-- **WebshopStrip** — 4-col jersey thumbs source (Sanity vs hardcoded), tape/rotation pattern, CTA copy, external-link indicator. Round 9.
+- **WebshopBanner** — composition (single-CTA banner pointer to external supplier per Round 9b lock; ink palette per F.1 to avoid YouthBlock adjacency). Round 9.
 - **Cream / ink / jersey rhythm token map** — locks after all section internals. Round 10.
 - **Mobile compression rules** — single-column rules at <640px. Implementation-time, not design-time.
 

--- a/docs/design/mockups/phase-4-homepage/ia-locked.md
+++ b/docs/design/mockups/phase-4-homepage/ia-locked.md
@@ -21,7 +21,9 @@
 [Phase 4 — body]
   <BannerSlot a>        drop-if-empty
   <NewsGrid>            6 article cards · NO event slot
-  <UpcomingMatches>  tabs: schedule | standings
+  <UpcomingMatches>     5-row chronological schedule (all KCVV teams) +
+                        inline expand-to-all + /kalender link when expanded
+                        (standings dropped from homepage — see upcoming-matches-locked.md)
   <BannerSlot b>        drop-if-empty
   <YouthBlock>          full-bleed jersey-deep interlude
   <WebshopBanner>       single-CTA banner pointing to external supplier (renamed from
@@ -70,7 +72,7 @@
 ## Open questions deferred to per-section rounds
 
 - **NewsGrid card composition** — 4 aspect-ratio variants (16:9 / square / 3:4 / text-only), tape rotation rules per card position, kicker / byline / articleType MonoLabel placement. Round 5 (NewsGrid + NewsCard).
-- **ScheduleStandingsBlock layout** — tabs vs split, schedule depth (next 3? next 5? grouped by week?), standings shape (group only or full table), KCVV row highlight (psd_club_id 1235), empty-state. Round 6.
+- **UpcomingMatches** (renamed from `<ScheduleStandingsBlock>`; standings dropped per Round 6a) — schedule depth, expand pattern, KCVV row highlight (psd_club_id 1235), empty-state. Round 6 / 6a / 6b.
 - **SponsorsBlock tier rendering** — main (`hoofdsponsor`) vs second (`sponsor`) layout density per tier; missing-logo fallback (italic Freight Display name treatment). Round 7.
 - **YouthBlock copy + composition** — JerseyShirt placement, headline treatment, stat ("220+ spelers · 16 ploegen" — verify still accurate), CTA copy, divisions mention. Round 8.
 - **WebshopBanner** — composition (single-CTA banner pointer to external supplier per Round 9b lock; ink palette per F.1 to avoid YouthBlock adjacency). Round 9.

--- a/docs/design/mockups/phase-4-homepage/newsgrid-locked.md
+++ b/docs/design/mockups/phase-4-homepage/newsgrid-locked.md
@@ -1,0 +1,119 @@
+# Phase 4 · NewsGrid + NewsCard — Locked
+
+**Locked 2026-05-07 across rounds 5, 5b, 5c, 5d, 5e, 5f.**
+
+## Composition
+
+```text
+<NewsGrid title="Laatste nieuws" articles={Article[]}>  // takes 1–5 articles
+  <SectionHeader> + "Alle berichten →" link
+  <div class="grid grid-cols-1 md:grid-cols-2"> // geometry D 50/50
+    <NewsCard variant="lead">                     // slot 0, 16:9, rotation a
+    <div>                                          // 2x2 right cluster
+      <div>                                        // top row
+        <NewsCard>                                 // slot 1, 16:9, rotation b
+        <NewsCard>                                 // slot 2, 16:9, rotation c
+      <div>                                        // bottom row
+        <NewsCard>                                 // slot 3, 16:9, rotation d
+        <NewsCard>                                 // slot 4, 16:9, rotation a
+```
+
+## Locked decisions
+
+| Round | Decision | Rationale |
+| --- | --- | --- |
+| 5 | **N.2 Broadsheet** with 5 cards (1 lead + 4 supporting) | One dominant lead, no orphan card |
+| 5b | **D · 50/50 split** — lead 1fr × 2 rows + 2×2 supporting 1fr | Mobile collapses to 1+2+2 (symmetric) |
+| 5c | **C.1 · All 16:9 on /** | text-only retired from homepage scope (coverImage required); aspect prop stays on NewsCard for other surfaces |
+| 5d | **T.1 · Slot index rotation cycle** (a/b/c/d/a) | Matches Phase 1 `<TapedCardGrid>` `ROTATION_POOL` |
+| 5e | **H.1 · Press-down hover** | Canonical per `feedback_canonical_press_down_hover` |
+| 5f | **E.1 · Graceful collapse** | Lead always; supporting fills in order; null at N=0 |
+
+## Data flow
+
+| Variable | Value | Source |
+| --- | --- | --- |
+| Articles count input | 1–5 | `articles.slice(3, 8)` from `ARTICLES_QUERY` |
+| Slice change vs today | `[3..8]` (5) instead of `[3..9]` (6) | one fewer article into the grid |
+| Aspect ratio per slot | `landscape-16-9` for all 5 | hard-coded in NewsGrid (NewsCard prop available) |
+| Rotation per slot | `[a, b, c, d, a]` cycle by index | hard-coded in NewsGrid |
+| Hover behaviour | `hover:translate-x-1 hover:translate-y-1 hover:shadow-none` | NewsCard primitive |
+| Click target | Whole card → Link to `/nieuws/{slug}` | NewsCard primitive |
+| Empty event slot | Removed | Phase 4 IA E.2 lock — featured event has its own band |
+| Featured event prop | Removed | Phase 4 IA E.2 lock |
+
+## Sparse-data behaviour (N = articles count)
+
+```text
+N = 0  →  return null (entire section hidden)
+N = 1  →  lead-only, full width
+N = 2  →  lead 50% + 1 supporting 50% (single row top)
+N = 3  →  lead 50% × 2 rows + 2 supporting (top row only)
+N = 4  →  lead 50% × 2 rows + 3 supporting (full top row + 1 bottom)
+N = 5+ →  lead 50% × 2 rows + 4 supporting (full 2×2)
+```
+
+The grid uses CSS Grid auto-flow; supporting slots are conditionally rendered. Implementation
+must collapse the 2x2 sub-grid to whichever rows are needed (no empty `<div>` placeholders).
+
+## NewsCard primitive contract
+
+```typescript
+interface NewsCardProps {
+  /** Article slug → link target /nieuws/{slug} */
+  slug: string;
+  /** Article title (PortableText with optional accent decorator OR plain string) */
+  title: string | PortableTextBlock[];
+  /** Lead/excerpt (optional — only the lead card uses this on /) */
+  lead?: string;
+  /** Article type → renders as <MonoLabel> pill (kicker) */
+  articleType: "interview" | "announcement" | "transfer" | "event";
+  /** Author display name */
+  author?: string;
+  /** ISO publish date */
+  publishedAt: string;
+  /** Cover image (required by article schema) */
+  coverImage: { url: string; alt: string };
+  /** Visual variant — controls headline size, lead presence, byline detail */
+  variant?: "lead" | "standard";  // default "standard"
+  /** Aspect ratio of the inner image — defaults to "landscape-16-9" on / */
+  aspectRatio?: "landscape-16-9" | "square" | "portrait-3-4";
+  /** Rotation slot — pulled from pool, set by parent NewsGrid */
+  rotation?: "a" | "b" | "c" | "d" | "none";
+}
+```
+
+`text-only` aspect variant deliberately not on the API. Master design §9.12 lists 4 aspect
+variants — Phase 4 ships 3. Reconsider in a later phase if a use case appears.
+
+## Reuse mandate
+
+NewsCard composes:
+- `<TapedCard rotation={rotation}>` — paper card primitive (Phase 1)
+- `<TapeStrip>` — tape decoration (Phase 0)
+- `<TapedFigure>` — inner image with aspect (Phase 1)
+- `<MonoLabel>` — articleType pill (Phase 0)
+- `<EditorialHeading level={3}>` — title with optional accent decorator (Phase 1)
+- `<EditorialLead>` — lead/excerpt for variant="lead" only (Phase 1)
+- `<EditorialByline>` — author + date (Phase 1)
+
+No new primitives introduced for NewsCard. Geometry-level CSS is the only Phase 4 addition.
+
+## VR baseline contract
+
+Per `docs/prd/visual-regression-testing.md` §12, NewsCard is in the Phase 3 Include list. Phase 4
+adds:
+- New stories per variant: `Article/NewsCard/Default`, `Article/NewsCard/Lead`,
+  `Article/NewsCard/SquareAspect`, `Article/NewsCard/PortraitAspect`.
+- New stories for NewsGrid sparse states: `Home/NewsGrid/Default5`, `Home/NewsGrid/Sparse4`,
+  `Home/NewsGrid/Sparse3`, `Home/NewsGrid/Sparse2`, `Home/NewsGrid/Sparse1`,
+  `Home/NewsGrid/Empty` (returns null — captured as a deliberately empty viewport).
+- Each new story carries `tags: ["autodocs", "vr"]` and ships baselines in the Phase 4 PR.
+
+## Open questions deferred to implementation
+
+- **Tape strip rotation per slot** — matches TapedCardGrid pool (-1° to -6°, 4–12% inset)? Yes.
+- **Section header treatment** — uses Phase 2 `<SectionHeader>` (now wraps `<EditorialHeading>` +
+  `<MonoLabelRow>`). No customization needed.
+- **Loading skeleton** — covered by `docs/prd/loading-skeleton-consistency.md`; not a Phase 4
+  decision.

--- a/docs/design/mockups/phase-4-homepage/round-1-hero-shape-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-1-hero-shape-comparisons.html
@@ -655,7 +655,7 @@
       <p>
         <strong>Reading the comparison.</strong> Each candidate shows only the hero band — the strip immediately under
         the (locked) MatchStrip + SiteHeader. Whatever is picked, the body-section spine below it (NewsGrid,
-        ScheduleStandings, Youth, Webshop, Sponsors) follows in Round 4.
+        UpcomingMatches, Youth, Webshop, Sponsors) follows in Round 4.
       </p>
       <p>
         <strong>Open consequences for later rounds.</strong> Variant A leans hardest on Round 2 (we'll need a

--- a/docs/design/mockups/phase-4-homepage/round-1-hero-shape-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-1-hero-shape-comparisons.html
@@ -1,0 +1,670 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 1 · Homepage hero shape</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --ink-soft: #2a2a2a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --tape: #d9b85a;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-deep: 6px 6px 0 0 var(--ink);
+        --rule: #1a1a1a;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1280px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, "Times New Roman", serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 56px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--rule);
+        box-shadow: var(--shadow-deep);
+      }
+      .candidate header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 18px 22px 14px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 26px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate header .desc {
+        max-width: 60ch;
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+      }
+      .candidate header .tradeoffs {
+        font-size: 12px;
+        line-height: 1.55;
+        max-width: 38ch;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .candidate .surface {
+        background: var(--cream);
+        padding: 36px 32px 44px;
+      }
+
+      /* ===== Hero primitives ===== */
+      .kicker {
+        display: inline-flex;
+        gap: 10px;
+        align-items: center;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+      }
+      .kicker .pill {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 3px 8px;
+        line-height: 1;
+      }
+      .kicker .dot {
+        opacity: 0.45;
+      }
+      .h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 14px 0 14px;
+      }
+      .h1.size-xl { font-size: 56px; }
+      .h1.size-lg { font-size: 38px; }
+      .h1.size-md { font-size: 26px; }
+      .h1 .accent { color: var(--jersey-deep); font-style: italic; }
+      .lead {
+        font-size: 16px;
+        line-height: 1.55;
+        max-width: 50ch;
+        margin: 0 0 16px;
+        opacity: 0.92;
+      }
+      .lead.compact { font-size: 14px; line-height: 1.5; max-width: 38ch; }
+      .byline {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .read-more {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--jersey-deep);
+        margin-top: 12px;
+        font-weight: bold;
+      }
+      .taped {
+        position: relative;
+        background: #fff;
+        padding: 8px 8px 10px;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+      }
+      .taped .tape {
+        position: absolute;
+        top: -10px;
+        width: 56px;
+        height: 14px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .taped .tape.left { left: 14px; }
+      .taped .tape.right { right: 14px; transform: rotate(3deg); }
+      .taped.rot-a { transform: rotate(-1deg); }
+      .taped.rot-b { transform: rotate(0.6deg); }
+      .taped.rot-c { transform: rotate(-0.4deg); }
+      .img {
+        width: 100%;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        position: relative;
+      }
+      .img::after {
+        content: attr(data-tag);
+        position: absolute;
+        bottom: 8px;
+        left: 8px;
+        background: rgba(26, 26, 26, 0.78);
+        color: var(--cream);
+        padding: 3px 8px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .img.aspect-16-9 { aspect-ratio: 16 / 9; }
+      .img.aspect-4-3 { aspect-ratio: 4 / 3; }
+      .img.aspect-square { aspect-ratio: 1 / 1; }
+      .caption {
+        font-size: 11px;
+        font-style: italic;
+        opacity: 0.75;
+        padding: 6px 4px 0;
+      }
+
+      /* ===== Layout: A (single spotlight) ===== */
+      .layout-spotlight {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 40px;
+        align-items: center;
+      }
+      @media (max-width: 880px) {
+        .layout-spotlight { grid-template-columns: 1fr; gap: 32px; }
+      }
+
+      /* ===== Layout: B (lead + sidebar) ===== */
+      .layout-lead-sidebar {
+        display: grid;
+        grid-template-columns: 64fr 36fr;
+        gap: 32px;
+      }
+      .lead-block { display: flex; flex-direction: column; }
+      .sidebar-block {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        padding-left: 24px;
+        border-left: 1px solid var(--ink);
+      }
+      .sidebar-block .label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .sidebar-card {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .sidebar-card .h3 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 18px;
+        line-height: 1.2;
+      }
+      @media (max-width: 880px) {
+        .layout-lead-sidebar { grid-template-columns: 1fr; }
+        .sidebar-block { padding-left: 0; border-left: 0; border-top: 1px solid var(--ink); padding-top: 24px; }
+      }
+
+      /* ===== Layout: C (lead trio) ===== */
+      .layout-trio {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 28px;
+      }
+      .trio-card {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .trio-card.lead { grid-column: span 1; }
+      @media (max-width: 880px) {
+        .layout-trio { grid-template-columns: 1fr; }
+      }
+      .trio-card .h3 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.18;
+      }
+      .trio-card .h3.lg { font-size: 26px; }
+
+      /* ===== Layout: D (carousel reskinned) ===== */
+      .carousel-shell {
+        position: relative;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 36px 32px 32px;
+        overflow: hidden;
+      }
+      .carousel-stack {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 32px;
+        align-items: center;
+      }
+      @media (max-width: 880px) {
+        .carousel-stack { grid-template-columns: 1fr; }
+      }
+      .carousel-shell .h1 { color: var(--cream); }
+      .carousel-shell .lead { opacity: 0.85; }
+      .carousel-shell .byline { color: var(--cream); opacity: 0.65; }
+      .carousel-controls {
+        margin-top: 28px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .dot-row { display: inline-flex; gap: 6px; align-items: center; }
+      .dot-row .pip {
+        width: 10px; height: 10px; border-radius: 50%;
+        border: 1px solid var(--cream);
+      }
+      .dot-row .pip.on { background: var(--cream); }
+      .dot-row .progress {
+        width: 56px; height: 2px; background: rgba(245, 239, 225, 0.25);
+        position: relative;
+      }
+      .dot-row .progress::after {
+        content: "";
+        position: absolute; left: 0; top: 0; bottom: 0; width: 35%;
+        background: var(--cream);
+      }
+
+      .footnote {
+        max-width: 1280px;
+        margin: 36px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+      .question-summary {
+        max-width: 1280px;
+        margin: 0 auto 28px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 1 · Homepage hero shape</div>
+      <h1>What shape is the homepage hero?</h1>
+      <p>
+        Today the top of <code>/</code> renders <code>&lt;FeaturedArticles&gt;</code>: a 3-article auto-rotating carousel
+        seeded from <code>articles.slice(0, 3)</code> (no editor pick). Phase 3 shipped
+        <code>&lt;EditorialHero placement="homepage"&gt;</code> as a <em>single-article spotlight</em> for one
+        explicitly-chosen slug. This round picks which shape the homepage hero takes. Round 2 then drills
+        <em>how the hero article(s) are selected</em>; Round 3 places the featured event; Round 4 locks the
+        body-section spine on top of all of those.
+      </p>
+    </header>
+
+    <div class="question-summary">
+      <strong>What's locked above this round.</strong> Phase 3 chrome — <code>&lt;MatchStrip&gt;</code>,
+      <code>&lt;SiteHeader&gt;</code>, <code>&lt;SiteFooter&gt;</code> — already sits above and below every variant.
+      Variants below show <em>only</em> the hero region (the band immediately under the chrome). The grid /
+      schedule / youth / shop / sponsors that follow are out-of-frame for this round.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ A — Single spotlight (Phase 3 as-shipped) ============ -->
+      <section class="candidate" id="A">
+        <header>
+          <div>
+            <div class="key">Variant A</div>
+            <div class="name">Single spotlight</div>
+          </div>
+          <div class="desc">
+            One editor-picked lead article rendered with the full Phase 3
+            <code>&lt;EditorialHero placement="homepage"&gt;</code>: kicker chips, italic display H1, lead
+            sentence, byline, taped 16:9 cover. Whole block is a Link to <code>/nieuws/{slug}</code>
+            with the canonical press-up hover. <strong>One article, one moment, one click target.</strong>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Strongest editorial weight<br />
+            + Reuses Phase 3 component as-is<br />
+            − Requires editor to pick a lead<br />
+            − Loses 2 of 3 currently-rotated stories
+          </div>
+        </header>
+        <div class="surface">
+          <div class="layout-spotlight">
+            <div>
+              <div class="kicker">
+                <span class="pill">Interview</span>
+                <span class="dot">·</span>
+                <span>5 mei 2026</span>
+                <span class="dot">·</span>
+                <span>6 min lezen</span>
+              </div>
+              <h2 class="h1 size-xl">
+                <em class="accent">"Met deze ploeg</em> <br />
+                kunnen we ver geraken."
+              </h2>
+              <p class="lead">
+                Aanvoerder Jens De Smet over de promotiekansen, het nieuwe trainingsritme en
+                waarom de groep dit jaar anders aanvoelt dan vorig seizoen.
+              </p>
+              <div class="byline">door Tom Janssens</div>
+              <div class="read-more">★ Lees verder →</div>
+            </div>
+            <div>
+              <div class="taped rot-b">
+                <div class="tape left"></div>
+                <div class="tape right"></div>
+                <div class="img aspect-16-9" data-tag="kcvv · jens"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ B — Lead + secondary sidebar ============ -->
+      <section class="candidate" id="B">
+        <header>
+          <div>
+            <div class="key">Variant B</div>
+            <div class="name">Lead + sidebar</div>
+          </div>
+          <div class="desc">
+            Magazine "front page" pattern: one big EditorialHero on the left at ~64% width, two
+            smaller secondary feature cards stacked on the right. Two extra editor-picks (or
+            "next 2 most recent"). Both right-column cards are Links; the lead is the dominant
+            click target.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Surfaces 3 stories, none rotating<br />
+            + Reads as broadsheet front page<br />
+            − Needs sidebar card design (new sub-component)<br />
+            − Three editorial picks per week is more work
+          </div>
+        </header>
+        <div class="surface">
+          <div class="layout-lead-sidebar">
+            <div class="lead-block">
+              <div class="kicker">
+                <span class="pill">Interview</span>
+                <span class="dot">·</span>
+                <span>5 mei 2026</span>
+                <span class="dot">·</span>
+                <span>6 min lezen</span>
+              </div>
+              <h2 class="h1 size-lg">
+                <em class="accent">"Met deze ploeg</em> kunnen we<br />ver geraken."
+              </h2>
+              <p class="lead">
+                Aanvoerder Jens De Smet over de promotiekansen, het nieuwe trainingsritme en
+                waarom de groep dit jaar anders aanvoelt dan vorig seizoen.
+              </p>
+              <div class="byline">door Tom Janssens · ★ lees verder →</div>
+              <div style="margin-top: 18px; max-width: 420px;">
+                <div class="taped rot-a">
+                  <div class="tape left"></div>
+                  <div class="tape right"></div>
+                  <div class="img aspect-16-9" data-tag="kcvv · jens"></div>
+                </div>
+              </div>
+            </div>
+            <div class="sidebar-block">
+              <div class="label">Ook deze week</div>
+              <div class="sidebar-card">
+                <div class="taped rot-c">
+                  <div class="tape left"></div>
+                  <div class="img aspect-4-3" data-tag="transfer"></div>
+                </div>
+                <div class="kicker">
+                  <span class="pill">Transfer</span>
+                  <span class="dot">·</span>
+                  <span>3 mei</span>
+                </div>
+                <div class="h3" style="font-family: ui-serif; font-style: italic; font-size: 19px; line-height: 1.2;">
+                  Wim Geeraerts tekent voor twee seizoenen.
+                </div>
+              </div>
+              <div class="sidebar-card">
+                <div class="taped rot-b">
+                  <div class="tape right"></div>
+                  <div class="img aspect-4-3" data-tag="event"></div>
+                </div>
+                <div class="kicker">
+                  <span class="pill">Evenement</span>
+                  <span class="dot">·</span>
+                  <span>10 mei</span>
+                </div>
+                <div class="h3" style="font-family: ui-serif; font-style: italic; font-size: 19px; line-height: 1.2;">
+                  Quiz in de kantine, vrijdagavond.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C — Lead trio (3-up TapedCardGrid) ============ -->
+      <section class="candidate" id="C">
+        <header>
+          <div>
+            <div class="key">Variant C</div>
+            <div class="name">Lead trio</div>
+          </div>
+          <div class="desc">
+            Three editorial cards side-by-side at hero size — all visible simultaneously. Same
+            primitives as NewsCard but at a larger display size. No carousel. Equivalent to
+            today's 3 featured articles, just static + reskinned.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Closest to today's editorial workflow<br />
+            + No editor pick needed (auto-fed)<br />
+            − Risks redundancy with NewsGrid below<br />
+            − Loses the single-spotlight emphasis of Phase 3 hero
+          </div>
+        </header>
+        <div class="surface">
+          <div class="layout-trio">
+            <div class="trio-card lead">
+              <div class="taped rot-a">
+                <div class="tape left"></div>
+                <div class="img aspect-16-9" data-tag="lead"></div>
+              </div>
+              <div class="kicker">
+                <span class="pill">Interview</span>
+                <span class="dot">·</span>
+                <span>5 mei</span>
+              </div>
+              <div class="h3 lg">
+                "Met deze ploeg kunnen we ver geraken."
+              </div>
+              <div class="byline">door Tom Janssens</div>
+            </div>
+            <div class="trio-card">
+              <div class="taped rot-b">
+                <div class="tape right"></div>
+                <div class="img aspect-16-9" data-tag="transfer"></div>
+              </div>
+              <div class="kicker">
+                <span class="pill">Transfer</span>
+                <span class="dot">·</span>
+                <span>3 mei</span>
+              </div>
+              <div class="h3">
+                Wim Geeraerts tekent voor twee seizoenen.
+              </div>
+              <div class="byline">door redactie</div>
+            </div>
+            <div class="trio-card">
+              <div class="taped rot-c">
+                <div class="tape left"></div>
+                <div class="img aspect-16-9" data-tag="event"></div>
+              </div>
+              <div class="kicker">
+                <span class="pill">Evenement</span>
+                <span class="dot">·</span>
+                <span>1 mei</span>
+              </div>
+              <div class="h3">
+                Quiz in de kantine, vrijdagavond.
+              </div>
+              <div class="byline">door redactie</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D — Carousel reskinned ============ -->
+      <section class="candidate" id="D">
+        <header>
+          <div>
+            <div class="key">Variant D</div>
+            <div class="name">Carousel reskinned</div>
+          </div>
+          <div class="desc">
+            Preserves today's auto-rotating 3-article behaviour but on the retro fanzine palette:
+            ink-band background, taped cover image, Pause/Play + dot indicator + progress bar
+            redrawn as monospace chrome. Most conservative — same editorial workflow,
+            same content shape.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + No editor workflow change<br />
+            + Familiar to returning visitors<br />
+            − Carousels are widely under-engaged with<br />
+            − Retains a "marketing" register at odds with the editorial-fanzine voice
+          </div>
+        </header>
+        <div class="surface" style="padding: 0;">
+          <div class="carousel-shell">
+            <div class="carousel-stack">
+              <div>
+                <div class="kicker" style="color: var(--cream);">
+                  <span class="pill" style="background: var(--cream); color: var(--ink);">Interview</span>
+                  <span class="dot" style="opacity: 0.55;">·</span>
+                  <span>5 mei 2026</span>
+                </div>
+                <h2 class="h1 size-lg">
+                  <em class="accent" style="color: #f0c264;">"Met deze ploeg</em><br />
+                  kunnen we ver geraken."
+                </h2>
+                <p class="lead">
+                  Aanvoerder Jens De Smet over de promotiekansen, het nieuwe trainingsritme en
+                  waarom de groep dit jaar anders aanvoelt.
+                </p>
+                <div class="byline">door Tom Janssens</div>
+                <div class="carousel-controls">
+                  <span>1 / 3</span>
+                  <span class="dot-row">
+                    <span class="pip on"></span>
+                    <span class="pip"></span>
+                    <span class="pip"></span>
+                  </span>
+                  <span class="dot-row"><span class="progress"></span></span>
+                  <span>auto · 5s</span>
+                  <span>‖ pauzeer</span>
+                </div>
+              </div>
+              <div>
+                <div class="taped rot-a">
+                  <div class="tape left"></div>
+                  <div class="tape right"></div>
+                  <div class="img aspect-16-9" data-tag="rotating"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the comparison.</strong> Each candidate shows only the hero band — the strip immediately under
+        the (locked) MatchStrip + SiteHeader. Whatever is picked, the body-section spine below it (NewsGrid,
+        ScheduleStandings, Youth, Webshop, Sponsors) follows in Round 4.
+      </p>
+      <p>
+        <strong>Open consequences for later rounds.</strong> Variant A leans hardest on Round 2 (we'll need a
+        clean editor-pick mechanism for the single hero article). Variant B introduces a new "secondary
+        feature card" sub-component that NewsCard cannot satisfy as-is. Variant C blurs the line between hero
+        and NewsGrid (Round 2 NewsGrid drill must explicitly differentiate the two). Variant D preserves the
+        carousel workflow but is the only option that keeps a client-side <code>"use client"</code> motion
+        component in the hero slot.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-10-featuredeventband-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-10-featuredeventband-comparisons.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 10 · FeaturedEventBand</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --jersey-deep-dark: #133d28;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 14px 18px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      /* Shared atoms */
+      .meta-line {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.85;
+        margin-bottom: 10px;
+      }
+      .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 32px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 0 0 12px;
+      }
+      .h .accent { color: #f0c264; }
+      .when {
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.92;
+        margin-bottom: 16px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 18px;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+        text-decoration: none;
+      }
+      .cta .arrow { color: var(--jersey-deep); }
+
+      /* Image placeholder — would render real coverImage */
+      .cover-img {
+        background: linear-gradient(135deg, var(--jersey-deep-soft), #f0c264);
+        position: relative;
+      }
+      .cover-img::after {
+        content: "Quiz \\1F37B";
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 24px;
+        color: var(--cream);
+        background: rgba(31, 95, 63, 0.55);
+      }
+
+      /* L.1 — Image left, text right */
+      .l1 {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 36px 28px;
+      }
+      .l1-grid {
+        display: grid;
+        grid-template-columns: 1fr 1.4fr;
+        gap: 32px;
+        align-items: center;
+      }
+      @media (max-width: 880px) { .l1-grid { grid-template-columns: 1fr; } }
+      .l1 .image {
+        position: relative;
+      }
+      .l1 .taped {
+        background: var(--cream);
+        padding: 8px 8px 10px;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 #000;
+        transform: rotate(-1deg);
+        position: relative;
+      }
+      .l1 .taped::before, .l1 .taped::after {
+        content: "";
+        position: absolute;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+      }
+      .l1 .taped::before { top: -8px; left: 16px; width: 50px; height: 12px; transform: rotate(-3deg); }
+      .l1 .taped::after { top: -8px; right: 18px; width: 44px; height: 11px; transform: rotate(3deg); }
+      .l1 .cover-img { aspect-ratio: 16/9; }
+      .l1 .meta-line { color: var(--cream); }
+
+      /* L.2 — Image right, text left */
+      .l2 {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 36px 28px;
+      }
+      .l2-grid {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 32px;
+        align-items: center;
+      }
+      @media (max-width: 880px) { .l2-grid { grid-template-columns: 1fr; } .l2 .image-col { order: -1; } }
+      .l2 .taped {
+        background: var(--cream);
+        padding: 8px 8px 10px;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 #000;
+        transform: rotate(1deg);
+        position: relative;
+      }
+      .l2 .taped::before {
+        content: "";
+        position: absolute;
+        top: -8px; right: 18px;
+        width: 50px; height: 12px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(3deg);
+      }
+      .l2 .cover-img { aspect-ratio: 16/9; }
+      .l2 .meta-line { color: var(--cream); }
+
+      /* L.3 — Backdrop image with text overlay */
+      .l3 {
+        position: relative;
+        overflow: hidden;
+        color: var(--cream);
+        min-height: 280px;
+      }
+      .l3-bg {
+        position: absolute;
+        inset: -8px;
+        z-index: 0;
+      }
+      .l3-bg .cover-img {
+        width: 100%;
+        height: 100%;
+        filter: blur(2px) brightness(0.7);
+      }
+      .l3-bg .cover-img::after {
+        font-size: 48px;
+      }
+      .l3-overlay {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, rgba(31, 95, 63, 0.85) 0%, rgba(19, 61, 40, 0.7) 60%, rgba(19, 61, 40, 0.92) 100%);
+        z-index: 1;
+      }
+      .l3-content {
+        position: relative;
+        z-index: 2;
+        padding: 48px 36px;
+        max-width: 620px;
+      }
+
+      /* L.4 — Inline ticket-stub */
+      .l4 {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 22px 28px;
+      }
+      .l4-stack {
+        display: grid;
+        grid-template-columns: auto auto 1fr auto;
+        gap: 20px;
+        align-items: center;
+      }
+      @media (max-width: 880px) { .l4-stack { grid-template-columns: 1fr; } }
+      .l4-stub {
+        background: #f0c264;
+        color: var(--ink);
+        padding: 12px 18px;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+        position: relative;
+      }
+      .l4-stub::before, .l4-stub::after {
+        content: "";
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        background: var(--jersey-deep);
+        border-radius: 50%;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      .l4-stub::before { left: -7px; }
+      .l4-stub::after { right: -7px; }
+      .l4 .cover-img {
+        width: 100px;
+        aspect-ratio: 16/9;
+        border: 1px solid var(--ink);
+      }
+      .l4 .cover-img::after {
+        font-size: 14px;
+      }
+      .l4 .text { min-width: 240px; }
+      .l4 .h { font-size: 22px; line-height: 1.18; margin-bottom: 4px; }
+      .l4 .when { margin-bottom: 0; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 10 · FeaturedEventBand composition</div>
+      <h1>FeaturedEventBand — composition</h1>
+      <p>
+        New component from Round 3 (IA · E.2). Jersey-deep band between EditorialHero and
+        bannerSlotA. Drop-if-empty. Renders one event flagged
+        <code>featuredOnHome === true</code> with future <code>dateStart</code>. This round
+        picks the layout.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Section background = jersey-deep. Section is
+      drop-if-empty. Renders one event with <code>title</code>, <code>dateStart</code> (required),
+      optional <code>dateEnd</code>, <code>coverImage</code>, optional <code>externalLink</code>.
+      Cream text + warm-yellow accent. <strong>This round picks the composition.</strong>
+    </div>
+
+    <div class="container">
+
+      <!-- L.1 — Image left, text right -->
+      <section class="candidate" id="L1">
+        <header>
+          <div>
+            <div class="key">L.1</div>
+            <div class="name">Image left (TapedFigure) · text right</div>
+            <div class="desc">
+              Cover image as a TapedFigure polaroid on the left (1fr), text + CTA on the right
+              (1.4fr). Image carries the visual moment; text is supportive. Mobile stacks
+              image-above-text.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Reuses TapedFigure (NewsCard cover, EditorialHero cover)<br />
+            + Image is real, not decorative<br />
+            − Vertical height larger than text-only<br />
+            − Two TapedFigures in a row if hero also has cover
+          </div>
+        </header>
+        <div class="l1">
+          <div class="l1-grid">
+            <div class="image">
+              <div class="taped">
+                <div class="cover-img"></div>
+              </div>
+            </div>
+            <div>
+              <div class="meta-line">Aanstaand evenement</div>
+              <h2 class="h"><span class="accent">Quiz</span> in de kantine, vrijdagavond.</h2>
+              <div class="when">Vr 10 mei · 20:00 · Kantine</div>
+              <a class="cta">Reserveer je plaats <span class="arrow">→</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- L.2 — Image right, text left -->
+      <section class="candidate" id="L2">
+        <header>
+          <div>
+            <div class="key">L.2</div>
+            <div class="name">Text left · image right (TapedFigure)</div>
+            <div class="desc">
+              Mirror of L.1. Text left (1.4fr), image right (1fr). Reading-order priority on
+              text. Mobile flips image to top.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Text gets reading priority<br />
+            + Image acts as "what's coming" pull<br />
+            − Mirror of L.1 — same band, same height<br />
+            − Mobile order reversal needs care
+          </div>
+        </header>
+        <div class="l2">
+          <div class="l2-grid">
+            <div>
+              <div class="meta-line">Aanstaand evenement</div>
+              <h2 class="h"><span class="accent">Quiz</span> in de kantine, vrijdagavond.</h2>
+              <div class="when">Vr 10 mei · 20:00 · Kantine</div>
+              <a class="cta">Reserveer je plaats <span class="arrow">→</span></a>
+            </div>
+            <div class="image-col">
+              <div class="taped">
+                <div class="cover-img"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- L.3 — Backdrop image with text overlay -->
+      <section class="candidate" id="L3">
+        <header>
+          <div>
+            <div class="key">L.3</div>
+            <div class="name">Image as backdrop · text overlay (YouthBlock pattern)</div>
+            <div class="desc">
+              Cover image fills the full section, blurred 2px, with jersey-deep gradient overlay.
+              Same backdrop pattern as YouthBlock. Text foreground, no separate image element.
+              Image becomes atmospheric.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Compact vertical, no extra image area<br />
+            + Atmospheric register<br />
+            − Same pattern as YouthBlock (could feel repetitive)<br />
+            − Cover image detail lost
+          </div>
+        </header>
+        <div class="l3">
+          <div class="l3-bg">
+            <div class="cover-img"></div>
+          </div>
+          <div class="l3-overlay"></div>
+          <div class="l3-content">
+            <div class="meta-line" style="color: var(--cream);">Aanstaand evenement</div>
+            <h2 class="h"><span class="accent">Quiz</span> in de kantine, vrijdagavond.</h2>
+            <div class="when">Vr 10 mei · 20:00 · Kantine</div>
+            <a class="cta">Reserveer je plaats <span class="arrow">→</span></a>
+          </div>
+        </div>
+      </section>
+
+      <!-- L.4 — Inline ticket-stub (compact) -->
+      <section class="candidate" id="L4">
+        <header>
+          <div>
+            <div class="key">L.4</div>
+            <div class="name">Inline ticket-stub · narrow band, compact</div>
+            <div class="desc">
+              Compact 1-row band. Yellow ticket-stub chip ("VR 10/05") + small thumbnail image
+              + headline + when + CTA. Smallest vertical footprint. Reads like a ticket clipped
+              to the page.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Smallest vertical footprint<br />
+            + Strong "ticket / save the date" register<br />
+            − Image very small (less visual weight)<br />
+            − Mobile must reflow gracefully
+          </div>
+        </header>
+        <div class="l4">
+          <div class="l4-stack">
+            <span class="l4-stub">VR · 10/05</span>
+            <div class="cover-img"></div>
+            <div class="text">
+              <div class="meta-line">Aanstaand evenement</div>
+              <h2 class="h"><span class="accent">Quiz</span> in de kantine.</h2>
+              <div class="when">20:00 · Kantine</div>
+            </div>
+            <a class="cta">Reserveer <span class="arrow">→</span></a>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>CTA copy.</strong> "Reserveer je plaats →" assumes the event has reservation
+        flow. If <code>externalLink.label</code> is present on the event, use that instead
+        ("Bekijk evenement" / "Meer info" / supplier-supplied label). Fallback when no
+        externalLink: link to <code>/evenementen/{slug}</code> with "Meer info →".
+      </p>
+      <p>
+        <strong>Out of scope.</strong> dateEnd display rules (event spans multiple days):
+        likely "10 mei – 12 mei" formatting at implementation. Time-zone formatting (always
+        Europe/Brussels). Empty externalLink fallback URL.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-1b-carousel-thumbnails-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-1b-carousel-thumbnails-comparisons.html
@@ -1,0 +1,826 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 1b · Carousel — keeping articles 2 & 3 visible</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --ink-soft: #2a2a2a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --tape: #d9b85a;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-deep: 6px 6px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1280px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, "Times New Roman", serif;
+        font-style: italic;
+        font-size: 36px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1280px;
+        margin: 0 auto 28px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 56px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-deep);
+      }
+      .candidate header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 18px 22px 14px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 26px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate header .desc {
+        max-width: 60ch;
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+      }
+      .candidate header .tradeoffs {
+        font-size: 12px;
+        line-height: 1.55;
+        max-width: 38ch;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .candidate .surface {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 0;
+      }
+
+      /* shared hero atoms */
+      .kicker {
+        display: inline-flex;
+        gap: 10px;
+        align-items: center;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        color: var(--cream);
+      }
+      .kicker .pill {
+        background: var(--cream);
+        color: var(--ink);
+        padding: 3px 8px;
+        line-height: 1;
+      }
+      .kicker .dot { opacity: 0.45; }
+      .h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 14px 0;
+        color: var(--cream);
+      }
+      .h1.lg { font-size: 44px; }
+      .h1.md { font-size: 28px; }
+      .h1.sm { font-size: 18px; }
+      .h1 .accent { color: #f0c264; font-style: italic; }
+      .lead {
+        font-size: 15px;
+        line-height: 1.55;
+        max-width: 50ch;
+        margin: 0 0 14px;
+        opacity: 0.88;
+      }
+      .byline {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.65;
+      }
+      .read-more {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: #f0c264;
+        margin-top: 12px;
+        font-weight: bold;
+      }
+      .taped {
+        position: relative;
+        background: var(--cream);
+        padding: 6px 6px 8px;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 #000;
+      }
+      .taped .tape {
+        position: absolute;
+        top: -8px;
+        width: 48px;
+        height: 12px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .taped .tape.left { left: 12px; }
+      .taped .tape.right { right: 12px; transform: rotate(3deg); }
+      .img {
+        width: 100%;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        position: relative;
+      }
+      .img.alt-1 { background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%); }
+      .img.alt-2 { background: linear-gradient(135deg, #4d2a2a 0%, #7a5454 50%, #c19a4a 100%); }
+      .img.alt-3 { background: linear-gradient(135deg, #2a3a4d 0%, #54627a 50%, #4a8ac1 100%); }
+      .img::after {
+        content: attr(data-tag);
+        position: absolute;
+        bottom: 6px;
+        left: 6px;
+        background: rgba(26, 26, 26, 0.78);
+        color: var(--cream);
+        padding: 2px 6px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .img.aspect-16-9 { aspect-ratio: 16 / 9; }
+      .img.aspect-square { aspect-ratio: 1 / 1; }
+
+      /* shared controls */
+      .controls {
+        display: inline-flex;
+        align-items: center;
+        gap: 14px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.85;
+        margin-top: 18px;
+      }
+      .progress {
+        display: inline-block;
+        width: 56px;
+        height: 2px;
+        background: rgba(245, 239, 225, 0.25);
+        position: relative;
+      }
+      .progress::after {
+        content: "";
+        position: absolute;
+        left: 0; top: 0; bottom: 0;
+        width: 35%;
+        background: var(--cream);
+      }
+
+      /* annotation chip */
+      .anno {
+        display: inline-block;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        background: var(--cream);
+        color: var(--ink);
+        padding: 2px 6px;
+      }
+
+      /* ===== Layout D.1 — strip below ===== */
+      .d1 { padding: 36px 32px 28px; }
+      .d1-main {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 36px;
+        align-items: center;
+      }
+      .d1-strip {
+        margin-top: 28px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        padding-top: 18px;
+        border-top: 1px solid rgba(245, 239, 225, 0.25);
+      }
+      .d1-thumb {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        opacity: 0.6;
+        cursor: pointer;
+      }
+      .d1-thumb.active {
+        opacity: 1;
+      }
+      .d1-thumb.active .img-shell {
+        outline: 2px solid #f0c264;
+        outline-offset: 2px;
+      }
+      .d1-thumb .img-shell {
+        width: 80px;
+        flex-shrink: 0;
+      }
+      .d1-thumb .meta-col {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 12px;
+        line-height: 1.3;
+      }
+      .d1-thumb .meta-col .num {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        opacity: 0.6;
+        letter-spacing: 0.14em;
+      }
+      .d1-thumb .meta-col .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+      }
+
+      /* ===== Layout D.2 — vertical side rail ===== */
+      .d2 {
+        display: grid;
+        grid-template-columns: 72fr 28fr;
+        gap: 0;
+        min-height: 460px;
+      }
+      .d2-main {
+        padding: 36px 28px 36px 32px;
+      }
+      .d2-rail {
+        background: rgba(245, 239, 225, 0.06);
+        border-left: 1px solid rgba(245, 239, 225, 0.2);
+        padding: 24px 22px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+      .d2-rail .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.6;
+      }
+      .d2-card {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        opacity: 0.55;
+        cursor: pointer;
+      }
+      .d2-card.active { opacity: 1; }
+      .d2-card.active .img-shell { outline: 2px solid #f0c264; outline-offset: 2px; }
+      .d2-card .num {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        opacity: 0.7;
+      }
+      .d2-card .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.25;
+      }
+
+      /* ===== Layout D.3 — focus carousel (3 visible, active expanded) ===== */
+      .d3 {
+        padding: 36px 32px;
+        display: grid;
+        grid-template-columns: 18fr 64fr 18fr;
+        gap: 18px;
+        align-items: center;
+      }
+      .d3-side {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        opacity: 0.55;
+        cursor: pointer;
+      }
+      .d3-side .num {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        opacity: 0.7;
+      }
+      .d3-side .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.2;
+      }
+      .d3-active {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 28px;
+        align-items: center;
+      }
+
+      /* ===== Layout D.4 — now playing + up next ===== */
+      .d4 { padding: 36px 32px; }
+      .d4-main {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 36px;
+        align-items: center;
+      }
+      .d4-upnext {
+        margin-top: 24px;
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        padding: 14px 16px;
+        background: rgba(245, 239, 225, 0.06);
+        border-left: 3px solid #f0c264;
+      }
+      .d4-upnext .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .d4-upnext .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 16px;
+        line-height: 1.25;
+      }
+      .d4-upnext .img-shell { width: 110px; flex-shrink: 0; }
+      .d4-upnext .meta-col {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .d4-upnext .arrow {
+        font-family: ui-monospace, monospace;
+        opacity: 0.7;
+      }
+
+      .footnote {
+        max-width: 1280px;
+        margin: 36px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+        color: var(--ink);
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+
+      @media (max-width: 880px) {
+        .d1-main, .d4-main, .d3-active { grid-template-columns: 1fr; }
+        .d2 { grid-template-columns: 1fr; }
+        .d3 { grid-template-columns: 1fr; }
+        .d2-rail { border-left: 0; border-top: 1px solid rgba(245, 239, 225, 0.2); }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 1b · D-sub-drill</div>
+      <h1>Carousel — how do articles 2 & 3 stay visible?</h1>
+      <p>
+        Round 1 leaning toward Variant D (carousel reskinned), with the concern: <em>"without
+        thumbnails for article 2/3, they will get snowed under."</em> Right — that's the standard
+        carousel failure mode (only the dot indicator hints at the other slides). Below: four ways
+        to keep the secondary articles persistently visible while preserving the auto-rotation.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from Round 1.</strong> Hero shape direction = <strong>D · Carousel reskinned</strong>
+      (ink band, retro chrome, auto-rotation preserved). A / B / C are off the table — drilling only
+      the thumbnail-visibility treatment now.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ D.1 — Strip below ============ -->
+      <section class="candidate" id="D1">
+        <header>
+          <div>
+            <div class="key">D.1</div>
+            <div class="name">Strip below</div>
+          </div>
+          <div class="desc">
+            Active article occupies the full hero band; below it, a 3-column horizontal strip shows
+            all 3 thumbnails (image + numbered label + truncated headline). Active thumb has a
+            jersey-yellow outline + full opacity; inactive thumbs sit at 60% opacity. Clicking a
+            thumb jumps the carousel.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + All 3 always visible<br />
+            + Each thumb is a real click target<br />
+            − Adds vertical height (~110px below the hero)<br />
+            − Mobile collapses to a horizontal scroll
+          </div>
+        </header>
+        <div class="surface">
+          <div class="d1">
+            <div class="d1-main">
+              <div>
+                <div class="kicker">
+                  <span class="pill">Interview</span>
+                  <span class="dot">·</span>
+                  <span>5 mei 2026</span>
+                  <span class="dot">·</span>
+                  <span>6 min lezen</span>
+                </div>
+                <h2 class="h1 lg">
+                  <em class="accent">"Met deze ploeg</em><br />
+                  kunnen we ver geraken."
+                </h2>
+                <p class="lead">
+                  Aanvoerder Jens De Smet over de promotiekansen, het nieuwe trainingsritme en
+                  waarom de groep dit jaar anders aanvoelt.
+                </p>
+                <div class="byline">door Tom Janssens</div>
+                <div class="read-more">★ Lees verder →</div>
+                <div class="controls">
+                  <span>1 / 3</span>
+                  <span class="progress"></span>
+                  <span>auto · 5s</span>
+                  <span>‖ pauzeer</span>
+                </div>
+              </div>
+              <div>
+                <div class="taped" style="transform: rotate(0.6deg);">
+                  <div class="tape left"></div>
+                  <div class="tape right"></div>
+                  <div class="img alt-1 aspect-16-9" data-tag="kcvv · jens"></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="d1-strip">
+              <div class="d1-thumb active">
+                <div class="img-shell">
+                  <div class="img alt-1 aspect-16-9" data-tag=""></div>
+                </div>
+                <div class="meta-col">
+                  <div class="num">1 / 3 · NU</div>
+                  <div class="h">"Met deze ploeg…"</div>
+                  <div class="byline" style="font-size: 9px; opacity: 0.5;">interview · 5 mei</div>
+                </div>
+              </div>
+              <div class="d1-thumb">
+                <div class="img-shell">
+                  <div class="img alt-2 aspect-16-9" data-tag=""></div>
+                </div>
+                <div class="meta-col">
+                  <div class="num">2 / 3</div>
+                  <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+                  <div class="byline" style="font-size: 9px; opacity: 0.5;">transfer · 3 mei</div>
+                </div>
+              </div>
+              <div class="d1-thumb">
+                <div class="img-shell">
+                  <div class="img alt-3 aspect-16-9" data-tag=""></div>
+                </div>
+                <div class="meta-col">
+                  <div class="num">3 / 3</div>
+                  <div class="h">Quiz in de kantine, vrijdag.</div>
+                  <div class="byline" style="font-size: 9px; opacity: 0.5;">evenement · 1 mei</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D.2 — Side rail (right) ============ -->
+      <section class="candidate" id="D2">
+        <header>
+          <div>
+            <div class="key">D.2</div>
+            <div class="name">Side rail</div>
+          </div>
+          <div class="desc">
+            Active article fills 72% of the hero band on the left; the right 28% is a vertical
+            stack of 3 thumb cards (image-on-top, kicker + headline below). Mirrors the
+            "newsstand front + side rack" pattern (Real Madrid / The Athletic). Active card is
+            outlined; on rotation, the outline migrates.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + All 3 visible without adding vertical height<br />
+            + Strong magazine "front + sidebar" register<br />
+            − Tightens the lead block (less width for headline)<br />
+            − Mobile must collapse rail below (becomes D.1-ish)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="d2">
+            <div class="d2-main">
+              <div class="kicker">
+                <span class="pill">Interview</span>
+                <span class="dot">·</span>
+                <span>5 mei 2026</span>
+                <span class="dot">·</span>
+                <span>6 min lezen</span>
+              </div>
+              <h2 class="h1 md">
+                <em class="accent">"Met deze ploeg</em> kunnen we<br />
+                ver geraken."
+              </h2>
+              <p class="lead">
+                Aanvoerder Jens De Smet over de promotiekansen, het nieuwe trainingsritme en
+                waarom de groep dit jaar anders aanvoelt.
+              </p>
+              <div style="margin-top: 14px; max-width: 460px;">
+                <div class="taped" style="transform: rotate(-0.4deg);">
+                  <div class="tape left"></div>
+                  <div class="img alt-1 aspect-16-9" data-tag="kcvv · jens"></div>
+                </div>
+              </div>
+              <div class="byline" style="margin-top: 14px;">door Tom Janssens</div>
+              <div class="controls">
+                <span>1 / 3</span>
+                <span class="progress"></span>
+                <span>auto · 5s</span>
+                <span>‖ pauzeer</span>
+              </div>
+            </div>
+
+            <div class="d2-rail">
+              <div class="label">Ook in beeld</div>
+              <div class="d2-card active">
+                <div class="img-shell">
+                  <div class="img alt-1 aspect-16-9" data-tag=""></div>
+                </div>
+                <div class="num">1 / 3 · NU</div>
+                <div class="h">"Met deze ploeg…"</div>
+              </div>
+              <div class="d2-card">
+                <div class="img-shell">
+                  <div class="img alt-2 aspect-16-9" data-tag=""></div>
+                </div>
+                <div class="num">2 / 3</div>
+                <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              </div>
+              <div class="d2-card">
+                <div class="img-shell">
+                  <div class="img alt-3 aspect-16-9" data-tag=""></div>
+                </div>
+                <div class="num">3 / 3</div>
+                <div class="h">Quiz in de kantine, vrijdag.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D.3 — Focus carousel ============ -->
+      <section class="candidate" id="D3">
+        <header>
+          <div>
+            <div class="key">D.3</div>
+            <div class="name">Focus carousel</div>
+          </div>
+          <div class="desc">
+            Three columns. Center column (64%) is the active article — full hero treatment (kicker
+            / headline / lead / cover). Left and right columns (~18% each) show the previous and
+            next articles as taped thumbs with truncated headline. On rotation, the trio shifts:
+            left → center, center → right, right → off-screen. Most balanced visibility.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + All 3 always visible at meaningful size<br />
+            + Strong "now / coming up" rhythm<br />
+            − Active block is narrower than D.1 (lead text wraps)<br />
+            − Animation choreography is more complex (3 concurrent transforms)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="d3">
+            <div class="d3-side">
+              <div class="taped" style="transform: rotate(-1deg);">
+                <div class="tape left"></div>
+                <div class="img alt-3 aspect-16-9" data-tag=""></div>
+              </div>
+              <div class="num">3 / 3 · vorige</div>
+              <div class="h">Quiz in de kantine.</div>
+            </div>
+
+            <div class="d3-active">
+              <div>
+                <div class="kicker">
+                  <span class="pill">Interview</span>
+                  <span class="dot">·</span>
+                  <span>5 mei</span>
+                </div>
+                <h2 class="h1 md">
+                  <em class="accent">"Met deze ploeg</em><br />
+                  kunnen we ver geraken."
+                </h2>
+                <p class="lead">
+                  Aanvoerder Jens De Smet over de promotiekansen en het nieuwe trainingsritme.
+                </p>
+                <div class="byline">door Tom Janssens · ★ lees verder →</div>
+                <div class="controls">
+                  <span>1 / 3 · NU</span>
+                  <span class="progress"></span>
+                  <span>auto · 5s</span>
+                </div>
+              </div>
+              <div>
+                <div class="taped" style="transform: rotate(0.4deg);">
+                  <div class="tape left"></div>
+                  <div class="tape right"></div>
+                  <div class="img alt-1 aspect-16-9" data-tag="kcvv · jens"></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="d3-side">
+              <div class="taped" style="transform: rotate(0.8deg);">
+                <div class="tape right"></div>
+                <div class="img alt-2 aspect-16-9" data-tag=""></div>
+              </div>
+              <div class="num">2 / 3 · volgende</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D.4 — Now playing / up next ============ -->
+      <section class="candidate" id="D4">
+        <header>
+          <div>
+            <div class="key">D.4</div>
+            <div class="name">Now playing / up next</div>
+          </div>
+          <div class="desc">
+            Active article gets the full hero treatment, but only ONE secondary article is
+            previewed at a time — the one coming up next on rotation. Rendered as a thin
+            "VOLGENDE →" band below the hero with a small thumb + headline. The third article
+            only becomes visible on rotation. Compact; mimics a "coming up" radio promo.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Adds zero vertical complexity beyond D.1<br />
+            + "Up next" framing is intuitive<br />
+            − Article 3 is still hidden until rotation<br />
+            − Only partially solves the original "snowed under" concern
+          </div>
+        </header>
+        <div class="surface">
+          <div class="d4">
+            <div class="d4-main">
+              <div>
+                <div class="kicker">
+                  <span class="pill">Interview</span>
+                  <span class="dot">·</span>
+                  <span>5 mei 2026</span>
+                  <span class="dot">·</span>
+                  <span>6 min lezen</span>
+                </div>
+                <h2 class="h1 lg">
+                  <em class="accent">"Met deze ploeg</em><br />
+                  kunnen we ver geraken."
+                </h2>
+                <p class="lead">
+                  Aanvoerder Jens De Smet over de promotiekansen, het nieuwe trainingsritme en
+                  waarom de groep dit jaar anders aanvoelt.
+                </p>
+                <div class="byline">door Tom Janssens</div>
+                <div class="read-more">★ Lees verder →</div>
+                <div class="controls">
+                  <span>1 / 3</span>
+                  <span class="progress"></span>
+                  <span>auto · 5s</span>
+                  <span>‖ pauzeer</span>
+                </div>
+              </div>
+              <div>
+                <div class="taped" style="transform: rotate(0.6deg);">
+                  <div class="tape left"></div>
+                  <div class="tape right"></div>
+                  <div class="img alt-1 aspect-16-9" data-tag="kcvv · jens"></div>
+                </div>
+              </div>
+            </div>
+            <div class="d4-upnext">
+              <div class="label">Volgende →</div>
+              <div class="img-shell">
+                <div class="img alt-2 aspect-16-9" data-tag=""></div>
+              </div>
+              <div class="meta-col">
+                <div class="anno">2 / 3 · TRANSFER</div>
+                <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+                <div class="byline" style="opacity: 0.55;">door redactie · 3 mei</div>
+              </div>
+              <div class="arrow">↗</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>How they auto-rotate.</strong> Every option above keeps a 5-second auto-rotation tick.
+        D.1 / D.2 swap which thumb is outlined. D.3 shifts the trio horizontally (left → center → right
+        rolls forward). D.4 swaps the "Volgende →" preview to whichever article is queued next.
+      </p>
+      <p>
+        <strong>What they all share.</strong> Active article = full Phase 3 EditorialHero treatment
+        (kicker chips · italic display H1 · lead · byline · taped 16:9 cover · "★ Lees verder →"
+        hover). Click anywhere in the active region jumps to <code>/nieuws/{slug}</code>.
+        Pause / play and progress bar live in the same spot in every variant.
+      </p>
+      <p>
+        <strong>Out of scope this sub-round.</strong> How the 3 articles get picked (Round 2 next),
+        whether the carousel is "use client" or server-rendered (implementation detail), exact motion
+        easing of the rotation transition, focus management between thumbs (Storybook later).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-2-hero-source-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-2-hero-source-comparisons.html
@@ -1,0 +1,740 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 2 · Hero source — how are the 3 articles picked?</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-deep: 6px 6px 0 0 var(--ink);
+        --studio-bg: #f6f6f7;
+        --studio-border: #d4d4d8;
+        --studio-input: #ffffff;
+        --studio-accent: #156dff;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1280px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 36px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1280px;
+        margin: 0 auto 20px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 28px;
+      }
+      @media (max-width: 1080px) {
+        .container { grid-template-columns: 1fr; }
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+        display: flex;
+        flex-direction: column;
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 24px;
+        line-height: 1.15;
+        margin: 4px 0 6px;
+      }
+      .candidate header .desc {
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+        max-width: 56ch;
+      }
+      .candidate .body {
+        padding: 18px 20px 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .panel-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 6px;
+      }
+
+      /* ===== Studio mockup ===== */
+      .studio {
+        background: var(--studio-bg);
+        border: 1px solid var(--studio-border);
+        font-family: -apple-system, "Segoe UI", sans-serif;
+        font-size: 13px;
+        color: #1a1d20;
+        padding: 14px 16px;
+      }
+      .studio .doc-title {
+        font-size: 15px;
+        font-weight: 600;
+        margin-bottom: 14px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: #2a2d31;
+      }
+      .studio .doc-title .icon {
+        width: 18px;
+        height: 18px;
+        background: var(--studio-accent);
+        color: white;
+        font-size: 11px;
+        line-height: 18px;
+        text-align: center;
+        font-weight: 700;
+      }
+      .studio .field {
+        margin-bottom: 12px;
+      }
+      .studio .field-label {
+        font-size: 12px;
+        font-weight: 600;
+        margin-bottom: 4px;
+        color: #2a2d31;
+      }
+      .studio .field-help {
+        font-size: 11px;
+        color: #6b7079;
+        margin-bottom: 4px;
+        line-height: 1.4;
+      }
+      .studio .input {
+        background: var(--studio-input);
+        border: 1px solid var(--studio-border);
+        padding: 7px 10px;
+        font-size: 13px;
+        border-radius: 2px;
+      }
+      .studio .toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+      }
+      .studio .toggle .switch {
+        width: 28px;
+        height: 16px;
+        background: var(--studio-accent);
+        border-radius: 16px;
+        position: relative;
+      }
+      .studio .toggle .switch::after {
+        content: "";
+        position: absolute;
+        right: 2px;
+        top: 2px;
+        width: 12px;
+        height: 12px;
+        background: white;
+        border-radius: 50%;
+      }
+      .studio .toggle.off .switch { background: #c8cbd0; }
+      .studio .toggle.off .switch::after { left: 2px; right: auto; }
+      .studio .ref-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--studio-input);
+        border: 1px solid var(--studio-border);
+        padding: 7px 10px;
+        font-size: 13px;
+        border-radius: 2px;
+        margin-bottom: 4px;
+      }
+      .studio .ref-row .grip {
+        font-family: monospace;
+        color: #c8cbd0;
+        cursor: grab;
+      }
+      .studio .ref-row .num {
+        font-family: monospace;
+        font-size: 11px;
+        color: #6b7079;
+        background: #eaecef;
+        padding: 1px 5px;
+        border-radius: 2px;
+      }
+      .studio .ref-row .article-icon {
+        width: 16px;
+        height: 16px;
+        background: #e8e9eb;
+        font-size: 10px;
+        line-height: 16px;
+        text-align: center;
+        font-weight: 600;
+        color: #6b7079;
+      }
+      .studio .add-ref {
+        font-size: 12px;
+        color: var(--studio-accent);
+        padding: 6px 10px;
+        border: 1px dashed var(--studio-border);
+        text-align: left;
+        margin-top: 4px;
+      }
+      .studio .row-list {
+        display: flex;
+        flex-direction: column;
+      }
+      .studio .article-row-tiny {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        background: var(--studio-input);
+        border: 1px solid var(--studio-border);
+        border-bottom: none;
+        padding: 8px 10px;
+        font-size: 12px;
+      }
+      .studio .article-row-tiny:last-child { border-bottom: 1px solid var(--studio-border); }
+      .studio .article-row-tiny .star {
+        font-size: 13px;
+        opacity: 0.5;
+      }
+      .studio .article-row-tiny.featured .star {
+        opacity: 1;
+        color: #f0a020;
+      }
+      .studio .article-row-tiny .meta {
+        flex: 1;
+      }
+      .studio .article-row-tiny .meta .t {
+        font-weight: 500;
+        color: #2a2d31;
+      }
+      .studio .article-row-tiny .meta .d {
+        font-size: 10px;
+        color: #6b7079;
+      }
+      .studio .article-row-tiny .at {
+        font-size: 10px;
+        color: #6b7079;
+      }
+      .studio .help-block {
+        background: #fffbe5;
+        border: 1px solid #f0d878;
+        padding: 8px 10px;
+        font-size: 11px;
+        color: #604a00;
+        line-height: 1.4;
+      }
+
+      /* ===== Result preview (the homepage hero D.1) ===== */
+      .result {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 14px 16px;
+        font-size: 11px;
+        font-family: ui-monospace, monospace;
+      }
+      .result-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 8px;
+      }
+      .hero-mini {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 10px;
+        align-items: stretch;
+        margin-bottom: 8px;
+      }
+      .hero-mini .left { display: flex; flex-direction: column; justify-content: center; }
+      .hero-mini .pill {
+        display: inline-block;
+        background: var(--cream);
+        color: var(--ink);
+        padding: 1px 5px;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+        width: fit-content;
+      }
+      .hero-mini .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.15;
+        color: var(--cream);
+        margin-bottom: 4px;
+      }
+      .hero-mini .h .accent { color: #f0c264; }
+      .hero-mini .b {
+        font-size: 9px;
+        opacity: 0.6;
+      }
+      .hero-mini .cover {
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        aspect-ratio: 16 / 9;
+        position: relative;
+        outline: 1px solid var(--cream);
+      }
+      .strip-mini {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 8px;
+        padding-top: 8px;
+        border-top: 1px solid rgba(245, 239, 225, 0.25);
+      }
+      .strip-mini .thumb {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        opacity: 0.55;
+      }
+      .strip-mini .thumb.active { opacity: 1; }
+      .strip-mini .thumb.active .img {
+        outline: 1px solid #f0c264;
+      }
+      .strip-mini .thumb .img {
+        width: 28px;
+        flex-shrink: 0;
+        aspect-ratio: 16 / 9;
+        background: linear-gradient(135deg, #2a4d3a, #c1a04a);
+      }
+      .strip-mini .thumb .img.alt-2 { background: linear-gradient(135deg, #4d2a2a, #c19a4a); }
+      .strip-mini .thumb .img.alt-3 { background: linear-gradient(135deg, #2a3a4d, #4a8ac1); }
+      .strip-mini .thumb .meta {
+        font-size: 9px;
+        line-height: 1.2;
+      }
+      .strip-mini .thumb .meta .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+      }
+      .strip-mini .thumb .meta .num {
+        opacity: 0.6;
+      }
+
+      /* ===== Edge case + cost callouts ===== */
+      .matrix {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+        font-size: 12px;
+        line-height: 1.5;
+      }
+      .matrix-row {
+        display: grid;
+        grid-template-columns: 130px 1fr;
+        gap: 12px;
+        padding: 8px 10px;
+        background: var(--cream-soft);
+        border-left: 3px solid var(--ink);
+      }
+      .matrix-row.warn { border-left-color: #c87a00; }
+      .matrix-row.cost-add { border-left-color: var(--jersey-deep); }
+      .matrix-row .k {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.75;
+      }
+      .matrix-row .v {
+        font-size: 12px;
+      }
+      .matrix-row code {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        background: rgba(26, 26, 26, 0.06);
+        padding: 1px 4px;
+      }
+
+      .footnote {
+        max-width: 1280px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 2 · Hero source</div>
+      <h1>How are the 3 hero articles picked?</h1>
+      <p>
+        Round 1 + 1b locked: hero shape = <strong>D.1 carousel with strip-below thumbnails</strong>.
+        Visual output is identical regardless of source. This round drills the editorial workflow:
+        which of the published articles end up in the carousel, who decides, and what happens at
+        the edges (0 featured, 1 featured, 5+ featured, no published articles).
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from Round 1 / 1b.</strong> Carousel reskinned (<strong>D</strong>) ·
+      strip-below thumbnails (<strong>D.1</strong>). All 4 candidates below render the same
+      D.1 hero — the difference is upstream.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ S.1 — Auto: 3 most recent ============ -->
+      <section class="candidate" id="S1">
+        <header>
+          <div class="key">S.1</div>
+          <div class="name">Auto · 3 most recent</div>
+          <div class="desc">
+            Today's behavior, kept as-is. Carousel renders the 3 most recently published articles
+            ordered by <code>publishedAt desc</code>. Editor does nothing — every new article
+            becomes the lead the moment it publishes; the previous lead demotes to slot 2.
+          </div>
+        </header>
+        <div class="body">
+          <div>
+            <div class="panel-label">Studio editor view</div>
+            <div class="studio">
+              <div class="doc-title"><span class="icon">A</span> Article — "Met deze ploeg…"</div>
+              <div class="field">
+                <div class="field-label">Title</div>
+                <div class="input">"Met deze ploeg kunnen we ver geraken."</div>
+              </div>
+              <div class="field">
+                <div class="field-label">Published at</div>
+                <div class="input">5 mei 2026 · 09:30</div>
+              </div>
+              <div class="field">
+                <div class="field-label">Featured</div>
+                <div class="toggle off"><span class="switch"></span><span>Off — not used by homepage hero</span></div>
+              </div>
+              <div class="help-block">
+                The <code>featured</code> field is on the schema but the homepage hero ignores it.
+                No editor action selects which articles appear — recency wins.
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Resulting hero (always)</div>
+            <div class="result">
+              <div class="result-label">/ — homepage hero</div>
+              <div class="hero-mini">
+                <div class="left">
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                  <div class="b">5 mei · most recent</div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="thumb active"><div class="img"></div><div class="meta"><div class="num">1/3</div><div class="h">Interview</div></div></div>
+                <div class="thumb"><div class="img alt-2"></div><div class="meta"><div class="num">2/3</div><div class="h">Transfer</div></div></div>
+                <div class="thumb"><div class="img alt-3"></div><div class="meta"><div class="num">3/3</div><div class="h">Event</div></div></div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Edge cases + cost</div>
+            <div class="matrix">
+              <div class="matrix-row"><div class="k">0 articles</div><div class="v">Hero hidden; page renders without the carousel band.</div></div>
+              <div class="matrix-row"><div class="k">1 or 2 articles</div><div class="v">Carousel renders with 1 or 2 thumbs; strip is <code>repeat(N, 1fr)</code>.</div></div>
+              <div class="matrix-row"><div class="k">5+ articles</div><div class="v">Slice the 3 newest; older articles drop off the hero into NewsGrid.</div></div>
+              <div class="matrix-row"><div class="k">Schema cost</div><div class="v"><strong>Zero.</strong> Ships the existing <code>ARTICLES_QUERY</code> as-is.</div></div>
+              <div class="matrix-row"><div class="k">Editor cost</div><div class="v"><strong>Zero per week.</strong> Article publish = automatic hero placement.</div></div>
+              <div class="matrix-row warn"><div class="k">Risk</div><div class="v">No editorial control. A throwaway transfer note can supplant a long-form interview the same day.</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ S.2 — article.featured boolean ============ -->
+      <section class="candidate" id="S2">
+        <header>
+          <div class="key">S.2</div>
+          <div class="name">Editor flips <code>featured</code> on each article</div>
+          <div class="desc">
+            Use the <code>featured</code> boolean already on the article schema. Hero shows the
+            3 most recent articles where <code>featured = true</code>; falls back to most-recent
+            (S.1 logic) if fewer than 3 are flagged. Editor curates by toggling the flag on
+            individual article documents.
+          </div>
+        </header>
+        <div class="body">
+          <div>
+            <div class="panel-label">Studio editor view</div>
+            <div class="studio">
+              <div class="doc-title"><span class="icon">A</span> Article — "Met deze ploeg…"</div>
+              <div class="field">
+                <div class="field-label">Featured</div>
+                <div class="field-help">Toggle on to surface this article in the homepage hero carousel. The 3 most recently flagged articles are shown.</div>
+                <div class="toggle"><span class="switch"></span><span>On — shown in homepage hero</span></div>
+              </div>
+              <div class="row-list" style="margin-top: 14px;">
+                <div class="panel-label" style="margin-bottom: 4px;">Currently flagged (admin view)</div>
+                <div class="article-row-tiny featured"><span class="star">★</span><div class="meta"><div class="t">"Met deze ploeg…"</div><div class="d">interview · 5 mei</div></div><span class="at">1/3</span></div>
+                <div class="article-row-tiny featured"><span class="star">★</span><div class="meta"><div class="t">Wim G. tekent voor 2 seizoenen.</div><div class="d">transfer · 3 mei</div></div><span class="at">2/3</span></div>
+                <div class="article-row-tiny featured"><span class="star">★</span><div class="meta"><div class="t">Quiz in de kantine, vrijdag.</div><div class="d">event · 1 mei</div></div><span class="at">3/3</span></div>
+                <div class="article-row-tiny"><span class="star">★</span><div class="meta"><div class="t">U17 wint van VKT.</div><div class="d">match · 28 apr</div></div><span class="at">—</span></div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Resulting hero</div>
+            <div class="result">
+              <div class="result-label">/ — homepage hero · featured curated</div>
+              <div class="hero-mini">
+                <div class="left">
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                  <div class="b">5 mei · ★ flagged</div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="thumb active"><div class="img"></div><div class="meta"><div class="num">1/3 ★</div><div class="h">Interview</div></div></div>
+                <div class="thumb"><div class="img alt-2"></div><div class="meta"><div class="num">2/3 ★</div><div class="h">Transfer</div></div></div>
+                <div class="thumb"><div class="img alt-3"></div><div class="meta"><div class="num">3/3 ★</div><div class="h">Event</div></div></div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Edge cases + cost</div>
+            <div class="matrix">
+              <div class="matrix-row"><div class="k">0 flagged</div><div class="v">Falls back to S.1: 3 most recent published.</div></div>
+              <div class="matrix-row"><div class="k">1 or 2 flagged</div><div class="v">Use the flagged ones first, fill remaining slots with most-recent unflagged.</div></div>
+              <div class="matrix-row"><div class="k">5+ flagged</div><div class="v">Show 3 newest flagged; older flagged ones still appear in NewsGrid.</div></div>
+              <div class="matrix-row"><div class="k">Schema cost</div><div class="v"><strong>Zero.</strong> <code>featured</code> already exists. <strong>Query change only:</strong> <code>order(featured desc, publishedAt desc)</code>.</div></div>
+              <div class="matrix-row"><div class="k">Editor cost</div><div class="v">~5s per article. One toggle per published doc; flip off when superseded.</div></div>
+              <div class="matrix-row warn"><div class="k">Risk</div><div class="v">Stale flags drift over time (editor forgets to flip off). Monthly Studio "review featured" task likely needed.</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ S.3 — homePage.heroArticles[] ordered ref array ============ -->
+      <section class="candidate" id="S3">
+        <header>
+          <div class="key">S.3</div>
+          <div class="name">Curated array on <code>homePage</code> document</div>
+          <div class="desc">
+            New field <code>homePage.heroArticles</code> — an ordered array of 1–3 article
+            references on the existing <code>homePage</code> singleton (mirrors
+            <code>bannerSlotA/B/C</code>). Editor opens one document and explicitly picks the
+            carousel order. Most editorial control; one place to manage the hero.
+          </div>
+        </header>
+        <div class="body">
+          <div>
+            <div class="panel-label">Studio editor view</div>
+            <div class="studio">
+              <div class="doc-title"><span class="icon">H</span> Homepage</div>
+              <div class="field">
+                <div class="field-label">Hero articles</div>
+                <div class="field-help">Pick 1–3 articles for the homepage hero carousel. Drag to reorder. Slot 1 leads.</div>
+                <div class="ref-row"><span class="grip">⋮⋮</span><span class="num">1</span><span class="article-icon">A</span><span style="flex:1;">"Met deze ploeg…" · interview · 5 mei</span><span style="opacity:0.5;">×</span></div>
+                <div class="ref-row"><span class="grip">⋮⋮</span><span class="num">2</span><span class="article-icon">A</span><span style="flex:1;">Wim G. tekent voor 2 seizoenen. · transfer · 3 mei</span><span style="opacity:0.5;">×</span></div>
+                <div class="ref-row"><span class="grip">⋮⋮</span><span class="num">3</span><span class="article-icon">A</span><span style="flex:1;">Quiz in de kantine, vrijdag. · event · 1 mei</span><span style="opacity:0.5;">×</span></div>
+                <div class="add-ref">＋ Add article reference (max 3)</div>
+              </div>
+              <div class="field">
+                <div class="field-label">Banner slot A</div>
+                <div class="ref-row"><span class="article-icon">B</span><span style="flex:1;">Sponsor banner · KCVV trainings</span></div>
+              </div>
+              <div class="help-block">
+                Other homepage controls (banner slots, matchesSliderPlaceholder) already live on
+                this same document — heroArticles fits the existing pattern.
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Resulting hero</div>
+            <div class="result">
+              <div class="result-label">/ — homepage hero · explicit pick</div>
+              <div class="hero-mini">
+                <div class="left">
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                  <div class="b">slot 1 · curated</div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="thumb active"><div class="img"></div><div class="meta"><div class="num">slot 1</div><div class="h">Interview</div></div></div>
+                <div class="thumb"><div class="img alt-2"></div><div class="meta"><div class="num">slot 2</div><div class="h">Transfer</div></div></div>
+                <div class="thumb"><div class="img alt-3"></div><div class="meta"><div class="num">slot 3</div><div class="h">Event</div></div></div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Edge cases + cost</div>
+            <div class="matrix">
+              <div class="matrix-row"><div class="k">Empty array</div><div class="v">Fall back to S.1 (3 most recent). Never block the hero on a missed update.</div></div>
+              <div class="matrix-row"><div class="k">1 or 2 picked</div><div class="v">Render only the picks (1 or 2 thumbs). No auto-fill.</div></div>
+              <div class="matrix-row"><div class="k">Picked article unpublished</div><div class="v">Skip it; if &lt; 3 valid, fill remaining slots from S.1 fallback.</div></div>
+              <div class="matrix-row cost-add"><div class="k">Schema cost</div><div class="v"><strong>Sanity migration.</strong> Add field to <code>homePage.ts</code>; no data backfill (default empty = S.1 behavior).</div></div>
+              <div class="matrix-row"><div class="k">Editor cost</div><div class="v">~30s per change. One trip to the homepage doc to swap the lead. Predictable.</div></div>
+              <div class="matrix-row"><div class="k">Risk</div><div class="v">Forgotten updates feel stale visibly (same lead for weeks). Visible to editor — easier to remember.</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ S.4 — Hybrid: 1 lead + 2 auto-fill ============ -->
+      <section class="candidate" id="S4">
+        <header>
+          <div class="key">S.4</div>
+          <div class="name">Hybrid · 1 lead pick + 2 auto-fill</div>
+          <div class="desc">
+            Singleton <code>homePage.leadArticle</code> reference. Slot 1 of the carousel = the
+            picked lead. Slots 2 + 3 = the next 2 most-recent published articles, excluding the
+            lead. Editor manages one decision (the lead); recency does the rest.
+          </div>
+        </header>
+        <div class="body">
+          <div>
+            <div class="panel-label">Studio editor view</div>
+            <div class="studio">
+              <div class="doc-title"><span class="icon">H</span> Homepage</div>
+              <div class="field">
+                <div class="field-label">Lead article</div>
+                <div class="field-help">Pick one article to lead the hero carousel. Slots 2 & 3 fill automatically with the next 2 most recent published articles.</div>
+                <div class="ref-row"><span class="article-icon">A</span><span style="flex:1;">"Met deze ploeg…" · interview · 5 mei</span><span style="opacity:0.5;">×</span></div>
+              </div>
+              <div class="field">
+                <div class="field-label">Auto-fill (preview)</div>
+                <div class="row-list">
+                  <div class="article-row-tiny"><span class="star" style="opacity:0.3;">+</span><div class="meta"><div class="t">Wim G. tekent voor 2 seizoenen.</div><div class="d">transfer · 3 mei · auto</div></div><span class="at">slot 2</span></div>
+                  <div class="article-row-tiny"><span class="star" style="opacity:0.3;">+</span><div class="meta"><div class="t">Quiz in de kantine, vrijdag.</div><div class="d">event · 1 mei · auto</div></div><span class="at">slot 3</span></div>
+                </div>
+              </div>
+              <div class="help-block">
+                Read-only "auto-fill" preview keeps editors honest about what they'll actually
+                see published. Auto rows update as new articles publish.
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Resulting hero</div>
+            <div class="result">
+              <div class="result-label">/ — homepage hero · lead + auto</div>
+              <div class="hero-mini">
+                <div class="left">
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                  <div class="b">slot 1 · curated lead</div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="thumb active"><div class="img"></div><div class="meta"><div class="num">1/3 ★</div><div class="h">Interview</div></div></div>
+                <div class="thumb"><div class="img alt-2"></div><div class="meta"><div class="num">2/3 auto</div><div class="h">Transfer</div></div></div>
+                <div class="thumb"><div class="img alt-3"></div><div class="meta"><div class="num">3/3 auto</div><div class="h">Event</div></div></div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="panel-label">Edge cases + cost</div>
+            <div class="matrix">
+              <div class="matrix-row"><div class="k">No lead picked</div><div class="v">Fall back to S.1 (3 most recent).</div></div>
+              <div class="matrix-row"><div class="k">Lead unpublished</div><div class="v">Treat as no lead → S.1 fallback. Studio shows a warning chip.</div></div>
+              <div class="matrix-row"><div class="k">Only 1 other published</div><div class="v">Carousel renders 2 thumbs; strip is <code>repeat(2, 1fr)</code>.</div></div>
+              <div class="matrix-row cost-add"><div class="k">Schema cost</div><div class="v"><strong>Small Sanity migration.</strong> Add singleton <code>leadArticle</code> ref. No data backfill needed.</div></div>
+              <div class="matrix-row"><div class="k">Editor cost</div><div class="v">~15s per change. One field, one document. Less ceremony than S.3.</div></div>
+              <div class="matrix-row"><div class="k">Risk</div><div class="v">Slots 2 + 3 still drift with publish order — editor cannot pin a "second story". For most weeks, that's fine.</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> S.1 = zero effort, zero control. S.2 = light effort,
+        per-article control, fragile to flag-drift. S.3 = explicit ordered list in one place, costs
+        a Sanity migration. S.4 = "lead first, recency for the rest" — middle ground in effort and
+        control.
+      </p>
+      <p>
+        <strong>One subtle point.</strong> S.2 and S.3 are not mutually exclusive — we could keep
+        the <code>featured</code> boolean for NewsGrid prioritization (later round) while using a
+        ref array for the hero. The choice here is purely about the hero source.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> NewsGrid feed (later round). Featured event
+        placement (Round 3). Whether the carousel becomes "use client" (implementation detail).
+        Studio guidance copy (separate from data shape — handled by Sanity Studio editor-ux
+        rework, see <code>project_sanity_studio_ux_rework</code>).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-3-featured-event-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-3-featured-event-comparisons.html
@@ -1,0 +1,635 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 3 · Featured event placement</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-deep: 6px 6px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1320px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 36px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 28px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+        display: flex;
+        flex-direction: column;
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 24px;
+        line-height: 1.15;
+        margin: 4px 0 6px;
+      }
+      .candidate header .desc {
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+        max-width: 56ch;
+      }
+      .surface { background: var(--cream); padding: 0; }
+
+      /* ===== Schematic page ===== */
+      .pageshape {
+        display: flex;
+        flex-direction: column;
+      }
+      .band {
+        position: relative;
+        padding: 14px 18px;
+        border-bottom: 1px solid var(--ink);
+        font-size: 12px;
+        line-height: 1.4;
+      }
+      .band:last-child { border-bottom: none; }
+      .band .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .band .sub {
+        font-size: 11px;
+        opacity: 0.6;
+        margin-top: 3px;
+      }
+      .band.locked { background: var(--cream-deep); }
+      .band.locked .label::before { content: "★ LOCKED · "; opacity: 0.6; font-style: italic; }
+      .band.event-call { background: var(--jersey-deep); color: var(--cream); }
+      .band.event-call .sub { opacity: 0.85; }
+      .band.event-call .label { color: #f0c264; }
+
+      .band.hero {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 18px;
+      }
+      .band.hero .label { color: var(--cream); }
+      .band.hero .sub { opacity: 0.7; }
+      .band.hero .hero-mini {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 12px;
+        align-items: center;
+        margin-top: 10px;
+      }
+      .band.hero .hero-mini .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 16px;
+        line-height: 1.2;
+        color: var(--cream);
+      }
+      .band.hero .hero-mini .h .accent { color: #f0c264; }
+      .band.hero .hero-mini .pill {
+        display: inline-block;
+        background: var(--cream);
+        color: var(--ink);
+        padding: 1px 5px;
+        font-size: 9px;
+        font-family: ui-monospace, monospace;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin-bottom: 4px;
+      }
+      .band.hero .hero-mini .cover {
+        background: linear-gradient(135deg, #2a4d3a, #c1a04a);
+        aspect-ratio: 16 / 9;
+        outline: 1px solid var(--cream);
+      }
+      .band.hero .strip-mini {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 10px;
+        margin-top: 10px;
+        padding-top: 8px;
+        border-top: 1px solid rgba(245, 239, 225, 0.25);
+        font-size: 9px;
+        opacity: 0.85;
+      }
+      .band.hero .strip-mini .t {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        opacity: 0.6;
+      }
+      .band.hero .strip-mini .t.a { opacity: 1; }
+      .band.hero .strip-mini .t .img {
+        width: 24px;
+        aspect-ratio: 16 / 9;
+        background: #547a5e;
+      }
+      .band.hero .strip-mini .t .img.alt-2 { background: #7a5454; }
+      .band.hero .strip-mini .t .img.alt-3 { background: #54627a; }
+      .band.hero .strip-mini .t.a .img { outline: 1px solid #f0c264; }
+
+      /* ===== NewsGrid schematic ===== */
+      .grid-mini {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+        margin-top: 10px;
+      }
+      .card-mini {
+        background: #fff;
+        border: 1px solid var(--ink);
+        padding: 6px 8px 8px;
+        position: relative;
+        font-size: 11px;
+        line-height: 1.3;
+      }
+      .card-mini.event {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        border-color: var(--ink);
+        outline: 2px solid #f0c264;
+        outline-offset: -2px;
+      }
+      .card-mini .img {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background: linear-gradient(135deg, #547a5e, #c1a04a);
+        margin-bottom: 6px;
+      }
+      .card-mini.event .img { background: linear-gradient(135deg, #1f5f3f, #f0c264); }
+      .card-mini .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 1px 4px;
+        margin-bottom: 3px;
+      }
+      .card-mini.event .pill { background: #f0c264; color: var(--ink); }
+      .card-mini .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 11px;
+        line-height: 1.2;
+      }
+      @media (max-width: 700px) {
+        .grid-mini { grid-template-columns: 1fr 1fr; }
+      }
+
+      /* ===== Featured-event standalone band ===== */
+      .event-band {
+        display: grid;
+        grid-template-columns: 35fr 65fr;
+        gap: 16px;
+        align-items: center;
+        margin-top: 8px;
+      }
+      .event-band .img {
+        background: linear-gradient(135deg, #1f5f3f, #f0c264);
+        aspect-ratio: 16 / 9;
+        outline: 2px solid #f0c264;
+      }
+      .event-band .meta { display: flex; flex-direction: column; gap: 6px; }
+      .event-band .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: #f0c264;
+        color: var(--ink);
+        padding: 2px 6px;
+        width: fit-content;
+      }
+      .event-band .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 18px;
+        line-height: 1.18;
+      }
+      .event-band .when {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .event-band .cta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: #f0c264;
+        font-weight: bold;
+      }
+
+      /* ===== Footer / context callouts ===== */
+      .matrix {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 8px;
+        font-size: 11px;
+        line-height: 1.5;
+        padding: 14px 18px;
+        background: var(--cream-soft);
+      }
+      .matrix-row {
+        display: grid;
+        grid-template-columns: 110px 1fr;
+        gap: 12px;
+      }
+      .matrix-row .k {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.65;
+      }
+      .matrix-row code {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        background: rgba(26, 26, 26, 0.06);
+        padding: 1px 4px;
+      }
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 3 · Featured event placement</div>
+      <h1>Where does the next featured event live on the homepage?</h1>
+      <p>
+        Today the homepage fetches one event from <code>EventRepository.findNextFeatured()</code>
+        (next upcoming event with <code>featuredOnHome = true</code>) and tucks it inside
+        <code>&lt;NewsGrid&gt;</code> as a special card. Phase 4 redesigns that decision. Below: 4
+        placements, all using the same event fields (<code>title</code>, <code>dateStart</code>,
+        optional <code>dateEnd</code>, <code>coverImage</code>, optional <code>externalLink</code>).
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Hero shape = D.1 (carousel · strip-below thumbs).
+      Hero source = S.2 (article.featured boolean). The schematics below show the body of <code>/</code>
+      in compressed form so you can see the event's relative position.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ E.1 — Inline NewsGrid card ============ -->
+      <section class="candidate" id="E1">
+        <header>
+          <div class="key">E.1</div>
+          <div class="name">Inline NewsGrid card · today's behavior</div>
+          <div class="desc">
+            Featured event keeps its current spot inside <code>&lt;NewsGrid&gt;</code> — one slot
+            of the grid renders as a special "EVENEMENT" card with jersey-deep background +
+            jersey-yellow outline. Mixed editorial + event grid. Promoted to the lead grid slot.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="pageshape">
+            <div class="band locked"><div class="label">MatchStrip + SiteHeader</div></div>
+            <div class="band hero locked">
+              <div class="label">EditorialHero · D.1</div>
+              <div class="hero-mini">
+                <div>
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="t a"><div class="img"></div><span>1/3 NU</span></div>
+                <div class="t"><div class="img alt-2"></div><span>2/3</span></div>
+                <div class="t"><div class="img alt-3"></div><span>3/3</span></div>
+              </div>
+            </div>
+            <div class="band">
+              <div class="label">NewsGrid · 6 articles + 1 event</div>
+              <div class="grid-mini">
+                <div class="card-mini event">
+                  <div class="img"></div>
+                  <div class="pill">Evenement · 10 mei</div>
+                  <div class="h">Quiz in de kantine, vrijdagavond.</div>
+                </div>
+                <div class="card-mini">
+                  <div class="img"></div>
+                  <div class="pill">Aankondiging</div>
+                  <div class="h">Inschrijvingen jeugd geopend.</div>
+                </div>
+                <div class="card-mini">
+                  <div class="img"></div>
+                  <div class="pill">Wedstrijd</div>
+                  <div class="h">U17 wint van VKT met 3-1.</div>
+                </div>
+                <div class="card-mini">
+                  <div class="img"></div>
+                  <div class="pill">Aankondiging</div>
+                  <div class="h">Trainingsschema mei online.</div>
+                </div>
+                <div class="card-mini">
+                  <div class="img"></div>
+                  <div class="pill">Aankondiging</div>
+                  <div class="h">Nieuwe truitjes binnenkort.</div>
+                </div>
+                <div class="card-mini">
+                  <div class="img"></div>
+                  <div class="pill">Wedstrijd</div>
+                  <div class="h">Reserves veroveren punt.</div>
+                </div>
+              </div>
+            </div>
+            <div class="band locked"><div class="label">… ScheduleStandings · Youth · Webshop · Sponsors · SiteFooter</div></div>
+          </div>
+          <div class="matrix">
+            <div class="matrix-row"><div class="k">Editor</div><div class="v">Per event: toggle <code>featuredOnHome = true</code>. One per week typical.</div></div>
+            <div class="matrix-row"><div class="k">No featured event</div><div class="v">NewsGrid renders 6 article cards (no event slot). Same as today.</div></div>
+            <div class="matrix-row"><div class="k">Tradeoff</div><div class="v">+ Familiar to editors · − Event quietly competes with article cards in the same grid; visual hierarchy depends on outline alone.</div></div>
+            <div class="matrix-row"><div class="k">Schema cost</div><div class="v"><strong>Zero.</strong> <code>featuredOnHome</code> already exists.</div></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ E.2 — Standalone band BEFORE NewsGrid ============ -->
+      <section class="candidate" id="E2">
+        <header>
+          <div class="key">E.2</div>
+          <div class="name">Standalone band · between hero and NewsGrid</div>
+          <div class="desc">
+            Featured event becomes its own full-width section directly below the hero — a jersey-deep
+            band with a 2-column "image + title + when + CTA" composition. Distinct from news. Read
+            as a "what's coming up at the club this week" callout above the editorial body.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="pageshape">
+            <div class="band locked"><div class="label">MatchStrip + SiteHeader</div></div>
+            <div class="band hero locked">
+              <div class="label">EditorialHero · D.1</div>
+              <div class="hero-mini">
+                <div>
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="t a"><div class="img"></div><span>1/3 NU</span></div>
+                <div class="t"><div class="img alt-2"></div><span>2/3</span></div>
+                <div class="t"><div class="img alt-3"></div><span>3/3</span></div>
+              </div>
+            </div>
+            <div class="band event-call">
+              <div class="label">FeaturedEventBand · between hero and grid</div>
+              <div class="event-band">
+                <div class="img"></div>
+                <div class="meta">
+                  <span class="pill">Evenement · 10 mei</span>
+                  <div class="h">Quiz in de kantine, vrijdagavond 20:00.</div>
+                  <div class="when">Vr 10 mei · 20:00 · Kantine</div>
+                  <div class="cta">→ Reserveer je plaats</div>
+                </div>
+              </div>
+            </div>
+            <div class="band">
+              <div class="label">NewsGrid · 6 articles, no event slot</div>
+              <div class="grid-mini">
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Inschrijvingen jeugd.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Wedstrijd</div><div class="h">U17 wint 3-1.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Trainingsschema mei.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Nieuwe truitjes.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Wedstrijd</div><div class="h">Reserves veroveren punt.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Transfer</div><div class="h">Wim G. tekent voor 2 seizoenen.</div></div>
+              </div>
+            </div>
+            <div class="band locked"><div class="label">… ScheduleStandings · Youth · Webshop · Sponsors · SiteFooter</div></div>
+          </div>
+          <div class="matrix">
+            <div class="matrix-row"><div class="k">Editor</div><div class="v">Per event: toggle <code>featuredOnHome = true</code>. One per week typical.</div></div>
+            <div class="matrix-row"><div class="k">No featured event</div><div class="v">Band hidden entirely; NewsGrid sits flush against hero.</div></div>
+            <div class="matrix-row"><div class="k">Tradeoff</div><div class="v">+ Strong visual hierarchy + clear call-to-action · − Adds a section the editor must remember to flag, or it stays empty.</div></div>
+            <div class="matrix-row"><div class="k">Schema cost</div><div class="v"><strong>Zero.</strong> <code>featuredOnHome</code> already exists; new <code>&lt;FeaturedEventBand&gt;</code> component.</div></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ E.3 — Standalone band AFTER NewsGrid ============ -->
+      <section class="candidate" id="E3">
+        <header>
+          <div class="key">E.3</div>
+          <div class="name">Standalone band · after NewsGrid, before YouthBlock</div>
+          <div class="desc">
+            Same shape as E.2 but lower in the page. Sits between the editorial body (hero +
+            news) and the brand interlude (youth + shop). Reads as "after you've caught up on
+            news, here's what's next on the calendar." Less prominent than E.2.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="pageshape">
+            <div class="band locked"><div class="label">MatchStrip + SiteHeader</div></div>
+            <div class="band hero locked">
+              <div class="label">EditorialHero · D.1</div>
+              <div class="hero-mini">
+                <div>
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="t a"><div class="img"></div><span>1/3 NU</span></div>
+                <div class="t"><div class="img alt-2"></div><span>2/3</span></div>
+                <div class="t"><div class="img alt-3"></div><span>3/3</span></div>
+              </div>
+            </div>
+            <div class="band">
+              <div class="label">NewsGrid · 6 articles, no event slot</div>
+              <div class="grid-mini">
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Inschrijvingen jeugd.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Wedstrijd</div><div class="h">U17 wint 3-1.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Trainingsschema mei.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Nieuwe truitjes.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Wedstrijd</div><div class="h">Reserves veroveren punt.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Transfer</div><div class="h">Wim G. tekent voor 2 seizoenen.</div></div>
+              </div>
+            </div>
+            <div class="band locked"><div class="label">… ScheduleStandingsBlock</div></div>
+            <div class="band event-call">
+              <div class="label">FeaturedEventBand · between schedule and youth</div>
+              <div class="event-band">
+                <div class="img"></div>
+                <div class="meta">
+                  <span class="pill">Evenement · 10 mei</span>
+                  <div class="h">Quiz in de kantine, vrijdagavond 20:00.</div>
+                  <div class="when">Vr 10 mei · 20:00 · Kantine</div>
+                  <div class="cta">→ Reserveer je plaats</div>
+                </div>
+              </div>
+            </div>
+            <div class="band locked"><div class="label">… YouthBlock · Webshop · Sponsors · SiteFooter</div></div>
+          </div>
+          <div class="matrix">
+            <div class="matrix-row"><div class="k">Editor</div><div class="v">Same as E.2.</div></div>
+            <div class="matrix-row"><div class="k">No featured event</div><div class="v">Band hidden; ScheduleStandings sits flush against YouthBlock.</div></div>
+            <div class="matrix-row"><div class="k">Tradeoff</div><div class="v">+ Doesn't compete with hero · − Lower-prominence; bigger risk of being missed by visitors who bounce after the news grid.</div></div>
+            <div class="matrix-row"><div class="k">Schema cost</div><div class="v">Same as E.2.</div></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ E.4 — Retire from homepage ============ -->
+      <section class="candidate" id="E4">
+        <header>
+          <div class="key">E.4</div>
+          <div class="name">Retire featured event from homepage</div>
+          <div class="desc">
+            Events live only on <code>/evenementen</code>. Homepage gets a cleaner editorial
+            spine — no event slot in the grid, no event band. The kalender + events list page
+            handles event prominence; SiteHeader nav already exposes <code>/evenementen</code>.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="pageshape">
+            <div class="band locked"><div class="label">MatchStrip + SiteHeader</div></div>
+            <div class="band hero locked">
+              <div class="label">EditorialHero · D.1</div>
+              <div class="hero-mini">
+                <div>
+                  <span class="pill">Interview</span>
+                  <div class="h"><span class="accent">"Met deze ploeg…"</span></div>
+                </div>
+                <div class="cover"></div>
+              </div>
+              <div class="strip-mini">
+                <div class="t a"><div class="img"></div><span>1/3 NU</span></div>
+                <div class="t"><div class="img alt-2"></div><span>2/3</span></div>
+                <div class="t"><div class="img alt-3"></div><span>3/3</span></div>
+              </div>
+            </div>
+            <div class="band">
+              <div class="label">NewsGrid · 6 articles only</div>
+              <div class="grid-mini">
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Inschrijvingen jeugd.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Wedstrijd</div><div class="h">U17 wint 3-1.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Trainingsschema mei.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Aank.</div><div class="h">Nieuwe truitjes.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Wedstrijd</div><div class="h">Reserves veroveren punt.</div></div>
+                <div class="card-mini"><div class="img"></div><div class="pill">Transfer</div><div class="h">Wim G. tekent voor 2 seizoenen.</div></div>
+              </div>
+            </div>
+            <div class="band locked"><div class="label">… ScheduleStandings · Youth · Webshop · Sponsors · SiteFooter</div></div>
+          </div>
+          <div class="matrix">
+            <div class="matrix-row"><div class="k">Editor</div><div class="v">No homepage event work. <code>featuredOnHome</code> field becomes legacy / unused (consider removing in cleanup).</div></div>
+            <div class="matrix-row"><div class="k">No featured event</div><div class="v">N/A — homepage doesn't surface events.</div></div>
+            <div class="matrix-row"><div class="k">Tradeoff</div><div class="v">+ Cleanest homepage spine · + Editor saves a per-event step · − Visitors who land on / and never click "Evenementen" miss the upcoming quiz.</div></div>
+            <div class="matrix-row"><div class="k">Schema cost</div><div class="v">Optional cleanup: remove <code>featuredOnHome</code> from event schema in Phase 9.</div></div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Background.</strong> The event field is <code>featuredOnHome</code>, not <code>featured</code>.
+        That keeps it distinct from <code>article.featured</code> (Round 2 lock). Same boolean pattern, two
+        different schemas — no field reuse, no ambiguity.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Event detail page redesign (Phase 6). Events list / kalender
+        page redesign (Phase 6). Event schema field additions (location, RSVP) — separate question.
+        <code>&lt;FeaturedEventBand&gt;</code> visual treatment beyond placement (its tape rotation,
+        whether it uses TapedFigure for the cover image, how the CTA renders) — locks in a sub-round
+        if E.2 or E.3 wins.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-4-spine-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-4-spine-comparisons.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 4 · Body section spine</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1400px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 36px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1400px;
+        margin: 0 auto 28px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .grid {
+        max-width: 1400px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 24px;
+      }
+      @media (max-width: 1180px) { .grid { grid-template-columns: repeat(2, 1fr); } }
+      @media (max-width: 640px) { .grid { grid-template-columns: 1fr; } }
+
+      .col {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+        padding: 14px 14px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .col-head {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding-bottom: 8px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .col-head .key {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .col-head .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 19px;
+        line-height: 1.2;
+      }
+      .col-head .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        opacity: 0.78;
+      }
+      .stack { display: flex; flex-direction: column; gap: 0; }
+      .band {
+        position: relative;
+        padding: 10px 12px;
+        border-left: 1px solid var(--ink);
+        border-right: 1px solid var(--ink);
+        border-bottom: 1px solid var(--ink);
+        font-size: 12px;
+        line-height: 1.35;
+      }
+      .band:first-child { border-top: 1px solid var(--ink); }
+      .band .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+      }
+      .band .sub {
+        font-size: 11px;
+        opacity: 0.7;
+        margin-top: 2px;
+      }
+      .band.locked { background: var(--cream-deep); }
+      .band.locked .label { opacity: 0.6; }
+      .band.locked .label::before { content: "★ "; }
+      .band.in-play .label { opacity: 0.85; }
+
+      /* Background tokens — cream/ink/jersey rhythm */
+      .bg-cream { background: var(--cream); }
+      .bg-cream-soft { background: var(--cream-soft); }
+      .bg-cream-deep { background: var(--cream-deep); }
+      .bg-ink { background: var(--ink); color: var(--cream); }
+      .bg-jersey { background: var(--jersey-deep); color: var(--cream); }
+
+      /* Heights communicating relative weight */
+      .h-strip { min-height: 36px; }
+      .h-chrome { min-height: 40px; }
+      .h-hero { min-height: 110px; }
+      .h-event { min-height: 70px; }
+      .h-grid { min-height: 130px; }
+      .h-block { min-height: 70px; }
+      .h-block-short { min-height: 56px; }
+
+      .legend {
+        max-width: 1400px;
+        margin: 12px auto 24px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        font-size: 11px;
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+      .legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .swatch {
+        display: inline-block;
+        width: 14px;
+        height: 14px;
+        border: 1px solid var(--ink);
+      }
+      .footnote {
+        max-width: 1400px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.55;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 4 · Spine</div>
+      <h1>Order of the 4 sections after NewsGrid</h1>
+      <p>
+        Hero (D.1) → FeaturedEventBand → NewsGrid is locked at the top. SiteFooter is locked at the
+        bottom. This round picks the order of the four remaining body sections in between:
+        <strong>ScheduleStandingsBlock</strong>, <strong>YouthBlock</strong>,
+        <strong>WebshopStrip</strong>, <strong>SponsorsBlock</strong>. Sponsors is conventionally the
+        commercial close in every variant — the variability is in the three sections above it.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Hero shape = D.1 carousel + strip-below thumbnails ·
+      Hero source = S.2 article.featured boolean · Featured event = E.2 standalone band between hero
+      and NewsGrid. Banner slots A/B/C deferred to a separate round.
+    </div>
+
+    <div class="legend">
+      <span><span class="swatch" style="background: var(--cream);"></span>cream (paper)</span>
+      <span><span class="swatch" style="background: var(--cream-soft);"></span>cream-soft</span>
+      <span><span class="swatch" style="background: var(--cream-deep);"></span>cream-deep</span>
+      <span><span class="swatch" style="background: var(--ink);"></span>ink</span>
+      <span><span class="swatch" style="background: var(--jersey-deep);"></span>jersey-deep</span>
+    </div>
+
+    <div class="grid">
+
+      <!-- ============ Spine A — Schedule next, brand mid, commercial close ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">Spine A</div>
+          <div class="name">Schedule first, youth interlude, commercial close</div>
+          <div class="desc">
+            Data follows news (read → check fixtures → standings). Brand interlude breaks the
+            editorial flow before the commercial close. Most conventional fanzine cadence.
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip · chrome</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader · chrome</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1 carousel</div><div class="sub" style="opacity:0.7;">3 articles · article.featured</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div><div class="sub" style="opacity:0.85;">jersey-deep band</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid · 6 cards</div></div>
+          <div class="band bg-cream h-block in-play"><div class="label">ScheduleStandings</div><div class="sub">tabs: schedule / standings</div></div>
+          <div class="band bg-jersey h-block in-play"><div class="label">YouthBlock · full-bleed</div><div class="sub">JerseyShirt interlude</div></div>
+          <div class="band bg-cream h-block-short in-play"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-cream-deep h-block in-play"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter · chrome</div></div>
+        </div>
+      </div>
+
+      <!-- ============ Spine B — Youth interlude first, data, commercial close ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">Spine B</div>
+          <div class="name">Youth interlude first, schedule, commercial close</div>
+          <div class="desc">
+            Brand interlude breaks the editorial flow before data hits. Visitor reads news, sees
+            "this is who we're building", then checks the calendar before the commercial close.
+            Most magazine-feeling.
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip · chrome</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader · chrome</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1 carousel</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid · 6 cards</div></div>
+          <div class="band bg-jersey h-block in-play"><div class="label">YouthBlock · full-bleed</div></div>
+          <div class="band bg-cream h-block in-play"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-cream-soft h-block-short in-play"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-cream-deep h-block in-play"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter · chrome</div></div>
+        </div>
+      </div>
+
+      <!-- ============ Spine C — Schedule next, brand outro before commercial ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">Spine C</div>
+          <div class="name">Schedule, webshop, youth as outro, sponsors</div>
+          <div class="desc">
+            Data + commercial pair early; YouthBlock becomes the warm "thank you for visiting"
+            outro just before sponsors. Useful if Sponsors should feel like a separate civic
+            section rather than a brand close.
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip · chrome</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader · chrome</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1 carousel</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid · 6 cards</div></div>
+          <div class="band bg-cream h-block in-play"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-cream-soft h-block-short in-play"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-jersey h-block in-play"><div class="label">YouthBlock · full-bleed</div></div>
+          <div class="band bg-cream-deep h-block in-play"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter · chrome</div></div>
+        </div>
+      </div>
+
+      <!-- ============ Spine D — Schedule late ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">Spine D</div>
+          <div class="name">Brand mid, commercial pair, schedule late</div>
+          <div class="desc">
+            Editorial → brand → commercial → data → sponsors. Schedule sits low (closer to
+            sponsors). Risk: data gets lost above the footer. Useful only if schedule isn't a
+            primary draw.
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip · chrome</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader · chrome</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1 carousel</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid · 6 cards</div></div>
+          <div class="band bg-jersey h-block in-play"><div class="label">YouthBlock · full-bleed</div></div>
+          <div class="band bg-cream-soft h-block-short in-play"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-cream h-block in-play"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-cream-deep h-block in-play"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter · chrome</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Sponsors stays last in every variant.</strong> Convention from
+        <code>reference_sponsor_tiers</code> + ubiquitous "commercial close before footer". Variability
+        is in the 3 sections above it.
+      </p>
+      <p>
+        <strong>Why MatchStrip ≠ ScheduleStandings.</strong> MatchStrip (Phase 3 chrome) shows ONE next
+        match peek above the hero. ScheduleStandings (Phase 4 body section) shows the next several
+        matches + the group standings. They serve different jobs at different positions; not redundant.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Banner slots A/B/C between sections (separate round).
+        Cream/ink/jersey rhythm token map (later, after section internals lock). Mobile-specific
+        compression of the spine (Phase 4 implementation; layout intentionally collapses to a single
+        column at &lt;640px).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-4b-banner-slots-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-4b-banner-slots-comparisons.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 4b · Banner slot retention</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape: #d9b85a;
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1400px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 32px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner {
+        max-width: 1400px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 12px;
+        line-height: 1.5;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .grid {
+        max-width: 1400px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 24px;
+      }
+      @media (max-width: 1180px) { .grid { grid-template-columns: repeat(2, 1fr); } }
+      @media (max-width: 640px) { .grid { grid-template-columns: 1fr; } }
+
+      .col {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+        padding: 14px 14px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .col-head { padding-bottom: 8px; border-bottom: 1px dashed var(--ink); }
+      .col-head .key {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .col-head .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 18px;
+        line-height: 1.2;
+        margin: 4px 0 4px;
+      }
+      .col-head .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        opacity: 0.78;
+      }
+      .stack { display: flex; flex-direction: column; gap: 0; }
+      .band {
+        position: relative;
+        padding: 8px 12px;
+        border-left: 1px solid var(--ink);
+        border-right: 1px solid var(--ink);
+        border-bottom: 1px solid var(--ink);
+        font-size: 11px;
+        line-height: 1.3;
+      }
+      .band:first-child { border-top: 1px solid var(--ink); }
+      .band .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .band .sub { font-size: 10px; opacity: 0.65; margin-top: 2px; }
+      .band.locked { background: var(--cream-deep); }
+      .band.locked .label::before { content: "★ "; opacity: 0.6; }
+      .band.locked .label { opacity: 0.6; }
+      .bg-cream { background: var(--cream); }
+      .bg-cream-soft { background: var(--cream-soft); }
+      .bg-cream-deep { background: var(--cream-deep); }
+      .bg-ink { background: var(--ink); color: var(--cream); }
+      .bg-jersey { background: var(--jersey-deep); color: var(--cream); }
+      .bg-banner {
+        background:
+          repeating-linear-gradient(
+            45deg,
+            #f0d878 0,
+            #f0d878 8px,
+            #d9b85a 8px,
+            #d9b85a 16px
+          );
+        color: var(--ink);
+      }
+      .bg-banner .label { color: var(--ink); }
+      .h-strip { min-height: 30px; }
+      .h-chrome { min-height: 32px; }
+      .h-hero { min-height: 70px; }
+      .h-event { min-height: 42px; }
+      .h-grid { min-height: 80px; }
+      .h-block { min-height: 46px; }
+      .h-banner { min-height: 28px; }
+
+      .footnote {
+        max-width: 1400px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.55;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 4b · Banner slots</div>
+      <h1>Banner slot retention on the locked spine</h1>
+      <p>
+        Today the homepage exposes 3 optional <code>banner</code> refs (<code>bannerSlotA/B/C</code> on
+        the homePage Sanity document) — generic promotional / sponsor banners with image + alt + href.
+        Each slot is already drop-if-empty (no banner ref → section hidden). This round drills how many
+        slots Phase 4 keeps, and where they sit in the locked Spine A. Yellow striped bands below mark
+        banner positions.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Hero D.1 carousel + S.2 source · FeaturedEventBand
+      (E.2) between hero and NewsGrid · Spine A: NewsGrid → ScheduleStandings → Youth → Webshop →
+      Sponsors. Banner positions vary across the 4 candidates below.
+    </div>
+
+    <div class="grid">
+
+      <!-- ============ BS.1 — Keep all 3 ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">BS.1</div>
+          <div class="name">Keep all 3 slots</div>
+          <div class="desc">
+            Three banner positions, drop-if-empty: between event-and-grid, between
+            schedule-and-youth, between webshop-and-sponsors. Editor-flexible. Most legacy-faithful.
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-banner h-banner"><div class="label">→ bannerSlotA</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-banner h-banner"><div class="label">→ bannerSlotB</div></div>
+          <div class="band bg-jersey h-block locked"><div class="label">YouthBlock</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-banner h-banner"><div class="label">→ bannerSlotC</div></div>
+          <div class="band bg-cream-deep h-block locked"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter</div></div>
+        </div>
+      </div>
+
+      <!-- ============ BS.2 — 2 slots ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">BS.2</div>
+          <div class="name">2 slots · drop the middle</div>
+          <div class="desc">
+            Keep slot A (high-attention, between event and grid) and slot C (commercial cluster
+            with shop + sponsors). Drop slot B (was between schedule and youth — interrupts the
+            data → brand transition).
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-banner h-banner"><div class="label">→ bannerSlotA</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-jersey h-block locked"><div class="label">YouthBlock</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-banner h-banner"><div class="label">→ bannerSlotC</div></div>
+          <div class="band bg-cream-deep h-block locked"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter</div></div>
+        </div>
+      </div>
+
+      <!-- ============ BS.3 — 1 slot ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">BS.3</div>
+          <div class="name">1 slot · between News and Schedule</div>
+          <div class="desc">
+            One banner only, between the editorial body (NewsGrid) and the data band
+            (ScheduleStandings). Single high-attention placement; lets the editor target one
+            promotion without crowding the spine.
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid</div></div>
+          <div class="band bg-banner h-banner"><div class="label">→ bannerSlot (one)</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-jersey h-block locked"><div class="label">YouthBlock</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-cream-deep h-block locked"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter</div></div>
+        </div>
+      </div>
+
+      <!-- ============ BS.4 — Drop all ============ -->
+      <div class="col">
+        <div class="col-head">
+          <div class="key">BS.4</div>
+          <div class="name">Drop all banner slots</div>
+          <div class="desc">
+            Cleanest editorial spine. Sponsor visibility lives entirely in
+            <code>SponsorsBlock</code> + <code>SiteFooter</code>; promotional callouts go through
+            the FeaturedEventBand. Removes 3 ref fields from <code>homePage</code> (small migration).
+          </div>
+        </div>
+        <div class="stack">
+          <div class="band bg-ink h-strip locked"><div class="label">MatchStrip</div></div>
+          <div class="band bg-cream h-chrome locked"><div class="label">SiteHeader</div></div>
+          <div class="band bg-ink h-hero locked"><div class="label">EditorialHero · D.1</div></div>
+          <div class="band bg-jersey h-event locked"><div class="label">FeaturedEventBand</div></div>
+          <div class="band bg-cream-soft h-grid locked"><div class="label">NewsGrid</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">ScheduleStandings</div></div>
+          <div class="band bg-jersey h-block locked"><div class="label">YouthBlock</div></div>
+          <div class="band bg-cream h-block locked"><div class="label">WebshopStrip</div></div>
+          <div class="band bg-cream-deep h-block locked"><div class="label">SponsorsBlock</div></div>
+          <div class="band bg-ink h-chrome locked"><div class="label">SiteFooter</div></div>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>What is a banner today?</strong> A simple <code>banner</code> Sanity document
+        with <code>image</code> + <code>alt</code> + <code>href</code>. No tier, no expiry, no
+        analytics binding. Used historically for sponsor-of-the-month placements and ad-hoc
+        promos (e.g. season-ticket reminders, away-trip carpooling sign-ups).
+      </p>
+      <p>
+        <strong>If banners stay,</strong> the redesign treats them with the cream/ink retro
+        palette (taped frame, jersey-tape strip, hard shadow) — not yellow stripes. The yellow
+        striping above is just so banner positions are visible against the locked spine.
+      </p>
+      <p>
+        <strong>If banners go,</strong> we remove <code>bannerSlotA/B/C</code> from
+        <code>homePage</code> in a Sanity migration. Existing <code>banner</code> documents stay
+        (other surfaces may use them later) — the homepage just stops referencing them.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-5-newsgrid-structure-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5-newsgrid-structure-comparisons.html
@@ -507,11 +507,11 @@
 
     <div class="footnote">
       <p>
-        <strong>What's the same in every variant.</strong> 6 cards · `<code>tags[0]</code>` (or
+        <strong>What's the same in every variant.</strong> 6 cards · <code>tags[0]</code> (or
         articleType once #1470 ships) renders as the MonoLabel pill · publishedAt + author render
         in the meta line · taped paper card primitive (TapedCard) · canonical press-down hover
-        applied at card level · NewsGrid header reuses Phase 2's `<SectionHeader>` (now thin
-        wrapper over `<EditorialHeading>` + `<MonoLabelRow>`).
+        applied at card level · NewsGrid header reuses Phase 2's <code>&lt;SectionHeader&gt;</code>
+        (now thin wrapper over <code>&lt;EditorialHeading&gt;</code> + <code>&lt;MonoLabelRow&gt;</code>).
       </p>
       <p>
         <strong>What this round does NOT decide.</strong> How aspect-ratio is assigned per card

--- a/docs/design/mockups/phase-4-homepage/round-5-newsgrid-structure-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5-newsgrid-structure-comparisons.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 5 · NewsGrid structure</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1320px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 36px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+        display: flex;
+        flex-direction: column;
+      }
+      .candidate header {
+        display: flex;
+        gap: 24px;
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin: 4px 0 6px;
+      }
+      .candidate header .desc {
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+        max-width: 60ch;
+      }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--cream-soft);
+        padding: 28px 24px 32px;
+      }
+      .section-title {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .section-title .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+      }
+      .section-title .all {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      /* ===== Card primitive ===== */
+      .card {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 8px 8px 10px;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .card .tape {
+        position: absolute;
+        top: -8px;
+        width: 44px;
+        height: 12px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .card .tape.right { right: 14px; transform: rotate(3deg); left: auto; }
+      .card .tape.left { left: 14px; }
+      .card.rot-a { transform: rotate(-0.4deg); }
+      .card.rot-b { transform: rotate(0.4deg); }
+      .card.rot-c { transform: rotate(-0.8deg); }
+      .card.rot-d { transform: rotate(0.8deg); }
+      .card.rot-flat { transform: none; }
+      .card .img {
+        width: 100%;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        position: relative;
+      }
+      .card .img.alt-2 { background: linear-gradient(135deg, #4d2a2a 0%, #c19a4a 100%); }
+      .card .img.alt-3 { background: linear-gradient(135deg, #2a3a4d 0%, #4a8ac1 100%); }
+      .card .img.alt-4 { background: linear-gradient(135deg, #3a2a4d 0%, #8a4ac1 100%); }
+      .card .img.alt-5 { background: linear-gradient(135deg, #4d3a2a 0%, #c17a4a 100%); }
+      .card .img.alt-6 { background: linear-gradient(135deg, #2a4d4d 0%, #4ac1c1 100%); }
+      .card .img.aspect-16-9 { aspect-ratio: 16 / 9; }
+      .card .img.aspect-square { aspect-ratio: 1 / 1; }
+      .card .img.aspect-3-4 { aspect-ratio: 3 / 4; }
+      .card.text-only { background: var(--ink); color: var(--cream); }
+      .card.text-only .pill { background: var(--cream); color: var(--ink); }
+      .card .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 2px 5px;
+        width: fit-content;
+      }
+      .card .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.2;
+      }
+      .card.lg .h { font-size: 22px; }
+      .card .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.6;
+      }
+      .card.text-only .meta { opacity: 0.7; }
+      .card.text-only .h { font-size: 16px; }
+      .card.lead .h { font-size: 26px; }
+
+      /* ===== N.1 — Strict 3×2 uniform ===== */
+      .grid-n1 {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-template-rows: repeat(2, auto);
+        gap: 16px;
+      }
+      @media (max-width: 880px) {
+        .grid-n1 { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 600px) {
+        .grid-n1 { grid-template-columns: 1fr; }
+      }
+
+      /* ===== N.2 — Broadsheet lead + 5 ===== */
+      .grid-n2 {
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr;
+        grid-template-rows: auto auto;
+        gap: 16px;
+      }
+      .n2-lead {
+        grid-column: 1 / 2;
+        grid-row: 1 / 3;
+        display: flex;
+        flex-direction: column;
+      }
+      @media (max-width: 880px) {
+        .grid-n2 { grid-template-columns: 1fr 1fr; }
+        .n2-lead { grid-column: 1 / 3; grid-row: auto; }
+      }
+      @media (max-width: 600px) {
+        .grid-n2 { grid-template-columns: 1fr; }
+        .n2-lead { grid-column: 1 / 2; }
+      }
+
+      /* ===== N.3 — Asymmetric editorial ===== */
+      .grid-n3 {
+        display: grid;
+        grid-template-columns: repeat(12, 1fr);
+        grid-auto-rows: minmax(180px, auto);
+        gap: 16px;
+      }
+      .n3-portrait { grid-column: span 4; grid-row: span 2; }
+      .n3-square-1 { grid-column: span 4; grid-row: span 1; }
+      .n3-square-2 { grid-column: span 4; grid-row: span 1; }
+      .n3-wide-1 { grid-column: span 4; grid-row: span 1; }
+      .n3-wide-2 { grid-column: span 4; grid-row: span 1; }
+      .n3-wide-3 { grid-column: span 4; grid-row: span 1; }
+      @media (max-width: 880px) {
+        .grid-n3 { grid-template-columns: repeat(6, 1fr); }
+        .n3-portrait { grid-column: span 6; grid-row: auto; }
+        .n3-square-1, .n3-square-2 { grid-column: span 3; }
+        .n3-wide-1, .n3-wide-2, .n3-wide-3 { grid-column: span 6; }
+      }
+      @media (max-width: 600px) {
+        .grid-n3 { grid-template-columns: 1fr; }
+        .n3-portrait, .n3-square-1, .n3-square-2,
+        .n3-wide-1, .n3-wide-2, .n3-wide-3 { grid-column: span 1; }
+      }
+
+      /* ===== N.4 — Mixed 2-row ===== */
+      .grid-n4 {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        grid-template-rows: auto auto;
+        gap: 16px;
+      }
+      .n4-row1-a { grid-column: span 2; }
+      .n4-row1-b { grid-column: span 2; }
+      .n4-row2 { grid-column: span 1; }
+      @media (max-width: 880px) {
+        .grid-n4 { grid-template-columns: repeat(2, 1fr); }
+        .n4-row1-a, .n4-row1-b { grid-column: span 2; }
+        .n4-row2 { grid-column: span 1; }
+      }
+      @media (max-width: 600px) {
+        .grid-n4 { grid-template-columns: 1fr; }
+        .n4-row1-a, .n4-row1-b, .n4-row2 { grid-column: span 1; }
+      }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 5 · NewsGrid structure</div>
+      <h1>How is the NewsGrid laid out?</h1>
+      <p>
+        The IA round locked NewsGrid as the body section after the FeaturedEventBand: 6 article
+        cards, no event slot. This round drills the <em>structural arrangement</em> — number of
+        cards, sizes, and how they tile into the page. Aspect-ratio assignment per card and tape
+        rotation rules drill in subsequent sub-rounds.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> NewsGrid receives 6 articles
+      (<code>articles.slice(3, 9)</code> — skipping the 3 hero articles). Aspect-ratio variants
+      available: <code>landscape-16-9 · square · portrait-3-4 · text-only</code>. Below: 4
+      structural arrangements, all rendered with realistic Sanity-shape data.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ N.1 — Strict 3×2 uniform ============ -->
+      <section class="candidate" id="N1">
+        <header>
+          <div>
+            <div class="key">N.1</div>
+            <div class="name">Strict 3×2 uniform</div>
+          </div>
+          <div class="desc">
+            6 equal cards in a 3-column, 2-row grid. All 16:9. Tape rotation alternates per card
+            (a/b/c/d) so the grid feels hand-pasted, not mechanical, but the structure is
+            predictable.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most predictable for editors<br />
+            + Trivial responsive collapse (3→2→1)<br />
+            − Loses magazine rhythm<br />
+            − Aspect-ratio prop barely used (only 16:9)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Laatste nieuws</span>
+            <span class="all">Alle berichten →</span>
+          </div>
+          <div class="grid-n1">
+            <div class="card rot-a"><span class="tape left"></span><div class="img alt-2 aspect-16-9"></div><span class="pill">Transfer</span><div class="h">Wim G. tekent voor 2 seizoenen.</div><div class="meta">3 mei · door redactie</div></div>
+            <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 aspect-16-9"></div><span class="pill">Wedstrijd</span><div class="h">U17 wint van VKT met 3-1.</div><div class="meta">28 apr · door Tom Janssens</div></div>
+            <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 aspect-16-9"></div><span class="pill">Aankondiging</span><div class="h">Inschrijvingen jeugd geopend.</div><div class="meta">25 apr · door redactie</div></div>
+            <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 aspect-16-9"></div><span class="pill">Aankondiging</span><div class="h">Trainingsschema mei online.</div><div class="meta">22 apr · door redactie</div></div>
+            <div class="card rot-a"><span class="tape left"></span><div class="img alt-6 aspect-16-9"></div><span class="pill">Wedstrijd</span><div class="h">Reserves veroveren punt op het veld.</div><div class="meta">20 apr · door Tom Janssens</div></div>
+            <div class="card rot-b"><span class="tape right"></span><div class="img aspect-16-9"></div><span class="pill">Aankondiging</span><div class="h">Nieuwe truitjes binnenkort beschikbaar.</div><div class="meta">18 apr · door redactie</div></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ N.2 — Broadsheet lead + 5 supporting ============ -->
+      <section class="candidate" id="N2">
+        <header>
+          <div>
+            <div class="key">N.2</div>
+            <div class="name">Broadsheet · lead + 5 supporting</div>
+          </div>
+          <div class="desc">
+            One large lead card on the left (2 col × 2 row, 16:9 large image, bigger headline). Right
+            side: 5 stacked smaller cards (mix of 16:9 and text-only). Reads as a printed front
+            page below the masthead.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Strong editorial weight on the lead<br />
+            + Full aspect-ratio prop usage<br />
+            − Lead repeats the EditorialHero's "spotlight one article" pattern<br />
+            − 5 stacked cards on right tightens text
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Laatste nieuws</span>
+            <span class="all">Alle berichten →</span>
+          </div>
+          <div class="grid-n2">
+            <div class="card rot-a lead n2-lead">
+              <span class="tape left"></span>
+              <span class="tape right"></span>
+              <div class="img alt-2 aspect-16-9"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+              <div class="meta">3 mei · door redactie · 4 min lezen</div>
+            </div>
+            <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 aspect-16-9"></div><span class="pill">Wedstrijd</span><div class="h">U17 wint 3-1.</div><div class="meta">28 apr</div></div>
+            <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Inschrijvingen jeugd.</div><div class="meta">25 apr</div></div>
+            <div class="card rot-d text-only"><span class="pill">Aank.</span><div class="h">Trainingsschema mei online.</div><div class="meta">22 apr · tekst-only</div></div>
+            <div class="card rot-a"><span class="tape right"></span><div class="img alt-6 aspect-16-9"></div><span class="pill">Wedstrijd</span><div class="h">Reserves veroveren punt.</div><div class="meta">20 apr</div></div>
+            <div class="card rot-b text-only"><span class="pill">Aank.</span><div class="h">Nieuwe truitjes binnenkort.</div><div class="meta">18 apr · tekst-only</div></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ N.3 — Asymmetric editorial ============ -->
+      <section class="candidate" id="N3">
+        <header>
+          <div>
+            <div class="key">N.3</div>
+            <div class="name">Asymmetric editorial · woven 12-col</div>
+          </div>
+          <div class="desc">
+            12-column grid woven with mixed aspects. 1 portrait (3:4, spans 4 cols × 2 rows),
+            2 squares (4 cols each), 3 landscape (4 cols each). Every aspect-ratio variant gets
+            used at least once; the grid feels hand-set.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most magazine-feeling cadence<br />
+            + Exercises every aspect variant<br />
+            − Slot positions dictate aspect (less editor flexibility)<br />
+            − Responsive collapse needs care
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Laatste nieuws</span>
+            <span class="all">Alle berichten →</span>
+          </div>
+          <div class="grid-n3">
+            <div class="card rot-a n3-portrait">
+              <span class="tape left"></span>
+              <span class="tape right"></span>
+              <div class="img alt-2 aspect-3-4"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+              <div class="meta">3 mei · 4 min lezen</div>
+            </div>
+            <div class="card rot-b n3-square-1"><span class="tape right"></span><div class="img alt-3 aspect-square"></div><span class="pill">Wedstrijd</span><div class="h">U17 wint 3-1.</div></div>
+            <div class="card rot-c n3-square-2"><span class="tape left"></span><div class="img alt-4 aspect-square"></div><span class="pill">Aankondiging</span><div class="h">Inschrijvingen jeugd.</div></div>
+            <div class="card rot-d n3-wide-1"><span class="tape right"></span><div class="img alt-5 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Trainingsschema mei online.</div></div>
+            <div class="card rot-a n3-wide-2"><span class="tape left"></span><div class="img alt-6 aspect-16-9"></div><span class="pill">Wedstrijd</span><div class="h">Reserves veroveren punt.</div></div>
+            <div class="card rot-b n3-wide-3"><span class="tape right"></span><div class="img aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Nieuwe truitjes binnenkort.</div></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ N.4 — Mixed 2-row ============ -->
+      <section class="candidate" id="N4">
+        <header>
+          <div>
+            <div class="key">N.4</div>
+            <div class="name">Mixed 2-row · 2 large + 4 small</div>
+          </div>
+          <div class="desc">
+            Row 1: 2 large cards side-by-side (one 16:9 landscape, one square). Row 2: 4 smaller
+            equal-width cards (mix of 16:9 + text-only). Compromise between strict-uniform and
+            full asymmetric — predictable rows, varied aspects within rows.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Mid-complexity, predictable<br />
+            + Exercises 16:9 + square + text-only<br />
+            − Portrait 3:4 still unused at this slot<br />
+            − Less hand-pasted than N.3
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Laatste nieuws</span>
+            <span class="all">Alle berichten →</span>
+          </div>
+          <div class="grid-n4">
+            <div class="card rot-a lg n4-row1-a">
+              <span class="tape left"></span>
+              <span class="tape right"></span>
+              <div class="img alt-2 aspect-16-9"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei · door redactie · 4 min</div>
+            </div>
+            <div class="card rot-b lg n4-row1-b">
+              <span class="tape right"></span>
+              <div class="img alt-3 aspect-square"></div>
+              <span class="pill">Wedstrijd</span>
+              <div class="h">U17 wint van VKT met 3-1.</div>
+              <div class="meta">28 apr · door Tom Janssens</div>
+            </div>
+            <div class="card rot-c n4-row2"><span class="tape left"></span><div class="img alt-4 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Inschrijvingen jeugd.</div></div>
+            <div class="card rot-d text-only n4-row2"><span class="pill">Aank.</span><div class="h">Trainingsschema mei online.</div><div class="meta">22 apr</div></div>
+            <div class="card rot-a n4-row2"><span class="tape right"></span><div class="img alt-6 aspect-16-9"></div><span class="pill">Wedstrijd</span><div class="h">Reserves veroveren punt.</div></div>
+            <div class="card rot-b text-only n4-row2"><span class="pill">Aank.</span><div class="h">Nieuwe truitjes binnenkort.</div><div class="meta">18 apr</div></div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>What's the same in every variant.</strong> 6 cards · `<code>tags[0]</code>` (or
+        articleType once #1470 ships) renders as the MonoLabel pill · publishedAt + author render
+        in the meta line · taped paper card primitive (TapedCard) · canonical press-down hover
+        applied at card level · NewsGrid header reuses Phase 2's `<SectionHeader>` (now thin
+        wrapper over `<EditorialHeading>` + `<MonoLabelRow>`).
+      </p>
+      <p>
+        <strong>What this round does NOT decide.</strong> How aspect-ratio is assigned per card
+        (Round 5b — editor pick? auto by article-type? slot-templated?). Tape rotation pattern
+        (Round 5c — alternating? deterministic by index? randomized? Sanity-driven?). Card hover
+        + click behaviour (Round 5d). Empty / single-card states (Round 5e).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-5b-newsgrid-1-plus-4-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5b-newsgrid-1-plus-4-comparisons.html
@@ -1,0 +1,672 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 5b · NewsGrid 1+4 geometry</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1320px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 34px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+      }
+      .candidate header {
+        display: flex;
+        gap: 24px;
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin: 4px 0 6px;
+      }
+      .candidate header .desc {
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+        max-width: 60ch;
+      }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      /* ===== Side-by-side: desktop and mobile previews ===== */
+      .surface {
+        background: var(--cream-soft);
+        padding: 24px;
+        display: grid;
+        grid-template-columns: 1fr 280px;
+        gap: 24px;
+      }
+      @media (max-width: 880px) {
+        .surface { grid-template-columns: 1fr; }
+      }
+      .surface .preview-wrap {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .surface .preview-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .surface .desktop-pad {
+        background: var(--cream);
+        border: 1px solid var(--ink);
+        padding: 16px;
+      }
+      .surface .mobile-pad {
+        background: var(--cream);
+        border: 1px solid var(--ink);
+        padding: 14px;
+        max-width: 280px;
+      }
+
+      .section-title {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 14px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .section-title .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 18px;
+      }
+      .section-title .all {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+      .mobile-pad .section-title .h { font-size: 14px; }
+      .mobile-pad .section-title .all { font-size: 8px; }
+
+      /* ===== Card primitive ===== */
+      .card {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 6px 6px 8px;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        height: 100%;
+      }
+      .card .tape {
+        position: absolute;
+        top: -6px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .card .tape.right { right: 14px; transform: rotate(3deg); left: auto; }
+      .card .tape.left { left: 14px; }
+      .card.rot-a { transform: rotate(-0.4deg); }
+      .card.rot-b { transform: rotate(0.4deg); }
+      .card.rot-c { transform: rotate(-0.8deg); }
+      .card.rot-d { transform: rotate(0.8deg); }
+      .card .img {
+        width: 100%;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        position: relative;
+      }
+      .card .img.alt-2 { background: linear-gradient(135deg, #4d2a2a 0%, #c19a4a 100%); }
+      .card .img.alt-3 { background: linear-gradient(135deg, #2a3a4d 0%, #4a8ac1 100%); }
+      .card .img.alt-4 { background: linear-gradient(135deg, #3a2a4d 0%, #8a4ac1 100%); }
+      .card .img.alt-5 { background: linear-gradient(135deg, #4d3a2a 0%, #c17a4a 100%); }
+      .card .img.aspect-16-9 { aspect-ratio: 16 / 9; }
+      .card .img.aspect-square { aspect-ratio: 1 / 1; }
+      .card .img.aspect-3-4 { aspect-ratio: 3 / 4; }
+      .card .img.fill {
+        flex: 1;
+        height: auto;
+        aspect-ratio: auto;
+      }
+      .card .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 1px 5px;
+        width: fit-content;
+      }
+      .card .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 12px;
+        line-height: 1.18;
+      }
+      .card.lead .h { font-size: 18px; }
+      .card.lead-big .h { font-size: 22px; }
+      .card .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.6;
+      }
+      .mobile-pad .card .h { font-size: 11px; }
+      .mobile-pad .card.lead .h { font-size: 14px; }
+
+      /* ===== A — Lead 2fr + 4 stacked right (1fr) ===== */
+      .grid-A {
+        display: grid;
+        grid-template-columns: 2fr 1fr;
+        grid-template-rows: repeat(4, 1fr);
+        gap: 12px;
+        min-height: 460px;
+      }
+      .grid-A .lead { grid-column: 1; grid-row: 1 / 5; }
+      .grid-A .small-1 { grid-column: 2; grid-row: 1; }
+      .grid-A .small-2 { grid-column: 2; grid-row: 2; }
+      .grid-A .small-3 { grid-column: 2; grid-row: 3; }
+      .grid-A .small-4 { grid-column: 2; grid-row: 4; }
+      .grid-A-mobile {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+      }
+      .mobile-pad .card.lead .img { aspect-ratio: 16/9; }
+
+      /* ===== B — Lead 3fr + 2x2 right (2fr) · 60/40 lead-dominant ===== */
+      .grid-B {
+        display: grid;
+        grid-template-columns: 3fr 2fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 12px;
+        min-height: 380px;
+      }
+      .grid-B .lead { grid-column: 1; grid-row: 1 / 3; }
+      .grid-B .b-2 { grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .grid-B .b-2 .card { grid-column: auto; }
+      .grid-B .b-3 { grid-column: 2; grid-row: 2; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .grid-B-mobile {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+      }
+      .grid-B-mobile .row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+      }
+
+      /* ===== C — Lead full row + 4-col below ===== */
+      .grid-C {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        grid-template-rows: auto auto;
+        gap: 12px;
+      }
+      .grid-C .lead { grid-column: 1 / 5; grid-row: 1; }
+      .grid-C .small { grid-column: span 1; grid-row: 2; }
+      .grid-C-mobile {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+      }
+      .grid-C-mobile .row2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+      }
+
+      /* ===== D — Lead 50% + 2x2 50% ===== */
+      .grid-D {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 12px;
+        min-height: 380px;
+      }
+      .grid-D .lead { grid-column: 1; grid-row: 1 / 3; }
+      .grid-D .b-2 { grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .grid-D .b-3 { grid-column: 2; grid-row: 2; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .grid-D-mobile { display: grid; grid-template-columns: 1fr; gap: 10px; }
+      .grid-D-mobile .row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+      .breakpoint-note {
+        font-size: 11px;
+        font-family: ui-monospace, monospace;
+        opacity: 0.6;
+        margin-top: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 5b · NewsGrid 1+4 geometry</div>
+      <h1>How are 1 lead + 4 supporting arranged?</h1>
+      <p>
+        Round 5 leaning toward N.2 (broadsheet) but with <strong>5 cards (1 lead + 4 supporting)</strong>
+        instead of 6 — symmetric, no orphan card. This sub-round drills the geometry: where the
+        lead sits, how the 4 cards tile around it, and how each pattern collapses on tablet / mobile.
+        Page.tsx changes from <code>articles.slice(3, 9)</code> to <code>articles.slice(3, 8)</code>
+        (5 articles into NewsGrid).
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from Round 5.</strong> N.2 broadsheet direction with a single dominant lead
+      card. <strong>This sub-round</strong> picks the supporting-card geometry. Each candidate
+      shows a desktop preview alongside its mobile collapse so the responsive behaviour locks at
+      the same time as the desktop layout.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ A — 2fr lead + 4 stacked right ============ -->
+      <section class="candidate" id="A">
+        <header>
+          <div>
+            <div class="key">A</div>
+            <div class="name">Lead 2fr + 4 stacked (1fr column)</div>
+          </div>
+          <div class="desc">
+            Direct extension of today's 2:1 layout (1 lead + 2 stacked) — same column proportions,
+            just 4 stacked cards on the right instead of 2. Lead is very tall (its height equals
+            4 small card heights). Each small card image fills the available height.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most familiar to today's 2:1 mental model<br />
+            + Right column reads like a "more headlines" rail<br />
+            − Lead becomes very tall — image must fill or get a tall portrait crop<br />
+            − Mobile has to stack 1+4 = 5 cards vertically (long scroll)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="preview-wrap">
+            <div class="preview-label">Desktop · ≥880px</div>
+            <div class="desktop-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+              <div class="grid-A">
+                <div class="card rot-a lead-big lead">
+                  <span class="tape left"></span><span class="tape right"></span>
+                  <div class="img alt-2 fill"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+                  <div class="meta">3 mei · door redactie · 4 min</div>
+                </div>
+                <div class="card rot-b small-1"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                <div class="card rot-c small-2"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschrijvingen jeugd.</div></div>
+                <div class="card rot-d small-3"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Trainingsschema mei.</div></div>
+                <div class="card rot-a small-4"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves veroveren punt.</div></div>
+              </div>
+              <div class="breakpoint-note">grid-cols: 2fr 1fr · grid-rows: 1fr×4 · lead spans rows 1-4</div>
+            </div>
+          </div>
+          <div class="preview-wrap">
+            <div class="preview-label">Mobile · &lt;640px</div>
+            <div class="mobile-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">→</span></div>
+              <div class="grid-A-mobile">
+                <div class="card rot-a lead">
+                  <span class="tape left"></span>
+                  <div class="img alt-2 aspect-16-9"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+                  <div class="meta">3 mei</div>
+                </div>
+                <div class="card rot-b"><div class="img alt-3 aspect-16-9"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                <div class="card rot-c"><div class="img alt-4 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Inschr.</div></div>
+                <div class="card rot-d"><div class="img alt-5 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Training.</div></div>
+                <div class="card rot-a"><div class="img aspect-16-9"></div><span class="pill">Wedstr.</span><div class="h">Reserves.</div></div>
+              </div>
+              <div class="breakpoint-note">5 cards stacked · 1+1+1+1+1</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ B — 2fr lead + 2x2 right (RECOMMENDED for "1-2-2 mobile") ============ -->
+      <section class="candidate" id="B">
+        <header>
+          <div>
+            <div class="key">B</div>
+            <div class="name">Lead 3fr + 2×2 grid right (2fr) · 60/40 lead-dominant</div>
+          </div>
+          <div class="desc">
+            Lead takes 60% width on the left, supporting 4 cards in a 2×2 grid take the remaining
+            40% on the right (each supporting card ≈ 20% of total width). Lead's height = 2
+            supporting card heights. Lead is the visual anchor; supporting cards are
+            secondary. Mobile collapses to <strong>1 + 2 + 2</strong>.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Lead clearly dominant; cards stay secondary<br />
+            + Lead height is bounded (2 row-heights, not 4 like A)<br />
+            + Mobile = "1–2–2"<br />
+            − Supporting cards are smaller than in D — text wraps tighter
+          </div>
+        </header>
+        <div class="surface">
+          <div class="preview-wrap">
+            <div class="preview-label">Desktop · ≥880px</div>
+            <div class="desktop-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+              <div class="grid-B">
+                <div class="card rot-a lead-big lead">
+                  <span class="tape left"></span><span class="tape right"></span>
+                  <div class="img alt-2 fill"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+                  <div class="meta">3 mei · door redactie · 4 min</div>
+                </div>
+                <div class="b-2">
+                  <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                  <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+                </div>
+                <div class="b-3">
+                  <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+                  <div class="card rot-a"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div></div>
+                </div>
+              </div>
+              <div class="breakpoint-note">grid-cols: 3fr 2fr · right is nested 1fr 1fr × 2 rows · lead = 60% width</div>
+            </div>
+          </div>
+          <div class="preview-wrap">
+            <div class="preview-label">Mobile · &lt;640px</div>
+            <div class="mobile-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">→</span></div>
+              <div class="grid-B-mobile">
+                <div class="card rot-a lead">
+                  <span class="tape left"></span>
+                  <div class="img alt-2 aspect-16-9"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                  <div class="meta">3 mei</div>
+                </div>
+                <div class="row">
+                  <div class="card rot-b"><div class="img alt-3 aspect-16-9"></div><span class="pill">W.</span><div class="h">U17 3-1.</div></div>
+                  <div class="card rot-c"><div class="img alt-4 aspect-16-9"></div><span class="pill">A.</span><div class="h">Inschr.</div></div>
+                </div>
+                <div class="row">
+                  <div class="card rot-d"><div class="img alt-5 aspect-16-9"></div><span class="pill">A.</span><div class="h">Training.</div></div>
+                  <div class="card rot-a"><div class="img aspect-16-9"></div><span class="pill">W.</span><div class="h">Reserves.</div></div>
+                </div>
+              </div>
+              <div class="breakpoint-note">1 + 2 + 2 = 5 cards · symmetric</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C — Lead full + 4-col row below ============ -->
+      <section class="candidate" id="C">
+        <header>
+          <div>
+            <div class="key">C</div>
+            <div class="name">Lead full-width + 4-col row below</div>
+          </div>
+          <div class="desc">
+            Lead spans the full width on top (banner-style), 4 supporting cards in a single 4-col
+            row below. Most front-page-newspaper feel (banner above, columns below). Tablet
+            collapses to 2-col supporting; mobile to 1-col stack.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Strongest hierarchy — lead is undeniably the lead<br />
+            + Each supporting card has equal weight<br />
+            − Lead is very wide; competes with EditorialHero spotlight register<br />
+            − Total vertical height is greater than B
+          </div>
+        </header>
+        <div class="surface">
+          <div class="preview-wrap">
+            <div class="preview-label">Desktop · ≥880px</div>
+            <div class="desktop-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+              <div class="grid-C">
+                <div class="card rot-a lead-big lead">
+                  <span class="tape left"></span><span class="tape right"></span>
+                  <div class="img alt-2 aspect-16-9"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+                  <div class="meta">3 mei · door redactie · 4 min</div>
+                </div>
+                <div class="card rot-b small"><span class="tape right"></span><div class="img alt-3 aspect-16-9"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                <div class="card rot-c small"><span class="tape left"></span><div class="img alt-4 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+                <div class="card rot-d small"><span class="tape right"></span><div class="img alt-5 aspect-16-9"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+                <div class="card rot-a small"><span class="tape left"></span><div class="img aspect-16-9"></div><span class="pill">Wedstr.</span><div class="h">Reserves.</div></div>
+              </div>
+              <div class="breakpoint-note">grid-cols: repeat(4, 1fr) · lead spans 1/-1 row 1</div>
+            </div>
+          </div>
+          <div class="preview-wrap">
+            <div class="preview-label">Mobile · &lt;640px</div>
+            <div class="mobile-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">→</span></div>
+              <div class="grid-C-mobile">
+                <div class="card rot-a lead">
+                  <span class="tape left"></span>
+                  <div class="img alt-2 aspect-16-9"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                  <div class="meta">3 mei</div>
+                </div>
+                <div class="row2">
+                  <div class="card rot-b"><div class="img alt-3 aspect-16-9"></div><span class="pill">W.</span><div class="h">U17 3-1.</div></div>
+                  <div class="card rot-c"><div class="img alt-4 aspect-16-9"></div><span class="pill">A.</span><div class="h">Inschr.</div></div>
+                </div>
+                <div class="row2">
+                  <div class="card rot-d"><div class="img alt-5 aspect-16-9"></div><span class="pill">A.</span><div class="h">Training.</div></div>
+                  <div class="card rot-a"><div class="img aspect-16-9"></div><span class="pill">W.</span><div class="h">Reserves.</div></div>
+                </div>
+              </div>
+              <div class="breakpoint-note">1 + 2 + 2 = 5 cards (same shape as B mobile)</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D — Lead 1fr + 2x2 1fr ============ -->
+      <section class="candidate" id="D">
+        <header>
+          <div>
+            <div class="key">D</div>
+            <div class="name">Lead 1fr + 2×2 grid 1fr · 50/50 split</div>
+          </div>
+          <div class="desc">
+            Lead and supporting take equal width (1fr each). 2×2 grid on the right means each
+            supporting card is the same size as half the lead. Less hierarchy than B because the
+            lead doesn't dominate horizontally. Mobile collapses identically to B (1+2+2).
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most balanced visual weight<br />
+            + Mobile = 1+2+2 (same as B)<br />
+            − Lead has less "lead" feel<br />
+            − Supporting cards are larger, can compete with the lead headline
+          </div>
+        </header>
+        <div class="surface">
+          <div class="preview-wrap">
+            <div class="preview-label">Desktop · ≥880px</div>
+            <div class="desktop-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+              <div class="grid-D">
+                <div class="card rot-a lead lead-big">
+                  <span class="tape left"></span><span class="tape right"></span>
+                  <div class="img alt-2 fill"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+                  <div class="meta">3 mei · door redactie · 4 min</div>
+                </div>
+                <div class="b-2">
+                  <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                  <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+                </div>
+                <div class="b-3">
+                  <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+                  <div class="card rot-a"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves.</div></div>
+                </div>
+              </div>
+              <div class="breakpoint-note">grid-cols: 1fr 1fr · 50/50 split · lead = supporting cluster width</div>
+            </div>
+          </div>
+          <div class="preview-wrap">
+            <div class="preview-label">Mobile · &lt;640px</div>
+            <div class="mobile-pad">
+              <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">→</span></div>
+              <div class="grid-D-mobile">
+                <div class="card rot-a lead">
+                  <span class="tape left"></span>
+                  <div class="img alt-2 aspect-16-9"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                  <div class="meta">3 mei</div>
+                </div>
+                <div class="row">
+                  <div class="card rot-b"><div class="img alt-3 aspect-16-9"></div><span class="pill">W.</span><div class="h">U17 3-1.</div></div>
+                  <div class="card rot-c"><div class="img alt-4 aspect-16-9"></div><span class="pill">A.</span><div class="h">Inschr.</div></div>
+                </div>
+                <div class="row">
+                  <div class="card rot-d"><div class="img alt-5 aspect-16-9"></div><span class="pill">A.</span><div class="h">Training.</div></div>
+                  <div class="card rot-a"><div class="img aspect-16-9"></div><span class="pill">W.</span><div class="h">Reserves.</div></div>
+                </div>
+              </div>
+              <div class="breakpoint-note">1 + 2 + 2 (identical to B)</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Answering "does 1:4 scale to mobile?"</strong> Yes — every variant above collapses
+        cleanly. <strong>B and C and D</strong> all give the user-suggested <strong>1+2+2</strong>
+        mobile shape. <strong>A</strong> collapses to 1+1+1+1+1 (long stack) because its desktop
+        right column is already a 1-col stack — the most direct extension of today's 2:1 layout
+        but the most awkward mobile.
+      </p>
+      <p>
+        <strong>Tablet step.</strong> Between desktop and mobile (640–880px), B/C/D step through a
+        2-col grid for supporting cards (lead becomes full-width above, 2 cards per row below). A
+        steps to a 2-col stack on the right that's awkward — the lead can't easily match height.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Aspect-ratio assignment per slot (Round 5c — does
+        the lead get 16:9 always, or can it be square / 3:4? do supporting cards mix aspect?). Tape
+        rotation pattern (Round 5d — alternating? deterministic by slot? randomized? Sanity-driven
+        for editor control?). Card hover behaviour (Round 5e). Empty / single-card states (Round 5f).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-5c-newscard-aspect-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5c-newscard-aspect-comparisons.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 5c · NewsCard aspect-ratio assignment</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1320px;
+        margin: 0 auto 28px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 34px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .text-only-callout {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: #fff8d6;
+        border: 1px solid #c89500;
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .text-only-callout strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: block;
+        margin-bottom: 4px;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+      }
+      .candidate header {
+        display: flex;
+        gap: 24px;
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate header .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin: 4px 0 6px;
+      }
+      .candidate header .desc {
+        font-size: 13px;
+        line-height: 1.55;
+        opacity: 0.85;
+        max-width: 60ch;
+      }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--cream-soft);
+        padding: 28px 24px 32px;
+      }
+      .section-title {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 14px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .section-title .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 18px;
+      }
+      .section-title .all {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      /* === Card === */
+      .card {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 6px 6px 8px;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        height: 100%;
+      }
+      .card .tape {
+        position: absolute;
+        top: -6px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .card .tape.right { right: 14px; transform: rotate(3deg); left: auto; }
+      .card .tape.left { left: 14px; }
+      .card.rot-a { transform: rotate(-0.4deg); }
+      .card.rot-b { transform: rotate(0.4deg); }
+      .card.rot-c { transform: rotate(-0.8deg); }
+      .card.rot-d { transform: rotate(0.8deg); }
+      .card .img {
+        width: 100%;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        position: relative;
+      }
+      .card .img.alt-2 { background: linear-gradient(135deg, #4d2a2a 0%, #c19a4a 100%); }
+      .card .img.alt-3 { background: linear-gradient(135deg, #2a3a4d 0%, #4a8ac1 100%); }
+      .card .img.alt-4 { background: linear-gradient(135deg, #3a2a4d 0%, #8a4ac1 100%); }
+      .card .img.alt-5 { background: linear-gradient(135deg, #4d3a2a 0%, #c17a4a 100%); }
+      .card .img.aspect-16-9 { aspect-ratio: 16 / 9; }
+      .card .img.aspect-square { aspect-ratio: 1 / 1; }
+      .card .img.aspect-3-4 { aspect-ratio: 3 / 4; }
+      .card .img.fill { flex: 1; height: auto; aspect-ratio: auto; min-height: 120px; }
+      .card .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 1px 5px;
+        width: fit-content;
+      }
+      .card .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 12px;
+        line-height: 1.18;
+      }
+      .card.lead .h { font-size: 18px; }
+      .card .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.6;
+      }
+
+      /* === Locked geometry: D 50/50 with 2x2 right === */
+      .grid-D {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 12px;
+        min-height: 380px;
+      }
+      .grid-D .lead { grid-column: 1; grid-row: 1 / 3; }
+      .grid-D .b-2 { grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .grid-D .b-3 { grid-column: 2; grid-row: 2; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 5c · NewsCard aspect assignment</div>
+      <h1>Which aspect ratio does each NewsCard use?</h1>
+      <p>
+        The locked D geometry has 1 lead (50% width × 2 rows) and 4 supporting cards (each ≈ 25%
+        width). Master design §9.12 specifies <code>&lt;NewsCard&gt;</code> takes an
+        <code>aspectRatio</code> prop so mixed-aspect grids stay coherent. This round drills the
+        rule for which aspect each card uses.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from Round 5b.</strong> Geometry D · 50/50 split · lead 1fr × 2 rows ·
+      supporting 4 cards in a 2×2 grid (each card ≈ 25% width). Same geometry across all 4
+      candidates below — only image aspect changes.
+    </div>
+
+    <div class="text-only-callout">
+      <strong>Surfaced from your last question · text-only NewsCard</strong>
+      <code>article.coverImage</code> is required by the schema (see
+      <code>packages/sanity-schemas/src/article.ts:122</code>: <code>validation: (r) =>
+      r.required()</code>). So <strong>no published article ever lacks a cover image</strong> —
+      text-only has no natural data trigger. Three options for what to do with it: (a) drop it
+      from Phase 4 entirely (master design intent narrows from 4 aspect variants to 3), (b) make
+      it editor-electable via a new <code>displayAspect</code> field on the article schema, (c)
+      reserve it as a slot-templated decorative choice (e.g. supporting card #4 always renders as
+      text-only regardless of cover image). The candidates below explore (a) by default;
+      candidate C.4 represents (b).
+    </div>
+
+    <div class="container">
+
+      <!-- ============ C.1 — All 16:9 ============ -->
+      <section class="candidate" id="C1">
+        <header>
+          <div>
+            <div class="key">C.1</div>
+            <div class="name">All 16:9 · no mixing</div>
+          </div>
+          <div class="desc">
+            Every card uses 16:9 landscape regardless of slot. <code>aspectRatio</code> prop
+            exists on <code>&lt;NewsCard&gt;</code> for downstream pages (article-detail
+            sidebar, related content) but the homepage hard-codes 16:9 everywhere.
+            Simplest. Master design intent (mixed aspects) deferred to other surfaces.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + No editorial workload around aspect picks<br />
+            + Visually consistent rhythm<br />
+            − Aspect prop barely used on homepage<br />
+            − Loses the "fanzine cut-and-paste" variation
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+          <div class="grid-D">
+            <div class="card rot-a lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+              <div class="meta">3 mei · door redactie</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-a"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves veroveren punt.</div></div>
+            </div>
+          </div>
+          <div style="margin-top: 14px; font-size: 11px; font-family: ui-monospace, monospace; opacity: 0.65;">
+            Lead → 16:9 · Supporting → 16:9 × 4
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C.2 — Lead 16:9 + supporting square ============ -->
+      <section class="candidate" id="C2">
+        <header>
+          <div>
+            <div class="key">C.2</div>
+            <div class="name">Lead 16:9 · supporting all 1:1 square · slot-templated</div>
+          </div>
+          <div class="desc">
+            Lead keeps the cinematic 16:9 (matches its dominant width). Supporting cards switch
+            to 1:1 square — a tighter, denser grid that complements the lead's wide crop. Rule
+            is slot-driven: lead = 16:9, every supporting = square. No editor input.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Lead vs supporting visual hierarchy is cleaner<br />
+            + Square crops work well with social-media-style cropping habits<br />
+            − Existing 16:9 cover images get center-cropped to square (loses sides)<br />
+            − Supporting card heights are taller than C.1
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+          <div class="grid-D">
+            <div class="card rot-a lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+              <div class="meta">3 mei · door redactie</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 aspect-square"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 aspect-square"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 aspect-square"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-a"><span class="tape left"></span><div class="img aspect-square"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div></div>
+            </div>
+          </div>
+          <div style="margin-top: 14px; font-size: 11px; font-family: ui-monospace, monospace; opacity: 0.65;">
+            Lead → 16:9 (fill, dominant) · Supporting → 1:1 × 4
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C.3 — Templated by article-type ============ -->
+      <section class="candidate" id="C3">
+        <header>
+          <div>
+            <div class="key">C.3</div>
+            <div class="name">Templated by article-type · interview = 3:4 portrait</div>
+          </div>
+          <div class="desc">
+            <code>aspectRatio</code> selected automatically from <code>articleType</code>:
+            interview → 3:4 portrait (matches the interview hero crop), transfer → 16:9 wide
+            (matches transfer-detail hero), event/announcement → 1:1 square. Lead always renders
+            16:9 regardless of type for visual anchor consistency. No editor input.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Aspect implicitly signals article-type (extra editorial cue)<br />
+            + Reuses crop logic that exists for detail-page heroes<br />
+            − Tightens visual rhythm to articleType distribution (3 transfers in a row = 3 wide cards)<br />
+            − Same 4 supporting cards may end up all-square if article mix lacks variety
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+          <div class="grid-D">
+            <div class="card rot-a lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+              <div class="meta">3 mei · door redactie</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 aspect-square"></div><span class="pill">Wedstrijd</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 aspect-3-4"></div><span class="pill">Interview</span><div class="h">Sara Cools — duo-interview.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 aspect-square"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-a"><span class="tape left"></span><div class="img aspect-16-9"></div><span class="pill">Transfer</span><div class="h">Reserves: Karel B. tekent.</div></div>
+            </div>
+          </div>
+          <div style="margin-top: 14px; font-size: 11px; font-family: ui-monospace, monospace; opacity: 0.65;">
+            Lead → 16:9 always · Supporting: interview → 3:4 · transfer → 16:9 · event/announcement → 1:1
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C.4 — Editor-elected per article ============ -->
+      <section class="candidate" id="C4">
+        <header>
+          <div>
+            <div class="key">C.4</div>
+            <div class="name">Editor-elected per article · new <code>displayAspect</code> field</div>
+          </div>
+          <div class="desc">
+            New optional field on the article schema: <code>displayAspect: "auto" | "16-9" |
+            "1-1" | "3-4" | "text-only"</code>, default <code>"auto"</code> (= 16:9). Editor
+            picks per article when they want a non-default crop. Most flexibility; only
+            candidate that keeps text-only viable.
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Maximum editor control<br />
+            + Keeps text-only viable as an editor-elected variant<br />
+            + Exercises every aspect from master design intent<br />
+            − Editor workload + cognitive load<br />
+            − Schema migration<br />
+            − Editor must remember which aspect crops well per cover image
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Laatste nieuws</span><span class="all">Alle berichten →</span></div>
+          <div class="grid-D">
+            <div class="card rot-a lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent voor twee seizoenen.</div>
+              <div class="meta">3 mei · displayAspect=auto (16:9)</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 aspect-square"></div><span class="pill">Wedstrijd</span><div class="h">U17 wint 3-1.</div><div class="meta">aspect=1-1</div></div>
+              <div class="card rot-c" style="background: var(--ink); color: var(--cream);"><span class="pill" style="background: var(--cream); color: var(--ink);">Aank.</span><div class="h" style="margin-top: auto;">Trainingsschema mei online.</div><div class="meta" style="opacity: 0.7;">aspect=text-only · editor pick</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 aspect-3-4"></div><span class="pill">Interview</span><div class="h">Sara — interview.</div><div class="meta">aspect=3-4</div></div>
+              <div class="card rot-a"><span class="tape left"></span><div class="img aspect-16-9"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div><div class="meta">aspect=auto</div></div>
+            </div>
+          </div>
+          <div style="margin-top: 14px; font-size: 11px; font-family: ui-monospace, monospace; opacity: 0.65;">
+            Each card pulls <code>displayAspect</code> from its article doc · default "auto" = 16:9
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> C.1 = simplest, drops the master-design intent of mixed
+        aspects on the homepage. C.2 = single rule (lead vs supporting), no editor input, principled.
+        C.3 = signals article-type via crop, reuses detail-page crop logic. C.4 = full flexibility,
+        keeps text-only viable, costs a schema migration + per-article editor effort.
+      </p>
+      <p>
+        <strong>Master design says "4 aspect variants."</strong> If C.1 wins on the homepage, NewsCard
+        still ships all 4 aspect variants in Storybook for use on other surfaces (article-detail
+        related content, search results, kalender) — Phase 4 just doesn't exercise them on
+        <code>/</code>. Master design intent stays intact at the primitive level.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Tape rotation rules per slot (Round 5d).
+        NewsCard hover behaviour (Round 5e). text-only typographic treatment beyond "ink bg + cream
+        text" (Round 5f, only if C.4 wins). Empty / single-card NewsGrid states (Round 5g).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-5d-newscard-rotation-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5d-newscard-rotation-comparisons.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 5d · NewsCard tape rotation rules</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-hard: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+        --rot-a: -0.5deg;
+        --rot-b: -0.25deg;
+        --rot-c: 0.25deg;
+        --rot-d: 0.5deg;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 34px; margin: 6px 0 10px; letter-spacing: -0.02em; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 28px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-hard);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; }
+      .candidate header .rule {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        background: rgba(26, 26, 26, 0.06);
+        padding: 4px 8px;
+        margin-top: 8px;
+        line-height: 1.5;
+      }
+      .surface {
+        background: var(--cream-soft);
+        padding: 24px 20px 28px;
+      }
+      .grid-D {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 12px;
+        min-height: 320px;
+      }
+      .grid-D .lead { grid-column: 1; grid-row: 1 / 3; }
+      .grid-D .b-2 { grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .grid-D .b-3 { grid-column: 2; grid-row: 2; display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .card {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 6px 6px 8px;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        height: 100%;
+      }
+      .card .tape {
+        position: absolute;
+        top: -6px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .card .tape.right { right: 14px; transform: rotate(3deg); left: auto; }
+      .card .tape.left { left: 14px; }
+      .card .img {
+        width: 100%;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+        position: relative;
+      }
+      .card .img.alt-2 { background: linear-gradient(135deg, #4d2a2a 0%, #c19a4a 100%); }
+      .card .img.alt-3 { background: linear-gradient(135deg, #2a3a4d 0%, #4a8ac1 100%); }
+      .card .img.alt-4 { background: linear-gradient(135deg, #3a2a4d 0%, #8a4ac1 100%); }
+      .card .img.alt-5 { background: linear-gradient(135deg, #4d3a2a 0%, #c17a4a 100%); }
+      .card .img.fill { flex: 1; min-height: 80px; }
+      .card .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 1px 5px;
+        width: fit-content;
+      }
+      .card .h { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 12px; line-height: 1.18; }
+      .card.lead .h { font-size: 16px; }
+
+      /* Rotation classes — production values from globals.css. Subtle by design. */
+      .rot-none { transform: none; }
+      .rot-a { transform: rotate(-0.5deg); }
+      .rot-b { transform: rotate(-0.25deg); }
+      .rot-c { transform: rotate(0.25deg); }
+      .rot-d { transform: rotate(0.5deg); }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+      .annotate-row {
+        margin-top: 10px;
+        font-size: 10px;
+        font-family: ui-monospace, monospace;
+        opacity: 0.65;
+        text-align: center;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 5d · NewsCard rotation</div>
+      <h1>How is tape rotation assigned per NewsCard?</h1>
+      <p>
+        Phase 1's <code>&lt;TapedCardGrid&gt;</code> already established a deterministic-by-slot-index
+        rotation pattern: <code>ROTATION_POOL[index % 4]</code> cycling a/b/c/d (= -0.5° / -0.25° /
+        +0.25° / +0.5°). NewsGrid uses a custom 1+4 layout (not TapedCardGrid), so it picks its
+        own rule but respects the precedent of "deterministic, no run-time randomness."
+      </p>
+      <p>
+        Rotations below render at production values — <code>a = -0.5°</code>, <code>b = -0.25°</code>,
+        <code>c = +0.25°</code>, <code>d = +0.5°</code>. Subtle by design (Phase 0 token spec).
+        At full-page rendering, the difference reads as "hand-pasted" rather than "tilted."
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Geometry D · 50/50 split · 5 cards (1 lead + 2×2
+      supporting) · all 16:9 aspect (C.1). Rotation rule below applies to the rest position only —
+      hover behaviour drills next round.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ T.1 — Slot index cycle ============ -->
+      <section class="candidate" id="T1">
+        <header>
+          <div class="key">T.1</div>
+          <div class="name">Slot index cycle (matches Phase 1 TapedCardGrid)</div>
+          <div class="desc">
+            Treat the 5 cards as a flat indexed list. Slot 0 (lead) → a · Slot 1 → b · Slot 2 →
+            c · Slot 3 → d · Slot 4 → a. Same rule as Phase 1's TapedCardGrid. Lead has subtle
+            rotation; supporting cards cycle the full a/b/c/d range.
+          </div>
+          <div class="rule">slots = [a, b, c, d, a] · cycle(4) by index</div>
+        </header>
+        <div class="surface">
+          <div class="grid-D">
+            <div class="card rot-a lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent.</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-b"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-c"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-d"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-a"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div></div>
+            </div>
+          </div>
+          <div class="annotate-row">
+            lead = a (-0.5°) · supp1 = b (-0.25°) · supp2 = c (+0.25°) · supp3 = d (+0.5°) · supp4 = a (-0.5°)
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ T.2 — Lead anchored, supporting cycle ============ -->
+      <section class="candidate" id="T2">
+        <header>
+          <div class="key">T.2</div>
+          <div class="name">Lead anchored (none) · 4 supporting cycle a/b/c/d</div>
+          <div class="desc">
+            Lead stays flat (rotation=none) — anchors the section visually. The 4 supporting
+            cards cycle a/b/c/d in slot order, matching the TapedCardGrid pattern. Most magazine
+            "lead anchored, edges fluttery" feel.
+          </div>
+          <div class="rule">slots = [none, a, b, c, d]</div>
+        </header>
+        <div class="surface">
+          <div class="grid-D">
+            <div class="card rot-none lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent.</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-a"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-b"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-c"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-d"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div></div>
+            </div>
+          </div>
+          <div class="annotate-row">
+            lead = none (0°) · supp1 = a (-0.5°) · supp2 = b (-0.25°) · supp3 = c (+0.25°) · supp4 = d (+0.5°)
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ T.3 — Symmetric pairs ============ -->
+      <section class="candidate" id="T3">
+        <header>
+          <div class="key">T.3</div>
+          <div class="name">Symmetric pairs · paired toward center</div>
+          <div class="desc">
+            Lead = none. Top-row supporting (1+2) lean outward (a, d). Bottom-row supporting (3+4)
+            lean inward toward the lead (b, c). Cards "frame" the lead. Most designed feel; least
+            organic / fanzine.
+          </div>
+          <div class="rule">slots = [none, a (out), d (out), b (in), c (in)]</div>
+        </header>
+        <div class="surface">
+          <div class="grid-D">
+            <div class="card rot-none lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent.</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-a"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-d"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-b"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-c"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div></div>
+            </div>
+          </div>
+          <div class="annotate-row">
+            lead = none · top row = a/d (lean outward) · bottom row = b/c (lean inward)
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ T.4 — All flat ============ -->
+      <section class="candidate" id="T4">
+        <header>
+          <div class="key">T.4</div>
+          <div class="name">All flat (rotation = none)</div>
+          <div class="desc">
+            No card rotation. The tape strips, hard shadow, and slight crooked pinning of the
+            tape itself create the "stamped onto the page" feel without any per-card rotation.
+            Cleanest, most predictable. Removes a class of subtle visual jitter.
+          </div>
+          <div class="rule">slots = [none, none, none, none, none]</div>
+        </header>
+        <div class="surface">
+          <div class="grid-D">
+            <div class="card rot-none lead">
+              <span class="tape left"></span><span class="tape right"></span>
+              <div class="img alt-2 fill"></div>
+              <span class="pill">Transfer</span>
+              <div class="h">Wim Geeraerts tekent.</div>
+            </div>
+            <div class="b-2">
+              <div class="card rot-none"><span class="tape right"></span><div class="img alt-3 fill"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+              <div class="card rot-none"><span class="tape left"></span><div class="img alt-4 fill"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+            </div>
+            <div class="b-3">
+              <div class="card rot-none"><span class="tape right"></span><div class="img alt-5 fill"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+              <div class="card rot-none"><span class="tape left"></span><div class="img fill"></div><span class="pill">Wedstr.</span><div class="h">Reserves punt.</div></div>
+            </div>
+          </div>
+          <div class="annotate-row">
+            lead = none · all supporting = none · only tape strip + shadow create the paper feel
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Why no random / hash rotation?</strong> Phase 1 deliberately picked deterministic
+        slot-index rotation — same index always gets the same rotation, so the layout is stable across
+        re-renders, page refreshes, and feed changes. T.1 and T.2 follow this. Hashing by slug would
+        keep stability per article but break visual rhythm when the article order changes (next-most-recent
+        would never sit in the same position relative to its siblings).
+      </p>
+      <p>
+        <strong>Tape strip rotation is separate.</strong> Phase 1 also cycles the tape strip's own
+        rotation through 6 values (-1° to -6°) and 4 inset positions (4–12% from edge). That layer
+        of variation is independent of the card body rotation rule chosen here — the tape always
+        looks hand-pasted regardless of which card-rotation rule wins.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> NewsCard hover (Round 5e — canonical press-down per
+        <code>feedback_canonical_press_down_hover</code>). Empty / single-card states (Round 5f).
+        Whether the lead card has its own custom rotation override prop (likely no — the rule
+        should apply identically).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-5e-newscard-hover-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5e-newscard-hover-comparisons.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 5e · NewsCard hover behaviour</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-up: 8px 8px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 30px; margin: 6px 0 10px; letter-spacing: -0.02em; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 28px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; }
+      .surface {
+        background: var(--cream-soft);
+        padding: 28px 20px;
+        display: flex;
+        gap: 20px;
+        justify-content: center;
+        flex-wrap: wrap;
+        min-height: 260px;
+      }
+      .demo-card {
+        position: relative;
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+        padding: 6px 6px 8px;
+        width: 200px;
+        transform: rotate(-0.25deg);
+        transition: all 300ms ease;
+      }
+      .demo-card .tape {
+        position: absolute;
+        top: -6px;
+        left: 14px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .demo-card .img {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background: linear-gradient(135deg, #4d2a2a 0%, #c19a4a 100%);
+      }
+      .demo-card .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 1px 5px;
+        margin: 6px 0 2px;
+      }
+      .demo-card .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.18;
+      }
+      .demo-card .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.6;
+        margin-top: 4px;
+      }
+
+      /* H.1 — Press-down (canonical per feedback_canonical_press_down_hover) */
+      .h1-rest { /* default */ }
+      .h1-hover {
+        transform: rotate(-0.25deg) translate(4px, 4px);
+        box-shadow: none;
+      }
+
+      /* H.2 — Press-up (matches EditorialHero) */
+      .h2-rest { /* default */ }
+      .h2-hover {
+        transform: rotate(-0.25deg) translate(-2px, -2px);
+        box-shadow: var(--shadow-up);
+      }
+
+      /* H.3 — None / static */
+      .h3-rest { /* default */ }
+      .h3-hover {
+        outline: 2px solid var(--jersey-deep);
+        outline-offset: 2px;
+      }
+
+      .demo-row {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        align-items: center;
+      }
+      .demo-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .annotate {
+        margin-top: 14px;
+        padding: 10px 14px;
+        background: var(--cream-deep);
+        font-size: 11px;
+        line-height: 1.5;
+        font-family: ui-monospace, monospace;
+      }
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 5e · NewsCard hover</div>
+      <h1>How does a NewsCard respond to hover/focus?</h1>
+      <p>
+        Each candidate shows two states side-by-side: <strong>rest</strong> (left) and
+        <strong>hovered</strong> (right). Memory <code>feedback_canonical_press_down_hover</code>
+        locks "every paper-stamped interactive primitive uses press-down hover," but
+        EditorialHero placement="homepage" uses press-UP. NewsCard picks one — and the rule
+        carries to every NewsCard usage site (homepage, related-content, search results).
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Geometry D · 50/50 · 5 cards · all 16:9 · slot
+      index rotation cycle. Hover behaviour drills here.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ H.1 — Press-down (canonical) ============ -->
+      <section class="candidate" id="H1">
+        <header>
+          <div class="key">H.1</div>
+          <div class="name">Press-down (canonical)</div>
+          <div class="desc">
+            Card translates +4px/+4px (down-right), shadow becomes 0 (collapses). Card looks
+            "pressed into the page". Matches every other paper-stamped primitive in the system
+            (TapedCard, MonoLabel button, etc.) per memory.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="demo-row">
+            <div class="demo-label">Rest</div>
+            <div class="demo-card h1-rest">
+              <div class="tape"></div>
+              <div class="img"></div>
+              <div class="pill">Transfer</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei</div>
+            </div>
+          </div>
+          <div class="demo-row">
+            <div class="demo-label">Hover / focus</div>
+            <div class="demo-card h1-hover">
+              <div class="tape"></div>
+              <div class="img"></div>
+              <div class="pill">Transfer</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei</div>
+            </div>
+          </div>
+        </div>
+        <div class="annotate">
+          <strong>transform:</strong> +4px x · +4px y<br />
+          <strong>box-shadow:</strong> 4px 4px 0 → none<br />
+          <strong>matches:</strong> TapedCard · MonoLabel · button · feedback_canonical_press_down_hover
+        </div>
+      </section>
+
+      <!-- ============ H.2 — Press-up (matches EditorialHero) ============ -->
+      <section class="candidate" id="H2">
+        <header>
+          <div class="key">H.2</div>
+          <div class="name">Press-up (matches EditorialHero)</div>
+          <div class="desc">
+            Card translates -2px/-2px (up-left), shadow grows to 8px. Card lifts off the page.
+            Matches the hero's hover behaviour for visual consistency at the homepage scroll.
+            Departs from the canonical press-down rule.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="demo-row">
+            <div class="demo-label">Rest</div>
+            <div class="demo-card h2-rest">
+              <div class="tape"></div>
+              <div class="img"></div>
+              <div class="pill">Transfer</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei</div>
+            </div>
+          </div>
+          <div class="demo-row">
+            <div class="demo-label">Hover / focus</div>
+            <div class="demo-card h2-hover">
+              <div class="tape"></div>
+              <div class="img"></div>
+              <div class="pill">Transfer</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei</div>
+            </div>
+          </div>
+        </div>
+        <div class="annotate">
+          <strong>transform:</strong> -2px x · -2px y<br />
+          <strong>box-shadow:</strong> 4px 4px 0 → 8px 8px 0<br />
+          <strong>matches:</strong> EditorialHero placement="homepage"<br />
+          <strong>conflicts:</strong> feedback_canonical_press_down_hover
+        </div>
+      </section>
+
+      <!-- ============ H.3 — None / outline ============ -->
+      <section class="candidate" id="H3">
+        <header>
+          <div class="key">H.3</div>
+          <div class="name">No transform · jersey-deep outline only</div>
+          <div class="desc">
+            No card movement. Hover/focus adds a 2px jersey-deep outline (inset 2px). Cleanest,
+            no motion at all. Best for accessibility (no implied "depth"). Loses the tactile
+            paper feedback the rest of the system communicates.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="demo-row">
+            <div class="demo-label">Rest</div>
+            <div class="demo-card h3-rest">
+              <div class="tape"></div>
+              <div class="img"></div>
+              <div class="pill">Transfer</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei</div>
+            </div>
+          </div>
+          <div class="demo-row">
+            <div class="demo-label">Hover / focus</div>
+            <div class="demo-card h3-hover">
+              <div class="tape"></div>
+              <div class="img"></div>
+              <div class="pill">Transfer</div>
+              <div class="h">Wim G. tekent voor 2 seizoenen.</div>
+              <div class="meta">3 mei</div>
+            </div>
+          </div>
+        </div>
+        <div class="annotate">
+          <strong>transform:</strong> none<br />
+          <strong>outline:</strong> 0 → 2px solid jersey-deep, offset 2px<br />
+          <strong>matches:</strong> nothing in current system (new pattern)
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> H.1 = canonical, matches everything except the hero.
+        H.2 = matches the hero specifically — visually consistent at the homepage scroll but
+        breaks the system-wide rule. H.3 = removes motion entirely; trades tactile feedback for
+        accessibility safety.
+      </p>
+      <p>
+        <strong>Why does the hero use press-up?</strong> The hero is the largest visual element on
+        the homepage and its press-up "lifts toward the reader" reads as inviting at scale.
+        Smaller cards pressing up at the same scale create more visual noise (5 cards lifting
+        simultaneously vs. 1 large hero). Press-down on cards keeps the page "flat" while the
+        hero is the only element with depth.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Reduced-motion fallback (always shown — applies
+        to whichever wins). Focus-visible ring spec (separate from hover transform). NewsCard
+        click target / hit-area (the entire card is a Link in every variant).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-5f-newsgrid-sparse-states-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-5f-newsgrid-sparse-states-comparisons.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 5f · NewsGrid empty / sparse states</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 30px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; max-width: 70ch; }
+      .surface {
+        background: var(--cream-soft);
+        padding: 24px 20px;
+      }
+
+      /* === Card === */
+      .card {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 6px 6px 8px;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        height: 100%;
+      }
+      .card .tape {
+        position: absolute;
+        top: -6px;
+        left: 14px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .card .img {
+        flex: 1;
+        min-height: 60px;
+        background: linear-gradient(135deg, #2a4d3a 0%, #547a5e 50%, #c1a04a 100%);
+      }
+      .card .img.alt-2 { background: linear-gradient(135deg, #4d2a2a, #c19a4a); }
+      .card .img.alt-3 { background: linear-gradient(135deg, #2a3a4d, #4a8ac1); }
+      .card .img.alt-4 { background: linear-gradient(135deg, #3a2a4d, #8a4ac1); }
+      .card .img.alt-5 { background: linear-gradient(135deg, #4d3a2a, #c17a4a); }
+      .card .pill {
+        display: inline-block;
+        font-family: ui-monospace, monospace;
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 1px 5px;
+        width: fit-content;
+      }
+      .card .h { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 12px; line-height: 1.18; }
+      .card.lead .h { font-size: 16px; }
+      .card.placeholder {
+        background: var(--cream-deep);
+        opacity: 0.6;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        text-align: center;
+        padding: 24px 12px;
+      }
+      .card.placeholder .img { display: none; }
+      .card.placeholder .pill { display: none; }
+      .rot-a { transform: rotate(-0.5deg); }
+      .rot-b { transform: rotate(-0.25deg); }
+      .rot-c { transform: rotate(0.25deg); }
+      .rot-d { transform: rotate(0.5deg); }
+      .rot-none { transform: none; }
+
+      /* === States === */
+      .states-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 880px) { .states-grid { grid-template-columns: 1fr; } }
+      .state-block {
+        background: #fff;
+        border: 1px dashed var(--ink);
+        padding: 14px;
+      }
+      .state-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 8px;
+      }
+      .state-empty {
+        padding: 28px 14px;
+        text-align: center;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.55;
+        background: var(--cream);
+        border: 1px solid var(--ink);
+      }
+
+      /* Geometry — 1 lead (1fr) + 2x2 right (1fr) */
+      .grid-D {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 8px;
+        min-height: 220px;
+      }
+      .grid-D .lead { grid-column: 1; grid-row: 1 / 3; }
+      .grid-D .b-2 { grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+      .grid-D .b-3 { grid-column: 2; grid-row: 2; display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+      .grid-D-lead-only {
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr;
+        min-height: 220px;
+      }
+      .grid-D-1plus1 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+        min-height: 200px;
+      }
+      .grid-D-1plus2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        gap: 8px;
+        min-height: 220px;
+      }
+      .grid-D-1plus2 .lead { grid-column: 1; grid-row: 1 / 3; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+      .annotate {
+        margin-top: 14px;
+        padding: 10px 14px;
+        background: var(--cream-deep);
+        font-size: 11px;
+        line-height: 1.5;
+        font-family: ui-monospace, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 5f · NewsGrid empty / sparse</div>
+      <h1>What does NewsGrid render with 0–4 articles?</h1>
+      <p>
+        Realistic data flow: <code>articles.slice(3, 8)</code> = 5 articles. But the site can have
+        fewer published — at first launch, after a content prune, with category filters applied
+        (later phases), or when the most recent 3 are all in the hero. This round picks the rule
+        for sparse-data behaviour. Each candidate shows what the grid renders at N = 0, 1, 2,
+        and 3 articles.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Geometry D · 50/50 · 5 cards (1 lead + 2×2)
+      when N ≥ 5 · all 16:9 · slot-index rotation · press-down hover. <strong>This round picks
+      what happens when N &lt; 5.</strong>
+    </div>
+
+    <div class="container">
+
+      <!-- ============ E.1 — Graceful collapse ============ -->
+      <section class="candidate" id="E1">
+        <header>
+          <div class="key">E.1</div>
+          <div class="name">Graceful collapse · render N cards, hide empty slots</div>
+          <div class="desc">
+            Lead always renders if at least 1 article. Supporting slots fill in slot-index order;
+            unfilled slots are not rendered. Geometry adapts: lead-only at N=1 (full width),
+            lead + 1 at N=2 (50/50), lead + 2 at N=3 (lead 50% × 2 rows, 2 supp top row only),
+            etc. Section returns null at N=0.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="states-grid">
+            <div class="state-block">
+              <div class="state-label">N = 0 articles</div>
+              <div class="state-empty">section returns null<br />(no NewsGrid section on the page)</div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 1 article · lead-only full width</div>
+              <div class="grid-D-lead-only">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim Geeraerts tekent voor 2 seizoenen.</div>
+                </div>
+              </div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 2 articles · lead + 1 at 50/50</div>
+              <div class="grid-D-1plus1">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                </div>
+                <div class="card rot-b">
+                  <div class="tape"></div>
+                  <div class="img alt-3"></div>
+                  <span class="pill">Wedstr.</span>
+                  <div class="h">U17 wint 3-1.</div>
+                </div>
+              </div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 3 articles · lead + 2 (top row only)</div>
+              <div class="grid-D-1plus2">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                </div>
+                <div style="grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 8px;">
+                  <div class="card rot-b"><div class="tape"></div><div class="img alt-3"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                  <div class="card rot-c"><div class="tape"></div><div class="img alt-4"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+                </div>
+                <div style="grid-column: 2; grid-row: 2;"></div>
+              </div>
+            </div>
+          </div>
+          <div class="annotate">
+            <strong>rule:</strong> render `min(N, 5)` cards · lead always present at N≥1 · supporting fills slot index 1,2,3,4 in order · empty slots not rendered<br />
+            <strong>edge:</strong> N=0 → return null (no section header, no card grid)
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ E.2 — Hide section under threshold ============ -->
+      <section class="candidate" id="E2">
+        <header>
+          <div class="key">E.2</div>
+          <div class="name">Hide entire section if N &lt; 3</div>
+          <div class="desc">
+            Section requires at least 3 articles to render. Below threshold, NewsGrid returns null
+            entirely (no header, no cards). At N=3+, render the geometry from E.1 (graceful
+            collapse). Avoids the "lonely lead card" look.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="states-grid">
+            <div class="state-block">
+              <div class="state-label">N = 0 / 1 / 2 articles</div>
+              <div class="state-empty">section returns null<br />(no NewsGrid section, regardless of which articles exist)</div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 3 articles · same as E.1 N=3</div>
+              <div class="grid-D-1plus2">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                </div>
+                <div style="grid-column: 2; grid-row: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 8px;">
+                  <div class="card rot-b"><div class="tape"></div><div class="img alt-3"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                  <div class="card rot-c"><div class="tape"></div><div class="img alt-4"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+                </div>
+                <div style="grid-column: 2; grid-row: 2;"></div>
+              </div>
+            </div>
+          </div>
+          <div class="annotate">
+            <strong>rule:</strong> if N &lt; 3 → return null · else render with E.1 geometry<br />
+            <strong>tradeoff:</strong> avoids sparse layouts but loses content visibility at N=1,2
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ E.3 — Placeholder cards ============ -->
+      <section class="candidate" id="E3">
+        <header>
+          <div class="key">E.3</div>
+          <div class="name">Placeholder cards · "geen recent nieuws"</div>
+          <div class="desc">
+            All 5 slots always render. Empty slots become muted "geen recent nieuws" placeholder
+            cards (cream-deep background, opacity 0.6, no image, no pill). Preserves the full
+            geometry visually but signals empty state. Section returns null only at N=0.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="states-grid">
+            <div class="state-block">
+              <div class="state-label">N = 0 articles</div>
+              <div class="state-empty">section returns null<br />(no NewsGrid section on the page)</div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 1 · 1 real + 4 placeholders</div>
+              <div class="grid-D">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                </div>
+                <div class="b-2">
+                  <div class="card placeholder rot-b">geen recent nieuws</div>
+                  <div class="card placeholder rot-c">geen recent nieuws</div>
+                </div>
+                <div class="b-3">
+                  <div class="card placeholder rot-d">geen recent nieuws</div>
+                  <div class="card placeholder rot-a">geen recent nieuws</div>
+                </div>
+              </div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 3 · 3 real + 2 placeholders</div>
+              <div class="grid-D">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                </div>
+                <div class="b-2">
+                  <div class="card rot-b"><div class="tape"></div><div class="img alt-3"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                  <div class="card rot-c"><div class="tape"></div><div class="img alt-4"></div><span class="pill">Aank.</span><div class="h">Inschr. jeugd.</div></div>
+                </div>
+                <div class="b-3">
+                  <div class="card placeholder rot-d">geen recent nieuws</div>
+                  <div class="card placeholder rot-a">geen recent nieuws</div>
+                </div>
+              </div>
+            </div>
+            <div class="state-block">
+              <div class="state-label">N = 5 · all real (full layout)</div>
+              <div class="grid-D">
+                <div class="card rot-a lead">
+                  <div class="tape"></div>
+                  <div class="img alt-2"></div>
+                  <span class="pill">Transfer</span>
+                  <div class="h">Wim G. tekent.</div>
+                </div>
+                <div class="b-2">
+                  <div class="card rot-b"><div class="tape"></div><div class="img alt-3"></div><span class="pill">Wedstr.</span><div class="h">U17 wint 3-1.</div></div>
+                  <div class="card rot-c"><div class="tape"></div><div class="img alt-4"></div><span class="pill">Aank.</span><div class="h">Inschr.</div></div>
+                </div>
+                <div class="b-3">
+                  <div class="card rot-d"><div class="tape"></div><div class="img alt-5"></div><span class="pill">Aank.</span><div class="h">Training mei.</div></div>
+                  <div class="card rot-a"><div class="tape"></div><div class="img"></div><span class="pill">Wedstr.</span><div class="h">Reserves.</div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="annotate">
+            <strong>rule:</strong> always render full geometry · empty slots = placeholder cards<br />
+            <strong>tradeoff:</strong> full geometry preserved but creates "fake content" debt
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> E.1 = adapts geometry to content (most flexible, no fake
+        content). E.2 = hides section to avoid sparse layouts (loses content visibility on launch
+        / pruned states). E.3 = preserves full geometry with placeholders (most visually
+        consistent but feels deceptive).
+      </p>
+      <p>
+        <strong>Why not "auto-resize lead to fill remaining space"?</strong> A 5th option (lead
+        grows when supporting is sparse) was considered and dropped — it makes the lead's image
+        size unpredictable, breaks the cropping contract on coverImage, and creates layout shifts
+        as new articles publish. Phase 4 should commit to a stable lead size.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Loading states (separate from sparse data — the
+        loading skeleton question lives in <code>docs/prd/loading-skeleton-consistency.md</code>).
+        Mobile collapse rules at sparse N (1+1, 1+2 stack vertically; not a separate decision).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-6-schedule-standings-layout-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-6-schedule-standings-layout-comparisons.html
@@ -1,0 +1,650 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 6 · ScheduleStandingsBlock layout</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: rgba(31, 95, 63, 0.12);
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 32px; margin: 6px 0 10px; letter-spacing: -0.02em; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; max-width: 60ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--cream-soft);
+        padding: 28px 24px;
+      }
+
+      .section-title {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 14px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .section-title .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+      }
+      .section-title .all {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+      }
+
+      /* === Schedule list === */
+      .schedule {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 14px 16px;
+        transform: rotate(-0.25deg);
+      }
+      .schedule .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 10px;
+      }
+      .schedule-item {
+        display: grid;
+        grid-template-columns: 60px 1fr auto;
+        gap: 10px;
+        padding: 10px 0;
+        border-bottom: 1px dashed rgba(26, 26, 26, 0.18);
+        align-items: center;
+      }
+      .schedule-item:last-child { border-bottom: 0; }
+      .schedule-item .when {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        line-height: 1.3;
+      }
+      .schedule-item .when .day { font-weight: 700; }
+      .schedule-item .when .time { opacity: 0.6; font-size: 10px; }
+      .schedule-item .matchup {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .schedule-item .matchup .teams {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.2;
+      }
+      .schedule-item .matchup .teams .kcvv { font-weight: 700; }
+      .schedule-item .matchup .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.6;
+      }
+      .schedule-item .badge {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 2px 6px;
+      }
+      .schedule-item .badge.home { background: var(--jersey-deep); }
+
+      /* === Standings table === */
+      .standings {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 14px 16px;
+        transform: rotate(0.25deg);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+      }
+      .standings .label {
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 10px;
+      }
+      .standings table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .standings th, .standings td {
+        text-align: left;
+        padding: 5px 4px;
+        border-bottom: 1px dashed rgba(26, 26, 26, 0.18);
+      }
+      .standings th {
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.65;
+      }
+      .standings td .pos { font-weight: 700; }
+      .standings td .team {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+      }
+      .standings td .pts { font-weight: 700; }
+      .standings tr.kcvv-row {
+        background: var(--jersey-deep-soft);
+        outline: 2px solid var(--jersey-deep);
+        outline-offset: -2px;
+      }
+      .standings tr.kcvv-row td .team { font-weight: 700; color: var(--jersey-deep); }
+      .standings .num { text-align: right; font-variant-numeric: tabular-nums; }
+      .standings tbody td:first-child { width: 32px; text-align: center; }
+
+      /* === Layouts === */
+      .layout-l1 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      .layout-l3 {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+      .layout-l4 {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .layout-l4 .standings-collapse {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 14px 18px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .layout-l4 .standings-collapse .arrow { opacity: 0.6; }
+      @media (max-width: 880px) {
+        .layout-l1 { grid-template-columns: 1fr; }
+      }
+
+      /* === Tabs (L.2) === */
+      .tabs {
+        display: flex;
+        gap: 0;
+        margin-bottom: 16px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .tab {
+        flex: 1;
+        padding: 10px 16px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        text-align: center;
+        background: transparent;
+        border: 1px solid var(--ink);
+        border-bottom: none;
+        cursor: pointer;
+      }
+      .tab.active {
+        background: var(--ink);
+        color: var(--cream);
+      }
+      .tab:not(.active) { background: var(--cream-soft); opacity: 0.7; }
+      .tab-content {
+        background: #fff;
+        border: 1px solid var(--ink);
+        border-top: none;
+        box-shadow: var(--shadow-card);
+        padding: 14px 16px;
+      }
+      .tab-content.standings table th, .tab-content.standings table td {
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+      }
+      .tab-content .label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 10px;
+      }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 6 · ScheduleStandingsBlock layout</div>
+      <h1>Schedule + standings — one block, what shape?</h1>
+      <p>
+        New section in Phase 4 — combines the next several matches with the league standings on a
+        single homepage band. Replaces today's <code>&lt;MatchesSlider&gt;</code> (which only
+        shows matches, no standings). Phase 3 chrome <code>&lt;MatchStrip&gt;</code> still handles
+        the "next match peek" above the hero — this section goes deeper.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Section sits between bannerSlotA and bannerSlotB
+      on the spine (right after NewsGrid). Data: <code>getNextMatches()</code> from BFF
+      (PSD-sourced) + <code>getRanking(teamId=1235)</code> (new homepage call). KCVV row in
+      standings highlighted by <code>team_id === 1235</code>.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ L.1 — Side-by-side split ============ -->
+      <section class="candidate" id="L1">
+        <header>
+          <div>
+            <div class="key">L.1</div>
+            <div class="name">Side-by-side split</div>
+            <div class="desc">
+              Schedule on left, standings on right. Both visible at once. Mobile stacks
+              schedule above standings. Most data exposed without interaction.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Both visible at once<br />
+            + No interaction needed<br />
+            − Doubles horizontal real-estate<br />
+            − Mobile = tall stacked block
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Wedstrijden &amp; stand</span></div>
+          <div class="layout-l1">
+            <div class="schedule">
+              <div class="label">Komende wedstrijden</div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+                <div class="matchup">
+                  <div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div>
+                  <div class="meta">U17 · gewest.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div>
+                  <div class="meta">Reserves · prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 19/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 25/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — RC Mechelen</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+            </div>
+            <div class="standings">
+              <div class="label">Stand · 1ste provinciale A</div>
+              <table>
+                <thead><tr><th>#</th><th>Team</th><th class="num">G</th><th class="num">W</th><th class="num">DP</th><th class="num">Pt</th></tr></thead>
+                <tbody>
+                  <tr><td><span class="pos">1</span></td><td><span class="team">RC Mechelen</span></td><td class="num">22</td><td class="num">17</td><td class="num">+34</td><td class="num pts">53</td></tr>
+                  <tr><td><span class="pos">2</span></td><td><span class="team">FC Werchter</span></td><td class="num">22</td><td class="num">15</td><td class="num">+22</td><td class="num pts">48</td></tr>
+                  <tr class="kcvv-row"><td><span class="pos">3</span></td><td><span class="team">KCVV</span></td><td class="num">22</td><td class="num">14</td><td class="num">+18</td><td class="num pts">45</td></tr>
+                  <tr><td><span class="pos">4</span></td><td><span class="team">VK Tildonk</span></td><td class="num">22</td><td class="num">12</td><td class="num">+5</td><td class="num pts">38</td></tr>
+                  <tr><td><span class="pos">5</span></td><td><span class="team">Steenokkerzeel</span></td><td class="num">22</td><td class="num">11</td><td class="num">+1</td><td class="num pts">35</td></tr>
+                  <tr><td><span class="pos">6</span></td><td><span class="team">SK Heffen</span></td><td class="num">22</td><td class="num">9</td><td class="num">−3</td><td class="num pts">29</td></tr>
+                  <tr><td><span class="pos">…</span></td><td colspan="5" style="text-align: center; opacity: 0.5; font-size: 11px;">Volledige stand op /ranking →</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.2 — Tabs ============ -->
+      <section class="candidate" id="L2">
+        <header>
+          <div>
+            <div class="key">L.2</div>
+            <div class="name">Tabs · "Wedstrijden / Stand"</div>
+            <div class="desc">
+              Two tab buttons; click switches the panel. Default tab = Wedstrijden (matches)
+              since "what's next?" is the more time-sensitive question. Saves vertical space;
+              hides one of the two until interaction.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Compact vertical footprint<br />
+            + Focused single-panel reading<br />
+            − Hides one of the two by default<br />
+            − Requires "use client" component (motion + state)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Wedstrijden &amp; stand</span></div>
+          <div class="tabs">
+            <button class="tab active">Komende wedstrijden</button>
+            <button class="tab">Stand · 1ste prov. A</button>
+          </div>
+          <div class="tab-content">
+            <div class="schedule" style="transform: none; box-shadow: none; border: none; padding: 0;">
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+                <div class="matchup">
+                  <div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div>
+                  <div class="meta">U17 · gewest.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div>
+                  <div class="meta">Reserves · prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 19/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 25/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — RC Mechelen</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.3 — Stacked ============ -->
+      <section class="candidate" id="L3">
+        <header>
+          <div>
+            <div class="key">L.3</div>
+            <div class="name">Stacked · schedule above standings</div>
+            <div class="desc">
+              Schedule first (full width), standings below (full width). Both visible without
+              interaction. Vertically tall. Each block can use its full width to breathe.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Both visible at full width<br />
+            + No interaction, no client component<br />
+            − Tall section (≈600px desktop)<br />
+            − Mobile is even taller
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Wedstrijden &amp; stand</span></div>
+          <div class="layout-l3">
+            <div class="schedule">
+              <div class="label">Komende wedstrijden</div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+                <div class="matchup">
+                  <div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div>
+                  <div class="meta">U17 · gewest.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div>
+                  <div class="meta">Reserves · prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+            </div>
+            <div class="standings">
+              <div class="label">Stand · 1ste provinciale A</div>
+              <table>
+                <thead><tr><th>#</th><th>Team</th><th class="num">G</th><th class="num">W</th><th class="num">G</th><th class="num">V</th><th class="num">DP</th><th class="num">Pt</th></tr></thead>
+                <tbody>
+                  <tr><td><span class="pos">1</span></td><td><span class="team">RC Mechelen</span></td><td class="num">22</td><td class="num">17</td><td class="num">2</td><td class="num">3</td><td class="num">+34</td><td class="num pts">53</td></tr>
+                  <tr><td><span class="pos">2</span></td><td><span class="team">FC Werchter</span></td><td class="num">22</td><td class="num">15</td><td class="num">3</td><td class="num">4</td><td class="num">+22</td><td class="num pts">48</td></tr>
+                  <tr class="kcvv-row"><td><span class="pos">3</span></td><td><span class="team">KCVV</span></td><td class="num">22</td><td class="num">14</td><td class="num">3</td><td class="num">5</td><td class="num">+18</td><td class="num pts">45</td></tr>
+                  <tr><td><span class="pos">4</span></td><td><span class="team">VK Tildonk</span></td><td class="num">22</td><td class="num">12</td><td class="num">2</td><td class="num">8</td><td class="num">+5</td><td class="num pts">38</td></tr>
+                  <tr><td><span class="pos">5</span></td><td><span class="team">Steenokkerzeel</span></td><td class="num">22</td><td class="num">11</td><td class="num">2</td><td class="num">9</td><td class="num">+1</td><td class="num pts">35</td></tr>
+                  <tr><td><span class="pos">6</span></td><td><span class="team">SK Heffen</span></td><td class="num">22</td><td class="num">9</td><td class="num">2</td><td class="num">11</td><td class="num">−3</td><td class="num pts">29</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.4 — Schedule primary + standings collapsed ============ -->
+      <section class="candidate" id="L4">
+        <header>
+          <div>
+            <div class="key">L.4</div>
+            <div class="name">Schedule primary · standings as expand link</div>
+            <div class="desc">
+              Schedule shows in full. Below it: a single-row "Stand · KCVV staat 3e · 45pt →"
+              link that either expands inline or routes to <code>/ranking</code>. Prioritizes
+              schedule; standings is one click away with the headline summary visible.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Schedule gets full prominence<br />
+            + Standings summary is still visible (rank + points)<br />
+            − Full standings table requires interaction<br />
+            − Only really suits fans who care more about fixtures than tables
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title"><span class="h">Komende wedstrijden</span></div>
+          <div class="layout-l4">
+            <div class="schedule">
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+                <div class="matchup">
+                  <div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div>
+                  <div class="meta">U17 · gewest.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div>
+                  <div class="meta">Reserves · prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZO 19/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge">UIT</span>
+              </div>
+              <div class="schedule-item">
+                <div class="when"><div class="day">ZA 25/05</div><div class="time">15:00</div></div>
+                <div class="matchup">
+                  <div class="teams"><span class="kcvv">KCVV</span> — RC Mechelen</div>
+                  <div class="meta">A-ploeg · 1ste prov.</div>
+                </div>
+                <span class="badge home">THUIS</span>
+              </div>
+            </div>
+            <div class="standings-collapse">
+              <span>STAND · 1ste prov. A · KCVV staat <strong style="color: var(--jersey-deep);">3e</strong> met <strong style="color: var(--jersey-deep);">45 pt</strong></span>
+              <span class="arrow">Volledige stand →</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>What's the same in every variant.</strong> Schedule items are tape-card list rows
+        with day/time + matchup + home/away badge. Standings is a tabular list with KCVV row
+        highlighted (jersey-deep tint + outline). Schedule is server-rendered (BFF call); standings
+        is server-rendered (BFF call).
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Schedule depth (next 3 / 5 / week-grouped — Round 6b).
+        Standings shape (full / KCVV-context / top 5 — Round 6c). Per-match link target (Round 6d).
+        Hover behaviour (canonical press-down). Mobile collapse rules (each variant collapses
+        deterministically; explicit rules in lock spec).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-6a-schedule-standings-scope-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-6a-schedule-standings-scope-comparisons.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 6a · Schedule + standings scope</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: rgba(31, 95, 63, 0.12);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 30px; margin: 6px 0 10px; letter-spacing: -0.02em; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .conflict-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: #fff8d6;
+        border: 1px solid #c89500;
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .conflict-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: block;
+        margin-bottom: 4px;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; }
+      .surface { background: var(--cream-soft); padding: 22px 18px; }
+
+      .tabs {
+        display: flex;
+        gap: 0;
+        margin-bottom: 12px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .tab {
+        flex: 1;
+        padding: 8px 12px;
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        text-align: center;
+        background: transparent;
+        border: 1px solid var(--ink);
+        border-bottom: none;
+      }
+      .tab.active { background: var(--ink); color: var(--cream); }
+      .tab:not(.active) { background: var(--cream-soft); opacity: 0.7; }
+
+      .panel {
+        background: #fff;
+        border: 1px solid var(--ink);
+        border-top: none;
+        box-shadow: var(--shadow-card);
+        padding: 12px 14px;
+        font-size: 12px;
+      }
+      .panel-title {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 10px;
+      }
+      .schedule-row {
+        display: grid;
+        grid-template-columns: 56px 1fr auto;
+        gap: 8px;
+        padding: 6px 0;
+        border-bottom: 1px dashed rgba(26, 26, 26, 0.18);
+        align-items: center;
+        font-size: 11px;
+        line-height: 1.3;
+      }
+      .schedule-row:last-child { border-bottom: 0; }
+      .schedule-row .day { font-family: ui-monospace, monospace; font-weight: 700; font-size: 10px; }
+      .schedule-row .time { font-family: ui-monospace, monospace; font-size: 9px; opacity: 0.6; }
+      .schedule-row .teams { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 12px; }
+      .schedule-row .meta { font-family: ui-monospace, monospace; font-size: 8px; opacity: 0.55; letter-spacing: 0.1em; text-transform: uppercase; }
+      .schedule-row .badge { font-family: ui-monospace, monospace; font-size: 8px; letter-spacing: 0.14em; text-transform: uppercase; padding: 1px 5px; }
+      .schedule-row .badge.home { background: var(--jersey-deep); color: var(--cream); }
+      .schedule-row .badge.away { background: var(--ink); color: var(--cream); }
+      .kcvv { font-weight: 700; }
+
+      table.standings {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+      }
+      table.standings th, table.standings td {
+        text-align: left;
+        padding: 4px 4px;
+        border-bottom: 1px dashed rgba(26, 26, 26, 0.18);
+      }
+      table.standings th { font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; opacity: 0.65; }
+      table.standings .num { text-align: right; font-variant-numeric: tabular-nums; }
+      table.standings tr.kcvv-row {
+        background: var(--jersey-deep-soft);
+        outline: 1.5px solid var(--jersey-deep);
+        outline-offset: -2px;
+      }
+      table.standings tr.kcvv-row .team { font-weight: 700; color: var(--jersey-deep); }
+      table.standings .team { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 12px; }
+      table.standings .pts { font-weight: 700; }
+
+      .picker {
+        display: flex;
+        gap: 4px;
+        margin-bottom: 10px;
+        flex-wrap: wrap;
+      }
+      .pick {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        padding: 4px 8px;
+        background: var(--cream-deep);
+        border: 1px solid var(--ink);
+        cursor: pointer;
+      }
+      .pick.active { background: var(--jersey-deep); color: var(--cream); }
+
+      .note {
+        margin-top: 10px;
+        padding: 8px 10px;
+        background: var(--cream-deep);
+        font-size: 10px;
+        line-height: 1.5;
+        font-family: ui-monospace, monospace;
+        opacity: 0.85;
+      }
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 6a · Scope (precursor to depth)</div>
+      <h1>What scope does each tab cover?</h1>
+      <p>
+        Round 6 locked the L.2 tabs layout, but Round 6b (depth) revealed a real mismatch:
+        all-team schedule paired with single-team standings is incoherent. This round picks the
+        scope of each tab.
+      </p>
+    </header>
+
+    <div class="conflict-banner">
+      <strong>The conflict, clearly stated.</strong>
+      Round 6 mockups showed: Wedstrijden tab = all KCVV teams (A · U17 · U15 · Res …), Stand
+      tab = 1ste provinciale A only. A visitor sees U17 vs Werchter on tab 1, then a 1ste-prov-A
+      table on tab 2 — no way to know where U17 sits in the U17 ranking. Pick a coherent scope
+      per tab below before re-asking schedule depth.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ S.1 — Both A-team only ============ -->
+      <section class="candidate" id="S1">
+        <header>
+          <div class="key">S.1</div>
+          <div class="name">Both A-team only</div>
+          <div class="desc">
+            Wedstrijden = next A-team fixtures · Stand = 1ste prov. A. Internally consistent.
+            Section on the homepage is laser-focused on the senior team. Loses youth / reserves
+            visibility from <code>/</code>.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="tabs">
+            <button class="tab active">Komende A-wedstrijden</button>
+            <button class="tab">Stand 1ste prov. A</button>
+          </div>
+          <div class="panel">
+            <div class="schedule-row">
+              <div><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+              <div><div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZO 19/05</div><div class="time">15:00</div></div>
+              <div><div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge away">UIT</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZA 25/05</div><div class="time">15:00</div></div>
+              <div><div class="teams"><span class="kcvv">KCVV</span> — RC Mechelen</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZO 02/06</div><div class="time">15:00</div></div>
+              <div><div class="teams">FC Werchter — <span class="kcvv">KCVV</span></div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge away">UIT</span>
+            </div>
+          </div>
+          <div class="note">
+            Filters: <code>kcvv_team_id === 1235 (A-ploeg)</code> on the schedule call · standings table for the A-team's group only · "U17 / U15 / Reserves" matches & tables live on per-team pages and <code>/kalender</code> only.
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ S.2 — Both all-team (multi-table picker) ============ -->
+      <section class="candidate" id="S2">
+        <header>
+          <div class="key">S.2</div>
+          <div class="name">Both all-team · multi-table picker</div>
+          <div class="desc">
+            Wedstrijden = all upcoming KCVV matches across teams · Stand = a team-picker
+            (A-ploeg / U21 / U17 / U15 / Res …) with each team's own standings table on
+            selection. Most complete; heaviest UX.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="tabs">
+            <button class="tab">Komende wedstrijden</button>
+            <button class="tab active">Stand</button>
+          </div>
+          <div class="panel">
+            <div class="picker">
+              <span class="pick active">A-PLOEG</span>
+              <span class="pick">U21</span>
+              <span class="pick">U17</span>
+              <span class="pick">U15</span>
+              <span class="pick">RES.</span>
+            </div>
+            <div class="panel-title">Stand A-ploeg · 1ste prov. A</div>
+            <table class="standings">
+              <thead><tr><th>#</th><th>Team</th><th class="num">G</th><th class="num">DP</th><th class="num">Pt</th></tr></thead>
+              <tbody>
+                <tr><td>1</td><td><span class="team">RC Mechelen</span></td><td class="num">22</td><td class="num">+34</td><td class="num pts">53</td></tr>
+                <tr><td>2</td><td><span class="team">FC Werchter</span></td><td class="num">22</td><td class="num">+22</td><td class="num pts">48</td></tr>
+                <tr class="kcvv-row"><td>3</td><td><span class="team">KCVV</span></td><td class="num">22</td><td class="num">+18</td><td class="num pts">45</td></tr>
+                <tr><td>4</td><td><span class="team">VK Tildonk</span></td><td class="num">22</td><td class="num">+5</td><td class="num pts">38</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="note">
+            Schedule call = all upcoming · 5 BFF standings calls (one per active KCVV team-id) — cached. Picker is "use client" — initial render = A-ploeg, click swaps table without server round-trip.
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ S.3 — Mixed scope, named honestly ============ -->
+      <section class="candidate" id="S3">
+        <header>
+          <div class="key">S.3</div>
+          <div class="name">Mixed scope · named honestly</div>
+          <div class="desc">
+            Wedstrijden = all KCVV upcoming matches (community view). Stand =
+            <strong>explicitly A-ploeg only</strong> (label says "Stand A-ploeg"). Conflict
+            acknowledged via labeling: schedule = "what's coming up at the club", standings =
+            "headline rank for the senior team."
+          </div>
+        </header>
+        <div class="surface">
+          <div class="tabs">
+            <button class="tab active">Komende wedstrijden</button>
+            <button class="tab">Stand A-ploeg</button>
+          </div>
+          <div class="panel">
+            <div class="schedule-row">
+              <div><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+              <div><div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+              <div><div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div><div class="meta">U17 · gewest.</div></div>
+              <span class="badge away">UIT</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZO 12/05</div><div class="time">14:00</div></div>
+              <div><div class="teams"><span class="kcvv">KCVV U15</span> — Tisselt</div><div class="meta">U15 · gewest.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+              <div><div class="teams"><span class="kcvv">Reserves</span> — Steenokkerzeel</div><div class="meta">Reserves · prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+          </div>
+          <div class="note">
+            Schedule = all KCVV teams · Stand tab is explicitly named "Stand A-ploeg" so a visitor checking U17's matches doesn't expect to find U17's table here · per-team standings on team pages.
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ S.4 — Drop standings entirely ============ -->
+      <section class="candidate" id="S4">
+        <header>
+          <div class="key">S.4</div>
+          <div class="name">Drop standings · schedule-only block</div>
+          <div class="desc">
+            No tabs. Section becomes a single-purpose <code>&lt;ScheduleBlock&gt;</code> showing
+            all upcoming KCVV matches. Standings live on <code>/ranking</code> (or per-team
+            pages). Cleanest. Loses the "we're 3rd" headline signal from <code>/</code>.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="panel" style="border-top: 1px solid var(--ink);">
+            <div class="panel-title">Komende wedstrijden</div>
+            <div class="schedule-row">
+              <div><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+              <div><div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+              <div><div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div><div class="meta">U17 · gewest.</div></div>
+              <span class="badge away">UIT</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZO 12/05</div><div class="time">14:00</div></div>
+              <div><div class="teams"><span class="kcvv">KCVV U15</span> — Tisselt</div><div class="meta">U15 · gewest.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row">
+              <div><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+              <div><div class="teams"><span class="kcvv">Reserves</span> — Steenokkerzeel</div><div class="meta">Reserves · prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-row" style="opacity: 0.7;">
+              <div></div>
+              <div style="text-align: right; font-family: ui-monospace, monospace; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;">Volledige stand op /ranking →</div>
+              <span></span>
+            </div>
+          </div>
+          <div class="note">
+            Section renamed: <code>&lt;ScheduleStandingsBlock&gt;</code> → <code>&lt;UpcomingMatches&gt;</code> (or similar). Issue #1526 AC list updated. /ranking page unchanged from today (it's a separate phase).
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> S.1 is purest A-team focus (loses youth/reserves
+        visibility on /). S.2 is most complete (heaviest UX — picker + 5 BFF standings calls).
+        S.3 is honest about mixed scope via labels (matches = community, standings = headline
+        only). S.4 simplifies by dropping the second tab entirely (loses headline rank signal).
+      </p>
+      <p>
+        <strong>What this resolves for Round 6b.</strong> If S.1 wins → schedule depth picks
+        next-N A-team fixtures (likely 3 since A plays once a week). If S.2/S.3 win → schedule
+        depth picks next-N across all teams (5 or grouped-by-week makes sense). If S.4 wins →
+        schedule depth picks all-team count, no standings to coordinate with.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-6b-schedule-depth-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-6b-schedule-depth-comparisons.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 6b · Schedule depth</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: rgba(31, 95, 63, 0.12);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 30px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 28px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; max-width: 56ch; }
+      .surface { background: var(--cream-soft); padding: 24px 20px; }
+
+      .tabs {
+        display: flex;
+        gap: 0;
+        margin-bottom: 14px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .tab {
+        flex: 1;
+        padding: 8px 14px;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        text-align: center;
+        background: transparent;
+        border: 1px solid var(--ink);
+        border-bottom: none;
+      }
+      .tab.active { background: var(--ink); color: var(--cream); }
+      .tab:not(.active) { background: var(--cream-soft); opacity: 0.7; }
+
+      .panel {
+        background: #fff;
+        border: 1px solid var(--ink);
+        border-top: none;
+        box-shadow: var(--shadow-card);
+        padding: 12px 14px;
+      }
+
+      .schedule-item {
+        display: grid;
+        grid-template-columns: 60px 1fr auto;
+        gap: 10px;
+        padding: 8px 0;
+        border-bottom: 1px dashed rgba(26, 26, 26, 0.18);
+        align-items: center;
+      }
+      .schedule-item:last-child { border-bottom: 0; }
+      .schedule-item .when {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        line-height: 1.3;
+      }
+      .schedule-item .when .day { font-weight: 700; }
+      .schedule-item .when .time { opacity: 0.6; font-size: 10px; }
+      .schedule-item .matchup {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .schedule-item .matchup .teams {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.2;
+      }
+      .schedule-item .matchup .teams .kcvv { font-weight: 700; }
+      .schedule-item .matchup .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        opacity: 0.6;
+      }
+      .schedule-item .badge {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--ink);
+        color: var(--cream);
+        padding: 2px 6px;
+      }
+      .schedule-item .badge.home { background: var(--jersey-deep); }
+
+      .week-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin: 12px 0 6px;
+        padding-top: 8px;
+        border-top: 1px dashed rgba(26, 26, 26, 0.3);
+      }
+      .week-label:first-child { margin-top: 0; padding-top: 0; border-top: none; }
+
+      .more-link {
+        margin-top: 12px;
+        text-align: center;
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        padding: 8px 0;
+        border-top: 1px dashed rgba(26, 26, 26, 0.3);
+      }
+
+      .scroll-track {
+        display: flex;
+        gap: 12px;
+        overflow-x: auto;
+        padding: 4px 4px 14px;
+        scroll-snap-type: x mandatory;
+      }
+      .scroll-card {
+        flex: 0 0 220px;
+        background: var(--cream);
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 10px 12px;
+        scroll-snap-align: start;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .scroll-card .when {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .scroll-card .teams {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.18;
+      }
+      .scroll-card .teams .kcvv { font-weight: 700; }
+      .scroll-card .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 9px;
+        opacity: 0.6;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      .scroll-hint {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        opacity: 0.6;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        padding-top: 8px;
+        text-align: center;
+      }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 6b · Schedule depth</div>
+      <h1>How many matches show in the Wedstrijden tab?</h1>
+      <p>
+        L.2 tabs locked in Round 6. This round picks the schedule depth — how many upcoming
+        matches the Wedstrijden tab renders. Realistic: KCVV has ~5–8 teams playing once per
+        week, so the data set is rich.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from Rounds 6 + 6a.</strong> Section is a <strong>single schedule panel</strong>
+      — no tabs (Round 6's L.2 lock superseded by Round 6a's S.4 drop). Section will be renamed from
+      <code>&lt;ScheduleStandingsBlock&gt;</code> to <code>&lt;UpcomingMatches&gt;</code>. Standings
+      live on <code>/ranking</code>. Schedule items use when + matchup + home/away badge format.
+      This round picks how many rows render.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ D.1 — Next 3 ============ -->
+      <section class="candidate" id="D1">
+        <header>
+          <div class="key">D.1</div>
+          <div class="name">Next 3 matches · compact</div>
+          <div class="desc">
+            Most glanceable — only the very next 3 matches across all KCVV teams. Forces
+            visitors to hit <code>/kalender</code> for anything beyond the immediate weekend.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="panel">
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+              <div class="matchup">
+                <div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div>
+                <div class="meta">A-ploeg · 1ste prov.</div>
+              </div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+              <div class="matchup">
+                <div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div>
+                <div class="meta">U17 · gewest.</div>
+              </div>
+              <span class="badge">UIT</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+              <div class="matchup">
+                <div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div>
+                <div class="meta">Reserves · prov.</div>
+              </div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="more-link">Volledige kalender →</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D.2 — Next 5 ============ -->
+      <section class="candidate" id="D2">
+        <header>
+          <div class="key">D.2</div>
+          <div class="name">Next 5 matches · scannable</div>
+          <div class="desc">
+            Five rows — covers the next ~1–2 weekends across teams. Default proven by the
+            mockups in Round 6. Right balance of weight and skim-ability.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="panel">
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+              <div class="matchup"><div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+              <div class="matchup"><div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div><div class="meta">U17 · gewest.</div></div>
+              <span class="badge">UIT</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+              <div class="matchup"><div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div><div class="meta">Reserves · prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZO 19/05</div><div class="time">15:00</div></div>
+              <div class="matchup"><div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge">UIT</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 25/05</div><div class="time">15:00</div></div>
+              <div class="matchup"><div class="teams"><span class="kcvv">KCVV</span> — RC Mechelen</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="more-link">Volledige kalender →</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D.3 — Grouped by week ============ -->
+      <section class="candidate" id="D3">
+        <header>
+          <div class="key">D.3</div>
+          <div class="name">This week + next week · grouped headers</div>
+          <div class="desc">
+            All matches in the current week, then all matches in the next week. Grouped under
+            week labels ("Dit weekend", "Volgend weekend"). Variable count (typically 5–8).
+            Most natural for fans planning their weekend.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="panel">
+            <div class="week-label">Dit weekend · 11–12 mei</div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 11/05</div><div class="time">15:00</div></div>
+              <div class="matchup"><div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZO 12/05</div><div class="time">10:30</div></div>
+              <div class="matchup"><div class="teams">FC Werchter — <span class="kcvv">KCVV U17</span></div><div class="meta">U17 · gewest.</div></div>
+              <span class="badge">UIT</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZO 12/05</div><div class="time">14:00</div></div>
+              <div class="matchup"><div class="teams"><span class="kcvv">KCVV U15</span> — Tisselt</div><div class="meta">U15 · gewest.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="week-label">Volgend weekend · 18–19 mei</div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZA 18/05</div><div class="time">14:30</div></div>
+              <div class="matchup"><div class="teams"><span class="kcvv">KCVV Reserves</span> — Steenokkerzeel</div><div class="meta">Reserves · prov.</div></div>
+              <span class="badge home">THUIS</span>
+            </div>
+            <div class="schedule-item">
+              <div class="when"><div class="day">ZO 19/05</div><div class="time">15:00</div></div>
+              <div class="matchup"><div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div><div class="meta">A-ploeg · 1ste prov.</div></div>
+              <span class="badge">UIT</span>
+            </div>
+            <div class="more-link">Volledige kalender →</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ D.4 — Horizontal scroll-track (today's slider) ============ -->
+      <section class="candidate" id="D4">
+        <header>
+          <div class="key">D.4</div>
+          <div class="name">Horizontal scroll-track · "MatchesSlider" replacement</div>
+          <div class="desc">
+            All upcoming matches as scroll-snap cards in a horizontal track. Closest to today's
+            <code>&lt;MatchesSlider&gt;</code>. Each card is a tape-card. Mouse drag / swipe /
+            arrow keys to navigate.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="panel">
+            <div class="scroll-track">
+              <div class="scroll-card">
+                <div class="when">ZA 11/05 · 15:00</div>
+                <div class="teams"><span class="kcvv">KCVV</span> — VK Tildonk</div>
+                <div class="meta">A · prov · THUIS</div>
+              </div>
+              <div class="scroll-card">
+                <div class="when">ZO 12/05 · 10:30</div>
+                <div class="teams">Werchter — <span class="kcvv">KCVV U17</span></div>
+                <div class="meta">U17 · gewest · UIT</div>
+              </div>
+              <div class="scroll-card">
+                <div class="when">ZO 12/05 · 14:00</div>
+                <div class="teams"><span class="kcvv">KCVV U15</span> — Tisselt</div>
+                <div class="meta">U15 · gewest · THUIS</div>
+              </div>
+              <div class="scroll-card">
+                <div class="when">ZA 18/05 · 14:30</div>
+                <div class="teams"><span class="kcvv">KCVV Res.</span> — SOK</div>
+                <div class="meta">Res · prov · THUIS</div>
+              </div>
+              <div class="scroll-card">
+                <div class="when">ZO 19/05 · 15:00</div>
+                <div class="teams">SK Heffen — <span class="kcvv">KCVV</span></div>
+                <div class="meta">A · prov · UIT</div>
+              </div>
+              <div class="scroll-card">
+                <div class="when">ZA 25/05 · 15:00</div>
+                <div class="teams"><span class="kcvv">KCVV</span> — RC Mechelen</div>
+                <div class="meta">A · prov · THUIS</div>
+              </div>
+              <div class="scroll-card">
+                <div class="when">ZO 26/05 · 10:30</div>
+                <div class="teams"><span class="kcvv">KCVV U17</span> — Eppegem</div>
+                <div class="meta">U17 · gewest · THUIS</div>
+              </div>
+            </div>
+            <div class="scroll-hint">← scroll →</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Realistic data context.</strong> KCVV has 5–8 teams playing once per week.
+        D.1 = ~½ a weekend. D.2 = full current weekend + next weekend's lead. D.3 = both weekends
+        in full. D.4 = everything upcoming, scroll-snap.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Standings shape (Round 6c — full table /
+        KCVV-context / top 5). Per-match link target — clicking a row → <code>/match/{id}</code>
+        is the obvious default; only confirm if there's reason to deviate.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-7-sponsorsblock-layout-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-7-sponsorsblock-layout-comparisons.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 7 · SponsorsBlock layout</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 32px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--cream-deep);
+        padding: 32px 24px 36px;
+      }
+
+      .section-title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 24px;
+        margin-bottom: 20px;
+        text-align: center;
+      }
+      .section-sub {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        text-align: center;
+        opacity: 0.65;
+        margin-top: -14px;
+        margin-bottom: 22px;
+      }
+      .tier-label {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 10px;
+        text-align: center;
+      }
+
+      /* Logo card */
+      .logo {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        text-align: center;
+        line-height: 1.2;
+        filter: grayscale(100%);
+        transition: filter 200ms ease;
+        position: relative;
+      }
+      .logo:hover { filter: grayscale(0%); }
+      .logo.main { font-size: 18px; padding: 22px 16px; min-height: 90px; }
+      .logo.second { font-size: 13px; padding: 14px 10px; min-height: 64px; }
+      .logo.tape::before {
+        content: "";
+        position: absolute;
+        top: -7px;
+        left: 14px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .logo.color-1 { color: #c00; background: #fff; }
+      .logo.color-2 { color: #006bb3; background: #fff; }
+      .logo.color-3 { color: #2d6e2d; background: #fff; }
+      .logo.color-4 { color: #7a3d00; background: #fff; }
+      .logo.color-5 { color: #6a4400; background: #fff; }
+      .logo.color-6 { color: #b30086; background: #fff; }
+      .logo.color-7 { color: #006666; background: #fff; }
+      .logo.color-8 { color: #cc6600; background: #fff; }
+
+      .rot-a { transform: rotate(-0.5deg); }
+      .rot-b { transform: rotate(-0.25deg); }
+      .rot-c { transform: rotate(0.25deg); }
+      .rot-d { transform: rotate(0.5deg); }
+      .rot-none { transform: none; }
+
+      /* L.1 — Tiered grid */
+      .l1-main {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+        margin-bottom: 28px;
+      }
+      .l1-second {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 14px;
+      }
+      @media (max-width: 880px) {
+        .l1-main { grid-template-columns: 1fr 1fr; }
+        .l1-second { grid-template-columns: repeat(3, 1fr); }
+      }
+      @media (max-width: 600px) {
+        .l1-main { grid-template-columns: 1fr; }
+        .l1-second { grid-template-columns: 1fr 1fr; }
+      }
+
+      /* L.2 — Single equal grid */
+      .l2-grid {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 14px;
+      }
+      @media (max-width: 880px) {
+        .l2-grid { grid-template-columns: repeat(3, 1fr); }
+      }
+      @media (max-width: 600px) {
+        .l2-grid { grid-template-columns: 1fr 1fr; }
+      }
+
+      /* L.3 — Classifieds (irregular) */
+      .l3-grid {
+        display: grid;
+        grid-template-columns: repeat(8, 1fr);
+        grid-auto-rows: minmax(80px, auto);
+        gap: 12px;
+      }
+      .l3-grid .logo.main {
+        grid-column: span 4;
+        grid-row: span 1;
+      }
+      .l3-grid .logo.main.lead {
+        grid-column: span 4;
+        grid-row: span 2;
+        font-size: 24px;
+      }
+      .l3-grid .logo.second { grid-column: span 2; }
+      @media (max-width: 880px) {
+        .l3-grid { grid-template-columns: repeat(4, 1fr); }
+        .l3-grid .logo.main { grid-column: span 4; grid-row: auto; }
+        .l3-grid .logo.main.lead { grid-column: span 4; grid-row: auto; }
+        .l3-grid .logo.second { grid-column: span 2; }
+      }
+
+      /* L.4 — Horizontal scroll */
+      .l4-track {
+        display: flex;
+        gap: 14px;
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+        padding-bottom: 14px;
+      }
+      .l4-track .logo {
+        flex: 0 0 200px;
+        scroll-snap-align: start;
+      }
+      .l4-track .logo.main { flex: 0 0 240px; }
+      .scroll-hint {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        opacity: 0.6;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        text-align: center;
+        margin-top: 12px;
+      }
+      .all-sponsors-link {
+        margin-top: 24px;
+        padding-top: 14px;
+        border-top: 1px dashed rgba(26, 26, 26, 0.35);
+        text-align: center;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--ink);
+      }
+      .all-sponsors-link a {
+        color: var(--jersey-deep);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        font-weight: 700;
+      }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 7 · SponsorsBlock</div>
+      <h1>How are sponsors arranged on the homepage?</h1>
+      <p>
+        SponsorsBlock receives all sponsors with <code>tier === "hoofdsponsor"</code> or
+        <code>tier === "sponsor"</code> (sympathisanten excluded per
+        <code>reference_sponsor_tiers</code>). Realistic data: 1–3 hoofdsponsors and 8–15 sponsors.
+        Logos are greyscale by default and reveal full colour on hover (CSS <code>filter:
+        grayscale(100%)</code> + transition). This round picks the layout.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from prior rounds.</strong> Section sits last in the body before
+      SiteFooter (Spine A · BS.1 keeps bannerSlotC just before sponsors). Greyscale-default
+      colour-on-hover is the locked logo treatment. This round picks the grid.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ L.1 — Tiered grid ============ -->
+      <section class="candidate" id="L1">
+        <header>
+          <div>
+            <div class="key">L.1</div>
+            <div class="name">Tiered grid · main row + second row</div>
+            <div class="desc">
+              Hoofdsponsors in a top row of 3 (larger logos). Below them, sponsors in a row of
+              5 (smaller logos). Hierarchy is explicit. Most conventional sponsor-page pattern.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Tier hierarchy crystal clear<br />
+            + Easy editor mental model<br />
+            − Two distinct logo sizes per row<br />
+            − Top row breaks if &lt; 3 hoofdsponsors
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">Met dank aan onze sponsors</div>
+          <div class="tier-label">Hoofdsponsors</div>
+          <div class="l1-main">
+            <div class="logo main color-1 rot-a">Crossing Auto</div>
+            <div class="logo main color-2 rot-b">KBC Verzekeringen</div>
+            <div class="logo main color-3 rot-c">Bouw Janssens</div>
+          </div>
+          <div class="tier-label">Sponsors</div>
+          <div class="l1-second">
+            <div class="logo second color-4 rot-d">De Bonte Slager</div>
+            <div class="logo second color-5 rot-a">Hapje &amp; Tapje</div>
+            <div class="logo second color-6 rot-b">Fitness Plus</div>
+            <div class="logo second color-7 rot-c">AC Audio</div>
+            <div class="logo second color-8 rot-d">Wouters Schilder</div>
+            <div class="logo second color-1 rot-a">Steenhouwerij Dupont</div>
+            <div class="logo second color-2 rot-b">Verbiest Auto</div>
+            <div class="logo second color-3 rot-c">Tandarts Heyligen</div>
+            <div class="logo second color-4 rot-d">Praktijk Berk</div>
+            <div class="logo second color-5 rot-a">De Sportshop</div>
+          </div>
+          <div class="all-sponsors-link">
+            <a href="/sponsors">Alle sponsors &amp; sympathisanten →</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.2 — Single equal grid ============ -->
+      <section class="candidate" id="L2">
+        <header>
+          <div>
+            <div class="key">L.2</div>
+            <div class="name">Single equal grid · all sponsors equal size</div>
+            <div class="desc">
+              No size hierarchy. All hoofdsponsors and sponsors render at the same logo size in a
+              single 5-column grid. Order: hoofdsponsors first, then sponsors. Cleanest grid;
+              loses the tier-emphasis cue.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Cleanest grid, single sizing rule<br />
+            + Most paper-newspaper register<br />
+            − Tier hierarchy invisible<br />
+            − Hoofdsponsors lose emphasis they paid for
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">Met dank aan onze sponsors</div>
+          <div class="l2-grid">
+            <div class="logo main color-1 rot-a" style="font-size: 14px; padding: 14px 10px; min-height: 64px;">Crossing Auto</div>
+            <div class="logo main color-2 rot-b" style="font-size: 14px; padding: 14px 10px; min-height: 64px;">KBC Verzekeringen</div>
+            <div class="logo main color-3 rot-c" style="font-size: 14px; padding: 14px 10px; min-height: 64px;">Bouw Janssens</div>
+            <div class="logo second color-4 rot-d">De Bonte</div>
+            <div class="logo second color-5 rot-a">Hapje &amp; Tapje</div>
+            <div class="logo second color-6 rot-b">Fitness Plus</div>
+            <div class="logo second color-7 rot-c">AC Audio</div>
+            <div class="logo second color-8 rot-d">Wouters Schilder</div>
+            <div class="logo second color-1 rot-a">Dupont</div>
+            <div class="logo second color-2 rot-b">Verbiest Auto</div>
+            <div class="logo second color-3 rot-c">Heyligen</div>
+            <div class="logo second color-4 rot-d">Praktijk Berk</div>
+            <div class="logo second color-5 rot-a">De Sportshop</div>
+          </div>
+          <div class="all-sponsors-link">
+            <a href="/sponsors">Alle sponsors &amp; sympathisanten →</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.3 — Classifieds-style ============ -->
+      <section class="candidate" id="L3">
+        <header>
+          <div>
+            <div class="key">L.3</div>
+            <div class="name">Classifieds · irregular newspaper grid</div>
+            <div class="desc">
+              12-column woven grid. One large hoofdsponsor (4 × 2 cells) anchors. Remaining
+              hoofdsponsors take 4 × 1 cells. Sponsors fill 2-cell slots. Most fanzine /
+              classifieds-page feel. Slot sizes hand-tuned per tier.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most magazine-feeling register<br />
+            + Tier hierarchy via slot size, not row<br />
+            − Slot-tuned for specific N values<br />
+            − Lead hoofdsponsor gets disproportionate emphasis
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">Met dank aan onze sponsors</div>
+          <div class="l3-grid">
+            <div class="logo main lead color-1 rot-a">Crossing Auto</div>
+            <div class="logo main color-2 rot-b">KBC Verzekeringen</div>
+            <div class="logo main color-3 rot-c">Bouw Janssens</div>
+            <div class="logo second color-4 rot-d">De Bonte</div>
+            <div class="logo second color-5 rot-a">Hapje &amp; Tapje</div>
+            <div class="logo second color-6 rot-b">Fitness Plus</div>
+            <div class="logo second color-7 rot-c">AC Audio</div>
+            <div class="logo second color-8 rot-d">Wouters Schilder</div>
+            <div class="logo second color-1 rot-a">Dupont</div>
+            <div class="logo second color-2 rot-b">Verbiest Auto</div>
+            <div class="logo second color-3 rot-c">Heyligen</div>
+            <div class="logo second color-4 rot-d">Berk</div>
+            <div class="logo second color-5 rot-a">Sportshop</div>
+          </div>
+          <div class="all-sponsors-link">
+            <a href="/sponsors">Alle sponsors &amp; sympathisanten →</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.4 — Horizontal scroll ============ -->
+      <section class="candidate" id="L4">
+        <header>
+          <div>
+            <div class="key">L.4</div>
+            <div class="name">Horizontal scroll-track · sponsor reel</div>
+            <div class="desc">
+              Single-row horizontal scroll. Hoofdsponsors first (slightly larger), sponsors after.
+              Compact vertical footprint. Reads like a sponsor-banner reel that you scroll
+              through. Mobile-friendly by default.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Compact vertical (1 row)<br />
+            + Mobile-native (already scrolls)<br />
+            − Hides ~half the sponsors below the fold<br />
+            − No grid presence on the page
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">Met dank aan onze sponsors</div>
+          <div class="l4-track">
+            <div class="logo main color-1 rot-a">Crossing Auto</div>
+            <div class="logo main color-2 rot-b">KBC Verzekeringen</div>
+            <div class="logo main color-3 rot-c">Bouw Janssens</div>
+            <div class="logo second color-4 rot-d">De Bonte</div>
+            <div class="logo second color-5 rot-a">Hapje &amp; Tapje</div>
+            <div class="logo second color-6 rot-b">Fitness Plus</div>
+            <div class="logo second color-7 rot-c">AC Audio</div>
+            <div class="logo second color-8 rot-d">Wouters Schilder</div>
+            <div class="logo second color-1 rot-a">Dupont</div>
+            <div class="logo second color-2 rot-b">Verbiest Auto</div>
+            <div class="logo second color-3 rot-c">Heyligen</div>
+            <div class="logo second color-4 rot-d">Berk</div>
+            <div class="logo second color-5 rot-a">Sportshop</div>
+          </div>
+          <div class="scroll-hint">← scroll voor meer sponsors →</div>
+          <div class="all-sponsors-link">
+            <a href="/sponsors">Alle sponsors &amp; sympathisanten →</a>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Note on logos.</strong> Real production logos are SVG / PNG files uploaded by
+        editors per sponsor. The italic Freight Display name treatment shown above is a fallback
+        for sponsors without a logo asset uploaded — and a mockup convenience here. Greyscale +
+        colour on hover applies uniformly via CSS <code>filter</code>.
+      </p>
+      <p>
+        <strong>Out of scope this round.</strong> Spotlight section (sponsors flagged
+        <code>featured: true</code> + <code>description</code> shown — likely a separate sub-component).
+        Per-logo card variant (TapedCard? plain tile? square frame?) — Round 7b.
+        Tape rotation pool (likely follows the same pattern as NewsGrid). Empty / single-tier states.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-7b-sponsor-logo-treatment-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-7b-sponsor-logo-treatment-comparisons.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 7b · Sponsor logo container treatment</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+      }
+      .candidate header {
+        padding: 14px 18px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 19px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; }
+      .surface {
+        background: var(--cream-deep);
+        padding: 28px 20px 32px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 12px;
+      }
+      .logo-base {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 10px;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        text-align: center;
+        line-height: 1.2;
+        min-height: 70px;
+        filter: grayscale(100%);
+        transition: filter 200ms ease;
+        position: relative;
+      }
+      .logo-base:hover { filter: grayscale(0%); }
+      .rot-a { transform: rotate(-0.5deg); }
+      .rot-b { transform: rotate(-0.25deg); }
+      .rot-c { transform: rotate(0.25deg); }
+      .rot-d { transform: rotate(0.5deg); }
+
+      /* C.1 — Paper card, no tape */
+      .c1 {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+      }
+      /* C.2 — Paper card with tape strip on every logo */
+      .c2 {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+      }
+      .c2::before {
+        content: "";
+        position: absolute;
+        top: -7px;
+        left: 14px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      /* C.3 — Borderless tile */
+      .c3 {
+        background: var(--cream);
+        border: none;
+        box-shadow: none;
+      }
+      .color-1 { color: #c00; background: #fff; }
+      .color-2 { color: #006bb3; background: #fff; }
+      .color-3 { color: #2d6e2d; background: #fff; }
+      .color-4 { color: #7a3d00; background: #fff; }
+      .color-5 { color: #6a4400; background: #fff; }
+      .color-6 { color: #b30086; background: #fff; }
+      .c3.color-1, .c3.color-2, .c3.color-3, .c3.color-4, .c3.color-5, .c3.color-6 {
+        background: var(--cream);
+      }
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 7b · Sponsor logo container</div>
+      <h1>How does each sponsor logo render?</h1>
+      <p>
+        Same L.2 grid layout in every variant — only the per-logo container changes.
+        13 logos shown for direct comparison. Remember: in production each cell shows the actual
+        SVG/PNG logo file, not the italic name treatment used here as a fallback.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked from Round 7.</strong> L.2 single equal grid · all sponsors same size ·
+      hoofdsponsors first then sponsors · /sponsors link at the bottom · greyscale-default,
+      colour-on-hover. This sub-round picks the per-logo container treatment.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ C.1 — Paper card, no tape ============ -->
+      <section class="candidate" id="C1">
+        <header>
+          <div class="key">C.1</div>
+          <div class="name">Paper card · no tape per logo</div>
+          <div class="desc">
+            Each logo sits inside a clean white paper card (border + hard shadow + subtle
+            rotation per slot). No tape strip per logo — keeps the grid scannable at 13 cells.
+            Most balanced: paper register without ornament clutter.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="grid">
+            <div class="logo-base c1 rot-a color-1">Crossing Auto</div>
+            <div class="logo-base c1 rot-b color-2">KBC</div>
+            <div class="logo-base c1 rot-c color-3">Bouw Janssens</div>
+            <div class="logo-base c1 rot-d color-4">De Bonte</div>
+            <div class="logo-base c1 rot-a color-5">Hapje &amp; Tapje</div>
+            <div class="logo-base c1 rot-b color-6">Fitness Plus</div>
+            <div class="logo-base c1 rot-c color-1">AC Audio</div>
+            <div class="logo-base c1 rot-d color-2">Wouters</div>
+            <div class="logo-base c1 rot-a color-3">Dupont</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C.2 — Paper card WITH tape ============ -->
+      <section class="candidate" id="C2">
+        <header>
+          <div class="key">C.2</div>
+          <div class="name">Paper card · tape strip on every logo</div>
+          <div class="desc">
+            Each logo gets a tape strip (jersey-tape green, top-left, slight rotation). Most
+            paper-pasted register, mirrors NewsCard tape exactly. At 13 logos, the tape grid
+            becomes a visual rhythm of its own.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="grid">
+            <div class="logo-base c2 rot-a color-1">Crossing Auto</div>
+            <div class="logo-base c2 rot-b color-2">KBC</div>
+            <div class="logo-base c2 rot-c color-3">Bouw Janssens</div>
+            <div class="logo-base c2 rot-d color-4">De Bonte</div>
+            <div class="logo-base c2 rot-a color-5">Hapje &amp; Tapje</div>
+            <div class="logo-base c2 rot-b color-6">Fitness Plus</div>
+            <div class="logo-base c2 rot-c color-1">AC Audio</div>
+            <div class="logo-base c2 rot-d color-2">Wouters</div>
+            <div class="logo-base c2 rot-a color-3">Dupont</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ C.3 — Borderless tile ============ -->
+      <section class="candidate" id="C3">
+        <header>
+          <div class="key">C.3</div>
+          <div class="name">Borderless tile · no card, no shadow</div>
+          <div class="desc">
+            Logos sit directly on the cream background with no card frame. No rotation. Cleanest,
+            most minimal. Logos float as a "wall of marks" rather than as papered card grid.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="grid">
+            <div class="logo-base c3 color-1">Crossing Auto</div>
+            <div class="logo-base c3 color-2">KBC</div>
+            <div class="logo-base c3 color-3">Bouw Janssens</div>
+            <div class="logo-base c3 color-4">De Bonte</div>
+            <div class="logo-base c3 color-5">Hapje &amp; Tapje</div>
+            <div class="logo-base c3 color-6">Fitness Plus</div>
+            <div class="logo-base c3 color-1">AC Audio</div>
+            <div class="logo-base c3 color-2">Wouters</div>
+            <div class="logo-base c3 color-3">Dupont</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> C.1 = paper register without per-logo ornament (most
+        scalable visually at 13+ cells). C.2 = paper register with maximum ornament (mirrors
+        NewsCard treatment exactly). C.3 = wall-of-logos with no per-logo frame (most clinical
+        when production logos arrive on white backgrounds).
+      </p>
+      <p>
+        <strong>Production reality.</strong> Real uploaded logos may be transparent PNG, white-bg
+        SVG, or coloured. The card frames in C.1/C.2 normalize varying logo backgrounds; C.3 risks
+        white-on-white when a sponsor's logo has a white background.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-7c-sponsor-minimal-treatments-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-7c-sponsor-minimal-treatments-comparisons.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 7c · Sponsor logo · minimal treatments</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 26px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 13px; line-height: 1.55; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 12px;
+        line-height: 1.5;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 1080px) { .container { grid-template-columns: 1fr; } }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+      }
+      .candidate header {
+        padding: 14px 18px 12px;
+        border-bottom: 1px dashed var(--ink);
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 18px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; }
+      .surface {
+        background: var(--cream-deep);
+        padding: 28px 18px 32px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 14px;
+      }
+      .logo-base {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 8px;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        text-align: center;
+        line-height: 1.2;
+        min-height: 70px;
+        filter: grayscale(100%);
+        transition: filter 200ms ease;
+      }
+      .logo-base:hover { filter: grayscale(0%); }
+
+      /* Note: half logos shown on white-bg (production reality) so the contrast
+         with cream/cream-soft variants becomes visible. */
+      .white-bg { background: #fff; }
+      .cream-bg { background: var(--cream); }
+      .color-1 { color: #c00; }
+      .color-2 { color: #006bb3; }
+      .color-3 { color: #2d6e2d; }
+      .color-4 { color: #7a3d00; }
+      .color-5 { color: #6a4400; }
+      .color-6 { color: #b30086; }
+
+      /* M.1 — Borderless · pure cream */
+      .m1 .logo-base {
+        background: transparent;
+      }
+      /* M.2 — Hairline ink border, no shadow */
+      .m2 .logo-base {
+        background: #fff;
+        border: 1px solid var(--ink);
+      }
+      /* M.3 — Cream-soft tile, no border */
+      .m3 .logo-base {
+        background: var(--cream-soft);
+      }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 7c · Minimal logo treatments</div>
+      <h1>Minimal treatments — addressing the "too busy" concern</h1>
+      <p>
+        Round 7b's three options all carried paper-card weight. Quieter alternatives below — no
+        tape, no rotation, no hard shadow. Only the per-logo frame varies. Each variant shows 9
+        cells: greyscale-default, with hover producing colour. Six logos render with a colored
+        wordmark; three (placeholder) render plain to mimic logos that arrive on a white
+        background.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Owner concern.</strong> "Each sponsor also has its own logo — might be too busy
+      with tapes/rotation alongside the rest of the homepage's paper-pasted weight." This sub-round
+      offers three quieter levels of per-logo frame.
+    </div>
+
+    <div class="container">
+
+      <!-- M.1 — Borderless -->
+      <section class="candidate" id="M1">
+        <header>
+          <div class="key">M.1</div>
+          <div class="name">Borderless · pure cream backdrop</div>
+          <div class="desc">
+            Logos sit directly on the cream-deep section background. No frame, no fill, no
+            shadow. Quietest. Risk: a sponsor's logo with a white background blends into nothing
+            (loses edge definition). For SVG / transparent PNG logos, this is fine.
+          </div>
+        </header>
+        <div class="surface m1">
+          <div class="grid">
+            <div class="logo-base color-1">Crossing Auto</div>
+            <div class="logo-base color-2">KBC Verzekeringen</div>
+            <div class="logo-base color-3">Bouw Janssens</div>
+            <div class="logo-base color-4">De Bonte Slager</div>
+            <div class="logo-base color-5">Hapje &amp; Tapje</div>
+            <div class="logo-base color-6">Fitness Plus</div>
+            <div class="logo-base white-bg color-1">AC Audio</div>
+            <div class="logo-base white-bg color-2">Wouters Schilder</div>
+            <div class="logo-base white-bg color-3">Steenhouwerij Dupont</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- M.2 — Hairline border -->
+      <section class="candidate" id="M2">
+        <header>
+          <div class="key">M.2</div>
+          <div class="name">Hairline ink border · 1px frame, no shadow</div>
+          <div class="desc">
+            Each logo gets a 1px ink hairline border on a white tile. No shadow, no rotation, no
+            tape. Provides edge definition for white-bg logos. Most "uniform marks board" feel.
+            Slight visual quietness compared to paper cards.
+          </div>
+        </header>
+        <div class="surface m2">
+          <div class="grid">
+            <div class="logo-base color-1">Crossing Auto</div>
+            <div class="logo-base color-2">KBC Verzekeringen</div>
+            <div class="logo-base color-3">Bouw Janssens</div>
+            <div class="logo-base color-4">De Bonte Slager</div>
+            <div class="logo-base color-5">Hapje &amp; Tapje</div>
+            <div class="logo-base color-6">Fitness Plus</div>
+            <div class="logo-base color-1">AC Audio</div>
+            <div class="logo-base color-2">Wouters Schilder</div>
+            <div class="logo-base color-3">Steenhouwerij Dupont</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- M.3 — Cream-soft tile -->
+      <section class="candidate" id="M3">
+        <header>
+          <div class="key">M.3</div>
+          <div class="name">Cream-soft tile · subtle tone shift, no border</div>
+          <div class="desc">
+            Each logo on a cream-soft fill (slightly darker than the section background). No
+            border, no shadow. The tone shift gives logos a frame without an explicit line. Most
+            paper-y in feel; quietest in detail.
+          </div>
+        </header>
+        <div class="surface m3">
+          <div class="grid">
+            <div class="logo-base color-1">Crossing Auto</div>
+            <div class="logo-base color-2">KBC Verzekeringen</div>
+            <div class="logo-base color-3">Bouw Janssens</div>
+            <div class="logo-base color-4">De Bonte Slager</div>
+            <div class="logo-base color-5">Hapje &amp; Tapje</div>
+            <div class="logo-base color-6">Fitness Plus</div>
+            <div class="logo-base color-1">AC Audio</div>
+            <div class="logo-base color-2">Wouters Schilder</div>
+            <div class="logo-base color-3">Steenhouwerij Dupont</div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Reading the trade.</strong> M.1 = quietest, but white-bg logos disappear. M.2 =
+        hairline frame solves white-bg risk with minimum ornament. M.3 = soft-tone tile reads as
+        paper, no explicit border, keeps the cream/ink palette uniform.
+      </p>
+      <p>
+        <strong>Out of scope.</strong> Whether the SponsorsBlock section itself sits inside an
+        outer paper card frame (likely yes — section header gets a tape strip). That's a section-level
+        decision, not a per-logo one.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-8-youthblock-composition-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-8-youthblock-composition-comparisons.html
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 8 · YouthBlock composition</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 30px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 0;
+        position: relative;
+        overflow: hidden;
+        min-height: 320px;
+      }
+
+      /* Jersey shirt SVG-like illustration */
+      .jersey {
+        position: relative;
+        width: 220px;
+        height: 280px;
+        background:
+          /* sleeves */
+          linear-gradient(135deg, transparent 35%, var(--ink) 35%, var(--ink) 38%, transparent 38%) no-repeat,
+          /* stripes */
+          repeating-linear-gradient(
+            90deg,
+            transparent 0,
+            transparent 28px,
+            rgba(0, 0, 0, 0.18) 28px,
+            rgba(0, 0, 0, 0.18) 56px
+          ),
+          var(--jersey-deep-soft);
+        border: 2px solid var(--ink);
+        border-radius: 12% 12% 8% 8% / 8% 8% 6% 6%;
+        clip-path: polygon(
+          25% 0%, 35% 0%, 40% 6%, 60% 6%, 65% 0%, 75% 0%,
+          100% 22%, 95% 38%, 80% 30%,
+          80% 100%, 20% 100%, 20% 30%, 5% 38%, 0% 22%
+        );
+      }
+      .jersey-number {
+        position: absolute;
+        bottom: 36%;
+        left: 50%;
+        transform: translateX(-50%);
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 88px;
+        color: var(--ink);
+        text-shadow: 2px 2px 0 var(--cream);
+        line-height: 1;
+      }
+
+      .text {
+        color: var(--cream);
+      }
+      .text .meta {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 14px;
+      }
+      .text .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 48px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 0 0 16px;
+      }
+      .text .h .accent { color: #f0c264; }
+      .text .lead {
+        font-size: 16px;
+        line-height: 1.55;
+        opacity: 0.92;
+        max-width: 50ch;
+        margin: 0 0 18px;
+      }
+      .text .stat {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 8px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin-right: 18px;
+      }
+      .text .stat strong {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 28px;
+        color: #f0c264;
+        font-weight: 900;
+      }
+      .text .divisions {
+        margin-top: 18px;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .text .divisions span {
+        margin-right: 14px;
+      }
+      .text .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 22px;
+        padding: 10px 18px;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 #000;
+      }
+
+      /* L.1 — Image left, text right */
+      .l1 {
+        display: grid;
+        grid-template-columns: 1fr 1.4fr;
+        gap: 36px;
+        padding: 48px 36px;
+        align-items: center;
+      }
+      .l1 .image-col { display: flex; justify-content: center; }
+      @media (max-width: 880px) { .l1 { grid-template-columns: 1fr; } }
+
+      /* L.2 — Image right, text left */
+      .l2 {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 36px;
+        padding: 48px 36px;
+        align-items: center;
+      }
+      .l2 .image-col { display: flex; justify-content: center; }
+      @media (max-width: 880px) { .l2 { grid-template-columns: 1fr; } .l2 .image-col { order: -1; } }
+
+      /* L.3 — Centered image + text below */
+      .l3 {
+        padding: 48px 36px;
+        text-align: center;
+      }
+      .l3 .image-wrap {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 26px;
+      }
+      .l3 .text { display: inline-block; max-width: 720px; }
+      .l3 .text .lead { margin-left: auto; margin-right: auto; }
+
+      /* L.4 — Decorative background JerseyShirt (large, behind) + text foreground */
+      .l4 {
+        position: relative;
+        padding: 60px 36px;
+      }
+      .l4 .image-col {
+        position: absolute;
+        top: -60px;
+        right: -50px;
+        opacity: 0.16;
+      }
+      .l4 .image-col .jersey {
+        width: 400px;
+        height: 460px;
+      }
+      .l4 .image-col .jersey-number { font-size: 160px; opacity: 0.9; }
+      .l4 .text {
+        position: relative;
+        max-width: 640px;
+      }
+      .l4 .text .h { font-size: 56px; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 8 · YouthBlock composition</div>
+      <h1>How is the youth interlude composed?</h1>
+      <p>
+        Full-bleed jersey-deep band between WebshopStrip… wait — between ScheduleStandings and
+        WebshopStrip per Spine A. Reuses <code>&lt;JerseyShirt&gt;</code> primitive (Phase 3
+        deliverable). Hardcoded copy. This round picks the layout — image position vs text.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked.</strong> Section is full-bleed (no max-width). Background = jersey-deep.
+      Text colour = cream. Accent colour = #f0c264 (warm yellow). Stats (220+ spelers · 16 ploegen)
+      are hardcoded today — verifying current accuracy is a Sanity-rework concern (not Phase 4 scope).
+      Divisions (Bovenbouw / Middenbouw / Onderbouw per <code>project_youth_divisions</code>)
+      may surface explicitly. Reuses <code>&lt;JerseyShirt&gt;</code> from Phase 3.
+    </div>
+
+    <div class="container">
+
+      <!-- ============ L.1 — Image left, text right ============ -->
+      <section class="candidate" id="L1">
+        <header>
+          <div>
+            <div class="key">L.1</div>
+            <div class="name">Image left · text right</div>
+            <div class="desc">
+              JerseyShirt fills the left column (1fr); text fills the right column (1.4fr). Mobile
+              stacks image-above-text. Image carries the visual weight on its own, balanced by
+              the text density on the right.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Conventional reading order<br />
+            + Image is supportive, not dominant<br />
+            − Mobile = jersey on top + tall text below<br />
+            − Right-column text wraps tighter
+          </div>
+        </header>
+        <div class="surface">
+          <div class="l1">
+            <div class="image-col">
+              <div class="jersey"><div class="jersey-number">9</div></div>
+            </div>
+            <div class="text">
+              <div class="meta">Word jeugdspeler</div>
+              <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+              <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+              <div class="stat"><strong>220+</strong>spelers</div>
+              <div class="stat"><strong>16</strong>ploegen</div>
+              <div class="divisions"><span>· Bovenbouw</span><span>· Middenbouw</span><span>· Onderbouw</span></div>
+              <a class="cta">Schrijf je in →</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.2 — Image right, text left ============ -->
+      <section class="candidate" id="L2">
+        <header>
+          <div>
+            <div class="key">L.2</div>
+            <div class="name">Image right · text left</div>
+            <div class="desc">
+              Mirror of L.1. Text on the left (1.4fr), JerseyShirt on the right (1fr). Reading
+              order = text-first. Mobile flips: jersey above text. Image still supportive but
+              acts as a "where to next" visual anchor at the right.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Text gets reading priority<br />
+            + Image acts as visual pull to right<br />
+            − Mobile order needs explicit reversal<br />
+            − Right-aligned image less anchored
+          </div>
+        </header>
+        <div class="surface">
+          <div class="l2">
+            <div class="text">
+              <div class="meta">Word jeugdspeler</div>
+              <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+              <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+              <div class="stat"><strong>220+</strong>spelers</div>
+              <div class="stat"><strong>16</strong>ploegen</div>
+              <div class="divisions"><span>· Bovenbouw</span><span>· Middenbouw</span><span>· Onderbouw</span></div>
+              <a class="cta">Schrijf je in →</a>
+            </div>
+            <div class="image-col">
+              <div class="jersey"><div class="jersey-number">9</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.3 — Centered image + text below ============ -->
+      <section class="candidate" id="L3">
+        <header>
+          <div>
+            <div class="key">L.3</div>
+            <div class="name">Centered image · text below</div>
+            <div class="desc">
+              JerseyShirt centered at the top, text centered below. Symmetric vertical. Reads as
+              a "shrine" composition — the jersey is the icon, the text is the explanation.
+              Mobile and desktop look identical.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Same composition mobile and desktop<br />
+            + Image = icon, strongest emphasis<br />
+            − Symmetrical = quieter, less editorial<br />
+            − Text-block reads centered (harder to scan than left-aligned)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="l3">
+            <div class="image-wrap">
+              <div class="jersey"><div class="jersey-number">9</div></div>
+            </div>
+            <div class="text">
+              <div class="meta">Word jeugdspeler</div>
+              <h2 class="h"><span class="accent">De toekomst</span> van Elewijt.</h2>
+              <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel.</p>
+              <div class="stat"><strong>220+</strong>spelers</div>
+              <div class="stat"><strong>16</strong>ploegen</div>
+              <div style="margin-top: 22px;"><a class="cta">Schrijf je in →</a></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ============ L.4 — Decorative bg + text foreground ============ -->
+      <section class="candidate" id="L4">
+        <header>
+          <div>
+            <div class="key">L.4</div>
+            <div class="name">Background JerseyShirt · text foreground</div>
+            <div class="desc">
+              JerseyShirt huge, behind the text (top-right offset, low opacity). Text fills the
+              foreground at editorial scale. Most "poster" feel — image is decorative
+              atmosphere, headline is the message.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most editorial weight on the headline<br />
+            + Image becomes pattern, not subject<br />
+            − Image is barely-there; weakens jersey-illustration vocabulary<br />
+            − Mobile must reposition or hide image
+          </div>
+        </header>
+        <div class="surface">
+          <div class="l4">
+            <div class="image-col">
+              <div class="jersey"><div class="jersey-number">9</div></div>
+            </div>
+            <div class="text">
+              <div class="meta">Word jeugdspeler</div>
+              <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+              <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+              <div class="stat"><strong>220+</strong>spelers</div>
+              <div class="stat"><strong>16</strong>ploegen</div>
+              <a class="cta">Schrijf je in →</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Note on the JerseyShirt placeholder.</strong> The shirt above is a CSS sketch with
+        a number "9" — production renders the real <code>&lt;JerseyShirt&gt;</code> primitive
+        from Phase 3. Per <code>project_jersey_illustration_vocabulary</code>: jersey-deep
+        underprint + ink overprint + ink stripes; no Celtic green / no sponsors / no
+        photo-realism. The number choice (canonical jersey number? randomized? rotating per
+        page-load?) is a Phase-3-primitive decision, not a Phase 4 one — defaults from the
+        primitive carry through here.
+      </p>
+      <p>
+        <strong>Out of scope.</strong> Whether stats ("220+ spelers · 16 ploegen") come from
+        Sanity or stay hardcoded (likely hardcoded for Phase 4; Studio rework concern). CTA
+        copy ("Schrijf je in" vs "Word jeugdspeler" vs "Ontdek de jeugdwerking") — separate
+        sub-round if the answer here doesn't already pin it. Background pattern / texture
+        beyond solid jersey-deep — separate question.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-8b-youthblock-imagery-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-8b-youthblock-imagery-comparisons.html
@@ -396,7 +396,7 @@
             <div class="desc">
               Several small JerseyShirts arranged on the right side as a low-opacity decorative
               cluster. They're atmosphere, not subject. JerseyShirt vocabulary stays alive but at
-              the right scale (multiple small > one big). No real photo needed.
+              the right scale (multiple small &gt; one big). No real photo needed.
             </div>
           </div>
           <div class="tradeoffs">

--- a/docs/design/mockups/phase-4-homepage/round-8b-youthblock-imagery-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-8b-youthblock-imagery-comparisons.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 8b · YouthBlock imagery</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-dark: #133d28;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        position: relative;
+        overflow: hidden;
+        min-height: 320px;
+        color: var(--cream);
+      }
+      .text-block {
+        position: relative;
+        padding: 48px 36px;
+        z-index: 2;
+        max-width: 620px;
+      }
+      .meta-line {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 14px;
+      }
+      .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 48px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 0 0 16px;
+      }
+      .h .accent { color: #f0c264; }
+      .lead {
+        font-size: 16px;
+        line-height: 1.55;
+        opacity: 0.92;
+        max-width: 50ch;
+        margin: 0 0 18px;
+      }
+      .stat {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 8px;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin-right: 18px;
+      }
+      .stat strong {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 28px;
+        color: #f0c264;
+        font-weight: 900;
+      }
+      .divisions {
+        margin-top: 16px;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .divisions span { margin-right: 14px; }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 22px;
+        padding: 10px 18px;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 #000;
+      }
+
+      /* === N.1 — Text-only on jersey-deep === */
+      .n1 {
+        background: var(--jersey-deep);
+      }
+
+      /* === N.2 — Real youth team photo full-bleed, darkened overlay === */
+      .n2 {
+        background:
+          linear-gradient(135deg, rgba(19, 61, 40, 0.88) 0%, rgba(19, 61, 40, 0.65) 60%, rgba(19, 61, 40, 0.92) 100%),
+          /* photo placeholder — would be a real /images/youth-team.jpg */
+          repeating-linear-gradient(45deg, #5e7a5e 0, #5e7a5e 4px, #4d6a4d 4px, #4d6a4d 8px);
+      }
+      .n2 .photo-credit {
+        position: absolute;
+        bottom: 14px;
+        right: 18px;
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        opacity: 0.55;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--cream);
+        z-index: 2;
+      }
+
+      /* === N.3 — Pattern of small JerseyShirts === */
+      .n3 {
+        background: var(--jersey-deep);
+        position: relative;
+      }
+      .n3::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+          radial-gradient(circle 50px at 80% 20%, rgba(245, 239, 225, 0.06) 30%, transparent 32%),
+          radial-gradient(circle 40px at 92% 60%, rgba(245, 239, 225, 0.05) 30%, transparent 32%),
+          radial-gradient(circle 36px at 75% 85%, rgba(245, 239, 225, 0.05) 30%, transparent 32%),
+          radial-gradient(circle 30px at 85% 40%, rgba(245, 239, 225, 0.04) 30%, transparent 32%);
+        z-index: 1;
+      }
+      .n3 .jersey-pattern {
+        position: absolute;
+        top: 30px;
+        right: 30px;
+        bottom: 30px;
+        width: 40%;
+        z-index: 1;
+        opacity: 0.85;
+      }
+      .n3 .pattern-jersey {
+        position: absolute;
+        background:
+          repeating-linear-gradient(90deg, transparent 0, transparent 12px, rgba(0,0,0,0.18) 12px, rgba(0,0,0,0.18) 24px),
+          rgba(255, 255, 255, 0.06);
+        border: 2px solid var(--ink);
+        clip-path: polygon(20% 0%, 30% 0%, 35% 6%, 65% 6%, 70% 0%, 80% 0%, 100% 22%, 92% 38%, 80% 30%, 80% 100%, 20% 100%, 20% 30%, 8% 38%, 0% 22%);
+      }
+      .n3 .pattern-jersey.j1 { width: 80px; height: 100px; top: 18%; right: 12%; transform: rotate(-8deg); }
+      .n3 .pattern-jersey.j2 { width: 70px; height: 88px; top: 50%; right: 28%; transform: rotate(6deg); opacity: 0.85; }
+      .n3 .pattern-jersey.j3 { width: 64px; height: 80px; top: 12%; right: 38%; transform: rotate(-3deg); opacity: 0.7; }
+      .n3 .pattern-jersey.j4 { width: 58px; height: 72px; top: 70%; right: 45%; transform: rotate(10deg); opacity: 0.55; }
+
+      /* === N.4 — Polaroid taped photo === */
+      .n4 {
+        background: var(--jersey-deep);
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: 0;
+      }
+      @media (max-width: 880px) { .n4 { grid-template-columns: 1fr; } .n4 .polaroid-wrap { order: -1; } }
+      .n4 .text-block { max-width: none; }
+      .n4 .polaroid-wrap {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 36px;
+      }
+      .polaroid {
+        position: relative;
+        background: var(--cream);
+        padding: 10px 10px 28px;
+        border: 1px solid var(--ink);
+        box-shadow: 6px 6px 0 0 #000;
+        transform: rotate(-1deg);
+        max-width: 320px;
+      }
+      .polaroid::before {
+        content: "";
+        position: absolute;
+        top: -10px;
+        left: 18px;
+        width: 60px;
+        height: 14px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .polaroid::after {
+        content: "";
+        position: absolute;
+        top: -8px;
+        right: 20px;
+        width: 50px;
+        height: 12px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(2deg);
+      }
+      .polaroid .photo {
+        width: 100%;
+        aspect-ratio: 4 / 3;
+        background:
+          linear-gradient(rgba(19, 61, 40, 0.45), rgba(19, 61, 40, 0.45)),
+          repeating-linear-gradient(45deg, #5e7a5e 0, #5e7a5e 4px, #4d6a4d 4px, #4d6a4d 8px);
+        margin-bottom: 10px;
+      }
+      .polaroid .caption {
+        text-align: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 12px;
+        color: var(--ink);
+      }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 8b · YouthBlock imagery</div>
+      <h1>YouthBlock — quieter image directions</h1>
+      <p>
+        Round 8 over-amplified the JerseyShirt. Today's <code>&lt;YouthSection&gt;</code> is
+        actually text-only — no image at all. Below: four quieter image options, each consistent
+        with the retro-fanzine vocabulary.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked.</strong> Full-bleed jersey-deep section. Cream text. Editorial accent =
+      #f0c264 (warm yellow). Stats hardcoded ("220+ spelers · 16 ploegen"). Divisions =
+      Bovenbouw / Middenbouw / Onderbouw. CTA → /jeugd. <strong>This sub-round picks the
+      imagery direction.</strong>
+    </div>
+
+    <div class="container">
+
+      <!-- N.1 — Text only -->
+      <section class="candidate" id="N1">
+        <header>
+          <div>
+            <div class="key">N.1</div>
+            <div class="name">Text only · no image</div>
+            <div class="desc">
+              Closest to today's behaviour. Pure text on solid jersey-deep. No imagery. Quietest
+              and most predictable. Section reads as a "statement" interlude rather than a hero
+              image.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + No image asset to maintain<br />
+            + No fade / overlay concerns<br />
+            − Can feel flat compared to other body sections<br />
+            − Loses the "moment" feel
+          </div>
+        </header>
+        <div class="surface n1">
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+            <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+            <div class="stat"><strong>220+</strong>spelers</div>
+            <div class="stat"><strong>16</strong>ploegen</div>
+            <div class="divisions"><span>· Bovenbouw</span><span>· Middenbouw</span><span>· Onderbouw</span></div>
+            <a class="cta">Schrijf je in →</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- N.2 — Real youth team photo, full-bleed, darkened -->
+      <section class="candidate" id="N2">
+        <header>
+          <div>
+            <div class="key">N.2</div>
+            <div class="name">Real youth team photo · full-bleed, darkened jersey overlay</div>
+            <div class="desc">
+              Section background = a real youth-team photo (e.g. group shot, training session)
+              with a darkened jersey-deep gradient over it (88% → 65% → 92% from corners). Cream
+              text reads on top. Section ships with one curated photo asset; editor swaps via
+              Sanity later.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Most editorial weight — real kids, real club<br />
+            + Photo gives section a sense of place<br />
+            − Requires photo asset, hotspot tuning, accessibility (alt text)<br />
+            − Photo dates the page faster than illustration
+          </div>
+        </header>
+        <div class="surface n2">
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+            <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+            <div class="stat"><strong>220+</strong>spelers</div>
+            <div class="stat"><strong>16</strong>ploegen</div>
+            <div class="divisions"><span>· Bovenbouw</span><span>· Middenbouw</span><span>· Onderbouw</span></div>
+            <a class="cta">Schrijf je in →</a>
+          </div>
+          <div class="photo-credit">photo · KCVV jeugd 2025</div>
+        </div>
+      </section>
+
+      <!-- N.3 — Pattern of small JerseyShirts -->
+      <section class="candidate" id="N3">
+        <header>
+          <div>
+            <div class="key">N.3</div>
+            <div class="name">Decorative pattern · small jerseys cluster</div>
+            <div class="desc">
+              Several small JerseyShirts arranged on the right side as a low-opacity decorative
+              cluster. They're atmosphere, not subject. JerseyShirt vocabulary stays alive but at
+              the right scale (multiple small > one big). No real photo needed.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Reuses Phase 3 JerseyShirt at appropriate scale<br />
+            + No photo to maintain<br />
+            − Decorative-only patterns can feel like wallpaper<br />
+            − Mobile must hide / reposition
+          </div>
+        </header>
+        <div class="surface n3">
+          <div class="jersey-pattern">
+            <div class="pattern-jersey j1"></div>
+            <div class="pattern-jersey j2"></div>
+            <div class="pattern-jersey j3"></div>
+            <div class="pattern-jersey j4"></div>
+          </div>
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+            <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+            <div class="stat"><strong>220+</strong>spelers</div>
+            <div class="stat"><strong>16</strong>ploegen</div>
+            <div class="divisions"><span>· Bovenbouw</span><span>· Middenbouw</span><span>· Onderbouw</span></div>
+            <a class="cta">Schrijf je in →</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- N.4 — Polaroid taped photo (right column) -->
+      <section class="candidate" id="N4">
+        <header>
+          <div>
+            <div class="key">N.4</div>
+            <div class="name">Polaroid taped photo · right column</div>
+            <div class="desc">
+              Real youth team photo inside a taped polaroid frame (cream paper, jersey-tape strips,
+              slight rotation, italic caption). Photo lives inside the same TapedFigure vocabulary
+              as the rest of the homepage. Smaller than full-bleed; still a real moment.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Reuses TapedFigure (consistent with NewsCard / EditorialHero cover)<br />
+            + Photo is smaller, ages more gracefully<br />
+            + Mobile collapses cleanly (polaroid above text)<br />
+            − Still requires curated photo asset
+          </div>
+        </header>
+        <div class="surface n4">
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span><br />van Elewijt.</h2>
+            <p class="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.</p>
+            <div class="stat"><strong>220+</strong>spelers</div>
+            <div class="stat"><strong>16</strong>ploegen</div>
+            <div class="divisions"><span>· Bovenbouw</span><span>· Middenbouw</span><span>· Onderbouw</span></div>
+            <a class="cta">Schrijf je in →</a>
+          </div>
+          <div class="polaroid-wrap">
+            <div class="polaroid">
+              <div class="photo"></div>
+              <div class="caption">U13 — voorjaarstraining</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Photo source.</strong> Whichever direction wins (N.2 or N.4), the photo asset
+        will be a single curated image stored in <code>/public/images/youth-*.jpg</code> for now.
+        A future iteration could move it to a Sanity field on a dedicated <code>youthLanding</code>
+        document so the editor can rotate it seasonally — outside Phase 4 scope.
+      </p>
+      <p>
+        <strong>Out of scope.</strong> Headline copy ("De toekomst van Elewijt" — keep as-is per
+        retro-fanzine source mockups). CTA copy ("Schrijf je in →" vs "Word jeugdspeler" vs
+        "Ontdek onze jeugdwerking" — quick sub-round if needed). Photo aspect / focal point
+        guidance for editors (Phase 7 youth-landing concern).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-9-webshopstrip-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-9-webshopstrip-comparisons.html
@@ -1,0 +1,461 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 9 · WebshopStrip</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 28px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 14px 18px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--cream);
+        padding: 28px 24px 32px;
+      }
+
+      .section-title {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--ink);
+      }
+      .section-title .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+      }
+      .section-title .all {
+        font-family: ui-monospace, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 16px;
+      }
+      @media (max-width: 880px) { .grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 600px) { .grid { grid-template-columns: 1fr; } }
+
+      .product {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+        padding: 8px;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .product .img {
+        width: 100%;
+        aspect-ratio: 4 / 5;
+        background: linear-gradient(135deg, var(--jersey-deep), var(--jersey-deep-soft));
+        position: relative;
+        overflow: hidden;
+      }
+      .product.alt-1 .img { background: linear-gradient(135deg, var(--jersey-deep), var(--jersey-deep-soft)); }
+      .product.alt-2 .img { background: linear-gradient(135deg, #4d2a2a, #c19a4a); }
+      .product.alt-3 .img { background: linear-gradient(135deg, var(--ink), #444); }
+      .product.alt-4 .img { background: linear-gradient(135deg, #c1a04a, #f0c264); }
+      .product .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.2;
+        padding: 0 4px 4px;
+      }
+      .product .price {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.12em;
+        opacity: 0.7;
+        padding: 0 4px 4px;
+      }
+      .product.tape::before {
+        content: "";
+        position: absolute;
+        top: -7px;
+        left: 14px;
+        width: 36px;
+        height: 10px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .rot-a { transform: rotate(-0.5deg); }
+      .rot-b { transform: rotate(-0.25deg); }
+      .rot-c { transform: rotate(0.25deg); }
+      .rot-d { transform: rotate(0.5deg); }
+
+      /* Jersey illustration mock */
+      .jersey-mock {
+        width: 70%;
+        height: 80%;
+        position: absolute;
+        left: 15%;
+        top: 10%;
+        background:
+          repeating-linear-gradient(90deg, transparent 0, transparent 14px, rgba(0,0,0,0.18) 14px, rgba(0,0,0,0.18) 28px),
+          var(--jersey-deep-soft);
+        border: 2px solid var(--ink);
+        clip-path: polygon(20% 0%, 30% 0%, 35% 6%, 65% 6%, 70% 0%, 80% 0%, 100% 22%, 92% 38%, 80% 30%, 80% 100%, 20% 100%, 20% 30%, 8% 38%, 0% 22%);
+      }
+
+      /* Mixed merch icons */
+      .merch-icon {
+        font-size: 60px;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        opacity: 0.85;
+      }
+
+      .strip-cta {
+        margin-top: 20px;
+        padding: 14px 18px;
+        background: var(--ink);
+        color: var(--cream);
+        text-align: center;
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-card);
+      }
+      .strip-cta a { color: var(--cream); text-decoration: underline; text-underline-offset: 3px; }
+      .strip-cta .arrow { color: #f0c264; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 9 · WebshopStrip</div>
+      <h1>WebshopStrip — what fills the 4 thumbnails?</h1>
+      <p>
+        Today's <code>&lt;WebshopSection&gt;</code> is a single static image (<code>/images/jerseys.png</code>)
+        + external link to KCVV's webshop. Phase 4 (per issue spec) becomes 4 thumbnails in a
+        4-col grid. This round picks what fills each thumbnail and where the data lives.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked.</strong> 4-col grid (<code>repeat(4, 1fr)</code> on desktop, 2-col on
+      tablet, 1-col on mobile). Each thumb is a clickable Link target — either to a specific
+      webshop product or the webshop home. /webshop external link visible at section bottom in
+      every variant. This sub-round picks the <em>thumbnail content</em>.
+    </div>
+
+    <div class="container">
+
+      <!-- W.1 — 4 jersey photos hardcoded -->
+      <section class="candidate" id="W1">
+        <header>
+          <div>
+            <div class="key">W.1</div>
+            <div class="name">4 jersey photos · hardcoded</div>
+            <div class="desc">
+              4 hardcoded jersey product photos (home / away / training / GK). Each thumb links
+              to its specific product on the external webshop. Photos stored in
+              <code>/public/images/webshop/*.jpg</code>. Closest to issue spec.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + No editor work<br />
+            + Photos are real product imagery<br />
+            − Must update images each season<br />
+            − Hardcoded URLs drift if webshop restructures
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Webshop</span>
+            <span class="all">Naar de webshop ↗</span>
+          </div>
+          <div class="grid">
+            <div class="product alt-1 rot-a">
+              <div class="img"></div>
+              <div class="name">Thuisshirt 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+            <div class="product alt-2 rot-b">
+              <div class="img"></div>
+              <div class="name">Uitshirt 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+            <div class="product alt-3 rot-c">
+              <div class="img"></div>
+              <div class="name">Trainings­shirt</div>
+              <div class="price">€ 45</div>
+            </div>
+            <div class="product alt-4 rot-d">
+              <div class="img"></div>
+              <div class="name">Doelman 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- W.2 — 4 JerseyShirt illustrations -->
+      <section class="candidate" id="W2">
+        <header>
+          <div>
+            <div class="key">W.2</div>
+            <div class="name">4 <code>&lt;JerseyShirt&gt;</code> illustrations · no photos</div>
+            <div class="desc">
+              4 thumbnails using the Phase 3 <code>&lt;JerseyShirt&gt;</code> primitive — each
+              shows a different jersey variation (home stripes, away contrast, training plain,
+              GK alt-color). No product photo assets needed. Reuses Phase 3 primitive at small
+              scale (where the owner is comfortable with the JerseyShirt).
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Reuses Phase 3 primitive at right scale<br />
+            + Zero photo asset maintenance<br />
+            − Reads more illustrative than commercial<br />
+            − May not match the actual on-sale jerseys
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Webshop</span>
+            <span class="all">Naar de webshop ↗</span>
+          </div>
+          <div class="grid">
+            <div class="product rot-a">
+              <div class="img"><div class="jersey-mock"></div></div>
+              <div class="name">Thuisshirt 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+            <div class="product rot-b">
+              <div class="img" style="background: linear-gradient(135deg, #4d2a2a, #c19a4a);"><div class="jersey-mock" style="background: repeating-linear-gradient(90deg, transparent 0, transparent 14px, rgba(0,0,0,0.18) 14px, rgba(0,0,0,0.18) 28px), #cf9f4a;"></div></div>
+              <div class="name">Uitshirt 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+            <div class="product rot-c">
+              <div class="img" style="background: linear-gradient(135deg, #1a1a1a, #444);"><div class="jersey-mock" style="background: repeating-linear-gradient(90deg, transparent 0, transparent 14px, rgba(0,0,0,0.3) 14px, rgba(0,0,0,0.3) 28px), #2a2a2a;"></div></div>
+              <div class="name">Trainings­shirt</div>
+              <div class="price">€ 45</div>
+            </div>
+            <div class="product rot-d">
+              <div class="img" style="background: linear-gradient(135deg, #c1a04a, #f0c264);"><div class="jersey-mock" style="background: repeating-linear-gradient(90deg, transparent 0, transparent 14px, rgba(0,0,0,0.18) 14px, rgba(0,0,0,0.18) 28px), #ddb968;"></div></div>
+              <div class="name">Doelman 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- W.3 — Mixed merch -->
+      <section class="candidate" id="W3">
+        <header>
+          <div>
+            <div class="key">W.3</div>
+            <div class="name">Mixed merch · jersey + scarf + hat + mug</div>
+            <div class="desc">
+              4 different product categories — diversifies the surface beyond jerseys. Reads more
+              like a "shop sampler". Departs from the issue spec ("4-column jersey thumbnails")
+              but better reflects a real webshop catalogue.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Surfaces full merch range<br />
+            + More interesting visual variety<br />
+            − Departs from issue spec<br />
+            − Each thumb requires its own asset
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Webshop</span>
+            <span class="all">Naar de webshop ↗</span>
+          </div>
+          <div class="grid">
+            <div class="product alt-1 rot-a">
+              <div class="img"><div class="jersey-mock"></div></div>
+              <div class="name">Thuisshirt 2025</div>
+              <div class="price">€ 65</div>
+            </div>
+            <div class="product alt-3 rot-b">
+              <div class="img"><div class="merch-icon">🧣</div></div>
+              <div class="name">Sjaal "Plezante"</div>
+              <div class="price">€ 22</div>
+            </div>
+            <div class="product alt-2 rot-c">
+              <div class="img"><div class="merch-icon">🧢</div></div>
+              <div class="name">Pet — KCVV crest</div>
+              <div class="price">€ 18</div>
+            </div>
+            <div class="product alt-4 rot-d">
+              <div class="img"><div class="merch-icon">☕</div></div>
+              <div class="name">Mok "Compagnie"</div>
+              <div class="price">€ 12</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- W.4 — Sanity-driven -->
+      <section class="candidate" id="W4">
+        <header>
+          <div>
+            <div class="key">W.4</div>
+            <div class="name">Sanity-driven · editor manages 4 products</div>
+            <div class="desc">
+              New <code>homePage.webshopProducts</code> array of 4 (or 1–4) ref-or-inline product
+              entries. Each entry has image + name + price + url. Editor swaps quarterly without
+              code change. Visually identical to W.1 / W.2 / W.3 — the difference is data source.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Editor controls without code change<br />
+            + Survives webshop restructures<br />
+            − Sanity migration required<br />
+            − Editor must manage seasonal changes
+          </div>
+        </header>
+        <div class="surface">
+          <div class="section-title">
+            <span class="h">Webshop</span>
+            <span class="all">Naar de webshop ↗</span>
+          </div>
+          <div class="grid">
+            <div class="product alt-1 rot-a">
+              <div class="img"></div>
+              <div class="name">Thuisshirt 2025</div>
+              <div class="price">€ 65 · editor pick</div>
+            </div>
+            <div class="product alt-2 rot-b">
+              <div class="img"></div>
+              <div class="name">Uitshirt 2025</div>
+              <div class="price">€ 65 · editor pick</div>
+            </div>
+            <div class="product alt-3 rot-c">
+              <div class="img"></div>
+              <div class="name">Trainings­shirt</div>
+              <div class="price">€ 45 · editor pick</div>
+            </div>
+            <div class="product alt-4 rot-d">
+              <div class="img"></div>
+              <div class="name">Doelman 2025</div>
+              <div class="price">€ 65 · editor pick</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>External link.</strong> Every thumbnail and the section CTA points to the external
+        webshop (a Shopify-style store on a separate domain). Section CTA "Naar de webshop ↗" is
+        always visible. Per-thumb URLs go to their specific product pages where applicable.
+      </p>
+      <p>
+        <strong>Out of scope.</strong> Whether prices are shown (small editor commitment — could
+        drift with sales). Whether sale / new / sold-out badges render (likely no for Phase 4).
+        Hover behaviour (canonical press-down per memory).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-9b-webshop-pointer-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-9b-webshop-pointer-comparisons.html
@@ -1,0 +1,472 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 9b · Webshop pointer (no specific products)</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+        --shadow-card: 3px 3px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .reframe-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: #fff8d6;
+        border: 1px solid #c89500;
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .reframe-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: block;
+        margin-bottom: 4px;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 14px 18px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--cream);
+        padding: 36px 28px;
+      }
+
+      .meta-line {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 12px;
+      }
+      .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 36px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 0 0 14px;
+      }
+      .h .accent { color: var(--jersey-deep); }
+      .lead {
+        font-size: 15px;
+        line-height: 1.55;
+        max-width: 50ch;
+        margin: 0 0 16px;
+        opacity: 0.92;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 22px;
+        background: var(--ink);
+        color: var(--cream);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--jersey-deep);
+        text-decoration: none;
+      }
+      .cta .arrow { color: #f0c264; }
+      .cta-secondary {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 22px;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+        text-decoration: none;
+      }
+      .ext { font-size: 14px; }
+
+      /* P.1 — Single CTA card */
+      .p1 {
+        display: grid;
+        grid-template-columns: 60fr 40fr;
+        gap: 32px;
+        align-items: center;
+      }
+      @media (max-width: 880px) { .p1 { grid-template-columns: 1fr; } }
+      .p1 .visual {
+        background: var(--jersey-deep);
+        aspect-ratio: 4/3;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+        position: relative;
+        overflow: hidden;
+        transform: rotate(-0.5deg);
+      }
+      .p1 .visual .jersey-mock {
+        position: absolute;
+        inset: 18%;
+        background:
+          repeating-linear-gradient(90deg, transparent 0, transparent 14px, rgba(0,0,0,0.18) 14px, rgba(0,0,0,0.18) 28px),
+          var(--jersey-deep-soft);
+        border: 2px solid var(--ink);
+        clip-path: polygon(20% 0%, 30% 0%, 35% 6%, 65% 6%, 70% 0%, 80% 0%, 100% 22%, 92% 38%, 80% 30%, 80% 100%, 20% 100%, 20% 30%, 8% 38%, 0% 22%);
+      }
+
+      /* P.2 — Two-column with category chips */
+      .p2 { display: grid; grid-template-columns: 1fr 1fr; gap: 36px; align-items: center; }
+      @media (max-width: 880px) { .p2 { grid-template-columns: 1fr; } }
+      .p2 .chips {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        margin-bottom: 20px;
+      }
+      .chip {
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        background: var(--cream-soft);
+        padding: 10px 14px;
+        border-left: 3px solid var(--jersey-deep);
+        display: flex;
+        gap: 12px;
+        align-items: baseline;
+      }
+      .chip .name { font-weight: 700; }
+      .chip .desc-line {
+        font-family: ui-sans-serif, sans-serif;
+        font-style: italic;
+        font-size: 13px;
+        opacity: 0.85;
+        text-transform: none;
+        letter-spacing: 0;
+      }
+
+      /* P.3 — Wide jersey-tape banner */
+      .p3 {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 36px 28px;
+        position: relative;
+        overflow: hidden;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+      }
+      .p3 .tape-line {
+        position: absolute;
+        top: -12px;
+        left: 30px;
+        right: 30px;
+        height: 18px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-0.5deg);
+      }
+      .p3 .h { color: var(--cream); }
+      .p3 .h .accent { color: #f0c264; }
+      .p3 .lead { color: var(--cream); opacity: 0.92; }
+      .p3 .cta {
+        background: var(--cream);
+        color: var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+      }
+      .p3 .cta .arrow { color: var(--jersey-deep); }
+
+      /* P.4 — Inline ticket-stub */
+      .p4 {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+        padding: 22px 28px;
+        background: var(--cream-soft);
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+        flex-wrap: wrap;
+      }
+      .p4 .stub {
+        flex: 0 0 auto;
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 12px 18px;
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        position: relative;
+      }
+      .p4 .stub::before, .p4 .stub::after {
+        content: "";
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        background: var(--cream-soft);
+        border-radius: 50%;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      .p4 .stub::before { left: -7px; }
+      .p4 .stub::after { right: -7px; }
+      .p4 .text-block { flex: 1; min-width: 280px; }
+      .p4 .text-block .h { font-size: 22px; margin-bottom: 4px; }
+      .p4 .text-block .lead { font-size: 13px; margin-bottom: 0; }
+      .p4 .actions { display: flex; gap: 10px; flex-shrink: 0; flex-wrap: wrap; }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 9b · Webshop pointer</div>
+      <h1>Webshop block — pointer to external supplier, not a product gallery</h1>
+      <p>
+        Round 9 was wrong premise. KCVV doesn't sell merch directly — the section is a
+        click-through to an external supplier (training gear + limited personalized "club
+        packages"). Audience is primarily youth and parents who need training kit. No specific
+        products to advertise — just the pointer + context.
+      </p>
+    </header>
+
+    <div class="reframe-banner">
+      <strong>What's actually true (owner clarification 2026-05-07).</strong>
+      No in-site store. Always external link. Use case = youth/parents picking general training
+      gear from the supplier + limited personalized "club packages" (bundled new-player kit).
+      Section needs to: tell visitors the supplier exists, frame the use case, single CTA
+      click-through. Specific product thumbnails are misleading (no stock guarantee, no per-item
+      curation effort).
+    </div>
+
+    <div class="container">
+
+      <!-- P.1 — Single CTA card with one visual -->
+      <section class="candidate" id="P1">
+        <header>
+          <div>
+            <div class="key">P.1</div>
+            <div class="name">Single CTA card · one visual + headline + CTA</div>
+            <div class="desc">
+              Two-column: visual on the left (a single tape-rotated jersey illustration), text +
+              CTA on the right. Honest single-purpose card. Reuses <code>&lt;JerseyShirt&gt;</code>
+              at right scale (small thumbnail-sized). One click-through. Cleanest.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Single click-through, no clutter<br />
+            + No product stock to maintain<br />
+            − Doesn't differentiate "training gear" vs "club packages"<br />
+            − Single visual carries less variety
+          </div>
+        </header>
+        <div class="surface">
+          <div class="p1">
+            <div class="visual"><div class="jersey-mock"></div></div>
+            <div>
+              <div class="meta-line">Webshop · supplier link</div>
+              <h2 class="h"><span class="accent">Trainingsgear</span><br />en clubpakketten.</h2>
+              <p class="lead">Onze partner levert alle trainingsuitrusting en gepersonaliseerde clubpakketten voor jeugd- en seniorenspelers. Snelle levering op de club.</p>
+              <a class="cta">Naar de webshop <span class="arrow ext">↗</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- P.2 — Two-column with category chips -->
+      <section class="candidate" id="P2">
+        <header>
+          <div>
+            <div class="key">P.2</div>
+            <div class="name">Two-column · headline + category chips</div>
+            <div class="desc">
+              Headline + lead on the left. Right: 3 category chips ("Trainingskledij" /
+              "Clubpakketten jeugd" / "Personalisatie") that explain what's available without
+              listing specific products. Single CTA below. Honest about category breadth.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Differentiates use cases without faking products<br />
+            + Lower stock-management cognitive load<br />
+            − Three rows of text feels busier than P.1<br />
+            − Chips might read as actionable when they're descriptive
+          </div>
+        </header>
+        <div class="surface">
+          <div class="p2">
+            <div>
+              <div class="meta-line">Webshop · supplier link</div>
+              <h2 class="h"><span class="accent">Trainingsgear</span><br />op maat van de club.</h2>
+              <p class="lead">Onze partner verzorgt de uitrusting voor onze jeugd- en seniorenspelers. Bestellingen verlopen via hun externe webshop.</p>
+              <a class="cta">Naar de webshop <span class="arrow ext">↗</span></a>
+            </div>
+            <div class="chips">
+              <div class="chip"><span class="name">Trainingskledij</span><span class="desc-line">algemeen aanbod van de leverancier</span></div>
+              <div class="chip"><span class="name">Clubpakketten jeugd</span><span class="desc-line">gebundelde startuitrusting</span></div>
+              <div class="chip"><span class="name">Personalisatie</span><span class="desc-line">naam + nummer op aanvraag</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- P.3 — Wide jersey-tape banner -->
+      <section class="candidate" id="P3">
+        <header>
+          <div>
+            <div class="key">P.3</div>
+            <div class="name">Wide jersey-tape banner</div>
+            <div class="desc">
+              Full-width jersey-deep band, single line of huge editorial copy + CTA. Reads as a
+              poster strip — a moment of brand emphasis between Webshop and Sponsors. Most
+              minimal information density; strongest typographic moment.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Strongest typographic moment<br />
+            + Simplest to maintain<br />
+            − Visual register competes with FeaturedEventBand (also jersey-deep)<br />
+            − Less informative
+          </div>
+        </header>
+        <div class="surface" style="padding: 24px;">
+          <div class="p3">
+            <div class="tape-line"></div>
+            <div class="meta-line" style="color: var(--cream); opacity: 0.8;">Webshop · onze partner</div>
+            <h2 class="h"><span class="accent">Trainingsgear</span> bestel je rechtstreeks bij onze partner.</h2>
+            <p class="lead">Trainingskledij, clubpakketten en personalisatie voor onze jeugd- en seniorenspelers.</p>
+            <a class="cta">Naar de webshop <span class="arrow ext">↗</span></a>
+          </div>
+        </div>
+      </section>
+
+      <!-- P.4 — Inline ticket-stub -->
+      <section class="candidate" id="P4">
+        <header>
+          <div>
+            <div class="key">P.4</div>
+            <div class="name">Inline ticket-stub · narrow horizontal band</div>
+            <div class="desc">
+              Compact one-row banner with a TicketStub-style chip on the left ("WEBSHOP") + headline +
+              two CTAs (primary "Naar de webshop", secondary "Clubpakketten →"). Smallest
+              vertical footprint. Two click-through actions for the two main use cases.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Compact (saves homepage vertical space)<br />
+            + Two CTAs split the use cases (general / packages)<br />
+            − Less editorial weight<br />
+            − Two CTAs introduce decision noise
+          </div>
+        </header>
+        <div class="surface" style="padding: 24px;">
+          <div class="p4">
+            <span class="stub">WEBSHOP</span>
+            <div class="text-block">
+              <div class="h"><span class="accent">Trainingsgear</span> via onze partner.</div>
+              <div class="lead">Algemene uitrusting + clubpakketten + personalisatie.</div>
+            </div>
+            <div class="actions">
+              <a class="cta-secondary">Clubpakketten →</a>
+              <a class="cta">Naar de webshop <span class="arrow ext">↗</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Section name change.</strong> "WebshopStrip" implied product strip — likely
+        renames to <code>&lt;WebshopPointer&gt;</code> or <code>&lt;WebshopBanner&gt;</code>
+        depending on which variant wins. The Phase 4 issue AC list will be updated accordingly.
+      </p>
+      <p>
+        <strong>External link target.</strong> All variants point to a single external URL
+        configured in <code>EXTERNAL_LINKS.webshop</code>. P.4's secondary "Clubpakketten" CTA
+        could deep-link to a clubpakketten landing page on the supplier site if one exists —
+        otherwise it points to the same root URL as the primary CTA.
+      </p>
+      <p>
+        <strong>Out of scope.</strong> Whether the supplier offers a deep-linkable
+        "/jeugd-pakket" URL (verifiable later — not a Phase 4 design concern). Whether KCVV
+        adopts an inhouse store later (definitely not Phase 4).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-9c-webshop-image-treatments-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-9c-webshop-image-treatments-comparisons.html
@@ -382,7 +382,7 @@
         <div class="t1-surface">
           <div class="t1">
             <div class="polaroid">
-              <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="KCVV kits 2025" />
+              <img src="/images/jerseys.png" alt="KCVV kits 2025" />
               <div class="caption">KCVV kits — seizoen 2025</div>
             </div>
             <div>
@@ -417,7 +417,7 @@
         </header>
         <div class="t2-surface">
           <div class="t2-bg">
-            <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="" />
+            <img src="/images/jerseys.png" alt="" />
           </div>
           <div class="t2-overlay"></div>
           <div class="t2-content">
@@ -452,7 +452,7 @@
         <div class="t3-surface">
           <div class="t3">
             <div class="duotone-frame">
-              <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="KCVV kits" />
+              <img src="/images/jerseys.png" alt="KCVV kits" />
               <div class="halftone-overlay"></div>
             </div>
             <div>
@@ -488,7 +488,7 @@
         </header>
         <div class="t4-surface">
           <div class="t4-strip">
-            <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="KCVV kits 2025" />
+            <img src="/images/jerseys.png" alt="KCVV kits 2025" />
           </div>
           <div class="t4-banner">
             <div class="t4-banner-card">

--- a/docs/design/mockups/phase-4-homepage/round-9c-webshop-image-treatments-comparisons.html
+++ b/docs/design/mockups/phase-4-homepage/round-9c-webshop-image-treatments-comparisons.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 9c · Webshop · jerseys.png treatment</title>
+    <style>
+      :root {
+        --cream: #f5efe1;
+        --cream-soft: #ece5d3;
+        --cream-deep: #ddd4ba;
+        --ink: #1a1a1a;
+        --jersey-deep: #1f5f3f;
+        --jersey-deep-soft: #2a7a52;
+        --jersey-deep-dark: #133d28;
+        --tape-jersey: rgba(31, 95, 63, 0.78);
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 14px 18px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 20px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 12px; line-height: 1.5; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      .meta-line {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 12px;
+      }
+      .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 32px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 0 0 14px;
+      }
+      .h .accent { color: var(--jersey-deep); }
+      .lead {
+        font-size: 14px;
+        line-height: 1.55;
+        max-width: 50ch;
+        margin: 0 0 16px;
+        opacity: 0.92;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 22px;
+        background: var(--ink);
+        color: var(--cream);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--jersey-deep);
+        text-decoration: none;
+      }
+      .cta .arrow { color: #f0c264; }
+
+      /* ========== T.1 — Polaroid TapedFigure ========== */
+      .t1-surface {
+        background: var(--cream);
+        padding: 36px 28px;
+      }
+      .t1 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 36px;
+        align-items: center;
+      }
+      @media (max-width: 880px) { .t1 { grid-template-columns: 1fr; } }
+      .polaroid {
+        position: relative;
+        background: var(--cream);
+        padding: 12px 12px 36px;
+        border: 1px solid var(--ink);
+        box-shadow: 6px 6px 0 0 var(--ink);
+        transform: rotate(-1deg);
+        max-width: 480px;
+      }
+      .polaroid::before, .polaroid::after {
+        content: "";
+        position: absolute;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+      }
+      .polaroid::before {
+        top: -10px; left: 24px;
+        width: 60px; height: 14px;
+        transform: rotate(-3deg);
+      }
+      .polaroid::after {
+        top: -8px; right: 30px;
+        width: 50px; height: 12px;
+        transform: rotate(3deg);
+      }
+      .polaroid img {
+        width: 100%;
+        display: block;
+        margin-bottom: 10px;
+      }
+      .polaroid .caption {
+        text-align: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        color: var(--ink);
+        position: absolute;
+        bottom: 12px;
+        left: 0;
+        right: 0;
+      }
+
+      /* ========== T.2 — Section backdrop (blur + gradient) ========== */
+      .t2-surface {
+        position: relative;
+        overflow: hidden;
+        color: var(--cream);
+        min-height: 320px;
+        display: grid;
+        align-items: center;
+        padding: 48px 36px;
+      }
+      .t2-bg {
+        position: absolute;
+        inset: -8px;
+        z-index: 0;
+      }
+      .t2-bg img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+        filter: blur(3px) brightness(0.7);
+      }
+      .t2-overlay {
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, rgba(31, 95, 63, 0.88) 0%, rgba(19, 61, 40, 0.78) 60%, rgba(19, 61, 40, 0.95) 100%);
+        z-index: 1;
+      }
+      .t2-content {
+        position: relative;
+        z-index: 2;
+        max-width: 620px;
+      }
+      .t2-content .h { color: var(--cream); }
+      .t2-content .h .accent { color: #f0c264; }
+      .t2-content .lead { color: var(--cream); opacity: 0.92; }
+      .t2-content .cta {
+        background: var(--cream);
+        color: var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+      }
+      .t2-content .cta .arrow { color: var(--jersey-deep); }
+
+      /* ========== T.3 — Halftone / duotone print treatment ========== */
+      .t3-surface {
+        background: var(--cream);
+        padding: 36px 28px;
+        position: relative;
+      }
+      .t3 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 36px;
+        align-items: center;
+      }
+      @media (max-width: 880px) { .t3 { grid-template-columns: 1fr; } }
+      .duotone-frame {
+        position: relative;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+        transform: rotate(-0.5deg);
+        background: var(--jersey-deep);
+        overflow: hidden;
+      }
+      .duotone-frame::before {
+        content: "";
+        position: absolute;
+        top: -8px; left: 18px;
+        width: 56px; height: 12px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+        z-index: 2;
+      }
+      .duotone-frame img {
+        width: 100%;
+        display: block;
+        filter: grayscale(100%) contrast(1.15) brightness(1.05);
+        mix-blend-mode: multiply;
+      }
+      .duotone-frame .halftone-overlay {
+        position: absolute;
+        inset: 0;
+        background:
+          radial-gradient(circle 1px at 1px 1px, rgba(0,0,0,0.55) 1px, transparent 1.5px),
+          var(--jersey-deep);
+        background-size: 4px 4px, 100% 100%;
+        mix-blend-mode: multiply;
+        opacity: 0.45;
+        pointer-events: none;
+      }
+
+      /* ========== T.4 — Narrow strip background under banner ========== */
+      .t4-surface {
+        position: relative;
+        overflow: hidden;
+        padding: 0;
+      }
+      .t4-strip {
+        position: relative;
+        height: 220px;
+        overflow: hidden;
+      }
+      .t4-strip img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center 40%;
+        filter: grayscale(60%) brightness(0.92);
+      }
+      .t4-strip::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, transparent 0%, transparent 30%, var(--cream) 100%);
+      }
+      .t4-banner {
+        background: var(--cream);
+        padding: 0 28px 32px;
+        margin-top: -50px;
+        position: relative;
+        z-index: 2;
+      }
+      .t4-banner-card {
+        background: var(--cream);
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 var(--ink);
+        padding: 24px 28px;
+        position: relative;
+      }
+      .t4-banner-card::before {
+        content: "";
+        position: absolute;
+        top: -9px; left: 28px;
+        width: 70px; height: 14px;
+        background: var(--tape-jersey);
+        opacity: 0.85;
+        transform: rotate(-3deg);
+      }
+      .t4-stack {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 20px;
+        align-items: center;
+      }
+      @media (max-width: 700px) { .t4-stack { grid-template-columns: 1fr; } }
+
+      .footnote {
+        max-width: 1320px;
+        margin: 28px auto 0;
+        font-size: 12px;
+        line-height: 1.6;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 14px 18px;
+      }
+      .footnote strong {
+        font-family: ui-monospace, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 11px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 9c · jerseys.png in retro register</div>
+      <h1>Bringing today's jersey photo into the retro vocabulary</h1>
+      <p>
+        Today's <code>/images/jerseys.png</code> is a clean modern flat-lay of 5 KCVV kits.
+        Below: four ways to keep that image in Phase 4 without breaking the fanzine voice.
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Locked.</strong> Webshop section is a pointer to an external supplier (no in-site
+      products). The image is identity-level ("these are our kits") not transactional ("these
+      are products you can buy"). All variants below honour that — no specific-product CTAs.
+      Image source: <code>/images/jerseys.png</code> (existing).
+    </div>
+
+    <div class="container">
+
+      <!-- ========== T.1 — Polaroid TapedFigure ========== -->
+      <section class="candidate" id="T1">
+        <header>
+          <div>
+            <div class="key">T.1</div>
+            <div class="name">Polaroid · taped paper frame</div>
+            <div class="desc">
+              The image sits inside a polaroid-style TapedFigure: cream paper border, two
+              jersey-tape strips, slight rotation, italic caption. The photo is unmodified —
+              fully visible at full clarity. The frame brings it into the retro vocabulary.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Image fully visible, undistorted<br />
+            + Reuses TapedFigure (consistent with NewsCard)<br />
+            − Photo modernity contrasts with cream/ink palette<br />
+            − Polaroid framing makes it feel "pinned up" rather than current
+          </div>
+        </header>
+        <div class="t1-surface">
+          <div class="t1">
+            <div class="polaroid">
+              <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="KCVV kits 2025" />
+              <div class="caption">KCVV kits — seizoen 2025</div>
+            </div>
+            <div>
+              <div class="meta-line">Webshop · supplier link</div>
+              <h2 class="h"><span class="accent">Trainingsgear</span><br />en clubpakketten.</h2>
+              <p class="lead">Onze partner levert alle trainingsuitrusting en gepersonaliseerde clubpakketten voor jeugd- en seniorenspelers.</p>
+              <a class="cta">Naar de webshop <span class="arrow">↗</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ========== T.2 — Backdrop with blur + jersey-deep gradient ========== -->
+      <section class="candidate" id="T2">
+        <header>
+          <div>
+            <div class="key">T.2</div>
+            <div class="name">Section backdrop · blur + jersey-deep gradient (YouthBackdrop pattern)</div>
+            <div class="desc">
+              Image fills the full section background, blurred 3px and darkened, with a
+              jersey-deep gradient overlay (88/78/95). Photo becomes atmospheric texture rather
+              than a literal product shot. Same pattern as YouthBlock for visual consistency.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Same backdrop pattern as YouthBlock — consistent<br />
+            + Photo loses literal product detail (ageing matters less)<br />
+            − Photo content (5 kits) becomes invisible<br />
+            − May feel too similar to YouthBlock if both use this treatment
+          </div>
+        </header>
+        <div class="t2-surface">
+          <div class="t2-bg">
+            <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="" />
+          </div>
+          <div class="t2-overlay"></div>
+          <div class="t2-content">
+            <div class="meta-line" style="opacity: 0.85;">Webshop · supplier link</div>
+            <h2 class="h"><span class="accent">Trainingsgear</span><br />en clubpakketten.</h2>
+            <p class="lead">Onze partner levert alle trainingsuitrusting en gepersonaliseerde clubpakketten voor jeugd- en seniorenspelers.</p>
+            <a class="cta">Naar de webshop <span class="arrow">↗</span></a>
+          </div>
+        </div>
+      </section>
+
+      <!-- ========== T.3 — Halftone / duotone print treatment ========== -->
+      <section class="candidate" id="T3">
+        <header>
+          <div>
+            <div class="key">T.3</div>
+            <div class="name">Halftone duotone print · jersey-deep tinted, dot pattern</div>
+            <div class="desc">
+              Image rendered greyscale + jersey-deep multiply blend + halftone dot overlay. Reads
+              as a printed-newspaper photo. Photo content stays partly visible (shapes still
+              recognisable) but enters the printed-zine register fully. Most fanzine treatment.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Strongest fanzine register<br />
+            + Photo enters cream/ink palette without breaking voice<br />
+            − Detail in kits gets sacrificed to dot pattern<br />
+            − CSS-driven halftone is approximate; may not work on all browsers
+          </div>
+        </header>
+        <div class="t3-surface">
+          <div class="t3">
+            <div class="duotone-frame">
+              <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="KCVV kits" />
+              <div class="halftone-overlay"></div>
+            </div>
+            <div>
+              <div class="meta-line">Webshop · supplier link</div>
+              <h2 class="h"><span class="accent">Trainingsgear</span><br />en clubpakketten.</h2>
+              <p class="lead">Onze partner levert alle trainingsuitrusting en gepersonaliseerde clubpakketten voor jeugd- en seniorenspelers.</p>
+              <a class="cta">Naar de webshop <span class="arrow">↗</span></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ========== T.4 — Narrow image strip + banner card on top ========== -->
+      <section class="candidate" id="T4">
+        <header>
+          <div>
+            <div class="key">T.4</div>
+            <div class="name">Narrow photo strip · banner card overlapping</div>
+            <div class="desc">
+              The image fills a narrow horizontal band (220px tall, mild grayscale 60% + slight
+              brightness reduction). A taped banner card sits halfway over it, holding the
+              headline + CTA. Image is environmental backdrop; the card is the content. Quiet
+              transition between photo and cream paper below.
+            </div>
+          </div>
+          <div class="tradeoffs">
+            <strong>Tradeoffs</strong>
+            + Image has its own real estate<br />
+            + Banner card carries the message<br />
+            + Strong layered "magazine spread" feel<br />
+            − Banner card mid-overlap is unusual; needs care on mobile
+          </div>
+        </header>
+        <div class="t4-surface">
+          <div class="t4-strip">
+            <img src="/Users/kevinvanransbeeck/Sites/KCVV/kcvv-redesign-phase-4-design/apps/web/public/images/jerseys.png" alt="KCVV kits 2025" />
+          </div>
+          <div class="t4-banner">
+            <div class="t4-banner-card">
+              <div class="t4-stack">
+                <div>
+                  <div class="meta-line">Webshop · supplier link</div>
+                  <h2 class="h" style="font-size: 26px;"><span class="accent">Trainingsgear</span> en clubpakketten via onze partner.</h2>
+                  <p class="lead" style="margin-bottom: 0;">Algemene uitrusting + gepersonaliseerde clubpakketten voor jeugd- en seniorenspelers.</p>
+                </div>
+                <a class="cta">Naar de webshop <span class="arrow">↗</span></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+    </div>
+
+    <div class="footnote">
+      <p>
+        <strong>Image asset.</strong> Same <code>/images/jerseys.png</code> in every variant —
+        7.7 MB PNG. For production, ship a smaller WebP at the rendered display size; lazy-load
+        unless the section is above the fold (it isn't).
+      </p>
+      <p>
+        <strong>Out of scope.</strong> Whether the image gets refreshed each season (Phase 7
+        editor concern). Image alt text variants. Whether T.3's halftone effect is implemented in
+        SVG, CSS, or as a pre-processed asset (implementation detail; effect locks first).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/sponsorsblock-locked.md
+++ b/docs/design/mockups/phase-4-homepage/sponsorsblock-locked.md
@@ -1,0 +1,93 @@
+# Phase 4 · `<SponsorsBlock>` — Locked
+
+**Locked 2026-05-07 across rounds 7, 7b (rejected for being too busy), 7c.**
+
+## Composition
+
+```text
+<SponsorsBlock>                         // server component
+  <SectionHeader title="Met dank aan onze sponsors">
+  <ul class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5">
+    {sponsors.map(s => (
+      <li>
+        <Link href={s.url} target="_blank" rel="noopener">
+          <SponsorLogo            // cream-soft tile · M.3
+            logo={s.logo}
+            name={s.name}        // accessible label / fallback wordmark
+          />
+        </Link>
+      </li>
+    ))}
+  </ul>
+  <Link href="/sponsors">Alle sponsors &amp; sympathisanten →</Link>
+```
+
+## Data flow
+
+| Aspect | Value | Source |
+| --- | --- | --- |
+| Source | Sanity `sponsor[]` ordered by tier then name | `SPONSORS_QUERY` (existing or new) |
+| Filter | `tier in ["hoofdsponsor", "sponsor"]` AND `active === true` | Per `reference_sponsor_tiers` |
+| Sort | hoofdsponsors first, then sponsors (alphabetical within tier) | Tier ordering convention |
+| Per-logo treatment | Greyscale by default → colour on hover via `filter: grayscale(100%)` + transition | Per `reference_sponsor_tiers` rule (locked 2026-04-28) |
+| Tile | Cream-soft fill (`var(--cream-soft)`), no border, no shadow, no rotation | Round 7c M.3 |
+| Tile size | Equal across hoofdsponsors and sponsors | Round 7 L.2 |
+| Click target | Whole tile → external link to `s.url` | New tab, `rel="noopener"` |
+| /sponsors link | "Alle sponsors &amp; sympathisanten →" — visible always at section bottom | Round 7 owner add |
+| Empty state | Section returns null if 0 sponsors match filter | Same convention as NewsGrid / UpcomingMatches |
+
+## Locked decisions
+
+| Round | Decision | Rationale |
+| --- | --- | --- |
+| 7 | **L.2 · Single equal grid** | All sponsors same size; cleanest grid; tier hierarchy not on homepage |
+| 7b | ~~Paper card with rotation/tape~~ → **rejected** | Too busy alongside paper-pasted weight elsewhere on the page |
+| 7c | **M.3 · Cream-soft tile, no border, no shadow** | Quietest separation that still handles white-bg logos via tone shift |
+
+## Responsive grid
+
+```css
+grid-cols-2          /* mobile <640px  */
+sm:grid-cols-3       /* sm  ≥640px     */
+lg:grid-cols-5       /* lg  ≥1024px    */
+```
+
+Gap: 14px desktop, 10px mobile. Tile padding: 14px × 8px. Min-height: 70px (logo doesn't
+affect grid height when shorter).
+
+## Tier hierarchy on homepage
+
+**Not visible.** Hoofdsponsors and sponsors render at identical size on `/`. Tier is preserved
+via order only (hoofdsponsors first). For full tier-explicit hierarchy with sympathisanten,
+visitors click "Alle sponsors &amp; sympathisanten →" to `/sponsors` (Phase 7 redesign).
+
+## Hover / focus
+
+- Tile cursor: `pointer`
+- Greyscale → colour transition: `filter` over 200ms ease
+- `prefers-reduced-motion: reduce` → drop the transition; instant snap
+- No translate / shadow change on hover (kept calm)
+- Focus-visible: 2px jersey-deep outline at 2px offset (a11y standard, applies to keyboard nav)
+
+## Section-level treatment
+
+The section header ("Met dank aan onze sponsors") gets the standard `<SectionHeader>` from
+Phase 2 (now wraps `<EditorialHeading>` + `<MonoLabelRow>`). The section background is
+`cream-deep` so the tiles' cream-soft fill produces the tone shift.
+
+## VR baseline contract
+
+- Story: `Home/SponsorsBlock/Default` — 3 hoofdsponsors + 10 sponsors
+- Story: `Home/SponsorsBlock/HoofdsponsorsOnly` — 3 hoofdsponsors, no sponsors
+- Story: `Home/SponsorsBlock/SponsorsOnly` — 0 hoofdsponsors, 8 sponsors
+- Story: `Home/SponsorsBlock/Empty` — returns null
+- Story: `Home/SponsorsBlock/MissingLogos` — mix of sponsors with/without `logo` (renders italic
+  Freight Display name fallback in the no-logo cells)
+
+## Out of scope this section
+
+- **Spotlight section** (`featured: true` sponsors with `description`) — that's a separate
+  sub-component shown only on the dedicated `/sponsors` page (Phase 7), not on `/`.
+- **Per-tier styling** — homepage doesn't expose tier hierarchy visually. Tier-explicit
+  rendering lives on `/sponsors` (Phase 7).
+- **Logo upload tooling** — Studio editor-ux rework concern, separate ticket.

--- a/docs/design/mockups/phase-4-homepage/upcoming-matches-locked.md
+++ b/docs/design/mockups/phase-4-homepage/upcoming-matches-locked.md
@@ -1,0 +1,91 @@
+# Phase 4 · `<UpcomingMatches>` — Locked
+
+**Locked 2026-05-07 across rounds 6 (superseded), 6a, 6b.**
+**Renamed from `<ScheduleStandingsBlock>` to `<UpcomingMatches>`.**
+
+## What changed vs the original Phase 4 issue
+
+Issue #1526 originally listed `<ScheduleStandingsBlock>` with both schedule and standings as
+tabs. Round 6a (scope) revealed a fundamental mismatch: schedule across all KCVV teams paired
+with standings for one team is incoherent. Resolved with **S.4 — drop standings entirely**:
+
+- Section becomes single-purpose `<UpcomingMatches>`.
+- Standings live only on `/ranking` (separate page, unchanged).
+- No tabs (Round 6's L.2 lock superseded).
+- Issue #1526 AC list needs updating before PRD lands.
+
+## Composition
+
+```text
+<UpcomingMatches>                                // server component shell
+  <SectionHeader title="Komende wedstrijden">
+  <UpcomingMatchesClient initialMatches={Match[]}>  // "use client" for expand state
+    <ul>
+      <li> // row × 5 collapsed, all upcoming when expanded
+        <Link href="/match/{id}">
+          <span class="when"> day · time </span>
+          <span class="matchup"> {home} — {away} </span>
+          <span class="meta"> {team_label} · {competition} </span>
+          <span class="badge">{is_home ? "THUIS" : "UIT"}</span>
+    </ul>
+    {totalUpcoming > 5 && !expanded && (
+      <button>Toon alle {N} wedstrijden ↓</button>
+    )}
+    {expanded && (
+      <Link href="/kalender">Volledige kalender →</Link>
+    )}
+```
+
+## Data flow
+
+| Aspect | Value | Source |
+| --- | --- | --- |
+| Source endpoint | `bff.getNextMatches()` | Already used by today's homepage; same call |
+| Filter | None — all KCVV teams across competitions | Per S.4 lock (community schedule scope) |
+| Sort | `date asc` (chronological) | BFF default |
+| Default count | 5 | Round 6b D.5 lock |
+| Expand trigger | `totalUpcoming > 5` | Hide button if ≤ 5 upcoming |
+| Expanded view | All upcoming matches in the same chronological list | No grouping |
+| `/kalender` link | Visible only when expanded | Round 6b D.5 lock |
+| Empty state (0 upcoming) | Return null (entire section hidden) | Same convention as NewsGrid E.1 |
+| Per-row click target | Whole row → `Link` to `/match/{id}` | Standard match-detail route |
+| KCVV team highlight | KCVV team name rendered with `font-weight: 700` per team-side (home or away) | Comparison via `home_team.id === 1235 \|\| away_team.id === 1235` |
+| Home / away badge | THUIS (jersey-deep bg) or UIT (ink bg), monospace caps | Match `is_home` field |
+
+## Locked decisions
+
+| Round | Decision | Rationale |
+| --- | --- | --- |
+| 6 | ~~L.2 tabs~~ → **superseded** | Round 6a dropped one of the two tabs; tabs no longer needed |
+| 6a | **S.4 · Drop standings, schedule-only** | Mismatch between all-team schedule and single-team standings; resolved by removing standings |
+| 6b | **D.5 · 5 default + inline expand to all + /kalender link visible only when expanded** | User-specified hybrid pattern |
+
+## Rotation + hover + paper treatment
+
+- Section container is a `<TapedCard>` with `rotation="b"` (subtle -0.25°) — single anchor card.
+- Schedule rows are inside the card; rows do not individually rotate.
+- Each row is a `<Link>` with the canonical press-down hover applied to the row itself
+  (not the card). Per `feedback_canonical_press_down_hover`.
+- Expand button uses press-down hover too. Stamped paper button.
+- `/kalender` link (post-expand) is plain text with `↗` arrow indicator.
+
+## Mobile
+
+Mobile (<640px): same row format. Day/time stacks above teams instead of left-of. Badge stays
+right-aligned. Expand button grows to full width.
+
+## VR baseline contract
+
+- Story: `Home/UpcomingMatches/Default5` (5 upcoming, collapsed)
+- Story: `Home/UpcomingMatches/ExactlyFive` (5 upcoming, expand button hidden)
+- Story: `Home/UpcomingMatches/SparseUnder5` (3 upcoming, no expand button)
+- Story: `Home/UpcomingMatches/Empty` (0 upcoming, returns null)
+- Expanded state covered by Storybook controls; the expand interaction is captured by component
+  test (Vitest) rather than VR (which captures static frames).
+
+## Open questions deferred
+
+- Whether expansion animation uses CSS height-transition or pop-in (no transition). Default:
+  pop-in (no animation). Reduces complexity.
+- Whether the count badge ("Toon alle 12 wedstrijden") shows team count or match count. Match count.
+- Future enhancement: filter pills per division (deferred — not Phase 4).

--- a/docs/design/mockups/phase-4-homepage/webshopbanner-locked.md
+++ b/docs/design/mockups/phase-4-homepage/webshopbanner-locked.md
@@ -1,0 +1,89 @@
+# Phase 4 · `<WebshopBanner>` — Locked
+
+**Locked 2026-05-07 across rounds 9 (rejected — wrong premise), 9b (P.3 picked), 9c (rejected — image treatments).**
+**Renamed from `<WebshopStrip>` to `<WebshopBanner>`.**
+
+## What changed vs the original Phase 4 issue
+
+Issue #1526 originally described `<WebshopStrip>` as "4-column jersey thumbnails." Round 9
+revealed that **KCVV does not run an in-site store** — every transaction goes to an external
+supplier — so a 4-thumbnail product gallery would advertise items the supplier may not stock,
+require seasonal asset maintenance, and mislead visitors. Section reframed as a banner pointer
+(no specific products); renamed to `<WebshopBanner>`.
+
+## Composition
+
+```text
+<WebshopBanner>                                 // server component
+  <div class="jersey-deep-band tape-strip">
+    <span class="meta">WEBSHOP · onze partner</span>
+    <h2><EditorialHeading><span className="accent">Trainingsgear</span> bestel je rechtstreeks bij onze partner.</EditorialHeading></h2>
+    <p className="lead">Trainingskledij, clubpakketten en personalisatie voor onze jeugd- en seniorenspelers.</p>
+    <a href={EXTERNAL_LINKS.webshop} target="_blank" rel="noopener">
+      Naar de webshop ↗
+    </a>
+  </div>
+```
+
+## Spec
+
+| Aspect | Value |
+| --- | --- |
+| Section background | Solid `var(--ink)` (revised after adjacency review) |
+| Top tape strip | Full-width jersey-tape green strip (-0.5° rotation, 18px tall, top -12px) — same colour as before, now contrasts against ink |
+| Text colour | `var(--cream)` |
+| Accent colour | `#f0c264` (warm yellow) on "Trainingsgear" |
+| Headline | `<EditorialHeading>` italic, accent decorator on "Trainingsgear" |
+| Lead | "Trainingskledij, clubpakketten en personalisatie voor onze jeugd- en seniorenspelers." |
+| CTA | Cream paper button, ink text, jersey-deep shadow, `↗` external indicator |
+| External link | `EXTERNAL_LINKS.webshop` constant (existing) |
+| Hover | Canonical press-down on the CTA |
+| Image | None |
+| Editor input | None — pure code |
+
+## Locked decisions
+
+| Round | Decision | Rationale |
+| --- | --- | --- |
+| 9 | ~~4 product thumbnails~~ → **rejected** | KCVV doesn't sell — no specific products to advertise |
+| 9b | **P.3 · Wide jersey-tape banner** | Most minimal info density, strongest typographic moment, single CTA |
+| 9c | ~~Incorporate jerseys.png~~ → **rejected** | Owner preferred solid-colour version after seeing image treatments |
+
+## Adjacency resolved
+
+WebshopBanner originally locked as jersey-deep, which created two adjacent jersey-deep bands
+with YouthBlock. Owner-locked fix (2026-05-07): **WebshopBanner uses solid ink instead of
+jersey-deep**. This contrasts cleanly with YouthBlock's jersey-deep + photo backdrop and reads
+as a "press release / classified ad" register. Tape strip stays jersey-tape green (now
+contrasts against ink rather than blending).
+
+```text
+[YouthBlock jersey-deep + photo backdrop] ← green
+[WebshopBanner ink]                       ← dark band (contrast)
+[bannerSlotC cream]                       ← cream beat
+[SponsorsBlock cream-deep]                ← cream close
+```
+
+Three-tone rhythm: green → ink → cream-pair, ending the page on the lighter notes.
+
+## Reuse mandate
+
+Banner composes:
+- `<EditorialHeading>` with accent decorator (Phase 1)
+- `<TapeStrip>` (Phase 0) for the top jersey-tape band
+- `<MonoLabel>` (Phase 0) for the "WEBSHOP · onze partner" meta line
+- `<Button variant="primary">` (Phase 2 atom rework) for the CTA
+
+No new primitives.
+
+## VR baseline contract
+
+- Story: `Home/WebshopBanner/Default` — desktop, full banner
+- Story: `Home/WebshopBanner/Mobile` — viewport at 375px
+- VR-tag both. No image / no live data — fully deterministic.
+
+## Out of scope
+
+- Photo asset experimentation (already drilled in 9c — owner explicitly rejected).
+- Sanity-driven copy or CTA URL — stays hardcoded, `EXTERNAL_LINKS.webshop` is the single source.
+- Per-category deep-links to the external supplier (verifiable later — not Phase 4 design concern).

--- a/docs/design/mockups/phase-4-homepage/youthblock-locked.md
+++ b/docs/design/mockups/phase-4-homepage/youthblock-locked.md
@@ -1,0 +1,83 @@
+# Phase 4 · `<YouthBlock>` — Locked
+
+**Locked 2026-05-07 across rounds 8 (rejected — over-amplified JerseyShirt), 8b (corrected after owner clarification).**
+
+## Composition
+
+```text
+<YouthBlock>                                  // server component
+  <YouthBackdrop>                             // existing component, reskinned palette
+    <Image src="/images/youth-trainers.jpg" blur="2px" />
+    <div className="bg-gradient (jersey-deep 90% → 75% → 50%)" />
+  </YouthBackdrop>
+  <div className="text-block">
+    <span className="meta-line">Word jeugdspeler</span>
+    <h2><EditorialHeading><span className="accent">De toekomst</span> van Elewijt.</EditorialHeading></h2>
+    <p className="lead">Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel.</p>
+    <div className="stats">
+      <span className="stat"><strong>220+</strong> spelers</span>
+      <span className="stat"><strong>16</strong> ploegen</span>
+    </div>
+    <Link href="/jeugd" className="cta">Ontdek onze jeugd →</Link>
+  </div>
+```
+
+## Key decisions
+
+| Round | Decision | Rationale |
+| --- | --- | --- |
+| 8 | ~~Big JerseyShirt as section visual~~ → **rejected** | "Don't like the big jersey here" — owner rejected |
+| 8b | **N.2 · Today's pattern reskinned** (blurred photo + jersey-deep gradient) | Direct continuity from current `<YouthBackdrop>`, fades cleanly |
+
+## Backdrop spec
+
+- Photo asset: `/images/youth-trainers.jpg` (existing — kept). Future swap when a better photo is curated.
+- Blur: `2px` filter blur applied to image (matches today's behavior).
+- Gradient overlay: `linear-gradient(135deg, var(--jersey-deep) / 88% 0%, var(--jersey-deep) / 65% 60%, var(--jersey-deep-dark) / 92% 100%)`. Approximates today's `from-kcvv-green-dark/90 via-kcvv-green-dark/75 to-kcvv-green-dark/50` swapped to retro palette tokens.
+- Mobile gradient direction: `bg-gradient-to-b` (vertical) — same as today.
+- Desktop gradient direction: `md:bg-gradient-to-r` (horizontal) — same as today.
+
+## Text + CTA
+
+- Meta line: `Word jeugdspeler` (uppercase mono, opacity 0.7)
+- Headline: `De toekomst van Elewijt.` — `<EditorialHeading>` italic with accent decorator on "De toekomst" (yellow #f0c264)
+- Lead: `Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en Onderbouw delen één doel: voetbal als zelfontplooiing — nooit als prestatie alleen.`
+  - **Note:** This is new copy proposing a fuller lead. Verify with owner before merge — today's lead is `"Meer dan 220 jonge spelers en 16 ploegen trainen elke week op Sportpark Elewijt. Van de allerkleinsten tot de U21."` Either is acceptable; redesign vocabulary preferred.
+- Stats: `220+ spelers · 16 ploegen` (hardcoded — verify accuracy at implementation time)
+- Divisions: `· Bovenbouw · Middenbouw · Onderbouw` (mono uppercase line) — only if adding the divisions row reads well; cut if cluttered
+- CTA: `Ontdek onze jeugd →` (cream paper button on jersey-deep) — keeping current copy; "Schrijf je in" alternative if the page becomes a sign-up funnel later.
+
+## Hardcoded vs Sanity
+
+YouthBlock content stays hardcoded in Phase 4 — same as today. Future Sanity migration to a
+`youthLanding` document is a Phase 7 concern (jeugd landing redesign). Editor doesn't need to
+touch this surface for now.
+
+## Reuse mandate
+
+YouthBlock composes:
+- `<YouthBackdrop>` — existing component, palette swap only (kcvv-green-dark → jersey-deep tokens)
+- `<EditorialHeading>` with `accent` decorator (Phase 1)
+- `<MonoLabel>` (Phase 0) for the meta line and stats
+- `<Button variant="primary">` (Phase 2 atom rework) for the CTA
+
+No new primitives. The `<JerseyShirt>` primitive from Phase 3 is **NOT used in YouthBlock**
+(per Round 8 owner rejection — JerseyShirt vocabulary lives elsewhere on the site, not here).
+
+## Mobile
+
+Mobile (<640px): same composition, gradient flips to vertical, headline scales down via clamp.
+Photo asset is the same; cropping handled by `object-cover object-top` (today's behavior).
+
+## VR baseline contract
+
+- Story: `Home/YouthBlock/Default` — desktop with full backdrop + text
+- Story: `Home/YouthBlock/Mobile` — viewport at 375px width
+- VR-tag both. Photo asset is deterministic; gradient overlay is deterministic; no flake risk.
+
+## Out of scope this section
+
+- Photo asset replacement — Phase 4 keeps `/images/youth-trainers.jpg`. New photo curation is
+  a future ticket, not a Phase 4 deliverable.
+- Sanity migration of YouthBlock copy — Phase 7 jeugd landing concern.
+- Lead-copy A/B — owner can confirm at implementation time which lead variant ships.

--- a/docs/plans/2026-05-07-redesign-phase-4-plan.md
+++ b/docs/plans/2026-05-07-redesign-phase-4-plan.md
@@ -5,9 +5,9 @@
 > **Master design:** `docs/plans/2026-04-27-redesign-master-design.md`
 > **Design brief:** `docs/design/mockups/phase-4-homepage/` — 11 round HTMLs + 7 `*-locked.md` specs (all locked 2026-05-07)
 > **Predecessor plan:** `docs/plans/2026-05-03-redesign-phase-3-plan.md` (structure mirrored)
-> **Sub-issues to create:** 11 children of #1526 (see §15 for `gh` recipes + GraphQL `addBlockedBy` script)
+> **Sub-issues to create:** 12 children of #1526 (see §15 for `gh` recipes + GraphQL `addBlockedBy` script)
 
-This plan executes the 11 Phase 4 sub-issues. Each is a separate Ralph-eligible work item with its own PR. This document is the source of execution order, file paths, acceptance criteria, and `addBlockedBy` graph.
+This plan executes the 12 Phase 4 sub-issues. Each is a separate Ralph-eligible work item with its own PR. This document is the source of execution order, file paths, acceptance criteria, and `addBlockedBy` graph.
 
 ---
 
@@ -245,7 +245,10 @@ Run once before opening any sub-issue:
 **Files to delete (or move to _legacy/):**
 
 - `apps/web/src/components/home/WebshopSection/`
-- `/public/images/jerseys.png` — keep in repo for now (other surfaces may use it); just stop importing it.
+
+**Files to retain (out of deletion scope):**
+
+- `apps/web/public/images/jerseys.png` — retained in the repo for other surfaces. WebshopBanner does not import it; just remove the import in the legacy WebshopSection move.
 
 **Implementation:**
 
@@ -452,7 +455,7 @@ Move (not delete) into a `_legacy/` directory for blame trace; deletion happens 
 
 ## Definition of done — overall
 
-- All 11 sub-issues closed.
+- All 12 sub-issues closed.
 - All VR baselines committed in their respective sub-issue PRs.
 - `pnpm --filter @kcvv/web check-all` green on `main` after final merge.
 - Storybook `Pages/Homepage` reviewable.

--- a/docs/plans/2026-05-07-redesign-phase-4-plan.md
+++ b/docs/plans/2026-05-07-redesign-phase-4-plan.md
@@ -1,0 +1,513 @@
+# Phase 4 — Implementation plan
+
+> **PRD:** `docs/prd/redesign-phase-4.md`
+> **Tracking issue:** [#1526](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1526)
+> **Master design:** `docs/plans/2026-04-27-redesign-master-design.md`
+> **Design brief:** `docs/design/mockups/phase-4-homepage/` — 11 round HTMLs + 7 `*-locked.md` specs (all locked 2026-05-07)
+> **Predecessor plan:** `docs/plans/2026-05-03-redesign-phase-3-plan.md` (structure mirrored)
+> **Sub-issues to create:** 11 children of #1526 (see §15 for `gh` recipes + GraphQL `addBlockedBy` script)
+
+This plan executes the 11 Phase 4 sub-issues. Each is a separate Ralph-eligible work item with its own PR. This document is the source of execution order, file paths, acceptance criteria, and `addBlockedBy` graph.
+
+---
+
+## Pre-flight
+
+Run once before opening any sub-issue:
+
+1. **Worktree:** `pnpm ralph create 1526` to create the isolated worktree on `feat/issue-1526-tracer` (sub-branches per issue thereafter).
+2. **Phase 3 merged on `main`:** verify `<EditorialHero>`, `<SiteHeader>`, `<MatchStrip>`, `<SiteFooter>`, `<PlayerFigure>`, `<JerseyShirt>`, `<EndMark>`, `<QASectionDivider>` are all merged. `gh pr list --state merged --search "Phase 3"` should list #1632, #1633, #1634, #1635, #1636, #1637, #1638, #1640, #1641, #1642.
+3. **VR baseline drift check:** `pnpm vr` against current `main` to confirm no pre-existing failures before the redesign work starts.
+4. **Audit existing call sites of legacy components to be retired:**
+   - `<FeaturedArticles>`: `apps/web/src/components/home/FeaturedArticles/`. Single consumer in `apps/web/src/app/(landing)/page.tsx`.
+   - `<MatchWidget>`: `apps/web/src/components/home/MatchWidget/`. Single consumer in `(landing)/page.tsx`.
+   - `<MatchesSliderSection>`: `apps/web/src/components/home/MatchesSliderSection/`. Single consumer.
+   - `<WebshopSection>`: `apps/web/src/components/home/WebshopSection/`. Single consumer.
+   - Today's `<NewsGrid>`: `apps/web/src/components/home/NewsGrid/` — will be rebuilt in place; existing tests need rewrites.
+   - Today's `<YouthSection>` + `<YouthBackdrop>`: stays, palette swap only.
+   - Today's `<SponsorsSection>` + `<SponsorsBlock>`: SponsorsSection wrapper stays; SponsorsBlock gets rewritten internally.
+5. **No Sanity migrations needed.** Confirm `article.featured` and `event.featuredOnHome` exist in `packages/sanity-schemas/src/`.
+6. **Master design doc** open in another tab — §6 deltas of the PRD fold back into this doc as sub-issues complete.
+
+---
+
+## Task 4.0 — Tracer · `<TapeStrip color="warm">` variant
+
+**Sub-issue:** create as child of #1526, no `blockedBy`. Title: `4.0 · Tracer — <TapeStrip color="warm"> primitive variant`.
+
+**Goal:** Smallest cross-layer slice that proves the Phase 4 architecture works. The warm-tape variant is the only new primitive Phase 4 introduces; landing it first unblocks `<FeaturedEventBand>` and any future jersey-deep surface.
+
+**Files to modify:**
+
+- `apps/web/src/app/globals.css` — add `--tape-warm: rgba(240, 194, 100, 0.85);` token.
+- `apps/web/src/components/design-system/TapeStrip/TapeStrip.tsx` — extend `color` prop union to `"jersey" | "warm"`. Add CSS branch.
+- `apps/web/src/components/design-system/TapeStrip/TapeStrip.stories.tsx` — add `WarmOnJerseyDeep` story (jersey-deep panel + warm tape strip).
+- `apps/web/src/components/design-system/TapedFigure/TapedFigure.tsx` — extend `tape[].color` enum to accept `"warm"`. Pass through to underlying TapeStrip.
+
+**Implementation:**
+
+1. Add the token to `globals.css` next to `--tape-jersey`. Append-only; do not remove `--tape-jersey`.
+2. Update `TapeStrip` `color` prop. Default stays `"jersey"`.
+3. Update `TapedFigure` `tape[]` array element type.
+4. New story `WarmOnJerseyDeep` — single tape strip on a jersey-deep panel for VR.
+5. `pnpm vr:update:story TapeStrip` to capture baseline.
+6. `pnpm --filter @kcvv/web check-all` must be green before opening PR.
+
+**Acceptance:**
+
+- `<TapeStrip color="warm">` renders.
+- `<TapedFigure tape={[{ color: "warm" }]}>` renders.
+- VR baseline committed.
+- `pnpm --filter @kcvv/web check-all` green.
+
+**Closes:** PRD §3 tracer.
+
+---
+
+## Task 4.A.1 — `<NewsCard>` aspectRatio + rotation props
+
+**Sub-issue:** `4.A.1 · <NewsCard> aspectRatio + rotation props`. `addBlockedBy 4.0`.
+
+**Goal:** Extend the existing `<NewsCard>` primitive with the props `<NewsGrid>` will require.
+
+**Files to modify:**
+
+- `apps/web/src/components/article/NewsCard/NewsCard.tsx` — add props per `newsgrid-locked.md`.
+- `apps/web/src/components/article/NewsCard/NewsCard.stories.tsx` — add stories per aspect + per rotation.
+
+**Implementation:**
+
+1. Add `aspectRatio?: "landscape-16-9" | "square" | "portrait-3-4"` (default `"landscape-16-9"`).
+2. Add `rotation?: "a" | "b" | "c" | "d" | "none"` (default `"none"`).
+3. Wire props to underlying `<TapedFigure>` for the inner image and `<TapedCard>` for the card rotation.
+4. Update Storybook with `Article/NewsCard/Default` (16:9), `Article/NewsCard/SquareAspect`, `Article/NewsCard/PortraitAspect`, plus rotation variants on the default aspect.
+5. VR baselines for each new story.
+6. No regression on existing NewsCard usages — verify by running `pnpm vr` and checking diffs.
+
+**Acceptance:**
+
+- All new props work; defaults preserve current rendering.
+- Storybook + VR baselines committed.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.B.1 — `<NewsGrid>` rebuild
+
+**Sub-issue:** `4.B.1 · <NewsGrid> rebuild (1+4 · 50/50 · slot rotation)`. `addBlockedBy 4.A.1`.
+
+**Goal:** Rebuild `<NewsGrid>` from a 1+2 to a 1+4 layout per `newsgrid-locked.md`.
+
+**Files to modify:**
+
+- `apps/web/src/components/home/NewsGrid/NewsGrid.tsx` — full rewrite of geometry.
+- `apps/web/src/components/home/NewsGrid/NewsGrid.stories.tsx` — sparse-state stories.
+- `apps/web/src/components/home/NewsGrid/NewsGrid.test.tsx` — tests for sparse-N renders.
+
+**Implementation:**
+
+1. Drop the `featuredEvent` prop entirely. `<FeaturedEventBand>` now owns event display (separate component, separate section in page.tsx).
+2. New geometry: CSS Grid, `grid-template-columns: 1fr 1fr`, lead spans both rows in left column, supporting cards fill 2x2 right cluster.
+3. Sparse states (E.1): if articles.length < 5, conditionally render only the slots that have data. Sub-grid for 2x2 collapses to single row when < 4 supporting.
+4. Mobile (<880px) collapses to: lead full-width on top, 2x2 grid below = 1+2+2 layout.
+5. Per-slot rotation cycle `[a, b, c, d, a]` passed to `<NewsCard rotation={...}>`.
+6. `aspectRatio="landscape-16-9"` forced on every card.
+7. Stories: Default5, Sparse4, Sparse3, Sparse2, Sparse1, Empty (returns null — captured deliberately).
+8. Tests: assert returns null at N=0, assert correct slot count at N=1..5, assert lead is always slot 0.
+
+**Acceptance:**
+
+- All sparse states render correctly.
+- VR baselines for each.
+- Existing tests retained where still valid; new tests added for sparse rendering.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.B.2 — `<UpcomingMatches>` rename + rebuild
+
+**Sub-issue:** `4.B.2 · <UpcomingMatches> rename + schedule depth + expand`. `addBlockedBy 4.0`.
+
+**Goal:** Rename and rebuild today's `<MatchesSliderSection>` per `upcoming-matches-locked.md`.
+
+**Files to create:**
+
+- `apps/web/src/components/home/UpcomingMatches/UpcomingMatches.tsx`
+- `apps/web/src/components/home/UpcomingMatches/UpcomingMatchesClient.tsx` (use client — handles expand state)
+- `apps/web/src/components/home/UpcomingMatches/UpcomingMatches.stories.tsx`
+- `apps/web/src/components/home/UpcomingMatches/UpcomingMatches.test.tsx`
+- `apps/web/src/components/home/UpcomingMatches/index.ts`
+
+**Files to delete (or move to _legacy/):**
+
+- `apps/web/src/components/home/MatchWidget/`
+- `apps/web/src/components/home/MatchesSliderSection/`
+
+**Implementation:**
+
+1. Server component shell — receives `matches: Match[]`, calls `<UpcomingMatchesClient>` with `initialMatches`.
+2. Client component — renders 5 rows by default. State `expanded: boolean`. Expand button only renders when `totalUpcoming > 5`. `/kalender` link only renders when expanded (per Round 6b D.5 lock).
+3. Row format: 56px when column (day + time mono) + matchup column (home — away italic, KCVV side bold when team_id === 1235) + badge (THUIS / UIT). Each row is a `<Link>` to `/match/{id}`.
+4. Empty state: return null at 0 upcoming.
+5. Mobile <640px: when column stacks above matchup column inside each row.
+6. Stories: Default5 (5 matches), ExactlyFive (5 matches with no expand), SparseUnder5 (3 matches), Empty (returns null), Expanded (12 matches in expanded state via Storybook arg).
+7. Tests: assert returns null at 0, assert expand button only when >5, assert row count + click target.
+
+**Acceptance:**
+
+- All states render correctly.
+- VR baselines committed.
+- Page.tsx integration updated to call `<UpcomingMatches>` instead of `<MatchWidget>` + `<MatchesSliderSection>` (this happens in 4.D.1).
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.B.3 — `<SponsorsBlock>` homepage variant
+
+**Sub-issue:** `4.B.3 · <SponsorsBlock> homepage variant (single grid + cream-soft tile)`. `addBlockedBy 4.0`.
+
+**Goal:** Rewrite SponsorsBlock per `sponsorsblock-locked.md`.
+
+**Files to modify:**
+
+- `apps/web/src/components/sponsors/SponsorsBlock/SponsorsBlock.tsx` — rewrite layout + tile treatment.
+- `apps/web/src/components/sponsors/SponsorsBlock/SponsorsBlock.stories.tsx` — new stories.
+- `apps/web/src/components/sponsors/SponsorsBlock/SponsorsBlock.test.tsx` — tier filter tests.
+
+**Files to verify untouched:**
+
+- `apps/web/src/components/home/SponsorsSection/SponsorsSection.tsx` — wrapper stays.
+
+**Implementation:**
+
+1. Filter: `tier in ["hoofdsponsor", "sponsor"] && active === true`. Order: hoofdsponsors first.
+2. Single equal grid: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5`. Gap 14px desktop, 10px mobile.
+3. Per-logo tile: cream-soft background (`bg-cream-soft`), no border, no shadow, no rotation. Min-height 70px.
+4. Greyscale-default + colour-on-hover via CSS `filter: grayscale(100%)` + `transition-property: filter`. Wrap in `motion-reduce:transition-none` for reduced-motion.
+5. Each tile is `<Link href={s.url} target="_blank" rel="noopener">`.
+6. Below the grid: `<Link href="/sponsors">Alle sponsors &amp; sympathisanten →</Link>` (mono uppercase styling).
+7. Empty state: return null.
+8. Stories: Default (3 hoofd + 10 sponsor), HoofdsponsorsOnly, SponsorsOnly, Empty, MissingLogos (italic Freight Display name fallback).
+
+**Acceptance:**
+
+- Tile treatment matches lock spec (M.3).
+- VR baselines for all 5 stories.
+- `/sponsors` link renders.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.B.4 — `<YouthBlock>` palette swap
+
+**Sub-issue:** `4.B.4 · <YouthBlock> palette swap to retro vocabulary`. `addBlockedBy 4.0`.
+
+**Goal:** Migrate the existing `<YouthSection>` + `<YouthBackdrop>` to the retro tokens per `youthblock-locked.md`. Optional component rename to `<YouthBlock>`.
+
+**Files to modify:**
+
+- `apps/web/src/components/home/YouthSection/YouthSection.tsx` (or rename `YouthBlock.tsx`).
+- `apps/web/src/components/home/YouthSection/YouthBackdrop.tsx` — gradient palette token swap.
+- `apps/web/src/components/home/YouthSection/YouthSection.stories.tsx`.
+
+**Implementation:**
+
+1. Backdrop gradient swap: `from-kcvv-green-dark/90 via-kcvv-green-dark/75 to-kcvv-green-dark/50` → use jersey-deep tokens at 88/65/92 (matches Round 8b N.2).
+2. `bg` SectionConfig in `(landing)/page.tsx` changes from `"kcvv-green-dark"` to a redesign token (still effectively the same colour family, but uses retro tokens).
+3. Headline: `<EditorialHeading>` italic with accent decorator on "De toekomst" (yellow #f0c264).
+4. Meta-line "Word jeugdspeler" (mono uppercase, opacity 0.7).
+5. Stats line: `<MonoLabel>` for "220+ spelers · 16 ploegen". Verify accuracy at implementation; copy is hardcoded.
+6. CTA: `<Button variant="primary">` with "Ontdek onze jeugd →" text (current copy preserved).
+7. Mobile: gradient flips to vertical (existing behaviour).
+8. Stories: Default (desktop) + Mobile (375px viewport).
+
+**Acceptance:**
+
+- Backdrop palette swapped; photo asset unchanged.
+- Typography migrated to retro vocabulary.
+- VR baselines updated.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.B.5 — `<WebshopBanner>` rename + rebuild
+
+**Sub-issue:** `4.B.5 · <WebshopBanner> rename + ink palette + single CTA`. `addBlockedBy 4.0`.
+
+**Goal:** Replace `<WebshopSection>` with a new `<WebshopBanner>` per `webshopbanner-locked.md`.
+
+**Files to create:**
+
+- `apps/web/src/components/home/WebshopBanner/WebshopBanner.tsx`
+- `apps/web/src/components/home/WebshopBanner/WebshopBanner.stories.tsx`
+- `apps/web/src/components/home/WebshopBanner/index.ts`
+
+**Files to delete (or move to _legacy/):**
+
+- `apps/web/src/components/home/WebshopSection/`
+- `/public/images/jerseys.png` — keep in repo for now (other surfaces may use it); just stop importing it.
+
+**Implementation:**
+
+1. Section background: solid `var(--ink)`. Tape strip on top with default jersey color (now contrasts cleanly against ink).
+2. Meta line: "WEBSHOP · ONZE PARTNER" (mono uppercase, opacity 0.85, cream).
+3. Headline: `<EditorialHeading>` italic with accent on "Trainingsgear".
+4. Lead: "Trainingskledij, clubpakketten en personalisatie voor onze jeugd- en seniorenspelers."
+5. CTA: cream paper button with ink text, jersey-deep shadow, "↗" indicator. `<Link>` to `EXTERNAL_LINKS.webshop` (existing constant). `target="_blank"` + `rel="noopener"`.
+6. No image. No products.
+7. Stories: Default + Mobile.
+
+**Acceptance:**
+
+- Renders per `webshopbanner-locked.md` spec.
+- VR baselines.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.B.6 — `<FeaturedEventBand>` NEW
+
+**Sub-issue:** `4.B.6 · <FeaturedEventBand> new component (depends on warm-tape)`. `addBlockedBy 4.0`.
+
+**Goal:** New component per `featuredeventband-locked.md`.
+
+**Files to create:**
+
+- `apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx`
+- `apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.stories.tsx`
+- `apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.test.tsx`
+- `apps/web/src/components/home/FeaturedEventBand/index.ts`
+
+**Implementation:**
+
+1. Server component. Props: `event: FeaturedEventStub | null`.
+2. Drop-if-empty: `if (!event || !event.coverImage) return null;`.
+3. Section background: `var(--jersey-deep)`.
+4. Layout: CSS Grid `1fr 1.4fr`, gap 32px, padding 36px 28px, items-center.
+5. Image column: `<TapedFigure aspect="landscape-16-9" rotation="a" tape={[{ color: "warm" }]}>` containing `<Image src={event.coverImage.url} fill alt={event.coverImage.alt} />`.
+6. Text column: meta-line "AANSTAAND EVENEMENT", `<EditorialHeading>` for title with accent decorator, when-line `formatDateTime(dateStart, dateEnd)` + " · " + `event.location || "Kantine"`, CTA.
+7. CTA: `event.externalLink?.label || "Meer info →"` linking to `event.externalLink?.url || /evenementen/${event.slug}`.
+8. Mobile: grid collapses to single column. Image stays above text (no order reversal).
+9. Date helper: extend `formatDateTime` to handle dateEnd range. If same day, show single date. If multi-day, show "10 mei – 12 mei" range.
+10. Stories: Default (typical event), NoExternalLink (internal `/evenementen/{slug}` fallback CTA), MultiDay (dateStart + dateEnd), Empty (returns null).
+11. Tests: assert returns null when event is null, when coverImage missing, when dateStart in the past.
+
+**Acceptance:**
+
+- Renders per `featuredeventband-locked.md`.
+- Drop-if-empty works.
+- VR baselines for all stories.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.C.1 — Homepage carousel client component
+
+**Sub-issue:** `4.C.1 · Homepage hero carousel (D.1 strip-below thumbnails)`. `addBlockedBy 4.0`.
+
+**Goal:** Wrap `<EditorialHero placement="homepage">` in a client carousel per Round 1b D.1 lock.
+
+**Files to create:**
+
+- `apps/web/src/components/home/HomepageHeroCarousel/HomepageHeroCarousel.tsx` ("use client")
+- `apps/web/src/components/home/HomepageHeroCarousel/HomepageHeroCarousel.stories.tsx`
+- `apps/web/src/components/home/HomepageHeroCarousel/HomepageHeroCarousel.test.tsx`
+- `apps/web/src/components/home/HomepageHeroCarousel/index.ts`
+
+**Implementation:**
+
+1. "use client" directive.
+2. Props: `articles: HeroArticle[]` (typically 3, supports 1–3).
+3. State: `activeIndex: number`, `paused: boolean`.
+4. Auto-advance every 5s when not paused. `useEffect` with `setInterval`. Pause on hover, focus, or `prefers-reduced-motion: reduce`.
+5. Active slide: `<EditorialHero placement="homepage" {...articles[activeIndex]} />`.
+6. Strip below: 3 thumb buttons in a row. Active thumb: outlined `#f0c264`, opacity 1. Inactives: opacity 0.6. Each thumb is a `<button>` (a11y: aria-label "Toon artikel: {title}", aria-pressed when active).
+7. Pause/play button + progress bar: monospace styling, sits with the strip.
+8. Reduced-motion: drop transitions; auto-advance disabled; arrows still work.
+9. Stories: Default (3 articles), TwoArticles (2 thumbs), SingleArticle (no carousel chrome), Paused (initial state).
+10. Tests: arrow keys advance, click thumb jumps, pause toggles paused state, auto-advance interval.
+
+**Acceptance:**
+
+- Carousel renders, auto-advances, thumbs work.
+- Reduced-motion fallback static.
+- VR baselines on the active-slide states (rotation animation deliberately not VR-tested).
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.C.2 — Article query update
+
+**Sub-issue:** `4.C.2 · ARTICLES_QUERY featured-first ordering`. `addBlockedBy 4.0`.
+
+**Goal:** Update the homepage article fetch query to surface `featured: true` articles in the carousel.
+
+**Files to modify:**
+
+- `apps/web/src/lib/sanity/queries/articles.ts` (or wherever `ARTICLES_QUERY` lives)
+- `apps/web/src/lib/sanity/sanity.types.ts` — regenerated via `sanity typegen` after the query change.
+- Tests in `apps/web/src/lib/effect/services/repositories/article.repository.test.ts`.
+
+**Implementation:**
+
+1. Change `order(publishedAt desc)` to `order(featured desc, publishedAt desc)`.
+2. Run `pnpm --filter @kcvv/studio typegen` to regenerate types.
+3. Verify Effect Schema decodes against the new shape (no schema change since `featured` was already included in the projection).
+4. Tests: assert flagged articles surface first, fallback to recency when fewer than 3 are flagged.
+
+**Acceptance:**
+
+- Query updated; types regenerated; tests pass.
+- No regression in NewsGrid (it now receives slice [3..8] = articles 3..7 of the ordered list).
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Task 4.D.1 — Homepage page.tsx integration
+
+**Sub-issue:** `4.D.1 · Homepage page.tsx new section ordering + legacy drop`. `addBlockedBy 4.B.1, 4.B.2, 4.B.3, 4.B.4, 4.B.5, 4.B.6, 4.C.1, 4.C.2`.
+
+**Goal:** Re-wire the homepage to compose all new sections per the IA lock.
+
+**Files to modify:**
+
+- `apps/web/src/app/(landing)/page.tsx` — main integration.
+- `apps/web/src/app/(landing)/loading.tsx` — skeleton matches new sections.
+- `apps/web/src/components/home/index.ts` — barrel export updates.
+
+**Files to delete or move to `_legacy/`:**
+
+- `apps/web/src/components/home/FeaturedArticles/`
+- `apps/web/src/components/home/MatchWidget/` (already deleted in 4.B.2)
+- `apps/web/src/components/home/MatchesSliderSection/` (already deleted in 4.B.2)
+- `apps/web/src/components/home/WebshopSection/` (already deleted in 4.B.5)
+
+Move (not delete) into a `_legacy/` directory for blame trace; deletion happens in Phase 9 cleanup.
+
+**Implementation:**
+
+1. New section ordering:
+   ```text
+   <HomepageHeroCarousel articles={featuredArticles} />
+   <FeaturedEventBand event={featuredEvent} />
+   <BannerSlot a />
+   <NewsGrid articles={newsGridArticles} />
+   <UpcomingMatches matches={matches} />
+   <BannerSlot b />
+   <YouthBlock />
+   <WebshopBanner />
+   <BannerSlot c />
+   <SponsorsBlock />
+   ```
+2. Data fetches:
+   - Articles: existing fetch, ordering now `featured desc, publishedAt desc`. Slice `[0..3]` for hero, `[3..8]` for grid.
+   - Featured event: existing `EventRepository.findNextFeatured()` (no change).
+   - Matches: existing `getNextMatches()` (no change).
+   - Banners: existing fetch (unchanged).
+   - Sponsors: existing fetch (unchanged).
+3. Drop imports for `FeaturedArticles`, `MatchWidget`, `MatchesSliderSection`, `WebshopSection`.
+4. Delete the old `youthSection` `bg: "kcvv-green-dark"` SectionConfig — `<YouthBlock>` self-contains its background now.
+5. Skeleton (`loading.tsx`) matches new section heights.
+6. Section-stack handling: bannerSlots remain optional refs on `homePage`. Each drop-if-empty.
+
+**Acceptance:**
+
+- Homepage renders the full new composition end-to-end.
+- Legacy components moved (not deleted) to `_legacy/`.
+- Playwright e2e `homepage.spec.ts` updated for new section ordering.
+- `pnpm --filter @kcvv/web check-all` green.
+- Manual smoke test: load `/` in dev server, verify all sections render, hover all interactive elements.
+
+---
+
+## Task 4.D.2 — Pages/Homepage Storybook + e2e
+
+**Sub-issue:** `4.D.2 · Pages/Homepage Storybook story + Playwright e2e update`. `addBlockedBy 4.D.1`.
+
+**Goal:** Storybook coverage for the assembled homepage + e2e regression.
+
+**Files to modify:**
+
+- `apps/web/src/app/(landing)/page.stories.tsx` (or create — Storybook can mount full pages).
+- `apps/web/e2e/homepage.spec.ts` — Playwright spec.
+
+**Implementation:**
+
+1. Storybook Pages/Homepage story with realistic mock data covering: full data, sparse NewsGrid, no FeaturedEventBand, no UpcomingMatches, no SponsorsBlock.
+2. NOT vr-tagged (per Phase 0.5 decision; VR is at component level only).
+3. Playwright e2e:
+   - Section ordering: hero carousel first, then event band (when present), then NewsGrid…
+   - Carousel auto-advances + thumb click works.
+   - UpcomingMatches expand button works.
+   - Sponsors logos hover transitions through colour.
+4. Run `pnpm --filter @kcvv/web e2e` to verify.
+
+**Acceptance:**
+
+- Pages/Homepage story loads cleanly.
+- Playwright e2e green.
+- `pnpm --filter @kcvv/web check-all` green.
+
+---
+
+## Definition of done — overall
+
+- All 11 sub-issues closed.
+- All VR baselines committed in their respective sub-issue PRs.
+- `pnpm --filter @kcvv/web check-all` green on `main` after final merge.
+- Storybook `Pages/Homepage` reviewable.
+- Playwright e2e `homepage.spec.ts` green.
+- Owner review of `/` on staging (e2e build).
+- CodeRabbit feedback addressed.
+- Issue #1526 closed with sign-off comment linking each section's `*-locked.md` file.
+- Master design `§5.1 Homepage` section updated to reflect locked composition (this happens during the final close-out of issue #1526).
+
+---
+
+## §15 — Sub-issue creation recipes
+
+After PRD lock, run from inside the worktree:
+
+```bash
+# 4.0 Tracer
+gh issue create \
+  --title "feat(ui): redesign phase 4.0 — <TapeStrip color=\"warm\"> primitive variant" \
+  --body "$(cat <<'EOF'
+> Phase 4 tracer per PRD `docs/prd/redesign-phase-4.md` §3.
+
+Lands the warm-tape variant + Storybook + VR baseline. Unblocks 4.B.6 and any future jersey-deep surface.
+
+## Scope
+
+- `--tape-warm: rgba(240, 194, 100, 0.85)` token in `apps/web/src/app/globals.css`
+- `<TapeStrip>` color prop union extended to include "warm"
+- `<TapedFigure>` tape[].color enum extended
+- `TapeStrip.stories.tsx` adds `WarmOnJerseyDeep` story
+- VR baseline captured
+
+## Acceptance
+
+- [ ] Token added (append-only, --tape-jersey preserved)
+- [ ] TapeStrip + TapedFigure prop unions extended
+- [ ] WarmOnJerseyDeep story
+- [ ] VR baseline committed
+- [ ] check-all green
+EOF
+)" \
+  --label "redesign,ready,tracer-bullet" \
+  --milestone "redesign-retro-terrace-fanzine"
+```
+
+Repeat similarly for 4.A.1, 4.B.1–6, 4.C.1–2, 4.D.1–2. Each issue body lists files-to-modify + acceptance bullets sourced from this plan.
+
+After all issues exist, wire `addBlockedBy` via the GraphQL mutation:
+
+```bash
+# Get issue node IDs
+PARENT_ID=$(gh api graphql -f query='query { repository(owner:"soniCaH", name:"www.kcvvelewijt.be") { issue(number: 1526) { id } } }' --jq '.data.repository.issue.id')
+
+# Per child, add blockedBy edges per the dependency graph in PRD §4
+# (use the addBlockedBy mutation; NEVER addSubIssue per feedback_blockedby_not_subissues memory)
+```
+
+A scripted version lives at `scripts/phase-4-issues.sh` (created in 4.0 PR).

--- a/docs/plans/2026-05-07-redesign-phase-4-plan.md
+++ b/docs/plans/2026-05-07-redesign-phase-4-plan.md
@@ -3,7 +3,7 @@
 > **PRD:** `docs/prd/redesign-phase-4.md`
 > **Tracking issue:** [#1526](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1526)
 > **Master design:** `docs/plans/2026-04-27-redesign-master-design.md`
-> **Design brief:** `docs/design/mockups/phase-4-homepage/` — 11 round HTMLs + 7 `*-locked.md` specs (all locked 2026-05-07)
+> **Design brief:** `docs/design/mockups/phase-4-homepage/` — 24 round HTMLs + 7 `*-locked.md` specs (all locked 2026-05-07)
 > **Predecessor plan:** `docs/plans/2026-05-03-redesign-phase-3-plan.md` (structure mirrored)
 > **Sub-issues to create:** 12 children of #1526 (see §15 for `gh` recipes + GraphQL `addBlockedBy` script)
 
@@ -128,7 +128,12 @@ Run once before opening any sub-issue:
 
 **Sub-issue:** `4.B.2 · <UpcomingMatches> rename + schedule depth + expand`. `addBlockedBy 4.0`.
 
-**Goal:** Rename and rebuild today's `<MatchesSliderSection>` per `upcoming-matches-locked.md`.
+**Goal:** Build `<UpcomingMatches>` per `upcoming-matches-locked.md`. Two lineage threads converge here:
+
+1. **Replaces the original Phase 4 issue's `<ScheduleStandingsBlock>` proposal** — standings are dropped from the homepage entirely (Round 6a S.4 lock; standings live on `/ranking` only). Component is schedule-only — no tabs, no standings table.
+2. **Absorbs today's `<MatchesSliderSection>` and `<MatchWidget>` legacy components** — both are deleted (moved to `_legacy/`). The new component renders 5 chronological matches default + inline expand-to-all.
+
+This dual-rename matters for implementation drift: the spec's name (`<ScheduleStandingsBlock>`) and the legacy code's name (`<MatchesSliderSection>` / `<MatchWidget>`) are both retired in favour of `<UpcomingMatches>`.
 
 **Files to create:**
 

--- a/docs/prd/redesign-phase-4.md
+++ b/docs/prd/redesign-phase-4.md
@@ -80,26 +80,26 @@ If the tracer fails, every Phase 4 sub-issue depending on the warm tape (`<Featu
 ## 4. Sub-issues — children of #1526
 
 ```text
-4.0   #TBA  — Tracer bullet · <TapeStrip color="warm"> primitive variant
+4.0   #1670  — Tracer bullet · <TapeStrip color="warm"> primitive variant
    ↓
    ├── 4.A — Primitives track (parallel after 4.0)
-   │     4.A.1  #TBA  <NewsCard> aspectRatio + rotation props
+   │     4.A.1  #1671  <NewsCard> aspectRatio + rotation props
    │
    ├── 4.B — Section components track (parallel after 4.A.1)
-   │     4.B.1  #TBA  <NewsGrid> rebuild (1+4 · 50/50 geometry)
-   │     4.B.2  #TBA  <UpcomingMatches> renamed + schedule-depth + expand
-   │     4.B.3  #TBA  <SponsorsBlock> homepage variant (single grid · M.3 tiles)
-   │     4.B.4  #TBA  <YouthBlock> palette swap on existing <YouthSection>/<YouthBackdrop>
-   │     4.B.5  #TBA  <WebshopBanner> renamed + ink palette
-   │     4.B.6  #TBA  <FeaturedEventBand> NEW component (depends on 4.0 warm tape)
+   │     4.B.1  #1672  <NewsGrid> rebuild (1+4 · 50/50 geometry)
+   │     4.B.2  #1673  <UpcomingMatches> renamed + schedule-depth + expand
+   │     4.B.3  #1674  <SponsorsBlock> homepage variant (single grid · M.3 tiles)
+   │     4.B.4  #1675  <YouthBlock> palette swap on existing <YouthSection>/<YouthBackdrop>
+   │     4.B.5  #1676  <WebshopBanner> renamed + ink palette
+   │     4.B.6  #1677  <FeaturedEventBand> NEW component (depends on 4.0 warm tape)
    │
    ├── 4.C — EditorialHero homepage placement track (after 4.B.* ready)
-   │     4.C.1  #TBA  Carousel client component (D.1 strip-below thumbnails) wraps <EditorialHero placement="homepage">
-   │     4.C.2  #TBA  Article query update — `order(featured desc, publishedAt desc)`; fallback to most-recent if < 3 flagged
+   │     4.C.1  #1678  Carousel client component (D.1 strip-below thumbnails) wraps <EditorialHero placement="homepage">
+   │     4.C.2  #1679  Article query update — `order(featured desc, publishedAt desc)`; fallback to most-recent if < 3 flagged
    │
    └── 4.D — Homepage page.tsx integration (final, after all 4.B/4.C merged)
-         4.D.1  #TBA  Compose new section ordering; drop legacy components
-         4.D.2  #TBA  Pages/Homepage Storybook story rebuild
+         4.D.1  #1680  Compose new section ordering; drop legacy components
+         4.D.2  #1681  Pages/Homepage Storybook story rebuild
 ```
 
 **Dependency edges (`addBlockedBy` GraphQL mutations):**

--- a/docs/prd/redesign-phase-4.md
+++ b/docs/prd/redesign-phase-4.md
@@ -1,0 +1,329 @@
+# Redesign — Phase 4: Homepage rebuild
+
+> **Master design reference:** `docs/plans/2026-04-27-redesign-master-design.md`
+> **Design brief:** `docs/design/mockups/phase-4-homepage/` (10 rounds + sub-rounds, all locked 2026-05-07)
+> **Tracking issue:** [#1526](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1526)
+> **Implementation plan:** `docs/plans/2026-05-07-redesign-phase-4-plan.md` _(authored after this PRD)_
+> **Milestone:** `redesign-retro-terrace-fanzine`
+> **Epic:** KCVV Elewijt redesign — retro-terrace fanzine aesthetic
+> **Predecessor:** [#1525](https://github.com/soniCaH/www.kcvvelewijt.be/issues/1525) — Phase 3 (Tier C figures + EditorialHero + chrome)
+> **Blocks:** Phase 5 (article-detail rebuild), Phase 6 (player profiles + match detail), Phase 7 (landings) — all later phases consume the homepage's components on other surfaces
+> **Owner:** _you_
+> **Estimate:** ~3 weeks (1 week design exploration ✅ done · 1.5 weeks implementation · 0.5 week migration / VR baselines)
+
+---
+
+## 1. Problem statement
+
+The homepage today is a stack of legacy components (`<FeaturedArticles>` rotating carousel, hardcoded `<MatchWidget>`, `<MatchesSlider>`, `<NewsGrid>` with embedded event card, `<YouthSection>`, static `<WebshopSection>`, `<SponsorsBlock>`) that all predate the retro-terrace-fanzine redesign. With Phase 3 chrome merged (`<SiteHeader>` + `<MatchStrip>` + `<SiteFooter>` + `<EditorialHero>`), the homepage body is the most visible surface still on legacy aesthetics.
+
+Three problems are open today:
+
+1. **Body sections render as legacy components.** `<FeaturedArticles>` is a rotating carousel with no visual identity tied to the redesign. `<NewsGrid>` mixes events into the article grid, breaking the "events are calendar items, news is editorial" distinction. `<MatchWidget>` + `<MatchesSlider>` duplicate work that the new chrome `<MatchStrip>` already covers (next-match peek). `<YouthSection>` works but is on the legacy palette. `<WebshopSection>` is a static photo with no editorial register. `<SponsorsBlock>` shows tier hierarchy that doesn't match the redesign's flat-grid aesthetic.
+
+2. **Editorial workflow is invisible to editors.** Today's hero just slices the 3 most-recent articles — no editorial control over which articles surface as the homepage lead. There's no way to flag a story as "this is the lead this week."
+
+3. **The featured event hides inside the news grid.** Events tagged `featuredOnHome` render as a special card inside `<NewsGrid>`, where they compete visually with article cards. The event-vs-article hierarchy is muddled.
+
+Without Phase 4, the redesign chrome (header / matchstrip / footer / hero) frames a homepage body that's still on legacy register. Phase 5+ blocks until the homepage exemplar exists.
+
+---
+
+## 2. Scope
+
+**Packages touched:** `apps/web` (primary). `apps/web/src/components/home/*` is essentially rewritten. One Phase 0/1 primitive update (`<TapeStrip>` warm variant). No Sanity schema migrations.
+
+**In scope:**
+
+- **`<EditorialHero placement="homepage">`** — already shipped in Phase 3 (#1637, #1638). Phase 4 wires it into the homepage and ships the **D.1 carousel + strip-below thumbnails** behaviour: 3 articles auto-rotating with all 3 thumbs visible below, slot-deterministic rotation cycle, `article.featured` boolean source. **New "use client" component** for the rotation state.
+- **`<FeaturedEventBand>`** — NEW component. Jersey-deep band between hero and NewsGrid. Image-left (TapedFigure with warm-yellow tape variant) + text-right + CTA. Drop-if-empty. Driven by `event.featuredOnHome`.
+- **`<NewsGrid>`** — rebuilt. 1 lead + 4 supporting · 50/50 split · 2×2 supporting cluster · all `landscape-16-9` aspect · slot-index rotation cycle (matches Phase 1 `<TapedCardGrid>`). Sparse states E.1 (graceful collapse). Receives `articles.slice(3, 8)` (5 articles, was 6). Featured event slot removed (now lives in FeaturedEventBand).
+- **`<NewsCard>`** — primitive update. Adds `aspectRatio` and `rotation` props per locked NewsGrid spec. Storybook + VR for new variants. `landscape-16-9 / square / portrait-3-4` ship; `text-only` deferred (no clear data trigger; coverImage is required).
+- **`<UpcomingMatches>`** — RENAMED from `<ScheduleStandingsBlock>`. Schedule-only block (standings dropped per Round 6a); 5 chronological matches default + inline-expand-to-all (use client) + `/kalender` link visible only when expanded. Replaces today's `<MatchWidget>` + `<MatchesSlider>`.
+- **`<YouthBlock>`** — palette swap on the existing `<YouthSection>` + `<YouthBackdrop>`. Keep blurred-photo backdrop pattern; change overlay tokens from kcvv-green-dark to jersey-deep. Update typography to retro vocabulary (`<EditorialHeading>` with accent decorator). Photo asset stays as `/images/youth-trainers.jpg`.
+- **`<WebshopBanner>`** — RENAMED from `<WebshopStrip>`. Single-purpose ink-palette banner pointing to external supplier. No specific products. Editorial copy + single CTA. Ink (not jersey-deep) to avoid adjacency conflict with YouthBlock.
+- **`<SponsorsBlock>`** — homepage variant. Single equal grid (no tier-size hierarchy on `/`); cream-soft tile per logo (M.3 — no border, no shadow, no rotation, just a subtle tone shift); greyscale-default + colour-on-hover. `/sponsors` link at the bottom.
+- **`<TapeStrip>`** — primitive update. Adds `color="warm"` variant for use on jersey-deep sections (cream/yellow tape contrast).
+- **Homepage `page.tsx` integration** — re-wire `apps/web/src/app/(landing)/page.tsx` to compose the new section ordering: Hero → FeaturedEventBand → bannerSlotA → NewsGrid → UpcomingMatches → bannerSlotB → YouthBlock → WebshopBanner → bannerSlotC → SponsorsBlock. Drop `<FeaturedArticles>`, `<MatchWidget>`, `<MatchesSlider>`, `<WebshopSection>` legacy components.
+
+**Out of scope:**
+
+- **Article detail page** (Phase 5).
+- **Player profiles, match detail, team detail, kalender, events list / detail** (Phase 6).
+- **Sponsors page** (Phase 7).
+- **Sanity schema migrations.** No new fields needed — `article.featured` and `event.featuredOnHome` already exist.
+- **`<PosterWordmark>`** — explicitly retired in Phase 3 PRD §2; `<SiteFooter>` H3 wordmark plays the closing-band role.
+- **Standings on the homepage.** Round 6a dropped them — too incoherent to pair with all-team schedule. Standings live on `/ranking` only (unchanged).
+- **`<NewsCard>` text-only aspect variant.** Article schema requires `coverImage`; no natural data trigger. Master design's 4th aspect variant deferred to a future phase if a use case appears.
+- **WebshopBanner imagery.** Owner explicitly preferred solid-colour version; `/images/jerseys.png` is not used in the new banner.
+- **YouthBlock photo replacement.** Existing `/images/youth-trainers.jpg` stays. New photo curation is a future ticket.
+
+---
+
+## 3. Tracer bullet
+
+The thinnest cross-layer slice that proves the Phase 4 architecture works:
+
+> **Land `<TapeStrip color="warm">` variant + Storybook story + VR baseline.**
+
+The warm-tape variant is the only new primitive Phase 4 introduces, and it cuts across multiple sub-issues (`<FeaturedEventBand>` requires it; future jersey-deep surfaces will reuse it). Demonstrated by:
+- `<TapeStrip>` extended `color` union to include `"warm"`.
+- `--tape-warm: rgba(240, 194, 100, 0.85)` token added to `globals.css`.
+- `TapeStrip.stories.tsx` adds a story group `WarmOnJerseyDeep` showing the new variant against a jersey-deep panel.
+- VR baseline captured.
+- `pnpm --filter @kcvv/web check-all` green.
+
+If the tracer fails, every Phase 4 sub-issue depending on the warm tape (`<FeaturedEventBand>`, future jersey-deep surfaces) is at risk. If it passes, the four tracks below can fan out.
+
+---
+
+## 4. Sub-issues — children of #1526
+
+```text
+4.0   #TBA  — Tracer bullet · <TapeStrip color="warm"> primitive variant
+   ↓
+   ├── 4.A — Primitives track (parallel after 4.0)
+   │     4.A.1  #TBA  <NewsCard> aspectRatio + rotation props
+   │
+   ├── 4.B — Section components track (parallel after 4.A.1)
+   │     4.B.1  #TBA  <NewsGrid> rebuild (1+4 · 50/50 geometry)
+   │     4.B.2  #TBA  <UpcomingMatches> renamed + schedule-depth + expand
+   │     4.B.3  #TBA  <SponsorsBlock> homepage variant (single grid · M.3 tiles)
+   │     4.B.4  #TBA  <YouthBlock> palette swap on existing <YouthSection>/<YouthBackdrop>
+   │     4.B.5  #TBA  <WebshopBanner> renamed + ink palette
+   │     4.B.6  #TBA  <FeaturedEventBand> NEW component (depends on 4.0 warm tape)
+   │
+   ├── 4.C — EditorialHero homepage placement track (after 4.B.* ready)
+   │     4.C.1  #TBA  Carousel client component (D.1 strip-below thumbnails) wraps <EditorialHero placement="homepage">
+   │     4.C.2  #TBA  Article query update — `order(featured desc, publishedAt desc)`; fallback to most-recent if < 3 flagged
+   │
+   └── 4.D — Homepage page.tsx integration (final, after all 4.B/4.C merged)
+         4.D.1  #TBA  Compose new section ordering; drop legacy components
+         4.D.2  #TBA  Pages/Homepage Storybook story rebuild
+```
+
+**Dependency edges (`addBlockedBy` GraphQL mutations):**
+
+- All 4.A / 4.B sub-issues blocked by `4.0` (tracer must pass first)
+- `4.B.6` (FeaturedEventBand) explicitly blocked by `4.0` (consumes warm-tape variant)
+- `4.B.1` (NewsGrid) blocked by `4.A.1` (consumes new NewsCard props)
+- `4.C.1` (carousel client component) blocked by `4.B.*` design completeness (no specific component dep)
+- `4.D.1` (page.tsx integration) blocked by ALL 4.B + 4.C sub-issues
+- `4.D.2` (Storybook) blocked by `4.D.1`
+
+Per `feedback_blockedby_not_subissues` memory, dependencies use GraphQL `addBlockedBy` mutation — never `addSubIssue`.
+
+---
+
+## 5. Acceptance criteria per sub-issue
+
+### 5.0 Tracer (`<TapeStrip color="warm">` end-to-end)
+
+- `<TapeStrip>` `color` prop accepts `"warm"` in addition to existing values.
+- Token `--tape-warm: rgba(240, 194, 100, 0.85)` added to `apps/web/src/app/globals.css`.
+- `TapeStrip.stories.tsx` adds a `WarmOnJerseyDeep` story showing the variant against a jersey-deep panel.
+- VR baseline captured.
+- `pnpm --filter @kcvv/web check-all` green.
+
+### 5.A.1 — `<NewsCard>` props update
+
+- New `aspectRatio` prop: `"landscape-16-9" | "square" | "portrait-3-4"`. Default `"landscape-16-9"`.
+- New `rotation` prop: `"a" | "b" | "c" | "d" | "none"`. Default `"none"`.
+- Storybook stories per aspect variant + per rotation.
+- VR baselines for each new story.
+- No regression on existing NewsCard usages.
+
+### 5.B.1 — `<NewsGrid>` rebuild
+
+- Implements the 1 lead + 4 supporting layout (50/50 split, 2×2 supporting cluster).
+- Receives `articles: Article[]` (1–5 elements). N=0 returns null.
+- Geometry adapts per N per Round 5f E.1 lock (sparse states).
+- All cards render with `aspectRatio="landscape-16-9"` (Round 5c C.1).
+- Slot-index rotation cycle: `[a, b, c, d, a]` (Round 5d T.1).
+- Featured event prop removed (now in FeaturedEventBand).
+- Articles slice changes to `[3..8]` (5 articles, was 6).
+- Mobile collapse: 1+2+2 (Round 5b D mobile spec).
+- Stories: Default5, Sparse4, Sparse3, Sparse2, Sparse1, Empty.
+
+### 5.B.2 — `<UpcomingMatches>` (renamed)
+
+- Renamed from `<ScheduleStandingsBlock>`. Component file moves; references to old name purged.
+- Default render: 5 chronological matches across all KCVV teams.
+- "Toon alle X wedstrijden ↓" inline expand button when `totalUpcoming > 5`. Uses "use client" for state.
+- When expanded: renders all upcoming + "Volledige kalender →" link to `/kalender`.
+- `/kalender` link hidden in collapsed state.
+- KCVV team-name highlighted (font-weight: 700) when team_id === 1235 on either side.
+- Each row links to `/match/{id}`.
+- Empty state (0 upcoming): return null.
+
+### 5.B.3 — `<SponsorsBlock>` (homepage variant)
+
+- Filter: `tier in ["hoofdsponsor", "sponsor"] && active === true`. Order: hoofdsponsors first.
+- Single equal grid (5 cols desktop, 3 tablet, 2 mobile).
+- Per-logo treatment: cream-soft tile, no border, no shadow, no rotation (Round 7c M.3).
+- Greyscale-default, colour-on-hover via CSS `filter: grayscale(100%)` + transition. Respect `prefers-reduced-motion`.
+- "Alle sponsors & sympathisanten →" link to `/sponsors` at section bottom.
+- Empty state: return null.
+
+### 5.B.4 — `<YouthBlock>` palette swap
+
+- Existing `<YouthSection>` + `<YouthBackdrop>` retained. Token swap only.
+- Backdrop gradient: `kcvv-green-dark/90 → 75 → 50` becomes `jersey-deep/88 → 65 → 92` (per Round 8b N.2).
+- Typography migrates to `<EditorialHeading>` italic with accent decorator on "De toekomst".
+- Stats (220+ spelers · 16 ploegen) hardcoded.
+- CTA stays "Ontdek onze jeugd →" (current copy).
+
+### 5.B.5 — `<WebshopBanner>` (renamed)
+
+- Renamed from `<WebshopStrip>`. Component file moves.
+- Section background: solid `var(--ink)` (not jersey-deep — per F.1 lock to avoid adjacency conflict).
+- Top tape strip: full-width jersey-tape green (-0.5° rotation).
+- Editorial copy: `Trainingsgear bestel je rechtstreeks bij onze partner.` (with accent on "Trainingsgear").
+- Single CTA: "Naar de webshop ↗" → `EXTERNAL_LINKS.webshop` (existing constant).
+- No image. No products. No editor input.
+
+### 5.B.6 — `<FeaturedEventBand>` NEW
+
+- Server component. Returns null if no future event with `featuredOnHome === true && coverImage`.
+- Section background: `var(--jersey-deep)`.
+- Layout: image left 1fr (TapedFigure with `tape="warm"`) + text right 1.4fr.
+- Text fields: meta line "AANSTAAND EVENEMENT", `<EditorialHeading>` for title with accent decorator, when-line (`formatDateTime(dateStart, dateEnd)` + location fallback "Kantine"), CTA.
+- CTA: `event.externalLink.label || "Meer info →"` → `event.externalLink.url || /evenementen/{slug}`.
+- Mobile: stacks image-above-text.
+
+### 5.C.1 — Homepage carousel client component
+
+- "Use client" wrapper around `<EditorialHero placement="homepage">` rendering 3 articles (slice 0..3).
+- Strip-below thumbnails (Round 1b D.1): all 3 thumbs in a row beneath the active hero. Active outlined `#f0c264` jersey-yellow, inactives at 60% opacity. Click jumps the carousel.
+- Auto-rotate every 5s. Pause on hover or focus.
+- Pause/play button + progress bar (existing FeaturedArticles UX, retro chrome reskin).
+- Reduced-motion: drop transitions; static initial slide; arrow keys still work.
+
+### 5.C.2 — Article query update
+
+- `ARTICLES_QUERY` order changes from `order(publishedAt desc)` to `order(featured desc, publishedAt desc)`.
+- Slot 0..2 fill the carousel (S.2 hero source per Round 2). Slot 3..7 fill NewsGrid.
+- Fewer than 3 flagged → fallback uses most-recent (current behaviour for slots not flagged).
+
+### 5.D.1 — Homepage `page.tsx` integration
+
+- New section order:
+  ```text
+  EditorialHero D.1 → FeaturedEventBand → bannerSlotA → NewsGrid → UpcomingMatches → bannerSlotB → YouthBlock → WebshopBanner → bannerSlotC → SponsorsBlock
+  ```
+- Drop imports + usages of `<FeaturedArticles>`, `<MatchWidget>`, `<MatchesSlider>`, `<WebshopSection>`. Move legacy components to `apps/web/src/components/home/_legacy/` for blame trace; delete in Phase 9 cleanup.
+- All three bannerSlots retained (BS.1 lock); each drop-if-empty.
+
+### 5.D.2 — Pages/Homepage Storybook
+
+- `Pages/Homepage` story rebuilt with full new composition. Not vr-tagged (per Phase 0.5 decision; Playwright e2e covers `/` smoke test).
+- Includes empty states for FeaturedEventBand, NewsGrid sparse, UpcomingMatches empty, SponsorsBlock empty.
+
+---
+
+## 6. Data flow per section
+
+| Section | Source | Filter / Sort | Empty state |
+| --- | --- | --- | --- |
+| EditorialHero D.1 carousel | Sanity `article` | `order(featured desc, publishedAt desc)`, slice [0..3] | Hide if 0; render 1 / 2 thumbs if 1–2 |
+| FeaturedEventBand | Sanity `event` | `featuredOnHome && dateStart >= now()`, sort dateStart asc, take 1 | Return null |
+| NewsGrid | Sanity `article` | Same query as carousel, slice [3..8] | Return null at N=0; graceful collapse 1–4 |
+| UpcomingMatches | BFF `getNextMatches()` | sort date asc, all KCVV teams | Return null at 0 |
+| YouthBlock | Hardcoded | n/a | n/a |
+| WebshopBanner | Hardcoded | n/a | n/a |
+| SponsorsBlock | Sanity `sponsor` | `tier in ['hoofdsponsor','sponsor'] && active`, hoofdsponsors first | Return null |
+| Banner slots A/B/C | Sanity `homePage.bannerSlot[A/B/C]` ref | n/a | Each drop-if-empty |
+
+No new schema fields. `article.featured` and `event.featuredOnHome` already exist. Query change for hero ordering is the only data-side change.
+
+---
+
+## 7. VR baseline contract
+
+Per `docs/prd/visual-regression-testing.md` §12, every new `UI/<Name>` story and modified `Layout/<Component>` story commits baselines in the same PR.
+
+Phase 4 baselines:
+
+- **Tracer:** `UI/TapeStrip/WarmOnJerseyDeep`.
+- **NewsCard variants:** `Article/NewsCard/Default`, `Article/NewsCard/Lead`, `Article/NewsCard/SquareAspect`, `Article/NewsCard/PortraitAspect`.
+- **NewsGrid sparse states:** `Home/NewsGrid/Default5`, `Home/NewsGrid/Sparse4`, `Home/NewsGrid/Sparse3`, `Home/NewsGrid/Sparse2`, `Home/NewsGrid/Sparse1`, `Home/NewsGrid/Empty`.
+- **UpcomingMatches:** `Home/UpcomingMatches/Default5`, `Home/UpcomingMatches/ExactlyFive`, `Home/UpcomingMatches/SparseUnder5`, `Home/UpcomingMatches/Empty`.
+- **SponsorsBlock:** `Home/SponsorsBlock/Default`, `Home/SponsorsBlock/HoofdsponsorsOnly`, `Home/SponsorsBlock/SponsorsOnly`, `Home/SponsorsBlock/Empty`, `Home/SponsorsBlock/MissingLogos`.
+- **FeaturedEventBand:** `Home/FeaturedEventBand/Default`, `Home/FeaturedEventBand/NoExternalLink`, `Home/FeaturedEventBand/MultiDay`, `Home/FeaturedEventBand/Empty`.
+- **YouthBlock:** `Home/YouthBlock/Default`, `Home/YouthBlock/Mobile`.
+- **WebshopBanner:** `Home/WebshopBanner/Default`, `Home/WebshopBanner/Mobile`.
+- **Pages/Homepage:** Storybook only, not VR-tagged (per Phase 0.5 decision; Playwright e2e covers `/`).
+
+Per `feedback_vr_baseline_in_same_pr` memory: all baselines captured and committed in the same PR as the source diff. Per `feedback_vr_storybook_static_freshness`: rebuild storybook-static immediately before `vr:update`.
+
+---
+
+## 8. Analytics
+
+Per `feedback_analytics_prd_requirement` memory, every new user-facing feature ships analytics events.
+
+New events for Phase 4:
+
+- **`hero_carousel_view`** — fires when carousel comes into viewport. Properties: `{ activeSlug }`.
+- **`hero_carousel_advance`** — fires on auto-advance. Properties: `{ fromSlug, toSlug, slot }`.
+- **`hero_carousel_thumb_click`** — fires when user clicks a thumb to jump. Properties: `{ targetSlug, fromSlot, toSlot }`.
+- **`hero_carousel_pause`** — pause toggled. Properties: `{ paused: boolean }`.
+- **`featured_event_click`** — fires on FeaturedEventBand CTA click. Properties: `{ eventSlug, externalLink: boolean }`.
+- **`upcoming_matches_expand`** — fires when user clicks "Toon alle X wedstrijden". Properties: `{ totalCount }`.
+- **`upcoming_matches_kalender_click`** — fires on "Volledige kalender →". Properties: `{ wasExpanded }`.
+- **`webshop_banner_click`** — fires on WebshopBanner CTA. Properties: `{ source: "homepage" }`.
+- **`sponsor_logo_click`** — fires when a sponsor tile is clicked. Properties: `{ sponsorId, tier, source: "homepage" }`.
+
+GTM tags + GA4 reports updated in same PR.
+
+---
+
+## 9. Risks + mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Carousel "use client" component is the first non-server-rendered piece on `/` since Phase 3 | Lazy-mount; skeleton first paint matches first slide static; reduced-motion fallback static |
+| `article.featured` flag drift (editors forget to flip off) | Phase 4 includes a Studio editor-ux guidance update on the article doc explaining the homepage hero behaviour |
+| Two adjacent jersey-deep bands (YouthBlock + originally WebshopBanner) | Resolved at design time: WebshopBanner uses ink instead of jersey-deep |
+| Green-on-green tape on FeaturedEventBand | Resolved at design time: warm-tape variant introduced |
+| Mobile collapse complexity for 1+2+2 NewsGrid | Storybook viewport testing + explicit Mobile story; CSS Grid `auto-flow` handles graceful collapse |
+| Featured event coverImage missing in editor data | Drop-if-empty rule treats missing coverImage same as no event |
+| `getNextMatches()` might return 100s of upcoming matches | Inline expand reveals all but pagination not needed for KCVV's typical match volume; revisit if data exceeds ~30 matches |
+
+---
+
+## 10. Definition of done
+
+- All sub-issues closed.
+- All VR baselines committed.
+- `pnpm --filter @kcvv/web check-all` green.
+- Storybook `Pages/Homepage` reviewable.
+- Playwright e2e `homepage.spec.ts` updated for new section ordering.
+- Owner review of `/` on staging (e2e build).
+- CodeRabbit feedback addressed.
+- Issue #1526 closed with sign-off comment linking each section's `*-locked.md` file.
+
+---
+
+## 11. Concurrent feature work
+
+Per master design §7 rules: concurrent PRs that touch a redesigned component must use the new primitives (no new code on retired patterns). Concurrent PRs on un-redesigned surfaces (player profiles, match detail, kalender, event detail) continue using legacy tokens — that's fine until Phase 6 picks them up.
+
+Token additions (`--tape-warm`) are append-only — no token gets removed until Phase 9.
+
+---
+
+## 12. Locked design references
+
+Source-of-truth specs for each section live in `docs/design/mockups/phase-4-homepage/`:
+
+- `ia-locked.md` — homepage IA, section order, banner slots, palette rhythm
+- `newsgrid-locked.md` — NewsGrid + NewsCard composition
+- `upcoming-matches-locked.md` — UpcomingMatches (renamed from ScheduleStandingsBlock)
+- `sponsorsblock-locked.md` — SponsorsBlock
+- `youthblock-locked.md` — YouthBlock
+- `webshopbanner-locked.md` — WebshopBanner (renamed from WebshopStrip)
+- `featuredeventband-locked.md` — FeaturedEventBand (new)
+- `round-*.html` — comparison HTMLs preserved for diff history
+
+If implementation reveals a locked decision was wrong, halt the relevant sub-issue, re-enter the design checkpoint per master design §8.5, document the failure mode in the phase issue close-out comment.


### PR DESCRIPTION
## Summary

Lands the Phase 4 design checkpoint, PRD, and implementation plan. **No code changes** — all design artefacts live under `docs/`. Code work happens in 12 follow-up issues (#1670–#1681) that reference these files.

Refs #1526.

## What's in the diff

**Design checkpoint** — `docs/design/mockups/phase-4-homepage/`:
- 24 round HTMLs (one per drill round / sub-round), preserved with locked-state for diff history.
- 7 `*-locked.md` specs: `ia-locked`, `newsgrid-locked`, `upcoming-matches-locked`, `sponsorsblock-locked`, `youthblock-locked`, `webshopbanner-locked`, `featuredeventband-locked`.

**PRD** — `docs/prd/redesign-phase-4.md`. Mirrors Phase 3 PRD structure (problem → scope → tracer → sub-issue tree → ACs → data flow → VR contract → analytics → risks → DoD).

**Plan** — `docs/plans/2026-05-07-redesign-phase-4-plan.md`. 12 bite-sized tasks with file paths + acceptance criteria, sub-issue creation recipes, `addBlockedBy` graph.

## Locked decisions (changes vs original issue scope)

- ~~`<PosterWordmark>`~~ retired (Phase 3 `<SiteFooter>` H3 already plays the closing-band role).
- ~~Standings on homepage~~ dropped (Round 6a — incoherent with all-team schedule). `<ScheduleStandingsBlock>` → renamed `<UpcomingMatches>`.
- ~~`<NewsCard>` text-only aspect~~ retired from homepage (no data trigger; `coverImage` required).
- `<WebshopStrip>` → renamed `<WebshopBanner>`; ink palette (not jersey-deep) to avoid green-on-green adjacency with YouthBlock.
- New `<FeaturedEventBand>` component introduced (Round 3 E.2).
- New `<TapeStrip color="warm">` primitive variant introduced as the Phase 0/1 follow-up needed by FeaturedEventBand on jersey-deep sections.

## Sub-issues opened (under #1526)

| # | Title | Blocked by |
|---|---|---|
| #1670 | 4.0 Tracer · `<TapeStrip color="warm">` | — |
| #1671 | 4.A.1 `<NewsCard>` aspectRatio + rotation props | #1670 |
| #1672 | 4.B.1 `<NewsGrid>` rebuild | #1670, #1671 |
| #1673 | 4.B.2 `<UpcomingMatches>` | #1670 |
| #1674 | 4.B.3 `<SponsorsBlock>` | #1670 |
| #1675 | 4.B.4 `<YouthBlock>` palette swap | #1670 |
| #1676 | 4.B.5 `<WebshopBanner>` | #1670 |
| #1677 | 4.B.6 `<FeaturedEventBand>` | #1670 |
| #1678 | 4.C.1 Hero carousel client component | #1670 |
| #1679 | 4.C.2 ARTICLES_QUERY featured-first | #1670 |
| #1680 | 4.D.1 page.tsx integration | all of B.1–6, C.1–2 |
| #1681 | 4.D.2 Storybook + e2e | #1680 |

19 `addBlockedBy` edges wired via GraphQL (per `feedback_blockedby_not_subissues` memory — never `addSubIssue`).

## Test plan

- [ ] Owner reviews PRD §2 (scope) and §4 (sub-issue tree) for any missed locks
- [ ] Owner spot-checks 2–3 `*-locked.md` specs against the round HTMLs they came from
- [ ] Owner verifies the 12 sub-issues exist on GitHub with correct `addBlockedBy` graph
- [ ] CI green (markdown lint + link check; no code touched)

## Next step after merge

`/ralph create 1670` (the tracer) on a new worktree. Tracer must pass before any other Phase 4 sub-issue can start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Phase 4 homepage redesign docs: PRD, implementation plan and many locked design mockups.
  * Introduced the Featured Event band, NewsGrid/NewsCard rules (layouts, aspect/rotation, sparse/empty states), Upcoming Matches, YouthBlock palette/treatment, SponsorsBlock, and WebshopBanner guidance.
  * Added tape “warm” visual variant and VR baseline/acceptance criteria for deterministic stories and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->