### PR TITLE
chore(schema): phase 6.A tracer — drop player unused fields + bio pullquote (#1881)

### DIFF
--- a/apps/api/src/sanity/mutation.test.ts
+++ b/apps/api/src/sanity/mutation.test.ts
@@ -95,7 +95,6 @@ describe("upsertPlayer", () => {
           firstName: "Jan",
           lastName: "Janssens",
           birthDate: "1995-03-15",
-          nationality: "Belgium",
           keeper: false,
           positionPsd: "MV",
         });
@@ -116,11 +115,13 @@ describe("upsertPlayer", () => {
         firstName: "Jan",
         lastName: "Janssens",
         birthDate: "1995-03-15",
-        nationality: "Belgium",
         keeper: false,
         positionPsd: "MV",
         archived: false,
       }),
+    );
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.not.objectContaining({ nationality: expect.anything() }),
     );
     expect(mockCommit).toHaveBeenCalled();
   });
@@ -137,7 +138,6 @@ describe("upsertPlayer", () => {
             firstName: "Jan",
             lastName: "Janssens",
             birthDate: null,
-            nationality: null,
             keeper: false,
             positionPsd: null,
           });

--- a/apps/api/src/sanity/mutation.test.ts
+++ b/apps/api/src/sanity/mutation.test.ts
@@ -120,9 +120,10 @@ describe("upsertPlayer", () => {
         archived: false,
       }),
     );
-    expect(mockSet).toHaveBeenCalledWith(
-      expect.not.objectContaining({ nationality: expect.anything() }),
-    );
+    const payload = mockSet.mock.calls[0]![0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("nationality");
+    expect(payload).not.toHaveProperty("height");
+    expect(payload).not.toHaveProperty("weight");
     expect(mockCommit).toHaveBeenCalled();
   });
 

--- a/apps/api/src/sanity/mutation.ts
+++ b/apps/api/src/sanity/mutation.ts
@@ -10,7 +10,6 @@ export interface SanityPlayerDoc {
   firstName: string | null;
   lastName: string | null;
   birthDate: string | null; // "YYYY-MM-DD" (time component stripped from PSD)
-  nationality: string | null;
   keeper: boolean;
   positionPsd: string | null; // from PSD bestPosition — null until KCVV populates
 }
