### PR TITLE
chore(config): disable CodeRabbit ESLint tool

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,3 +20,14 @@ reviews:
     - "!apps/web/test/vr/__snapshots__/**/*.png"
     - "!apps/web/test/vr/__diff_output__/**/*.png"
     - "!apps/web/test/vr/__received_output__/**/*.png"
+
+  # CodeRabbit's sandbox runs ESLint from the repo root with ESLint 9's
+  # flat-config semantics. Our flat configs live per-workspace
+  # (`apps/web/eslint.config.mjs`, etc.), so ESLint exits with
+  # "couldn't find an eslint.config.(js|mjs|cjs) file" on every reviewed
+  # file. Our own CI (`pnpm --filter @kcvv/web lint`) already enforces
+  # ESLint per-workspace, so CodeRabbit's run is duplicate coverage —
+  # disabling it removes the noise without losing real signal.
+  tools:
+    eslint:
+      enabled: false


### PR DESCRIPTION
## Summary

CodeRabbit's sandbox started reporting "ESLint couldn't find an `eslint.config.(js|mjs|cjs)` file" on every reviewed file in #1757 (and will on every future PR). Their ESLint 9.39.4 flat-config check runs from the repo root, where we have no config — our flat configs live per-workspace (`apps/web/eslint.config.mjs`, `apps/api/eslint.config.mjs`, etc.).

Our own CI (`pnpm --filter @kcvv/web lint`) already enforces ESLint per-workspace and gates PRs on it, so CodeRabbit's run is duplicate (and broken) coverage. Disabling it removes the noise without losing real signal.

## Test plan

- [ ] Merge and observe the next PR — CodeRabbit should no longer post the "🔧 ESLint" tool-failure block.
- [ ] Our CI lint job still runs and still fails the PR on lint errors (no behaviour change to local/CI lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling configuration to optimize code review processes.

**Note:** This release contains no user-facing changes. The update involves internal configuration adjustments only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1758)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->