### PR TITLE
docs(redesign): phase 4 round 8c — YouthBlock overlay locked (#1700)

### DIFF
--- a/docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html
+++ b/docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html
@@ -1,0 +1,491 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 4 · Round 8c · YouthBlock overlay weight + pattern</title>
+    <style>
+      :root {
+        --cream: #f5f1e6;
+        --cream-soft: #ede8da;
+        --ink: #0a0a0a;
+        --warm: #f0c264;
+
+        /* Live brand palette (apps/web/src/app/globals.css) */
+        --jersey-deep:      #008755;          /* live --color-jersey-deep */
+        --jersey-deep-dark-brand:    #005a39; /* candidate brand-consistent token */
+        --jersey-deep-dark-mockup:   #133d28; /* candidate desaturated mockup forest */
+
+        --shadow-rest: 4px 4px 0 0 var(--ink);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 28px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 8px; max-width: 80ch; font-size: 14px; line-height: 1.6; }
+
+      .lock-banner {
+        max-width: 1320px;
+        margin: 0 auto 24px;
+        background: var(--cream-soft);
+        border: 1px dashed var(--ink);
+        padding: 12px 16px;
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .lock-banner strong {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+
+      .container {
+        max-width: 1320px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 36px;
+      }
+
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--ink);
+        box-shadow: var(--shadow-rest);
+      }
+      .candidate header {
+        padding: 16px 20px 12px;
+        border-bottom: 1px dashed var(--ink);
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+        flex-wrap: wrap;
+      }
+      .candidate header .key { font-family: ui-monospace, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; opacity: 0.7; }
+      .candidate header .name { font-family: ui-serif, Georgia, serif; font-style: italic; font-size: 22px; line-height: 1.15; margin: 4px 0 6px; }
+      .candidate header .desc { font-size: 13px; line-height: 1.55; opacity: 0.85; max-width: 56ch; }
+      .candidate header .tradeoffs {
+        font-size: 11px;
+        line-height: 1.5;
+        max-width: 36ch;
+        font-family: ui-monospace, monospace;
+      }
+      .candidate header .tradeoffs strong {
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      /* === Surface — shared structure across all variants === */
+      .surface {
+        position: relative;
+        overflow: hidden;
+        min-height: 360px;
+        color: var(--cream);
+      }
+      .surface .photo {
+        position: absolute;
+        inset: -16px;                         /* matches blur=2px overscan in YouthBackdrop */
+        background-image: url("../../../../apps/web/public/images/youth-trainers.jpg");
+        background-size: cover;
+        background-position: center top;
+        filter: blur(2px);
+        z-index: 0;
+      }
+      .surface .gradient {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+      }
+      .surface .pattern {
+        position: absolute;
+        inset: 0;
+        z-index: 2;
+        pointer-events: none;
+      }
+      .text-block {
+        position: relative;
+        z-index: 3;
+        padding: 56px 40px;
+        max-width: 640px;
+      }
+      .meta-line {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin-bottom: 14px;
+      }
+      .h {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 48px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        margin: 0 0 18px;
+      }
+      .h .accent { color: var(--warm); }
+      .lead {
+        font-size: 16px;
+        line-height: 1.55;
+        opacity: 0.92;
+        max-width: 50ch;
+        margin: 0 0 18px;
+      }
+      .stats {
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.85;
+        margin: 0 0 22px;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 4px;
+        padding: 10px 18px;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: ui-monospace, monospace;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 700;
+        border: 1px solid var(--ink);
+        box-shadow: 4px 4px 0 0 #000;
+      }
+
+      /* === Per-variant gradients & overlays ============================== */
+
+      /* 8c.A — round-8b baseline 88/65/92, brand-consistent #005a39 third stop */
+      .a .gradient {
+        background: linear-gradient(
+          135deg,
+          color-mix(in srgb, var(--jersey-deep) 88%, transparent) 0%,
+          color-mix(in srgb, var(--jersey-deep) 65%, transparent) 60%,
+          color-mix(in srgb, var(--jersey-deep-dark-brand) 92%, transparent) 100%
+        );
+      }
+
+      /* 8c.B — round-8b baseline 88/65/92, desaturated #133d28 third stop */
+      .b .gradient {
+        background: linear-gradient(
+          135deg,
+          color-mix(in srgb, var(--jersey-deep) 88%, transparent) 0%,
+          color-mix(in srgb, var(--jersey-deep) 65%, transparent) 60%,
+          color-mix(in srgb, var(--jersey-deep-dark-mockup) 92%, transparent) 100%
+        );
+      }
+
+      /* 8c.C — heavy overlay 95/82/97, brand-consistent third stop. Photo
+         survives only as ghost texture in the highlights. */
+      .c .gradient {
+        background: linear-gradient(
+          135deg,
+          color-mix(in srgb, var(--jersey-deep) 95%, transparent) 0%,
+          color-mix(in srgb, var(--jersey-deep) 82%, transparent) 60%,
+          color-mix(in srgb, var(--jersey-deep-dark-brand) 97%, transparent) 100%
+        );
+      }
+
+      /* 8c.D — baseline gradient + retro halftone dot pattern (cream @ 8%) */
+      .d .gradient {
+        background: linear-gradient(
+          135deg,
+          color-mix(in srgb, var(--jersey-deep) 88%, transparent) 0%,
+          color-mix(in srgb, var(--jersey-deep) 65%, transparent) 60%,
+          color-mix(in srgb, var(--jersey-deep-dark-brand) 92%, transparent) 100%
+        );
+      }
+      .d .pattern {
+        background-image: radial-gradient(
+          circle at 1px 1px,
+          rgba(245, 241, 230, 0.05) 1px,
+          transparent 1.6px
+        );
+        background-size: 8px 8px;
+        mix-blend-mode: screen;
+      }
+
+      /* 8c.E — baseline gradient + jersey-stripe pattern overlay at low opacity */
+      .e .gradient {
+        background: linear-gradient(
+          135deg,
+          color-mix(in srgb, var(--jersey-deep) 88%, transparent) 0%,
+          color-mix(in srgb, var(--jersey-deep) 65%, transparent) 60%,
+          color-mix(in srgb, var(--jersey-deep-dark-brand) 92%, transparent) 100%
+        );
+      }
+      .e .pattern {
+        background-image: repeating-linear-gradient(
+          135deg,
+          rgba(0, 135, 85, 0.18) 0 28px,
+          rgba(245, 241, 230, 0.05) 28px 56px
+        );
+        mix-blend-mode: overlay;
+      }
+
+      /* === Side-by-side mode toggle for tighter A/B/C visual scan ========= */
+      .grid-pair {
+        max-width: 1320px;
+        margin: 12px auto 36px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 980px) {
+        .grid-pair { grid-template-columns: 1fr; }
+      }
+      .grid-pair .candidate { box-shadow: none; border-color: rgba(10, 10, 10, 0.5); }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 4 · Round 8c · #1700 · LOCKED 2026-05-08</div>
+      <h1>YouthBlock — overlay weight & pattern exploration</h1>
+      <p>
+        <strong>Locked 2026-05-08:</strong> Q1 → 8c.B (<code>#133d28</code>
+        third stop) + Q2 → 8c.D with dots softened to <code>0.05</code> alpha.
+        Three tokens ship in #1697: <code>--color-jersey-deep-dark</code>
+        (atomic), <code>--gradient-jersey-deep-overlay</code> (composed
+        baseline 88/65/92), <code>--pattern-halftone-dots</code> (5% cream
+        dots, 8×8 grid, screen blend). 8c.A/8c.C/8c.E retained for the
+        record.
+      </p>
+      <p>
+        Implementation feedback on round-8b N.2 (#1675): the photo reads through too
+        much against the live brand <code>--color-jersey-deep: #008755</code>. The
+        round-8b mockup used <code>#1f5f3f</code> (desaturated forest) which never
+        landed in live tokens. This round answers two questions:
+      </p>
+      <p>
+        <strong>Q1 — palette:</strong> brand-consistent <code>#005a39</code>
+        (8c.A) vs. desaturated mockup <code>#133d28</code> (8c.B) for the
+        third gradient stop / new <code>--color-jersey-deep-dark</code> token (#1697).
+      </p>
+      <p>
+        <strong>Q2 — overlay strategy:</strong> baseline 88/65/92 alphas
+        (8c.A), heavier 95/82/97 (8c.C), or baseline + retro pattern overlay
+        (8c.D dot halftone, 8c.E barber-pole stripes).
+      </p>
+    </header>
+
+    <div class="lock-banner">
+      <strong>Out of scope</strong><br />
+      Diagonal section seams. The diagonal-to-StripedSeam migration is tracked at
+      #1701 — every variant below renders YouthBlock as a standalone surface so
+      the comparison stays clean.
+    </div>
+
+    <div class="container">
+      <!-- =====================================================================
+           Q1 · Palette — 8c.A vs 8c.B at the same baseline alpha
+           ===================================================================== -->
+
+      <div class="grid-pair">
+        <article class="candidate a">
+          <header>
+            <div>
+              <div class="key">8c.A · Q1 — brand-consistent palette</div>
+              <h2 class="name">Baseline alphas, <code>#005a39</code> third stop</h2>
+              <p class="desc">
+                Same 88/65/92 alpha steps as round-8b N.2, but the third stop
+                lands on a brand-darkened green (a darker shade of live
+                <code>#008755</code>). Photo bleeds through; gradient stays
+                tonally consistent with existing jersey-deep surfaces site-wide.
+              </p>
+            </div>
+            <div class="tradeoffs">
+              <strong>Pro</strong>
+              Tokens consistent with FeaturedEventBand, StampBadge, etc.<br />
+              <strong>Con</strong>
+              Lighter / brighter feel than the round-8b mockup intent.
+            </div>
+          </header>
+          <div class="surface">
+            <div class="photo"></div>
+            <div class="gradient"></div>
+            <div class="text-block">
+              <div class="meta-line">Word jeugdspeler</div>
+              <h2 class="h"><span class="accent">De toekomst</span> van Elewijt.</h2>
+              <p class="lead">
+                Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en
+                Onderbouw delen één doel.
+              </p>
+              <div class="stats">220+ spelers · 16 ploegen</div>
+              <a class="cta" href="#">Ontdek onze jeugd →</a>
+            </div>
+          </div>
+        </article>
+
+        <article class="candidate b">
+          <header>
+            <div>
+              <div class="key">8c.B · Q1 — desaturated mockup palette</div>
+              <h2 class="name">Baseline alphas, <code>#133d28</code> third stop</h2>
+              <p class="desc">
+                Same 88/65/92 alphas; third stop lands on the desaturated
+                forest from the round-8b mockup. Reads as a moodier, more
+                printed-feeling green — but introduces a third green that
+                doesn't exist anywhere else in the live system.
+              </p>
+            </div>
+            <div class="tradeoffs">
+              <strong>Pro</strong>
+              Closer to the round-8b mockup intent; richer retro feel.<br />
+              <strong>Con</strong>
+              Third green token; risk of subtle palette drift if reused.
+            </div>
+          </header>
+          <div class="surface">
+            <div class="photo"></div>
+            <div class="gradient"></div>
+            <div class="text-block">
+              <div class="meta-line">Word jeugdspeler</div>
+              <h2 class="h"><span class="accent">De toekomst</span> van Elewijt.</h2>
+              <p class="lead">
+                Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en
+                Onderbouw delen één doel.
+              </p>
+              <div class="stats">220+ spelers · 16 ploegen</div>
+              <a class="cta" href="#">Ontdek onze jeugd →</a>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <!-- =====================================================================
+           Q2 · Overlay weight & pattern — 8c.C / 8c.D / 8c.E
+           (all assume the brand-consistent palette winning Q1)
+           ===================================================================== -->
+
+      <article class="candidate c">
+        <header>
+          <div>
+            <div class="key">8c.C · Q2 — heavier overlay</div>
+            <h2 class="name">Photo as ghost texture (95/82/97 alphas)</h2>
+            <p class="desc">
+              Crank the overlay so the photo barely surfaces — visible only as a
+              subtle texture in the lighter regions. Removes any "stock photo"
+              read; the photo becomes paper noise rather than imagery. Owner
+              feedback on #1675 leaned toward heavier overlay; this answers it.
+            </p>
+          </div>
+          <div class="tradeoffs">
+            <strong>Pro</strong>
+            Photo never competes with text; consistent with FeaturedEventBand's
+            ink-dense feel.<br />
+            <strong>Con</strong>
+            Why have the photo at all? May warrant dropping it (→ #730 photo
+            curation backlog).
+          </div>
+        </header>
+        <div class="surface">
+          <div class="photo"></div>
+          <div class="gradient"></div>
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span> van Elewijt.</h2>
+            <p class="lead">
+              Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en
+              Onderbouw delen één doel.
+            </p>
+            <div class="stats">220+ spelers · 16 ploegen</div>
+            <a class="cta" href="#">Ontdek onze jeugd →</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="candidate d">
+        <header>
+          <div>
+            <div class="key">8c.D · Q2 — halftone dot pattern</div>
+            <h2 class="name">Baseline gradient + cream halftone dots @ 8%</h2>
+            <p class="desc">
+              Baseline 88/65/92 alphas; layer a fine cream dot grid (8px,
+              <code>screen</code> blend, ~18% per dot) on top. The dots read as
+              risograph / printed-programme texture — same vocabulary as the
+              fanzine source mockups — without committing to a heavier opaque
+              overlay.
+            </p>
+          </div>
+          <div class="tradeoffs">
+            <strong>Pro</strong>
+            Adds retro print texture. Reusable as a tokenized pattern
+            (<code>--pattern-halftone-dots</code>) for other dark surfaces.<br />
+            <strong>Con</strong>
+            New primitive; needs Storybook story + VR baseline. Pattern can
+            moiré on smaller viewports.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="photo"></div>
+          <div class="gradient"></div>
+          <div class="pattern"></div>
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span> van Elewijt.</h2>
+            <p class="lead">
+              Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en
+              Onderbouw delen één doel.
+            </p>
+            <div class="stats">220+ spelers · 16 ploegen</div>
+            <a class="cta" href="#">Ontdek onze jeugd →</a>
+          </div>
+        </div>
+      </article>
+
+      <article class="candidate e">
+        <header>
+          <div>
+            <div class="key">8c.E · Q2 — jersey-stripe pattern</div>
+            <h2 class="name">Baseline gradient + barber-pole jersey stripes</h2>
+            <p class="desc">
+              Baseline alphas; layer the existing
+              <code>--pattern-jersey-stripes</code> at low opacity with
+              <code>overlay</code> blend. Reuses the redesign's jersey vocabulary
+              (StripedSeam, JerseyShirt) — most "in voice" of the three Q2
+              options, but the stripes can clash with the photo.
+            </p>
+          </div>
+          <div class="tradeoffs">
+            <strong>Pro</strong>
+            Reuses an existing tokenized pattern. Strongest brand-vocabulary
+            tie-in.<br />
+            <strong>Con</strong>
+            Stripes + diagonal gradient + photo = three competing geometries.
+            Can read busy on small viewports.
+          </div>
+        </header>
+        <div class="surface">
+          <div class="photo"></div>
+          <div class="gradient"></div>
+          <div class="pattern"></div>
+          <div class="text-block">
+            <div class="meta-line">Word jeugdspeler</div>
+            <h2 class="h"><span class="accent">De toekomst</span> van Elewijt.</h2>
+            <p class="lead">
+              Onze jeugdwerking groeit elk jaar. Bovenbouw, Middenbouw en
+              Onderbouw delen één doel.
+            </p>
+            <div class="stats">220+ spelers · 16 ploegen</div>
+            <a class="cta" href="#">Ontdek onze jeugd →</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html
+++ b/docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html
@@ -201,13 +201,15 @@
         );
       }
 
-      /* 8c.D — baseline gradient + retro halftone dot pattern (cream @ 8%) */
+      /* 8c.D — LOCKED COMBO (8c.B palette + 8c.D dot overlay).
+         Baseline gradient at the desaturated #133d28 third stop +
+         retro halftone dot pattern at 5% cream. */
       .d .gradient {
         background: linear-gradient(
           135deg,
           color-mix(in srgb, var(--jersey-deep) 88%, transparent) 0%,
           color-mix(in srgb, var(--jersey-deep) 65%, transparent) 60%,
-          color-mix(in srgb, var(--jersey-deep-dark-brand) 92%, transparent) 100%
+          color-mix(in srgb, var(--jersey-deep-dark-mockup) 92%, transparent) 100%
         );
       }
       .d .pattern {
@@ -412,14 +414,16 @@
       <article class="candidate d">
         <header>
           <div>
-            <div class="key">8c.D · Q2 — halftone dot pattern</div>
-            <h2 class="name">Baseline gradient + cream halftone dots @ 8%</h2>
+            <div class="key">8c.D · Q2 — halftone dot pattern (LOCKED)</div>
+            <h2 class="name">Baseline gradient + cream halftone dots @ 5%</h2>
             <p class="desc">
-              Baseline 88/65/92 alphas; layer a fine cream dot grid (8px,
-              <code>screen</code> blend, ~18% per dot) on top. The dots read as
+              Baseline 88/65/92 alphas at the desaturated <code>#133d28</code>
+              third stop (8c.B palette); layer a fine cream dot grid (8px,
+              <code>screen</code> blend, 5% per dot) on top. The dots read as
               risograph / printed-programme texture — same vocabulary as the
               fanzine source mockups — without committing to a heavier opaque
-              overlay.
+              overlay. Iterated 0.18 → 0.10 → 0.05 alpha until the dots stopped
+              competing with the photo.
             </p>
           </div>
           <div class="tradeoffs">

--- a/docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html
+++ b/docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html
@@ -252,6 +252,22 @@
         .grid-pair { grid-template-columns: 1fr; }
       }
       .grid-pair .candidate { box-shadow: none; border-color: rgba(10, 10, 10, 0.5); }
+
+      /* Q2 row — three candidates side-by-side at desktop, wraps to a
+         single column on narrow viewports so the tradeoff text and surface
+         photos stay legible. */
+      .q2-comparison-row {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 24px;
+      }
+      @media (max-width: 1080px) {
+        .q2-comparison-row { grid-template-columns: 1fr; }
+      }
+      .q2-comparison-row .candidate { box-shadow: none; border-color: rgba(10, 10, 10, 0.5); }
+      .q2-comparison-row .candidate header { flex-direction: column; gap: 12px; }
+      .q2-comparison-row .text-block { padding: 36px 28px; }
+      .q2-comparison-row .h { font-size: 36px; }
     </style>
   </head>
   <body>
@@ -371,9 +387,14 @@
 
       <!-- =====================================================================
            Q2 · Overlay weight & pattern — 8c.C / 8c.D / 8c.E
-           (all assume the brand-consistent palette winning Q1)
+           Palette mix: 8c.C and 8c.E render against the Q1-winning brand
+           palette (`#005a39`) — they're the alternatives that lost Q2 and
+           are kept for the record. 8c.D is the LOCKED COMBO and uses the
+           desaturated 8c.B third stop (`#133d28`), so the rendered tile
+           matches the documented lock without scrolling back to the Q1 row.
            ===================================================================== -->
 
+      <div class="q2-comparison-row">
       <article class="candidate c">
         <header>
           <div>
@@ -490,6 +511,7 @@
           </div>
         </div>
       </article>
+      </div>
     </div>
   </body>
 </html>

--- a/docs/design/mockups/phase-4-homepage/youthblock-locked.md
+++ b/docs/design/mockups/phase-4-homepage/youthblock-locked.md
@@ -8,7 +8,7 @@
 <YouthBlock>                                  // server component
   <YouthBackdrop>                             // existing component, reskinned palette
     <Image src="/images/youth-trainers.jpg" blur="2px" />
-    <div className="bg-gradient (jersey-deep 90% → 75% → 50%)" />
+    <div className="bg-[var(--gradient-jersey-deep-overlay)]" />
   </YouthBackdrop>
   <div className="text-block">
     <span className="meta-line">Word jeugdspeler</span>
@@ -58,7 +58,7 @@
   ```
   - Cream dots @ 5% alpha on an 8×8 grid, `screen` blend mode.
   - Layered ON TOP of `--gradient-jersey-deep-overlay` to add subtle risograph print texture without competing with the photo.
-- Mobile gradient direction: `135deg` works on both viewports — no orientation flip needed (round-8c locked at desktop only; verify mobile at implementation).
+- Mobile gradient direction: gradient flips to vertical on `<640px` (today's `bg-gradient-to-b md:bg-gradient-to-r` behavior preserved). Round-8c was authored at the desktop 135deg axis — implementers should re-render the composed `--gradient-jersey-deep-overlay` along the vertical axis on mobile by overriding the gradient direction at the consumer side.
 
 ## Text + CTA
 

--- a/docs/design/mockups/phase-4-homepage/youthblock-locked.md
+++ b/docs/design/mockups/phase-4-homepage/youthblock-locked.md
@@ -1,6 +1,6 @@
 # Phase 4 · `<YouthBlock>` — Locked
 
-**Locked 2026-05-07 across rounds 8 (rejected — over-amplified JerseyShirt), 8b (corrected after owner clarification).**
+**Locked 2026-05-08 across rounds 8 (rejected — over-amplified JerseyShirt), 8b (palette + composition), 8c (overlay weight + halftone dots — `round-8c-youthblock-overlay-weight.html`).**
 
 ## Composition
 
@@ -28,14 +28,37 @@
 | --- | --- | --- |
 | 8 | ~~Big JerseyShirt as section visual~~ → **rejected** | "Don't like the big jersey here" — owner rejected |
 | 8b | **N.2 · Today's pattern reskinned** (blurred photo + jersey-deep gradient) | Direct continuity from current `<YouthBackdrop>`, fades cleanly |
+| 8c · Q1 | **8c.B — desaturated `#133d28` third stop** | Round-8b mockup intent matched; brand-bright `#005a39` read too light against the photo |
+| 8c · Q2 | **8c.D — baseline gradient + halftone dots @ 0.05 alpha** | Adds risograph print texture without competing with the photo; heavy 8c.C made the photo redundant |
 
 ## Backdrop spec
 
 - Photo asset: `/images/youth-trainers.jpg` (existing — kept). Future swap when a better photo is curated.
 - Blur: `2px` filter blur applied to image (matches today's behavior).
-- Gradient overlay: `linear-gradient(135deg, var(--jersey-deep) / 88% 0%, var(--jersey-deep) / 65% 60%, var(--jersey-deep-dark) / 92% 100%)`. Approximates today's `from-kcvv-green-dark/90 via-kcvv-green-dark/75 to-kcvv-green-dark/50` swapped to retro palette tokens.
-- Mobile gradient direction: `bg-gradient-to-b` (vertical) — same as today.
-- Desktop gradient direction: `md:bg-gradient-to-r` (horizontal) — same as today.
+- **Gradient overlay** (single composed token from #1697):
+  ```css
+  --gradient-jersey-deep-overlay: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-jersey-deep) 88%, transparent) 0%,
+    color-mix(in srgb, var(--color-jersey-deep) 65%, transparent) 60%,
+    color-mix(in srgb, var(--color-jersey-deep-dark) 92%, transparent) 100%
+  );
+  ```
+  - Composed at the token level so `<YouthBackdrop>` consumes a single CSS custom property — no inline 88/65/92 alphas leak into component code.
+  - Reusable on any future jersey-deep photographic surface; not YouthBlock-specific in name.
+  - `--color-jersey-deep-dark: #133d28` is the atomic third stop (8c.B).
+- **Halftone dot pattern** (separate composed token):
+  ```css
+  --pattern-halftone-dots: radial-gradient(
+    circle at 1px 1px,
+    rgba(245, 241, 230, 0.05) 1px,
+    transparent 1.6px
+  );
+  /* applied with background-size: 8px 8px; mix-blend-mode: screen; */
+  ```
+  - Cream dots @ 5% alpha on an 8×8 grid, `screen` blend mode.
+  - Layered ON TOP of `--gradient-jersey-deep-overlay` to add subtle risograph print texture without competing with the photo.
+- Mobile gradient direction: `135deg` works on both viewports — no orientation flip needed (round-8c locked at desktop only; verify mobile at implementation).
 
 ## Text + CTA
 


### PR DESCRIPTION
Closes #1700

## Summary

Locks the YouthBlock backdrop recipe across two questions answered in `round-8c-youthblock-overlay-weight.html`:

- **Q1 — palette:** 8c.B — desaturated `#133d28` third stop wins over brand-bright `#005a39`. Brand-bright read too light against the photo; the round-8b mockup intent is preserved.
- **Q2 — overlay:** 8c.D — baseline 88/65/92 alphas + halftone dots at `0.05` cream alpha (softened from 0.18 → 0.10 → 0.05 across three iterations). Heavy 8c.C made the photo redundant; soft dots add risograph print texture without competing.

## Token recipe (delivered in #1697)

Three new tokens compose at the token level so consumer code (`<YouthBackdrop>`, future jersey-deep photo surfaces) never carries inline alpha values:

```css
--color-jersey-deep-dark: #133d28;

--gradient-jersey-deep-overlay: linear-gradient(
  135deg,
  color-mix(in srgb, var(--color-jersey-deep) 88%, transparent) 0%,
  color-mix(in srgb, var(--color-jersey-deep) 65%, transparent) 60%,
  color-mix(in srgb, var(--color-jersey-deep-dark) 92%, transparent) 100%
);

--pattern-halftone-dots: radial-gradient(
  circle at 1px 1px,
  rgba(245, 241, 230, 0.05) 1px,
  transparent 1.6px
);
/* consumer: background-size: 8px 8px; mix-blend-mode: screen; */
```

#1697's blocked-by on #1700 has been removed; #1697 can now ship with the locked values.

## Files

- `docs/design/mockups/phase-4-homepage/round-8c-youthblock-overlay-weight.html` (new — five variants A/B/C/D/E with the locked pair flagged in the header)
- `docs/design/mockups/phase-4-homepage/youthblock-locked.md` (updated — round-8c added to the decision table, backdrop spec rewritten around the composed tokens)

## Test plan

- [x] Mockup renders the real `apps/web/public/images/youth-trainers.jpg` (path bug `../../../` → `../../../../` fixed mid-iteration)
- [x] Five variants visible side-by-side; Q1/Q2 sections separated
- [ ] Owner re-confirms the locked combo on the mockup once the PR is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Dutch design mockup for Phase 4 YouthBlock showing five visual variants (A–E) demonstrating different gradient and pattern overlay treatments (including deeper overlay, halftone dots, and stripe/jersey effects) in a side-by-side Q1/Q2 comparison layout.
  * Updated the YouthBlock “Locked” spec (locked: 2026-05-08) with rationale for overlay/color choices, refined composed-gradient and halftone/stripe guidance, and updated mobile rendering guidance for vertical layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->