### PR TITLE
feat(schema): articleImage/videoBlock width enum + qaBlock.groupAtTail (#1843)

### DIFF
--- a/apps/studio-staging/migrations/articleimage-videoblock-width/index.ts
+++ b/apps/studio-staging/migrations/articleimage-videoblock-width/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Staging counterpart to `apps/studio/migrations/articleimage-videoblock-width/`.
+ * See `packages/sanity-studio/src/migrations/articleimage-videoblock-width.ts`
+ * for the full contract — both studios share the same source.
+ *
+ * Phase 5 article-body width migration (#1843): translates the legacy
+ * `articleImage.fullBleed` / `videoBlock.fullBleed` booleans into the new
+ * `width: 'prose' | 'wide' | 'bleed'` enum and unsets the legacy field.
+ * Idempotent — re-runs are safe.
+ *
+ * Run against staging first:
+ *   npx sanity@latest migration run articleimage-videoblock-width --project vhb33jaz --dataset staging --dry-run
+ *   npx sanity@latest migration run articleimage-videoblock-width --project vhb33jaz --dataset staging
+ */
+import {articleImageVideoBlockWidthMigration} from '@kcvv/sanity-studio/migrations'
+
+export default articleImageVideoBlockWidthMigration

--- a/apps/studio/migrations/articleimage-videoblock-width/index.ts
+++ b/apps/studio/migrations/articleimage-videoblock-width/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Production counterpart to `apps/studio-staging/migrations/articleimage-videoblock-width/`.
+ * See `packages/sanity-studio/src/migrations/articleimage-videoblock-width.ts`
+ * for the full contract.
+ *
+ * Phase 5 article-body width migration (#1843): translates the legacy
+ * `articleImage.fullBleed` / `videoBlock.fullBleed` booleans into the new
+ * `width: 'prose' | 'wide' | 'bleed'` enum and unsets the legacy field.
+ * Idempotent — re-runs are safe.
+ *
+ * Production usage of `fullBleed` is light (single-digit articles at PR
+ * time, exact count not enumerated), so the patch volume on a real run
+ * should stay small. Dry-run first and verify the patch list before
+ * applying.
+ *
+ * Run against production AFTER staging has been verified:
+ *   npx sanity@latest migration run articleimage-videoblock-width --project vhb33jaz --dataset production --dry-run
+ *   npx sanity@latest migration run articleimage-videoblock-width --project vhb33jaz --dataset production
+ */
+import {articleImageVideoBlockWidthMigration} from '@kcvv/sanity-studio/migrations'
+
+export default articleImageVideoBlockWidthMigration

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -447,6 +447,7 @@
   /* ===== Redesign / Layout & Motion (Phase 0) ===== */
 
   --container-prose:    680px;
+  --container-wide:     1040px;
   --container-page:     1120px;
   --container-default:  1200px;
   /* --max-width-outer (1440px) already exists — reuse for full-bleed */

--- a/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
+++ b/apps/web/src/components/article/SanityArticleBody/SanityArticleBody.tsx
@@ -54,14 +54,35 @@ const TABLE_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
 interface ArticleImageValue {
   asset?: { url?: string };
   alt?: string;
-  width?: number;
+  /**
+   * Phase 5 width enum (#1843). Pre-#1843 articles ship as
+   * `width: undefined` + `fullBleed?: boolean`; migrated articles ship
+   * as `width: 'prose' | 'wide' | 'bleed'` + `fullBleed: undefined`.
+   * Tests historically passed a numeric `width` to override the
+   * Next.js `<Image>` width prop, but the GROQ projection has never
+   * actually populated it — the renderer falls through to 800/450
+   * regardless. Typed loosely so legacy numeric values still parse.
+   * Part C of the Phase 5 migration replaces this block with a
+   * TapedFigure-based renderer that properly honours the enum.
+   */
+  width?: "prose" | "wide" | "bleed" | number;
   height?: number;
+  /** Legacy boolean — replaced by `width` in #1843. */
   fullBleed?: boolean;
 }
 
 function ArticleImageBlock({ value }: { value: ArticleImageValue }) {
   if (!value.asset?.url) return null;
-  const isFullBleed = value.fullBleed === true;
+  // One-release fallback (#1843): prefer the new `width` enum, fall
+  // back to the legacy `fullBleed` boolean for un-migrated content.
+  // `width === 'wide'` currently renders identically to `prose` in this
+  // legacy renderer — Part C of the Phase 5 migration replaces this
+  // block with a TapedFigure-based renderer that properly honours
+  // `wide`.
+  const isFullBleed = value.width === "bleed" || value.fullBleed === true;
+  // Only numeric `width` values feed Next.js' Image `width` prop; the
+  // new string enum is purely a layout signal handled above.
+  const imagePixelWidth = typeof value.width === "number" ? value.width : 800;
   return (
     <figure
       className={cn(
@@ -72,7 +93,7 @@ function ArticleImageBlock({ value }: { value: ArticleImageValue }) {
       <Image
         src={value.asset.url}
         alt={value.alt ?? ""}
-        width={value.width ?? 800}
+        width={imagePixelWidth}
         height={value.height ?? 450}
         className="h-auto w-full transition-transform duration-300 ease-in-out hover:scale-105"
         sizes={isFullBleed ? "100vw" : "(max-width: 768px) 100vw, 720px"}

--- a/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
+++ b/apps/web/src/components/article/VideoBlock/VideoBlock.tsx
@@ -14,6 +14,16 @@ export interface VideoBlockValue {
   embedUrl?: string | null;
   videoPosterUrl?: string | null;
   caption?: string | null;
+  /**
+   * Phase 5 width enum (#1843). Pre-#1843 articles ship as
+   * `width: undefined` + `fullBleed?: boolean`; migrated articles ship
+   * as `width: 'prose' | 'wide' | 'bleed'` + `fullBleed: undefined`.
+   * This renderer reads both via a one-release fallback in
+   * `isFullBleed` — Part C of the Phase 5 migration rewires
+   * `<VideoBlock>` onto TapedFigure and honours `wide` properly.
+   */
+  width?: "prose" | "wide" | "bleed" | null;
+  /** Legacy boolean — replaced by `width` in #1843. */
   fullBleed?: boolean | null;
 }
 
@@ -53,8 +63,9 @@ function resolveAnalyticsContext(
  *  - poster image (upload path) so the browser doesn't fetch any video
  *    bytes until the reader presses play (`preload="none"`)
  *  - optional `<figcaption>` underneath the video
- *  - `fullBleed` opt-in that drops the rounded corners and breaks out
- *    of the prose column via `.full-bleed` (mirrors `articleImage`)
+ *  - `fullBleed` opt-in (#1843: superseded by `width: 'bleed'`) that
+ *    drops the rounded corners and breaks out of the prose column via
+ *    `.full-bleed` (mirrors `articleImage`)
  *
  * Phase 4 (#1366) wires `article_video_play` / `article_video_complete`
  * analytics. The upload path binds `onPlay` / `onEnded` directly. The
@@ -142,7 +153,9 @@ function renderUpload(
   const src = value.videoAsset?.url;
   if (typeof src !== "string" || src.length === 0) return null;
   const mimeType = value.videoAsset?.mimeType ?? undefined;
-  const fullBleed = value.fullBleed === true;
+  // One-release fallback (#1843): prefer the new `width` enum, fall
+  // back to the legacy `fullBleed` boolean for un-migrated content.
+  const fullBleed = value.width === "bleed" || value.fullBleed === true;
   const posterUrl =
     typeof value.videoPosterUrl === "string" && value.videoPosterUrl.length > 0
       ? value.videoPosterUrl
@@ -252,7 +265,9 @@ function renderEmbed(
   className: string | undefined,
   analyticsContext: AnalyticsContext | null,
 ) {
-  const fullBleed = value.fullBleed === true;
+  // One-release fallback (#1843): prefer the new `width` enum, fall
+  // back to the legacy `fullBleed` boolean for un-migrated content.
+  const fullBleed = value.width === "bleed" || value.fullBleed === true;
   const caption = trimmedCaption(value);
   const parsed = parseEmbedUrl(url);
   if (parsed === null) {

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -373,6 +373,7 @@ export type QaBlock = {
       _key: string;
     } & QaPair
   >;
+  groupAtTail?: boolean;
 };
 
 export type VideoBlock = {
@@ -391,7 +392,7 @@ export type VideoBlock = {
     _type: "image";
   };
   caption?: string;
-  fullBleed?: boolean;
+  width?: "prose" | "wide" | "bleed";
 };
 
 export type ArticleImage = {
@@ -404,7 +405,7 @@ export type ArticleImage = {
     _type: "image";
   };
   alt?: string;
-  fullBleed?: boolean;
+  width?: "prose" | "wide" | "bleed";
 };
 
 export type TeamReference = {
@@ -1144,7 +1145,7 @@ export type ARTICLES_QUERY_RESULT = Array<{
           _type: "image";
         };
         alt?: string;
-        fullBleed?: boolean;
+        width?: "bleed" | "prose" | "wide";
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1310,6 +1311,7 @@ export type ARTICLES_QUERY_RESULT = Array<{
             _key: string;
           } & QaPair
         >;
+        groupAtTail?: boolean;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1392,7 +1394,7 @@ export type ARTICLES_QUERY_RESULT = Array<{
           _type: "image";
         };
         caption?: string;
-        fullBleed?: boolean;
+        width?: "bleed" | "prose" | "wide";
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1516,7 +1518,7 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
           _type: "image";
         };
         alt?: string;
-        fullBleed?: boolean;
+        width?: "bleed" | "prose" | "wide";
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1687,6 +1689,7 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
             _key: string;
           } & QaPair
         >;
+        groupAtTail?: boolean;
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;
@@ -1772,7 +1775,7 @@ export type ARTICLE_BY_SLUG_QUERY_RESULT = {
           _type: "image";
         };
         caption?: string;
-        fullBleed?: boolean;
+        width?: "bleed" | "prose" | "wide";
         fileUrl: null;
         fileSize: null;
         fileMimeType: null;

--- a/apps/web/src/stories/foundation/SpacingAndIcons.mdx
+++ b/apps/web/src/stories/foundation/SpacingAndIcons.mdx
@@ -267,13 +267,17 @@ typical interactions. All values are defined in `src/app/globals.css`.
 ### Container widths
 
 `--container-prose` (680px) caps long-form article text at a comfortable
-measure; `--container-default` (1200px) is the standard page-content width
-between the cream surface gutters. `--max-width-outer` (1440px) — already
-present from earlier work — remains the full-bleed cap.
+measure; `--container-wide` (1040px) widens editorial media (article images,
+video) beyond prose while staying clearly bounded; `--container-default`
+(1200px) is the standard page-content width between the cream surface
+gutters. `--max-width-outer` (1440px) — already present from earlier work
+— remains the full-bleed cap.
 
 <div style={{ marginBottom: '24px' }}>
   <div style={{ height: '8px', background: 'var(--color-jersey)', width: 'var(--container-prose)', maxWidth: '100%', marginBottom: '4px' }} />
   <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2', marginBottom: '12px' }}>--container-prose · 680px (article body cap)</div>
+  <div style={{ height: '8px', background: 'var(--color-jersey)', width: 'var(--container-wide)', maxWidth: '100%', marginBottom: '4px' }} />
+  <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2', marginBottom: '12px' }}>--container-wide · 1040px (wide editorial media)</div>
   <div style={{ height: '8px', background: 'var(--color-jersey-deep)', width: 'var(--container-default)', maxWidth: '100%', marginBottom: '4px' }} />
   <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2' }}>--container-default · 1200px (standard page content)</div>
 </div>

--- a/packages/sanity-schemas/src/articleImage.ts
+++ b/packages/sanity-schemas/src/articleImage.ts
@@ -20,11 +20,13 @@ export const articleImage = defineType({
       validation: (r) => r.required().warning('Provide descriptive alt text for accessibility'),
     }),
     defineField({
-      name: 'fullBleed',
-      title: 'Full bleed',
-      type: 'boolean',
-      description: 'Stretch image to full viewport width',
-      initialValue: false,
+      name: 'width',
+      title: 'Width',
+      type: 'string',
+      description:
+        'Breedte van de afbeelding in het artikel. `prose` = standaard tekstbreedte; `wide` = breder dan tekst (1040px); `bleed` = volledige schermbreedte.',
+      options: {list: ['prose', 'wide', 'bleed']},
+      initialValue: 'prose',
     }),
   ],
   preview: {

--- a/packages/sanity-schemas/src/qaBlock.ts
+++ b/packages/sanity-schemas/src/qaBlock.ts
@@ -138,6 +138,14 @@ export const qaBlock = defineType({
       of: [{type: 'qaPair'}],
       validation: (r) => r.min(1).error('At least one Q&A pair required.'),
     }),
+    defineField({
+      name: 'groupAtTail',
+      title: 'Onderaan groeperen',
+      type: 'boolean',
+      description:
+        'Groepeer deze Q&A onderaan het artikel in plaats van in de tekstvloei.',
+      initialValue: false,
+    }),
   ],
   preview: {
     select: {pairs: 'pairs'},

--- a/packages/sanity-schemas/src/videoBlock.ts
+++ b/packages/sanity-schemas/src/videoBlock.ts
@@ -125,7 +125,7 @@ export const videoBlock = defineType({
       title: 'Width',
       type: 'string',
       description:
-        'Breedte van de afbeelding in het artikel. `prose` = standaard tekstbreedte; `wide` = breder dan tekst (1040px); `bleed` = volledige schermbreedte.',
+        'Breedte van de video in het artikel. `prose` = standaard tekstbreedte; `wide` = breder dan tekst (1040px); `bleed` = volledige schermbreedte.',
       options: {list: ['prose', 'wide', 'bleed']},
       initialValue: 'prose',
     }),

--- a/packages/sanity-schemas/src/videoBlock.ts
+++ b/packages/sanity-schemas/src/videoBlock.ts
@@ -43,8 +43,8 @@ const SOFT_MAX_VIDEO_BYTES = 150 * 1024 * 1024
  * the `embedUrl` escape hatch for YouTube/Vimeo links — exactly one of
  * the two must be set, enforced via a Rule.custom on the object. The
  * preview falls back to whichever is populated. Phase 3 (#1365) layers
- * on `poster`, `caption`, `fullBleed`, and a non-blocking size warning
- * on the upload.
+ * on `poster`, `caption`, a `width` enum (prose/wide/bleed), and a
+ * non-blocking size warning on the upload.
  */
 export const videoBlock = defineType({
   name: 'videoBlock',
@@ -121,12 +121,13 @@ export const videoBlock = defineType({
       description: 'Optioneel onderschrift dat onder de video verschijnt.',
     }),
     defineField({
-      name: 'fullBleed',
-      title: 'Full bleed',
-      type: 'boolean',
+      name: 'width',
+      title: 'Width',
+      type: 'string',
       description:
-        'Strek de video over de volle breedte van het scherm (geen afgeronde hoeken).',
-      initialValue: false,
+        'Breedte van de afbeelding in het artikel. `prose` = standaard tekstbreedte; `wide` = breder dan tekst (1040px); `bleed` = volledige schermbreedte.',
+      options: {list: ['prose', 'wide', 'bleed']},
+      initialValue: 'prose',
     }),
   ],
   // Object-level XOR: exactly one of uploadedFile / embedUrl must be set.

--- a/packages/sanity-studio/src/migrations/articleimage-videoblock-width.test.ts
+++ b/packages/sanity-studio/src/migrations/articleimage-videoblock-width.test.ts
@@ -1,0 +1,176 @@
+import {at, set, unset} from 'sanity/migrate'
+import {describe, expect, it} from 'vitest'
+import {
+  type ArticleWithWidthBlocksDoc,
+  migrateArticleImageVideoBlockWidth,
+} from './articleimage-videoblock-width'
+
+describe('migrateArticleImageVideoBlockWidth', () => {
+  it('returns undefined when body is missing', () => {
+    expect(migrateArticleImageVideoBlockWidth({_id: 'no-body'})).toBeUndefined()
+  })
+
+  it('returns undefined when body is explicitly null', () => {
+    expect(
+      migrateArticleImageVideoBlockWidth({
+        _id: 'null-body',
+        body: null,
+      } as unknown as ArticleWithWidthBlocksDoc),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when body has no articleImage/videoBlock entries', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'no-targets',
+      body: [
+        {_type: 'block', _key: 'b-1', children: []},
+        {_type: 'qaBlock', _key: 'qb-1', pairs: []},
+        {_type: 'transferFact', _key: 't-1'},
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toBeUndefined()
+  })
+
+  it('migrates an articleImage with fullBleed: true → width: bleed', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'img-bleed',
+      body: [
+        {
+          _type: 'articleImage',
+          _key: 'img-1',
+          fullBleed: true,
+        },
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toEqual([
+      at('body[_key=="img-1"].width', set('bleed')),
+      at('body[_key=="img-1"].fullBleed', unset()),
+    ])
+  })
+
+  it('migrates an articleImage with fullBleed: false → width: prose', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'img-prose',
+      body: [
+        {
+          _type: 'articleImage',
+          _key: 'img-1',
+          fullBleed: false,
+        },
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toEqual([
+      at('body[_key=="img-1"].width', set('prose')),
+      at('body[_key=="img-1"].fullBleed', unset()),
+    ])
+  })
+
+  it('migrates an articleImage with missing fullBleed → width: prose (still unsets the legacy field)', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'img-missing',
+      body: [
+        {
+          _type: 'articleImage',
+          _key: 'img-1',
+          // fullBleed intentionally absent
+        },
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toEqual([
+      at('body[_key=="img-1"].width', set('prose')),
+      // Always unset legacy field even when source had none — Sanity
+      // stores `false`/`null` as real values distinct from "not set".
+      at('body[_key=="img-1"].fullBleed', unset()),
+    ])
+  })
+
+  it('migrates a videoBlock with fullBleed: true → width: bleed', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'vid-bleed',
+      body: [
+        {
+          _type: 'videoBlock',
+          _key: 'vid-1',
+          fullBleed: true,
+        },
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toEqual([
+      at('body[_key=="vid-1"].width', set('bleed')),
+      at('body[_key=="vid-1"].fullBleed', unset()),
+    ])
+  })
+
+  it('migrates a videoBlock with missing fullBleed → width: prose', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'vid-missing',
+      body: [
+        {
+          _type: 'videoBlock',
+          _key: 'vid-1',
+        },
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toEqual([
+      at('body[_key=="vid-1"].width', set('prose')),
+      at('body[_key=="vid-1"].fullBleed', unset()),
+    ])
+  })
+
+  it('emits patches for a mix of articleImage and videoBlock in one article', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'mixed',
+      body: [
+        {_type: 'articleImage', _key: 'img-1', fullBleed: true},
+        {_type: 'block', _key: 'para', children: []},
+        {_type: 'videoBlock', _key: 'vid-1', fullBleed: false},
+        {_type: 'articleImage', _key: 'img-2'},
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toEqual([
+      at('body[_key=="img-1"].width', set('bleed')),
+      at('body[_key=="img-1"].fullBleed', unset()),
+      at('body[_key=="vid-1"].width', set('prose')),
+      at('body[_key=="vid-1"].fullBleed', unset()),
+      at('body[_key=="img-2"].width', set('prose')),
+      at('body[_key=="img-2"].fullBleed', unset()),
+    ])
+  })
+
+  it('is idempotent — skips blocks that already have width set, even if fullBleed lingers', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'already-migrated',
+      body: [
+        {_type: 'articleImage', _key: 'img-1', width: 'wide'},
+        {_type: 'videoBlock', _key: 'vid-1', width: 'bleed', fullBleed: true},
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toBeUndefined()
+  })
+
+  it('skips target blocks that are missing their _key (no stable patch path)', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'no-key',
+      body: [
+        // _key intentionally absent — can't construct a stable patch path.
+        {_type: 'articleImage', fullBleed: true} as {
+          _type: 'articleImage'
+          fullBleed: boolean
+        },
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toBeUndefined()
+  })
+
+  it('ignores non-target block types entirely (qaBlock, transferFact, plain block)', () => {
+    const doc: ArticleWithWidthBlocksDoc = {
+      _id: 'ignore-non-targets',
+      body: [
+        {_type: 'qaBlock', _key: 'qb-1'},
+        {_type: 'transferFact', _key: 't-1'},
+        {_type: 'block', _key: 'b-1', children: []},
+      ],
+    }
+    expect(migrateArticleImageVideoBlockWidth(doc)).toBeUndefined()
+  })
+})

--- a/packages/sanity-studio/src/migrations/articleimage-videoblock-width.ts
+++ b/packages/sanity-studio/src/migrations/articleimage-videoblock-width.ts
@@ -1,0 +1,104 @@
+import {at, defineMigration, set, unset} from 'sanity/migrate'
+
+/**
+ * Shape-detection + patch description for the Phase 5 article-body
+ * `articleImage` + `videoBlock` width migration (#1843).
+ *
+ * The legacy shape on each of these blocks was:
+ *
+ *   { ..., fullBleed?: boolean }
+ *
+ * The new shape is:
+ *
+ *   { ..., width: 'prose' | 'wide' | 'bleed' }
+ *
+ * Translation rule (locked in `phase-5-article-detail/articleimage-locked.md`
+ * + `videoblock-locked.md`):
+ *
+ *   fullBleed === true                       → width: 'bleed'
+ *   fullBleed === false (or missing/null)    → width: 'prose'
+ *
+ * The legacy `fullBleed` field is unset after the patch so the schema
+ * (which no longer declares it) stays authoritative. We always emit the
+ * unset patch — even when `fullBleed` was `false` or missing — because
+ * Sanity treats `false` as a real stored value distinct from "not set".
+ *
+ * Idempotent: if `width` is already set on a block, the block is left
+ * alone. Useful for re-runs after partial application or when the
+ * staging dataset is migrated before production.
+ *
+ * Exported separately from `defineMigration` so unit tests can exercise
+ * the branching against synthetic documents without a Sanity dataset.
+ */
+export interface BlockWithWidthLike {
+  _key?: string
+  _type?: string
+  fullBleed?: unknown
+  width?: unknown
+}
+
+export interface ArticleWithWidthBlocksDoc {
+  _id?: string
+  _type?: string
+  body?: unknown
+}
+
+type Patch = ReturnType<typeof at>
+
+const TARGET_TYPES = new Set(['articleImage', 'videoBlock'])
+
+function asTargetBlock(value: unknown): BlockWithWidthLike | null {
+  if (typeof value !== 'object' || value === null) return null
+  const block = value as BlockWithWidthLike
+  if (typeof block._type !== 'string' || !TARGET_TYPES.has(block._type)) {
+    return null
+  }
+  return block
+}
+
+export function migrateArticleImageVideoBlockWidth(
+  doc: ArticleWithWidthBlocksDoc,
+): Patch[] | undefined {
+  const body = Array.isArray(doc.body) ? doc.body : null
+  if (!body) return undefined
+
+  const patches: Patch[] = []
+
+  for (const blockRaw of body) {
+    const block = asTargetBlock(blockRaw)
+    if (!block) continue
+    const blockKey = block._key
+    if (!blockKey) continue
+
+    // Idempotent: a block that already has `width` set is treated as
+    // already migrated and left alone (including any lingering
+    // `fullBleed` field). Documented behaviour — keeps re-runs safe
+    // and avoids overwriting an editor-chosen `wide` value with a
+    // stale `fullBleed` translation.
+    if (typeof block.width === 'string' && block.width.length > 0) continue
+
+    const nextWidth = block.fullBleed === true ? 'bleed' : 'prose'
+    const pathRoot = `body[_key=="${blockKey}"]`
+    patches.push(at(`${pathRoot}.width`, set(nextWidth)))
+    // Always unset the legacy `fullBleed` field, even when it was
+    // missing/`false`. Sanity stores `false` as a real boolean value
+    // distinct from "not set", so a conditional unset (gated on
+    // `fullBleed === true`) would leave `false`/`null` stragglers
+    // in the document.
+    patches.push(at(`${pathRoot}.fullBleed`, unset()))
+  }
+
+  return patches.length > 0 ? patches : undefined
+}
+
+export default defineMigration({
+  title:
+    'Migrate articleImage.fullBleed + videoBlock.fullBleed → width enum (#1843)',
+  documentTypes: ['article'],
+
+  migrate: {
+    document(doc) {
+      return migrateArticleImageVideoBlockWidth(doc as ArticleWithWidthBlocksDoc)
+    },
+  },
+})

--- a/packages/sanity-studio/src/migrations/index.ts
+++ b/packages/sanity-studio/src/migrations/index.ts
@@ -36,3 +36,12 @@ export type {
   QaBlockLike as QaPairRespondentsBlock,
   QaPairLike as QaPairRespondentsPair,
 } from './qa-pair-respondents'
+
+export {
+  default as articleImageVideoBlockWidthMigration,
+  migrateArticleImageVideoBlockWidth,
+} from './articleimage-videoblock-width'
+export type {
+  ArticleWithWidthBlocksDoc as ArticleImageVideoBlockWidthDoc,
+  BlockWithWidthLike as ArticleImageVideoBlockWidthBlock,
+} from './articleimage-videoblock-width'


### PR DESCRIPTION
Closes #1843. Part A of #1829 (umbrella).

## Summary

- `articleImage.fullBleed: boolean` → `width: 'prose' | 'wide' | 'bleed'` enum.
- `videoBlock.fullBleed: boolean` → same enum.
- `qaBlock.groupAtTail: boolean` opt-in flag.
- Sanity migration `articleimage-videoblock-width` registered in both studios.
- `<SanityArticleBody>` + `<VideoBlock>` updated to read `width === 'bleed' || fullBleed === true` (one-release fallback; no visual change).
- `--container-wide: 1040px` token added to `apps/web/src/app/globals.css` for Part C consumption.

## Manual step before / after merge

- [x] Staging migration applied (136 documents processed, 3 mutations, 1 transaction — re-run dry verified zero patches → idempotent).
- [ ] Run production migration after merge:
  ```bash
  cd apps/studio
  npx sanity@latest migration run articleimage-videoblock-width --project=vhb33jaz --dataset=production --dry-run
  npx sanity@latest migration run articleimage-videoblock-width --project=vhb33jaz --dataset=production --no-dry-run
  ```

## Test plan

- [x] `pnpm --filter @kcvv/sanity-schemas type-check`
- [x] `pnpm --filter @kcvv/sanity-studio type-check`
- [x] `pnpm --filter @kcvv/sanity-studio test` (covers `migrateArticleImageVideoBlockWidth` unit tests — 11 cases)
- [x] `pnpm --filter @kcvv/web check-all` (lint, type-check, 3195 tests, Next.js build)
- [x] Staging migration dry-run reviewed and applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced width layout options (prose, wide, bleed) for article images and videos, replacing the previous full-bleed toggle.
  * Added option to group Q&A blocks at the end of articles.

* **Chores**
  * Added an idempotent migration to translate legacy full-bleed values into the new width enum with staging and production entrypoints.
  * Updated content types/schemas to use the new width field.

* **Tests**
  * Added unit tests verifying migration behavior and idempotency.

* **Documentation**
  * Added a new container width token (1040px) and updated visual docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->