### PR TITLE
feat(news): order ARTICLES_QUERY featured-first then by date (#1679)

### DIFF
--- a/apps/web/src/lib/repositories/article.repository.test.ts
+++ b/apps/web/src/lib/repositories/article.repository.test.ts
@@ -206,6 +206,79 @@ describe("ArticleRepository", () => {
 
       expect(a.title).toBe("");
     });
+
+    it("ARTICLES_QUERY orders by featured desc, publishedAt desc (Phase 4.C.2)", async () => {
+      const { ARTICLES_QUERY } = await import("./article.repository");
+      expect(ARTICLES_QUERY).toContain(
+        "order(featured desc, publishedAt desc)",
+      );
+      expect(ARTICLES_QUERY).not.toContain("order(publishedAt desc)");
+    });
+
+    it("preserves the GROQ-imposed featured-first ordering (no client-side re-sort)", async () => {
+      const newest = makeArticleListRow({
+        id: "newest-unfeatured",
+        publishedAt: "2026-03-25T10:00:00Z",
+        featured: false,
+      });
+      const olderFeatured = makeArticleListRow({
+        id: "older-featured",
+        publishedAt: "2026-03-10T10:00:00Z",
+        featured: true,
+      });
+      const oldestFeatured = makeArticleListRow({
+        id: "oldest-featured",
+        publishedAt: "2026-03-05T10:00:00Z",
+        featured: true,
+      });
+      // Server returns featured-first, then recency within each tier.
+      mockFetch.mockResolvedValueOnce([olderFeatured, oldestFeatured, newest]);
+
+      const articles = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* ArticleRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      expect(articles.map((a) => a.id)).toEqual([
+        "older-featured",
+        "oldest-featured",
+        "newest-unfeatured",
+      ]);
+    });
+
+    it("falls back to recency when fewer than 3 articles are flagged featured", async () => {
+      const onlyFeatured = makeArticleListRow({
+        id: "only-featured",
+        publishedAt: "2026-03-20T10:00:00Z",
+        featured: true,
+      });
+      const recentB = makeArticleListRow({
+        id: "recent-b",
+        publishedAt: "2026-03-18T10:00:00Z",
+        featured: false,
+      });
+      const recentC = makeArticleListRow({
+        id: "recent-c",
+        publishedAt: "2026-03-12T10:00:00Z",
+        featured: false,
+      });
+      mockFetch.mockResolvedValueOnce([onlyFeatured, recentB, recentC]);
+
+      const articles = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* ArticleRepository;
+          return yield* repo.findAll();
+        }),
+      );
+
+      expect(articles.map((a) => a.id)).toEqual([
+        "only-featured",
+        "recent-b",
+        "recent-c",
+      ]);
+    });
   });
 
   describe("toHomepageArticle", () => {

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -27,6 +27,11 @@ export const ARTICLE_TAGS_QUERY = defineQuery(
   `array::unique(*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])`,
 );
 
+// Intentionally pure chronological order — paginated listings power the
+// /nieuws archive (`app/(landing)/nieuws/actions.ts`) and the youth-news
+// section on /jeugd (`app/(landing)/jeugd/page.tsx`). Archive UX assumes
+// strict date ordering so readers can scan by publication date; the
+// featured-first rule applies only to the homepage feed (ARTICLES_QUERY).
 export const ARTICLES_PAGINATED_QUERY =
   defineQuery(`*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishedAt desc) [$offset...$end] {
   "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -12,8 +12,12 @@ import { formatArticleDate } from "../utils/dates";
 
 // ─── GROQ Queries ────────────────────────────────────────────────────────────
 
+// Phase 4.C.2 — Round 2 S.2 lock: featured articles surface first in the
+// homepage carousel (slots 0..2); ties and overflow fall back to recency.
+// `featured: false` articles still appear after all featured ones, so the
+// NewsGrid slice [3..8] inherits the same ordering automatically.
 export const ARTICLES_QUERY =
-  defineQuery(`*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishedAt desc) {
+  defineQuery(`*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {
   "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -313,6 +313,25 @@ export type TransferFact = {
   noteAttribution?: string;
 };
 
+export type QaSectionDivider = {
+  _type: "qaSectionDivider";
+  title?: Array<{
+    children?: Array<{
+      marks?: Array<string>;
+      text?: string;
+      _type: "span";
+      _key: string;
+    }>;
+    style?: "normal";
+    listItem?: never;
+    markDefs?: null;
+    level?: number;
+    _type: "block";
+    _key: string;
+  }>;
+  kicker?: string;
+};
+
 export type QaPair = {
   _type: "qaPair";
   question?: string;
@@ -500,6 +519,9 @@ export type Article = {
     | ({
         _key: string;
       } & QaBlock)
+    | ({
+        _key: string;
+      } & QaSectionDivider)
     | ({
         _key: string;
       } & TransferFact)
@@ -1004,6 +1026,7 @@ export type AllSanitySchemaTypes =
   | Subject
   | EventFact
   | TransferFact
+  | QaSectionDivider
   | QaPair
   | QaBlock
   | VideoBlock
@@ -1033,7 +1056,7 @@ export type AllSanitySchemaTypes =
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLES_QUERY
-// Query: *[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishedAt desc) {  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }}
+// Query: *[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }}
 export type ARTICLES_QUERY_RESULT = Array<{
   id: string;
   title: string;
@@ -1220,6 +1243,33 @@ export type ARTICLES_QUERY_RESULT = Array<{
             _key: string;
           } & QaPair
         >;
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: null;
+        videoAsset: null;
+        videoPosterUrl: null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "qaSectionDivider";
+        title?: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: never;
+          markDefs?: null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }>;
+        kicker?: string;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1568,6 +1618,34 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
             _key: string;
           } & QaPair
         >;
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: null;
+        videoAsset: null;
+        videoPosterUrl: null;
+        otherClubLogoUrl: null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "qaSectionDivider";
+        title?: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: never;
+          markDefs?: null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }>;
+        kicker?: string;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -2383,7 +2461,7 @@ export type TEAMS_LANDING_QUERY_RESULT = Array<{
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
-    '*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishedAt desc) {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }\n}': ARTICLES_QUERY_RESULT;
+    '*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }\n}': ARTICLES_QUERY_RESULT;
     'array::unique(*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])': ARTICLE_TAGS_QUERY_RESULT;
     '*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishedAt desc) [$offset...$end] {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
     '*[_type == "article" && references($documentId) && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishedAt desc) {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;


### PR DESCRIPTION
Closes #1679

## Summary

Phase 4.C.2 (Round 2 S.2 lock) — surfaces `featured: true` articles at the top of the homepage feed so the carousel (slots 0..2) prioritises them. NewsGrid (slice 3..8) inherits the same ordering automatically since both consume `ARTICLES_QUERY`.

## Changes

- `apps/web/src/lib/repositories/article.repository.ts` — `ARTICLES_QUERY` order clause changes from `order(publishedAt desc)` to `order(featured desc, publishedAt desc)`. Comment added documenting the locked spec reference.
- `apps/web/src/lib/sanity/sanity.types.ts` — regenerated via `pnpm --filter @kcvv/studio typegen`.
- `apps/web/src/lib/repositories/article.repository.test.ts` — three new tests:
  - asserts `ARTICLES_QUERY` contains `order(featured desc, publishedAt desc)` and no longer the legacy clause
  - asserts `findAll` preserves Sanity's featured-first ordering without client-side re-sort (mocked response with featured + unfeatured rows in expected order)
  - asserts recency fallback when fewer than 3 articles are flagged (1 featured + 2 unfeatured fill the carousel chronologically)

No schema migration — `article.featured` already exists. Unflagged articles still appear, just after every featured row.

## Testing

- 8 `findAll` tests pass (the 5 existing + 3 new).
- `pnpm --filter @kcvv/web check-all` — green.
- No VR work (data-layer change, no visual surface).

## Test plan

- [x] All 3,084 tests pass
- [x] Lint + type-check + build green
- [x] Sanity types regenerated
- [ ] Manual: confirm staging homepage carousel surfaces flagged articles first after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a QaSectionDivider content block type for articles

* **Improvements**
  * Homepage feed/carousel now prioritizes featured articles first, then recent articles by publication date; non-featured items follow featured ones
  * Paginated/archival listings continue to use strict chronological ordering

* **Tests**
  * Added tests to validate featured-first ordering, preservation of server ordering, and fallback to pure recency when few featured items exist

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1724)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->