### PR TITLE
feat(news): tail Q&A header — display-xl heading with jersey marker (#1874)

### DIFF
--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -39,7 +39,7 @@ import {
   qaBlocksToTailSection,
 } from "@/components/article/ArticleBody";
 import { QaBlock } from "@/components/article/blocks/QaBlock";
-import { MonoLabel } from "@/components/design-system/MonoLabel";
+import { EditorialHeading } from "@/components/design-system/EditorialHeading";
 import { ArticleCredits } from "@/components/article/ArticleCredits";
 import { VerderLezenRow } from "@/components/article/VerderLezenRow";
 import {
@@ -409,9 +409,10 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         ? (() => {
             // Phase 5.C: hoist `groupAtTail` qaBlocks out of the in-flow
             // body before rendering through <ArticleBody>. Tail blocks
-            // render after <EndMark> under a MonoLabel-headed Q&A
-            // section per the locked composition in
-            // `docs/design/mockups/phase-5-article-detail/interview-locked.md`.
+            // render after <EndMark> under an EditorialHeading-headed
+            // Q&A section per `tail-qa-header-locked.md` (5.d-tail-qa-header
+            // lock, supersedes the original MonoLabel header in
+            // `interview-locked.md`).
             const { inFlow, tailBlocks } = qaBlocksToTailSection(body);
             const hasTail = tailBlocks.length > 0;
             return (
@@ -445,8 +446,14 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
                         className="mx-auto w-full"
                         style={{ maxWidth: "var(--container-prose)" }}
                       >
-                        <header className="mb-8 flex justify-center">
-                          <MonoLabel tone="ink">Q&amp;A</MonoLabel>
+                        <header className="mb-8 text-center">
+                          <EditorialHeading
+                            level={2}
+                            size="display-xl"
+                            emphasis={{ text: "Q&A", highlight: true }}
+                          >
+                            Q&amp;A.
+                          </EditorialHeading>
                         </header>
                         <div className="flex flex-col gap-12">
                           {tailBlocks.map((block) => (


### PR DESCRIPTION
Closes #1874.

Implements the 5.d-tail-qa-header lock from PR #1875 / drill #1867.

## Summary

Single-file header swap on `apps/web/src/app/(main)/nieuws/[slug]/page.tsx:449-451`:

```diff
- <header className="mb-8 flex justify-center">
-   <MonoLabel tone="ink">Q&A</MonoLabel>
- </header>
+ <header className="mb-8 text-center">
+   <EditorialHeading
+     level={2}
+     size="display-xl"
+     emphasis={{ text: "Q&A", highlight: true }}
+   >
+     Q&A.
+   </EditorialHeading>
+ </header>
```

Plus:
- `MonoLabel` import dropped (no remaining usage in this file)
- `EditorialHeading` import added
- Comment at `page.tsx:410-415` updated to reference the new lock doc

## Lock spec compliance

| AC | State |
|---|---|
| Updated per lock doc | ✅ exact composition from `tail-qa-header-locked.md` |
| `MonoLabel` import dropped if unused | ✅ no remaining usages — `grep -n "MonoLabel"` returns only the comment reference |
| Outer `<section data-qa-tail-section="true" aria-label="Q&A">` preserved | ✅ untouched |
| No new design-system primitive | ✅ direct reuse of `<EditorialHeading>` (Phase 1) + `<HighlighterStroke>` (composed by EditorialHeading's `emphasis.highlight: true` path) |
| No schema migration | ✅ heading copy stays hardcoded |
| No new prop on `<EditorialHeading>` | ✅ existing API |
| Visual matches mockup option D | ⏳ verify on Vercel preview below |

## Quality gate

- ✅ `pnpm --filter @kcvv/web lint` — clean
- ✅ `pnpm --filter @kcvv/web type-check` — clean
- ✅ `pnpm --filter @kcvv/web test` — 3237 / 3237 passing
- ⚠️ `pnpm --filter @kcvv/web build` — fails on missing local `apps/web/.env.local` (Sanity `projectId`); pre-existing worktree friction, unrelated to this diff. CI builds fine.

## Visual verification

VR is **not** required — `Pages/*` stories are not VR-tested per `apps/web/CLAUDE.md` ("Page composition correctness is the e2e suite's job"). This is a route-level composition, not a Storybook primitive.

Please confirm the Vercel preview against `docs/design/mockups/phase-5-article-detail/5d-tail-qa-header/round-1-tail-qa-header-comparisons.html` option D on one of the seeded interview articles, e.g.:

- `<vercel-preview>/nieuws/phase-5-tracer-interview-matrix`
- `<vercel-preview>/nieuws/phase-5-interview-duo`

## Phase 5 closeout

Last child issue on tracker **#1860**. After merge, #1860 closeout can run: deferred note already on #1869, master design doc Phase 5 status + `apps/web/CLAUDE.md` audit + sign-off comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Q&A section header on article pages with improved visual styling, including centered alignment and highlight emphasis for enhanced readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->