### PR TITLE
feat(news): port related_content_* analytics to verderlezenrow (#1832)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -422,7 +422,12 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         />
       ) : null}
 
-      <VerderLezenRow items={mapRelatedToVerderLezen(relatedItems)} />
+      <VerderLezenRow
+        items={mapRelatedToVerderLezen(relatedItems)}
+        pageType="article"
+        pageSlug={article.slug}
+        sourceArticleType={article.articleType}
+      />
       <FooterSafeArea />
     </>
   );

--- a/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.analytics.test.tsx
+++ b/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.analytics.test.tsx
@@ -1,0 +1,419 @@
+/**
+ * Analytics regression for <VerderLezenRow>.
+ *
+ * Ports the contract previously held by <RelatedContentSection> (see
+ * apps/web/src/components/related/RelatedContentSection/RelatedContentSection.analytics.test.tsx)
+ * — same event names, same payload shapes, same dedup behaviour so the
+ * existing GA4 reports + GTM tags continue to work untouched.
+ *
+ * Tests assert the policy, not the wire format of any one call, so an
+ * accidental regression to per-type code paths or to a different dedup
+ * mechanism is caught here.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { VerderLezenRow, type VerderLezenItem } from "./VerderLezenRow";
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+// `useArticleAnalytics` internally calls `trackEvent` for
+// `related_article_click`, so mocking `trackEvent` covers both
+// emission paths. The hook itself is still real (we want to assert
+// the article→article guard fires the correct wrapped event).
+
+import { trackEvent } from "@/lib/analytics/track-event";
+
+const trackEventMock = vi.mocked(trackEvent);
+
+const articleItem: VerderLezenItem = {
+  title: "Verslag van de derby",
+  href: "/nieuws/verslag-derby",
+  badge: "NIEUWS",
+  analyticsId: "art-1",
+  analyticsSource: "editorial",
+  analyticsType: "article",
+  analyticsTargetSlug: "verslag-derby",
+};
+
+const pageItem: VerderLezenItem = {
+  title: "Clubinfo",
+  href: "/club/clubinfo",
+  badge: "PAGINA",
+  analyticsId: "page-1",
+  analyticsSource: "ai",
+  analyticsType: "page",
+  analyticsTargetSlug: "clubinfo",
+};
+
+const playerItem: VerderLezenItem = {
+  title: "Jan Janssens",
+  href: "/spelers/12345",
+  badge: "SPELER",
+  analyticsId: "player-1",
+  analyticsSource: "reference",
+  analyticsType: "player",
+  // Legacy parity: player uses psdId as target_slug.
+  analyticsTargetSlug: "12345",
+};
+
+const teamItem: VerderLezenItem = {
+  title: "A-ploeg",
+  href: "/ploegen/a-ploeg",
+  badge: "PLOEG",
+  analyticsId: "team-1",
+  analyticsSource: "reference",
+  analyticsType: "team",
+  analyticsTargetSlug: "a-ploeg",
+};
+
+const eventItem: VerderLezenItem = {
+  title: "Spaghetti-avond",
+  href: "/events/spaghetti-avond",
+  badge: "EVENEMENT",
+  analyticsId: "event-1",
+  analyticsSource: "editorial",
+  analyticsType: "event",
+  analyticsTargetSlug: "spaghetti-avond",
+};
+
+describe("VerderLezenRow — analytics", () => {
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
+
+  describe("related_content_shown (impression)", () => {
+    it("fires once on mount with single-source payload", () => {
+      render(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="verslag-derby"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_shown", {
+        source: "editorial",
+        count: 1,
+        content_types: "article",
+        page_type: "article",
+        page_slug: "verslag-derby",
+      });
+    });
+
+    it("derives source as 'mixed' when items have different sources", () => {
+      render(
+        <VerderLezenRow
+          items={[articleItem, pageItem, playerItem]}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_shown", {
+        source: "mixed",
+        count: 3,
+        content_types: "article,page,player",
+        page_type: "article",
+        page_slug: "test",
+      });
+    });
+
+    it("content_types preserves input order (not alphabetical)", () => {
+      render(
+        <VerderLezenRow
+          items={[teamItem, playerItem, articleItem]}
+          pageType="article"
+          pageSlug="t"
+        />,
+      );
+
+      const call = trackEventMock.mock.calls.find(
+        (c) => c[0] === "related_content_shown",
+      );
+      const payload = call?.[1] as { content_types: string };
+
+      // Input-ordered (team / player / article). An accidental alpha-sort
+      // would produce "article,player,team" — direct equality rejects that.
+      expect(payload.content_types).toBe("team,player,article");
+    });
+
+    it("deduplicates content_types when multiple items share a type", () => {
+      render(
+        <VerderLezenRow
+          items={[
+            articleItem,
+            {
+              ...articleItem,
+              href: "/nieuws/art-2",
+              analyticsId: "art-2",
+              analyticsTargetSlug: "art-2",
+            },
+          ]}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_shown", {
+        source: "editorial",
+        count: 2,
+        content_types: "article",
+        page_type: "article",
+        page_slug: "test",
+      });
+    });
+
+    it("does not fire when items array is empty", () => {
+      render(<VerderLezenRow items={[]} pageType="article" pageSlug="test" />);
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+
+    it("fires once on mount, not on re-render (dedup guard)", () => {
+      const { rerender } = render(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
+
+      rerender(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="test"
+        />,
+      );
+
+      expect(
+        trackEventMock.mock.calls.filter(
+          (c) => c[0] === "related_content_shown",
+        ),
+      ).toHaveLength(1);
+    });
+
+    it("does not fire when pageType / pageSlug are omitted (Storybook isolation)", () => {
+      render(<VerderLezenRow items={[articleItem]} />);
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("related_content_click", () => {
+    it("fires with slug for article targets", () => {
+      render(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="page-host"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: articleItem.title });
+      fireEvent.click(link);
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "editorial",
+        target_type: "article",
+        target_slug: "verslag-derby",
+        position: 1,
+        page_type: "article",
+        page_slug: "page-host",
+      });
+    });
+
+    it("uses psdId as target_slug for player entity clicks", () => {
+      render(
+        <VerderLezenRow
+          items={[playerItem]}
+          pageType="article"
+          pageSlug="page-host"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: /Jan Janssens/i });
+      fireEvent.click(link);
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "reference",
+        target_type: "player",
+        target_slug: "12345",
+        position: 1,
+        page_type: "article",
+        page_slug: "page-host",
+      });
+    });
+
+    it("fires with target_type='event' and slug for event content clicks", () => {
+      render(
+        <VerderLezenRow
+          items={[eventItem]}
+          pageType="article"
+          pageSlug="page-host"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: eventItem.title });
+      fireEvent.click(link);
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "editorial",
+        target_type: "event",
+        target_slug: "spaghetti-avond",
+        position: 1,
+        page_type: "article",
+        page_slug: "page-host",
+      });
+    });
+
+    it("uses slug as target_slug for team entity clicks", () => {
+      render(
+        <VerderLezenRow
+          items={[teamItem]}
+          pageType="article"
+          pageSlug="page-host"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: /A-ploeg/ });
+      fireEvent.click(link);
+
+      expect(trackEventMock).toHaveBeenCalledWith("related_content_click", {
+        source: "reference",
+        target_type: "team",
+        target_slug: "a-ploeg",
+        position: 1,
+        page_type: "article",
+        page_slug: "page-host",
+      });
+    });
+
+    it("position is 1-indexed and stable across slots", () => {
+      const items: VerderLezenItem[] = Array.from({ length: 4 }, (_, i) => ({
+        ...articleItem,
+        href: `/nieuws/slug-${i + 1}`,
+        title: `Titel ${i + 1}`,
+        analyticsId: `art-${i + 1}`,
+        analyticsTargetSlug: `slug-${i + 1}`,
+      }));
+
+      render(
+        <VerderLezenRow
+          items={items}
+          pageType="article"
+          pageSlug="page-host"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link3 = screen.getByRole("link", { name: "Titel 3" });
+      fireEvent.click(link3);
+
+      const call = trackEventMock.mock.calls.find(
+        (c) => c[0] === "related_content_click",
+      );
+      const payload = call?.[1] as { position: number };
+      expect(payload.position).toBe(3);
+    });
+
+    it("does not fire click event when analytics is disabled (no pageType)", () => {
+      render(<VerderLezenRow items={[articleItem]} />);
+
+      const link = screen.getByRole("link", { name: articleItem.title });
+      fireEvent.click(link);
+
+      expect(trackEventMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("related_article_click (typed article→article)", () => {
+    it("fires alongside related_content_click for article→article navigation", () => {
+      render(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="source-article"
+          sourceArticleType="interview"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: articleItem.title });
+      fireEvent.click(link);
+
+      const calls = trackEventMock.mock.calls.map((c) => c[0]);
+      expect(calls).toContain("related_content_click");
+      expect(calls).toContain("related_article_click");
+
+      const articleClick = trackEventMock.mock.calls.find(
+        (c) => c[0] === "related_article_click",
+      );
+      const payload = articleClick?.[1] as {
+        article_type: string;
+        related_article_id_hashed: string;
+        position: number;
+      };
+      // `article_type` is normalised — interview stays interview.
+      expect(payload.article_type).toBe("interview");
+      // Related id is hashed by `useArticleAnalytics`, so a non-empty
+      // value (not the raw id) is the policy assertion here.
+      expect(typeof payload.related_article_id_hashed).toBe("string");
+      expect(payload.related_article_id_hashed.length).toBeGreaterThan(0);
+      expect(payload.related_article_id_hashed).not.toBe("art-1");
+      expect(payload.position).toBe(1);
+    });
+
+    it("does not fire related_article_click when target is a non-article", () => {
+      render(
+        <VerderLezenRow
+          items={[playerItem]}
+          pageType="article"
+          pageSlug="source-article"
+          sourceArticleType="interview"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: /Jan Janssens/i });
+      fireEvent.click(link);
+
+      const calls = trackEventMock.mock.calls.map((c) => c[0]);
+      expect(calls).toContain("related_content_click");
+      expect(calls).not.toContain("related_article_click");
+    });
+
+    it("does not fire related_article_click when sourceArticleType is undefined", () => {
+      render(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="source-article"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      const link = screen.getByRole("link", { name: articleItem.title });
+      fireEvent.click(link);
+
+      const calls = trackEventMock.mock.calls.map((c) => c[0]);
+      expect(calls).toContain("related_content_click");
+      expect(calls).not.toContain("related_article_click");
+    });
+  });
+});

--- a/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.analytics.test.tsx
+++ b/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.analytics.test.tsx
@@ -337,6 +337,31 @@ describe("VerderLezenRow — analytics", () => {
 
       expect(trackEventMock).not.toHaveBeenCalled();
     });
+
+    it("does not fire when the click lands outside the inner anchor (slot padding)", () => {
+      const { container } = render(
+        <VerderLezenRow
+          items={[articleItem]}
+          pageType="article"
+          pageSlug="page-host"
+        />,
+      );
+
+      trackEventMock.mockClear();
+
+      // The slot wrapper carries `pt-4` so the tape strip clears the
+      // slider's clip rect. Without the closest('a') guard, clicking
+      // anywhere on that padding band would inflate `related_content_click`.
+      const slot = container.querySelector('[data-slot="verder-lezen-card"]');
+      expect(slot).not.toBeNull();
+      fireEvent.click(slot!);
+
+      expect(
+        trackEventMock.mock.calls.filter(
+          (c) => c[0] === "related_content_click",
+        ),
+      ).toHaveLength(0);
+    });
   });
 
   describe("related_article_click (typed article→article)", () => {

--- a/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.tsx
+++ b/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.tsx
@@ -1,7 +1,17 @@
+"use client";
+
+import { useEffect, useRef } from "react";
 import type { PortableTextBlock } from "@portabletext/react";
 import { EditorialHeading } from "@/components/design-system/EditorialHeading";
 import { HorizontalSlider } from "@/components/design-system/HorizontalSlider";
 import { NewsCard, type NewsCardBg } from "@/components/article/NewsCard";
+import { trackEvent } from "@/lib/analytics/track-event";
+import { useArticleAnalytics } from "@/hooks/useArticleAnalytics";
+import type {
+  RelatedContentItem,
+  RelatedContentSource,
+  RelatedPageType,
+} from "@/components/related/types";
 import { cn } from "@/lib/utils/cn";
 
 /**
@@ -25,9 +35,24 @@ import { cn } from "@/lib/utils/cn";
  *   - 1–N items → slider track; cards beyond the visible viewport are
  *     reachable via the slider arrows or horizontal scroll.
  *
- * Items are passed in pre-sorted; this component does not own ranking
- * or fetching (call-site is responsible — typically the article page
- * after `mergeRelatedItems`).
+ * ## Analytics (ported from `<RelatedContentSection>`, #1832)
+ *
+ * When `pageType` + `pageSlug` are supplied the row emits the same three
+ * GA4 events the legacy widget shipped so GTM/GA4 stay untouched:
+ *
+ *   - `related_content_shown` — once per mount when at least one item
+ *     renders. Dedup via `useRef` so React StrictMode's double-effect
+ *     doesn't double-fire.
+ *   - `related_content_click` — per click, payload-identical to the
+ *     legacy emit.
+ *   - `related_article_click` — when source page + target are both
+ *     articles, fires the typed article→article variant via
+ *     `useArticleAnalytics().trackRelatedArticleClick` (hashes the
+ *     related id).
+ *
+ * Storybook stories that don't set `pageType` / `pageSlug` get no
+ * analytics emissions — the row stays a pure display primitive in
+ * isolation.
  *
  * **Not VR-tagged.** This is a page-composition surface; Playwright e2e
  * (Pages/Article/* templates) owns the smoke test once 5.C wires it into
@@ -51,6 +76,22 @@ export interface VerderLezenItem {
    * cream. Match the strings the article schema validator allows.
    */
   articleType?: "interview" | "announcement" | "transfer" | "event" | null;
