### PR TITLE
docs(news): lock phase 5 body block design drills (#1840)

### DIFF
--- a/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-1-card-vocabulary-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-1-card-vocabulary-comparisons.html
@@ -69,6 +69,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-1-card-vocabulary-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-1-card-vocabulary-comparisons.html
@@ -1,0 +1,764 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-evt-inline · Round 1 · Card vocabulary</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey: #2d7a4f;
+        --color-jersey-deep: #1f5f3f;
+        --color-tape-jersey: #2d7a4f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-soft: 3px 3px 0 0 rgba(26, 26, 26, 0.85);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      /* ========== Shared atoms ========== */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        height: 22px;
+        padding: 0 9px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 600;
+      }
+      .mono-label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 36px;
+        padding: 0 16px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 600;
+        text-decoration: none;
+        border: 1px solid var(--color-ink);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+
+      /* ========== OPTION A — Mini EventDetailBlock ========== */
+      .opt-a-card {
+        position: relative;
+        background: var(--color-cream-soft);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        padding: 22px 24px 22px;
+        margin: 24px 0;
+      }
+      .opt-a-card .tape {
+        position: absolute;
+        top: -8px;
+        left: 36px;
+        width: 84px;
+        height: 18px;
+        background: var(--color-tape-jersey);
+        transform: rotate(-2deg);
+        opacity: 0.92;
+      }
+      .opt-a-head {
+        display: grid;
+        grid-template-columns: 76px 1fr;
+        gap: 18px;
+        align-items: start;
+      }
+      .opt-a-dateblock {
+        width: 76px;
+        text-align: center;
+        font-family: ui-serif, Georgia, serif;
+        color: var(--color-ink);
+        line-height: 1;
+      }
+      .opt-a-dateblock .m {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-bottom: 2px;
+      }
+      .opt-a-dateblock .d {
+        font-style: italic;
+        font-weight: 900;
+        font-size: 42px;
+        letter-spacing: -0.04em;
+        color: var(--color-ink);
+        line-height: 0.95;
+      }
+      .opt-a-dateblock .w {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-top: 3px;
+      }
+      .opt-a-titleblock {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .opt-a-title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 22px;
+        line-height: 1.2;
+        color: var(--color-ink);
+        margin: 0;
+      }
+      .opt-a-divider {
+        height: 0;
+        border-top: 1px dotted var(--color-ink-muted);
+        margin: 14px 0 12px;
+      }
+      .opt-a-meta {
+        display: grid;
+        grid-template-columns: 96px 1fr;
+        gap: 6px 16px;
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        font-style: italic;
+        color: var(--color-ink);
+      }
+      .opt-a-meta dt {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        font-style: normal;
+        padding-top: 3px;
+      }
+      .opt-a-meta dd {
+        margin: 0;
+      }
+      .opt-a-cta {
+        margin-top: 16px;
+      }
+
+      /* ========== OPTION B — Ticket-stub strip ========== */
+      .opt-b-card {
+        display: grid;
+        grid-template-columns: 96px 1fr auto;
+        gap: 0;
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        margin: 24px 0;
+        align-items: stretch;
+      }
+      .opt-b-stub {
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        padding: 14px 8px;
+        text-align: center;
+        border-right: 1px dashed var(--color-ink);
+        position: relative;
+      }
+      .opt-b-stub .m {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .opt-b-stub .d {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 36px;
+        line-height: 1;
+        margin-top: 2px;
+      }
+      .opt-b-stub .w {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.85;
+        margin-top: 4px;
+      }
+      .opt-b-body {
+        padding: 14px 18px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 6px;
+      }
+      .opt-b-pillrow {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .opt-b-title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 20px;
+        line-height: 1.2;
+        margin: 0;
+      }
+      .opt-b-meta {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 13px;
+        font-style: italic;
+        color: var(--color-ink-muted);
+      }
+      .opt-b-cta-cell {
+        display: flex;
+        align-items: center;
+        padding: 0 16px 0 8px;
+        border-left: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+
+      /* ========== OPTION C — Taped polaroid figure ========== */
+      .opt-c-card {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 25%, transparent);
+        padding: 22px 24px 26px;
+        margin: 30px 0 28px;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.6);
+        transform: rotate(-0.4deg);
+      }
+      .opt-c-tape-tl {
+        position: absolute;
+        top: -10px;
+        left: 22px;
+        width: 70px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.78);
+        transform: rotate(-5deg);
+      }
+      .opt-c-tape-br {
+        position: absolute;
+        bottom: -10px;
+        right: 28px;
+        width: 56px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.78);
+        transform: rotate(4deg);
+      }
+      .opt-c-kicker {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 6px;
+      }
+      .opt-c-title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 700;
+        font-size: 26px;
+        line-height: 1.15;
+        margin: 0 0 12px;
+        letter-spacing: -0.01em;
+      }
+      .opt-c-date {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 18px;
+        color: var(--color-ink);
+        margin: 0 0 4px;
+      }
+      .opt-c-meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0 0 14px;
+      }
+
+      /* ========== OPTION D — Two-line strip (no card) ========== */
+      .opt-d-card {
+        margin: 22px 0 26px;
+        padding: 14px 0 16px;
+        border-top: 2px solid var(--color-ink);
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .opt-d-row1 {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin-bottom: 6px;
+      }
+      .opt-d-date {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        font-weight: 600;
+      }
+      .opt-d-title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 22px;
+        line-height: 1.2;
+        margin: 0;
+      }
+      .opt-d-meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-top: 4px;
+        display: flex;
+        gap: 14px;
+      }
+      .opt-d-cta {
+        margin-top: 10px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-evt-inline · Round 1 · #1840</p>
+      <h1>
+        In-body eventFact — card vocabulary (mini-detail / ticket-stub /
+        polaroid / two-line)
+      </h1>
+      <p>
+        Drill 2.1 sub-round 1. Locks the visual for an eventFact PT block
+        when it sits inline inside <code>&lt;ArticleBody&gt;</code>. Two
+        cases share this visual: (1) inline-in-announcement (one event
+        callout inside an announcement) and (2) multi-eventFact-in-event
+        (subsequent eventFacts after the first one is absorbed by
+        <code>&lt;EventDetailBlock&gt;</code>).
+      </p>
+      <p>
+        Every option renders the same fixture: <em>Steakfestijn 2026</em>,
+        13 juni, locatie + adres + capaciteit + competitionTag, ticket
+        CTA. Wrapped in body prose paragraphs to show the rhythm inside an
+        article. Fusing behaviour (consecutive cards) is held for Round 2.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — MINI EVENTDETAILBLOCK ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Mini EventDetailBlock</div>
+          <div class="name">TapedCard family, compressed (no sessions / no note)</div>
+          <div class="desc">
+            Same vocabulary as the locked <code>&lt;EventDetailBlock&gt;</code>:
+            cream-soft TapedCard, jersey tape strip top, 76px date-block
+            left, tag pill + italic display title right, dotted ink-muted
+            divider, meta <code>&lt;dl&gt;</code> below, CTA at the bottom.
+            Compressed by dropping the sessions block and the note section
+            (those stay exclusive to the page-end EventDetailBlock).
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedCard + jersey tape (matches EventDetailBlock)<br />
+            ✓ 76px date block (same as EventDetailBlock head)<br />
+            ✓ italic display-sm title + dotted divider<br />
+            ✓ mono caps meta dl<br />
+            ✗ no sessions, no note (compression rules)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking presenteert dit seizoen drie open
+              kennismakingsmomenten. Het volgende staat al op de agenda en
+              de inschrijvingen openen vrijdag.
+            </p>
+            <article class="opt-a-card">
+              <span class="tape" aria-hidden="true"></span>
+              <header class="opt-a-head">
+                <div class="opt-a-dateblock">
+                  <div class="m">Juni</div>
+                  <div class="d">13</div>
+                  <div class="w">Vrij</div>
+                </div>
+                <div class="opt-a-titleblock">
+                  <span class="pill">Clubfeest</span>
+                  <h3 class="opt-a-title">Steakfestijn 2026</h3>
+                </div>
+              </header>
+              <div class="opt-a-divider"></div>
+              <dl class="opt-a-meta">
+                <dt>Locatie</dt>
+                <dd>Sportpark Elewijt</dd>
+                <dt>Adres</dt>
+                <dd>Driesstraat 14, Elewijt</dd>
+                <dt>Capaciteit</dt>
+                <dd>Max 180 plaatsen</dd>
+              </dl>
+              <a class="cta opt-a-cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <p>
+              Naast het festijn werken we ook aan een nieuwe formule voor
+              het paastornooi — daar volgt later in het seizoen meer info
+              over.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — TICKET-STUB STRIP ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Ticket-stub strip</div>
+          <div class="name">Date stub (jersey-deep) left, body center, CTA cell right</div>
+          <div class="desc">
+            Three-column horizontal: ticket-stub left (jersey-deep
+            background, dashed perforation), body center (tag pill +
+            italic title + meta), CTA cell right (cream-soft, dashed
+            perforation). One row tall on desktop, collapses to stacked on
+            mobile. Reads as a "tear-off ticket" — strongest single-glance
+            wayfinding.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TicketStub family (jersey-deep stub, dashed perforations)<br />
+            ✓ pill (same as EventDetailBlock head)<br />
+            ✓ italic display title<br />
+            ✗ no taped card, no sessions, no note
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking presenteert dit seizoen drie open
+              kennismakingsmomenten. Het volgende staat al op de agenda en
+              de inschrijvingen openen vrijdag.
+            </p>
+            <article class="opt-b-card">
+              <div class="opt-b-stub">
+                <div class="m">Juni</div>
+                <div class="d">13</div>
+                <div class="w">Vrij</div>
+              </div>
+              <div class="opt-b-body">
+                <div class="opt-b-pillrow">
+                  <span class="pill">Clubfeest</span>
+                  <span class="opt-b-meta"
+                    >Sportpark Elewijt · 18:00–22:00</span
+                  >
+                </div>
+                <h3 class="opt-b-title">Steakfestijn 2026</h3>
+              </div>
+              <div class="opt-b-cta-cell">
+                <a class="cta" href="#"
+                  >Inschrijven <span aria-hidden="true">→</span></a
+                >
+              </div>
+            </article>
+            <p>
+              Naast het festijn werken we ook aan een nieuwe formule voor
+              het paastornooi — daar volgt later in het seizoen meer info
+              over.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — TAPED POLAROID ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Taped polaroid (invitation register)</div>
+          <div class="name">Slightly rotated card with corner tape strips</div>
+          <div class="desc">
+            Cream-white polaroid with a subtle rotation, ochre tape strips
+            top-left and bottom-right, no date block — date + meta sit
+            inline below the title. Reads as a clipped event invitation
+            pinned into the article. Most fanzine-register; weakest at
+            single-glance date wayfinding.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedCard family with rotation<br />
+            ✓ ochre tape (warmer than jersey tape)<br />
+            ✗ no date block (date inline)<br />
+            ✗ NEW visual register vs EventDetailBlock
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking presenteert dit seizoen drie open
+              kennismakingsmomenten. Het volgende staat al op de agenda en
+              de inschrijvingen openen vrijdag.
+            </p>
+            <article class="opt-c-card">
+              <span class="opt-c-tape-tl" aria-hidden="true"></span>
+              <span class="opt-c-tape-br" aria-hidden="true"></span>
+              <div class="opt-c-kicker">
+                <span class="pill">Clubfeest</span>
+                <span class="mono-label">Open inschrijving</span>
+              </div>
+              <h3 class="opt-c-title">Steakfestijn 2026</h3>
+              <p class="opt-c-date">Vrijdag 13 juni · 18:00–22:00</p>
+              <p class="opt-c-meta">
+                Sportpark Elewijt · Driesstraat 14 · Max 180 plaatsen
+              </p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <p>
+              Naast het festijn werken we ook aan een nieuwe formule voor
+              het paastornooi — daar volgt later in het seizoen meer info
+              over.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — TWO-LINE STRIP ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Two-line strip (no card)</div>
+          <div class="name">Borderless: rule above, dotted rule below, content between</div>
+          <div class="desc">
+            No card chrome. A 2px ink rule above + dotted ink-muted below
+            bracket a two-line block: line 1 = mono caps date + pill +
+            italic title, line 2 = mono caps meta line. CTA inline below.
+            Lightest of the four; reads as a body-level callout, not a
+            distinct card.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ 2px ink rule (matches MissionBanner top rule)<br />
+            ✓ Phase 3-b dotted ink-muted divider<br />
+            ✓ italic display-sm title<br />
+            ✗ no card, no tape, no date block
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking presenteert dit seizoen drie open
+              kennismakingsmomenten. Het volgende staat al op de agenda en
+              de inschrijvingen openen vrijdag.
+            </p>
+            <article class="opt-d-card">
+              <div class="opt-d-row1">
+                <span class="opt-d-date">Vrij 13 jun</span>
+                <span class="pill">Clubfeest</span>
+                <h3 class="opt-d-title">Steakfestijn 2026</h3>
+              </div>
+              <div class="opt-d-meta">
+                <span>Sportpark Elewijt</span>
+                <span>18:00–22:00</span>
+                <span>Max 180</span>
+              </div>
+              <div class="opt-d-cta">
+                <a class="cta" href="#"
+                  >Inschrijven <span aria-hidden="true">→</span></a
+                >
+              </div>
+            </article>
+            <p>
+              Naast het festijn werken we ook aan een nieuwe formule voor
+              het paastornooi — daar volgt later in het seizoen meer info
+              over.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Family relation to <code>&lt;EventDetailBlock&gt;</code></strong>
+      <ul>
+        <li>
+          <strong>A · Mini-detail</strong> directly mirrors the locked
+          EventDetailBlock — same tape, same date block, same dotted
+          divider, same dl. Reader recognises "this is the same event
+          object as the one at the article tail."
+        </li>
+        <li>
+          <strong>B · Ticket-stub</strong> uses the TicketStub primitive
+          (already approved in design vocabulary). Strongest visual
+          difference from EventDetailBlock — easier to tell "primary"
+          from "secondary" event in a multi-eventFact event article.
+        </li>
+        <li>
+          <strong>C · Polaroid</strong> introduces a warmer ochre tape
+          and a rotation — most decorative but adds the most new vocabulary.
+        </li>
+        <li>
+          <strong>D · Two-line strip</strong> has the lightest footprint,
+          but weakest wayfinding when 3+ eventFacts stack consecutively.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Fields rendered (all options)</strong>
+      <ul>
+        <li>
+          title (required), date, startTime/endTime, location, address,
+          ageGroup/competitionTag (pill), ticketUrl + ticketLabel (CTA),
+          capacity.
+        </li>
+        <li>
+          <strong>NOT rendered:</strong> sessions[] (exclusive to
+          EventDetailBlock), note PT (exclusive to EventDetailBlock).
+          These compression rules keep the inline card visually lighter
+          than the page-end one.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-2-multi-card-behavior-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-2-multi-card-behavior-comparisons.html
@@ -1,0 +1,705 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-evt-inline · Round 2 · Multi-card behavior</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        height: 22px;
+        padding: 0 9px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 600;
+      }
+      .mono-label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 36px;
+        padding: 0 16px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 600;
+        text-decoration: none;
+        border: 1px solid var(--color-ink);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+      }
+
+      /* Polaroid base (locked Round 1 C). Variants tweak rotation and
+         margins. */
+      .polaroid {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 25%, transparent);
+        padding: 22px 24px 26px;
+        margin: 30px 0 28px;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.6);
+      }
+      .polaroid .tape-tl {
+        position: absolute;
+        top: -10px;
+        left: 22px;
+        width: 70px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.78);
+        transform: rotate(-5deg);
+      }
+      .polaroid .tape-br {
+        position: absolute;
+        bottom: -10px;
+        right: 28px;
+        width: 56px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.78);
+        transform: rotate(4deg);
+      }
+      .polaroid .kicker {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        margin-bottom: 6px;
+      }
+      .polaroid .title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 700;
+        font-size: 26px;
+        line-height: 1.15;
+        margin: 0 0 12px;
+        letter-spacing: -0.01em;
+      }
+      .polaroid .date {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 18px;
+        color: var(--color-ink);
+        margin: 0 0 4px;
+      }
+      .polaroid .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0 0 14px;
+      }
+
+      /* ============================================================
+         OPTION A — Identical rotation (-0.4deg every card)
+         All cards rotate the same way. Mechanical but stable.
+         ============================================================ */
+      .opt-a .polaroid {
+        transform: rotate(-0.4deg);
+      }
+
+      /* ============================================================
+         OPTION B — Alternating subtle rotations
+         -0.5° / +0.4° / -0.3° — handpinned variety.
+         ============================================================ */
+      .opt-b .polaroid:nth-child(odd) {
+        transform: rotate(-0.5deg);
+      }
+      .opt-b .polaroid:nth-child(even) {
+        transform: rotate(0.4deg);
+      }
+      .opt-b .polaroid:nth-of-type(3n) {
+        transform: rotate(-0.3deg);
+      }
+
+      /* ============================================================
+         OPTION C — Stronger alternating rotations + variable tape
+         -1.2° / +0.9° / -0.7°, tape colors and positions vary.
+         More "pinned-on-corkboard" feel.
+         ============================================================ */
+      .opt-c .polaroid:nth-child(odd) {
+        transform: rotate(-1.2deg);
+      }
+      .opt-c .polaroid:nth-child(even) {
+        transform: rotate(0.9deg);
+      }
+      .opt-c .polaroid:nth-of-type(3n) {
+        transform: rotate(-0.7deg);
+      }
+      .opt-c .polaroid:nth-child(even) .tape-tl {
+        left: auto;
+        right: 30px;
+        transform: rotate(6deg);
+        background: rgba(120, 200, 180, 0.7);
+      }
+      .opt-c .polaroid:nth-child(even) .tape-br {
+        right: auto;
+        left: 28px;
+        transform: rotate(-3deg);
+        background: rgba(120, 200, 180, 0.7);
+      }
+
+      /* ============================================================
+         OPTION D — First polaroid retained, subsequent flatten
+         Card 1 keeps full polaroid rotation + tape. Cards 2+ flatten
+         to the locked Round 1 D "two-line strip" treatment so the
+         body doesn't accumulate decoration.
+         ============================================================ */
+      .opt-d .polaroid:first-of-type {
+        transform: rotate(-0.4deg);
+      }
+      .opt-d .flat {
+        margin: 22px 0 26px;
+        padding: 14px 0 16px;
+        border-top: 1px dotted var(--color-ink-muted);
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .opt-d .flat-row {
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
+        flex-wrap: wrap;
+        margin-bottom: 4px;
+      }
+      .opt-d .flat-date {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        font-weight: 600;
+      }
+      .opt-d .flat-title {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 20px;
+        line-height: 1.2;
+        margin: 0;
+      }
+      .opt-d .flat-meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-top: 4px;
+        display: flex;
+        gap: 14px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-evt-inline · Round 2 · #1840</p>
+      <h1>
+        In-body eventFact — multi-card stacking (identical / subtle alt /
+        stronger alt / flatten-after-first)
+      </h1>
+      <p>
+        Locked Round 1 · <strong>C (Taped polaroid).</strong> Round 2
+        decides what happens when 3 consecutive eventFact polaroids stack
+        in a single article body — e.g. a tournament weekend with three
+        days each as its own eventFact, or an announcement listing three
+        kennismakingsmomenten back to back.
+      </p>
+      <p>
+        Same fixture across all four — three eventFacts: Steakfestijn (13
+        juni), Open trainingsmoment (20 juni), Paastornooi (4 juli). Each
+        renders with the locked Round 1 polaroid card; only the stacking
+        rule changes.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — IDENTICAL ROTATION ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Identical rotation</div>
+          <div class="name">Every polaroid rotates -0.4°</div>
+          <div class="desc">
+            Every card uses the same transform. Predictable, stable. Reads
+            as "three event cards" rather than "three pinned polaroids."
+            Cleanest CSS (single rule); weakest fanzine character.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ identical transform: rotate(-0.4deg)<br />
+            ✓ no per-card variation
+          </div>
+        </header>
+        <div class="surface opt-a">
+          <div class="prose">
+            <p>
+              Vóór de zomerstop staan er nog drie open momenten op de
+              agenda. Inschrijven kan al voor twee ervan.
+            </p>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Clubfeest</span>
+                <span class="mono-label">Open inschrijving</span>
+              </div>
+              <h3 class="title">Steakfestijn 2026</h3>
+              <p class="date">Vrijdag 13 juni · 18:00–22:00</p>
+              <p class="meta">Sportpark Elewijt · Max 180 plaatsen</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Training</span>
+                <span class="mono-label">U7 t/m U13</span>
+              </div>
+              <h3 class="title">Open trainingsmoment</h3>
+              <p class="date">Zaterdag 20 juni · 10:00–12:00</p>
+              <p class="meta">Trainingsveld 2 · Geen inschrijving nodig</p>
+            </article>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Tornooi</span>
+                <span class="mono-label">Alle jeugd</span>
+              </div>
+              <h3 class="title">Paastornooi 2026</h3>
+              <p class="date">Zaterdag 4 juli · 09:00–17:00</p>
+              <p class="meta">Hoofdterrein · Inschrijving via team-leader</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <p>
+              Meer momenten volgen in de loop van het seizoen — houd de
+              kalender in de gaten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — SUBTLE ALTERNATING ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Subtle alternating rotations</div>
+          <div class="name">-0.5° / +0.4° / -0.3° — gentle variety</div>
+          <div class="desc">
+            Subtle alternation: each card tilts a different small amount
+            in alternating directions. Same tape colors and positions
+            across all cards. Reads as "hand-pinned at slightly different
+            moments" without becoming a busy collage.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ nth-child(odd/even/3n) transform variants<br />
+            ✓ uniform tape style (ochre)<br />
+            ✓ range: -0.5° to +0.4°
+          </div>
+        </header>
+        <div class="surface opt-b">
+          <div class="prose">
+            <p>
+              Vóór de zomerstop staan er nog drie open momenten op de
+              agenda. Inschrijven kan al voor twee ervan.
+            </p>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Clubfeest</span>
+                <span class="mono-label">Open inschrijving</span>
+              </div>
+              <h3 class="title">Steakfestijn 2026</h3>
+              <p class="date">Vrijdag 13 juni · 18:00–22:00</p>
+              <p class="meta">Sportpark Elewijt · Max 180 plaatsen</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Training</span>
+                <span class="mono-label">U7 t/m U13</span>
+              </div>
+              <h3 class="title">Open trainingsmoment</h3>
+              <p class="date">Zaterdag 20 juni · 10:00–12:00</p>
+              <p class="meta">Trainingsveld 2 · Geen inschrijving nodig</p>
+            </article>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Tornooi</span>
+                <span class="mono-label">Alle jeugd</span>
+              </div>
+              <h3 class="title">Paastornooi 2026</h3>
+              <p class="date">Zaterdag 4 juli · 09:00–17:00</p>
+              <p class="meta">Hoofdterrein · Inschrijving via team-leader</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <p>
+              Meer momenten volgen in de loop van het seizoen — houd de
+              kalender in de gaten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — STRONGER ALTERNATING + TAPE VARIATION ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Stronger alt + tape variation</div>
+          <div class="name">-1.2° / +0.9° / -0.7° + tape colors/positions alternate</div>
+          <div class="desc">
+            Stronger rotations and per-card tape variation (ochre on odd,
+            mint on even; positions flipped). Reads as "pinned on a
+            corkboard." Strongest fanzine character; risks looking
+            decorative or messy when the body context is straight-laced.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ rotation: -1.2° to +0.9°<br />
+            ✓ alternating tape color (ochre + mint) — NEW<br />
+            ✓ tape position flips per card — NEW
+          </div>
+        </header>
+        <div class="surface opt-c">
+          <div class="prose">
+            <p>
+              Vóór de zomerstop staan er nog drie open momenten op de
+              agenda. Inschrijven kan al voor twee ervan.
+            </p>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Clubfeest</span>
+                <span class="mono-label">Open inschrijving</span>
+              </div>
+              <h3 class="title">Steakfestijn 2026</h3>
+              <p class="date">Vrijdag 13 juni · 18:00–22:00</p>
+              <p class="meta">Sportpark Elewijt · Max 180 plaatsen</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Training</span>
+                <span class="mono-label">U7 t/m U13</span>
+              </div>
+              <h3 class="title">Open trainingsmoment</h3>
+              <p class="date">Zaterdag 20 juni · 10:00–12:00</p>
+              <p class="meta">Trainingsveld 2 · Geen inschrijving nodig</p>
+            </article>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Tornooi</span>
+                <span class="mono-label">Alle jeugd</span>
+              </div>
+              <h3 class="title">Paastornooi 2026</h3>
+              <p class="date">Zaterdag 4 juli · 09:00–17:00</p>
+              <p class="meta">Hoofdterrein · Inschrijving via team-leader</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <p>
+              Meer momenten volgen in de loop van het seizoen — houd de
+              kalender in de gaten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — FIRST POLAROID, REST FLATTEN ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · First polaroid, rest flatten</div>
+          <div class="name">Card 1 = polaroid; card 2+ = flat two-line strip</div>
+          <div class="desc">
+            First eventFact in a run renders as the full polaroid (locked
+            Round 1 C). Subsequent consecutive eventFacts compress to a
+            flat two-line strip (italic title + mono caps date + meta
+            line, dotted rules above + below). The polaroid is "featured";
+            the rest are "list rows." Loses some unity but prevents
+            decoration accumulation.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ polaroid on first<br />
+            ✓ flat two-line strip on subsequent — NEW variant<br />
+            ✓ Phase 3-b dotted ink-muted dividers<br />
+            ⚠ introduces a second visual treatment for the same block
+          </div>
+        </header>
+        <div class="surface opt-d">
+          <div class="prose">
+            <p>
+              Vóór de zomerstop staan er nog drie open momenten op de
+              agenda. Inschrijven kan al voor twee ervan.
+            </p>
+            <article class="polaroid">
+              <span class="tape-tl" aria-hidden="true"></span>
+              <span class="tape-br" aria-hidden="true"></span>
+              <div class="kicker">
+                <span class="pill">Clubfeest</span>
+                <span class="mono-label">Open inschrijving</span>
+              </div>
+              <h3 class="title">Steakfestijn 2026</h3>
+              <p class="date">Vrijdag 13 juni · 18:00–22:00</p>
+              <p class="meta">Sportpark Elewijt · Max 180 plaatsen</p>
+              <a class="cta" href="#"
+                >Inschrijven <span aria-hidden="true">→</span></a
+              >
+            </article>
+            <div class="flat">
+              <div class="flat-row">
+                <span class="flat-date">Za 20 jun</span>
+                <span class="pill">Training</span>
+                <h3 class="flat-title">Open trainingsmoment</h3>
+              </div>
+              <div class="flat-meta">
+                <span>Trainingsveld 2</span>
+                <span>10:00–12:00</span>
+                <span>U7 t/m U13</span>
+              </div>
+            </div>
+            <div class="flat">
+              <div class="flat-row">
+                <span class="flat-date">Za 4 jul</span>
+                <span class="pill">Tornooi</span>
+                <h3 class="flat-title">Paastornooi 2026</h3>
+              </div>
+              <div class="flat-meta">
+                <span>Hoofdterrein</span>
+                <span>09:00–17:00</span>
+                <span>Alle jeugd</span>
+              </div>
+              <div style="margin-top: 10px">
+                <a class="cta" href="#"
+                  >Inschrijven <span aria-hidden="true">→</span></a
+                >
+              </div>
+            </div>
+            <p>
+              Meer momenten volgen in de loop van het seizoen — houd de
+              kalender in de gaten.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Trade-offs</strong>
+      <ul>
+        <li>
+          <strong>A · Identical</strong> — simplest, most predictable.
+          Polaroid rhythm fades on repeat; reads as "the design language
+          stalled".
+        </li>
+        <li>
+          <strong>B · Subtle alt</strong> — gentle variety. Each card
+          feels hand-pinned without becoming busy. CSS-only
+          (<code>nth-child</code>). Recommended path of least new
+          vocabulary.
+        </li>
+        <li>
+          <strong>C · Stronger alt + tape variation</strong> — boldest
+          fanzine register. Adds a second tape color (mint) to the
+          vocabulary — used nowhere else yet. Could overpower body
+          context.
+        </li>
+        <li>
+          <strong>D · First polaroid, rest flatten</strong> — explicit
+          "featured + list" hierarchy. Solves decoration accumulation
+          cleanly, but introduces a second visual variant for the same
+          schema block (more code, more tests).
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Reset rule</strong>
+      <ul>
+        <li>
+          For Options A / B / C: rotation pattern resets every time a
+          non-eventFact block (paragraph, image, qaBlock) sits between
+          two eventFacts — the CSS sibling-selector approach
+          (<code>nth-of-type</code>) handles this naturally inside one
+          PortableText render.
+        </li>
+        <li>
+          For Option D: the "first polaroid" rule resets after any
+          non-eventFact block too. A flat two-line eventFact only
+          renders when it immediately follows another eventFact in the
+          PT array.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-2-multi-card-behavior-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-2-multi-card-behavior-comparisons.html
@@ -66,6 +66,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);
@@ -684,14 +690,25 @@
           schema block (more code, more tests).
         </li>
       </ul>
