### PR TITLE
chore(news): Phase 5 closeout seed data fixes — eventFact ticketUrl + tracer relatedContent (#1868)

### DIFF
--- a/apps/web/scripts/seed-phase-5-announcements.mjs
+++ b/apps/web/scripts/seed-phase-5-announcements.mjs
@@ -22,6 +22,7 @@ import {
   COVER_IMAGE_ASSET_REF,
   FILE_ATTACHMENT_FILENAME,
   PUBLISHED_AT,
+  articleRefs,
   assertProductionGuard,
   blockquote,
   fileRef,
@@ -68,6 +69,13 @@ function buildTracerAnnouncementMatrix(fileAssetRef) {
     author: "Bestuur",
     lead: "Exhaustive sweep van alle body-blokken die in mededelingen voorkomen — koppen, afbeeldingen in drie breedtes, video, bijlage, tabel, en blockquote.",
     coverImage: imageRef(COVER_IMAGE_ASSET_REF),
+    // Cross-links so <VerderLezenRow> renders on this tracer.
+    relatedContent: articleRefs([
+      "article-phase-5-announcement-short",
+      "article-phase-5-announcement-long-form",
+      "article-phase-5-announcement-attachment-table",
+      "article-phase-5-event-matchday",
+    ]),
     body: [
       heading("tam-h-intro", "Inleiding", "h2"),
       paragraph(

--- a/apps/web/scripts/seed-phase-5-events.mjs
+++ b/apps/web/scripts/seed-phase-5-events.mjs
@@ -18,6 +18,7 @@
 import {
   COVER_IMAGE_ASSET_REF,
   PUBLISHED_AT,
+  articleRefs,
   assertProductionGuard,
   blockquote,
   heading,
@@ -60,6 +61,13 @@ function buildTracerEventMatrix() {
     author: "Jeugdvoorzitter",
     lead: "Exhaustive sweep van elke eventFact-variant — feature, overview met CTA, zonder CTA, zonder datum, sessies[], en cross-month range.",
     coverImage: imageRef(COVER_IMAGE_ASSET_REF),
+    // Cross-links so <VerderLezenRow> renders on this tracer.
+    relatedContent: articleRefs([
+      "article-phase-5-event-matchday",
+      "article-phase-5-event-multiday",
+      "article-phase-5-event-past-recap",
+      "article-phase-5-announcement-short",
+    ]),
     body: [
       // Feature eventFact — sessions[] driving the strip.
       {

--- a/apps/web/scripts/seed-phase-5-interviews.mjs
+++ b/apps/web/scripts/seed-phase-5-interviews.mjs
@@ -20,6 +20,7 @@
 import {
   COVER_IMAGE_ASSET_REF,
   PUBLISHED_AT,
+  articleRefs,
   assertProductionGuard,
   blockquote,
   heading,
@@ -101,6 +102,15 @@ function buildTracerInterviewMatrix() {
       customSubject(TRACER_SUBJECT_A_KEY, "Alex Tracer", "Aanvaller · A-ploeg"),
       customSubject(TRACER_SUBJECT_B_KEY, "Bram Variant", "Middenvelder · B-ploeg"),
     ],
+    // Cross-links so <VerderLezenRow> renders on this tracer. Three same-type
+    // interviews + one cross-type transfer exercise the related-content row's
+    // mixed-type rendering on the grilling bed.
+    relatedContent: articleRefs([
+      "article-phase-5-interview-duo",
+      "article-phase-5-interview-panel",
+      "article-phase-5-interview-rapid-fire",
+      "article-phase-5-transfer-multi",
+    ]),
     body: [
       paragraph(
         "tim-intro",

--- a/apps/web/scripts/seed-phase-5-transfers.mjs
+++ b/apps/web/scripts/seed-phase-5-transfers.mjs
@@ -154,7 +154,8 @@ function buildTracerTransferMatrix(opponentLogoRef) {
       },
 
       // eventFact side-mention — sometimes editors close transfer-windows
-      // with a "Presentatieavond" calendar item.
+      // with a "Presentatieavond" calendar item. The CTA path is exercised
+      // here so the tracer surfaces the "Aanmelden" button rendering.
       {
         _key: "ttm-ev",
         _type: "eventFact",
@@ -165,6 +166,8 @@ function buildTracerTransferMatrix(opponentLogoRef) {
         location: "Kantine KCVV",
         ageGroup: "Iedereen welkom",
         competitionTag: "Clubmoment",
+        ticketUrl: "https://kcvvelewijt.be/presentatieavond",
+        ticketLabel: "Aanmelden",
       },
 
       paragraph(

--- a/apps/web/scripts/seed-phase-5-transfers.mjs
+++ b/apps/web/scripts/seed-phase-5-transfers.mjs
@@ -22,6 +22,7 @@ import {
   COVER_IMAGE_ASSET_REF,
   OPPONENT_LOGO_FILENAME,
   PUBLISHED_AT,
+  articleRefs,
   assertProductionGuard,
   heading,
   imageRef,
@@ -67,6 +68,13 @@ function buildTracerTransferMatrix(opponentLogoRef) {
     author: "Sportieve cel",
     lead: "Exhaustive sweep van elke transferFact-variant en de zijde-blokken die in transferartikels voorkomen.",
     coverImage: imageRef(COVER_IMAGE_ASSET_REF),
+    // Cross-links so <VerderLezenRow> renders on this tracer.
+    relatedContent: articleRefs([
+      "article-phase-5-transfer-incoming",
+      "article-phase-5-transfer-outgoing",
+      "article-phase-5-transfer-multi",
+      "article-phase-5-interview-duo",
+    ]),
     body: [
       // Hero transferFact — incoming with full note + attribution.
       {

--- a/apps/web/scripts/seeds/phase-5-shared.mjs
+++ b/apps/web/scripts/seeds/phase-5-shared.mjs
@@ -180,6 +180,19 @@ export function qaPair({ key, question, tag = "standard", respondents }) {
   };
 }
 
+/**
+ * Build a `relatedContent` array of article references. Each entry carries
+ * a stable `_key` derived from the target article's `_id` so re-runs of
+ * the seed don't churn the array order or produce duplicate keys.
+ */
+export function articleRefs(targetIds) {
+  return targetIds.map((id) => ({
+    _key: `rel-${id}`,
+    _type: "reference",
+    _ref: id,
+  }));
+}
+
 // ─── Asset upserts (idempotent) ──────────────────────────────────────────────
 
 export async function upsertImageAsset(client, filename, sourcePath) {


### PR DESCRIPTION
Closes #1868
Refs #1860 (Phase 5 grilling pickup, findings #7b + #8)

## Changes

Two seed-data fixes captured during the Phase 5 grilling sessions:

### Commit 1 — `tracer-transfer-matrix` eventFact gains `ticketUrl` + `ticketLabel`

The side-mention eventFact in `seed-phase-5-transfers.mjs` (`ttm-ev`) was seeded without a `ticketUrl`, so the renderer correctly hid the CTA — the grilling pass surfaced an event-strip card that read as a dead end. Added a plausible CTA so the tracer now exercises the "Aanmelden" button path.

### Commit 2 — All four tracer-`*`-matrix articles get `relatedContent` cross-links

All 20 seeded Phase 5 articles previously left `relatedContent` empty, and the BFF `/related/<id>` endpoint returns `[]` for synthetic seed IDs. `<VerderLezenRow>` short-circuits when `items.length === 0` (`apps/web/src/components/article/VerderLezenRow/VerderLezenRow.tsx:203`), so the row never rendered on any grilling URL.

Each of the four `tracer-*-matrix` articles now sets `relatedContent` to three same-type realistic articles + one cross-type sibling. The four realistic articles per type stay without `relatedContent` for now — production articles in those slots typically have curated relatedContent or auto-derived items from real BFF cross-references, so leaving them empty mirrors the editor-workflow distribution.

Helper `articleRefs(targetIds)` added to `seeds/phase-5-shared.mjs` so each tracer gets stable `_key`s derived from the target `_id` — re-runs don't churn array order or produce duplicate keys.

## Cross-link map

| Tracer | `relatedContent` refs |
| --- | --- |
| `tracer-interview-matrix` | `interview-duo`, `interview-panel`, `interview-rapid-fire`, `transfer-multi` (cross-type) |
| `tracer-transfer-matrix` | `transfer-incoming`, `transfer-outgoing`, `transfer-multi`, `interview-duo` (cross-type) |
| `tracer-event-matrix` | `event-matchday`, `event-multiday`, `event-past-recap`, `announcement-short` (cross-type) |
| `tracer-announcement-matrix` | `announcement-short`, `announcement-long-form`, `announcement-attachment-table`, `event-matchday` (cross-type) |

## Seed status

- ✅ Seed re-executed against `SANITY_DATASET=staging` — all 20 documents upserted; new fields written.
- 🌐 Vercel preview (`kcvv-nextjs-git-feat-issue-1868-…vercel.app/nieuws/<slug>`) — reviewer to spot-check 2 tracer URLs in browser to confirm `<VerderLezenRow>` now renders + the `tracer-transfer-matrix` event-strip shows the "Aanmelden" button. DNS doesn't resolve from the harness machine, so I can't smoke-test from CLI.

## Test plan

- [x] `pnpm --filter @kcvv/web check-all` passes (lint + type-check + 3233 vitest tests + build).
- [x] Seed runs cleanly against staging.
- [ ] **Reviewer:** open `tracer-transfer-matrix` on the Vercel preview — confirm "Aanmelden" button visible inside `ttm-ev` event-strip card.
- [ ] **Reviewer:** open any 2 tracers on the Vercel preview — confirm `<VerderLezenRow>` ("Verder lezen") row renders at the bottom with the cross-linked articles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced phase-5 articles with related content sections, enabling readers to discover and navigate to related announcements, events, interviews, and transfer content throughout the platform.
  * Implemented consistent cross-article reference linking to improve content discoverability and help readers explore connected topics within phase-5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->