### PR TITLE
docs(news): phase 4.5 claude.md update + plan/lock audit cleanup (#1755)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -84,6 +84,25 @@ A new `Foundation/Patterns` MDX story documents `--pattern-jersey-stripes`, `--p
 
 `<Badge>` was retired in favour of `<MonoLabel variant="pill-…">`. The single consumer (`<MatchStatusBadge>`) was migrated to use MonoLabel pill variants directly.
 
+**Phase 4.5 additions (homepage refinement series):**
+
+- `<TapeStrip>` — added a `position: "left" | "right"` prop (anchors the strip on the host's top-left or top-right via `--tape-left` / `--tape-right`, both with a 12% fallback). Used by `<NewsCard>`'s R10 corner-pairing. The R9-locked `edge="torn"` variant was dropped at implementation (#1747) — `<TapeStrip>` ships clean-rectangular only and the `--tape-edge-{1..4}` / `--tape-mask-torn` tokens were never committed.
+- `<TapedFigure>` — photo-treatment primitive. The newsprint filter + paper-grain overlay apply globally via `.taped-figure` / `.taped-figure__photo` CSS rules in `globals.css` (R9 photo-treatment system). Each instance accepts a single optional `tape?: TapeStripProps`; the R9-locked two-strip slot cycle was rejected at PR review and the prop is hard-capped at one. Pass `data-tint="none"` to opt out of the warm tint on non-photographic image content.
+- `<EditorialHero>` — Phase 3 hero shell + R1.5 per-articleType variants (`announcement` / `interview` / `event` / `transfer`). Two `placement`s: `"detail"` (default — no link wrapper) and `"homepage"` (wrapped in `<Link>`, requires `slug`). Homepage placement adds a `hoverStyle?: "press" | "tilt-photo"` prop — `"press"` is the canonical paper-stamp press-down used by the (retired) `<HomepageHeroCarousel>`; `"tilt-photo"` lets only the cover `<TapedFigure>` tilt + scale on hover, used by the static `/` hero where a 2px translate on a full-width block reads as a twitch.
+- `<FeaturedUitgelichtRow>` — R1.6.A equal-3-up featured row for the homepage spine. Drops itself when no featured articles are present and renders fewer cards rather than padding from the recent-articles pool.
+- `<ClubshopBanner>` — renamed from `<WebshopBanner>` per R6.C. Jersey-deep-dark full-bleed band with mirrored `<StripedSeam>` top + bottom, the new copy ("Onze clubkledij." + Brandsfit attribution), and a small `<JerseyShirt>` flourish.
+- `<JerseyShirt>` — new design-system primitive: paper-graphic jersey illustration (two-pass print, jersey-deep underprint + ink overprint, ink stripes; no Celtic green/white, no sponsors, no photo-realism). Composes with `<TapedFigure>` for the PlayerFigure no-photo fallback per `project_jersey_illustration_vocabulary`.
+- `<HomepageHeroCarousel>` — retired and moved to `apps/web/src/components/home/_legacy/`. Replaced on `/` by a static `<EditorialHero placement="homepage" hoverStyle="tilt-photo">` + `<FeaturedUitgelichtRow>` per R1.B.
+
+**New tokens (Phase 4.5, R9 photo-treatment system in `globals.css`):**
+
+- `--color-tape-cream` — third tape colour (rgb(232 224 200 / 0.85)). Consumed by `<TapeStrip color="cream">` via inline `backgroundColor`.
+- `--filter-photo-newsprint` — warm sepia/saturate/hue-rotate tint applied to `.taped-figure > .taped-figure__photo img` so editorial photos read as printed on paper.
+- `--pattern-paper-grain` — fractal-noise SVG data-URL pattern overlaid on every `.taped-figure::after` at 4% opacity with `mix-blend-mode: multiply`.
+- `--shadow-photo-tape` (`2px 4px 0 0 ink`) + `--shadow-photo-tape-lift` (`4px 8px 0 0 ink`) — asymmetric offset shadows for the photo-card system.
+
+The R9-locked "layered hover Variant A" (photo `translateY(-2)` on parent `:hover`) was **retired in #1748** when R10 routed `<NewsCard>` hover through `<TapedCard interactive="press">` directly. The layered-lift idiom has no production consumers and the `--shadow-photo-tape-lift` token is intentionally orphaned for now in case a future surface re-introduces the model.
+
 ## Design Conventions
 
 **Storybook is the authoritative design system reference.** Check `Foundation/Colors`, `Foundation/Typography`, and `Foundation/Spacing & Icons` stories for all design tokens (colors, spacing, border-radius, typography). Do not hardcode values not defined there.

--- a/docs/design/mockups/phase-4-homepage/photo-treatment-system-locked.md
+++ b/docs/design/mockups/phase-4-homepage/photo-treatment-system-locked.md
@@ -25,7 +25,15 @@ implementation time:
    tape strip per photo in its type signature.
 
 The rest of the lock (newsprint filter, paper-grain overlay, photo
-shadow tokens, layered hover model) ships as authored.
+shadow tokens) ships as authored.
+
+3. **§7 Layered "lift" hover model (Variant A) — RETIRED at #1748.** R10
+   routed `<NewsCard>` hover through `<TapedCard interactive="press">`
+   directly, leaving the layered-lift idiom with no production
+   consumers. The `--shadow-photo-tape-lift` token stays defined for a
+   hypothetical future surface but is intentionally orphaned for now.
+   See `globals.css` `.taped-figure` block comment for the canonical
+   record of this revision.
 
 ## Decision
 

--- a/docs/design/mockups/phase-4-homepage/spine-revisit-locked.md
+++ b/docs/design/mockups/phase-4-homepage/spine-revisit-locked.md
@@ -121,3 +121,9 @@ R4.B implementation rolls into the same PR as the broader homepage
 restructure (hero swap, NewsGrid geometry, Uitgelicht row addition). It's
 a small change in `apps/web/src/app/(landing)/page.tsx` — about a dozen
 lines reshuffled.
+
+## Post-implementation amendments
+
+- **Implemented in #1754 (Phase 4.5.C.1).** `apps/web/src/app/(landing)/page.tsx` now lists sections in the R4.B order: hero → Uitgelicht → FeaturedEventBand → BannerSlot a → NewsGrid → UpcomingMatches → BannerSlot b → Youth → BannerSlot c → Sponsors → Clubshop. `SectionStack reserveFooterSafeArea={false}` retained so the jersey-deep-dark `<ClubshopBanner>` meets the cream footer top directly.
+- **Brandsfit partnership prominence tier (open follow-up).** Owner accepted the R4.B demotion as their editorial call; partnership terms were not re-litigated with Brandsfit. **Status: still open** — flag for revisit if Brandsfit raises it.
+- **Youth `paddingTop: "pt-0"` override.** The youth `SectionConfig` sets `paddingTop: "pt-0"` so the R5.B `<StripedSeam>` lands flush at the section boundary (default `pt-20` painted 80px of jersey-deep above the seam and the band read as "sandwiched"). Mirrored in the `Pages/Homepage` Storybook composition.

--- a/docs/design/mockups/phase-4-homepage/youth-revisit-locked.md
+++ b/docs/design/mockups/phase-4-homepage/youth-revisit-locked.md
@@ -188,3 +188,9 @@ schema work.
 - **StripedSeam height prop.** Verify the Phase 0 `<StripedSeam>` ships
   a configurable height OR extend it to accept one. Default Phase 0
   height may match the ~28px brief target without tuning.
+
+## Post-implementation amendments
+
+- **Implemented in #1752 (#1771) — top stripe band + dual CTA + emphasis shift.** `<StripedSeam height="xl" colorPair="cream-jersey-deep">` ships as the first child of `<YouthSection>` per path 1 from the lock. The cream-on-deep colour pair was picked over jersey-tonal greens at PR review to keep the band quieter on the photographic backdrop; ink hairlines around the seam were dropped (the cream stops carry the band's edge against the photo on their own, matching the Clubshop section's bare-seam treatment).
+- **Registration URL (open follow-up) — Resolved.** Secondary CTA points to `/club/inschrijven`, mirroring the SiteHeader "Word lid" link target.
+- **Section flush-top fix (#1754, Phase 4.5.C.1).** The homepage `SectionConfig` passes `paddingTop: "pt-0"` so the `<StripedSeam>` sits at the section's top edge directly. Without the override the SectionStack default `pt-20` left 80px of jersey-deep above the seam and the section read as "sandwiched."

--- a/docs/plans/2026-05-13-phase-4.5-refinement-audit.md
+++ b/docs/plans/2026-05-13-phase-4.5-refinement-audit.md
@@ -284,22 +284,33 @@ artefacts need a fresh visual lock in **Round R1.5**.
 
 ## E (updated). Resolution plan
 
-| Round    | Surface                                                                     | Status                                                                                                 |
-| -------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **R1**   | Hero placement (carousel vs single + Uitgelicht)                            | **Locked 2026-05-13 → R1.B (`hero-locked.md`)**                                                        |
-| **R1.5** | Per-articleType hero flourishes                                             | **Locked 2026-05-13 → hybrid (`hero-flourishes-locked.md`)**                                           |
-| **R1.6** | Uitgelicht row card sizing & density                                        | **Locked 2026-05-13 → R1.6.A (`uitgelicht-locked.md`)**                                                |
-| **R2**   | NewsGrid geometry (3×2 vs locked 1+4)                                       | **Locked 2026-05-14 → R2.B (`newsgrid-revisit-locked.md`)**                                            |
-| **R3**   | Per-card semantics vs rhythm (B4)                                           | **Locked 2026-05-14 → R3.B (`card-semantics-locked.md`)**                                              |
-| **R4**   | Section spine ordering (A4)                                                 | **Locked 2026-05-14 → R4.B (`spine-revisit-locked.md`)**                                               |
-| **R5**   | Youth top frame + dual CTA (A5, B1)                                         | **Locked 2026-05-14 → R5.B (`youth-revisit-locked.md`)**                                               |
-| **R6**   | Clubshop framing + jersey treatment (B3, B1)                                | **Locked 2026-05-14 → R6.C (`clubshop-revisit-locked.md`)**                                            |
-| **R7**   | Horizontal-stripe accent schema decision (B2)                               | **Locked 2026-05-14 → DROPPED (`stripe-accent-locked.md`)**                                            |
-| **R8**   | Full-bleed editorial photo moment                                           | **Locked 2026-05-14 → DROPPED (`r8-fullbleed-photo-locked.md`)** · FeaturedEventBand already covers it |
-| **R9**   | Photo treatment system (tape edge / colour / tint / grain / shadow / hover) | **Locked 2026-05-14 → tokens spec (`photo-treatment-system-locked.md`)**                               |
-| **R10**  | NewsCard structure (nested frame vs flush-edge)                             | **Locked 2026-05-14 → flush-edge only, no display variants (`card-structure-locked.md`)**              |
+| Round    | Surface                                                                     | Status                                                                                                 | Implementation                                                                                                                                                |
+| -------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **R1**   | Hero placement (carousel vs single + Uitgelicht)                            | **Locked 2026-05-13 → R1.B (`hero-locked.md`)**                                                        | **Implemented #1754 (4.5.C.1).** Static `<EditorialHero placement="homepage" hoverStyle="tilt-photo">` swaps the retired `<HomepageHeroCarousel>`.            |
+| **R1.5** | Per-articleType hero flourishes                                             | **Locked 2026-05-13 → hybrid (`hero-flourishes-locked.md`)**                                           | **Implemented #1749.** All four variants (announcement / interview / event / transfer) ship the locked kicker + below-H1 + below-hero artefacts.              |
+| **R1.6** | Uitgelicht row card sizing & density                                        | **Locked 2026-05-13 → R1.6.A (`uitgelicht-locked.md`)**                                                | **Implemented #1750.** `<FeaturedUitgelichtRow>` ships equal-3-up on cream paper with the R3.B background lookup applied to its cards.                        |
+| **R2**   | NewsGrid geometry (3×2 vs locked 1+4)                                       | **Locked 2026-05-14 → R2.B (`newsgrid-revisit-locked.md`)**                                            | **Implemented.** `<NewsGrid>` switched to 3×2 (6 cards) and the homepage slice widened from `[3..8]` → `[4..9]`.                                              |
+| **R3**   | Per-card semantics vs rhythm (B4)                                           | **Locked 2026-05-14 → R3.B (`card-semantics-locked.md`)**                                              | **Implemented.** Per-`articleType` `bg` lookup (transfer → jersey-deep, others → cream) consumed by `<NewsCard>` + `<FeaturedUitgelichtRow>`.                 |
+| **R4**   | Section spine ordering (A4)                                                 | **Locked 2026-05-14 → R4.B (`spine-revisit-locked.md`)**                                               | **Implemented #1754 (4.5.C.1).** Spine reordered on `/`: BannerSlot c promoted between Youth and Sponsors; `<ClubshopBanner>` closes the page.                |
+| **R5**   | Youth top frame + dual CTA (A5, B1)                                         | **Locked 2026-05-14 → R5.B (`youth-revisit-locked.md`)**                                               | **Implemented #1752 (+ #1754 page-config fix).** `<StripedSeam>` top band + dual CTA shipped; section now uses `paddingTop: "pt-0"` so the seam sits flush.   |
+| **R6**   | Clubshop framing + jersey treatment (B3, B1)                                | **Locked 2026-05-14 → R6.C (`clubshop-revisit-locked.md`)**                                            | **Implemented.** `<WebshopBanner>` renamed to `<ClubshopBanner>`; mirrored `<StripedSeam>` top + bottom + `<JerseyShirt>` flourish.                           |
+| **R7**   | Horizontal-stripe accent schema decision (B2)                               | **Locked 2026-05-14 → DROPPED (`stripe-accent-locked.md`)**                                            | **Implemented as drop.** No schema migration, no tagging work — R3.B per-articleType backgrounds carry the signal.                                            |
+| **R8**   | Full-bleed editorial photo moment                                           | **Locked 2026-05-14 → DROPPED (`r8-fullbleed-photo-locked.md`)** · FeaturedEventBand already covers it | **Implemented as drop.** No new band.                                                                                                                         |
+| **R9**   | Photo treatment system (tape edge / colour / tint / grain / shadow / hover) | **Locked 2026-05-14 → tokens spec (`photo-treatment-system-locked.md`)**                               | **Implemented with two amendments (#1747, #1748).** Torn-edge variant dropped; two-strip cycle reduced to one; layered "lift" hover model retired. See below. |
+| **R10**  | NewsCard structure (nested frame vs flush-edge)                             | **Locked 2026-05-14 → flush-edge only, no display variants (`card-structure-locked.md`)**              | **Implemented #1748.** `<NewsCard>` flush-edge structure; hover routes through `<TapedCard interactive="press">`.                                             |
 
-**All Phase 4.5 design rounds complete. Audit items A1–B6 resolved. Photo-treatment directives 1+4 resolved via R9. NewsCard structure fix locked at R10. Phase 3 chrome items (C1–C3) remain out of scope as originally noted.**
+**All Phase 4.5 design rounds complete and implemented.** Audit items A1–B6 resolved. Photo-treatment directives 1+4 resolved via R9 (with the §1 + §2 amendments noted in `photo-treatment-system-locked.md`). NewsCard structure fix locked at R10. Phase 3 chrome items (C1–C3) remain out of scope as originally noted.
+
+### Post-implementation amendments
+
+- **R9 §1 (torn-edge tape):** dropped at #1747 review. `<TapeStrip>` ships clean-rectangular only; `--tape-edge-{1..4}` / `--tape-mask-torn` never committed.
+- **R9 §2 (per-strip variety 1–2):** reduced to one strip per photo at #1747 review. `<TapedFigure>`'s `tape?` prop is hard-capped to a single optional `<TapeStrip>`.
+- **R9 §7 (layered "lift" hover Variant A):** retired at #1748. `<NewsCard>` hover now routes through `<TapedCard interactive="press">`. The `--shadow-photo-tape-lift` token stays defined but has no production consumer.
+
+### Open follow-ups status
+
+- **R4 — Brandsfit prominence tier (clubshop demotion):** owner accepted the R4.B demotion as their editorial call. No confirmation back from Brandsfit on tier expectations; the partnership terms haven't been re-litigated against the new spine. **Status: still open** — flag for revisit if Brandsfit raises it.
+- **R5 — Youth secondary CTA registration URL:** **Resolved.** Shipped as `/club/inschrijven` to mirror the SiteHeader "Word lid" link target (`apps/web/src/components/home/YouthSection/YouthSection.tsx`).
 
 ## G. Reference: brief sections mapped to locks
 


### PR DESCRIPTION
Closes #1755

## Summary

Final Phase 4.5 cleanup pass. Docs-only — no `apps/web` runtime code touched.

- **`apps/web/CLAUDE.md`**: new "Phase 4.5 additions" block under Redesign primitives documenting the `<TapeStrip position>` prop, R9 photo-treatment tokens (`--color-tape-cream`, `--filter-photo-newsprint`, `--pattern-paper-grain`, `--shadow-photo-tape`), `<TapedFigure>` single-strip cap, `<EditorialHero hoverStyle>` prop, `<HomepageHeroCarousel>` retirement, `<WebshopBanner>` → `<ClubshopBanner>` rename, `<JerseyShirt>` primitive, and the layered-lift hover retirement at #1748.
- **`docs/plans/2026-05-13-phase-4.5-refinement-audit.md`**: round table gains an Implementation column marking every round as implemented and pointing at the merge PR. Adds post-implementation amendments (R9 torn-edge dropped, two-strip cycle reduced, layered hover retired) and resolves the §F open follow-ups — Brandsfit prominence tier still open; Youth registration URL resolved to `/club/inschrijven`.
- **`docs/design/mockups/phase-4-homepage/photo-treatment-system-locked.md`**: amend "Revisions during implementation" with the layered-hover retirement (#1748).
- **`docs/design/mockups/phase-4-homepage/spine-revisit-locked.md` + `youth-revisit-locked.md`**: append post-implementation amendments documenting the shipped state, including the youth `paddingTop: "pt-0"` override that lands the StripedSeam flush at the section boundary.

## Test plan

- [x] `pnpm --filter @kcvv/api-contract build` passes
- [x] `pnpm --filter @kcvv/web type-check` passes
- [x] `pnpm --filter @kcvv/web lint` passes
- [ ] Manual: open updated CLAUDE.md and confirm the new Phase 4.5 additions block reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design system documentation for Phase 4.5 homepage refinements, including component updates and implementation details.
  * Added post-implementation amendments and follow-up notes for recent UI changes to the photo-treatment system, section ordering, and Youth section layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->