### PR TITLE
feat(news): thread article.titleRich accent decorator through editorialhero (#1830)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -50,6 +50,7 @@ import { resolveSubject } from "@/components/article/SubjectAttribution";
 import type { ArticleDetailVM } from "@/lib/repositories/article.repository";
 import type { TransferFactValue } from "@/components/article/blocks/TransferFact";
 import type { EventFactValue } from "@/components/article/blocks/EventFact";
+import { toPortableTextBlocks } from "@/lib/sanity/portable-text-bridge";
 
 interface ArticlePageProps {
   params: Promise<{ slug: string }>;
@@ -89,11 +90,15 @@ function renderArticleHero({
   firstTransferFact,
   firstEventFact,
 }: RenderArticleHeroArgs) {
-  // EditorialHero accepts string OR PortableTextBlock[] (accent-decorator
-  // PT title). The Sanity typegen for `titleRich` produces a shape that
-  // doesn't satisfy @portabletext/react's PortableTextBlock structurally;
-  // threading the rich-title through is tracked at #1830.
-  const titleProp = title;
+  // EditorialHero accepts string OR PortableTextBlock[] — prefer the
+  // rich shape so editor-marked `accent` spans render italic +
+  // jersey-deep on the H1. The Sanity typegen's PT shape is
+  // structurally narrower than @portabletext/react's `PortableTextBlock`
+  // (optional `children` + `markDefs: null`); `toPortableTextBlocks`
+  // bridges the two at the consumption boundary so the library type
+  // is satisfied without a wholesale typegen rewrite (#1830).
+  const titleRich = toPortableTextBlocks(article.titleRich);
+  const titleProp = titleRich.length > 0 ? titleRich : title;
   const lead = article.lead?.trim() || undefined;
   const author = article.author?.trim() || undefined;
   // Cover-image projection picks differ per variant (portrait crop for

--- a/apps/web/src/components/article/Article.stories.tsx
+++ b/apps/web/src/components/article/Article.stories.tsx
@@ -369,3 +369,80 @@ export const EventPast: Story = {
     },
   },
 };
+
+// Accent-decorator title — Sanity's constrained-PT `article.title`
+// emits an `accent` mark on one or more spans inside the H1, which
+// `<EditorialHeading>` renders italic + jersey-deep. #1830 wires
+// this through `page.tsx` via `toPortableTextBlocks(article.titleRich)`
+// — the page picks the PT shape when present, falling back to plain
+// `article.title` otherwise. This story exercises the rich path so
+// the visual treatment is reviewable end-to-end.
+const ACCENT_TITLE: PortableTextBlock[] = [
+  {
+    _type: "block",
+    _key: "accent-title-block",
+    style: "normal",
+    markDefs: [],
+    children: [
+      { _type: "span", _key: "a1", text: "De ", marks: [] },
+      {
+        _type: "span",
+        _key: "a2",
+        text: "wakker-roeper",
+        marks: ["accent"],
+      },
+      { _type: "span", _key: "a3", text: " staat klaar.", marks: [] },
+    ],
+  } as PortableTextBlock,
+];
+
+export const InterviewWithAccentTitle: Story = {
+  render: () => (
+    <>
+      <EditorialHero
+        variant="interview"
+        placement="detail"
+        title={ACCENT_TITLE}
+        lead="Trainer Wim Govaerts over de mentale switch die het seizoen kantelde."
+        author="Sofie Berthels"
+        date="23 mei 2026"
+        subjects={[COACH_SUBJECT]}
+        coverImage={{
+          url: fixtureImage("article-hero-interview", 0),
+          alt: "Wim Govaerts in de dug-out",
+        }}
+      />
+      <ArticleMetadata
+        date="23 mei 2026"
+        readingTime="6 min lezen"
+        shareConfig={SHARE_CONFIG}
+        articleType="interview"
+        className="mt-10"
+      />
+      <div className="max-w-inner-lg mx-auto mb-6 w-full px-6 lg:mb-10">
+        <ArticleBodyMotion>
+          <SanityArticleBody
+            className="article-body"
+            content={SHARED_BODY}
+            subjects={[COACH_SUBJECT]}
+          />
+        </ArticleBodyMotion>
+      </div>
+      <ArticleCredits
+        author="Sofie Berthels"
+        photographer="Karen De Smet"
+        subjects={[COACH_SUBJECT]}
+        publishedAt="2026-05-23T08:00:00.000Z"
+      />
+      <VerderLezenRow items={RELATED_ITEMS} />
+    </>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interview article whose H1 carries an `accent` decorator on the substring `wakker-roeper`. `<EditorialHeading>` renders the accented span italic + jersey-deep; the surrounding words stay in the regular H1 treatment. Exercises the `titleRich` → `<EditorialHero title={PT[]}>` path wired at #1830.",
+      },
+    },
+  },
+};

