### PR TITLE
feat(news): extend ARTICLES_QUERY for per-articleType homepage rendering (#1746)

### DIFF
--- a/apps/web/src/app/(landing)/nieuws/NewsListingClient.stories.tsx
+++ b/apps/web/src/app/(landing)/nieuws/NewsListingClient.stories.tsx
@@ -33,6 +33,10 @@ function makeMockArticle(
       heroShapes[id % heroShapes.length] ?? "article-hero-generic",
       id,
     ),
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
     ...overrides,
   };
 }

--- a/apps/web/src/app/(landing)/nieuws/NewsListingClient.test.tsx
+++ b/apps/web/src/app/(landing)/nieuws/NewsListingClient.test.tsx
@@ -23,6 +23,10 @@ function makeArticle(overrides: Partial<ArticleVM> = {}): ArticleVM {
     featured: false,
     coverImageUrl: null,
     tags: overrides.tags ?? [],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
     ...overrides,
   };
 }

--- a/apps/web/src/app/(landing)/nieuws/actions.test.ts
+++ b/apps/web/src/app/(landing)/nieuws/actions.test.ts
@@ -11,6 +11,10 @@ function makeArticle(overrides: Partial<ArticleVM> = {}): ArticleVM {
     featured: false,
     coverImageUrl: null,
     tags: [],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
     ...overrides,
   };
 }

--- a/apps/web/src/app/(landing)/nieuws/utils.test.ts
+++ b/apps/web/src/app/(landing)/nieuws/utils.test.ts
@@ -11,6 +11,10 @@ function makeArticle(id: string): ArticleVM {
     featured: false,
     coverImageUrl: null,
     tags: [],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
   };
 }
 

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -64,9 +64,7 @@ export async function generateMetadata(): Promise<Metadata> {
 function toHeroCarouselArticle(article: ArticleVM): HomepageHeroArticle {
   return {
     slug: article.slug,
-    // ARTICLES_QUERY does not project `articleType` today; default to
-    // "announcement" until the projection grows (out of scope for #1680).
-    variant: "announcement",
+    variant: article.articleType ?? "announcement",
     title: article.title,
     coverImage: article.coverImageUrl
       ? { url: article.coverImageUrl, alt: article.title }

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
@@ -12,6 +12,10 @@ function makeArticle(
     featured: false,
     coverImageUrl: null,
     tags: ["Jeugd"],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
     ...overrides,
   };
 }

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.test.tsx
@@ -13,6 +13,10 @@ function makeArticle(overrides: Partial<ArticleVM> = {}): ArticleVM {
     featured: false,
     coverImageUrl: null,
     tags: ["jeugd"],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
     ...overrides,
   };
 }

--- a/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.test.tsx
+++ b/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.test.tsx
@@ -20,6 +20,10 @@ const mockArticles = [
     featured: false,
     coverImageUrl: "https://cdn.sanity.io/img1.jpg",
     tags: [],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
   },
   {
     id: "article-2",
@@ -29,6 +33,10 @@ const mockArticles = [
     featured: false,
     coverImageUrl: null,
     tags: [],
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
   },
 ];
 

--- a/apps/web/src/lib/repositories/article.repository.test.ts
+++ b/apps/web/src/lib/repositories/article.repository.test.ts
@@ -32,6 +32,10 @@ function makeArticleListRow(
     featured: false,
     tags: ["Eerste ploeg", "Wedstrijdverslag"],
     coverImageUrl: "https://cdn.sanity.io/cover.webp",
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
     body: [],
     ...overrides,
   };

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -20,6 +20,31 @@ export const ARTICLES_QUERY =
   defineQuery(`*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {
   "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),
   "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",
+  articleType,
+  subjects[]{
+    _key, kind,
+    playerRef->{
+      _id, firstName, lastName, jerseyNumber, position,
+      "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
+      "psdImageUrl": psdImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
+      psdId
+    },
+    staffRef->{
+      _id, firstName, lastName, functionTitle,
+      "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"
+    },
+    customName, customRole,
+    "customPhotoUrl": customPhoto.asset->url + "?w=600&q=80&fm=webp&fit=max"
+  },
+  "firstTransferFact": body[_type == "transferFact"][0]{
+    direction, playerName, position, age,
+    otherClubName, until, note, noteAttribution, kcvvContext
+  },
+  "firstEventFact": body[_type == "eventFact"][0]{
+    title, date, endDate, startTime, endTime,
+    location, address, ageGroup, competitionTag,
+    ticketUrl, ticketLabel
+  },
   body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }
 }`);
 
@@ -158,6 +183,10 @@ export type ArticleVM = Omit<
     | "featured"
     | "tags"
     | "coverImageUrl"
+    | "articleType"
+    | "subjects"
+    | "firstTransferFact"
+    | "firstEventFact"
   >,
   "title" | "slug" | "featured" | "tags"
 > & {
@@ -215,6 +244,25 @@ function filterPublishedRelatedArticles(
   };
 }
 
+// `findPaginated` and `findRelated` use narrower GROQ projections that omit
+// the Phase 4.5 per-articleType fields (`articleType`, `subjects`,
+// `firstTransferFact`, `firstEventFact`). Widening them to `ArticleVM` keeps
+// the locked repository interface single-typed; consumers that need the new
+// fields call `findAll`.
+function widenToArticleVM(
+  row:
+    | ARTICLES_PAGINATED_QUERY_RESULT[number]
+    | RELATED_ARTICLES_QUERY_RESULT[number],
+): ArticleVM {
+  return {
+    ...row,
+    articleType: null,
+    subjects: null,
+    firstTransferFact: null,
+    firstEventFact: null,
+  };
+}
+
 export function toHomepageArticle(article: ArticleVM): HomepageArticle {
   return {
     href: `/nieuws/${article.slug}`,
@@ -265,10 +313,10 @@ export const ArticleRepositoryLive = Layer.succeed(ArticleRepository, {
       offset,
       end: offset + limit,
       category: category ?? "",
-    }),
+    }).pipe(Effect.map((rows) => rows.map(widenToArticleVM))),
   findTags: () => fetchGroq<ARTICLE_TAGS_QUERY_RESULT>(ARTICLE_TAGS_QUERY),
   findRelated: (documentId) =>
     fetchGroq<RELATED_ARTICLES_QUERY_RESULT>(RELATED_ARTICLES_QUERY, {
       documentId,
-    }),
+    }).pipe(Effect.map((rows) => rows.map(widenToArticleVM))),
 });

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -1056,7 +1056,7 @@ export type AllSanitySchemaTypes =
 
 // Source: ../web/src/lib/repositories/article.repository.ts
 // Variable: ARTICLES_QUERY