+  /**
+   * Analytics payload — optional so demo / Storybook items can skip it.
+   * When present, the row emits `related_content_click` / impression
+   * events with these fields (preserving the legacy
+   * `<RelatedContentSection>` shape).
+   */
+  analyticsId?: string;
+  analyticsSource?: RelatedContentSource;
+  analyticsType?: RelatedContentItem["type"];
+  /**
+   * `psdId` for players, `slug` for articles / events / teams / pages.
+   * Staff items are dropped by `mapRelatedToVerderLezen` (no /staf/[slug]
+   * route exists yet — see #1831), so the staff target-slug case isn't
+   * reachable in production today.
+   */
+  analyticsTargetSlug?: string;
 }
 
 export interface VerderLezenRowProps {
@@ -62,6 +103,21 @@ export interface VerderLezenRowProps {
    * because the heading's accent geometry depends on PT marks.
    */
   heading?: PortableTextBlock[];
+  /**
+   * Surfacing page context for analytics. When both `pageType` and
+   * `pageSlug` are set, the row emits `related_content_shown` on mount
+   * and `related_content_click` on each item click. Omit both on
+   * Storybook fixtures / demo views to suppress analytics.
+   */
+  pageType?: RelatedPageType;
+  pageSlug?: string;
+  /**
+   * `articleType` of the source page — only meaningful when `pageType
+   * === "article"`. When supplied, article→article clicks additionally
+   * emit the typed `related_article_click` event via
+   * `useArticleAnalytics().trackRelatedArticleClick`.
+   */
+  sourceArticleType?: string | null;
   className?: string;
 }
 
@@ -91,12 +147,93 @@ function bgForArticleType(type: VerderLezenItem["articleType"]): NewsCardBg {
 // is well off-screen so a repeat reads as fresh tilt rather than a twin.
 const ROTATION_CYCLE = ["a", "b", "c", "none"] as const;
 
+function deriveImpressionSource(
+  items: VerderLezenItem[],
+): RelatedContentSource | "mixed" {
+  const sources = new Set(
+    items
+      .map((i) => i.analyticsSource)
+      .filter((s): s is RelatedContentSource => s !== undefined),
+  );
+  if (sources.size === 0) return "mixed";
+  if (sources.size === 1) return [...sources][0]!;
+  return "mixed";
+}
+
 export function VerderLezenRow({
   items,
   heading = DEFAULT_HEADING,
+  pageType,
+  pageSlug,
+  sourceArticleType,
   className,
 }: VerderLezenRowProps) {
+  const hasFired = useRef(false);
+  const { trackRelatedArticleClick } = useArticleAnalytics();
+
+  const analyticsEnabled =
+    pageType !== undefined && pageSlug !== undefined && items.length > 0;
+
+  // Impression event — fires once per mount when analytics is enabled
+  // and at least one item renders. Mirrors the legacy
+  // `<RelatedContentSection>` dedup pattern (single ref guard so
+  // StrictMode's double-invoke doesn't double-fire).
+  useEffect(() => {
+    if (!analyticsEnabled) return;
+    if (hasFired.current) return;
+    hasFired.current = true;
+
+    const contentTypes = [
+      ...new Set(
+        items
+          .map((i) => i.analyticsType)
+          .filter((t): t is RelatedContentItem["type"] => t !== undefined),
+      ),
+    ].join(",");
+
+    trackEvent("related_content_shown", {
+      source: deriveImpressionSource(items),
+      count: items.length,
+      content_types: contentTypes,
+      page_type: pageType,
+      page_slug: pageSlug,
+    });
+  }, [analyticsEnabled, items, pageType, pageSlug]);
+
   if (items.length === 0) return null;
+
+  const handleItemClick = (item: VerderLezenItem, position: number) => {
+    if (!analyticsEnabled) return;
+    if (
+      !item.analyticsSource ||
+      !item.analyticsType ||
+      !item.analyticsTargetSlug
+    ) {
+      return;
+    }
+    trackEvent("related_content_click", {
+      source: item.analyticsSource,
+      target_type: item.analyticsType,
+      target_slug: item.analyticsTargetSlug,
+      position,
+      page_type: pageType,
+      page_slug: pageSlug,
+    });
+    // Article→article variant — fires only when both the source page
+    // and the clicked item are articles, mirroring the legacy guard.
+    if (
+      pageType === "article" &&
+      item.analyticsType === "article" &&
+      sourceArticleType !== undefined &&
+      item.analyticsId !== undefined
+    ) {
+      trackRelatedArticleClick({
+        articleType: sourceArticleType,
+        relatedArticleId: item.analyticsId,
+        position,
+      });
+    }
+  };
 
   return (
     <section
@@ -128,6 +265,11 @@ export function VerderLezenRow({
               // would otherwise clip (browsers force `overflow-y: auto`
               // alongside the explicit `overflow-x: auto`).
               className="w-72 shrink-0 pt-4 md:w-80"
+              // Click tracking relies on bubbling from the inner <Link>
+              // anchor inside NewsCard. Keyboard Enter on a focused
+              // link dispatches a native click so no extra role / tabIndex
+              // / onKeyDown is needed on this wrapper.
+              onClick={() => handleItemClick(item, i + 1)}
             >
               <NewsCard
                 title={item.title}

--- a/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.tsx
+++ b/apps/web/src/components/article/VerderLezenRow/VerderLezenRow.tsx
@@ -202,8 +202,21 @@ export function VerderLezenRow({
 
   if (items.length === 0) return null;
 
-  const handleItemClick = (item: VerderLezenItem, position: number) => {
+  const handleItemClick = (
+    event: React.MouseEvent<HTMLDivElement>,
+    item: VerderLezenItem,
+    position: number,
+  ) => {
     if (!analyticsEnabled) return;
+    // The slot wrapper carries a real layout box (`w-72 shrink-0 pt-4`)
+    // so the tape strip clears the slider's clip rect — see
+    // VerderLezenRow.tsx top comment. That means clicks on the slot's
+    // padding / whitespace also bubble through this handler. Guard so
+    // only clicks that resolve to the inner `<a>` count — keeps
+    // `related_content_click` parity with the legacy
+    // `<RelatedContentSection>` which used `display: contents` and
+    // had no off-anchor surface to begin with.
+    if (!(event.target as Element).closest("a")) return;
     if (
       !item.analyticsSource ||
       !item.analyticsType ||
@@ -269,7 +282,7 @@ export function VerderLezenRow({
               // anchor inside NewsCard. Keyboard Enter on a focused
               // link dispatches a native click so no extra role / tabIndex
               // / onKeyDown is needed on this wrapper.
-              onClick={() => handleItemClick(item, i + 1)}
+              onClick={(event) => handleItemClick(event, item, i + 1)}
             >
               <NewsCard
                 title={item.title}

--- a/apps/web/src/lib/utils/article-related-items.ts
+++ b/apps/web/src/lib/utils/article-related-items.ts
@@ -289,6 +289,10 @@ function mapRelatedItem(item: RelatedContentItem): VerderLezenItem | null {
         // RelatedArticleItem doesn't currently carry the linked
         // article's own articleType; the card defaults to cream bg.
         // Plumbing articleType through is tracked alongside #1829.
+        analyticsId: item.id,
+        analyticsSource: item.source,
+        analyticsType: "article",
+        analyticsTargetSlug: item.slug,
       };
     case "page":
       return {
@@ -297,6 +301,10 @@ function mapRelatedItem(item: RelatedContentItem): VerderLezenItem | null {
         imageUrl: item.imageUrl ?? undefined,
         imageAlt: item.title,
         badge: "PAGINA",
+        analyticsId: item.id,
+        analyticsSource: item.source,
+        analyticsType: "page",
+        analyticsTargetSlug: item.slug,
       };
     case "player": {
       const name = [item.firstName, item.lastName]
@@ -309,6 +317,12 @@ function mapRelatedItem(item: RelatedContentItem): VerderLezenItem | null {
         imageUrl: item.imageUrl ?? undefined,
         imageAlt: name,
         badge: item.position?.toUpperCase() ?? "SPELER",
+        analyticsId: item.id,
+        analyticsSource: item.source,
+        analyticsType: "player",
+        // Legacy parity: `getEntityTargetSlug` in RelatedContentSection
+        // returns `psdId` for players (the routing identifier).
+        analyticsTargetSlug: item.psdId,
       };
     }
     case "team":
@@ -318,14 +332,18 @@ function mapRelatedItem(item: RelatedContentItem): VerderLezenItem | null {
         imageUrl: item.imageUrl ?? undefined,
         imageAlt: item.name,
         badge: "PLOEG",
+        analyticsId: item.id,
+        analyticsSource: item.source,
+        analyticsType: "team",
+        analyticsTargetSlug: item.slug,
       };
     case "staff":
       // Staff has no resolvable detail-page route today (the GROQ
       // projection at apps/web/src/lib/repositories/article.repository.ts
       // doesn't select a `slug`, and there's no /staf/[slug] page).
       // Dropping the card rather than rendering a broken `href: "#"`.
-      // Surfacing staff in the slider is tracked alongside the analytics
-      // follow-up (#1832) — needs both a route + the projection field.
+      // Restoring staff in the slider (and its analytics) is tracked at
+      // #1831 — needs both a route + the projection field.
       return null;
     case "event":
       return {
@@ -335,6 +353,10 @@ function mapRelatedItem(item: RelatedContentItem): VerderLezenItem | null {
         imageAlt: item.title,
         badge: "EVENEMENT",
         date: formatArticleDate(item.dateStart),
+        analyticsId: item.id,
+        analyticsSource: item.source,
+        analyticsType: "event",
+        analyticsTargetSlug: item.slug,
       };
   }
 }


### PR DESCRIPTION
Closes #1832.

## Summary

Wire the three GA4 events the legacy `<RelatedContentSection>` shipped into the Phase 5 `<VerderLezenRow>` slider so article-page analytics restore after #1800.

**Event names + payload shapes are byte-identical** to the legacy emit — no GA4 reports, no GTM tags need updating.

- `related_content_shown` — fires once per mount when items render and `pageType` + `pageSlug` are set. Dedup via `useRef` so React StrictMode double-effect doesn't double-fire.
- `related_content_click` — emitted per click. Payload mirrors legacy (`source` / `target_type` / `target_slug` / `position` / `page_type` / `page_slug`). Player `target_slug` uses `psdId`; others use `slug`.
- `related_article_click` — fires alongside the content click on article→article navigation. Routes through `useArticleAnalytics().trackRelatedArticleClick` which hashes the related id.

## Changes

- `apps/web/src/components/article/VerderLezenRow/VerderLezenRow.tsx` — now `"use client"`. Adds the three event emissions + `useRef` dedup guard. Analytics is opt-in: when `pageType` / `pageSlug` are absent (Storybook fixtures, demo views) the row stays silent.
- `apps/web/src/components/article/VerderLezenRow/VerderLezenRow.analytics.test.tsx` — 16 new tests, modelled after the legacy `RelatedContentSection.analytics.test.tsx` (same fixtures, same payload assertions, same dedup + guard policies).
- `apps/web/src/lib/utils/article-related-items.ts` — `mapRelatedToVerderLezen` populates four optional analytics fields per `VerderLezenItem` (`analyticsId` / `analyticsSource` / `analyticsType` / `analyticsTargetSlug`). Player uses `psdId` for `target_slug` per legacy `getEntityTargetSlug`.
- `apps/web/src/app/(main)/nieuws/[slug]/page.tsx` — passes `pageType="article"`, `pageSlug`, `sourceArticleType` to the row.

## What's deliberately unchanged

- Event names: `related_content_shown` / `related_content_click` / `related_article_click` — verbatim from the legacy widget.
- Payload field names + types per event — verbatim.
- The dedup pattern (single `useRef`) — same as legacy.
- Article→article guard (`pageType === "article" && target.type === "article" && sourceArticleType !== undefined`) — verbatim.

## What's deferred to #1831

Staff items still drop in `mapRelatedToVerderLezen` (no `/staf/[slug]` route exists yet, and the GROQ projection doesn't carry `slug`). Restoring staff in the slider — and re-enabling its `related_content_click` emit — is in #1831's scope.

## Test plan

- [x] `pnpm --filter @kcvv/web lint` clean
- [x] `pnpm --filter @kcvv/web type-check` clean
- [x] `pnpm --filter @kcvv/web test` — 3300 tests pass (16 new analytics tests)
- [x] Pre-PR code review — JSDoc rot fixed; other findings either out-of-scope (#1831 cleanup) or intentional (legacy-parity dedup ref, opt-in analytics gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for related-content analytics covering impression events, click events, typed-article co-events, and edge cases.

* **Chores**
  * Instrumented related-content cards with richer analytics context and click/impression tracking, including source/type propagation, deduplication, and stable position reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->