--- a/apps/web/src/lib/sanity/portable-text-bridge.test.ts
+++ b/apps/web/src/lib/sanity/portable-text-bridge.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { toPortableTextBlocks } from "./portable-text-bridge";
+
+describe("toPortableTextBlocks", () => {
+  it("returns [] for null", () => {
+    expect(toPortableTextBlocks(null)).toEqual([]);
+  });
+
+  it("returns [] for undefined", () => {
+    expect(toPortableTextBlocks(undefined)).toEqual([]);
+  });
+
+  it("returns [] for an empty array", () => {
+    expect(toPortableTextBlocks([])).toEqual([]);
+  });
+
+  it("normalises `markDefs: null` (Sanity typegen) to `[]` (library shape)", () => {
+    const input = [
+      {
+        _type: "block",
+        _key: "b1",
+        children: [{ _type: "span", _key: "s1", text: "Hello", marks: [] }],
+        markDefs: null,
+        style: "normal",
+      },
+    ];
+    const out = toPortableTextBlocks(input);
+    expect(out[0]?.markDefs).toEqual([]);
+  });
+
+  it("defaults missing `children` to `[]`", () => {
+    const input = [
+      {
+        _type: "block",
+        _key: "b1",
+        markDefs: null,
+        style: "normal",
+      },
+    ];
+    const out = toPortableTextBlocks(input);
+    expect(out[0]?.children).toEqual([]);
+  });
+
+  it("preserves accent-marked spans untouched", () => {
+    const input = [
+      {
+        _type: "block",
+        _key: "b1",
+        children: [
+          { _type: "span", _key: "s1", text: "We zijn ", marks: [] },
+          {
+            _type: "span",
+            _key: "s2",
+            text: "klaar",
+            marks: ["accent"],
+          },
+          {
+            _type: "span",
+            _key: "s3",
+            text: " voor de volgende stap.",
+            marks: [],
+          },
+        ],
+        markDefs: null,
+        style: "normal",
+      },
+    ];
+    const out = toPortableTextBlocks(input);
+    expect(out[0]?.children).toHaveLength(3);
+    const accentSpan = (out[0]?.children?.[1] ?? null) as {
+      marks?: string[];
+    } | null;
+    expect(accentSpan?.marks).toContain("accent");
+  });
+
+  it("preserves the `_key` so React reconciliation stays stable", () => {
+    const input = [
+      {
+        _type: "block",
+        _key: "stable-key",
+        children: [],
+        markDefs: null,
+        style: "normal",
+      },
+    ];
+    expect(toPortableTextBlocks(input)[0]?._key).toBe("stable-key");
+  });
+});