-// Query: *[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }}
+// Query: *[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",  articleType,  subjects[]{    _key, kind,    playerRef->{      _id, firstName, lastName, jerseyNumber, position,      "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",      "psdImageUrl": psdImage.asset->url + "?w=600&q=80&fm=webp&fit=max",      psdId    },    staffRef->{      _id, firstName, lastName, functionTitle,      "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"    },    customName, customRole,    "customPhotoUrl": customPhoto.asset->url + "?w=600&q=80&fm=webp&fit=max"  },  "firstTransferFact": body[_type == "transferFact"][0]{    direction, playerName, position, age,    otherClubName, until, note, noteAttribution, kcvvContext  },  "firstEventFact": body[_type == "eventFact"][0]{    title, date, endDate, startTime, endTime,    location, address, ageGroup, competitionTag,    ticketUrl, ticketLabel  },  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }}
 export type ARTICLES_QUERY_RESULT = Array<{
   id: string;
   title: string;
@@ -1065,6 +1065,61 @@ export type ARTICLES_QUERY_RESULT = Array<{
   featured: boolean | false;
   tags: Array<string> | Array<never>;
   coverImageUrl: string | null;
+  articleType: "announcement" | "event" | "interview" | "transfer" | null;
+  subjects: Array<{
+    _key: string;
+    kind: "custom" | "player" | "staff" | null;
+    playerRef: {
+      _id: string;
+      firstName: string | null;
+      lastName: string | null;
+      jerseyNumber: number | null;
+      position:
+        | "Aanvaller"
+        | "Keeper"
+        | "Middenvelder"
+        | "Speler"
+        | "Verdediger"
+        | null;
+      transparentImageUrl: string | null;
+      psdImageUrl: string | null;
+      psdId: string | null;
+    } | null;
+    staffRef: {
+      _id: string;
+      firstName: string | null;
+      lastName: string | null;
+      functionTitle: string | null;
+      photoUrl: string | null;
+    } | null;
+    customName: string | null;
+    customRole: string | null;
+    customPhotoUrl: string | null;
+  }> | null;
+  firstTransferFact: {
+    direction: "extension" | "incoming" | "outgoing" | null;
+    playerName: string | null;
+    position: "Aanvaller" | "Keeper" | "Middenvelder" | "Verdediger" | null;
+    age: number | null;
+    otherClubName: string | null;
+    until: string | null;
+    note: string | null;
+    noteAttribution: string | null;
+    kcvvContext: string | null;
+  } | null;
+  firstEventFact: {
+    title: string | null;
+    date: string | null;
+    endDate: string | null;
+    startTime: string | null;
+    endTime: string | null;
+    location: string | null;
+    address: string | null;
+    ageGroup: string | null;
+    competitionTag: string | null;
+    ticketUrl: string | null;
+    ticketLabel: string | null;
+  } | null;
   body: Array<
     | {
         _key: string;
@@ -2461,7 +2516,7 @@ export type TEAMS_LANDING_QUERY_RESULT = Array<{
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
-    '*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }\n}': ARTICLES_QUERY_RESULT;
+    '*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(featured desc, publishedAt desc) {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n  articleType,\n  subjects[]{\n    _key, kind,\n    playerRef->{\n      _id, firstName, lastName, jerseyNumber, position,\n      "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n      "psdImageUrl": psdImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n      psdId\n    },\n    staffRef->{\n      _id, firstName, lastName, functionTitle,\n      "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max"\n    },\n    customName, customRole,\n    "customPhotoUrl": customPhoto.asset->url + "?w=600&q=80&fm=webp&fit=max"\n  },\n  "firstTransferFact": body[_type == "transferFact"][0]{\n    direction, playerName, position, age,\n    otherClubName, until, note, noteAttribution, kcvvContext\n  },\n  "firstEventFact": body[_type == "eventFact"][0]{\n    title, date, endDate, startTime, endTime,\n    location, address, ageGroup, competitionTag,\n    ticketUrl, ticketLabel\n  },\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }), "videoAsset": select(_type == "videoBlock" => uploadedFile.asset->{ url, size, mimeType, originalFilename }, null), "videoPosterUrl": select(_type == "videoBlock" => poster.asset->url + "?w=1200&q=80&fm=webp&fit=max", null), markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } } }\n}': ARTICLES_QUERY_RESULT;
     'array::unique(*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())].tags[])': ARTICLE_TAGS_QUERY_RESULT;
     '*[_type == "article" && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now()) && select($category == "" => true, $category in tags)] | order(publishedAt desc) [$offset...$end] {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=1200&q=80&fm=webp&fit=max"\n}': ARTICLES_PAGINATED_QUERY_RESULT;
     '*[_type == "article" && references($documentId) && publishedAt <= now() && (!defined(unpublishAt) || unpublishAt > now())] | order(publishedAt desc) {\n  "id": _id, "title": coalesce(pt::text(title), title, ""), "slug": coalesce(slug.current, ""), publishedAt, "featured": coalesce(featured, false), "tags": coalesce(tags, []),\n  "coverImageUrl": coverImage.asset->url + "?w=800&q=80&fm=webp&fit=max"\n}': RELATED_ARTICLES_QUERY_RESULT;


### PR DESCRIPTION
Closes #1746

Phase 4.5 tracer-bullet (PRD `docs/prd/redesign-phase-4.5-homepage-refinement.md` §5.5.0 + §3). Implements the locked interface contract from `docs/design/articles-query-interface.md` (Option A — fat single shape).

## Changes

- **`ARTICLES_QUERY` projection** — extended with `articleType`, `subjects[]` (player/staff/custom dispatch, `?w=600` portraits to match detail-page parity), `firstTransferFact`, `firstEventFact`. Body projection preserved.
- **`ArticleVM`** — Pick list grew by four fields; `title`/`slug`/`featured`/`tags` overrides preserved.
- **Sanity typegen regenerated** — `apps/web/src/lib/sanity/sanity.types.ts` reflects the new projection; no `any` / `unknown` leaks (proper union literals on all new fields).
- **`toHeroCarouselArticle`** (`apps/web/src/app/(landing)/page.tsx`) — now reads `article.articleType ?? "announcement"` for `variant`. The stale "out of scope for #1680" comment is gone.
- **`findPaginated` / `findRelated`** — keep their narrower GROQ projections (per interface §7) and widen to `ArticleVM` via a new `widenToArticleVM` helper, so the locked repository signature (`Effect<ArticleVM[]>`) stays single-typed and non-homepage callers pay zero new payload cost.
- **Test fixtures** — seven fixture builders across `nieuws/`, `jeugd/`, `related/`, and `article.repository.test.ts` now include the four new fields as `null` to match the generated GROQ types.

No new Sanity schema files, no migrations.

## Testing

- `pnpm --filter @kcvv/web check-all` — lint ✅, type-check ✅, 3094 tests ✅, build ✅.
- `pnpm turbo build --filter=@kcvv/api-contract` ✅.
- Manual: ran `sanity typegen generate` in `apps/studio`; the regenerated types pick up `articleType: "announcement" | "event" | "interview" | "transfer" | null` and the full per-kind `subjects[]` dispatch.
- The four non-homepage call sites (`/nieuws`, `/jeugd`, `/sponsors`, `/events`) compile clean — they receive `ArticleVM[]` with the new fields as `null` (paginated/related) or projected values (`findAll`) and ignore them.

## Open question resolution

- **Image sizing on subject portraits** — kept `?w=600` for parity with `ARTICLE_BY_SLUG_QUERY`. The R1.5 IV.3 16px thumb concern can be re-tuned in a follow-up if payload becomes an issue.
- **`findPaginated` / `findRelated` projection extension** — deferred per PRD §7, widened via helper to satisfy the locked repository interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Articles now include expanded metadata (type classification, subjects, and related facts).
  * Homepage carousel dynamically adapts presentation based on article type.

* **Tests**
  * Updated test fixtures to support expanded article data structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1757)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->