-      <strong style="display: block; margin-top: 12px">Reset rule</strong>
+      <strong style="display: block; margin-top: 12px">Counter behaviour</strong>
       <ul>
         <li>
-          For Options A / B / C: rotation pattern resets every time a
-          non-eventFact block (paragraph, image, qaBlock) sits between
-          two eventFacts — the CSS sibling-selector approach
-          (<code>nth-of-type</code>) handles this naturally inside one
-          PortableText render.
+          For Options A / B / C: <code>:nth-of-type()</code> counts
+          sibling elements of the same tag, not the same class, and
+          does <strong>not</strong> reset across intervening
+          non-matching siblings. With the locked CSS, three eventFact
+          polaroids separated by <code>&lt;p&gt;</code> paragraphs are
+          still numbered 1 · 2 · 3 globally — they render -0.5° / +0.4°
+          / -0.3°. That's the desired visual: varied rotations across
+          the whole article.
+        </li>
+        <li>
+          If a future design needs a true per-run reset, the renderer
+          must (a) wrap each contiguous eventFact run in a dedicated
+          container, (b) pass a run-scoped index prop and set
+          <code>transform</code> directly from JS, or (c) restructure
+          the PT serializer to group consecutive eventFacts (same
+          pattern as the rapid-fire qaBlock collapse).
         </li>
         <li>
           For Option D: the "first polaroid" rule resets after any

--- a/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-2-multi-card-behavior-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-2-multi-card-behavior-comparisons.html
@@ -238,10 +238,10 @@
          OPTION B — Alternating subtle rotations
          -0.5° / +0.4° / -0.3° — handpinned variety.
          ============================================================ */