--- a/apps/web/src/lib/sanity/portable-text-bridge.ts
+++ b/apps/web/src/lib/sanity/portable-text-bridge.ts
@@ -1,0 +1,44 @@
+import type { PortableTextBlock } from "@portabletext/react";
+
+/**
+ * Bridge between Sanity typegen's PT shape and `@portabletext/react`'s
+ * `PortableTextBlock`. Two mismatches need normalising:
+ *
+ *   - Sanity emits `children?:` (optional) while the library requires
+ *     `children: [...]`. We default to `[]` so the renderer doesn't
+ *     crash on a block that came back without spans.
+ *   - Sanity emits `markDefs?: null` (literal null) while the library
+ *     expects `markDefs?: PortableTextMarkDefinition[] | undefined`.
+ *     We coerce `null` → `[]` so the library's mark-resolution path
+ *     can safely iterate.
+ *
+ * The runtime data is valid PT; only the TS shape differs. The function
+ * returns a structurally-correct `PortableTextBlock[]` so consumers can
+ * pass it straight to `<PortableText value={...} />` (and to
+ * `<EditorialHero title={...}>` / `<EditorialHeading>` which accept the
+ * same shape).
+ *
+ * Returns an empty array when the input is null/undefined so call-sites
+ * can fall back to a plain-string title without an extra guard.
+ */
+export function toPortableTextBlocks(
+  input:
+    | ReadonlyArray<{
+        _type: string;
+        _key: string;
+        children?: ReadonlyArray<unknown>;
+        markDefs?: ReadonlyArray<unknown> | null;
+        style?: string;
+        level?: number;
+        listItem?: string | never;
+      }>
+    | null
+    | undefined,
+): PortableTextBlock[] {
+  if (!input || input.length === 0) return [];
+  return input.map((block) => ({
+    ...block,
+    children: (block.children ?? []) as PortableTextBlock["children"],
+    markDefs: (block.markDefs ?? []) as PortableTextBlock["markDefs"],
+  })) as PortableTextBlock[];
+}


### PR DESCRIPTION
Closes #1830.

## Summary

Editors can now mark spans inside the article title with the `accent` decorator and the H1 renders the marked span italic + jersey-deep on `/nieuws/[slug]`. The plumbing was wired in #1800 but swallowed the accent silently because the Sanity typegen's PT shape didn't structurally satisfy `@portabletext/react`'s `PortableTextBlock`.

## Approach (Approach A from the issue spec — type-bridge utility)

The two structural divergences between Sanity typegen and the library type:
- Sanity typegen emits `children?:` (optional) — library requires `children: [...]`.
- Sanity typegen emits `markDefs?: null` (literal null) — library expects `markDefs?: PortableTextMarkDefinition[]`.

`toPortableTextBlocks(richField)` normalises both at the consumption boundary so the library type is satisfied without a wholesale typegen rewrite. Returns `[]` for null/undefined so consumers can fall back to a plain-string title without an extra guard.

## Changes

- `apps/web/src/lib/sanity/portable-text-bridge.ts` — new utility.
- `apps/web/src/lib/sanity/portable-text-bridge.test.ts` — 7 unit tests covering null/undefined/empty input, `markDefs: null` normalisation, missing-children default, accent-mark preservation, `_key` stability.
- `apps/web/src/app/(main)/nieuws/[slug]/page.tsx` — `renderArticleHero` runs `article.titleRich` through the bridge and prefers the PT shape over plain `article.title` when available.
- `apps/web/src/components/article/Article.stories.tsx` — new `InterviewWithAccentTitle` story exercises the rich-title path end-to-end so the visual treatment is reviewable in Storybook + locked under future refactors. Plain-string title stories preserved as-is.

`<EditorialHero>` already accepts `string | PortableTextBlock[]` and delegates to `<EditorialHeading>` which renders the `accent` decorator natively — no component-side changes needed.

## Test plan

- [x] `pnpm --filter @kcvv/web lint` clean
- [x] `pnpm --filter @kcvv/web type-check` clean
- [x] `pnpm --filter @kcvv/web test` — 3195 tests pass (3188 + 7 new bridge tests)
- [x] Storybook eyeball pass — `Pages/Article/InterviewWithAccentTitle` confirms the H1 renders "De _wakker-roeper_ staat klaar." with the middle word italic + jersey-deep, surrounding words in regular H1 treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Article titles now support rich text formatting with styling capabilities (e.g., accent marks).

* **Tests**
  * Added comprehensive test coverage for rich text block conversion, including edge cases and shape normalization.

* **Documentation**
  * Added story example demonstrating articles with styled titles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->