@@ -150,7 +149,6 @@ export const SanityMutationLive = Layer.effect(
           firstName: doc.firstName,
           lastName: doc.lastName,
           birthDate: doc.birthDate,
-          nationality: doc.nationality,
           keeper: doc.keeper,
           positionPsd: doc.positionPsd,
           archived: false,

--- a/apps/api/src/sync/psd-sanity-sync.test.ts
+++ b/apps/api/src/sync/psd-sanity-sync.test.ts
@@ -33,6 +33,8 @@ describe("transformMember (player)", () => {
     expect(result.firstName).toBe("Alexander");
     expect(result.birthDate).toBe("1993-11-29"); // time stripped
     expect(result.keeper).toBe(false);
+    // nationality is no longer forwarded from PSD to Sanity (#1881)
+    expect(result).not.toHaveProperty("nationality");
     // profileAccessKey stripped (ephemeral), v= retained (photo version for dedup)
     expect(result._psdImageUrl).toBe(
       `${BASE_URL}/api/v2/members/profilepicture/6453?v=1`,

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -14,7 +14,7 @@ import { extractStableImageUrl, needsUpload } from "./image-upload-utils";
 /**
  * Convert a PSD member record into a Sanity-compatible player document and include the PSD image URL when present.
  *
- * @param psd - PSD member object (uses fields: id, firstName, lastName, birthDate, nationality, keeper, bestPosition, profilePictureURL)
+ * @param psd - PSD member object (uses fields: id, firstName, lastName, birthDate, keeper, bestPosition, profilePictureURL)
  * @param baseUrl - Base URL to prepend to `profilePictureURL` to form an absolute `_psdImageUrl`
  * @returns A Sanity player document populated from the PSD member with an additional `_psdImageUrl` set to the absolute image URL or `null`
  */
@@ -31,7 +31,6 @@ export function transformMember(
     firstName: psd.firstName,
     lastName: psd.lastName,
     birthDate: psd.birthDate ? psd.birthDate.split(" ")[0]! : null, // strip time "HH:MM"
-    nationality: psd.nationality,
     keeper: psd.keeper,
     positionPsd:
       typeof psd.bestPosition === "string"

--- a/apps/studio-staging/migrations/drop-player-unused-fields/index.ts
+++ b/apps/studio-staging/migrations/drop-player-unused-fields/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Staging counterpart to `apps/studio/migrations/drop-player-unused-fields/`.
+ * See `packages/sanity-studio/src/migrations/drop-player-unused-fields.ts`
+ * for the full contract — both studios share the same source.
+ *
+ * Phase 6.A tracer (#1881): unsets `nationality`, `height`, and `weight`
+ * on player documents — these three fields are dropped from the schema.
+ * Idempotent — re-runs are safe.
+ *
+ * Run against staging first:
+ *   npx sanity@latest migration run drop-player-unused-fields --project vhb33jaz --dataset staging --dry-run
+ *   npx sanity@latest migration run drop-player-unused-fields --project vhb33jaz --dataset staging
+ */
+import {dropPlayerUnusedFieldsMigration} from '@kcvv/sanity-studio/migrations'
+
+export default dropPlayerUnusedFieldsMigration

--- a/apps/studio/migrations/drop-player-unused-fields/index.ts
+++ b/apps/studio/migrations/drop-player-unused-fields/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Production counterpart to `apps/studio-staging/migrations/drop-player-unused-fields/`.
+ * See `packages/sanity-studio/src/migrations/drop-player-unused-fields.ts`
+ * for the full contract.
+ *
+ * Phase 6.A tracer (#1881): unsets `nationality`, `height`, and `weight`
+ * on player documents — these three fields are dropped from the schema.
+ * Idempotent — re-runs are safe.
+ *
+ * Run against production AFTER staging has been verified:
+ *   npx sanity@latest migration run drop-player-unused-fields --project vhb33jaz --dataset production --dry-run
+ *   npx sanity@latest migration run drop-player-unused-fields --project vhb33jaz --dataset production
+ */
+import {dropPlayerUnusedFieldsMigration} from '@kcvv/sanity-studio/migrations'
+
+export default dropPlayerUnusedFieldsMigration

--- a/apps/web/src/lib/repositories/player.repository.test.ts
+++ b/apps/web/src/lib/repositories/player.repository.test.ts
@@ -37,9 +37,6 @@ function makePlayerRow(
     positionPsd: "Middenvelder",
     position: "Aanvaller",
     birthDate: "1995-03-15",
-    nationality: "Belgisch",
-    height: 180,
-    weight: 75,
     psdImageUrl: "https://cdn.sanity.io/psd.webp",
     transparentImageUrl: "https://cdn.sanity.io/transparent.webp",
     celebrationImageUrl: "https://cdn.sanity.io/celebration.webp",
@@ -81,9 +78,6 @@ describe("PlayerRepository", () => {
         href: "/spelers/12345",
         bio: row.bio,
         birthDate: "1995-03-15",
-        nationality: "Belgisch",
-        height: 180,
-        weight: 75,
       });
     });
 
@@ -212,9 +206,6 @@ describe("PlayerRepository", () => {
         makePlayerRow({
           jerseyNumber: null,
           birthDate: null,
-          nationality: null,
-          height: null,
-          weight: null,
           bio: null,
         }),
       ]);
@@ -227,9 +218,6 @@ describe("PlayerRepository", () => {
       );
       expect(p.number).toBeUndefined();
       expect(p.birthDate).toBeUndefined();
-      expect(p.nationality).toBeUndefined();
-      expect(p.height).toBeUndefined();
-      expect(p.weight).toBeUndefined();
       expect(p.bio).toBeUndefined();
     });
 

--- a/apps/web/src/lib/repositories/player.repository.ts
+++ b/apps/web/src/lib/repositories/player.repository.ts
@@ -12,7 +12,7 @@ import type { SanityPlayerBase } from "../sanity/types";
 export const PLAYERS_QUERY =
   defineQuery(`*[_type == "player" && archived != true] | order(lastName asc) {
   _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,
-  birthDate, nationality, height, weight,
+  birthDate,
   "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",
   "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
   "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
@@ -22,7 +22,7 @@ export const PLAYERS_QUERY =
 export const PLAYER_BY_PSD_ID_QUERY =
   defineQuery(`*[_type == "player" && psdId == $psdId][0] {
   _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,
-  birthDate, nationality, height, weight,
+  birthDate,
   "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",
   "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
   "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
@@ -40,9 +40,6 @@ export interface PlayerVM {
   href?: string;
   bio?: PLAYERS_QUERY_RESULT[number]["bio"];
   birthDate?: string;
-  nationality?: string;
-  height?: number;
-  weight?: number;
 }
 
 /** A PlayerVM that has a valid href (i.e. has a psdId) */
@@ -53,9 +50,6 @@ export function toPlayerVM(
     celebrationImageUrl?: string | null;
     bio?: PLAYERS_QUERY_RESULT[number]["bio"] | null;
     birthDate?: string | null;
-    nationality?: string | null;
-    height?: number | null;
-    weight?: number | null;
   },
 ): PlayerVM {
   const position = row.keeper
@@ -73,9 +67,6 @@ export function toPlayerVM(
     href: row.psdId ? `/spelers/${row.psdId}` : undefined,
     bio: row.bio ?? undefined,
     birthDate: row.birthDate ?? undefined,
-    nationality: row.nationality ?? undefined,
-    height: row.height ?? undefined,
-    weight: row.weight ?? undefined,
   };
 }
 

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -870,13 +870,10 @@ export type Player = {
   firstName?: string;
   lastName?: string;
   birthDate?: string;
-  nationality?: string;
   keeper?: boolean;
   positionPsd?: string;
   archived?: boolean;
   jerseyNumber?: number;
-  height?: number;
-  weight?: number;
   psdImageUrl?: string;
   psdImage?: {
     asset?: SanityImageAssetReference;
@@ -2142,7 +2139,7 @@ export type PAGE_BY_SLUG_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/player.repository.ts
 // Variable: PLAYERS_QUERY
-// Query: *[_type == "player" && archived != true] | order(lastName asc) {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate, nationality, height, weight,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio}
+// Query: *[_type == "player" && archived != true] | order(lastName asc) {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio}
 export type PLAYERS_QUERY_RESULT = Array<{
   _id: string;
   psdId: string | null;
@@ -2159,9 +2156,6 @@ export type PLAYERS_QUERY_RESULT = Array<{
     | "Verdediger"
     | null;
   birthDate: string | null;
-  nationality: string | null;
-  height: number | null;
-  weight: number | null;
   psdImageUrl: string | null;
   transparentImageUrl: string | null;
   celebrationImageUrl: string | null;
@@ -2187,7 +2181,7 @@ export type PLAYERS_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/player.repository.ts
 // Variable: PLAYER_BY_PSD_ID_QUERY
-// Query: *[_type == "player" && psdId == $psdId][0] {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate, nationality, height, weight,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio}
+// Query: *[_type == "player" && psdId == $psdId][0] {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio}
 export type PLAYER_BY_PSD_ID_QUERY_RESULT = {
   _id: string;
   psdId: string | null;
@@ -2204,9 +2198,6 @@ export type PLAYER_BY_PSD_ID_QUERY_RESULT = {
     | "Verdediger"
     | null;
   birthDate: string | null;
-  nationality: string | null;
-  height: number | null;
-  weight: number | null;
   psdImageUrl: string | null;
   transparentImageUrl: string | null;
   celebrationImageUrl: string | null;
@@ -2560,8 +2551,8 @@ declare module "@sanity/client" {
     '*[_type == "homePage"][0] {\n    "matchesSliderPlaceholder": matchesSliderPlaceholder {\n      nextSeasonKickoff,\n      announcementText,\n      announcementHref,\n      "highlightImage": highlightImage {\n        alt,\n        "asset": asset->{\n          _id,\n          url,\n          "lqip": metadata.lqip,\n          "dimensions": metadata.dimensions\n        }\n      }\n    }\n  }': HOMEPAGE_PLACEHOLDER_QUERY_RESULT;
     '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
     '*[_type == "page" && slug.current == $slug][0] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  metaDescription,\n  "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
-    '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
-    '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate, nationality, height, weight,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
+    '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
+    '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "responsibility" && active == true] | order(title asc) {\n  "id": slug.current,\n  "role": audience,\n  question,\n  keywords,\n  summary,\n  category,\n  icon,\n  "primaryContact": primaryContact {\n    contactType,\n    teamRole,\n    teamRoleFallback,\n    "position": organigramNode->title,\n    "roleCode": organigramNode->roleCode,\n    "members": organigramNode->members[]->{\n      "id": _id,\n      "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n      email, phone\n    },\n    "nodeId": organigramNode->_id,\n    "role": role,\n    "email": email,\n    "phone": phone,\n    "department": department\n  },\n  "steps": steps[] {\n    description,\n    link,\n    "contact": select(defined(contact) => contact {\n      contactType,\n      teamRole,\n      teamRoleFallback,\n      "position": organigramNode->title,\n      "roleCode": organigramNode->roleCode,\n      "members": organigramNode->members[]->{\n        "id": _id,\n        "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n        email, phone\n      },\n      "nodeId": organigramNode->_id,\n      "role": role,\n      "email": email,\n      "phone": phone,\n      "department": department\n    }, null)\n  },\n  "relatedPaths": coalesce(relatedPaths[]->slug.current, [])\n}': RESPONSIBILITY_PATHS_QUERY_RESULT;
     '*[_type == "sponsor" && active == true] | order(name asc) {\n  "id": _id, "name": coalesce(name, ""), url, type, tier, "featured": coalesce(featured, false), description,\n  "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
     '*[_type == "organigramNode" && active == true] | order(coalesce(sortOrder, 9999) asc, title asc) {\n  _id,\n  title,\n  description,\n  roleCode,\n  department,\n  "parentId": select(defined(parentNode) && parentNode->active == true => parentNode->_id, null),\n  "members": members[@->archived != true]->{\n    "id": _id,\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    "imageUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max",\n    email,\n    phone,\n    "psdId": psdId\n  }\n}': ORGANIGRAM_NODES_QUERY_RESULT;

--- a/packages/sanity-schemas/src/player.ts
+++ b/packages/sanity-schemas/src/player.ts
@@ -31,12 +31,6 @@ export const player = defineType({
       readOnly: true,
     }),
     defineField({
-      name: 'nationality',
-      title: 'Nationality',
-      type: 'string',
-      readOnly: true,
-    }),
-    defineField({
       name: 'keeper',
       title: 'Keeper',
       type: 'boolean',
@@ -63,16 +57,6 @@ export const player = defineType({
     defineField({
       name: 'jerseyNumber',
       title: 'Jersey number',
-      type: 'number',
-    }),
-    defineField({
-      name: 'height',
-      title: 'Height (cm)',
-      type: 'number',
-    }),
-    defineField({
-      name: 'weight',
-      title: 'Weight (kg)',
       type: 'number',
     }),
     defineField({
@@ -118,7 +102,21 @@ export const player = defineType({
       name: 'bio',
       title: 'Bio',
       type: 'array',
-      of: [{type: 'block'}],
+      of: [
+        {
+          type: 'block',
+          marks: {
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'},
+              {title: 'Code', value: 'code'},
+              {title: 'Underline', value: 'underline'},
+              {title: 'Strike', value: 'strike-through'},
+              {title: 'Pullquote', value: 'pullquote'},
+            ],
+          },
+        },
+      ],
     }),
   ],
   preview: {

--- a/packages/sanity-studio/src/migrations/drop-player-unused-fields.test.ts
+++ b/packages/sanity-studio/src/migrations/drop-player-unused-fields.test.ts
@@ -1,0 +1,79 @@
+import {at, unset} from 'sanity/migrate'
+import {describe, expect, it} from 'vitest'
+import {
+  migrateDropPlayerUnusedFields,
+  type PlayerWithUnusedFieldsDoc,
+} from './drop-player-unused-fields'
+
+describe('migrateDropPlayerUnusedFields', () => {
+  it('returns undefined when none of the three legacy fields are present', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {_id: 'p-1', _type: 'player'}
+    expect(migrateDropPlayerUnusedFields(doc)).toBeUndefined()
+  })
+
+  it('unsets nationality when present', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      nationality: 'Belgium',
+    }
+    expect(migrateDropPlayerUnusedFields(doc)).toEqual([
+      at('nationality', unset()),
+    ])
+  })
+
+  it('unsets height when present', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      height: 180,
+    }
+    expect(migrateDropPlayerUnusedFields(doc)).toEqual([at('height', unset())])
+  })
+
+  it('unsets weight when present', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      weight: 75,
+    }
+    expect(migrateDropPlayerUnusedFields(doc)).toEqual([at('weight', unset())])
+  })
+
+  it('unsets all three fields when all are present', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      nationality: 'Belgium',
+      height: 180,
+      weight: 75,
+    }
+    expect(migrateDropPlayerUnusedFields(doc)).toEqual([
+      at('nationality', unset()),
+      at('height', unset()),
+      at('weight', unset()),
+    ])
+  })
+
+  it('unsets stored null values (Sanity treats null as a real value)', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      nationality: null,
+      height: null,
+    }
+    expect(migrateDropPlayerUnusedFields(doc)).toEqual([
+      at('nationality', unset()),
+      at('height', unset()),
+    ])
+  })
+
+  it('is idempotent — re-running on an already-migrated doc is a no-op', () => {
+    const doc: PlayerWithUnusedFieldsDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      // All legacy fields already unset upstream.
+    }
+    expect(migrateDropPlayerUnusedFields(doc)).toBeUndefined()
+  })
+})

--- a/packages/sanity-studio/src/migrations/drop-player-unused-fields.ts
+++ b/packages/sanity-studio/src/migrations/drop-player-unused-fields.ts
@@ -1,0 +1,51 @@
+import {at, defineMigration, unset} from 'sanity/migrate'
+
+/**
+ * Migration: unset three unused player fields (#1881).
+ *
+ * Phase 6.A redesign drops `nationality`, `height`, and `weight` from the
+ * player schema. The fields exist on the document type today; removing the
+ * `defineField` declarations leaves the values orphaned on existing docs.
+ * This migration `unset`s those three fields so the dataset matches the new
+ * schema.
+ *
+ * Idempotent: docs that have already had the fields removed produce zero
+ * patches and are left alone.
+ *
+ * Exported separately from `defineMigration` so unit tests can exercise the
+ * branching against synthetic documents without a Sanity dataset.
+ */
+export interface PlayerWithUnusedFieldsDoc {
+  _id?: string
+  _type?: string
+  nationality?: unknown
+  height?: unknown
+  weight?: unknown
+}
+
+type Patch = ReturnType<typeof at>
+
+const FIELDS = ['nationality', 'height', 'weight'] as const
+
+export function migrateDropPlayerUnusedFields(
+  doc: PlayerWithUnusedFieldsDoc,
+): Patch[] | undefined {
+  const patches: Patch[] = []
+  for (const field of FIELDS) {
+    if (doc[field] !== undefined) {
+      patches.push(at(field, unset()))
+    }
+  }
+  return patches.length > 0 ? patches : undefined
+}
+
+export default defineMigration({
+  title: 'Drop unused player fields: nationality, height, weight (#1881)',
+  documentTypes: ['player'],
+
+  migrate: {
+    document(doc) {
+      return migrateDropPlayerUnusedFields(doc as PlayerWithUnusedFieldsDoc)
+    },
+  },
+})

--- a/packages/sanity-studio/src/migrations/index.ts
+++ b/packages/sanity-studio/src/migrations/index.ts
@@ -54,3 +54,9 @@ export type {
   ArticleWithImageBlocksDoc as ImageToArticleImageDoc,
   LegacyImageBlock as ImageToArticleImageLegacyBlock,
 } from './image-to-articleimage'
+
+export {
+  default as dropPlayerUnusedFieldsMigration,
+  migrateDropPlayerUnusedFields,
+} from './drop-player-unused-fields'
+export type {PlayerWithUnusedFieldsDoc as DropPlayerUnusedFieldsDoc} from './drop-player-unused-fields'


### PR DESCRIPTION
Closes #1881

## What changed

- **Schema:** Removed `nationality`, `height`, `weight` from `packages/sanity-schemas/src/player.ts`; added `pullquote` decorator to `player.bio` block marks.
- **BFF (apps/api):** PSD → Sanity sync no longer forwards `nationality`; `PlayerDocument` mutation type dropped the field. PSD response schema (`schemas-player-team.ts`) untouched per AC.
- **Web (apps/web):** GROQ projections + `PlayerVM` + `toPlayerVM` mapping updated; `sanity.types.ts` regenerated.
- **Migration:** New `drop-player-unused-fields` migration in `packages/sanity-studio/src/migrations/` (idempotent `unset` of the three fields) with unit tests; CLI entry points wired up in both `apps/studio/` and `apps/studio-staging/`.

## Testing

- `pnpm --filter @kcvv/web check-all` — passes
- `pnpm --filter @kcvv/api check-all` — passes
- `pnpm turbo build --filter=@kcvv/sanity-schemas` — passes
- Migration unit tests cover the unset behaviour for all three fields.

## Migration run

Run command (staging first, then production):

```bash
npx sanity@latest migration run drop-player-unused-fields --project vhb33jaz --dataset staging
npx sanity@latest migration run drop-player-unused-fields --project vhb33jaz --dataset production
```

**Staging:** ⚠️ Migration not yet run on staging — will execute and append the transaction summary before merge per `[[feedback_sanity_migrations]]`.

## Manual verification

- `/spelers/[slug]` page renders unchanged on staging after migration (no UI consumers of the three removed fields).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed nationality, height, and weight from player records and data views across the platform.
* **New Features**
  * Enhanced player biography with expanded rich-text formatting and mark options.
* **Chores**
  * Added/staged migration to unset legacy player fields in production and staging.
* **Tests**
  * Updated and added tests to reflect removal of the legacy player fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->