### PR TITLE
chore(config): scope ImgBot to source images, ignore VR snapshots

### DIFF
--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,3 +1,13 @@
 {
-    "schedule": "daily"
+    "schedule": "daily",
+    "ignoredFiles": [
+        "apps/web/test/vr/__snapshots__/*",
+        "**/__snapshots__/*",
+        "**/*.snapshot.png",
+        "**/node_modules/*",
+        "**/.next/*",
+        "**/dist/*",
+        "**/storybook-static/*",
+        "**/coverage/*"
+    ]
 }

--- a/.imgbotconfig
+++ b/.imgbotconfig
@@ -1,13 +1,13 @@
 {
     "schedule": "daily",
     "ignoredFiles": [
-        "apps/web/test/vr/__snapshots__/*",
-        "**/__snapshots__/*",
+        "apps/web/test/vr/__snapshots__/**",
+        "**/__snapshots__/**",
         "**/*.snapshot.png",
-        "**/node_modules/*",
-        "**/.next/*",
-        "**/dist/*",
-        "**/storybook-static/*",
-        "**/coverage/*"
+        "**/node_modules/**",
+        "**/.next/**",
+        "**/dist/**",
+        "**/storybook-static/**",
+        "**/coverage/**"
     ]
 }


### PR DESCRIPTION
## Summary

- Adds an `ignoredFiles` allow/deny list to `.imgbotconfig` so ImgBot stops touching visual-regression baselines and generated artifacts.
- Scopes future ImgBot PRs to the actual source images we want optimised (e.g. `apps/web/public/**`).

## Why

PR #1580 swept in 100+ files including `apps/web/test/vr/__snapshots__/*.png`. Those baselines are pixel-exact references for Reg-Suit; any re-encoding (even lossless) shifts bytes and triggers false-positive VR diffs, forcing a full baseline recapture (`pnpm vr:update` ≈ 41 min). The same risk applies to anything inside `__snapshots__/`, `.next/`, `dist/`, `storybook-static/`, and `coverage/`.

## Test plan

- [ ] Close/refresh PR #1580 (or wait for next ImgBot run) and confirm only `apps/web/public/**` images are proposed.
- [ ] Verify no `test/vr/__snapshots__/` files appear in the next ImgBot diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude snapshot images and common build/output directories from automated image optimization processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->