### PR TITLE
docs(news): lock tail Q&A header — display-xl with jersey marker (#1867)

### DIFF
--- a/docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/compare.md
+++ b/docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/compare.md
@@ -1,0 +1,64 @@
+# 5.d-tail-qa-header · Tail Q&A section header — primitive map
+
+**Round 1.** Every visual choice in `round-1-tail-qa-header-comparisons.html`
+maps back to a locked primitive. Net-new vocabulary is called out as a delta
+(Δ). Per [[feedback_reuse_approved_primitives]].
+
+Reference locks consumed:
+
+- Phase 0 · `<StripedSeam>` — canonical full-bleed seam primitive
+- Phase 1 · `<EditorialHeading size="display-md|lg|xl">` — italic Freight Display headings
+- Phase 1 · `<MonoLabelRow>` — kicker rows ("_ X _")
+- Phase 1 · `<HighlighterStroke color="jersey">` — hand-drawn marker underline
+- Phase 3-b interview lock · `<QASectionDivider title>` flanking thin rules (italic centered subtitle)
+- 5.d3 lock · `section-break-locked.md` — kept E0 (Phase 3-b treatment) unchanged
+- `feedback_visual_preferences` — prefer typographic glyphs over Lucide equivalents
+- `feedback_border_spec_triple` — every divider/seam line ships `{weight, color-token, opacity}`
+- `feedback_monolabel_cream_full_opacity` — MonoLabel cream tone ships at full opacity (not used here; tail surface stays on cream)
+
+## Baseline vs. alternatives
+
+The baseline today is `<header class="mb-8 flex justify-center"><MonoLabel tone="ink">Q&A</MonoLabel></header>` at `apps/web/src/app/(main)/nieuws/[slug]/page.tsx:449-451`. Owner feedback: too quiet, "should be other typography, bigger". This drill replaces the baseline; no E0 carry-forward.
+
+## Use sites consuming this vocabulary
+
+- **Tail Q&A section** on `/nieuws/[slug]` for interview articles (and any future article variant where `groupAtTail` qaBlocks are hoisted out of the in-flow body). Single header per page when `tailBlocks.length > 0`.
+- Header sits AFTER `<ArticleBody>` (whose final element is `<EndMark>`) and BEFORE the first tail `<QaBlock>`. May be followed downstream by `<EventDetailBlock>` (event variant), `<ArticleCredits>`, `<VerderLezenRow>`.
+
+## Option-by-option vocabulary map
+
+| Element            | A — kicker + heading                                                                 | B — heading + rules                                                                                  | C — seam + heading                                                                                         | D — marker heading                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Header role        | New editorial section after EndMark                                                  | New editorial section after EndMark                                                                  | New page region after EndMark                                                                              | New editorial section after EndMark                                                                                            |
+| Visual             | Mono "_ Q&A _" kicker + italic display-md heading "Nog kort nagezweefd." centered    | Italic display-lg "Q&A." centered, flanked by 1px ink rules @ 0.55 opacity                           | Full-bleed striped seam (-45deg, ink/cream, 14px) → mono "Bonus · Q&A" kicker → italic display-lg heading  | Italic display-xl heading with `<HighlighterStroke color="jersey">` through "Q&A"                                              |
+| Width              | Prose width (680px)                                                                  | Prose width (680px)                                                                                  | **Full-bleed** seam (viewport) + prose-width heading                                                       | Prose width (680px)                                                                                                            |
+| Vertical footprint | ~96px (kicker + heading + spacing)                                                   | ~92px (heading + rules + spacing)                                                                    | ~140px (seam + kicker + heading + spacing)                                                                 | ~104px (heading + spacing)                                                                                                     |
+| Source primitives  | `<MonoLabelRow>` + `<EditorialHeading size="display-md">`                            | `<EditorialHeading size="display-lg">` + flanking thin rules (E0 vocabulary at larger heading scale) | `<StripedSeam height="sm" colorPair="ink-cream">` + `<MonoLabel>` + `<EditorialHeading size="display-lg">` | `<EditorialHeading size="display-xl" emphasis={{text:"Q&A", highlight:true}}>` (composes `<HighlighterStroke color="jersey">`) |
+| Period color       | Jersey-deep (existing convention)                                                    | Jersey-deep                                                                                          | Jersey-deep                                                                                                | Jersey-deep                                                                                                                    |
+| Echoes             | InterviewHero "_ AFSCHEID DUBBEL _" kicker; EndMark "_ Einde gesprek _" rhythm above | 5.d3 baseline E0 / Phase 3-b QASectionDivider — but scaled up so it reads as section, not subsection | Homepage region boundaries (StripedSeam)                                                                   | InterviewHero headline scale                                                                                                   |
+
+## Vocabulary deltas summary
+
+| Option | Δ count | Severity | Cost                                                                                        | Notes                                                                                                                                                                                                               |
+| ------ | ------- | -------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A**  | 0       | None     | Direct reuse of `<MonoLabelRow>` + `<EditorialHeading>`.                                    | Quietest. Voice-led. Rhymes with InterviewHero and EndMark patterns above. Risk: still quiet if the "_ Q&A _" kicker disappears against the cream like the current MonoLabel does.                                  |
+| **B**  | 0       | None     | Direct reuse of E0 5.d3 vocabulary at display-lg instead of display-sm.                     | Most internally consistent with body section breaks. Risk: at display-lg the heading + thin rules combo can read as a continuation of body section breaks rather than a new section.                                |
+| **C**  | 1       | Medium   | First in-article use of `<StripedSeam>`. Same register-shift cost flagged in 5.d3 option B. | Loudest separator. Reads as a page-region change. Risk: precedent — if accepted, future "tail sections" elsewhere may want it too, expanding StripedSeam's role from "page region" to "any major in-page boundary". |
+| **D**  | 0       | None     | Direct reuse of `<EditorialHeading emphasis.highlight>`.                                    | Voice-led, largest typography. HighlighterStroke marker calls out the section. Risk: display-xl is the InterviewHero scale; using it for the tail header may compete with the page's lede headline.                 |
+
+## Things this drill does NOT decide
+
+- **Copy of the heading.** "Q&A." vs. "Nog kort nagezweefd." vs. "Tot besluit." — copy is variable across articles and editor-controlled. Drill question: typography/chrome only. If the lock requires a freeform heading slot (option A/C), the implementation may either default to "Q&A" or accept a Sanity field — decide in the implementation spinout.
+- **Whether the tail section is visually distinguished from the article body** (different background, framed surface, etc.). All four options keep the tail on cream like the rest of the body. Background-shift is a separate question that could be revisited in a future round if option C feels insufficient.
+- **Mobile typography scale.** All variants assume the desktop scale shown in the mockup. Mobile rules + sizes follow the canonical EditorialHeading responsive token cascade — confirm at implementation time.
+- **What happens when `hasTail` is true but `tailBlocks.length === 0`.** Already handled in the existing `qaBlocksToTailSection` filter — out of scope.
+
+## Source-of-truth
+
+- Mockup HTML: `docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/round-1-tail-qa-header-comparisons.html`
+- Component sources: `apps/web/src/components/design-system/{EditorialHeading,MonoLabel,MonoLabelRow,StripedSeam,HighlighterStroke}/`
+- Current implementation: `apps/web/src/app/(main)/nieuws/[slug]/page.tsx:449-451`
+- Phase 3-b interview lock: `docs/design/mockups/phase-5-article-detail/interview-locked.md` (Q&A section structure)
+- 5.d3 lock: `docs/design/mockups/phase-5-article-detail/section-break-locked.md` (kept Phase 3-b treatment for mid-body breaks)
+- Tracker: #1860 · Spinout source: #1867
+- Memories consumed: [[feedback_reuse_approved_primitives]], [[feedback_visual_preferences]], [[feedback_border_spec_triple]], [[feedback_design_drill_pattern]], [[feedback_drill_visual_then_ia]], [[feedback_monolabel_cream_full_opacity]]

--- a/docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/round-1-tail-qa-header-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/round-1-tail-qa-header-comparisons.html
@@ -1,0 +1,584 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · Round 1 · Tail Q&amp;A section header (5.d-tail-qa-header)</title>
+    <style>
+      :root {
+        --color-cream: #f5efe1;
+        --color-cream-soft: #ece5d3;
+        --color-cream-deep: #ddd4ba;
+        --color-ink: #1a1a1a;
+        --color-ink-soft: #2a2a2a;
+        --color-ink-muted: #6a655a;
+        --color-jersey: #2d7a4f;
+        --color-jersey-deep: #1f5f3f;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --container-prose: 680px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page {
+        max-width: 1120px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 80ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        background: var(--color-cream-soft);
+        padding: 1px 4px;
+      }
+      .container {
+        max-width: 1120px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 32px;
+      }
+      .candidate {
+        background: #fff;
+        border: 1px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .candidate > header.card {
+        padding: 16px 22px 12px;
+        border-bottom: 1px dashed var(--color-ink);
+      }
+      .candidate > header.card .key {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        opacity: 0.7;
+      }
+      .candidate > header.card .name {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 22px;
+        line-height: 1.15;
+        margin-top: 4px;
+      }
+      .candidate > header.card .desc {
+        font-size: 12px;
+        line-height: 1.5;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .candidate > header.card .vocab {
+        font-size: 11px;
+        line-height: 1.55;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px dotted var(--color-ink-muted);
+      }
+      .candidate > header.card .vocab strong {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 10px;
+        display: block;
+        margin-bottom: 4px;
+        opacity: 0.7;
+      }
+
+      /* ============================================================
+         Body surface — cream, prose width
+         ============================================================ */
+      .surface {
+        background: var(--color-cream);
+        padding: 24px 0 32px;
+      }
+      .article-body {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+      }
+      .article-body p {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.65;
+        margin: 0 0 14px;
+        color: var(--color-ink);
+      }
+
+      /* ============================================================
+         Shared "context": EndMark above + first QaRow below the header
+         so each variant is judged against the actual rhythm it lives in.
+         ============================================================ */
+      .endmark {
+        max-width: var(--container-prose);
+        margin: 32px auto 0;
+        padding: 0 28px;
+        text-align: center;
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-size: 14px;
+        color: var(--color-ink-muted);
+        letter-spacing: 0.06em;
+      }
+      .endmark .stars {
+        color: var(--color-jersey-deep);
+        letter-spacing: 0.5em;
+        padding-left: 0.5em;
+      }
+      .qa-pair {
+        max-width: var(--container-prose);
+        margin: 0 auto;
+        padding: 0 28px;
+        display: grid;
+        grid-template-columns: 40px 1fr;
+        gap: 18px;
+        align-items: start;
+      }
+      .qa-pair .avatar {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: ui-serif, Georgia, serif;
+        font-weight: 700;
+        font-size: 16px;
+        margin-top: 4px;
+      }
+      .qa-pair .speaker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.7;
+        margin: 0 0 6px;
+      }
+      .qa-pair .question {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 600;
+        font-size: 22px;
+        line-height: 1.25;
+        margin: 0 0 8px;
+      }
+      .qa-pair .answer {
+        font-family: ui-serif, Georgia, serif;
+        font-size: 16px;
+        line-height: 1.6;
+        margin: 0;
+      }
+
+      /* ============================================================
+         A — MonoLabelRow kicker + EditorialHeading display-md
+            Echo of the InterviewHero "* AFSCHEID DUBBEL *" kicker pattern.
+         ============================================================ */
+      .header-A {
+        max-width: var(--container-prose);
+        margin: 32px auto 28px;
+        padding: 0 28px;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .header-A .kicker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 12px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--color-ink);
+        opacity: 0.85;
+      }
+      .header-A .kicker .star {
+        color: var(--color-jersey-deep);
+        padding: 0 0.6em;
+      }
+      .header-A .heading {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 36px;
+        line-height: 1.05;
+        letter-spacing: -0.01em;
+        color: var(--color-ink);
+      }
+      .header-A .heading .period {
+        color: var(--color-jersey-deep);
+      }
+
+      /* ============================================================
+         B — EditorialHeading display-lg + flanking ink rules
+            Mirrors the locked 5.d3 / Phase 3-b QASectionDivider
+            (italic centered + thin rules), scaled UP from display-sm
+            to display-lg so it reads as a new section, not a subsection.
+         ============================================================ */
+      .header-B {
+        max-width: var(--container-prose);
+        margin: 32px auto 28px;
+        padding: 0 28px;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 22px;
+      }
+      .header-B::before,
+      .header-B::after {
+        content: "";
+        height: 1px;
+        background: var(--color-ink);
+        opacity: 0.55;
+      }
+      .header-B .heading {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 44px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        color: var(--color-ink);
+        text-align: center;
+        white-space: nowrap;
+      }
+      .header-B .heading .period {
+        color: var(--color-jersey-deep);
+      }
+
+      /* ============================================================
+         C — Full-bleed StripedSeam above + EditorialHeading display-lg
+            Register shift: "the page just turned, here's the bonus".
+            Same primitive used to separate page regions on the homepage,
+            now introducing the tail. Highest visual energy of the four.
+         ============================================================ */
+      .header-C-seam {
+        width: 100%;
+        height: 14px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--color-ink) 0 8px,
+          var(--color-cream) 8px 16px
+        );
+        margin: 28px 0 0;
+      }
+      .header-C-title {
+        max-width: var(--container-prose);
+        margin: 24px auto 28px;
+        padding: 0 28px;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .header-C-title .kicker {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 11px;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .header-C-title .heading {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 44px;
+        line-height: 1.05;
+        letter-spacing: -0.015em;
+        color: var(--color-ink);
+      }
+      .header-C-title .heading .period {
+        color: var(--color-jersey-deep);
+      }
+
+      /* ============================================================
+         D — EditorialHeading display-xl with HighlighterStroke marker
+            on "Q&A". Voice-led, marker decoration calls the section
+            out as a feature. Biggest typography of the four. No rules,
+            no kicker — heading carries the whole moment.
+         ============================================================ */
+      .header-D {
+        max-width: var(--container-prose);
+        margin: 40px auto 28px;
+        padding: 0 28px;
+        text-align: center;
+      }
+      .header-D .heading {
+        font-family: ui-serif, Georgia, serif;
+        font-style: italic;
+        font-weight: 900;
+        font-size: 56px;
+        line-height: 1.0;
+        letter-spacing: -0.02em;
+        color: var(--color-ink);
+        display: inline-block;
+      }
+      .header-D .heading .marker {
+        position: relative;
+        display: inline-block;
+        z-index: 0;
+      }
+      .header-D .heading .marker::after {
+        content: "";
+        position: absolute;
+        left: -4%;
+        right: -4%;
+        bottom: 8%;
+        height: 38%;
+        background: var(--color-jersey);
+        opacity: 0.55;
+        z-index: -1;
+        transform: rotate(-1deg);
+        border-radius: 2px;
+      }
+      .header-D .heading .period {
+        color: var(--color-jersey-deep);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <p class="meta">Phase 5 · Round 1 · Drill #1867 · 5.d-tail-qa-header</p>
+      <h1>Tail Q&amp;A section header — typography drill</h1>
+      <p>
+        Owner feedback from the Phase 5 grilling session (2026-05-20):
+        the tail-grouped Q&amp;A's centered <code>&lt;MonoLabel
+        tone="ink"&gt;Q&amp;A&lt;/MonoLabel&gt;</code> reads too quietly between
+        <code>&lt;EndMark&gt;</code> above and the first <code>&lt;QaPair&gt;</code>
+        below — <em>"should be other typography, bigger"</em>. Drill resolves which
+        typography variant becomes the locked header for the tail section.
+      </p>
+      <p>
+        Each option renders the same context — closing <code>&lt;EndMark&gt;</code>
+        from the in-flow body, header treatment, first tail <code>&lt;QaPair&gt;</code>
+        — at <code>--container-prose</code> width (680px) on cream, so rhythm and
+        scale are visible at a glance. The locked Phase 3-b Q&amp;A row shape is
+        reused as the after-header context (monogram avatar · mono speaker tag ·
+        italic display-sm question · body-md answer).
+      </p>
+      <p>
+        Every variant composes only from already-locked primitives — no net-new
+        vocabulary. See <code>compare.md</code> in this folder for the per-option
+        source-primitive map.
+      </p>
+    </header>
+
+    <main class="container">
+
+      <!-- =================================================================
+           A — MonoLabelRow kicker + EditorialHeading display-md
+           ================================================================= -->
+      <section class="candidate">
+        <header class="card">
+          <p class="key">A · kicker + heading</p>
+          <p class="name">Kicker + display-md heading</p>
+          <p class="desc">
+            Small <code>&lt;MonoLabelRow&gt;</code> "* Q&amp;A *" kicker above a
+            centered italic <code>&lt;EditorialHeading size="display-md"&gt;</code>.
+            Echoes the InterviewHero opening pattern ("* AFSCHEID DUBBEL *") and
+            the EndMark "* Einde gesprek *" rhythm above. Quietest of the four;
+            voice-driven, no rules, no seam.
+          </p>
+          <p class="vocab">
+            <strong>Source primitives</strong>
+            • <code>&lt;MonoLabelRow&gt;</code> (kicker)<br />
+            • <code>&lt;EditorialHeading size="display-md"&gt;</code> italic<br />
+            • Jersey-deep period (existing EditorialHeading convention)<br />
+            <strong>Vocabulary delta</strong>
+            None. Direct reuse of two locked primitives.
+          </p>
+        </header>
+        <div class="surface">
+          <div class="endmark">
+            <span class="stars">* * *</span>
+          </div>
+          <header class="header-A">
+            <p class="kicker">
+              <span class="star">*</span>Q&amp;A<span class="star">*</span>
+            </p>
+            <h2 class="heading">Nog kort nagezweefd<span class="period">.</span></h2>
+          </header>
+          <article class="qa-pair">
+            <div class="avatar">L</div>
+            <div>
+              <p class="speaker">Lars · Aanvaller</p>
+              <p class="question">Wat was het moment waarop je dacht: nu lukt het?</p>
+              <p class="answer">"Halfweg de eerste helft, toen die bal binnen viel. Dan voel je dat de ploeg meekomt."</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- =================================================================
+           B — EditorialHeading display-lg + flanking ink rules
+           ================================================================= -->
+      <section class="candidate">
+        <header class="card">
+          <p class="key">B · heading + rules</p>
+          <p class="name">Display-lg heading + flanking rules</p>
+          <p class="desc">
+            Italic centered <code>&lt;EditorialHeading size="display-lg"&gt;</code>
+            flanked by 1px ink rules at 0.55 opacity. Same vocabulary as the locked
+            Phase 3-b body section breaks (E0 in 5.d3), scaled up from display-sm
+            to display-lg so it reads as a NEW section rather than a subsection.
+            Strong consistency with the body's own break treatment.
+          </p>
+          <p class="vocab">
+            <strong>Source primitives</strong>
+            • <code>&lt;EditorialHeading size="display-lg"&gt;</code> italic<br />
+            • Flanking thin rules: <code>QASectionDivider</code> baseline (E0 from
+            5.d3)<br />
+            • Jersey-deep period (existing convention)<br />
+            <strong>Vocabulary delta</strong>
+            None. Same shape as <code>&lt;QASectionDivider title&gt;</code> at
+            a larger heading size. Could land as a new prop on
+            <code>&lt;QASectionDivider&gt;</code> (e.g.
+            <code>headingSize="lg"</code>) or compose directly.
+          </p>
+        </header>
+        <div class="surface">
+          <div class="endmark">
+            <span class="stars">* * *</span>
+          </div>
+          <header class="header-B">
+            <h2 class="heading">Q&amp;A<span class="period">.</span></h2>
+          </header>
+          <article class="qa-pair">
+            <div class="avatar">L</div>
+            <div>
+              <p class="speaker">Lars · Aanvaller</p>
+              <p class="question">Wat was het moment waarop je dacht: nu lukt het?</p>
+              <p class="answer">"Halfweg de eerste helft, toen die bal binnen viel. Dan voel je dat de ploeg meekomt."</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- =================================================================
+           C — Full-bleed StripedSeam above + EditorialHeading display-lg
+           ================================================================= -->
+      <section class="candidate">
+        <header class="card">
+          <p class="key">C · seam + heading</p>
+          <p class="name">StripedSeam + display-lg heading</p>
+          <p class="desc">
+            Full-bleed <code>&lt;StripedSeam height="sm" colorPair="ink-cream"&gt;</code>
+            above a centered italic <code>&lt;EditorialHeading size="display-lg"&gt;</code>
+            with a small mono kicker beneath the seam. The seam is the canonical
+            primitive for separating page <em>regions</em>; using it inside a single
+            article reads as a register shift — "the page just turned, here's the
+            bonus track". Highest visual energy.
+          </p>
+          <p class="vocab">
+            <strong>Source primitives</strong>
+            • <code>&lt;StripedSeam height="sm" colorPair="ink-cream"&gt;</code><br />
+            • <code>&lt;MonoLabel&gt;</code> kicker (optional)<br />
+            • <code>&lt;EditorialHeading size="display-lg"&gt;</code> italic<br />
+            <strong>Vocabulary delta</strong>
+            First in-article use of <code>&lt;StripedSeam&gt;</code>. Same
+            register-shift cost the 5.d3 drill flagged for option B. If accepted
+            here, sets precedent for "tail section" as a page-region-equivalent
+            boundary.
+          </p>
+        </header>
+        <div class="surface" style="padding-top: 0;">
+          <div class="endmark" style="margin-top: 0; padding-top: 24px;">
+            <span class="stars">* * *</span>
+          </div>
+          <div class="header-C-seam"></div>
+          <header class="header-C-title">
+            <p class="kicker">Bonus · Q&amp;A</p>
+            <h2 class="heading">Nog kort nagezweefd<span class="period">.</span></h2>
+          </header>
+          <article class="qa-pair">
+            <div class="avatar">L</div>
+            <div>
+              <p class="speaker">Lars · Aanvaller</p>
+              <p class="question">Wat was het moment waarop je dacht: nu lukt het?</p>
+              <p class="answer">"Halfweg de eerste helft, toen die bal binnen viel. Dan voel je dat de ploeg meekomt."</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- =================================================================
+           D — EditorialHeading display-xl with HighlighterStroke marker
+           ================================================================= -->
+      <section class="candidate">
+        <header class="card">
+          <p class="key">D · marker heading</p>
+          <p class="name">Display-xl heading + marker on "Q&amp;A"</p>
+          <p class="desc">
+            Italic centered <code>&lt;EditorialHeading size="display-xl"
+            emphasis=&#123;&#123; text:"Q&amp;A", highlight:true &#125;&#125;&gt;</code>.
+            <code>&lt;HighlighterStroke color="jersey"&gt;</code> marker through
+            the keyword. No flanking rules, no kicker — the heading carries the
+            whole moment. Biggest typography of the four; loudest voice.
+          </p>
+          <p class="vocab">
+            <strong>Source primitives</strong>
+            • <code>&lt;EditorialHeading size="display-xl"&gt;</code> italic<br />
+            • <code>&lt;HighlighterStroke color="jersey"&gt;</code> on "Q&amp;A"<br />
+            • Jersey-deep period (existing convention)<br />
+            <strong>Vocabulary delta</strong>
+            None. Direct reuse. Display-xl is the InterviewHero headline size
+            — using it for the tail header equates the tail with a hero moment.
+            Risk: may compete with the InterviewHero at the top of the page.
+          </p>
+        </header>
+        <div class="surface">
+          <div class="endmark">
+            <span class="stars">* * *</span>
+          </div>
+          <header class="header-D">
+            <h2 class="heading">
+              <span class="marker">Q&amp;A</span><span class="period">.</span>
+            </h2>
+          </header>
+          <article class="qa-pair">
+            <div class="avatar">L</div>
+            <div>
+              <p class="speaker">Lars · Aanvaller</p>
+              <p class="question">Wat was het moment waarop je dacht: nu lukt het?</p>
+              <p class="answer">"Halfweg de eerste helft, toen die bal binnen viel. Dan voel je dat de ploeg meekomt."</p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+    </main>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/tail-qa-header-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/tail-qa-header-locked.md
@@ -1,0 +1,168 @@
+# Tail Q&A section header — locked
+
+**Drill:** 5.d-tail-qa-header · Round 1 · #1867
+**Locked:** 2026-05-21 by @climacon
+**Mockups:** `5d-tail-qa-header/round-1-tail-qa-header-comparisons.html`
+**Primitive map:** `5d-tail-qa-header/compare.md`
+**Tracker:** #1860 (Phase 5 closeout)
+**Implementation spinout:** #1874
+
+---
+
+## Decision
+
+**D — `<EditorialHeading size="display-xl">` with `<HighlighterStroke>`
+marker on "Q&A".** Centered, prose-width. No flanking rules, no kicker,
+no seam. The heading carries the whole moment.
+
+```text
+                      ▓▓▓▓▓
+                      Q&A.
+```
+
+- `<EditorialHeading size="display-xl" level={2} emphasis={{ text: "Q&A", highlight: true }}>Q&A.</EditorialHeading>`
+- Italic Freight Display 700 (`font-display`, `text-display-xl`).
+- `<HighlighterStroke color="jersey">` underprints the "Q&A" substring
+  (the existing `emphasis.highlight: true` path on `<EditorialHeading>`).
+- Centered (`text-align: center`) at prose width
+  (`--container-prose: 680px`).
+- Period rendered per the existing EditorialHeading convention.
+
+## Rationale
+
+- Owner feedback (2026-05-20 grilling): the existing
+  `<MonoLabel tone="ink">Q&A</MonoLabel>` was too quiet between
+  `<EndMark>` above and the first tail `<QaPair>` below —
+  _"should be other typography, bigger"_.
+- Option D delivers the biggest typography of the four and the
+  most distinct voice. The `<HighlighterStroke>` marker is the
+  system's strongest call-out gesture and signals the tail as a
+  feature, not a footnote.
+- Option A (kicker + display-md) was rejected as still too quiet —
+  the mono kicker risks the same fade-into-cream problem the
+  original `<MonoLabel>` had.
+- Option B (display-lg + flanking rules) was rejected because the
+  thin-rule subtitle vocabulary is already locked at mid-article
+  section breaks (5.d3). Reusing it for the tail header — even at
+  a larger heading size — risks reading as a continuation of body
+  section breaks rather than a new section after `<EndMark>`.
+- Option C (full-bleed `<StripedSeam>`) was rejected for the same
+  register-shift reason 5.d3 rejected its own option B: every prior
+  `<StripedSeam>` usage separates _page regions_, not in-article
+  sections. Promoting the tail to a page-region boundary would
+  expand `<StripedSeam>`'s remit and set a precedent we don't want.
+- Risk acknowledged: display-xl is the InterviewHero headline scale.
+  The page lede headline is `<EditorialHeading size="display-xl">`
+  (per master plan §5.2 InterviewHero spec). Two display-xl headings
+  on the same page is acceptable here because they are separated by
+  the entire article body, multiple `<PullQuote>`s, and `<EndMark>`.
+  The tail header is the second hero moment by design — it deserves
+  the same scale.
+
+## Locked component shape
+
+```tsx
+{
+  hasTail ? (
+    <section
+      data-qa-tail-section="true"
+      aria-label="Q&A"
+      className="bg-cream w-full px-4 pb-12 lg:px-0 lg:pb-16"
+    >
+      <div
+        className="mx-auto w-full"
+        style={{ maxWidth: "var(--container-prose)" }}
+      >
+        <header className="mb-8 text-center">
+          <EditorialHeading
+            level={2}
+            size="display-xl"
+            emphasis={{ text: "Q&A", highlight: true }}
+          >
+            Q&A.
+          </EditorialHeading>
+        </header>
+        <div className="flex flex-col gap-12">
+          {tailBlocks.map((block) => (
+            <QaBlock
+              key={block._key}
+              value={block}
+              subjects={article.subjects ?? null}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  ) : null;
+}
+```
+
+- Heading text is hardcoded as `"Q&A."`. The drill explicitly did
+  not introduce a Sanity field for editor-controlled copy here —
+  the tail header is a structural label, not editorial copy. If a
+  future article variant needs a different label, revisit then.
+- The `aria-label="Q&A"` on the outer `<section>` continues to
+  carry the accessible name (the visible `<h2>` and the section's
+  aria-label both saying "Q&A" is intentional; the visible heading
+  is what screen readers will announce on heading navigation).
+- The `<header>` wrapper drops `flex justify-center` in favour of
+  `text-center` — `<EditorialHeading>` is a block-level heading
+  and centers via text-align, not flex.
+
+## API impact
+
+- **None.** `<EditorialHeading>` already supports
+  `size="display-xl"` + `emphasis={{ text, highlight: true }}` (the
+  marker variant landed in Phase 1 — see `EditorialHeading.tsx:34-48`).
+- **No new component.** No new prop on `<EditorialHeading>`.
+- **No schema migration.** Heading copy stays hardcoded in the page.
+
+## What this drill resolves
+
+- ✅ "What typography for the tail Q&A section header?" — display-xl
+  italic + HighlighterStroke marker on "Q&A".
+- ✅ "Should the tail header reuse the mid-article section-break
+  vocabulary?" — No (option B rejected). Reusing thin-rule subtitle
+  at a larger scale would conflate body sections with the tail.
+- ✅ "Should `<StripedSeam>` cross into in-article use?" — No (option
+  C rejected). Stays at page-region boundaries.
+- ✅ "Should there be an editorial kicker / lede subtitle?" — No
+  (options A and C rejected). The marker-decorated heading carries
+  the whole moment.
+
+## What this drill does NOT decide
+
+- **Tail-section background or framing.** Tail stays on cream like
+  the rest of the body. A future round may revisit if the cream-on-
+  cream rhythm proves insufficient after seeing the lock in
+  production.
+- **Mobile typography scale.** Implementation follows the canonical
+  `<EditorialHeading>` responsive cascade for `size="display-xl"`
+  — verify at PR time with the Storybook viewport stories.
+- **`<EndMark>` to header gap.** Vertical rhythm between the in-flow
+  body's closing `<EndMark>` and the tail `<section>` is governed
+  by the parent `<ArticleBodyMotion>` + the tail section's own
+  padding. Tune at implementation if the gap reads wrong; not a
+  drill question.
+- **Whether other article variants surface a tail Q&A section at
+  all.** Currently only used by the interview variant (via
+  `qaBlocksToTailSection`). Other variants opt in by adding
+  `groupAtTail: true` to qaBlocks at the Sanity level — the
+  rendered header treatment is the same.
+
+## Net new primitives
+
+None. Direct reuse of `<EditorialHeading size="display-xl"
+emphasis={{ text, highlight: true }}>` — already in the system
+since Phase 1.
+
+## Source-of-truth
+
+- Mockup HTML: `docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/round-1-tail-qa-header-comparisons.html`
+- Primitive map: `docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/compare.md`
+- Current implementation: `apps/web/src/app/(main)/nieuws/[slug]/page.tsx:449-451`
+- EditorialHeading source: `apps/web/src/components/design-system/EditorialHeading/EditorialHeading.tsx`
+- HighlighterStroke source: `apps/web/src/components/design-system/HighlighterStroke/HighlighterStroke.tsx`
+- Phase 3-b interview lock: `docs/design/mockups/phase-5-article-detail/interview-locked.md`
+- 5.d3 lock (mid-article breaks): `docs/design/mockups/phase-5-article-detail/section-break-locked.md`
+- Memories consumed: [[feedback_reuse_approved_primitives]], [[feedback_visual_preferences]], [[feedback_design_drill_pattern]], [[feedback_drill_visual_then_ia]], [[feedback_monolabel_cream_full_opacity]].


### PR DESCRIPTION
Closes #1867.

## Summary

Design drill 5.d-tail-qa-header for the Phase 5 article-detail tail Q&A section header. Owner feedback from the 2026-05-20 grilling session: the existing `<MonoLabel tone="ink">Q&A</MonoLabel>` reads too quietly between `<EndMark>` above and the first tail `<QaPair>` below — *"should be other typography, bigger"*.

Four typography variants drilled side-by-side in HTML; owner locked **option D**: `<EditorialHeading size="display-xl" emphasis={{ text: "Q&A", highlight: true }}>` — italic Freight Display with `<HighlighterStroke color="jersey">` marker through "Q&A".

Direct reuse of Phase 1 primitives. No new component, no API change, no schema migration.

## Files added

- `docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/round-1-tail-qa-header-comparisons.html` — 4-variant mockup
- `docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/compare.md` — primitive map per [memory:feedback_reuse_approved_primitives]
- `docs/design/mockups/phase-5-article-detail/tail-qa-header-locked.md` — locked decision + rationale + component shape

## Implementation spinout

Filed as **#1874** (`ready` label). Code change is a single header swap at `apps/web/src/app/(main)/nieuws/[slug]/page.tsx:449-451`.

## Phase 5 closeout

Resolves grilling finding 4 on tracker #1860. With #1866 already merged and #1868 already merged, only #1874 (implementation) and #1869 (deferred eventFact navigability) remain before #1860 can close.

## Test plan

- [x] Pre-commit type-check passes (8 packages, full turbo cache)
- [x] Mockup HTML renders correctly in a browser at desktop width (visual lock based on this render)
- [ ] No CI tests apply — docs-only change. CI lint/markdown checks should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation and mockup comparisons for the Q&A section header.
  * Locked design specifications for the Tail Q&A section header styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->