-      .opt-b .polaroid:nth-child(odd) {
+      .opt-b .polaroid:nth-of-type(odd) {
         transform: rotate(-0.5deg);
       }
-      .opt-b .polaroid:nth-child(even) {
+      .opt-b .polaroid:nth-of-type(even) {
         transform: rotate(0.4deg);
       }
       .opt-b .polaroid:nth-of-type(3n) {
@@ -253,22 +253,22 @@
          -1.2° / +0.9° / -0.7°, tape colors and positions vary.
          More "pinned-on-corkboard" feel.
          ============================================================ */
-      .opt-c .polaroid:nth-child(odd) {
+      .opt-c .polaroid:nth-of-type(odd) {
         transform: rotate(-1.2deg);
       }
-      .opt-c .polaroid:nth-child(even) {
+      .opt-c .polaroid:nth-of-type(even) {
         transform: rotate(0.9deg);
       }
       .opt-c .polaroid:nth-of-type(3n) {
         transform: rotate(-0.7deg);
       }
-      .opt-c .polaroid:nth-child(even) .tape-tl {
+      .opt-c .polaroid:nth-of-type(even) .tape-tl {
         left: auto;
         right: 30px;
         transform: rotate(6deg);
         background: rgba(120, 200, 180, 0.7);
       }
-      .opt-c .polaroid:nth-child(even) .tape-br {
+      .opt-c .polaroid:nth-of-type(even) .tape-br {
         right: auto;
         left: 28px;
         transform: rotate(-3deg);
@@ -449,7 +449,7 @@
           </div>
           <div class="vocab">
             <strong>Vocabulary</strong>
-            ✓ nth-child(odd/even/3n) transform variants<br />
+            ✓ nth-of-type(odd/even/3n) transform variants<br />
             ✓ uniform tape style (ochre)<br />
             ✓ range: -0.5° to +0.4°
           </div>
@@ -668,7 +668,7 @@
         <li>
           <strong>B · Subtle alt</strong> — gentle variety. Each card
           feels hand-pinned without becoming busy. CSS-only
-          (<code>nth-child</code>). Recommended path of least new
+          (<code>nth-of-type</code>). Recommended path of least new
           vocabulary.
         </li>
         <li>

--- a/docs/design/mockups/phase-5-article-detail/5d-file/round-1-fileattachment-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-file/round-1-fileattachment-comparisons.html
@@ -1,0 +1,677 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-file · Round 1 · fileAttachment</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --color-pdf: #c0392b;
+        --color-word: #2563b3;
+        --color-excel: #15803d;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 38px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      /* ============================================================
+         OPTION A — Cream-soft restyle of legacy card layout
+         ============================================================ */
+      .opt-a {
+        display: flex;
+        align-items: stretch;
+        gap: 0;
+        background: var(--color-cream-soft);
+        border: 1px solid var(--color-ink);
+        box-shadow: 4px 4px 0 0 var(--color-ink);
+        margin: 22px 0;
+        text-decoration: none;
+        color: inherit;
+      }
+      .opt-a .accent {
+        width: 6px;
+        background: var(--color-pdf);
+        align-self: stretch;
+      }
+      .opt-a .icon {
+        display: flex;
+        align-items: center;
+        padding: 16px 14px 16px 18px;
+      }
+      .opt-a .icon svg {
+        width: 28px;
+        height: 28px;
+        color: var(--color-pdf);
+      }
+      .opt-a .body {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding: 14px 14px 14px 0;
+        flex: 1;
+        min-width: 0;
+      }
+      .opt-a .body .label {
+        font-family: ui-serif, Georgia, serif;
+        font-weight: 700;
+        font-size: 16px;
+        line-height: 1.3;
+        color: var(--color-ink);
+      }
+      .opt-a .body .sub {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-top: 4px;
+      }
+      .opt-a .meta {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 0 18px 0 8px;
+      }
+      .opt-a .size {
+        background: var(--color-cream);
+        border: 1px solid var(--color-ink-muted);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        color: var(--color-ink-muted);
+      }
+      .opt-a .download {
+        color: var(--color-ink);
+      }
+      .opt-a .download svg {
+        width: 20px;
+        height: 20px;
+      }
+
+      /* ============================================================
+         OPTION B — TapedCard "document" with corner stamp
+         ============================================================ */
+      .opt-b {
+        position: relative;
+        display: grid;
+        grid-template-columns: 88px 1fr auto;
+        gap: 0;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+        margin: 28px 0;
+        text-decoration: none;
+        color: inherit;
+        padding: 14px 16px 14px 0;
+      }
+      .opt-b .tape {
+        position: absolute;
+        top: -8px;
+        left: 38%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+      }
+      .opt-b .stamp {
+        align-self: center;
+        margin-left: 16px;
+        width: 64px;
+        height: 64px;
+        border: 2px solid var(--color-pdf);
+        border-radius: 4px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-pdf);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        transform: rotate(-3deg);
+        background: rgba(192, 57, 43, 0.06);
+      }
+      .opt-b .stamp .ext {
+        font-size: 16px;
+        font-weight: 800;
+        letter-spacing: 0.1em;
+      }
+      .opt-b .stamp .label {
+        font-size: 8px;
+        margin-top: 2px;
+      }
+      .opt-b .body {
+        align-self: center;
+        padding: 0 16px;
+        min-width: 0;
+      }
+      .opt-b .body .label {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 1.25;
+        color: var(--color-ink);
+      }
+      .opt-b .body .sub {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin-top: 4px;
+      }
+      .opt-b .cta {
+        align-self: center;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 36px;
+        padding: 0 14px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 600;
+        border: 1px solid var(--color-ink);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+        text-decoration: none;
+        margin-right: 0;
+      }
+      .opt-b .cta svg {
+        width: 14px;
+        height: 14px;
+      }
+
+      /* ============================================================
+         OPTION C — Inline-only (mono caps pill, no card)
+         ============================================================ */
+      .opt-c-block {
+        margin: 22px 0;
+      }
+      .opt-c {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        height: 40px;
+        padding: 0 16px 0 12px;
+        background: var(--color-cream);
+        border: 1px solid var(--color-ink);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        color: var(--color-ink);
+        text-decoration: none;
+      }
+      .opt-c .ext-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 22px;
+        padding: 0 7px;
+        background: var(--color-pdf);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+      .opt-c .size {
+        color: var(--color-ink-muted);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.1em;
+      }
+      .opt-c svg {
+        width: 14px;
+        height: 14px;
+        color: var(--color-ink-muted);
+      }
+
+      /* ============================================================
+         OPTION D — Receipt-strip (mono caps perforated card)
+         ============================================================ */
+      .opt-d {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 0;
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: 4px 4px 0 0 var(--color-ink);
+        margin: 22px 0;
+        text-decoration: none;
+        color: inherit;
+      }
+      .opt-d::before {
+        content: '';
+        position: absolute;
+      }
+      .opt-d .body {
+        padding: 12px 16px;
+        border-right: 1px dashed var(--color-ink);
+        min-width: 0;
+      }
+      .opt-d .body .header {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        margin-bottom: 4px;
+      }
+      .opt-d .body .ext {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-pdf);
+        font-weight: 700;
+      }
+      .opt-d .body .size {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .opt-d .body .label {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 17px;
+        font-weight: 600;
+        color: var(--color-ink);
+        margin: 0;
+      }
+      .opt-d .cta {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 18px;
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+      }
+      .opt-d .cta svg {
+        width: 22px;
+        height: 22px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul { margin: 8px 0 0; padding-left: 20px; }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-file · Round 1 · #1840</p>
+      <h1>
+        fileAttachment — cream-surface restyle (legacy / taped-document /
+        inline pill / receipt-strip)
+      </h1>
+      <p>
+        Drill 5.1. The legacy <code>&lt;DownloadButton&gt;</code> uses
+        white-on-gray with file-type colored accent bars and a hover
+        scale — visually disconnected from the cream surface. This round
+        decides the Phase 5 treatment.
+      </p>
+      <p>
+        Each option renders the same fixture: a PDF named "Trainingsschema
+        seizoen 2025-2026" (1.4 MB), wrapped in body prose. File-type
+        colour (PDF red) is preserved across options that keep type
+        indication; one option drops the file-type colour entirely.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — CREAM-SOFT LEGACY CARD ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Cream-soft legacy card</div>
+          <div class="name">Same layout, swapped to cream-soft + ink border</div>
+          <div class="desc">
+            Minimal change. The existing <code>&lt;DownloadButton&gt;</code>
+            card layout stays — accent bar left, icon, label + subtitle,
+            file size badge, download glyph right — but colours move to
+            the Phase 5 palette: cream-soft background, 1px ink border,
+            offset shadow. File-type accent bar keeps its colour (PDF
+            red, Word blue, Excel green, etc.) for quick type wayfinding.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ existing DownloadButton layout<br />
+            ✓ cream-soft bg + ink border + offset shadow<br />
+            ✓ file-type colour accent bar (preserved)<br />
+            ✓ press-down hover (canonical)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De trainingsindeling voor het komende seizoen ligt vast. Je
+              vindt het volledige overzicht in de bijlage hieronder.
+            </p>
+            <a class="opt-a" href="#">
+              <span class="accent" aria-hidden="true"></span>
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" stroke="currentColor" stroke-width="1.5" fill="none" />
+                  <path d="M14 2v6h6" stroke="currentColor" stroke-width="1.5" fill="none" />
+                </svg>
+              </span>
+              <span class="body">
+                <span class="label">Trainingsschema seizoen 2025–2026</span>
+                <span class="sub">PDF · 1,4 MB</span>
+              </span>
+              <span class="meta">
+                <span class="download">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                    <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" />
+                  </svg>
+                </span>
+              </span>
+            </a>
+            <p>
+              Lees vooral de toelichting bij de wijzigingen rond de
+              U13/U15 voorbereiding.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — TAPED DOCUMENT WITH CORNER STAMP ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Taped document with corner stamp</div>
+          <div class="name">TapedCard with tape strip + faux paper stamp + jersey-deep CTA</div>
+          <div class="desc">
+            Strongest fanzine character. Cream-white card with a single
+            ochre tape strip top, a stenciled-stamp "PDF" extension mark
+            on the left (jersey-stamp / ink stamp style, slight rotation),
+            italic display label in the center, and a jersey-deep CTA
+            pill on the right. Reads as "a paper document clipped to the
+            article."
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedCard family + ochre tape<br />
+            ✓ stenciled stamp glyph — NEW ornament (extension only)<br />
+            ✓ jersey-deep CTA pill (matches video play affordance)<br />
+            ⚠ stamp adds new ink vocabulary not used elsewhere
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De trainingsindeling voor het komende seizoen ligt vast. Je
+              vindt het volledige overzicht in de bijlage hieronder.
+            </p>
+            <a class="opt-b" href="#">
+              <span class="tape" aria-hidden="true"></span>
+              <span class="stamp" aria-hidden="true">
+                <span class="ext">PDF</span>
+                <span class="label">Bestand</span>
+              </span>
+              <span class="body">
+                <span class="label">Trainingsschema seizoen 2025–2026</span>
+                <span class="sub">1,4 MB · Bijgewerkt 12 mei</span>
+              </span>
+              <span class="cta">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" />
+                </svg>
+                Download
+              </span>
+            </a>
+            <p>
+              Lees vooral de toelichting bij de wijzigingen rond de
+              U13/U15 voorbereiding.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — INLINE-ONLY PILL ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Inline pill (no card)</div>
+          <div class="name">Compact extension pill + italic label, one row</div>
+          <div class="desc">
+            Lightest visual weight. A small jersey-deep / PDF-red type
+            pill ("PDF") on the left, italic serif label, mono caps file
+            size, ink border + offset shadow. Reads as a clickable
+            chip in the body — closest to a CTA. Loses the
+            "structural card" framing of A and B.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ Cream bg + ink border + offset shadow (CTA family)<br />
+            ✓ file-type pill (PDF red, etc.)<br />
+            ✓ italic serif label<br />
+            ✗ no per-file subtitle / description slot
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De trainingsindeling voor het komende seizoen ligt vast. Je
+              vindt het volledige overzicht in de bijlage hieronder.
+            </p>
+            <div class="opt-c-block">
+              <a class="opt-c" href="#">
+                <span class="ext-pill">PDF</span>
+                <span>Trainingsschema seizoen 2025–2026</span>
+                <span class="size">1,4 MB</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                  <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" />
+                </svg>
+              </a>
+            </div>
+            <p>
+              Lees vooral de toelichting bij de wijzigingen rond de
+              U13/U15 voorbereiding.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — RECEIPT-STRIP ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Receipt-strip (perforated card)</div>
+          <div class="name">Two-cell card: body + tear-off download cell</div>
+          <div class="desc">
+            Receipt / ticket-stub register. Two cells separated by a
+            dashed perforation: body cell (mono caps extension + size on
+            top, italic display label below) on the left; download cell
+            (cream-soft bg, ink download glyph) on the right.
+            File-type colour limited to the extension text. Quieter than
+            B; carries less "stamp" decoration.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TicketStub family (dashed perforation)<br />
+            ✓ mono caps + italic display split<br />
+            ✓ no decorative tape / stamp<br />
+            ✓ matches eventFact ticket-stub vocabulary (drill 2.1 R1 B was rejected, but the stub primitive still exists)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De trainingsindeling voor het komende seizoen ligt vast. Je
+              vindt het volledige overzicht in de bijlage hieronder.
+            </p>
+            <a class="opt-d" href="#">
+              <span class="body">
+                <span class="header">
+                  <span class="ext">PDF</span>
+                  <span class="size">1,4 MB</span>
+                </span>
+                <p class="label">Trainingsschema seizoen 2025–2026</p>
+              </span>
+              <span class="cta">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
+                  <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" />
+                </svg>
+              </span>
+            </a>
+            <p>
+              Lees vooral de toelichting bij de wijzigingen rond de
+              U13/U15 voorbereiding.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Variant question</strong>
+      <ul>
+        <li>
+          The legacy <code>&lt;DownloadButton&gt;</code> exposes a
+          <code>variant: "card" | "inline"</code> prop. Options A, B, D
+          are "card" variants; C is the "inline" variant. We could
+          keep both (pick one card option + Option C as the inline
+          variant), or drop the inline variant and use only one card
+          style.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Reuse signal</strong>
+      <ul>
+        <li>
+          <strong>A</strong> = least new vocabulary; lowest brand
+          character. <strong>B</strong> = strongest brand; adds a
+          stencil-stamp vocabulary not used elsewhere.
+          <strong>C</strong> = lightest; great as the inline variant.
+          <strong>D</strong> = reuses ticket-stub vocabulary from the
+          design system.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-file/round-1-fileattachment-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-file/round-1-fileattachment-comparisons.html
@@ -64,6 +64,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-img/round-1-figure-register-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-img/round-1-figure-register-comparisons.html
@@ -1,0 +1,485 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-img · Round 1 · Figure register</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey: #2d7a4f;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      /* Photo placeholder — a 3:2 cream-soft block with a faux newsprint
+         tint. Stands in for a real Next.js <Image> so the comparison
+         stays portable. */
+      .photo {
+        width: 100%;
+        aspect-ratio: 3 / 2;
+        background:
+          linear-gradient(
+            135deg,
+            rgba(80, 60, 40, 0.45) 0%,
+            rgba(180, 150, 100, 0.55) 35%,
+            rgba(120, 100, 70, 0.5) 65%,
+            rgba(60, 50, 35, 0.45) 100%
+          ),
+          repeating-linear-gradient(
+            45deg,
+            rgba(0, 0, 0, 0.05) 0px,
+            rgba(0, 0, 0, 0.05) 1px,
+            transparent 1px,
+            transparent 4px
+          );
+        filter: sepia(0.2) contrast(1.05);
+      }
+
+      /* ============================================================
+         OPTION A — TapedFigure with rotation + tape
+         Single ochre tape strip top-left, sub-1° rotation. Same
+         vocabulary as the eventFact polaroid (locked drill 2.1).
+         ============================================================ */
+      .opt-a-figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 25%, transparent);
+        padding: 10px;
+        margin: 30px 0 28px;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.6);
+        transform: rotate(-0.5deg);
+      }
+      .opt-a-figure .tape {
+        position: absolute;
+        top: -10px;
+        left: 36px;
+        width: 84px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.78);
+        transform: rotate(-4deg);
+      }
+
+      /* ============================================================
+         OPTION B — TapedFigure, no rotation, single tape strip
+         Squared up; same tape strip as A; lighter "pinned" feel.
+         ============================================================ */
+      .opt-b-figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 28px 0 26px;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+      .opt-b-figure .tape {
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+      }
+
+      /* ============================================================
+         OPTION C — TapedFigure, no rotation, no tape
+         Cream-soft frame, 1px ink border, no tape. "Clean editorial
+         figure" register.
+         ============================================================ */
+      .opt-c-figure {
+        background: var(--color-cream-soft);
+        border: 1px solid var(--color-ink);
+        padding: 10px;
+        margin: 24px 0;
+        box-shadow: 4px 4px 0 0 var(--color-ink);
+      }
+
+      /* ============================================================
+         OPTION D — Plain figure
+         No card chrome, just the photo + hairline below. Tightest
+         integration with body prose; reads as a flat in-line illustration.
+         ============================================================ */
+      .opt-d-figure {
+        margin: 22px 0 28px;
+        border-bottom: 1px solid var(--color-ink-muted);
+        padding-bottom: 10px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-img · Round 1 · #1840</p>
+      <h1>
+        articleImage — figure register (rotated polaroid / flat taped /
+        clean cream / plain)
+      </h1>
+      <p>
+        Drill 3.1 sub-round 1. Locks the visual treatment of a regular
+        in-body articleImage on the cream surface. Caption + credit
+        rendering, full-bleed flag, and aspect-ratio default are drilled
+        in subsequent rounds — all four options below render
+        caption-less.
+      </p>
+      <p>
+        Same fixture: a single landscape 3:2 photo placeholder wrapped in
+        body prose paragraphs. <code>&lt;TapedFigure&gt;</code> is the
+        existing design-system primitive (already used by NewsCard,
+        EditorialHero, FeaturedEventBand) — three of the four candidates
+        use it with different props.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — POLAROID (rotated + tape) ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Polaroid (rotated + tape)</div>
+          <div class="name">TapedFigure with rotation + single tape strip</div>
+          <div class="desc">
+            Direct sibling of the locked eventFact inline polaroid: sub-1°
+            rotation, single ochre tape strip top-left, cream-white frame
+            with subtle shadow. Strongest fanzine character; reads as
+            "snapshot pinned into the article."
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedFigure (rotation + tape)<br />
+            ✓ ochre tape (matches eventFact polaroid)<br />
+            ✓ same family as eventFact inline card
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen. Trainer
+              Vermeulen kwam dit jaar terug uit Diest om opnieuw bij de
+              U13 te staan.
+            </p>
+            <figure class="opt-a-figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img" aria-label="U13 training" ></div>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma. Aftrap om 14:00 op terrein 2; toegang gratis.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — FLAT TAPED FIGURE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Flat taped figure</div>
+          <div class="name">TapedFigure, no rotation, single tape strip top-center</div>
+          <div class="desc">
+            Squared up — no rotation. One small ochre tape strip
+            centered on the top edge. Reads as "stuck flat into the
+            article" rather than "pinned at an angle." Quieter than A
+            but still in the taped family.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedFigure (no rotation, tape)<br />
+            ✓ ochre tape<br />
+            ✓ same TapedFigure primitive as NewsCard / hero<br />
+            ✓ no per-figure rotation overhead
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen. Trainer
+              Vermeulen kwam dit jaar terug uit Diest om opnieuw bij de
+              U13 te staan.
+            </p>
+            <figure class="opt-b-figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img" aria-label="U13 training"></div>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma. Aftrap om 14:00 op terrein 2; toegang gratis.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — CLEAN CREAM FRAME ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Clean cream frame</div>
+          <div class="name">TapedFigure with no rotation, no tape</div>
+          <div class="desc">
+            The TapedFigure primitive stripped of its decorative props:
+            cream-soft frame with 1px ink border and offset shadow, no
+            tape, no rotation. "Editorial figure" register — reads as a
+            properly framed photograph in a long-form piece.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedFigure (no rotation, no tape)<br />
+            ✓ cream-soft bg (matches MissionBanner / ArticleCredits frame)<br />
+            ✓ 1px ink border + offset shadow<br />
+            ✗ no decorative tape
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen. Trainer
+              Vermeulen kwam dit jaar terug uit Diest om opnieuw bij de
+              U13 te staan.
+            </p>
+            <figure class="opt-c-figure">
+              <div class="photo" role="img" aria-label="U13 training"></div>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma. Aftrap om 14:00 op terrein 2; toegang gratis.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — PLAIN FIGURE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Plain figure</div>
+          <div class="name">No card chrome — photo on cream + ink hairline below</div>
+          <div class="desc">
+            Tightest body integration. The photo sits flat on cream with
+            a single 1px ink-muted hairline below it (where the caption
+            would attach). Reads as inline content rather than a
+            distinct card. Most newspaper-print register; weakest sense
+            of "this is a photograph."
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✗ no TapedFigure (no card, no tape, no frame)<br />
+            ✓ 1px ink-muted hairline below photo<br />
+            ⚠ doesn't reuse the design-system figure primitive
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen. Trainer
+              Vermeulen kwam dit jaar terug uit Diest om opnieuw bij de
+              U13 te staan.
+            </p>
+            <figure class="opt-d-figure">
+              <div class="photo" role="img" aria-label="U13 training"></div>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma. Aftrap om 14:00 op terrein 2; toegang gratis.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Existing TapedFigure usage</strong>
+      <ul>
+        <li>
+          NewsCard photos use TapedFigure with rotation + tape (fanzine
+          register for index surfaces).
+        </li>
+        <li>
+          EditorialHero photos use TapedFigure with rotation + tape (hero
+          register for article tops).
+        </li>
+        <li>
+          FeaturedEventBand poster uses TapedFigure with rotation + tape.
+        </li>
+        <li>
+          So: TapedFigure with rotation + tape is the "default" decorative
+          mode across the redesign. The question for in-body articleImage
+          is whether to continue that or pull back inside the prose flow.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Trade-offs</strong>
+      <ul>
+        <li>
+          <strong>A</strong> matches the redesign's strongest fanzine
+          register and signals "this is a featured photo" — but every
+          articleImage in the body would carry the same decorative
+          weight, which can become busy in image-heavy articles.
+        </li>
+        <li>
+          <strong>B</strong> keeps the family tie to A (same tape,
+          TapedFigure primitive) but flattens the rotation — quieter on
+          repeat, still distinctly KCVV.
+        </li>
+        <li>
+          <strong>C</strong> reuses the TapedFigure primitive without its
+          decorative props — editorial-figure register, plays well with
+          long-form prose, but loses the family signal.
+        </li>
+        <li>
+          <strong>D</strong> breaks from TapedFigure entirely — would
+          need fresh CSS and tests. Cheapest visually but weakens the
+          design-system narrative.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px"
+        >Out of scope for this round</strong
+      >
+      <ul>
+        <li>
+          Caption + credit fields (drilled at Round 2; requires schema
+          migration).
+        </li>
+        <li>
+          Full-bleed flag retention (drilled at Round 3).
+        </li>
+        <li>
+          Default aspect ratio + crop behaviour (drilled at Round 4).
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-img/round-1-figure-register-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-img/round-1-figure-register-comparisons.html
@@ -67,6 +67,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-img/round-2-caption-credit-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-img/round-2-caption-credit-comparisons.html
@@ -1,0 +1,581 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-img · Round 2 · Caption + credit</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey: #2d7a4f;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      .photo {
+        width: 100%;
+        aspect-ratio: 3 / 2;
+        background:
+          linear-gradient(
+            135deg,
+            rgba(80, 60, 40, 0.45) 0%,
+            rgba(180, 150, 100, 0.55) 35%,
+            rgba(120, 100, 70, 0.5) 65%,
+            rgba(60, 50, 35, 0.45) 100%
+          ),
+          repeating-linear-gradient(
+            45deg,
+            rgba(0, 0, 0, 0.05) 0px,
+            rgba(0, 0, 0, 0.05) 1px,
+            transparent 1px,
+            transparent 4px
+          );
+        filter: sepia(0.2) contrast(1.05);
+      }
+
+      /* Locked Round 1 B — flat TapedFigure, no rotation, single tape. */
+      .figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 28px 0;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+      .figure .tape {
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+      }
+
+      /* ============================================================
+         OPTION A — caption + credit (TapedFigure's existing API)
+         Single figcaption row: caption (italic serif body-sm, left) +
+         credit (mono caps ink-muted, right). Matches the existing
+         design-system primitive 1:1.
+         ============================================================ */
+      .opt-a-cap {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 8px 4px 0;
+      }
+      .opt-a-cap .caption {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+        flex: 1 1 60%;
+      }
+      .opt-a-cap .credit {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        white-space: nowrap;
+      }
+
+      /* ============================================================
+         OPTION B — caption only (no credit)
+         Single field, italic serif below the figure.
+         ============================================================ */
+      .opt-b-cap {
+        padding: 8px 4px 0;
+      }
+      .opt-b-cap .caption {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+      }
+
+      /* ============================================================
+         OPTION C — caption as PortableText + credit string
+         Caption supports inline links + accent decorator (jersey-deep
+         italic emphasis). Same render slot as A.
+         ============================================================ */
+      .opt-c-cap {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 8px 4px 0;
+      }
+      .opt-c-cap .caption {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+        flex: 1 1 60%;
+      }
+      .opt-c-cap .caption a {
+        color: var(--color-ink);
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+      }
+      .opt-c-cap .caption .accent {
+        color: var(--color-jersey-deep);
+        font-style: italic;
+        font-weight: 600;
+      }
+      .opt-c-cap .credit {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        white-space: nowrap;
+      }
+
+      /* ============================================================
+         OPTION D — no schema change; caption inline as paragraph
+         Author writes a paragraph after the image. Rendered as a
+         smaller-weight body paragraph with no special framing.
+         ============================================================ */
+      .opt-d-cap {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.5;
+        color: var(--color-ink-soft);
+        margin: 8px 0 24px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+      .footnote table {
+        border-collapse: collapse;
+        margin-top: 10px;
+        font-size: 12px;
+      }
+      .footnote th,
+      .footnote td {
+        border: 1px solid var(--color-ink-muted);
+        padding: 5px 9px;
+        text-align: left;
+      }
+      .footnote th {
+        background: rgba(0, 0, 0, 0.05);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-img · Round 2 · #1840</p>
+      <h1>
+        articleImage — caption + credit (full / caption-only / PT-caption /
+        none)
+      </h1>
+      <p>
+        Drill 3.1 sub-round 2. Locks whether captions and credits become
+        first-class schema fields, and how they render below the flat
+        TapedFigure from Round 1.
+      </p>
+      <p>
+        Current schema (<code>packages/sanity-schemas/src/articleImage.ts</code>)
+        has only <code>image</code> + <code>alt</code> + <code>fullBleed</code>.
+        TapedFigure supports <code>caption?: string</code> + <code>credit?: string</code> —
+        used today by NewsCard / EditorialHero / FeaturedEventBand. Three
+        of the four options below propose a schema migration to wire the
+        primitive's existing props.
+      </p>
+      <p>
+        Each option renders the same fixture: photo + a caption ("Trainer
+        Vermeulen geeft de U13 instructies vóór de eerste set partijen.")
+        + a credit ("Foto: An Verheyden") embedded in body prose.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — CAPTION + CREDIT (existing primitive) ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · caption + credit (string + string)</div>
+          <div class="name">Matches TapedFigure's existing API 1:1</div>
+          <div class="desc">
+            Adds two optional string fields to <code>articleImage</code>:
+            <code>caption</code> and <code>credit</code>. Renders inside
+            TapedFigure's existing <code>&lt;figcaption&gt;</code> — caption
+            italic serif body-sm on the left, credit mono caps ink-muted
+            on the right. Each row drops independently when its field is
+            blank.
+          </div>
+          <div class="vocab">
+            <strong>Schema migration</strong>
+            ✓ add <code>caption: string</code> (optional)<br />
+            ✓ add <code>credit: string</code> (optional)<br />
+            ✓ TapedFigure's existing figcaption API
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img" aria-label="U13 training"></div>
+              <figcaption class="opt-a-cap">
+                <p class="caption">
+                  Trainer Vermeulen geeft de U13 instructies vóór de
+                  eerste set partijen.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — CAPTION ONLY ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · caption only (string)</div>
+          <div class="name">One field, italic serif below the figure</div>
+          <div class="desc">
+            Adds only <code>caption: string</code> (optional). No credit
+            field at the schema level — image credit can be folded into
+            the caption text if the author wants to attribute. Simplest
+            migration; weakest provenance signal.
+          </div>
+          <div class="vocab">
+            <strong>Schema migration</strong>
+            ✓ add <code>caption: string</code> (optional)<br />
+            ✗ no <code>credit</code> field<br />
+            ⚠ credit must be appended manually inside caption text
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img" aria-label="U13 training"></div>
+              <figcaption class="opt-b-cap">
+                <p class="caption">
+                  Trainer Vermeulen geeft de U13 instructies vóór de
+                  eerste set partijen.
+                </p>
+              </figcaption>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — PT caption + string credit ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · PortableText caption + credit string</div>
+          <div class="name">Captions can carry inline links + accent decorator</div>
+          <div class="desc">
+            <code>caption</code> is a constrained Portable Text array
+            (paragraph block + <code>link</code> + <code>accent</code>
+            decorator). <code>credit</code> stays a plain string. Supports
+            captions like "Lars <em>Janssens</em>, <a>portretreeks</a>",
+            but requires TapedFigure to accept a PT renderer for caption
+            (small primitive change).
+          </div>
+          <div class="vocab">
+            <strong>Schema migration</strong>
+            ✓ add <code>caption: PortableText[]</code> (constrained marks)<br />
+            ✓ add <code>credit: string</code> (optional)<br />
+            ⚠ TapedFigure caption slot needs PT support (small refactor)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img" aria-label="U13 training"></div>
+              <figcaption class="opt-c-cap">
+                <p class="caption">
+                  Trainer Vermeulen geeft de U13 instructies vóór
+                  <span class="accent">de eerste set partijen</span> —
+                  <a href="#">portretreeks jeugd</a>.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — NO SCHEMA CHANGE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · No schema change (caption stays inline)</div>
+          <div class="name">Author writes a paragraph after the figure</div>
+          <div class="desc">
+            Schema stays as it is. Captions live as regular paragraph PT
+            blocks after the image. The renderer detects the pattern
+            (image followed by italic paragraph?) and styles the
+            paragraph as a caption — OR the author manually flags
+            "italic" on the paragraph. Most editor-flexible; weakest
+            structural binding.
+          </div>
+          <div class="vocab">
+            <strong>Schema migration</strong>
+            ✗ no schema change<br />
+            ⚠ caption is a separate PT block, not structurally bound<br />
+            ⚠ editor must remember to italic-mark + style as caption
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img" aria-label="U13 training"></div>
+            </figure>
+            <p class="opt-d-cap">
+              <em
+                >Trainer Vermeulen geeft de U13 instructies vóór de eerste
+                set partijen. Foto: An Verheyden.</em
+              >
+            </p>
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Schema migration burden</strong>
+      <ul>
+        <li>
+          Per <code>feedback_sanity_migrations</code>: A / B / C all
+          require a Sanity migration (staging + production). D is the
+          only option with zero schema impact.
+        </li>
+      </ul>
+
+      <strong style="display: block; margin-top: 12px">
+        Editor experience
+      </strong>
+      <table>
+        <tr>
+          <th>Option</th>
+          <th>Studio fields</th>
+          <th>Author burden</th>
+          <th>Rich text</th>
+        </tr>
+        <tr>
+          <td>A</td>
+          <td>caption + credit</td>
+          <td>two text boxes</td>
+          <td>plain strings only</td>
+        </tr>
+        <tr>
+          <td>B</td>
+          <td>caption only</td>
+          <td>one text box</td>
+          <td>plain string only</td>
+        </tr>
+        <tr>
+          <td>C</td>
+          <td>caption (PT) + credit</td>
+          <td>PT editor + text box</td>
+          <td>links + accent decorator</td>
+        </tr>
+        <tr>
+          <td>D</td>
+          <td>none</td>
+          <td>add paragraph, italic-mark it</td>
+          <td>full PT</td>
+        </tr>
+      </table>
+
+      <strong style="display: block; margin-top: 12px">
+        Existing photographer credit on article
+      </strong>
+      <ul>
+        <li>
+          Articles already have an <code>article.photographer</code> field
+          (locked in drill 5.d-int Round 2 — feeds <code>ArticleCredits</code> "Beeld" row).
+          That's an article-wide credit; per-figure credit overrides it
+          only when the figure has a different photographer.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-img/round-2-caption-credit-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-img/round-2-caption-credit-comparisons.html
@@ -67,6 +67,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-img/round-3-fullbleed-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-img/round-3-fullbleed-comparisons.html
@@ -1,0 +1,569 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-img · Round 3 · fullBleed flag</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+        --container-wide: 1040px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      .photo {
+        width: 100%;
+        aspect-ratio: 3 / 2;
+        background:
+          linear-gradient(
+            135deg,
+            rgba(80, 60, 40, 0.45) 0%,
+            rgba(180, 150, 100, 0.55) 35%,
+            rgba(120, 100, 70, 0.5) 65%,
+            rgba(60, 50, 35, 0.45) 100%
+          ),
+          repeating-linear-gradient(
+            45deg,
+            rgba(0, 0, 0, 0.05) 0px,
+            rgba(0, 0, 0, 0.05) 1px,
+            transparent 1px,
+            transparent 4px
+          );
+        filter: sepia(0.2) contrast(1.05);
+      }
+
+      /* Locked Round 1 B — flat TapedFigure (no rotation, single tape). */
+      .figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 28px auto;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+      .figure .tape {
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+      }
+
+      /* Locked Round 2 — caption + credit pulled from asset->description /
+         asset->creditLine. Drop each row when blank. */
+      .figcap {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 8px 4px 0;
+      }
+      .figcap .caption {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+        flex: 1 1 60%;
+      }
+      .figcap .credit {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        white-space: nowrap;
+      }
+
+      /* ============================================================
+         WIDTH VARIANTS
+         ============================================================ */
+      .w-prose {
+        max-width: var(--container-prose);
+        margin-left: auto;
+        margin-right: auto;
+      }
+      .w-wide {
+        max-width: var(--container-wide);
+        margin-left: auto;
+        margin-right: auto;
+      }
+      .w-bleed {
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+        border-radius: 0;
+      }
+
+      /* ============================================================
+         OPTION A — Keep fullBleed boolean
+         ============================================================ */
+      .opt-a-bleed {
+        margin: 32px calc(50% - 50vw);
+        max-width: 100vw;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+      }
+      .opt-a-bleed .tape {
+        display: none;
+      }
+      .opt-a-bleed .photo {
+        max-height: 70vh;
+      }
+
+      /* ============================================================
+         OPTION D — Replace with 3-position width enum
+         ============================================================ */
+      .opt-d-bleed {
+        margin: 32px calc(50% - 50vw);
+        max-width: 100vw;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+      }
+      .opt-d-bleed .tape {
+        display: none;
+      }
+      .opt-d-bleed .photo {
+        max-height: 70vh;
+      }
+
+      .surface .demo-label {
+        position: relative;
+        max-width: var(--container-prose);
+        margin: 0 auto 10px;
+        padding: 0 28px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--color-ink-muted);
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-img · Round 3 · #1840</p>
+      <h1>
+        articleImage — fullBleed flag (keep / drop / drop+migrate / replace
+        with width enum)
+      </h1>
+      <p>
+        Drill 3.2. Locks whether the existing
+        <code>articleImage.fullBleed</code> boolean stays in Phase 5, given
+        the cream-surface prose container is
+        <code>--container-prose: 680px</code>.
+      </p>
+      <p>
+        Locked so far · <strong>R1:</strong> flat TapedFigure (no rotation,
+        single tape) · <strong>R2:</strong> per-asset caption/credit from
+        <code>asset-&gt;description</code> + <code>asset-&gt;creditLine</code>.
+        Each option below renders the same fixture at the chosen width.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — KEEP fullBleed AS-IS ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Keep fullBleed (boolean)</div>
+          <div class="name">
+            Schema unchanged. `false` → prose-width; `true` → 100vw.
+          </div>
+          <div class="desc">
+            Phase 5 honours the existing
+            <code>fullBleed: boolean</code> field. When false (default),
+            the figure renders at <code>--container-prose</code> width
+            inside the body. When true, it breaks out of the prose
+            container and spans the full viewport — tape strip is
+            suppressed (a tape on a viewport-wide photo reads odd).
+            Captions stay at prose width even when the photo is bleed.
+          </div>
+          <div class="vocab">
+            <strong>Schema</strong>
+            ✓ no migration<br />
+            ✓ fullBleed: boolean (existing)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+          </div>
+          <p class="demo-label">— fullBleed: false (prose width 680px) —</p>
+          <figure class="figure w-prose">
+            <span class="tape" aria-hidden="true"></span>
+            <div class="photo" role="img" aria-label="U13 training"></div>
+            <figcaption class="figcap">
+              <p class="caption">
+                Trainer Vermeulen geeft de U13 instructies vóór de
+                eerste set partijen.
+              </p>
+              <p class="credit">Foto: An Verheyden</p>
+            </figcaption>
+          </figure>
+          <div class="prose">
+            <p>
+              Tussen de regenbuien door wisselden de spelers in twee
+              ploegen — een eerste voorzichtige aftasting van wat de
+              ploeg dit jaar in huis heeft.
+            </p>
+          </div>
+          <p class="demo-label">— fullBleed: true (100vw) —</p>
+          <figure class="figure opt-a-bleed">
+            <span class="tape" aria-hidden="true"></span>
+            <div class="photo" role="img" aria-label="U13 training"></div>
+          </figure>
+          <div class="prose">
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — DROP fullBleed (NO MIGRATION) ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Drop fullBleed (renderer ignores)</div>
+          <div class="name">
+            Schema keeps the field; renderer always renders prose-width.
+          </div>
+          <div class="desc">
+            Stop honouring <code>fullBleed</code> in the Phase 5 renderer.
+            All images render at <code>--container-prose</code> width.
+            Schema field stays (so old content doesn't error), but the
+            value is ignored. Studio could deprecate the field with a
+            <code>hidden: true</code> flag if desired. Zero migration;
+            existing fullBleed images degrade gracefully to prose width.
+          </div>
+          <div class="vocab">
+            <strong>Schema</strong>
+            ✓ no migration (field stays, ignored)<br />
+            ⚠ optional Studio hide
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+          </div>
+          <p class="demo-label">— fullBleed ignored (always prose) —</p>
+          <figure class="figure w-prose">
+            <span class="tape" aria-hidden="true"></span>
+            <div class="photo" role="img" aria-label="U13 training"></div>
+            <figcaption class="figcap">
+              <p class="caption">
+                Trainer Vermeulen geeft de U13 instructies vóór de
+                eerste set partijen.
+              </p>
+              <p class="credit">Foto: An Verheyden</p>
+            </figcaption>
+          </figure>
+          <div class="prose">
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — DROP + MIGRATE (REMOVE FIELD) ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Drop + migrate (remove field)</div>
+          <div class="name">
+            Sanity migration removes <code>fullBleed</code> from existing docs.
+          </div>
+          <div class="desc">
+            Same render behaviour as B (always prose-width), but the
+            field is removed from the schema and a migration script
+            strips the property from existing documents. Cleanest schema;
+            costs one migration (staging + production). Reversible if we
+            ever want a width variant — re-add the field with a clearer
+            name.
+          </div>
+          <div class="vocab">
+            <strong>Schema</strong>
+            ✓ migration: remove fullBleed from existing docs<br />
+            ✓ schema field removed<br />
+            ✓ cleanest end state
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+          </div>
+          <p class="demo-label">— field removed, always prose —</p>
+          <figure class="figure w-prose">
+            <span class="tape" aria-hidden="true"></span>
+            <div class="photo" role="img" aria-label="U13 training"></div>
+            <figcaption class="figcap">
+              <p class="caption">
+                Trainer Vermeulen geeft de U13 instructies vóór de
+                eerste set partijen.
+              </p>
+              <p class="credit">Foto: An Verheyden</p>
+            </figcaption>
+          </figure>
+          <div class="prose">
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — REPLACE WITH WIDTH ENUM ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Replace with 3-position width enum</div>
+          <div class="name">
+            <code>width: 'prose' | 'wide' | 'bleed'</code> (default `prose`)
+          </div>
+          <div class="desc">
+            Trades the boolean for a 3-position string field. `prose` =
+            680px (default), `wide` = ~1040px (breaks out of prose but
+            stays inside viewport gutters), `bleed` = 100vw. Gives
+            editors a middle option for "dramatic but still framed"
+            photos. Costs one migration to translate
+            <code>fullBleed: true</code> → <code>width: 'bleed'</code>
+            and absent → <code>width: 'prose'</code>.
+          </div>
+          <div class="vocab">
+            <strong>Schema</strong>
+            ✓ migration: fullBleed → width enum<br />
+            ✓ adds a "wide" middle ground<br />
+            ⚠ adds a third visual variant to test
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De jeugdwerking trainde vorige week op het hoofdterrein —
+              een seizoenstart met veel volk en zachte regen.
+            </p>
+          </div>
+          <p class="demo-label">— width: prose (680px) —</p>
+          <figure class="figure w-prose">
+            <span class="tape" aria-hidden="true"></span>
+            <div class="photo" role="img" aria-label="U13 training"></div>
+            <figcaption class="figcap">
+              <p class="caption">
+                Trainer Vermeulen geeft de U13 instructies vóór de
+                eerste set partijen.
+              </p>
+              <p class="credit">Foto: An Verheyden</p>
+            </figcaption>
+          </figure>
+          <p class="demo-label">— width: wide (~1040px) —</p>
+          <figure class="figure w-wide">
+            <span class="tape" aria-hidden="true"></span>
+            <div class="photo" role="img" aria-label="U13 training"></div>
+          </figure>
+          <p class="demo-label">— width: bleed (100vw) —</p>
+          <figure class="figure opt-d-bleed">
+            <div class="photo" role="img" aria-label="U13 training"></div>
+          </figure>
+          <div class="prose">
+            <p>
+              De eerste oefenwedstrijd staat al volgende zaterdag op het
+              programma.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Trade-off matrix</strong>
+      <ul>
+        <li>
+          <strong>A · Keep</strong> — zero work, but bleed photos
+          structurally break out of the prose surface. Reads dramatic;
+          tape on a viewport-wide photo would look wrong (suppressed).
+        </li>
+        <li>
+          <strong>B · Drop (ignore)</strong> — zero work, all photos
+          stay in prose. Old fullBleed authors lose the "dramatic"
+          escape hatch silently.
+        </li>
+        <li>
+          <strong>C · Drop + migrate</strong> — one migration, clean
+          schema. Same end-state as B but tidy.
+        </li>
+        <li>
+          <strong>D · Width enum</strong> — one migration, adds a "wide"
+          middle ground. Extra Storybook + VR per width variant. Most
+          design flexibility; most surface area.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px"
+        >Existing fullBleed usage</strong
+      >
+      <ul>
+        <li>
+          Sample query needed before locking C/D: count how many
+          published articles currently set <code>fullBleed: true</code>.
+          If &lt; 5, migration impact is trivial; if many, the visual
+          downgrade in B/C deserves a heads-up.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-img/round-3b-width-mobile-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-img/round-3b-width-mobile-comparisons.html
@@ -1,0 +1,695 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      Phase 5 · Drill 5.d-img · Round 3b · Width enum mobile fallback
+    </title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+        --container-wide: 1040px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 36px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      /* Split panels — left = desktop sim (1280-ish), right = mobile sim (375). */
+      .split {
+        display: grid;
+        grid-template-columns: 1fr 400px;
+        background: var(--color-cream);
+      }
+      @media (max-width: 1100px) {
+        .split {
+          grid-template-columns: 1fr;
+        }
+      }
+      .pane {
+        position: relative;
+        padding: 18px 0 28px;
+        overflow: hidden;
+      }
+      .pane + .pane {
+        border-left: 1px dashed var(--color-ink);
+      }
+      @media (max-width: 1100px) {
+        .pane + .pane {
+          border-left: 0;
+          border-top: 1px dashed var(--color-ink);
+        }
+      }
+      .pane-label {
+        position: absolute;
+        top: 6px;
+        right: 12px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        z-index: 2;
+      }
+
+      /* Desktop pane is a real flex-fluid pane; mobile pane simulates
+         375px viewport width. */
+      .pane.is-mobile {
+        max-width: 400px;
+        margin: 0 auto;
+      }
+      .pane.is-mobile .prose {
+        padding: 0 18px;
+        max-width: 100%;
+      }
+
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        color: var(--color-ink-soft);
+        margin: 0 0 16px;
+      }
+
+      .photo {
+        width: 100%;
+        aspect-ratio: 3 / 2;
+        background:
+          linear-gradient(
+            135deg,
+            rgba(80, 60, 40, 0.45) 0%,
+            rgba(180, 150, 100, 0.55) 35%,
+            rgba(120, 100, 70, 0.5) 65%,
+            rgba(60, 50, 35, 0.45) 100%
+          ),
+          repeating-linear-gradient(
+            45deg,
+            rgba(0, 0, 0, 0.05) 0px,
+            rgba(0, 0, 0, 0.05) 1px,
+            transparent 1px,
+            transparent 4px
+          );
+        filter: sepia(0.2) contrast(1.05);
+      }
+
+      /* Locked Round 1 B figure. */
+      .figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 22px auto;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+      .figure .tape {
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+        z-index: 1;
+      }
+      .figcap {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+        padding: 8px 4px 0;
+      }
+      .figcap .caption {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+        flex: 1 1 55%;
+      }
+      .figcap .credit {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        white-space: nowrap;
+      }
+
+      /* Width variants — desktop pane (no media-query needed at this
+         scale; the desktop pane is wide enough for `wide` to differ
+         from `prose`). */
+      .w-prose {
+        max-width: var(--container-prose);
+      }
+      .w-wide {
+        max-width: var(--container-wide);
+      }
+      .w-bleed {
+        max-width: none;
+        margin: 22px 0;
+        border: 0;
+        background: transparent;
+        padding: 0;
+        box-shadow: none;
+      }
+      .w-bleed .tape {
+        display: none;
+      }
+      .w-bleed .photo {
+        max-height: 70vh;
+      }
+
+      /* Mobile pane behaviour variants. Mobile pane width = 400px
+         simulated viewport. */
+      .pane.is-mobile .figure {
+        margin: 22px 18px;
+      }
+
+      /* OPT 1 — wide → prose on mobile (prose is already viewport-wide
+         minus padding; wide and prose render identically) */
+      .opt-1 .pane.is-mobile .w-wide,
+      .opt-1 .pane.is-mobile .w-prose {
+        max-width: 100%;
+      }
+      .opt-1 .pane.is-mobile .w-bleed {
+        max-width: 100%;
+        margin: 22px 0;
+      }
+      .opt-1 .pane.is-mobile .w-bleed .photo {
+        max-height: 60vh;
+      }
+
+      /* OPT 2 — wide → bleed on mobile (full-width photo, tape suppressed) */
+      .opt-2 .pane.is-mobile .w-prose {
+        max-width: 100%;
+      }
+      .opt-2 .pane.is-mobile .w-wide {
+        max-width: 100%;
+        margin: 22px 0;
+        border: 0;
+        background: transparent;
+        padding: 0;
+        box-shadow: none;
+      }
+      .opt-2 .pane.is-mobile .w-wide .tape {
+        display: none;
+      }
+      .opt-2 .pane.is-mobile .w-wide .photo {
+        max-height: 60vh;
+      }
+      .opt-2 .pane.is-mobile .w-bleed {
+        max-width: 100%;
+        margin: 22px 0;
+      }
+      .opt-2 .pane.is-mobile .w-bleed .photo {
+        max-height: 60vh;
+      }
+
+      /* OPT 3 — wide stays "wide-ish" via 92vw with tiny gutter */
+      .opt-3 .pane.is-mobile .w-prose {
+        max-width: 100%;
+      }
+      .opt-3 .pane.is-mobile .w-wide {
+        max-width: 92%;
+        margin: 22px auto;
+      }
+      .opt-3 .pane.is-mobile .w-bleed {
+        max-width: 100%;
+        margin: 22px 0;
+      }
+      .opt-3 .pane.is-mobile .w-bleed .photo {
+        max-height: 60vh;
+      }
+
+      .demo-label {
+        max-width: var(--container-prose);
+        margin: 16px auto 4px;
+        padding: 0 28px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--color-ink-muted);
+      }
+      .pane.is-mobile .demo-label {
+        padding: 0 18px;
+        font-size: 9px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-img · Round 3b · #1840</p>
+      <h1>
+        articleImage · width enum — mobile fallback (collapse-to-prose /
+        collapse-to-bleed / stay-wide-ish)
+      </h1>
+      <p>
+        Round 3 locked the 3-position <code>width: 'prose' | 'wide' | 'bleed'</code> enum.
+        Round 3b decides how each width renders on narrow viewports
+        (&lt; ~640px) — specifically what happens to <code>wide</code>,
+        which would overflow a phone screen at its desktop ~1040px.
+      </p>
+      <p>
+        Each candidate shows desktop (left) and a 400px-wide mobile
+        simulator (right), with all three width values rendered in
+        sequence. Locked figure vocabulary (Round 1 B + Round 2
+        per-asset caption/credit) is held constant.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION 1 — WIDE COLLAPSES TO PROSE ====================== -->
+      <section class="candidate opt-1">
+        <header class="card">
+          <div class="key">Mobile 1 · wide → prose</div>
+          <div class="name">wide collapses to prose width on mobile (identical to prose)</div>
+          <div class="desc">
+            On mobile, the figure container width clamps to viewport
+            minus body padding for both <code>prose</code> and
+            <code>wide</code>. They render identically on phones —
+            the "wide" semantic only matters on desktop+. <code>bleed</code>
+            still breaks out to 100vw (tape suppressed). Simplest CSS;
+            the editor's "wide" intent is lost on mobile.
+          </div>
+          <div class="vocab">
+            <strong>Mobile behaviour</strong>
+            ✓ prose = wide = viewport - padding<br />
+            ✓ bleed = 100vw (no tape)<br />
+            ✗ no special handling for wide
+          </div>
+        </header>
+        <div class="split">
+          <div class="pane">
+            <span class="pane-label">Desktop</span>
+            <div class="prose">
+              <p>
+                De jeugdwerking trainde vorige week op het hoofdterrein —
+                een seizoenstart met veel volk en zachte regen.
+              </p>
+            </div>
+            <p class="demo-label">— width: prose (680px) —</p>
+            <figure class="figure w-prose">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+              <figcaption class="figcap">
+                <p class="caption">
+                  Trainer Vermeulen geeft instructies vóór de eerste set
+                  partijen.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p class="demo-label">— width: wide (~1040px) —</p>
+            <figure class="figure w-wide">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+            </figure>
+            <p class="demo-label">— width: bleed (100vw) —</p>
+            <figure class="figure w-bleed">
+              <div class="photo" role="img"></div>
+            </figure>
+            <div class="prose">
+              <p>De eerste oefenwedstrijd staat zaterdag op het programma.</p>
+            </div>
+          </div>
+          <div class="pane is-mobile">
+            <span class="pane-label">Mobile 400px</span>
+            <div class="prose">
+              <p>
+                De jeugdwerking trainde vorige week op het hoofdterrein.
+              </p>
+            </div>
+            <p class="demo-label">— prose —</p>
+            <figure class="figure w-prose">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+              <figcaption class="figcap">
+                <p class="caption">
+                  Trainer Vermeulen geeft instructies.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p class="demo-label">— wide → prose —</p>
+            <figure class="figure w-wide">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+            </figure>
+            <p class="demo-label">— bleed —</p>
+            <figure class="figure w-bleed">
+              <div class="photo" role="img"></div>
+            </figure>
+            <div class="prose">
+              <p>De oefenwedstrijd staat zaterdag op het programma.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION 2 — WIDE COLLAPSES TO BLEED ====================== -->
+      <section class="candidate opt-2">
+        <header class="card">
+          <div class="key">Mobile 2 · wide → bleed</div>
+          <div class="name">wide collapses to 100vw on mobile (no tape)</div>
+          <div class="desc">
+            On mobile, the editor's "wide" intent is preserved by
+            promoting it to full-bleed — the photo spans the full phone
+            viewport (no body padding, no tape, no figure chrome).
+            <code>prose</code> stays prose-width;
+            <code>bleed</code> stays 100vw. Two distinct visual modes on
+            mobile (framed vs. bleed) instead of one.
+          </div>
+          <div class="vocab">
+            <strong>Mobile behaviour</strong>
+            ✓ prose = viewport - padding (framed)<br />
+            ✓ wide = bleed = 100vw (no tape)<br />
+            ✓ preserves editor's "dramatic" intent
+          </div>
+        </header>
+        <div class="split">
+          <div class="pane">
+            <span class="pane-label">Desktop</span>
+            <div class="prose">
+              <p>
+                De jeugdwerking trainde vorige week op het hoofdterrein —
+                een seizoenstart met veel volk en zachte regen.
+              </p>
+            </div>
+            <p class="demo-label">— width: prose (680px) —</p>
+            <figure class="figure w-prose">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+              <figcaption class="figcap">
+                <p class="caption">
+                  Trainer Vermeulen geeft instructies vóór de eerste set
+                  partijen.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p class="demo-label">— width: wide (~1040px) —</p>
+            <figure class="figure w-wide">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+            </figure>
+            <p class="demo-label">— width: bleed (100vw) —</p>
+            <figure class="figure w-bleed">
+              <div class="photo" role="img"></div>
+            </figure>
+            <div class="prose">
+              <p>De eerste oefenwedstrijd staat zaterdag op het programma.</p>
+            </div>
+          </div>
+          <div class="pane is-mobile">
+            <span class="pane-label">Mobile 400px</span>
+            <div class="prose">
+              <p>
+                De jeugdwerking trainde vorige week op het hoofdterrein.
+              </p>
+            </div>
+            <p class="demo-label">— prose —</p>
+            <figure class="figure w-prose">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+              <figcaption class="figcap">
+                <p class="caption">
+                  Trainer Vermeulen geeft instructies.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p class="demo-label">— wide → bleed —</p>
+            <figure class="figure w-wide">
+              <div class="photo" role="img"></div>
+            </figure>
+            <p class="demo-label">— bleed —</p>
+            <figure class="figure w-bleed">
+              <div class="photo" role="img"></div>
+            </figure>
+            <div class="prose">
+              <p>De oefenwedstrijd staat zaterdag op het programma.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION 3 — WIDE STAYS WIDE-ISH ====================== -->
+      <section class="candidate opt-3">
+        <header class="card">
+          <div class="key">Mobile 3 · wide stays wide-ish (92vw)</div>
+          <div class="name">wide keeps a small inset (92vw, no prose padding)</div>
+          <div class="desc">
+            On mobile, <code>wide</code> renders at 92vw — bigger than
+            prose (which sits inside a 18–28px body padding) but with a
+            small gutter (4vw each side) that visually distinguishes
+            from full-bleed. Keeps the "wide but framed" semantic on
+            phones. <code>bleed</code> still 100vw.
+          </div>
+          <div class="vocab">
+            <strong>Mobile behaviour</strong>
+            ✓ prose = viewport - padding<br />
+            ✓ wide = 92vw (4vw gutters)<br />
+            ✓ bleed = 100vw (no tape)<br />
+            ✓ preserves three distinct modes on mobile
+          </div>
+        </header>
+        <div class="split">
+          <div class="pane">
+            <span class="pane-label">Desktop</span>
+            <div class="prose">
+              <p>
+                De jeugdwerking trainde vorige week op het hoofdterrein —
+                een seizoenstart met veel volk en zachte regen.
+              </p>
+            </div>
+            <p class="demo-label">— width: prose (680px) —</p>
+            <figure class="figure w-prose">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+              <figcaption class="figcap">
+                <p class="caption">
+                  Trainer Vermeulen geeft instructies vóór de eerste set
+                  partijen.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p class="demo-label">— width: wide (~1040px) —</p>
+            <figure class="figure w-wide">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+            </figure>
+            <p class="demo-label">— width: bleed (100vw) —</p>
+            <figure class="figure w-bleed">
+              <div class="photo" role="img"></div>
+            </figure>
+            <div class="prose">
+              <p>De eerste oefenwedstrijd staat zaterdag op het programma.</p>
+            </div>
+          </div>
+          <div class="pane is-mobile">
+            <span class="pane-label">Mobile 400px</span>
+            <div class="prose">
+              <p>
+                De jeugdwerking trainde vorige week op het hoofdterrein.
+              </p>
+            </div>
+            <p class="demo-label">— prose —</p>
+            <figure class="figure w-prose">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+              <figcaption class="figcap">
+                <p class="caption">
+                  Trainer Vermeulen geeft instructies.
+                </p>
+                <p class="credit">Foto: An Verheyden</p>
+              </figcaption>
+            </figure>
+            <p class="demo-label">— wide (92vw) —</p>
+            <figure class="figure w-wide">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="photo" role="img"></div>
+            </figure>
+            <p class="demo-label">— bleed —</p>
+            <figure class="figure w-bleed">
+              <div class="photo" role="img"></div>
+            </figure>
+            <div class="prose">
+              <p>De oefenwedstrijd staat zaterdag op het programma.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Trade-offs</strong>
+      <ul>
+        <li>
+          <strong>Mobile 1 (collapse to prose)</strong> — simplest CSS,
+          but the editor's "wide" intent disappears on phones. Anyone
+          authoring "wide" implicitly means "let it stand out" — Mobile
+          1 silently downgrades.
+        </li>
+        <li>
+          <strong>Mobile 2 (collapse to bleed)</strong> — preserves
+          dramatic intent. Two modes on mobile (framed prose vs. 100vw)
+          — easy to test, easy to author. Possibly aggressive: a
+          three-position desktop control collapses to two on mobile.
+        </li>
+        <li>
+          <strong>Mobile 3 (wide-ish 92vw)</strong> — preserves all
+          three modes on mobile. A 4vw gutter visually distinguishes
+          wide from bleed. Most fidelity to the editor's intent;
+          slightly more CSS / more VR cases.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">
+        Constants across all options
+      </strong>
+      <ul>
+        <li>
+          <code>prose</code> on mobile = viewport minus 18–28px body
+          padding (already responsive — no change from drill 5.A.1).
+        </li>
+        <li>
+          <code>bleed</code> on mobile = 100vw, tape suppressed (same
+          as desktop).
+        </li>
+        <li>
+          Breakpoint = <code>~640px</code> (existing <code>md</code>
+          Tailwind breakpoint).
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-1-row-layout-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-1-row-layout-comparisons.html
@@ -66,6 +66,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-1-row-layout-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-1-row-layout-comparisons.html
@@ -1,0 +1,598 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-int Rapid-fire · Round 1 · Per-row layout</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 32px 0 36px;
+      }
+      .qa-section {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .qa-section-kicker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        text-align: center;
+        margin: 0 0 22px;
+      }
+      .qa-speaker-strip {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 18px;
+      }
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 16px;
+        letter-spacing: -0.02em;
+        flex-shrink: 0;
+      }
+      .speaker-tag {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .speaker-tag .name-strong {
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         OPTION A — Vertical stack
+         Trimmed-down QARow: Q above A, no per-row avatar; group avatar
+         hoisted to a "speaker strip" once above the list. Dotted ink-
+         muted divider between pairs (Phase 3-b primitive).
+         ============================================================ */
+      .rf-vertical .pair {
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .rf-vertical .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-vertical .q {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 17px;
+        line-height: 1.3;
+        margin: 0 0 4px;
+        color: var(--color-ink);
+      }
+      .rf-vertical .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink-soft);
+      }
+
+      /* ============================================================
+         OPTION B — Inline (one line per pair)
+         Q · A on a single line — Q in italic display, separator dot,
+         A in body. Wraps gracefully on narrow viewports.
+         ============================================================ */
+      .rf-inline .pair {
+        padding: 11px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        line-height: 1.45;
+      }
+      .rf-inline .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-inline .q {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 16px;
+        color: var(--color-ink);
+        margin: 0;
+      }
+      .rf-inline .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        color: var(--color-ink-soft);
+        margin: 0;
+      }
+      .rf-inline .sep {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        color: var(--color-ink-muted);
+        margin: 0 8px;
+        font-size: 13px;
+        vertical-align: 1px;
+      }
+
+      /* ============================================================
+         OPTION C — 2-column grid (Q | A)
+         Two-column at >= 480px, collapses to vertical stack on narrow
+         viewports. Q in italic display, A in body. Matches the legacy
+         "Sneltrein" rhythm but in cream vocabulary.
+         ============================================================ */
+      .rf-grid .pair {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+        gap: 20px;
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-grid .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-grid .q {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 16px;
+        line-height: 1.3;
+        margin: 0;
+        color: var(--color-ink);
+      }
+      .rf-grid .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink-soft);
+      }
+
+      /* ============================================================
+         OPTION D — Hanging Q (Q as left-rail label, A flows wide)
+         Mono caps short prompts on a fixed 120px left rail; answer
+         takes the rest of the width. Best when the question can be
+         compressed to ≤ 3 words ("Favoriete goal?") — but the editor
+         is free to use sentence questions.
+         ============================================================ */
+      .rf-hanging .pair {
+        display: grid;
+        grid-template-columns: 132px minmax(0, 1fr);
+        gap: 22px;
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-hanging .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-hanging .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .rf-hanging .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-int-rapidfire · Round 1 · #1840</p>
+      <h1>
+        Rapid-fire QARow — per-row layout (vertical / inline / grid / hanging)
+      </h1>
+      <p>
+        Drill 5.d-int-rapidfire Round 1 of ~4. Locks how a single rapid-fire
+        Q&amp;A pair lays out inside the row. Everything else — speaker scope,
+        row dividers, section opener — is held constant across all four
+        candidates and drilled in later rounds.
+      </p>
+      <p>
+        All four options share: a single hoisted speaker strip
+        (avatar + tag, top-left) so per-row chrome is minimal; dotted
+        ink-muted dividers between pairs; the prose container
+        (<code>--container-prose: 680px</code>) on the cream surface; and the
+        existing <code>Sneltrein</code> kicker placeholder at the top
+        (kicker treatment is locked separately in Round 4).
+      </p>
+      <p>
+        Fixture: 4 rapid-fire pairs with a single respondent (Lars Janssens,
+        aanvaller — <strong>L</strong>). Real prose so the rhythm difference
+        is honest.
+      </p>
+      <p>
+        Note: per the existing <code>QaGroupRapidFire</code> contract, rapid-fire
+        is intentionally single-respondent. Multi-respondent rapid-fire is
+        explicitly out of scope and will fall back to repeating standard QARows.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — VERTICAL STACK ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Vertical stack</div>
+          <div class="name">Q above A, single column, dotted dividers</div>
+          <div class="desc">
+            Trimmed-down standard QARow. Italic display-sm Q on top, body-md A
+            below, separated by a small gap. Hoisted speaker strip once at the
+            top. Reads as a transcript-lite — same vocabulary as standard QARow
+            but with avatar/tag chrome removed per row.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ italic Freight Display 600 question (matches QARow)<br />
+            ✓ Freight body answer<br />
+            ✓ Phase 3-b dotted ink-muted row divider<br />
+            ✓ Hoisted SubjectAvatar + speaker tag (5.d2 row scale)
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section rf-vertical">
+            <header class="qa-speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+
+            <div class="pair">
+              <p class="q">Favoriete goal van het seizoen?</p>
+              <p class="a">De volley tegen Diest in de slotminuut.</p>
+            </div>
+            <div class="pair">
+              <p class="q">Speler om naar te kijken?</p>
+              <p class="a">Wim. Hij maakt iedereen beter.</p>
+            </div>
+            <div class="pair">
+              <p class="q">Liedje in de bus voor de match?</p>
+              <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+            </div>
+            <div class="pair">
+              <p class="q">Eerste herinnering aan KCVV?</p>
+              <p class="a">Hand vasthouden van mijn pa, U7.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — INLINE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Inline (one line per pair)</div>
+          <div class="name">Q · A on one row, mono separator dot</div>
+          <div class="desc">
+            Maximum compression. Question and answer share a single line,
+            separated by a mono interpunct. Wraps gracefully when the answer
+            is too long — but only shines when answers stay short. Strongest
+            "rapid-fire" rhythm; weakest when answers run past one sentence.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ italic Freight Display 600 question (smaller — 16px)<br />
+            ✓ Freight body answer<br />
+            ✓ mono <code>·</code> separator (matches speaker-tag separator)<br />
+            ✓ Phase 3-b dotted ink-muted row divider
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section rf-inline">
+            <header class="qa-speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+
+            <div class="pair">
+              <span class="q">Favoriete goal van het seizoen?</span>
+              <span class="sep">·</span>
+              <span class="a">De volley tegen Diest in de slotminuut.</span>
+            </div>
+            <div class="pair">
+              <span class="q">Speler om naar te kijken?</span>
+              <span class="sep">·</span>
+              <span class="a">Wim. Hij maakt iedereen beter.</span>
+            </div>
+            <div class="pair">
+              <span class="q">Liedje in de bus voor de match?</span>
+              <span class="sep">·</span>
+              <span class="a"
+                >"Geen liedjes — koptelefoon op, ogen dicht."</span
+              >
+            </div>
+            <div class="pair">
+              <span class="q">Eerste herinnering aan KCVV?</span>
+              <span class="sep">·</span>
+              <span class="a">Hand vasthouden van mijn pa, U7.</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — 2-COL GRID ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · 2-column grid (Q | A)</div>
+          <div class="name">Q left, A right — 1fr · 1.4fr</div>
+          <div class="desc">
+            Closest sibling to the legacy Phase 2 <code>QaGroupRapidFire</code>
+            (1fr · 1.3fr grid). Question on the left, answer on the right,
+            both baseline-aligned. Lets the eye scan a Q column or an A
+            column independently. Falls back to a vertical stack at narrow
+            viewports.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ italic Freight Display 600 question (16px)<br />
+            ✓ Freight body answer<br />
+            ✓ <code>grid-template-columns: 1fr 1.4fr</code><br />
+            ✓ Phase 3-b dotted ink-muted row divider
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section rf-grid">
+            <header class="qa-speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+
+            <div class="pair">
+              <p class="q">Favoriete goal van het seizoen?</p>
+              <p class="a">De volley tegen Diest in de slotminuut.</p>
+            </div>
+            <div class="pair">
+              <p class="q">Speler om naar te kijken?</p>
+              <p class="a">Wim. Hij maakt iedereen beter.</p>
+            </div>
+            <div class="pair">
+              <p class="q">Liedje in de bus voor de match?</p>
+              <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+            </div>
+            <div class="pair">
+              <p class="q">Eerste herinnering aan KCVV?</p>
+              <p class="a">Hand vasthouden van mijn pa, U7.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — HANGING Q ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Hanging Q (mono left rail)</div>
+          <div class="name">Q as mono caps label (132px rail), A flows wide</div>
+          <div class="desc">
+            Strongest visual contrast with the standard QARow above. Q becomes
+            a tiny mono caps label on a fixed 132px left rail; A reads as the
+            "real content" in serif body. Reads as a key/value list or
+            interview cheat-sheet. Demands short questions to shine.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ mono caps label (matches MonoLabel / speaker tag)<br />
+            ✓ Freight Display body answer (16px)<br />
+            ✓ Fixed 132px left rail<br />
+            ✓ Phase 3-b dotted ink-muted row divider
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section rf-hanging">
+            <header class="qa-speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+
+            <div class="pair">
+              <p class="q">Favoriete goal van het seizoen?</p>
+              <p class="a">De volley tegen Diest in de slotminuut.</p>
+            </div>
+            <div class="pair">
+              <p class="q">Speler om naar te kijken?</p>
+              <p class="a">Wim. Hij maakt iedereen beter.</p>
+            </div>
+            <div class="pair">
+              <p class="q">Liedje in de bus voor de match?</p>
+              <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+            </div>
+            <div class="pair">
+              <p class="q">Eerste herinnering aan KCVV?</p>
+              <p class="a">Hand vasthouden van mijn pa, U7.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>What this round decides</strong>
+      <ul>
+        <li>
+          The per-pair geometry: vertical stack, inline single-line, 2-col
+          baseline grid, or mono-rail key/value.
+        </li>
+        <li>
+          The question typography baseline (italic Freight Display vs. mono
+          caps).
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px"
+        >What this round does NOT decide</strong
+      >
+      <ul>
+        <li>
+          <strong>Speaker scope</strong> — drilled in Round 2 (hoist
+          once / per-row / none). All options here pin the avatar strip to a
+          single hoisted position purely for honest comparison.
+        </li>
+        <li>
+          <strong>Row divider</strong> — drilled in Round 3 (dotted /
+          rule-only / blank / em-dash). All options here use the Phase 3-b
+          dotted ink-muted rule for honest comparison.
+        </li>
+        <li>
+          <strong>Section opener</strong> — drilled in Round 4 (kicker text,
+          "Sneltrein" tag, three-bar mark). All options here use a placeholder
+          star kicker.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-1b-hanging-q-mobile-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-1b-hanging-q-mobile-comparisons.html
@@ -1,0 +1,646 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      Phase 5 · Drill 5.d-int Rapid-fire · Round 1b · D mobile fallback
+    </title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+        --breakpoint-md: 640px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 24px;
+      }
+      @media (max-width: 1100px) {
+        .container {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 20px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      /* Viewport simulator — each candidate shows BOTH a desktop and a
+         mobile rendering of the same layout. Mobile is a fixed-width
+         frame (360px content + 24px padding) to mimic an iPhone SE. */
+      .viewport-stack {
+        display: flex;
+        flex-direction: column;
+      }
+      .viewport-frame {
+        background: var(--color-cream);
+        padding: 18px 0 22px;
+        position: relative;
+      }
+      .viewport-frame + .viewport-frame {
+        border-top: 1px dashed var(--color-ink);
+      }
+      .viewport-label {
+        position: absolute;
+        top: 8px;
+        right: 14px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .qa-section {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 22px 28px 0;
+      }
+      .viewport-frame.is-mobile .qa-section {
+        max-width: 360px;
+        padding: 22px 20px 0;
+      }
+      .qa-section-kicker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        text-align: center;
+        margin: 0 0 18px;
+      }
+      .qa-speaker-strip {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 16px;
+      }
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 16px;
+        flex-shrink: 0;
+      }
+      .speaker-tag {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .speaker-tag .name-strong {
+        color: var(--color-ink);
+      }
+
+      /* Desktop = locked hanging-Q (Option D from Round 1). */
+      .rf-hanging-desktop .pair {
+        display: grid;
+        grid-template-columns: 132px minmax(0, 1fr);
+        gap: 22px;
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-hanging-desktop .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-hanging-desktop .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .rf-hanging-desktop .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         MOBILE OPTION 1 — Q stacks above A
+         Q stays the same mono caps label, drops above the answer.
+         Visually still reads as "label · value".
+         ============================================================ */
+      .rf-mobile-stack .pair {
+        padding: 12px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .rf-mobile-stack .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-mobile-stack .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0 0 5px;
+        line-height: 1.45;
+      }
+      .rf-mobile-stack .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         MOBILE OPTION 2 — Narrower rail (88px)
+         Keep the desktop rhythm but tighten the rail. Q can wrap to
+         2 lines if needed; A flows in the remaining ~225px.
+         ============================================================ */
+      .rf-mobile-rail .pair {
+        display: grid;
+        grid-template-columns: 88px minmax(0, 1fr);
+        gap: 12px;
+        padding: 12px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-mobile-rail .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-mobile-rail .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 9px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.4;
+      }
+      .rf-mobile-rail .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         MOBILE OPTION 3 — Inline leader
+         Q becomes a mono caps leader inline with the answer's first
+         line, separated by a mono em-dash. Most compressed.
+         ============================================================ */
+      .rf-mobile-leader .pair {
+        padding: 12px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .rf-mobile-leader .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-mobile-leader .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+      }
+      .rf-mobile-leader .sep {
+        color: var(--color-ink-muted);
+        margin: 0 6px 0 4px;
+      }
+      .rf-mobile-leader .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        color: var(--color-ink);
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">
+        Phase 5 · Drill 5.d-int-rapidfire · Round 1b · #1840
+      </p>
+      <h1>
+        Hanging-Q rapid-fire — mobile fallback (stack / narrow rail / inline
+        leader)
+      </h1>
+      <p>
+        Round 1 chose <strong>Option D · Hanging Q (mono caps rail, 132px)</strong>.
+        Round 1b drills how that layout collapses below the
+        <code>--container-prose</code> breakpoint (≤ ~640px / iPhone-class
+        viewports), where a 132px rail would leave only ~190px for the
+        answer — too tight.
+      </p>
+      <p>
+        Each candidate shows the same content at desktop width (locked D) and
+        a 360px mobile frame (≈ iPhone SE) so the breakpoint shift is honest.
+        Fixture: same 4 rapid-fire pairs as Round 1. Speaker strip, dotted
+        dividers, kicker — all held constant.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== MOBILE OPTION 1 — Q STACKS ABOVE A ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Mobile 1 · Q stacks above A</div>
+          <div class="name">Mono caps Q on its own line, A below</div>
+          <div class="desc">
+            Drops the rail entirely below the breakpoint. Q stays as the same
+            mono caps label (10px, 0.16em tracking) but sits above the answer
+            with a 5px gap. Reads as a transcript-lite. Most legible for long
+            questions; weakest "rapid-fire" rhythm of the three.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ same MonoLabel typography as desktop<br />
+            ✓ no grid below <code>md</code><br />
+            ✓ Phase 3-b dotted ink-muted divider
+          </div>
+        </header>
+
+        <div class="viewport-stack">
+          <div class="viewport-frame">
+            <span class="viewport-label">Desktop ≥ 640px</span>
+            <div class="qa-section rf-hanging-desktop">
+              <header class="qa-speaker-strip">
+                <span class="avatar" aria-hidden="true">L</span>
+                <span class="speaker-tag"
+                  ><span class="name-strong">LARS JANSSENS</span> ·
+                  AANVALLER</span
+                >
+              </header>
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="viewport-frame is-mobile">
+            <span class="viewport-label">Mobile · 360px</span>
+            <div class="qa-section rf-mobile-stack">
+              <header class="qa-speaker-strip">
+                <span class="avatar" aria-hidden="true">L</span>
+                <span class="speaker-tag"
+                  ><span class="name-strong">LARS JANSSENS</span> ·
+                  AANVALLER</span
+                >
+              </header>
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== MOBILE OPTION 2 — NARROW RAIL ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Mobile 2 · Narrower rail (88px)</div>
+          <div class="name">Keep grid, tighten rail to 88px</div>
+          <div class="desc">
+            Preserves the desktop rhythm — Q on the left, A on the right —
+            but tightens the rail to 88px. Q tracks down a notch (9px,
+            0.14em) and can wrap to 2 lines. Best continuity desktop ↔ mobile;
+            weakest when questions need 3+ words to make sense.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ same grid pattern as desktop<br />
+            ✓ MonoLabel scales 10px → 9px<br />
+            ✓ Phase 3-b dotted ink-muted divider
+          </div>
+        </header>
+
+        <div class="viewport-stack">
+          <div class="viewport-frame">
+            <span class="viewport-label">Desktop ≥ 640px</span>
+            <div class="qa-section rf-hanging-desktop">
+              <header class="qa-speaker-strip">
+                <span class="avatar" aria-hidden="true">L</span>
+                <span class="speaker-tag"
+                  ><span class="name-strong">LARS JANSSENS</span> ·
+                  AANVALLER</span
+                >
+              </header>
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="viewport-frame is-mobile">
+            <span class="viewport-label">Mobile · 360px</span>
+            <div class="qa-section rf-mobile-rail">
+              <header class="qa-speaker-strip">
+                <span class="avatar" aria-hidden="true">L</span>
+                <span class="speaker-tag"
+                  ><span class="name-strong">LARS JANSSENS</span> ·
+                  AANVALLER</span
+                >
+              </header>
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== MOBILE OPTION 3 — INLINE LEADER ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Mobile 3 · Inline leader</div>
+          <div class="name">Q as inline mono caps leader, em-dash, A flows</div>
+          <div class="desc">
+            Maximum compression: Q sits inline with A on the first line,
+            joined by a mono em-dash. Reads as "LABEL — Answer." sentences.
+            Strongest rapid-fire pulse on mobile; demands very short Q labels
+            (1–2 words). Falls apart if Q wraps to a second line.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel inline with body text<br />
+            ✓ mono em-dash separator<br />
+            ✓ Phase 3-b dotted ink-muted divider
+          </div>
+        </header>
+
+        <div class="viewport-stack">
+          <div class="viewport-frame">
+            <span class="viewport-label">Desktop ≥ 640px</span>
+            <div class="qa-section rf-hanging-desktop">
+              <header class="qa-speaker-strip">
+                <span class="avatar" aria-hidden="true">L</span>
+                <span class="speaker-tag"
+                  ><span class="name-strong">LARS JANSSENS</span> ·
+                  AANVALLER</span
+                >
+              </header>
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="viewport-frame is-mobile">
+            <span class="viewport-label">Mobile · 360px</span>
+            <div class="qa-section rf-mobile-leader">
+              <header class="qa-speaker-strip">
+                <span class="avatar" aria-hidden="true">L</span>
+                <span class="speaker-tag"
+                  ><span class="name-strong">LARS JANSSENS</span> ·
+                  AANVALLER</span
+                >
+              </header>
+              <div class="pair">
+                <span class="q">Favoriete goal</span
+                ><span class="sep">—</span
+                ><span class="a">De volley tegen Diest in de slotminuut.</span>
+              </div>
+              <div class="pair">
+                <span class="q">Speler om te volgen</span
+                ><span class="sep">—</span
+                ><span class="a">Wim. Hij maakt iedereen beter.</span>
+              </div>
+              <div class="pair">
+                <span class="q">Bus-muziek</span
+                ><span class="sep">—</span
+                ><span class="a"
+                  >"Geen liedjes — koptelefoon op, ogen dicht."</span
+                >
+              </div>
+              <div class="pair">
+                <span class="q">Eerste KCVV-herinnering</span
+                ><span class="sep">—</span
+                ><span class="a">Hand vasthouden van mijn pa, U7.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Breakpoint</strong>
+      <ul>
+        <li>
+          Switch at <code>~640px</code> (the existing <code>md</code>
+          Tailwind breakpoint in <code>apps/web</code>). Below this the
+          132px rail compresses the answer column past comfortable reading;
+          above this the desktop hanging-Q layout stands.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px"
+        >Editorial note (relevant to mobile 2 and mobile 3)</strong
+      >
+      <ul>
+        <li>
+          Both rail-preserving options assume the editor authors short Q
+          labels ("Favoriete goal", "Bus-muziek") on rapid-fire pairs. This
+          will need to be called out in the Studio help text for the qaBlock
+          <code>tag: rapid-fire</code> branch — locked at Round 4 (kicker /
+          editorial guidance).
+        </li>
+        <li>
+          Mobile 1 (stack) is the only one that gracefully tolerates a long
+          editorial Q without breaking rhythm.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-2-speaker-scope-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-2-speaker-scope-comparisons.html
@@ -1,0 +1,486 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-int Rapid-fire · Round 2 · Speaker scope</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 32px 0 36px;
+      }
+      .qa-section {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 16px;
+        flex-shrink: 0;
+      }
+      .avatar-sm {
+        width: 22px;
+        height: 22px;
+        font-size: 11px;
+      }
+      .speaker-strip {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 18px;
+      }
+      .speaker-tag {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .speaker-tag .name-strong {
+        color: var(--color-ink);
+      }
+
+      /* The locked Round 1 hanging-Q rhythm — used in every candidate. */
+      .rf-pairs .pair {
+        display: grid;
+        grid-template-columns: 132px minmax(0, 1fr);
+        gap: 22px;
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-pairs .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-pairs .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .rf-pairs .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      /* Section-opener variants — these vary across the four candidates. */
+      .opener {
+        text-align: center;
+        margin: 0 0 22px;
+      }
+      .opener .kicker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+
+      /* Centered "speaker-as-kicker" — Option C merges identity into the
+         opener line (no separate strip below). */
+      .opener-merged {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .opener-merged .name-strong {
+        color: var(--color-ink);
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-int-rapidfire · Round 2 · #1840</p>
+      <h1>
+        Rapid-fire — speaker scope (full strip / avatar only / merged / none)
+      </h1>
+      <p>
+        Locked so far · <strong>Round 1:</strong> hanging-Q rail (132px) ·
+        <strong>Round 1b:</strong> Q stacks above A below
+        <code>~640px</code>. Round 2 decides whether/where the respondent
+        identity surfaces inside the rapid-fire block, given that the
+        <code>QaGroupRapidFire</code> contract is single-respondent.
+      </p>
+      <p>
+        Same fixture as Round 1 (Lars Janssens, aanvaller, 4 pairs). The Q/A
+        rhythm is identical across all four options; only the section
+        opener varies. Row divider treatment is still drilled separately in
+        Round 3.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — FULL SPEAKER STRIP ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Full speaker strip</div>
+          <div class="name">Kicker + avatar + name + role line</div>
+          <div class="desc">
+            Two-line opener: centered <code>★ Sneltrein</code> kicker, then a
+            left-aligned strip with avatar + "LARS JANSSENS · AANVALLER".
+            Loudest speaker presence — equivalent to the strip used in the
+            Round 1 comparison page.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel kicker<br />
+            ✓ <code>SubjectAvatar</code> (row scale, 32px)<br />
+            ✓ Mono speaker tag (matches QARow)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="opener">
+            <span class="kicker">★ Sneltrein</span>
+          </div>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — AVATAR ONLY ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Avatar only</div>
+          <div class="name">Kicker line, then a small left-aligned avatar disc</div>
+          <div class="desc">
+            Speaker is implied by a small (22px) monogram disc on the left,
+            standing alone above the pairs. No name, no role — the article
+            hero already named the subject. Keeps visual anchoring without
+            redundant text chrome.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel kicker<br />
+            ✓ <code>SubjectAvatar</code> scaled small (22px)<br />
+            ✓ no speaker tag
+          </div>
+        </header>
+        <div class="surface">
+          <div class="opener">
+            <span class="kicker">★ Sneltrein</span>
+          </div>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar avatar-sm" aria-hidden="true">L</span>
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — SPEAKER MERGED INTO KICKER ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Speaker merged into kicker</div>
+          <div class="name">
+            One centered line · avatar + "LARS · AANVALLER · SNELTREIN"
+          </div>
+          <div class="desc">
+            Single opener line. Avatar disc plus the speaker tag becomes the
+            kicker itself — no separate strip below. Most compact; trades
+            speaker prominence for vertical economy. Strongest when the
+            rapid-fire block sits inside a longer article body.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ <code>SubjectAvatar</code> (row scale, 22px) inline with mono caps<br />
+            ✓ mono separator dots (matches QARow speaker tag)<br />
+            ✓ no separate strip
+          </div>
+        </header>
+        <div class="surface">
+          <div class="opener">
+            <span class="opener-merged">
+              <span class="avatar avatar-sm" aria-hidden="true">L</span>
+              <span><span class="name-strong">LARS JANSSENS</span> · AANVALLER · SNELTREIN</span>
+            </span>
+          </div>
+          <div class="qa-section">
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — NO SPEAKER CHROME ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · No speaker chrome</div>
+          <div class="name">Kicker only — speaker established by hero / subjects strip</div>
+          <div class="desc">
+            Just the <code>★ Sneltrein</code> kicker, then straight into the
+            Q/A list. Speaker identity lives in the article hero +
+            <code>SubjectsStrip</code> already on the page. Cleanest reading,
+            but the rapid-fire block stops being self-contained — moving it
+            mid-article without surrounding hero/subjects context would
+            leave the reader guessing who's talking.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel kicker only<br />
+            ✗ no avatar<br />
+            ✗ no speaker tag<br />
+            (Implicit: relies on hero/SubjectsStrip context.)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="opener">
+            <span class="kicker">★ Sneltrein</span>
+          </div>
+          <div class="qa-section">
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>What this round decides</strong>
+      <ul>
+        <li>
+          Where the respondent identity surfaces inside the rapid-fire
+          block: a full strip (A), an avatar disc only (B), merged with the
+          kicker (C), or omitted entirely (D).
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px"
+        >Single-respondent constraint</strong
+      >
+      <ul>
+        <li>
+          Per the existing <code>QaGroupRapidFire</code> contract:
+          rapid-fire is single-respondent only. Per-row avatar repetition
+          (the standard QARow vocabulary) is not on the table — that's
+          redundant noise for a block that never changes speakers mid-list.
+        </li>
+        <li>
+          If a multi-respondent rapid-fire is ever authored, the qaBlock
+          tag dispatcher will fall back to standard QARows (not this block).
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-2-speaker-scope-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-2-speaker-scope-comparisons.html
@@ -66,6 +66,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-3-row-divider-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-3-row-divider-comparisons.html
@@ -1,0 +1,522 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-int Rapid-fire · Round 3 · Row divider</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 32px 0 36px;
+      }
+      .qa-section {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .qa-section-kicker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        text-align: center;
+        margin: 0 0 22px;
+      }
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 16px;
+        flex-shrink: 0;
+      }
+      .speaker-strip {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 18px;
+      }
+      .speaker-tag {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .speaker-tag .name-strong {
+        color: var(--color-ink);
+      }
+
+      /* Locked Round 1 hanging-Q rhythm (132px rail). */
+      .rf-pairs .pair {
+        display: grid;
+        grid-template-columns: 132px minmax(0, 1fr);
+        gap: 22px;
+        align-items: baseline;
+      }
+      .rf-pairs .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .rf-pairs .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         OPTION A — Dotted ink-muted (Phase 3-b primitive)
+         The current placeholder. 1px dotted border-bottom.
+         ============================================================ */
+      .div-dotted .pair {
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .div-dotted .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+
+      /* ============================================================
+         OPTION B — Solid hairline (ink-muted, 50% opacity)
+         Quieter than A. 1px solid line at low contrast.
+         ============================================================ */
+      .div-hairline .pair {
+        padding: 14px 0;
+        border-bottom: 1px solid color-mix(in srgb, var(--color-ink-muted) 50%, transparent);
+      }
+      .div-hairline .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+
+      /* ============================================================
+         OPTION C — Tight rows, no divider
+         Generous row padding gone; no line at all. Pure rhythm.
+         ============================================================ */
+      .div-none .pair {
+        padding: 8px 0;
+      }
+      .div-none .pair:first-child {
+        padding-top: 0;
+      }
+      .div-none .pair:last-child {
+        padding-bottom: 0;
+      }
+
+      /* ============================================================
+         OPTION D — Mono dot row (3 dots between pairs)
+         Three centered mono dots between pairs. Decorative, "fanzine"
+         register; reads as a typographic flourish.
+         ============================================================ */
+      .div-dotrow .pair {
+        padding: 12px 0;
+      }
+      .div-dotrow .pair:first-child {
+        padding-top: 0;
+      }
+      .div-dotrow .pair:last-child {
+        padding-bottom: 0;
+      }
+      .div-dotrow .dotrow {
+        text-align: center;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 14px;
+        color: var(--color-ink-muted);
+        letter-spacing: 0.4em;
+        padding: 2px 0;
+        line-height: 1;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-int-rapidfire · Round 3 · #1840</p>
+      <h1>
+        Rapid-fire — row divider (dotted / hairline / none / dot row)
+      </h1>
+      <p>
+        Locked so far · <strong>Round 1:</strong> hanging-Q rail (132px) ·
+        <strong>Round 1b:</strong> Q stacks above A below
+        <code>~640px</code> ·
+        <strong>Round 2:</strong> full speaker strip (kicker line + avatar +
+        name/role). Round 3 decides the row divider treatment between
+        pairs.
+      </p>
+      <p>
+        Same fixture as Rounds 1 &amp; 2. Q/A rhythm and speaker chrome are
+        identical across all four options; only the inter-pair separator
+        varies.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — DOTTED ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Dotted ink-muted</div>
+          <div class="name">1px dotted line (Phase 3-b primitive)</div>
+          <div class="desc">
+            The current placeholder. Matches the row divider used in the
+            standard <code>QARow</code> Phase 5 lock — explicit reuse of the
+            Phase 3-b dotted ink-muted vocabulary. Loudest of the four;
+            reads as a transcript or interview ruling.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ Phase 3-b dotted ink-muted (locked)<br />
+            ✓ matches standard <code>QARow</code> row divider<br />
+            ✓ 14px padding above/below
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs div-dotted">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — HAIRLINE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Solid hairline (50% ink-muted)</div>
+          <div class="name">1px solid ink-muted at 50% opacity</div>
+          <div class="desc">
+            Quieter cousin of A. Solid line instead of dotted, knocked down
+            to 50% opacity. Same rhythm but the line recedes — reads more
+            like a list separator than a rule. Sits below A in vocabulary
+            register; doesn't add new tokens but breaks parity with
+            standard <code>QARow</code>.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ ink-muted at 50% (color-mix)<br />
+            ✗ does NOT match standard <code>QARow</code><br />
+            ✓ 14px padding above/below
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs div-hairline">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — NONE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · No divider</div>
+          <div class="name">Tight rows, no line — pure rhythm</div>
+          <div class="desc">
+            No line at all. Rows tightened to 8px padding so the list reads
+            as a single rapid stream. Strongest "rapid-fire" pulse; weakest
+            row separation when the answer wraps to multiple lines (the
+            next Q-label can blend into the preceding A).
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✗ no border (rhythm only)<br />
+            ✓ 8px padding above/below<br />
+            ✗ does NOT match standard <code>QARow</code>
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs div-none">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — MONO DOT ROW ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Mono dot row</div>
+          <div class="name">3 centered mono dots between pairs (·  ·  ·)</div>
+          <div class="desc">
+            Typographic flourish. Three widely-spaced mono dots between
+            pairs (no line). Decorative fanzine register; reads as section
+            beats rather than ruling. Adds a new ornament to the
+            rapid-fire-only vocabulary — won't reappear elsewhere.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✗ no border<br />
+            ✓ mono · · · ornament (NEW — rapid-fire only)<br />
+            ⚠ adds vocabulary not used elsewhere
+          </div>
+        </header>
+        <div class="surface">
+          <p class="qa-section-kicker">★ Sneltrein</p>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs div-dotrow">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="dotrow" aria-hidden="true">· · ·</div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="dotrow" aria-hidden="true">· · ·</div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="dotrow" aria-hidden="true">· · ·</div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Reuse signal</strong>
+      <ul>
+        <li>
+          Option A (dotted ink-muted) is the only option that explicitly
+          reuses the locked standard <code>QARow</code> divider —
+          rapid-fire reads as the same family as standard, just compressed.
+          Per <code>feedback_reuse_approved_primitives</code>, this is the
+          path of least new vocabulary.
+        </li>
+        <li>
+          Options B and D introduce vocabulary that doesn't appear anywhere
+          else in the redesign (hairline solid, mono dot ornament). Worth
+          weighing the visual gain against that drift.
+        </li>
+        <li>
+          Option C goes the opposite direction: no chrome at all, banking
+          on pure rhythm. Cleanest if rapid-fire answers stay genuinely
+          short.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-3-row-divider-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-3-row-divider-comparisons.html
@@ -66,6 +66,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4-section-opener-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4-section-opener-comparisons.html
@@ -1,0 +1,560 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-int Rapid-fire · Round 4 · Section opener</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 32px 0 36px;
+      }
+      .qa-section {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 16px;
+        flex-shrink: 0;
+      }
+      .speaker-strip {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 18px;
+      }
+      .speaker-tag {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .speaker-tag .name-strong {
+        color: var(--color-ink);
+      }
+
+      /* Locked Round 1 hanging-Q rhythm + Round 3 dotted divider. */
+      .rf-pairs .pair {
+        display: grid;
+        grid-template-columns: 132px minmax(0, 1fr);
+        gap: 22px;
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-pairs .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-pairs .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .rf-pairs .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         OPENER A — Plain MonoLabel with star
+         ★ SNELTREIN — the placeholder used in all earlier rounds.
+         ============================================================ */
+      .opener-a {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        text-align: center;
+        margin: 0 0 22px;
+      }
+
+      /* ============================================================
+         OPENER B — Display italic word
+         "Sneltrein." — mixed-case italic Freight Display, left-aligned
+         to match the speaker strip below it.
+         ============================================================ */
+      .opener-b {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 22px;
+        line-height: 1.1;
+        color: var(--color-ink);
+        margin: 0 0 14px;
+        letter-spacing: -0.015em;
+      }
+
+      /* ============================================================
+         OPENER C — Three-bar accent + MonoLabel (legacy homage)
+         Three jersey-deep bars + SNELTREIN mono caps. Carries forward
+         the legacy QaGroupRapidFire visual signature, adapted to cream
+         + jersey-deep (no kcvv-green-bright).
+         ============================================================ */
+      .opener-c {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin: 0 0 18px;
+      }
+      .opener-c .bars {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .opener-c .bars span {
+        display: block;
+        width: 12px;
+        height: 2px;
+        background: var(--color-jersey-deep);
+      }
+      .opener-c .label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--color-jersey-deep);
+        font-weight: 600;
+      }
+
+      /* ============================================================
+         OPENER D — MonoLabel between hairlines
+         ─── SNELTREIN ─── ink hairlines on both sides, centered.
+         "Editorial section break" register.
+         ============================================================ */
+      .opener-d {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin: 0 0 22px;
+      }
+      .opener-d .rule {
+        flex: 1;
+        height: 1px;
+        background: var(--color-ink);
+      }
+      .opener-d .label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-int-rapidfire · Round 4 · #1840</p>
+      <h1>
+        Rapid-fire — section opener (mono / display / 3-bar / hairlines)
+      </h1>
+      <p>
+        Locked so far · <strong>R1:</strong> hanging-Q rail (132px) ·
+        <strong>R1b:</strong> Q stacks above A &lt; 640px ·
+        <strong>R2:</strong> full speaker strip ·
+        <strong>R3:</strong> dotted ink-muted divider. Round 4 is the
+        last: how the rapid-fire block introduces itself before the
+        speaker strip and pairs.
+      </p>
+      <p>
+        Label word is held constant ("Sneltrein") across all four options —
+        the visual treatment is what varies. Sneltrein is the legacy
+        editorial word from the Phase 2 <code>QaGroupRapidFire</code> and
+        carries forward unchanged.
+      </p>
+      <p>
+        Same fixture as Rounds 1–3.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPENER A — PLAIN MONO + STAR ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Opener A · Plain MonoLabel + star</div>
+          <div class="name">★ SNELTREIN — centered, mono caps, ink-muted</div>
+          <div class="desc">
+            The placeholder used through Rounds 1–3. Centered MonoLabel
+            (10px / 0.2em tracking) with a leading typographic star. Most
+            understated; reads as a quiet section beat.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel cream-surface (10px ink-muted)<br />
+            ✓ typographic star glyph (matches QASection kicker)<br />
+            ✗ no new tokens
+          </div>
+        </header>
+        <div class="surface">
+          <p class="opener-a">★ Sneltrein</p>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPENER B — DISPLAY ITALIC WORD ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Opener B · Display italic word</div>
+          <div class="name">Sneltrein. — italic Freight Display, left-aligned</div>
+          <div class="desc">
+            Larger, mixed-case italic Freight Display. Left-aligned so it
+            stacks naturally above the speaker strip. Reads as a section
+            title — gives rapid-fire the most editorial weight of the four.
+            Closest cousin to a chapter heading.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ italic Freight Display 600 (matches PullQuote / Q&amp;A)<br />
+            ✗ no MonoLabel<br />
+            ✗ no ornament
+          </div>
+        </header>
+        <div class="surface">
+          <h3 class="opener-b">Sneltrein.</h3>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPENER C — THREE-BAR ACCENT ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Opener C · Three-bar accent + MonoLabel</div>
+          <div class="name">▌▌▌ SNELTREIN — jersey-deep bars + mono caps</div>
+          <div class="desc">
+            Legacy homage. The original <code>QaGroupRapidFire</code> used
+            three small green bars + "Sneltrein" mono caps; this option
+            carries the visual signature forward, swapping the Phase 2
+            bright green for jersey-deep on cream. Strongest identity —
+            "this is rapid-fire" is unmistakable. Adds the three-bar
+            ornament to the vocabulary.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel jersey-deep (11px / 0.2em / 600)<br />
+            ✓ 3x jersey-deep bars (12px × 2px, 4px gap) — NEW<br />
+            ✓ legacy continuity from Phase 2
+          </div>
+        </header>
+        <div class="surface">
+          <header class="opener-c">
+            <span class="bars" aria-hidden="true">
+              <span></span>
+              <span></span>
+              <span></span>
+            </span>
+            <span class="label">Sneltrein</span>
+          </header>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPENER D — MONOLABEL BETWEEN HAIRLINES ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Opener D · MonoLabel between hairlines</div>
+          <div class="name">─── SNELTREIN ─── ink hairlines flanking the label</div>
+          <div class="desc">
+            Editorial section-break register. 1px ink hairlines on both
+            sides of the centered MonoLabel. Strongest break from the
+            surrounding article body — reads as "a new self-contained
+            section starts here". Same visual family as the locked
+            <code>ArticleCredits</code> top/bottom rules.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel cream-surface (10px ink, 600)<br />
+            ✓ 1px ink hairlines — same primitive as ArticleCredits<br />
+            ✗ no ornament beyond MonoLabel + rules
+          </div>
+        </header>
+        <div class="surface">
+          <header class="opener-d">
+            <span class="rule" aria-hidden="true"></span>
+            <span class="label">Sneltrein</span>
+            <span class="rule" aria-hidden="true"></span>
+          </header>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Trade-offs</strong>
+      <ul>
+        <li>
+          <strong>A</strong> is most understated — fewest new pixels, but
+          may not signal "this is a different mode" strongly enough when
+          embedded mid-article.
+        </li>
+        <li>
+          <strong>B</strong> is most editorial — gives rapid-fire chapter-
+          heading weight. May overpower a 4-pair block; better suited to
+          long lists.
+        </li>
+        <li>
+          <strong>C</strong> carries forward the legacy Phase 2 signature
+          — readers who knew the old design will recognise rapid-fire
+          immediately. Adds a small new ornament to the vocabulary.
+        </li>
+        <li>
+          <strong>D</strong> reuses the locked <code>ArticleCredits</code>
+          hairline primitive — strongest "self-contained section" cue,
+          zero new vocabulary.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4-section-opener-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4-section-opener-comparisons.html
@@ -66,6 +66,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4b-label-word-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4b-label-word-comparisons.html
@@ -65,6 +65,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4b-label-word-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-4b-label-word-comparisons.html
@@ -1,0 +1,494 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-int Rapid-fire · Round 4b · Label word</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 32px 0 36px;
+      }
+      .qa-section {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+
+      .avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 16px;
+        flex-shrink: 0;
+      }
+      .speaker-strip {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin: 0 0 18px;
+      }
+      .speaker-tag {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+      }
+      .speaker-tag .name-strong {
+        color: var(--color-ink);
+      }
+
+      /* Locked opener (Round 4 D) — MonoLabel between hairlines. */
+      .opener {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin: 0 0 22px;
+      }
+      .opener .rule {
+        flex: 1;
+        height: 1px;
+        background: var(--color-ink);
+      }
+      .opener .label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      /* Locked Round 1 hanging-Q rhythm + Round 3 dotted divider. */
+      .rf-pairs .pair {
+        display: grid;
+        grid-template-columns: 132px minmax(0, 1fr);
+        gap: 22px;
+        padding: 14px 0;
+        border-bottom: 1px dotted var(--color-ink-muted);
+        align-items: baseline;
+      }
+      .rf-pairs .pair:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .rf-pairs .q {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--color-ink-muted);
+        margin: 0;
+        line-height: 1.45;
+      }
+      .rf-pairs .a {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.55;
+        margin: 0;
+        color: var(--color-ink);
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">
+        Phase 5 · Drill 5.d-int-rapidfire · Round 4b · #1840
+      </p>
+      <h1>
+        Rapid-fire — label word (Dutch alternatives to "Sneltrein")
+      </h1>
+      <p>
+        Round 4 locked the opener treatment (MonoLabel between hairlines).
+        This round picks the actual word. Everything else is held constant
+        — only the label text changes between the hairlines.
+      </p>
+      <p>
+        "Sneltrein" was the Phase 2 word; user has flagged it as not the
+        right register for the redesign. Four Dutch alternatives below.
+        Casing follows the MonoLabel convention (all-caps display, mixed-
+        case authored value).
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — KORT & KRACHTIG ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Kort &amp; krachtig</div>
+          <div class="name">Klassieke Nederlandse interviewtaal</div>
+          <div class="desc">
+            Standard Dutch interview vocabulary — "short &amp; punchy".
+            Most journalistically conventional. Reads as a familiar
+            register; signals "fast Q&amp;A" without effort. Two words +
+            ampersand may look busy at MonoLabel scale.
+          </div>
+          <div class="vocab">
+            <strong>Register</strong>
+            ✓ journalistic / interview-genre familiar<br />
+            ✓ neutral &amp; safe<br />
+            ⚠ 3-token label (slightly long)
+          </div>
+        </header>
+        <div class="surface">
+          <header class="opener">
+            <span class="rule" aria-hidden="true"></span>
+            <span class="label">Kort &amp; krachtig</span>
+            <span class="rule" aria-hidden="true"></span>
+          </header>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — RECHT VOOR DE RAAP ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Recht voor de raap</div>
+          <div class="name">Spreektaal, club-stem</div>
+          <div class="desc">
+            Flemish/Dutch idiom meaning "straight to the point". Most
+            character of the four — sounds like a member of the kantine
+            talking. Strongest fit for the fanzine register; quickest to
+            feel KCVV-voice. Four-token label is on the long side at
+            MonoLabel scale.
+          </div>
+          <div class="vocab">
+            <strong>Register</strong>
+            ✓ spreektaal — strongest character<br />
+            ✓ matches "Er is maar één plezante compagnie" voice<br />
+            ⚠ longest label (4 tokens) — pushes hairlines short
+          </div>
+        </header>
+        <div class="surface">
+          <header class="opener">
+            <span class="rule" aria-hidden="true"></span>
+            <span class="label">Recht voor de raap</span>
+            <span class="rule" aria-hidden="true"></span>
+          </header>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — SNELLE RONDE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Snelle ronde</div>
+          <div class="name">Sport-neutraal</div>
+          <div class="desc">
+            "Quick round" — neutral, sport-adjacent. No metaphor, no idiom;
+            describes what's on the page. Shortest of the four. Closest
+            translation of "rapid-fire round" without train imagery. Risks
+            blandness — could just as easily be in any club's match
+            report.
+          </div>
+          <div class="vocab">
+            <strong>Register</strong>
+            ✓ shortest label (2 tokens)<br />
+            ✓ neutral / unambiguous<br />
+            ⚠ generic — lowest character
+          </div>
+        </header>
+        <div class="surface">
+          <header class="opener">
+            <span class="rule" aria-hidden="true"></span>
+            <span class="label">Snelle ronde</span>
+            <span class="rule" aria-hidden="true"></span>
+          </header>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — KORTE VRAGEN ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Korte vragen</div>
+          <div class="name">Descriptief, plain Vlaams</div>
+          <div class="desc">
+            "Short questions" — pure description. Tells the reader exactly
+            what's coming without any genre framing. Slightly different
+            framing than the others — describes the questions, not the
+            register. Most editor-friendly: an editor authoring a
+            rapid-fire block doesn't have to "feel" the brand voice to
+            label it correctly.
+          </div>
+          <div class="vocab">
+            <strong>Register</strong>
+            ✓ short label (2 tokens)<br />
+            ✓ descriptive — zero ambiguity<br />
+            ⚠ no character — purely functional
+          </div>
+        </header>
+        <div class="surface">
+          <header class="opener">
+            <span class="rule" aria-hidden="true"></span>
+            <span class="label">Korte vragen</span>
+            <span class="rule" aria-hidden="true"></span>
+          </header>
+          <div class="qa-section">
+            <header class="speaker-strip">
+              <span class="avatar" aria-hidden="true">L</span>
+              <span class="speaker-tag"
+                ><span class="name-strong">LARS JANSSENS</span> ·
+                AANVALLER</span
+              >
+            </header>
+            <div class="rf-pairs">
+              <div class="pair">
+                <p class="q">Favoriete goal</p>
+                <p class="a">De volley tegen Diest in de slotminuut.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Speler om te volgen</p>
+                <p class="a">Wim. Hij maakt iedereen beter.</p>
+              </div>
+              <div class="pair">
+                <p class="q">Bus-muziek</p>
+                <p class="a">"Geen liedjes — koptelefoon op, ogen dicht."</p>
+              </div>
+              <div class="pair">
+                <p class="q">Eerste KCVV-herinnering</p>
+                <p class="a">Hand vasthouden van mijn pa, U7.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Editorial vs. authored</strong>
+      <ul>
+        <li>
+          This label is <strong>not</strong> editor-authored per qaBlock;
+          it's a fixed string the renderer emits whenever a rapid-fire
+          group is detected. So the label is part of the design lock, not
+          a Studio field.
+        </li>
+        <li>
+          If we want editor override later, a <code>QaSection</code>-level
+          <code>label</code> field could be added (out of scope for this
+          drill). For now: one canonical word, locked here.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Other candidates considered</strong>
+      <ul>
+        <li><em>Snel &amp; kort</em> — too similar to "Kort &amp; krachtig"; less idiomatic.</li>
+        <li><em>In het kort</em> — reads as "in brief" / a summary, wrong meaning.</li>
+        <li><em>Vragenronde</em> — generic round-of-questions; doesn't carry the rapid feel.</li>
+        <li><em>Tot slot</em> — wrong meaning (implies an ending).</li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-table/round-1-htmltable-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-table/round-1-htmltable-comparisons.html
@@ -61,6 +61,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-table/round-1-htmltable-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-table/round-1-htmltable-comparisons.html
@@ -1,0 +1,570 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-table · Round 1 · htmlTable</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 38px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      .scroll-region {
+        overflow-x: auto;
+        margin: 22px 0;
+      }
+
+      /* ============================================================
+         OPTION A — Jersey-deep header + alternating rows + ink borders
+         ============================================================ */
+      .opt-a table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+      }
+      .opt-a thead th {
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-weight: 600;
+        text-align: left;
+        padding: 10px 12px;
+        border: 1px solid var(--color-ink);
+      }
+      .opt-a tbody td {
+        padding: 9px 12px;
+        border: 1px solid var(--color-ink-muted);
+        color: var(--color-ink);
+      }
+      .opt-a tbody tr:nth-child(odd) td { background: var(--color-cream); }
+      .opt-a tbody tr:nth-child(even) td { background: var(--color-cream-soft); }
+      .opt-a tbody td:first-child {
+        font-weight: 600;
+      }
+
+      /* ============================================================
+         OPTION B — Newsprint hairlines, italic display cells
+         ============================================================ */
+      .opt-b table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        border-top: 2px solid var(--color-ink);
+        border-bottom: 2px solid var(--color-ink);
+      }
+      .opt-b thead th {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-weight: 600;
+        color: var(--color-ink);
+        text-align: left;
+        padding: 10px 6px 8px;
+        border-bottom: 1px solid var(--color-ink);
+      }
+      .opt-b tbody td {
+        padding: 9px 6px;
+        color: var(--color-ink);
+        border-bottom: 1px dotted var(--color-ink-muted);
+      }
+      .opt-b tbody tr:last-child td { border-bottom: 0; }
+      .opt-b tbody td:first-child {
+        font-style: italic;
+        font-weight: 600;
+        font-size: 16px;
+      }
+
+      /* ============================================================
+         OPTION C — Card-wrapped with mono columns and zebra
+         ============================================================ */
+      .opt-c .card-wrap {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: 4px 4px 0 0 var(--color-ink);
+        margin: 22px 0;
+        overflow-x: auto;
+      }
+      .opt-c table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 13px;
+      }
+      .opt-c thead th {
+        background: var(--color-ink);
+        color: var(--color-cream);
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-weight: 600;
+        text-align: left;
+        padding: 10px 12px;
+      }
+      .opt-c thead th:not(:first-child) {
+        border-left: 1px dotted color-mix(in srgb, var(--color-cream) 25%, transparent);
+      }
+      .opt-c tbody td {
+        padding: 8px 12px;
+        color: var(--color-ink);
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .opt-c tbody td:not(:first-child) {
+        border-left: 1px dotted var(--color-ink-muted);
+      }
+      .opt-c tbody tr:nth-child(even) td { background: rgba(0, 0, 0, 0.025); }
+      .opt-c tbody td:first-child {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+        font-style: italic;
+        font-weight: 600;
+      }
+
+      /* ============================================================
+         OPTION D — Minimal newspaper table (typography only)
+         ============================================================ */
+      .opt-d table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: ui-serif, Georgia, serif;
+        font-size: 15px;
+      }
+      .opt-d thead th {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 10px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        font-weight: 600;
+        color: var(--color-ink-muted);
+        text-align: left;
+        padding: 8px 4px 6px;
+        border-bottom: 2px solid var(--color-ink);
+      }
+      .opt-d tbody td {
+        padding: 7px 4px;
+        color: var(--color-ink);
+      }
+      .opt-d tbody td:first-child {
+        font-weight: 600;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul { margin: 8px 0 0; padding-left: 20px; }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-table · Round 1 · #1840</p>
+      <h1>
+        htmlTable — cream-surface restyle (jersey-band / newsprint / dark
+        card / minimal)
+      </h1>
+      <p>
+        Drill 5.2. The legacy <code>HtmlTableBlock</code> wraps sanitized
+        HTML in a scroll container with a gray header band, alternating
+        white/gray rows, and a sticky first column on scroll. None of
+        those colours sit on cream. Four cream-friendly restyles below.
+      </p>
+      <p>
+        Same fixture across all options: a 5-row schedule table
+        (datum / tegenstander / locatie / scheidsrechter / uitslag).
+        Wrapped in body prose. The horizontal-scroll affordance + sticky
+        first column behaviour are preserved in every option (CSS
+        omitted for brevity, identical to legacy).
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — JERSEY-BAND ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Jersey-band header + alternating rows</div>
+          <div class="name">Jersey-deep header band, cream/cream-soft zebra, 1px ink borders</div>
+          <div class="desc">
+            Closest to a "club programme" table. Jersey-deep header band
+            (cream text, mono caps), 1px ink borders on every cell,
+            alternating cream + cream-soft body rows. First column
+            bolded for row identification. Most "stadium signage"
+            register.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ jersey-deep header band<br />
+            ✓ MonoLabel header typography<br />
+            ✓ 1px ink-muted body borders<br />
+            ✓ alternating cream / cream-soft zebra
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De voorbereidingskalender is rond. Vijf oefenwedstrijden in
+              juli en augustus, telkens op zaterdag.
+            </p>
+            <div class="scroll-region opt-a">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Datum</th>
+                    <th>Tegenstander</th>
+                    <th>Locatie</th>
+                    <th>Uitslag</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Za 12 jul</td><td>VK Veltem</td><td>Uit</td><td>2–1</td></tr>
+                  <tr><td>Za 19 jul</td><td>SK Berg</td><td>Thuis</td><td>3–0</td></tr>
+                  <tr><td>Za 26 jul</td><td>FC Perk</td><td>Uit</td><td>1–1</td></tr>
+                  <tr><td>Za 2 aug</td><td>KV Steenokkerzeel</td><td>Thuis</td><td>—</td></tr>
+                  <tr><td>Za 9 aug</td><td>RSC Sterrebeek</td><td>Uit</td><td>—</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>
+              Aftrap telkens om 14:00. Voor de thuiswedstrijden is er
+              kantine open vanaf 13:00.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — NEWSPRINT HAIRLINES ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · Newsprint hairlines</div>
+          <div class="name">2px ink top + bottom, 1px dotted row dividers, italic display first column</div>
+          <div class="desc">
+            "Sports section of a newspaper" register. No cell borders;
+            2px ink top + bottom bracket the whole table; rows separated
+            by dotted ink-muted (Phase 3-b primitive). First column in
+            italic display Freight — gives the row labels editorial
+            weight. No alternating row colours; relies on typography for
+            scannability.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ 2px ink top + bottom (matches MissionBanner rule)<br />
+            ✓ Phase 3-b dotted ink-muted row divider<br />
+            ✓ MonoLabel header typography<br />
+            ✓ italic Freight first column<br />
+            ✗ no zebra
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De voorbereidingskalender is rond. Vijf oefenwedstrijden in
+              juli en augustus, telkens op zaterdag.
+            </p>
+            <div class="scroll-region opt-b">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Datum</th>
+                    <th>Tegenstander</th>
+                    <th>Locatie</th>
+                    <th>Uitslag</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Za 12 jul</td><td>VK Veltem</td><td>Uit</td><td>2–1</td></tr>
+                  <tr><td>Za 19 jul</td><td>SK Berg</td><td>Thuis</td><td>3–0</td></tr>
+                  <tr><td>Za 26 jul</td><td>FC Perk</td><td>Uit</td><td>1–1</td></tr>
+                  <tr><td>Za 2 aug</td><td>KV Steenokkerzeel</td><td>Thuis</td><td>—</td></tr>
+                  <tr><td>Za 9 aug</td><td>RSC Sterrebeek</td><td>Uit</td><td>—</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>
+              Aftrap telkens om 14:00. Voor de thuiswedstrijden is er
+              kantine open vanaf 13:00.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — DARK CARD WITH MONO COLUMNS ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Dark card with mono columns</div>
+          <div class="name">Card wrapper + ink header band + mono body + zebra</div>
+          <div class="desc">
+            Most "data display" register. Whole table sits inside a 1px
+            ink border + offset shadow card (TapedCard family without
+            tape). Header band in solid ink, all body cells in
+            monospace (column alignment in fixed-width type), dotted
+            row + column dividers, subtle zebra on even rows. First
+            column in italic Freight to break the mono rhythm.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedCard-family wrapper (no tape)<br />
+            ✓ ink header band + cream text<br />
+            ✓ mono body cells + italic Freight first column<br />
+            ✓ dotted ink-muted row + column dividers
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De voorbereidingskalender is rond. Vijf oefenwedstrijden in
+              juli en augustus, telkens op zaterdag.
+            </p>
+            <div class="opt-c">
+              <div class="card-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Datum</th>
+                      <th>Tegenstander</th>
+                      <th>Locatie</th>
+                      <th>Uitslag</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr><td>Za 12 jul</td><td>VK Veltem</td><td>Uit</td><td>2–1</td></tr>
+                    <tr><td>Za 19 jul</td><td>SK Berg</td><td>Thuis</td><td>3–0</td></tr>
+                    <tr><td>Za 26 jul</td><td>FC Perk</td><td>Uit</td><td>1–1</td></tr>
+                    <tr><td>Za 2 aug</td><td>KV Steenokkerzeel</td><td>Thuis</td><td>—</td></tr>
+                    <tr><td>Za 9 aug</td><td>RSC Sterrebeek</td><td>Uit</td><td>—</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <p>
+              Aftrap telkens om 14:00. Voor de thuiswedstrijden is er
+              kantine open vanaf 13:00.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — MINIMAL ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · Minimal newspaper table</div>
+          <div class="name">Typography-only: mono caps headers + 2px under, no borders</div>
+          <div class="desc">
+            Quietest. Just typography: mono caps headers in ink-muted
+            with a 2px ink baseline below the header row, body cells in
+            Freight body, first column bolded. No cell borders, no row
+            zebra, no card. Tightest body integration — reads like a
+            classified ad table from a newspaper.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ MonoLabel header typography<br />
+            ✓ 2px ink header baseline<br />
+            ✗ no borders<br />
+            ✗ no zebra<br />
+            ✗ no card chrome
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              De voorbereidingskalender is rond. Vijf oefenwedstrijden in
+              juli en augustus, telkens op zaterdag.
+            </p>
+            <div class="scroll-region opt-d">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Datum</th>
+                    <th>Tegenstander</th>
+                    <th>Locatie</th>
+                    <th>Uitslag</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Za 12 jul</td><td>VK Veltem</td><td>Uit</td><td>2–1</td></tr>
+                  <tr><td>Za 19 jul</td><td>SK Berg</td><td>Thuis</td><td>3–0</td></tr>
+                  <tr><td>Za 26 jul</td><td>FC Perk</td><td>Uit</td><td>1–1</td></tr>
+                  <tr><td>Za 2 aug</td><td>KV Steenokkerzeel</td><td>Thuis</td><td>—</td></tr>
+                  <tr><td>Za 9 aug</td><td>RSC Sterrebeek</td><td>Uit</td><td>—</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>
+              Aftrap telkens om 14:00. Voor de thuiswedstrijden is er
+              kantine open vanaf 13:00.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Preserved behaviour (all options)</strong>
+      <ul>
+        <li>
+          Horizontal scroll wrapper for tables wider than the prose
+          column (legacy <code>useScrollHint</code>).
+        </li>
+        <li>
+          Sticky first column on scroll (legacy behaviour).
+        </li>
+        <li>
+          HTML sanitization rules unchanged
+          (<code>TABLE_SANITIZE_OPTIONS</code>).
+        </li>
+        <li>
+          Editor authors raw HTML in the schema; no migration; styling
+          is pure CSS / Tailwind on the wrapper.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Trade-offs</strong>
+      <ul>
+        <li>
+          <strong>A · Jersey-band</strong> — strongest brand;
+          jersey-deep header reads as "official club data."
+        </li>
+        <li>
+          <strong>B · Newsprint hairlines</strong> — quietest brand
+          presence; strongest editorial body fit; relies on typography
+          alone.
+        </li>
+        <li>
+          <strong>C · Dark card</strong> — best for dense numeric data
+          (rankings, statistics); mono body aligns columns visually.
+        </li>
+        <li>
+          <strong>D · Minimal</strong> — lightest footprint; weakest
+          column separation when content is text-heavy with wraps.
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-vid/round-1-frame-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-vid/round-1-frame-comparisons.html
@@ -61,6 +61,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-vid/round-1-frame-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-vid/round-1-frame-comparisons.html
@@ -1,0 +1,495 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-vid · Round 1 · Frame</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      /* Video poster placeholder — 16:9 dark sport scene. */
+      .video {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background:
+          radial-gradient(
+            ellipse at 40% 55%,
+            rgba(220, 190, 130, 0.85) 0%,
+            rgba(45, 122, 79, 0.6) 35%,
+            rgba(31, 95, 63, 0.85) 70%,
+            rgba(20, 60, 40, 0.95) 100%
+          );
+        position: relative;
+        overflow: hidden;
+      }
+      .video::after {
+        /* Silhouette of a player */
+        content: '';
+        position: absolute;
+        left: 38%;
+        top: 30%;
+        width: 18%;
+        height: 55%;
+        background: rgba(15, 25, 20, 0.6);
+        clip-path: polygon(
+          40% 0%, 60% 0%, 65% 15%, 70% 30%, 70% 55%, 90% 100%, 60% 100%,
+          55% 75%, 45% 75%, 40% 100%, 10% 100%, 30% 55%, 30% 30%, 35% 15%
+        );
+        filter: blur(0.5px);
+      }
+      .play-glyph {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 2;
+        pointer-events: none;
+      }
+      .play-glyph svg {
+        width: 64px;
+        height: 64px;
+        fill: rgba(255, 255, 255, 0.92);
+        filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.4));
+      }
+
+      /* Common figcaption styling — videoBlock has caption on the block,
+         not asset-side. */
+      .figcap {
+        padding: 8px 4px 0;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+      }
+
+      /* ============================================================
+         OPTION A — Match articleImage (flat TapedFigure with tape)
+         ============================================================ */
+      .opt-a-figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 28px 0;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+      .opt-a-figure .tape {
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+        z-index: 2;
+      }
+
+      /* ============================================================
+         OPTION B — TapedFigure, NO tape (frame stays)
+         ============================================================ */
+      .opt-b-figure {
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 28px 0;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+
+      /* ============================================================
+         OPTION C — Plain bordered figure (no tape, no card padding)
+         ============================================================ */
+      .opt-c-figure {
+        margin: 28px 0;
+        border: 1px solid var(--color-ink);
+        box-shadow: 4px 4px 0 0 var(--color-ink);
+      }
+      .opt-c-figure .figcap {
+        padding: 8px 14px 12px;
+        background: var(--color-cream-soft);
+      }
+
+      /* ============================================================
+         OPTION D — No frame at all
+         ============================================================ */
+      .opt-d-figure {
+        margin: 28px 0;
+      }
+      .opt-d-figure .figcap {
+        margin-top: 8px;
+        padding-left: 4px;
+        padding-right: 4px;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul { margin: 8px 0 0; padding-left: 20px; }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-vid · Round 1 · #1840</p>
+      <h1>
+        videoBlock — frame (TapedFigure with tape / TapedFigure no tape /
+        plain bordered / no frame)
+      </h1>
+      <p>
+        Drill 4.1. Locks the frame around the video poster/player on the
+        cream surface. The locked
+        <code>&lt;ArticleImage&gt;</code> Round 1 used a flat TapedFigure
+        with a single tape strip — this round asks whether video should
+        match, soften the decoration, or drop the frame entirely.
+      </p>
+      <p>
+        Each option renders the same fixture: 16:9 video poster (with a
+        play-glyph overlay placeholder — the actual play affordance is
+        drilled in Round 2), <code>caption</code> string from the
+        videoBlock schema, embedded in body prose. <code>poster</code>
+        is shown in every option so the comparison is honest — when no
+        poster is set, the video element starts black and behaves
+        identically across all four.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — MATCH ARTICLEIMAGE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option A · Match articleImage (TapedFigure + tape)</div>
+          <div class="name">Flat TapedFigure, single ochre tape top-center</div>
+          <div class="desc">
+            Identical vocabulary to the locked <code>articleImage</code>
+            R1: flat TapedFigure on cream-white, 1px subtle border, offset
+            shadow, single ochre tape strip top-center. Photo and video
+            read as the same body media family.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ matches articleImage R1 lock<br />
+            ✓ TapedFigure primitive (cream-white, single tape)<br />
+            ✓ one body media family
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="opt-a-figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="video">
+                <span class="play-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                </span>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — TAPEDFIGURE NO TAPE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option B · TapedFigure without tape</div>
+          <div class="name">Same frame as articleImage, tape strip removed</div>
+          <div class="desc">
+            TapedFigure primitive with the tape suppressed. Same
+            cream-white frame, same border + shadow, no decorative tape.
+            Reads as "video is a slightly different type of media — less
+            stationary than a photograph, so the printed-tape metaphor
+            fits less well."
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ TapedFigure primitive (tape=undefined)<br />
+            ✗ no decorative tape<br />
+            ⚠ breaks parity with articleImage R1
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="opt-b-figure">
+              <div class="video">
+                <span class="play-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                </span>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — PLAIN BORDERED FIGURE ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option C · Plain bordered figure</div>
+          <div class="name">1px ink border + offset shadow, no card padding</div>
+          <div class="desc">
+            Drops the TapedFigure primitive entirely. Video sits flush
+            inside a 1px ink border with a hard offset shadow; caption
+            attaches to a cream-soft band at the bottom of the same frame
+            (no padding between video and caption band). Reads as a TV
+            screen / monitor — most "this is a screen" register.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✗ no TapedFigure primitive<br />
+            ✓ 1px ink border + offset shadow (matches TapedCard family)<br />
+            ✓ cream-soft caption band attached to bottom edge
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="opt-c-figure">
+              <div class="video">
+                <span class="play-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                </span>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION D — NO FRAME ====================== -->
+      <section class="candidate">
+        <header class="card">
+          <div class="key">Option D · No frame</div>
+          <div class="name">Video sits flat on cream, caption below</div>
+          <div class="desc">
+            No card, no border, no tape. Video occupies the prose column
+            width with sharp corners; caption sits below in italic serif.
+            Tightest integration with body prose; weakest media-as-object
+            signal. Closest to the legacy renderer (minus the 4px rounded
+            corners).
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✗ no TapedFigure<br />
+            ✗ no border, no shadow<br />
+            ✓ caption matches articleImage figcap typography
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="opt-d-figure">
+              <div class="video">
+                <span class="play-glyph" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                </span>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Consistency signal</strong>
+      <ul>
+        <li>
+          Option A is the only one that achieves photo/video parity in
+          the body — readers see one "framed media" family across both
+          block types.
+        </li>
+        <li>
+          Options B–D each break parity in a different way: B keeps the
+          frame but drops the decoration; C swaps the frame; D drops the
+          frame entirely.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">
+        Out of scope this round
+      </strong>
+      <ul>
+        <li>
+          Play affordance (drilled in Round 2). The play glyph in every
+          option is a placeholder; the actual button design is decided
+          separately.
+        </li>
+        <li>
+          Width behavior (drilled in Round 3). Every option above is
+          shown at <code>--container-prose</code>; the width enum
+          decision is identical to the
+          <code>articleImage</code> R3 decision and may inherit it.
+        </li>
+        <li>
+          Embed iframe rendering (YouTube/Vimeo) — same frame applies to
+          both upload and embed paths. The play affordance differs (YT/Vimeo
+          render their own; uploads render ours).
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-vid/round-2-play-affordance-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-vid/round-2-play-affordance-comparisons.html
@@ -61,6 +61,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 32px;
       }
+      @media (max-width: 900px) {
+        .container {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+      }
       .candidate {
         background: #fff;
         border: 1px solid var(--color-ink);

--- a/docs/design/mockups/phase-5-article-detail/5d-vid/round-2-play-affordance-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-vid/round-2-play-affordance-comparisons.html
@@ -1,0 +1,530 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Drill 5.d-vid · Round 2 · Play affordance</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 38px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+
+      .container {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .prose {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .prose p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 17px;
+        line-height: 1.6;
+        color: var(--color-ink-soft);
+        margin: 0 0 18px;
+      }
+
+      /* Locked Round 1 A — flat TapedFigure with single ochre tape. */
+      .figure {
+        position: relative;
+        background: #fdfaf1;
+        border: 1px solid color-mix(in srgb, var(--color-ink) 30%, transparent);
+        padding: 10px;
+        margin: 28px 0;
+        box-shadow: 4px 4px 0 0 rgba(26, 26, 26, 0.7);
+      }
+      .figure .tape {
+        position: absolute;
+        top: -8px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-2deg);
+        width: 92px;
+        height: 16px;
+        background: rgba(255, 200, 110, 0.8);
+        z-index: 3;
+      }
+      .video {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background:
+          radial-gradient(
+            ellipse at 40% 55%,
+            rgba(220, 190, 130, 0.85) 0%,
+            rgba(45, 122, 79, 0.6) 35%,
+            rgba(31, 95, 63, 0.85) 70%,
+            rgba(20, 60, 40, 0.95) 100%
+          );
+        position: relative;
+        overflow: hidden;
+      }
+      .video::after {
+        content: '';
+        position: absolute;
+        left: 38%;
+        top: 30%;
+        width: 18%;
+        height: 55%;
+        background: rgba(15, 25, 20, 0.55);
+        clip-path: polygon(
+          40% 0%, 60% 0%, 65% 15%, 70% 30%, 70% 55%, 90% 100%, 60% 100%,
+          55% 75%, 45% 75%, 40% 100%, 10% 100%, 30% 55%, 30% 30%, 35% 15%
+        );
+        filter: blur(0.5px);
+      }
+      .figcap {
+        padding: 8px 4px 0;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        line-height: 1.45;
+        color: var(--color-ink-soft);
+        margin: 0;
+      }
+
+      /* ============================================================
+         OPTION A — Native HTML5 controls (no overlay)
+         The browser draws its own centered triangle on a translucent
+         poster overlay. We don't render any KCVV-branded button.
+         ============================================================ */
+      .opt-a .native-controls {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+      }
+      .opt-a .native-controls svg {
+        width: 64px;
+        height: 64px;
+        fill: rgba(255, 255, 255, 0.78);
+        background: rgba(0, 0, 0, 0.32);
+        border-radius: 50%;
+        padding: 14px;
+      }
+      .opt-a .native-bar {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 36px;
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.55), transparent);
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+        gap: 8px;
+        color: rgba(255, 255, 255, 0.92);
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        font-size: 11px;
+      }
+      .opt-a .native-bar svg {
+        width: 14px;
+        height: 14px;
+        fill: currentColor;
+      }
+      .opt-a .native-bar .timeline {
+        flex: 1;
+        height: 3px;
+        background: rgba(255, 255, 255, 0.3);
+        border-radius: 2px;
+        position: relative;
+      }
+      .opt-a .native-bar .timeline::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 100%;
+        width: 22%;
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 2px;
+      }
+
+      /* ============================================================
+         OPTION B — Centered jersey-deep play disc
+         Large circular button: jersey-deep bg, white triangle, 1px ink
+         border + offset shadow. Same vocabulary as the CTA button used
+         throughout the redesign.
+         ============================================================ */
+      .opt-b .play-disc {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 72px;
+        height: 72px;
+        background: var(--color-jersey-deep);
+        border-radius: 50%;
+        border: 2px solid var(--color-ink);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+      }
+      .opt-b .play-disc svg {
+        width: 30px;
+        height: 30px;
+        fill: var(--color-cream);
+        margin-left: 3px;
+      }
+
+      /* ============================================================
+         OPTION C · Corner pill (mono caps "▶ AFSPELEN")
+         Bottom-left corner pill — fanzine register. Matches the
+         eventFact CTA pill vocabulary.
+         ============================================================ */
+      .opt-c .play-pill {
+        position: absolute;
+        left: 16px;
+        bottom: 16px;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        height: 38px;
+        padding: 0 16px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        font-weight: 600;
+        text-decoration: none;
+        border: 1px solid var(--color-ink);
+        box-shadow: 3px 3px 0 0 var(--color-ink);
+        cursor: pointer;
+      }
+      .opt-c .play-pill svg {
+        width: 14px;
+        height: 14px;
+        fill: currentColor;
+      }
+
+      .footnote {
+        max-width: 1120px;
+        margin: 48px auto 0;
+        padding: 18px 22px;
+        border: 1px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-size: 13px;
+        line-height: 1.55;
+      }
+      .footnote strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+      }
+      .footnote ul { margin: 8px 0 0; padding-left: 20px; }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Drill 5.d-vid · Round 2 · #1840</p>
+      <h1>
+        videoBlock — play affordance (native / jersey-deep disc / corner
+        pill)
+      </h1>
+      <p>
+        Drill 4.2. Locks how the upload path signals "click to play"
+        before the video starts. Locked Round 1 frame (flat TapedFigure
+        + single ochre tape) is held constant across all three options.
+      </p>
+      <p>
+        Only applies to the upload path. The embed path (YouTube/Vimeo)
+        always renders the provider's own UI inside a privacy-enhanced
+        iframe — nothing we draw influences that. Behaviour: on click,
+        the custom button hides and the native HTML5 controls take over
+        for the rest of the playback (B and C).
+      </p>
+      <p>
+        Caption typography is held constant (italic Freight body-sm —
+        same as the locked articleImage figcap). Three options for the
+        play affordance only.
+      </p>
+    </header>
+
+    <div class="container">
+      <!-- ====================== OPTION A — NATIVE HTML5 CONTROLS ====================== -->
+      <section class="candidate opt-a">
+        <header class="card">
+          <div class="key">Option A · Native HTML5 controls</div>
+          <div class="name">No KCVV-branded button — browser draws its own</div>
+          <div class="desc">
+            <code>&lt;video controls poster=…&gt;</code> with no overlay.
+            Browser draws a translucent centered triangle on the poster
+            and renders its full controls bar on play. Zero custom code,
+            zero KCVV branding inside the player. Visually inconsistent
+            with the cream surface — controls are dark/translucent.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ zero custom UI<br />
+            ✗ browser chrome doesn't match cream surface<br />
+            ✓ accessible by default (browser handles focus/keys)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="video">
+                <span class="native-controls" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                </span>
+                <div class="native-bar" aria-hidden="true">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                  <span>0:42</span>
+                  <div class="timeline"></div>
+                  <span>3:08</span>
+                  <svg viewBox="0 0 24 24"><path d="M3 9v6h4l5 5V4L7 9H3z" /></svg>
+                  <svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zM5 10h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" /></svg>
+                </div>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION B — CENTERED JERSEY-DEEP DISC ====================== -->
+      <section class="candidate opt-b">
+        <header class="card">
+          <div class="key">Option B · Centered jersey-deep play disc</div>
+          <div class="name">72px disc · jersey-deep bg · white triangle · 2px ink border + offset shadow</div>
+          <div class="desc">
+            Large circular button centered on the poster. Same vocabulary
+            family as the CTA button (jersey-deep + ink border + offset
+            shadow). On click, the disc + poster hide and native HTML5
+            controls take over. Strongest KCVV-presence; reads as
+            "deliberate playable media."
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ jersey-deep + ink border + offset shadow (CTA family)<br />
+            ✓ 72px disc · white play triangle<br />
+            ✓ press-down hover (per <code>feedback_canonical_press_down_hover</code>)
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="video">
+                <button class="play-disc" type="button" aria-label="Speel video af">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                </button>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ====================== OPTION C — CORNER PILL ====================== -->
+      <section class="candidate opt-c">
+        <header class="card">
+          <div class="key">Option C · Corner pill ("▶ Afspelen")</div>
+          <div class="name">Bottom-left mono caps pill · jersey-deep bg · ink border + offset shadow</div>
+          <div class="desc">
+            Bottom-left corner pill with a triangle glyph + the word
+            "AFSPELEN". Reuses the eventFact CTA / button-pill
+            vocabulary; reads as "this is a labelled action, not a UI
+            primitive." Lower-key than the centered disc; the poster
+            stays the dominant visual.
+          </div>
+          <div class="vocab">
+            <strong>Vocabulary</strong>
+            ✓ mono caps pill (matches eventFact CTA)<br />
+            ✓ jersey-deep + ink border + offset shadow<br />
+            ✓ explicit Dutch label "AFSPELEN"
+          </div>
+        </header>
+        <div class="surface">
+          <div class="prose">
+            <p>
+              Bekijk hier de hoogtepunten van het derby tegen Diest —
+              gemaakt door An vanaf de tribune.
+            </p>
+            <figure class="figure">
+              <span class="tape" aria-hidden="true"></span>
+              <div class="video">
+                <button class="play-pill" type="button">
+                  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
+                  Afspelen
+                </button>
+              </div>
+              <figcaption class="figcap">
+                Hoogtepunten KCVV–Diest · 3–1
+              </figcaption>
+            </figure>
+            <p>
+              De compilatie loopt drie minuten — handig om snel terug te
+              keren op de drie KCVV-doelpunten.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="footnote">
+      <strong>Behaviour</strong>
+      <ul>
+        <li>
+          B and C both render the custom button + poster <em>before</em>
+          play. On click, the button + poster hide and the native HTML5
+          controls take over for scrubbing, fullscreen, volume, etc.
+          — no custom controls bar.
+        </li>
+        <li>
+          A skips the custom step entirely; the browser handles
+          everything from first paint.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">
+        Accessibility
+      </strong>
+      <ul>
+        <li>
+          B and C need <code>aria-label="Speel video af"</code> on the
+          button. Focus styles follow the design-system button family
+          (existing ring on focus-visible).
+        </li>
+        <li>
+          A inherits browser-default accessibility. Screen reader
+          announces "media player" with native controls.
+        </li>
+      </ul>
+      <strong style="display: block; margin-top: 12px">Out of scope</strong>
+      <ul>
+        <li>
+          Embed path (YouTube/Vimeo) — provider UI always; nothing to
+          decide here.
+        </li>
+        <li>
+          Width behavior — drilled separately in Round 3 (likely
+          inherits articleImage's width enum).
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-vid/round-2-play-affordance-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-vid/round-2-play-affordance-comparisons.html
@@ -468,7 +468,7 @@
             <figure class="figure">
               <span class="tape" aria-hidden="true"></span>
               <div class="video">
-                <button class="play-pill" type="button">
+                <button class="play-pill" type="button" aria-label="Speel video af">
                   <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg>
                   Afspelen
                 </button>

--- a/docs/design/mockups/phase-5-article-detail/articleimage-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/articleimage-locked.md
@@ -1,0 +1,166 @@
+# articleImage / image — locked (drill 5.d-img / #1840 drill 3)
+
+**Drill:** 5.d-img · Four visual rounds + aspect default · #1840 drills 3.1 + 3.2
+**Locked:** 2026-05-19 by @climacon
+**Mockups:**
+
+- `5d-img/round-1-figure-register-comparisons.html`
+- `5d-img/round-2-caption-credit-comparisons.html`
+- `5d-img/round-3-fullbleed-comparisons.html`
+- `5d-img/round-3b-width-mobile-comparisons.html`
+
+---
+
+> This lock supersedes the legacy `ArticleImageBlock` in `SanityArticleBody.tsx` (no caption / boolean fullBleed / 800×450 fallback). The locked rendering uses the existing `<TapedFigure>` design-system primitive, drives caption + credit from per-asset Sanity metadata, and replaces `fullBleed: boolean` with `width: 'prose' | 'wide' | 'bleed'`.
+
+## What this drill resolves
+
+- ✅ **R1 — Figure register:** Option B (flat TapedFigure, no rotation, single tape strip top-center).
+- ✅ **R2 — Caption + credit:** per-asset Sanity metadata (`asset->description` → caption, `asset->creditLine` → credit). No schema migration on `articleImage`.
+- ✅ **R3 — fullBleed flag:** Option D (replace with `width: 'prose' | 'wide' | 'bleed'` enum).
+- ✅ **R3b — Width mobile fallback:** Mobile 1 (wide collapses to prose on mobile; bleed stays bleed).
+- ✅ **Aspect default:** `aspect="auto"` (photo's native dimensions from `asset.metadata.dimensions`) + 70vh max-height clamp.
+
+## What this drill does NOT decide
+
+- **EXIF auto-extraction** — explicitly rejected by the owner. We do NOT enable `options.metadata: ['exif']` on the image type.
+- **Article-wide photographer override** — `article.photographer` (locked drill 5.d-int R2) keeps feeding `<ArticleCredits>` "Beeld" row; per-figure `asset->creditLine` only renders inline below the figure. No precedence rule needed — they're different surfaces.
+- **PortableText caption** — rejected in R2 in favour of plain string `asset->description`. If editors need inline links in a caption, that's a follow-up.
+
+## Locked field rendering
+
+### `articleImage` object (unchanged schema)
+
+```typescript
+defineType({
+  name: 'articleImage',
+  fields: [
+    {name: 'image', type: 'image', options: {hotspot: true}, validation: required()},
+    {name: 'alt', type: 'string', validation: required().warning()},
+    {name: 'width', type: 'string', options: {list: ['prose', 'wide', 'bleed']}, initialValue: 'prose'},
+    // fullBleed: boolean — REMOVED in migration
+  ],
+})
+```
+
+**Migration required:**
+
+```typescript
+// translate fullBleed → width
+fullBleed === true  → width: 'bleed'
+fullBleed !== true  → width: 'prose'
+unset fullBleed in all articleImage objects
+```
+
+### Asset-side metadata (no schema change; built-in Sanity fields)
+
+The renderer reads these from `image.asset->`. All optional:
+
+| Asset field | Visible? | Render slot | Notes |
+| --- | --- | --- | --- |
+| `asset->description` | ✅ if present | `<figcaption>` caption (italic Freight body-sm) | Editor sets in Studio asset detail view |
+| `asset->creditLine` | ✅ if present | `<figcaption>` credit (mono caps ink-muted, right side) | Editor sets in Studio asset detail view |
+| `asset->title` | ❌ internal only | Used in Studio asset browser; can fall back as `alt` if articleImage.alt is empty (preview/dev only — required validation should catch this) | |
+| `asset->metadata.dimensions` | — | Drives `aspect="auto"` natural ratio + Next.js Image `width`/`height` | Always present |
+
+### GROQ projection
+
+`articleImage` projections must extend the asset selection:
+
+```groq
+*[_type == "article" && slug.current == $slug][0]{
+  ...,
+  body[]{
+    ...,
+    _type == "articleImage" => {
+      ...,
+      image{
+        ...,
+        asset->{
+          _id,
+          url,
+          metadata{dimensions, lqip},
+          title,
+          description,
+          creditLine
+        }
+      }
+    }
+  }
+}
+```
+
+The existing article repository's body projection at `apps/web/src/lib/repositories/article.repository.ts` needs extension.
+
+### Renderer behaviour
+
+```tsx
+<TapedFigure
+  aspect="auto"
+  tape={{ color: 'ochre', length: 'sm', position: 'top-center', rotation: -2 }}
+  caption={asset.description ?? undefined}
+  credit={asset.creditLine ?? undefined}
+  bg="cream"
+  tint="newsprint"
+  // width=prose → max-width: var(--container-prose) (default behaviour)
+  // width=wide  → max-width: var(--container-wide) (NEW token, ~1040px)
+  // width=bleed → full-bleed escape via `mx-[calc(50%-50vw)] max-w-[100vw]`
+>
+  <Image
+    src={asset.url}
+    alt={articleImage.alt ?? ''}
+    width={asset.metadata.dimensions.width}
+    height={asset.metadata.dimensions.height}
+    style={{ maxHeight: '70vh', objectFit: 'contain' }}
+    sizes={width === 'bleed' ? '100vw' : width === 'wide' ? '(max-width: 640px) 100vw, 1040px' : '(max-width: 640px) 100vw, 680px'}
+  />
+</TapedFigure>
+```
+
+**Width rules:**
+
+- `prose` (default, 680px) — figure inside `--container-prose`, single tape strip, figcaption visible
+- `wide` (~1040px) — figure breaks out to a new `--container-wide` token; tape stays, figcaption stays. On mobile (`< 640px`) collapses to prose-width
+- `bleed` (100vw) — figure breaks to full viewport; **tape suppressed** (looks wrong on viewport-wide photos); figcaption stays at prose width, centered below the photo
+
+**70vh max-height clamp:** every figure (regardless of width) caps the rendered photo height at `70vh`. Prevents a portrait phone-photo from filling the entire desktop viewport. The figure container uses `object-fit: contain` so the photo letterboxes inside the clamp rather than cropping.
+
+### Tape behaviour
+
+- `prose` / `wide`: single ochre tape strip, ~92px wide, centered top edge, rotated -2°.
+- `bleed`: no tape (suppressed).
+- Tape color is the same ochre as the eventFact inline polaroid (drill 2.1 R1 lock) — single tape vocabulary across the body.
+
+### Component contract
+
+The Phase 5 `<ArticleBody>` PT serializer routes `articleImage` to a new internal renderer (or directly to `<TapedFigure>` with the props above). No new design-system primitive — `<TapedFigure>` already exists and is unchanged.
+
+**Storybook stories required** (per `feedback_state_coverage_stories`):
+- prose width · landscape native · with caption + credit
+- prose width · portrait native (tall photo, 70vh clamp triggers)
+- wide width · landscape · with caption only (no credit)
+- bleed · landscape · no caption/credit (asset has none)
+- prose · no caption / no credit (figcaption omitted entirely)
+- mobile viewport · prose / wide collapsed / bleed (Round 3b lock)
+
+## Net new vocabulary / schema
+
+- **Schema:** remove `articleImage.fullBleed` boolean, add `articleImage.width: 'prose' | 'wide' | 'bleed'`. One Sanity migration (staging + production).
+- **Tokens:** new `--container-wide: 1040px` token (additive; doesn't replace anything).
+- **Component:** `<ArticleImageBlock>` Phase 5 renderer (sibling to the legacy one in `SanityArticleBody`). No new design-system primitive.
+- **Editor workflow:** editors get a width dropdown (prose / wide / bleed) on each image block. Caption + credit are set on the **asset** in the Studio asset detail view (one-time per upload), not on each usage.
+
+## Downstream impact
+
+- **#1829 (5.B body migration)** — this drill unblocks the `<ArticleBody>` articleImage serializer wiring. The migration ships the new renderer + the Sanity migration + the GROQ projection extension.
+- **Legacy `ArticleImageBlock`** — stays in `SanityArticleBody.tsx` until that renderer retires. Existing articles read fine via the fullBleed → width translation done in the migration.
+- **`article.repository.ts`** — extend body projection's articleImage selection to include `asset->{title, description, creditLine, metadata}`.
+- **Studio UX (referenced in `project_sanity_studio_ux_rework`)** — surfacing `asset->description` and `asset->creditLine` to editors is part of the broader Studio UX rework, not blocking this drill.
+
+## Source-of-truth
+
+- Mockup HTML: paths listed above.
+- Schema: `packages/sanity-schemas/src/articleImage.ts` (migration in same PR as #1829).
+- Existing reference: `apps/web/src/components/design-system/TapedFigure/TapedFigure.tsx` (unchanged primitive).
+- Legacy renderer being replaced: `apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx:62-80` (`ArticleImageBlock`).
+- Memories consumed: `feedback_reuse_approved_primitives`, `feedback_sanity_migrations`, `feedback_design_data_audit`, `feedback_state_coverage_stories`.

--- a/docs/design/mockups/phase-5-article-detail/articleimage-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/articleimage-locked.md
@@ -29,7 +29,9 @@
 
 ## Locked field rendering
 
-### `articleImage` object (unchanged schema)
+### `articleImage` object (width enum added; caption/credit unchanged)
+
+R2 leaves the schema untouched for caption/credit (those come from the asset reference). R3 changes the schema by removing `fullBleed` and adding a `width` enum:
 
 ```typescript
 defineType({
@@ -37,8 +39,8 @@ defineType({
   fields: [
     {name: 'image', type: 'image', options: {hotspot: true}, validation: required()},
     {name: 'alt', type: 'string', validation: required().warning()},
-    {name: 'width', type: 'string', options: {list: ['prose', 'wide', 'bleed']}, initialValue: 'prose'},
-    // fullBleed: boolean — REMOVED in migration
+    {name: 'width', type: 'string', options: {list: ['prose', 'wide', 'bleed']}, initialValue: 'prose'},  // ADDED in R3 migration
+    // fullBleed: boolean — REMOVED in R3 migration
   ],
 })
 ```
@@ -79,7 +81,7 @@ The renderer reads these from `image.asset->`. All optional:
         asset->{
           _id,
           url,
-          metadata{dimensions, lqip},
+          metadata{dimensions{width, height}, lqip},
           title,
           description,
           creditLine

--- a/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
@@ -99,7 +99,7 @@ None of those are required for the locked design; this note is purely a future-p
 ```
 
 - Component path: `apps/web/src/components/article/blocks/EventFactInline/EventFactInline.tsx` (sibling to `EventDetailBlock`).
-- Storybook stories required per `feedback_state_coverage_stories.md`: single upcoming · single past · 3 stacked (rotation pattern) · stacked broken by paragraph (rotation reset) · minimal (only required fields) · CTA-less (no `ticketUrl`) · mobile viewport.
+- Storybook stories required per `feedback_state_coverage_stories.md`: single upcoming · single past · 3 stacked (rotation pattern) · stacked broken by paragraph (no rotation reset — cycle continues globally, per the Counter behaviour note above) · minimal (only required fields) · CTA-less (no `ticketUrl`) · mobile viewport.
 - The `<SanityArticleBody>` legacy `eventFact: () => <EventFactOverview>` serializer stays untouched for now — Phase 5's `<ArticleBody>` wires `EventFactInline` directly. Legacy is removed when `<SanityArticleBody>` itself retires (post-#1829).
 
 ## Net new vocabulary / schema

--- a/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
@@ -53,7 +53,17 @@ Consecutive polaroids tilt at small alternating angles. CSS-only via `nth-of-typ
 
 Reads as "hand-pinned at slightly different moments" without becoming a busy collage. Single tape color (ochre) across all cards — no per-card tape variation.
 
-**Reset rule:** the rotation pattern resets when any non-eventFact PT block (paragraph, image, qaBlock, …) sits between two eventFacts. The `nth-of-type` selector handles this naturally inside one PT render.
+**Counter behaviour (corrects an earlier draft of this doc):** `:nth-of-type()` counts sibling elements of the same **tag name** — not the same class. It does **not** reset across intervening non-matching elements. With the locked CSS above, three `eventFact` polaroids separated by `<p>` paragraphs are still numbered 1 · 2 · 3 globally, so they render at -0.5° · +0.4° · -0.3° (cycle continues across the prose).
+
+That's actually the desired visual: a varied 3-step rotation across all polaroids in the article, regardless of what's between them. The earlier "rotation pattern resets between eventFact runs" phrasing was inaccurate and is dropped.
+
+If a future design ever requires a *true* per-run reset (each contiguous block of eventFacts restarts at -0.5°), the renderer must either:
+
+1. Wrap each contiguous run of `eventFact` items in a dedicated container so `:nth-of-type` counts inside that scope only;
+2. Pass an explicit run-scoped `index` prop into each `<EventFactInline>` and set `style.transform` directly from JS (skip the CSS selector entirely); or
+3. Restructure the PT serializer to group consecutive `eventFact` blocks into a single grouping component before render (same pattern the qaBlock dispatcher uses for `rapid-fire` collapse — see drill 1.3 lock).
+
+None of those are required for the locked design; this note is purely a future-proofing reference.
 
 ## Polish defaults (locked alongside the visual rounds)
 

--- a/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
@@ -82,8 +82,8 @@ Reads as "hand-pinned at slightly different moments" without becoming a busy col
 
 ```tsx
 <EventFactInline
-  value={eventFactValue}          // EventFactValue from the body PT
-  isPast={deriveIsPast(value)}    // computed page-level, same helper as EventDetailBlock
+  value={eventFactValue}                    // EventFactValue from the body PT
+  isPast={deriveIsPast(eventFactValue)}     // computed page-level, same helper as EventDetailBlock
   className?={…}
 />
 ```

--- a/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/eventfact-inline-locked.md
@@ -1,0 +1,113 @@
+# In-body eventFact — locked (drill 5.d-evt-inline / #1840 drill 2.1)
+
+**Drill:** 5.d-evt-inline · One existence decision + two visual rounds + polish defaults · #1840 drill 2.1
+**Locked:** 2026-05-19 by @climacon
+**Mockups:**
+
+- `5d-evt-inline/round-1-card-vocabulary-comparisons.html`
+- `5d-evt-inline/round-2-multi-card-behavior-comparisons.html`
+
+---
+
+> This lock supersedes the legacy Phase 2 `<EventFactOverview>` (dark-band full-bleed). The qaBlock-style "first eventFact absorbed by hero strip" rule from #1798 stands unchanged — this drill only covers what happens to subsequent eventFacts and to eventFacts authored inside non-event articles.
+
+## Existence — locked (broad case)
+
+The "additional eventFact in body" case **stays** in Phase 5. Two real-world cases share one visual:
+
+1. **Inline-in-announcement** — an `announcement` article references an upcoming event via an inline eventFact. Author choice; no hero strip.
+2. **Multi-eventFact in event articles** — subsequent eventFacts after the first one is absorbed by `<EventDetailBlock>` (e.g. a tournament weekend with 3 days, each authored as its own eventFact).
+
+Schema unchanged. `eventFact` stays in the body block type list (`packages/sanity-schemas/src/article.ts:228`).
+
+## Visual lock
+
+### Round 1 — Card vocabulary: **C (Taped polaroid)**
+
+A slightly rotated cream-white polaroid with ochre tape strips top-left + bottom-right, pinned into the body flow. No date block — date sits inline below the title in italic Freight Display.
+
+```text
+                ┌── tape (-5°) ───┐
+            ╔════════════════════════════════╗
+            ║  [Clubfeest pill]  Open …      ║
+            ║                                ║
+            ║  Steakfestijn 2026             ║   ← italic Freight 700, 26px
+            ║  Vrijdag 13 juni · 18:00–22:00 ║   ← italic Freight 600, 18px
+            ║                                ║
+            ║  SPORTPARK · MAX 180 PLAATSEN  ║   ← mono caps, 10px ink-muted
+            ║                                ║
+            ║  [ INSCHRIJVEN → ]             ║   ← jersey-deep button
+            ╚════════════════════════════════╝
+                                  └─ tape (+4°)
+```
+
+### Round 2 — Multi-card stacking: **B (Subtle alternating rotations)**
+
+Consecutive polaroids tilt at small alternating angles. CSS-only via `nth-of-type`:
+
+```css
+.eventfact-polaroid:nth-of-type(odd)   { transform: rotate(-0.5deg); }
+.eventfact-polaroid:nth-of-type(even)  { transform: rotate( 0.4deg); }
+.eventfact-polaroid:nth-of-type(3n)    { transform: rotate(-0.3deg); }
+```
+
+Reads as "hand-pinned at slightly different moments" without becoming a busy collage. Single tape color (ochre) across all cards — no per-card tape variation.
+
+**Reset rule:** the rotation pattern resets when any non-eventFact PT block (paragraph, image, qaBlock, …) sits between two eventFacts. The `nth-of-type` selector handles this naturally inside one PT render.
+
+## Polish defaults (locked alongside the visual rounds)
+
+- **Past-event treatment** — mirrors `<EventDetailBlock>`: tag pill replaced by muted `Afgelopen` pill, CTA hidden entirely, everything else stays visible as a historical record. `isPast` derivation reuses the same `deriveIsPast(eventFact)` helper from the page-level Server Component, passed down as a prop.
+- **Skip condition** — none. Always renders when authored. Unlike `<EventDetailBlock>` (which skips when `sessions/address/capacity/note` are all blank to avoid hero-strip duplication), the inline card has no surrounding context to be redundant against — an author placing an eventFact in the body is making an explicit editorial choice.
+- **Mobile behavior** — polaroid keeps its sub-1° rotation; tape strips stay. Width clamped to `--container-prose` minus body padding (works down to 320px without overflow). No special mobile fallback needed.
+- **Compression rules** — `sessions[]` and `note` PortableText are **NOT** rendered inline. Both stay exclusive to `<EventDetailBlock>`. This keeps the inline card visually lighter than the page-end card and prevents inline reproductions of the full event detail.
+
+## Locked field rendering
+
+| Field | Inline polaroid | `<EventDetailBlock>` (for reference) |
+| --- | --- | --- |
+| `title` | ✅ italic Freight 700, 26px | ✅ |
+| `date` + `endDate` | ✅ italic Freight 600, 18px (resolved range) | ✅ |
+| `startTime` / `endTime` | ✅ appended to date line | ✅ |
+| `sessions[]` | ❌ compressed out | ✅ |
+| `location` | ✅ mono caps meta line | ✅ |
+| `address` | ✅ mono caps meta line | ✅ |
+| `capacity` | ✅ mono caps meta line | ✅ |
+| `ageGroup` | ✅ mono-label kicker (right of pill) | ✅ |
+| `competitionTag` | ✅ jersey-deep pill | ✅ |
+| `ticketUrl` + `ticketLabel` | ✅ jersey-deep CTA button (hidden when `isPast`) | ✅ |
+| `note` (PT) | ❌ compressed out | ✅ |
+
+## Component contract
+
+```tsx
+<EventFactInline
+  value={eventFactValue}          // EventFactValue from the body PT
+  isPast={deriveIsPast(value)}    // computed page-level, same helper as EventDetailBlock
+  className?={…}
+/>
+```
+
+- Component path: `apps/web/src/components/article/blocks/EventFactInline/EventFactInline.tsx` (sibling to `EventDetailBlock`).
+- Storybook stories required per `feedback_state_coverage_stories.md`: single upcoming · single past · 3 stacked (rotation pattern) · stacked broken by paragraph (rotation reset) · minimal (only required fields) · CTA-less (no `ticketUrl`) · mobile viewport.
+- The `<SanityArticleBody>` legacy `eventFact: () => <EventFactOverview>` serializer stays untouched for now — Phase 5's `<ArticleBody>` wires `EventFactInline` directly. Legacy is removed when `<SanityArticleBody>` itself retires (post-#1829).
+
+## Net new vocabulary / schema
+
+- **Schema:** none. Reuses existing `eventFact` block unchanged.
+- **Component:** `<EventFactInline>` (new, sibling to `<EventDetailBlock>`).
+- **Tokens:** none. Reuses existing ochre tape, jersey-deep pill/CTA, Freight Display italic, mono caps label, cream surface.
+- **CSS:** new `nth-of-type` rotation pattern (≤ 4 lines).
+
+## Downstream impact
+
+- **#1829 (5.B body migration)** — this drill unblocks the `<ArticleBody>` eventFact serializer wiring. The migration ships `<EventFactInline>` alongside the rewritten `<QaGroupRapidFire>` from drill 1.3.
+- **Legacy `<EventFactOverview>`** — kept in `apps/web/src/components/article/blocks/EventFact/` for `<SanityArticleBody>` only; retires when `<SanityArticleBody>` does.
+- **`feedback_reuse_approved_primitives`** — polaroid reuses TapedCard family + ochre tape + jersey-deep pill/CTA + Freight Display. No new primitives.
+
+## Source-of-truth
+
+- Mockup HTML: `5d-evt-inline/round-1-card-vocabulary-comparisons.html`, `5d-evt-inline/round-2-multi-card-behavior-comparisons.html`.
+- Schema: `packages/sanity-schemas/src/eventFact.ts` (unchanged).
+- Existing reference: `apps/web/src/components/article/blocks/EventDetailBlock/EventDetailBlock.tsx` (page-end card — sibling).
+- Memories consumed: `feedback_reuse_approved_primitives`, `feedback_design_data_audit`, `feedback_state_coverage_stories`, `feedback_no_magazine_chrome`.

--- a/docs/design/mockups/phase-5-article-detail/fileattachment-htmltable-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/fileattachment-htmltable-locked.md
@@ -1,0 +1,159 @@
+# fileAttachment + htmlTable — locked (drill 5.d-file + 5.d-table / #1840 drill 5)
+
+**Drill:** 5.d-file + 5.d-table · One visual round each + inline pairing · #1840 drills 5.1 + 5.2
+**Locked:** 2026-05-19 by @climacon
+**Mockups:**
+
+- `5d-file/round-1-fileattachment-comparisons.html`
+- `5d-table/round-1-htmltable-comparisons.html`
+
+---
+
+> This lock supersedes the legacy `<DownloadButton>` (white-bg gray-border with file-type colored accent bar and scale hover) and the legacy `HtmlTableBlock` (gray header band with alternating white/gray rows). Both restyle for the Phase 5 cream surface without any schema migration.
+
+## What this drill resolves
+
+- ✅ **5.1 card variant:** Option B (Taped document with corner stamp) — TapedCard family, single ochre tape strip top, stenciled file-type stamp (rotated -3°), italic display label, jersey-deep "Download" CTA pill on the right.
+- ✅ **5.1 inline variant:** Option C (compact pill) — single-row chip with file-type pill + italic serif label + mono caps size + download glyph.
+- ✅ **5.2 table treatment:** Hybrid C+A — dark card wrapper (from C) with jersey-deep header band (from A) and mono body cells (from C).
+
+## What this drill does NOT decide
+
+- **Schema migrations** — none. `fileAttachment` and `htmlTable` schemas stay unchanged. All work is in `apps/web` CSS / component refactor.
+- **Sticky first column / scroll hint** — preserved verbatim from the legacy `HtmlTableBlock` (`useScrollHint` hook, sticky-on-scroll first column).
+- **HTML sanitization** — preserved (`TABLE_SANITIZE_OPTIONS` unchanged).
+- **File-type colour palette** — kept as the legacy `FILE_TYPES` lookup table (PDF red, Word blue, Excel green, PowerPoint orange, ZIP amber, other gray). Restyle only changes how those colours sit on the cream surface, not the palette.
+
+## 5.1 — `<DownloadButton>` Phase 5 spec
+
+### Card variant (default, Option B)
+
+```text
+            ┌── ochre tape strip (-2° rotation, top-center) ─┐
+            │                                                 │
+   ╔════════════════════════════════════════════════════════╗
+   ║  ┌──────┐                                              ║
+   ║  │ PDF  │  Trainingsschema seizoen 2025-2026     [⬇ Download]  ║
+   ║  │ stamp│  1,4 MB · Bijgewerkt 12 mei                  ║
+   ║  └──────┘                                              ║
+   ╚════════════════════════════════════════════════════════╝
+```
+
+- **Card:** cream-white background (`#fdfaf1`), 1px subtle ink border, 4px offset shadow `rgba(26,26,26,0.7)`, no rotation.
+- **Tape strip:** ochre `rgba(255, 200, 110, 0.8)`, 92px × 16px, centered top, rotated -2°. Single tape per card (same vocabulary as articleImage R1 lock).
+- **Stamp (left):** 64px × 64px square, 2px file-type-coloured border, 4px corner radius, transparent file-type-coloured background tint (6% opacity), rotated -3°. Mono caps "PDF" (16px / 800 weight) + "Bestand" subtitle (8px). Stamp is purely decorative — accessibility hidden.
+- **Body (center):** italic Freight Display 18px / 700 / italic for the label; mono caps 10px / 0.14em for the subtitle ("1,4 MB · Bijgewerkt …" — last-updated date is optional, drop when absent).
+- **CTA (right):** jersey-deep mono caps "Download" pill — 36px height, ink border, 3px offset shadow, press-down hover. Same vocabulary as the locked video play pill (drill 4.2).
+- **Hover:** canonical press-down on the whole anchor — `hover:translate-x-1 hover:translate-y-1 hover:shadow-none transition-all duration-300`.
+- **Focus:** standard design-system focus ring on the anchor.
+
+### Inline variant (Option C — for in-prose references)
+
+```text
+   [PDF] Trainingsschema seizoen 2025-2026  1,4 MB  ⬇
+```
+
+- **Chip:** cream background, 1px ink border, 3px offset shadow, 40px height, inline-flex with 10px gap.
+- **Extension pill (left):** file-type-coloured background (PDF red, Word blue, etc.), cream text, mono caps 9px / 0.16em, 22px height, 7px horizontal padding.
+- **Label (center):** italic Freight Display 16px, ink colour.
+- **Size:** mono caps 11px / 0.1em, ink-muted.
+- **Download glyph:** ink-muted, 14px.
+- **Hover:** canonical press-down.
+
+### Variant selection
+
+The legacy `variant: "card" | "inline"` prop is preserved. Default stays `card` (B). Editors pick `inline` when the file reference fits inside prose flow (e.g., "Bekijk het [PDF chip] voor meer details").
+
+### Stamp colour rule
+
+- PDF → red `#c0392b`
+- Word → blue `#2563b3`
+- Excel → green `#15803d`
+- PowerPoint → orange `#f97316`
+- ZIP → amber `#d97706`
+- Other → gray `#6b7280`
+
+Same `FILE_TYPES` lookup table as the legacy `<DownloadButton>` — only the visual presentation changes. Stamp colour applies to: the stamp border, the stamp background tint, and the extension text. CTA pill stays jersey-deep regardless of file type.
+
+## 5.2 — `<HtmlTableBlock>` Phase 5 spec
+
+### Hybrid card with jersey header (locked spec)
+
+```text
+   ╔══════════════════════════════════════════════════════════╗
+   ║ DATUM ⋮ TEGENSTANDER ⋮ LOCATIE ⋮ UITSLAG    ← jersey-deep header band, cream mono caps
+   ╠══════════════════════════════════════════════════════════╣
+   ║ Za 12 jul ⋮ VK Veltem  ⋮ Uit   ⋮ 2-1                    ║
+   ║ ...........................................              ← dotted ink-muted row divider
+   ║ Za 19 jul ⋮ SK Berg    ⋮ Thuis ⋮ 3-0                    ║
+   ║ ...........................................              ║
+   ║ ...                                                       ║
+   ╚══════════════════════════════════════════════════════════╝
+   └── 1px ink border + 4px offset shadow (TapedCard family, no tape)
+```
+
+- **Card wrapper:** 1px ink border, 4px offset shadow `var(--color-ink)`, white background, no tape, no rotation. Overflow-x: auto (preserves legacy horizontal scroll).
+- **Header band:** `background: var(--color-jersey-deep)`, cream text. Mono caps 10px / 0.18em / 600 weight, left-aligned, 10px × 12px padding.
+- **Header column dividers:** 1px dotted at 25% cream opacity (`color-mix(in srgb, var(--color-cream) 25%, transparent)`) — visible against jersey-deep, same intent as the locked C's dotted-on-ink.
+- **Body cells:** monospace 13px (`--font-mono`), 8px × 12px padding, ink colour. Mono font aligns columns visually for numeric / fixture data.
+- **First column override:** italic Freight Display 15px / 600 / italic. Breaks the mono rhythm; gives row identifiers editorial weight. Applies to `tbody td:first-child` only.
+- **Row dividers:** 1px dotted `--color-ink-muted` `border-top` on every `tbody td`. Last row has no bottom divider (relies on card edge).
+- **Column dividers in body:** 1px dotted `--color-ink-muted` `border-left` on every `tbody td:not(:first-child)`.
+- **Zebra (subtle):** even rows `background: rgba(0, 0, 0, 0.025)` — very faint ink tint, aids row scanning without competing with the dotted dividers.
+
+### Preserved legacy behaviour
+
+- **Horizontal scroll wrapper** — `overflow-x: auto` on the card wrapper. Legacy `useScrollHint` hook keeps managing the scroll-hint affordance.
+- **Sticky first column on scroll** — legacy CSS preserved. First column gets `position: sticky`, `left: 0`, `z-index: 10` when the parent has horizontal overflow. Header `th:first-child` also sticks (`z-index: 20`). Box-shadow `2px 0 4px -1px rgba(0,0,0,0.08)` for the sticky edge.
+- **HTML sanitization** — `TABLE_SANITIZE_OPTIONS` unchanged.
+
+### Editor experience
+
+No Studio change. Editors continue to paste raw HTML into `htmlTable.html` (the field's purpose remains "Drupal table import"). The new Phase 5 styling is applied entirely on the rendering side via the wrapper's Tailwind classes.
+
+## Component contracts
+
+### `<DownloadButton>` — refactor
+
+Path: `apps/web/src/components/design-system/DownloadButton/DownloadButton.tsx` (refactor in place; the legacy export stays the only export).
+
+**Storybook stories required** (per `feedback_state_coverage_stories`):
+
+- card / PDF · with size · with description
+- card / Word · with size · no description
+- card / ZIP · no size
+- card / other (unrecognised mime) · ensures fallback colour
+- inline / PDF · with size
+- inline / Word · no size
+- hover state (visual regression captures the press-down)
+- mobile viewport — card wraps gracefully when label is long
+
+### `<HtmlTableBlock>` — refactor
+
+Path: `apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx` — extract `HtmlTableBlock` into its own component file so it can be consumed by the new `<ArticleBody>` PT serializer too.
+
+**Storybook stories required:**
+
+- Schedule table (5 rows × 4 cols) — locked-spec exemplar
+- Wide table (8 cols) — confirms horizontal scroll + sticky first column
+- Single-column table — confirms the layout doesn't break with minimal data
+- Empty/whitespace HTML — confirms `null` return guard
+
+## Net new vocabulary / schema
+
+- **Schema:** none. `fileAttachment` and `htmlTable` schemas stay untouched.
+- **Tokens:** none new. Reuses jersey-deep, cream, cream-soft, ink, ink-muted, existing file-type colours.
+- **Components:** in-place refactor of `<DownloadButton>` + extraction of `<HtmlTableBlock>` into its own file.
+
+## Downstream impact
+
+- **#1829 (5.B body migration)** — this drill unblocks the `<ArticleBody>` serializer wiring for both block types. The migration ships the refactored `<DownloadButton>` and extracted `<HtmlTableBlock>`.
+- **Other `<DownloadButton>` consumers** — search the codebase for `DownloadButton` usage outside article bodies (staff bios, club pages, downloads index). The restyle propagates to all of them automatically; visual regression baselines need refresh.
+- **Legacy `HtmlTableBlock`** — inlined in `SanityArticleBody.tsx` today. Extract first (no behaviour change), then refactor styling. Two PR-friendly steps.
+
+## Source-of-truth
+
+- Mockup HTML: paths listed above.
+- Schema (unchanged): `packages/sanity-schemas/src/fileAttachment.ts`, `packages/sanity-schemas/src/htmlTable.ts`.
+- Existing components being refactored: `apps/web/src/components/design-system/DownloadButton/DownloadButton.tsx`, `apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx` (`HtmlTableBlock` inline).
+- Memories consumed: `feedback_reuse_approved_primitives`, `feedback_canonical_press_down_hover`, `feedback_state_coverage_stories`.

--- a/docs/design/mockups/phase-5-article-detail/interview-rapidfire-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/interview-rapidfire-locked.md
@@ -1,0 +1,122 @@
+# Interview rapid-fire — locked (drill 5.d-int-rapidfire / #1840 drill 1.3)
+
+**Drill:** 5.d-int-rapidfire · Six rounds · #1840 drill 1.3
+**Locked:** 2026-05-19 by @climacon
+**Mockups:**
+
+- `5d-int-rapidfire/round-1-row-layout-comparisons.html`
+- `5d-int-rapidfire/round-1b-hanging-q-mobile-comparisons.html`
+- `5d-int-rapidfire/round-2-speaker-scope-comparisons.html`
+- `5d-int-rapidfire/round-3-row-divider-comparisons.html`
+- `5d-int-rapidfire/round-4-section-opener-comparisons.html`
+- `5d-int-rapidfire/round-4b-label-word-comparisons.html`
+
+---
+
+> This lock supersedes the legacy Phase 2 `<QaGroupRapidFire>` (cream-redesign rewrite). The qaBlock `tag: rapid-fire` collapse rule from drill 1.2 (consecutive rapid-fire pairs → single group) stands unchanged — only the visual treatment changes.
+
+## What this drill resolves
+
+- ✅ Per-pair Q/A layout — **Round 1 D** (hanging-Q rail, mono caps Q on 132px left rail, body answer on the right).
+- ✅ Mobile fallback — **Round 1b 1** (Q stacks above A below `~640px`).
+- ✅ Speaker scope — **Round 2 A** (full speaker strip: kicker line + avatar + name + role).
+- ✅ Row divider — **Round 3 A** (dotted ink-muted, matches standard `<QARow>` divider — Phase 3-b primitive).
+- ✅ Section opener — **Round 4 D** (MonoLabel centered between two 1px ink hairlines).
+- ✅ Label word — **Round 4b A** (`Kort & Krachtig`).
+
+## What this drill does NOT decide
+
+- **Multi-respondent rapid-fire** — explicitly out of scope. The qaBlock dispatcher already treats `rapid-fire` as single-respondent; a multi-respondent rapid-fire authored value falls back to repeating standard `<QARow>`s.
+- **Editor-authored label override** — the `Kort & Krachtig` string is a renderer constant, not a schema field. A `QaSection`-level `label` override could be revisited if editorial need surfaces; out of scope for #1840.
+- **Per-pair `tag` other than `rapid-fire`** — `standard` / `key` / `quote` are drilled separately (1.1, 1.2, 5.A.2 PullQuote lock).
+
+## Locked component shape
+
+```text
+─────────────────  Kort & Krachtig  ─────────────────       ← centered MonoLabel between 1px ink hairlines
+
+[●L] LARS JANSSENS · AANVALLER                              ← full speaker strip (32px avatar + mono tag)
+
+FAVORIETE GOAL           De volley tegen Diest in de slot­minuut.   ← hanging-Q row: 132px mono caps rail · 22px gap · body
+............................................................        ← Phase 3-b dotted ink-muted divider
+SPELER OM TE VOLGEN      Wim. Hij maakt iedereen beter.
+............................................................
+BUS-MUZIEK               "Geen liedjes — koptelefoon op, ogen dicht."
+............................................................
+EERSTE KCVV-HERINNERING  Hand vasthouden van mijn pa, U7.
+```
+
+### Section opener — `RuledLabel` shape
+
+- **Layout:** flex row · `gap: 14px` · 1px ink rule on each side · `flex: 1` rules · centered label.
+- **Label typography:** `--font-mono` · 10px · `letter-spacing: 0.22em` · `text-transform: uppercase` · `font-weight: 600` · `color: --color-ink`.
+- **Label value:** authored as `"Kort & Krachtig"` (title-case both words). MonoLabel CSS renders it `KORT & KRACHTIG`.
+- **Spacing:** 22px margin-bottom between the ruled label and the speaker strip below.
+- **Reuse:** same primitive family as the locked `<ArticleCredits>` 1px-ink-rules-top-and-bottom block. Worth extracting a shared `<RuledLabel>` (rules + centered MonoLabel) if a third consumer surfaces — single-consumer for now.
+
+### Speaker strip
+
+Same as the existing standard `<QARow>` `SpeakerHeader`:
+
+- 32px `SubjectAvatar` (row scale, monogram, jersey-deep on cream).
+- Mono caps tag: `<NAME>` (color `--color-ink`) `·` `<ROLE>` (color `--color-ink-muted`).
+- `flex items-center gap-3`, 18px margin-bottom before the pair list.
+
+### Pair rhythm (desktop ≥ 640px)
+
+- **Grid:** `grid-template-columns: 132px minmax(0, 1fr)` · `gap: 22px` · `align-items: baseline`.
+- **Q label:** mono caps · 10px · `letter-spacing: 0.16em` · `text-transform: uppercase` · `color: --color-ink-muted` · `line-height: 1.45`.
+- **A answer:** Freight Display body · 16px · `line-height: 1.55` · `color: --color-ink`.
+- **Row padding:** 14px top + bottom · 1px dotted `--color-ink-muted` `border-bottom` on every pair except the last.
+- **Editorial guidance for Q labels:** keep to ≤ 3 words; renders best at 1–2 tokens. Long sentence-style questions belong on a standard QARow, not a rapid-fire pair. (Will be added to the Studio help text on the qaBlock `tag: rapid-fire` branch.)
+
+### Pair rhythm (mobile < 640px)
+
+- **Grid collapses** to a single column. Q label sits above A with 5px gap.
+- Q typography unchanged (same 10px MonoLabel).
+- A typography unchanged (same 16px Freight body).
+- Row padding tightens to 12px top + bottom.
+- Dotted `--color-ink-muted` `border-bottom` between pairs unchanged.
+
+### Breakpoint
+
+- Switch at **640px** (existing `md` Tailwind breakpoint in `apps/web`). No new breakpoint token.
+
+## Component contract
+
+The existing `<QaGroupRapidFire>` (currently in `apps/web/src/components/article/blocks/QaBlock/QaGroupRapidFire.tsx`) is rewritten to match this lock. The qaBlock dispatcher's behaviour (collapse consecutive `rapid-fire` pairs into one group, flatten to `respondents[0]`) is unchanged.
+
+```tsx
+<QaGroupRapidFire
+  respondent={{ firstName, fullName, role }}    // single — collapsed by dispatcher
+  pairs={[                                       // 1..N rapid-fire pairs
+    { question: "Favoriete goal", answer: <PortableText … /> },
+    …
+  ]}
+/>
+```
+
+- The component renders the ruled-label opener + speaker strip + the pair grid.
+- The component does NOT render the `Kort & Krachtig` label as editor input — it's a constant inside the renderer.
+- Storybook needs a state-coverage story per `feedback_state_coverage_stories.md`: short pairs · long pairs · 2 pairs · 8+ pairs · mobile viewport · empty answer.
+
+## Net new vocabulary / schema
+
+- **Schema:** none. Reuses existing qaBlock `tag: rapid-fire`, `respondents[]` (flattened to `[0]`), and `question`.
+- **Design tokens:** none.
+- **Component:** in-place rewrite of `<QaGroupRapidFire>` — no rename, no new file path.
+- **Potential extraction:** `<RuledLabel>` (1px ink rules + centered MonoLabel) — defer until a third consumer surfaces.
+
+## Downstream impact
+
+- **#1829 (5.B body migration)** — this unblocks the `<ArticleBody>` consumer's `rapid-fire` branch. Body migration can ship the rewritten `<QaGroupRapidFire>` against this lock.
+- **Storybook** — existing `QaGroupRapidFire.stories.tsx` needs full refresh against the locked vocabulary (cream surface, hanging Q, hairline opener, "Kort & Krachtig" label).
+- **Studio help text** — add a one-liner on `qaBlock.tag` describing the rapid-fire editorial guidance (short Q labels ≤ 3 words).
+- **`feedback_reuse_approved_primitives`** — opener reuses the `<ArticleCredits>` ink-hairline family; row divider reuses Phase 3-b dotted ink-muted; speaker strip reuses `<QARow>`'s `SpeakerHeader`.
+
+## Source-of-truth
+
+- Mockup HTML: paths listed above.
+- Phase 5 article shell placement: between `<EndMark>` candidate and `<ArticleCredits>` — same as standard `<QARow>` body flow (no special placement rules).
+- Memories consumed: `feedback_reuse_approved_primitives`, `feedback_monolabel_cream_full_opacity`, `feedback_no_magazine_chrome`, `feedback_drill_visual_then_ia`, `feedback_state_coverage_stories`.
+- Existing interview locks that remain unchanged: `interview-locked.md` (QA row number style + ArticleCredits block).

--- a/docs/design/mockups/phase-5-article-detail/videoblock-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/videoblock-locked.md
@@ -1,0 +1,171 @@
+# videoBlock — locked (drill 5.d-vid / #1840 drill 4)
+
+**Drill:** 5.d-vid · Two visual rounds + width inheritance · #1840 drills 4.1 + 4.2
+**Locked:** 2026-05-19 by @climacon
+**Mockups:**
+
+- `5d-vid/round-1-frame-comparisons.html`
+- `5d-vid/round-2-play-affordance-comparisons.html`
+
+---
+
+> This lock supersedes the legacy `VideoBlock` in `apps/web/src/components/article/VideoBlock/VideoBlock.tsx` (black-bg figure, 4px rounded corners, native HTML5 controls always, boolean `fullBleed`). The locked Phase 5 rendering frames the player in the same flat `<TapedFigure>` as `<articleImage>`, adds a KCVV-branded play affordance on the upload path, and inherits the `width: 'prose' | 'wide' | 'bleed'` enum from drill 3.
+
+## What this drill resolves
+
+- ✅ **R1 — Frame:** Option A (match articleImage — flat TapedFigure, single ochre tape strip top-center, cream-white frame, ink-subtle border, offset shadow).
+- ✅ **R2 — Play affordance (upload path):** Option C (bottom-left mono caps pill, triangle glyph + label "Afspelen", jersey-deep bg + ink border + offset shadow).
+- ✅ **Width enum:** inherit articleImage R3 — `width: 'prose' | 'wide' | 'bleed'`. Mobile fallback: `wide → prose`. Bleed suppresses tape.
+- ✅ **Caption rendering:** italic Freight body-sm, matches articleImage figcap typography (the existing videoBlock `caption: string` field stays as-is).
+
+## What this drill does NOT decide
+
+- **Embed path play UI** — YouTube/Vimeo render their own provider chrome inside the privacy-enhanced iframe. Nothing we draw inside the frame influences that. Our frame (locked R1 A) wraps the iframe identically to the upload path; the provider's play button sits inside the iframe.
+- **Custom controls bar during playback** — explicitly out of scope. On click, our corner pill + poster hide and native HTML5 controls take over for the rest of the session. No KCVV-branded scrubber, fullscreen, volume.
+- **Analytics integration** — `article_video_play` / `article_video_complete` instrumentation from #1366 is preserved verbatim. The custom play button click handler triggers `onPlay` analytics in parallel with native playback start.
+
+## Locked field rendering
+
+### `videoBlock` schema (migration required)
+
+```typescript
+defineType({
+  name: 'videoBlock',
+  fields: [
+    {name: 'uploadedFile', type: 'file', /* unchanged */},
+    {name: 'embedUrl', type: 'url', /* unchanged */},
+    {name: 'poster', type: 'image', options: {hotspot: true}, /* unchanged */},
+    {name: 'caption', type: 'string', /* unchanged */},
+    {name: 'width', type: 'string', options: {list: ['prose', 'wide', 'bleed']}, initialValue: 'prose'},
+    // fullBleed: boolean — REMOVED in migration
+  ],
+  validation: /* XOR uploadedFile/embedUrl — unchanged */,
+})
+```
+
+**Migration:** bundled with the `articleImage.fullBleed → width` migration from drill 3.2. Same translation rule:
+
+```typescript
+fullBleed === true  → width: 'bleed'
+fullBleed !== true  → width: 'prose'
+unset fullBleed in all videoBlock objects
+```
+
+### Render — upload path
+
+```tsx
+<TapedFigure
+  aspect="landscape-16-9"   // forced 16:9 for video, never auto
+  tape={{ color: 'ochre', length: 'sm', position: 'top-center', rotation: -2 }}
+  caption={value.caption?.trim() || undefined}
+  bg="cream"
+  tint="none"   // newsprint tint shifts video poster colors; "none" preserves them
+  // width behaviour inherited from articleImage R3 lock
+>
+  <div className="relative">
+    {!isPlaying && value.poster && (
+      <Image src={value.poster.url} alt="" fill className="object-cover" />
+    )}
+    {!isPlaying && (
+      <button
+        type="button"
+        onClick={onPlayClick}
+        aria-label="Speel video af"
+        className="absolute bottom-4 left-4 inline-flex h-9 items-center gap-2 border border-ink bg-jersey-deep px-4 font-mono text-[11px] uppercase tracking-[0.14em] text-cream shadow-paper-press transition-all duration-300 hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
+      >
+        <PlayTriangleIcon className="h-3.5 w-3.5" />
+        Afspelen
+      </button>
+    )}
+    {isPlaying && (
+      <video
+        ref={videoRef}
+        src={value.uploadedFile.asset.url}
+        controls
+        autoPlay
+        playsInline
+        onPlay={handleAnalyticsPlay}
+        onEnded={handleAnalyticsComplete}
+        className="block h-full w-full"
+      />
+    )}
+  </div>
+</TapedFigure>
+```
+
+### Render — embed path
+
+```tsx
+<TapedFigure aspect="landscape-16-9" tape={…} bg="cream" tint="none">
+  <iframe
+    src={parsedEmbedUrl}              // youtube-nocookie.com / player.vimeo.com
+    title={value.caption ?? "Video"}
+    allow="accelerated-2d-canvas; autoplay; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    referrerPolicy="strict-origin-when-cross-origin"
+    className="block h-full w-full border-0"
+  />
+</TapedFigure>
+```
+
+Provider chrome (YT/Vimeo play button + controls) sits inside the iframe. The TapedFigure frame, tape strip, and figcaption are ours.
+
+### Width rules (inherited from articleImage R3 / R3b)
+
+| Width | Desktop ≥ 640px | Mobile &lt; 640px | Tape |
+| --- | --- | --- | --- |
+| `prose` (default) | 680px | viewport - padding | ✅ |
+| `wide` | ~1040px | collapses to prose | ✅ |
+| `bleed` | 100vw | 100vw | ❌ suppressed |
+
+`tint="none"` on every video (unlike articleImage's `tint="newsprint"`) — the newsprint sepia would shift video poster colours wrongly.
+
+### Play affordance contract
+
+- **Pill geometry:** 36px height · `px-4` padding · `h-3.5 w-3.5` triangle icon · 8px gap · `border-ink` 1px · `shadow-paper-press` offset shadow.
+- **Position:** `absolute bottom-4 left-4` inside the 16:9 video container.
+- **Hover:** canonical press-down (per `feedback_canonical_press_down_hover`) — `hover:translate-x-1 hover:translate-y-1 hover:shadow-none transition-all duration-300`.
+- **Label:** Dutch caps "Afspelen" — locked, not editor-authored.
+- **Triangle:** locked `M8 5v14l11-7z` 24×24 viewBox · `fill="currentColor"` (cream on jersey-deep).
+- **Click handler:** sets `isPlaying = true`, hides poster + pill, mounts `<video controls autoPlay>`. Native HTML5 controls take over from here.
+- **Visibility on first paint:** pill is the ONLY click target — clicking the poster image itself does nothing (the pill is what's interactive). This keeps the affordance honest.
+
+### Caption rendering
+
+`caption: string` (existing schema field, unchanged) renders via TapedFigure's `figcap` slot — italic Freight body-sm 14px, color `--color-ink-soft`. Matches the locked articleImage figcap typography 1:1. Skipped entirely when blank.
+
+## Component contract
+
+**Path:** `apps/web/src/components/article/VideoBlock/VideoBlock.tsx` (refactor existing file; do not create a Phase-5-only sibling — `<SanityArticleBody>` will retire and the new renderer is the only one).
+
+**Storybook stories required** (per `feedback_state_coverage_stories`):
+
+- Upload path · with poster · before play · prose width
+- Upload path · without poster · before play (black 16:9 + pill on black)
+- Upload path · playing state (native controls visible)
+- Embed path · YouTube
+- Embed path · Vimeo
+- prose / wide / bleed width variants
+- Mobile viewport · prose / wide collapsed / bleed
+- With caption · without caption (figcap omitted)
+
+## Net new vocabulary / schema
+
+- **Schema:** remove `videoBlock.fullBleed`, add `videoBlock.width: 'prose' | 'wide' | 'bleed'`. One Sanity migration (bundled with articleImage's identical migration in the same PR).
+- **Tokens:** none new. Reuses `--container-prose`, `--container-wide` (added in drill 3), jersey-deep, ink, cream, ochre tape.
+- **Component:** none new. Refactor existing `<VideoBlock>` to use TapedFigure + the locked play pill.
+
+## Downstream impact
+
+- **#1829 (5.B body migration)** — this drill unblocks the `<ArticleBody>` videoBlock serializer wiring. Migration ships the refactored `<VideoBlock>` + the Sanity migration (bundled with articleImage).
+- **Analytics (#1366)** — preserved. Custom pill click handler chains into native playback start; existing `onPlay`/`onEnded` analytics fire as before. Embed-path analytics keep the `window` blur heuristic from the legacy code.
+- **Newsprint tint** — explicit `tint="none"` on videoBlock distinguishes it from articleImage's `tint="newsprint"`. Worth a one-liner in the TapedFigure docs.
+- **Studio UX** — editors see a new width dropdown (prose / wide / bleed) on each video block. Same dropdown lands on articleImage; consistent control across both block types.
+
+## Source-of-truth
+
+- Mockup HTML: paths listed above.
+- Schema: `packages/sanity-schemas/src/videoBlock.ts` (migration in same PR as #1829).
+- Existing reference: `apps/web/src/components/article/VideoBlock/VideoBlock.tsx` (legacy renderer being refactored).
+- Sibling lock: `docs/design/mockups/phase-5-article-detail/articleimage-locked.md` (width enum + mobile fallback inherited).
+- Memories consumed: `feedback_reuse_approved_primitives`, `feedback_sanity_migrations`, `feedback_canonical_press_down_hover`, `feedback_state_coverage_stories`.

--- a/docs/design/mockups/phase-5-article-detail/videoblock-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/videoblock-locked.md
@@ -64,7 +64,12 @@ unset fullBleed in all videoBlock objects
 >
   <div className="relative">
     {!isPlaying && value.poster && (
-      <Image src={value.poster.url} alt="" fill className="object-cover" />
+      // `pointer-events-none` keeps the poster non-interactive so that the
+      // pill below is the ONLY click target (see "Visibility on first paint"
+      // below). Without it, an absolutely-positioned poster sitting under
+      // the pill in DOM order is harmless, but a future refactor that wraps
+      // the Image (e.g. for a lightbox) would silently steal the click.
+      <Image src={value.poster.url} alt="" fill className="object-cover pointer-events-none" />
     )}
     {!isPlaying && (
       <button
@@ -128,7 +133,7 @@ Provider chrome (YT/Vimeo play button + controls) sits inside the iframe. The Ta
 - **Label:** Dutch caps "Afspelen" — locked, not editor-authored.
 - **Triangle:** locked `M8 5v14l11-7z` 24×24 viewBox · `fill="currentColor"` (cream on jersey-deep).
 - **Click handler:** sets `isPlaying = true`, hides poster + pill, mounts `<video controls autoPlay>`. Native HTML5 controls take over from here.
-- **Visibility on first paint:** pill is the ONLY click target — clicking the poster image itself does nothing (the pill is what's interactive). This keeps the affordance honest.
+- **Visibility on first paint:** pill is the ONLY click target — the poster `<Image>` carries `pointer-events-none` so clicks pass through. Implementers MUST keep this rule when refactoring (e.g. don't wrap the Image in a lightbox anchor without restoring the click handoff). This keeps the affordance honest.
 
 ### Caption rendering
 


### PR DESCRIPTION
## Summary

- Locks visual treatments for every PT block type the legacy `<SanityArticleBody>` renders that wasn't yet covered by Phase 5's `<ArticleBody>` primitive. Unblocks #1829 (body migration).
- 17 visual comparison HTML pages + 5 lock docs under `docs/design/mockups/phase-5-article-detail/`.
- No code changes — pure design work. Implementation lives in #1829.

## What's locked

| Drill | Decision (one-liner) |
| --- | --- |
| 1.3 qaBlock rapid-fire | hanging-Q rail (132px mono caps) · mobile Q-stacks-above-A · full speaker strip · dotted ink-muted divider · MonoLabel-between-hairlines opener · label `Kort & Krachtig` |
| 2.1 eventFact inline | taped polaroid with subtle alternating rotations (`nth-of-type`) · past mirrors `<EventDetailBlock>` · `sessions[]`+`note` compressed out · new `<EventFactInline>` component |
| 3.1 articleImage figure | flat `<TapedFigure>` (no rotation, single ochre tape) · caption + credit from per-asset Sanity metadata (`asset->description` + `asset->creditLine`) · `aspect=\"auto\"` + 70vh max-height |
| 3.2 articleImage width | replace `fullBleed: boolean` with `width: 'prose' \| 'wide' \| 'bleed'` enum · new `--container-wide: 1040px` token · mobile `wide → prose`, `bleed` keeps bleed (tape suppressed) |
| 4.1 videoBlock frame | matches articleImage R1 (TapedFigure + single ochre tape) · `aspect=\"landscape-16-9\"` · `tint=\"none\"` |
| 4.2 videoBlock play | bottom-left mono caps `▶ Afspelen` pill (jersey-deep + ink border + press-down hover) · embed path uses provider chrome · width enum inherits from articleImage |
| 5.1 fileAttachment | card = TapedCard + ochre tape + file-type stencil stamp + jersey-deep CTA · inline = compact chip with file-type pill + italic label + size + download glyph |
| 5.2 htmlTable | hybrid: ink-bordered card + jersey-deep header band + monospace body + italic Freight first column + dotted ink-muted dividers + subtle 2.5% ink zebra |

## Schema migrations bundled for #1829

- `articleImage.fullBleed` → `articleImage.width` (`prose` \| `wide` \| `bleed`) — `fullBleed: true` → `width: 'bleed'`, else `prose`; drop the boolean
- `videoBlock.fullBleed` → `videoBlock.width` (`prose` \| `wide` \| `bleed`) — identical translation

Both migrations ship in the same PR (the implementation PR, #1829), not this one.

## Lock docs

- `interview-rapidfire-locked.md` (drill 1.3)
- `eventfact-inline-locked.md` (drill 2.1)
- `articleimage-locked.md` (drill 3.1 + 3.2)
- `videoblock-locked.md` (drill 4.1 + 4.2)
- `fileattachment-htmltable-locked.md` (drill 5.1 + 5.2)

## Out of scope

- Implementation code (lands in #1829).
- Schema migration scripts (land in #1829).
- VR baselines / Storybook stories for the new components (land in #1829 with the implementation).

## Test plan

- [ ] Skim each `*-locked.md` doc end-to-end to confirm the locked spec matches your recollection of the drill rounds.
- [ ] Open the comparison HTML pages locally if you want to revisit any of the visual rounds:
  - `docs/design/mockups/phase-5-article-detail/5d-int-rapidfire/round-*.html`
  - `docs/design/mockups/phase-5-article-detail/5d-evt-inline/round-*.html`
  - `docs/design/mockups/phase-5-article-detail/5d-img/round-*.html`
  - `docs/design/mockups/phase-5-article-detail/5d-vid/round-*.html`
  - `docs/design/mockups/phase-5-article-detail/5d-file/round-*.html`
  - `docs/design/mockups/phase-5-article-detail/5d-table/round-*.html`
- [ ] Confirm #1829 acceptance criteria can be authored against the locked specs.

Closes #1840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive set of Phase‑5 design mockups and locked specs for article UI: image/figure width and caption/credit patterns, video framing and play affordances with width/mobile behavior, inline event “polaroid” cards and multi‑card stacking, file‑attachment variants, html table styles, and rapid‑fire/interview row/layout/divider/opener/speaker options — includes trade‑offs, footnotes and Storybook coverage requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->