### PR TITLE
docs(news): 5.0 tracer audit — ARTICLE_BY_SLUG_QUERY projection (#1782)

### DIFF
--- a/docs/prd/redesign-phase-5-article-detail.md
+++ b/docs/prd/redesign-phase-5-article-detail.md
@@ -181,6 +181,23 @@ Known projection extensions to investigate during 5.0:
 
 **Zero expected.** Confirmed in 5.0 audit. Any net-new field is spun out as a follow-up with explicit schema-migration scope, NOT folded into Phase 5.
 
+### 5.0 tracer audit (2026-05-17, #1782)
+
+Outcome: **no projection extension required.** `ARTICLE_BY_SLUG_QUERY` (`apps/web/src/lib/repositories/article.repository.ts:76`) already ships every field consumed by `<EditorialHero placement="detail" variant={articleType}>` for all four live variants. Per-variant verification:
+
+| Variant        | Required hero props                                                                         | Projection source                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `announcement` | `title` / `titleRich` / `lead` / `coverImageUrl` / `category` (= `tags[0]`) / `publishedAt` | `title` (pt::text) + `titleRich` + `lead` + `coverImageUrl` + `tags` + `publishedAt` — all projected.                |
+| `interview`    | `subjects[]` (playerRef + staffRef + custom\*) + `coverImagePortraitUrl`                    | `subjects[]{ _key, kind, playerRef->{…}, staffRef->{…}, customName, customRole, customPhotoUrl }` + portrait crop.   |
+| `transfer`     | `feature: TransferFactValue` (first `transferFact` from body) + `otherClubLogoUrl`          | `body[]{ ..., "otherClubLogoUrl": select(_type == "transferFact" => …) }` — derived client-side by TransferTemplate. |
+| `event`        | `feature: EventFactValue` (first `eventFact` from body) + `coverImageUrl`                   | `body[]{ ... }` spread carries every `eventFact` field — derived client-side by EventTemplate.                       |
+
+Body PT shape: the `body[]{ ... }` spread preserves `marks[]` on text spans, so the `accent` decorator (a flat mark name — no markDef) ships unchanged. `markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } }` covers the only mark that needs reference expansion.
+
+`firstTransferFact` / `firstEventFact` (present on `ARTICLES_QUERY` for card listings) are **intentionally absent** on `ARTICLE_BY_SLUG_QUERY`: the detail templates derive them by filtering `body[]` client-side (`TransferTemplate.tsx:68`, `EventTemplate.tsx:67`), so duplicating them at projection level would be dead data.
+
+`matchPreview` / `matchRecap` remain gated on #1470; re-audit when those `articleType` values land.
+
 ---
 
 ## 6. Analytics


### PR DESCRIPTION
Closes #1782

## Audit outcome

**No projection extension required.** `ARTICLE_BY_SLUG_QUERY` (`apps/web/src/lib/repositories/article.repository.ts:76`) already ships every field consumed by `<EditorialHero placement="detail" variant={articleType}>` for all four live `articleType` values.

## Per-variant verification

| Variant        | Required hero props                                                                  | Projection coverage                                                                                                                  |
| -------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
| `announcement` | `title` / `titleRich` / `lead` / `coverImageUrl` / `category` / `publishedAt`        | `title` (pt::text), `titleRich`, `lead`, `coverImageUrl`, `tags`, `publishedAt` — all projected.                                     |
| `interview`    | `subjects[]` (playerRef + staffRef + custom*) + `coverImagePortraitUrl`              | `subjects[]{ _key, kind, playerRef->{…}, staffRef->{…}, customName, customRole, customPhotoUrl }` + hotspot-aware 4:5 portrait crop. |
| `transfer`     | `feature: TransferFactValue` (first `transferFact` from body) + `otherClubLogoUrl`   | `body[]{ ..., "otherClubLogoUrl": select(_type == "transferFact" => …) }` — TransferTemplate derives the first match client-side.    |
| `event`        | `feature: EventFactValue` (first `eventFact` from body) + `coverImageUrl`            | `body[]{ ... }` spread carries every `eventFact` field — EventTemplate derives the first match client-side.                          |

`matchPreview` / `matchRecap` remain gated on #1470; re-audit when those `articleType` values land.

## Body PT + accent decorator

The `body[]{ ... }` spread preserves `marks[]` on text spans, so the `accent` decorator (a flat mark name — no markDef) ships unchanged. `markDefs[]{ ..., _type == "internalLink" => { ..., "reference": reference->{ _type, "slug": slug.current, psdId } } }` covers the only mark that needs reference expansion.

## firstTransferFact / firstEventFact — intentionally absent on detail query

`firstTransferFact` / `firstEventFact` are present on `ARTICLES_QUERY` (homepage / card listings) but **not** on `ARTICLE_BY_SLUG_QUERY`. This is correct: the detail templates derive them by filtering `body[]` client-side (`TransferTemplate.tsx:68`, `EventTemplate.tsx:67`), so duplicating them at projection level would be dead data.

## Changes

- `docs/prd/redesign-phase-5-article-detail.md` §5 — appended "5.0 tracer audit" section recording these findings so they're discoverable from the PRD (PR descriptions rot).

## Testing

- `pnpm --filter @kcvv/web check-all` — lint + type-check + tests + build all pass.
- Audit-only change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added audit documentation for Phase 5 article detail page redesign, confirming implementation requirements for data handling and content properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->