### PR TITLE
fix(api): skip PSD "no image available" placeholder during player sync (#1895)

### DIFF
--- a/apps/api/src/sanity/mutation.test.ts
+++ b/apps/api/src/sanity/mutation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Effect, Layer } from "effect";
 import {
+  PSD_PLACEHOLDER_IMAGE_SHA1,
   SanityMutation,
   SanityMutationLive,
   SanityMutationError,
@@ -436,6 +437,106 @@ describe("uploadPlayerImage", () => {
       expect(result.left).toBeInstanceOf(SanityMutationError);
       expect(result.left.message).toContain("not allowed");
     }
+  });
+
+  it("skips upload and patch when bytes match the PSD placeholder SHA-1 (#1895)", async () => {
+    // Build a 20-byte buffer that hex-encodes to PSD_PLACEHOLDER_IMAGE_SHA1
+    // so the SHA-1 digest call returns the known placeholder hash.
+    const placeholderHashBytes = new Uint8Array(20);
+    for (let i = 0; i < 20; i++) {
+      placeholderHashBytes[i] = parseInt(
+        PSD_PLACEHOLDER_IMAGE_SHA1.slice(i * 2, i * 2 + 2),
+        16,
+      );
+    }
+    const digestSpy = vi
+      .spyOn(crypto.subtle, "digest")
+      .mockResolvedValueOnce(placeholderHashBytes.buffer);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // Only one fetch is expected (PSD); the Sanity upload must NOT fire.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+
+    const patchCallsBefore = mockClientPatch.mock.calls.length;
+
+    await run(
+      Effect.gen(function* () {
+        const mutation = yield* SanityMutation;
+        yield* mutation.uploadPlayerImage(
+          "42",
+          "https://kcvv.prosoccerdata.com/img/placeholder.jpg?profileAccessKey=abc",
+          "https://kcvv.prosoccerdata.com/img/placeholder.jpg?v=1",
+        );
+      }),
+    );
+
+    expect(digestSpy).toHaveBeenCalledTimes(1);
+    expect(digestSpy).toHaveBeenCalledWith("SHA-1", expect.any(ArrayBuffer));
+    // Exactly one fetch (PSD) — Sanity upload was never invoked
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // psdImage patch was NOT issued
+    expect(mockClientPatch.mock.calls.length).toBe(patchCallsBefore);
+
+    digestSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it("uploads + patches when bytes do NOT match the PSD placeholder SHA-1", async () => {
+    // Force the digest to return a non-placeholder hash (all zeros) so the
+    // skip branch does not fire and the upload path runs to completion.
+    const nonPlaceholderHashBytes = new Uint8Array(20);
+    const digestSpy = vi
+      .spyOn(crypto.subtle, "digest")
+      .mockResolvedValueOnce(nonPlaceholderHashBytes.buffer);
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      new Response(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ document: { _id: "image-real-bytes" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await run(
+      Effect.gen(function* () {
+        const mutation = yield* SanityMutation;
+        yield* mutation.uploadPlayerImage(
+          "99",
+          "https://kcvv.prosoccerdata.com/img/real.jpg?profileAccessKey=xyz",
+          "https://kcvv.prosoccerdata.com/img/real.jpg?v=1",
+        );
+      }),
+    );
+
+    // PSD fetch + Sanity upload both happened
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // psdImage patch fired with the new asset _id
+    expect(mockClientPatch).toHaveBeenCalledWith("player-psd-99");
+    const lastPatchResult =
+      mockClientPatch.mock.results[mockClientPatch.mock.results.length - 1]!
+        .value.set;
+    expect(lastPatchResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        psdImage: {
+          _type: "image",
+          asset: { _type: "reference", _ref: "image-real-bytes" },
+        },
+      }),
+    );
+
+    digestSpy.mockRestore();
+    fetchSpy.mockRestore();
   });
 
   it("rejects invalid URLs", async () => {

--- a/apps/api/src/sanity/mutation.ts
+++ b/apps/api/src/sanity/mutation.ts
@@ -3,6 +3,20 @@ import { Context, Effect, Layer } from "effect";
 import { WorkerEnvTag } from "../env";
 import { sanityClientConfig } from "./config";
 
+/**
+ * SHA-1 (hex, lowercase, 40 chars) of PSD's "no image available" placeholder
+ * image bytes. Sanity asset _ids embed this same SHA-1 — the placeholder
+ * asset currently uploaded to staging is
+ * `image-6607821528ffa87bb0d39b159a7a4aa81dc78683-350x350-jpg` and
+ * production carries the same bytes → same hash, so the constant works for
+ * both datasets.
+ *
+ * Used by `uploadPlayerImage` to skip the placeholder during sync (#1895)
+ * so the Phase 6.A `<PlayerHero>` illustration fallback fires correctly.
+ */
+export const PSD_PLACEHOLDER_IMAGE_SHA1 =
+  "6607821528ffa87bb0d39b159a7a4aa81dc78683";
+
 // ─── Document shapes written to Sanity ───────────────────────────────────────
 
 export interface SanityPlayerDoc {
@@ -249,6 +263,40 @@ export const SanityMutationLive = Layer.effect(
           yield* Effect.log(
             `[uploadPlayerImage] player=${psdId} body_bytes=${arrayBuffer.byteLength} content-type=${contentType}`,
           );
+
+          // PSD's "no image available" placeholder slips through this code
+          // path: PSD returns it as a real image (HTTP 200, valid JPEG bytes)
+          // for any player that lacks a real photo, so the previous early
+          // 404 guard doesn't catch it. Sanity's asset deduplication means
+          // every placeholder upload across syncs lands on the same asset
+          // ref — every affected player ends up sharing one common
+          // `image-<sha1>-...` id. We detect by computing SHA-1 of the
+          // bytes and matching against the known placeholder hash.
+          //
+          // Phase 6.A design (lock 6.d2) requires the player profile photo
+          // column to be EITHER a real player photo OR the canonical
+          // `<PlayerFigure>` illustration fallback — never the silhouette.
+          // Skipping the upload here keeps `psdImage` unset on those
+          // players so the fallback fires correctly.
+          //
+          // Issue #1895 / originating screenshot: Memphis Vercammen.
+          const sha1Buffer = yield* Effect.tryPromise({
+            try: () => crypto.subtle.digest("SHA-1", arrayBuffer),
+            catch: (cause) =>
+              new SanityMutationError(
+                `Failed to hash image bytes for player ${psdId}`,
+                cause,
+              ),
+          });
+          const sha1Hex = Array.from(new Uint8Array(sha1Buffer))
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("");
+          if (sha1Hex === PSD_PLACEHOLDER_IMAGE_SHA1) {
+            yield* Effect.log(
+              `[uploadPlayerImage] player=${psdId} bytes match PSD "no image available" placeholder (sha1=${sha1Hex}) — skipping upload and patch so PlayerHero illustration fallback fires`,
+            );
+            return;
+          }
 
           // Use REST API directly — client.assets.upload() uses Node.js internals
           // incompatible with Cloudflare Workers runtime.

--- a/apps/studio-staging/migrations/unset-player-placeholder-psd-image/index.ts
+++ b/apps/studio-staging/migrations/unset-player-placeholder-psd-image/index.ts
@@ -8,9 +8,14 @@
  * every player document whose `psdImage.asset._ref` matches PSD's
  * "no image available" placeholder asset. Idempotent — re-runs are safe.
  *
- * Run against staging FIRST:
- *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset staging --dry-run
+ * Run against staging FIRST. The Sanity CLI defaults to dry-run mode; the
+ * second command MUST include `--no-dry-run` to actually apply changes.
+ *
+ *   # Preview (dry-run, default)
  *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset staging
+ *
+ *   # Apply (writes changes)
+ *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset staging --no-dry-run
  */
 import {unsetPlayerPlaceholderPsdImageMigration} from '@kcvv/sanity-studio/migrations'
 

--- a/apps/studio-staging/migrations/unset-player-placeholder-psd-image/index.ts
+++ b/apps/studio-staging/migrations/unset-player-placeholder-psd-image/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Staging counterpart to
+ * `apps/studio/migrations/unset-player-placeholder-psd-image/`.
+ * See `packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.ts`
+ * for the full contract.
+ *
+ * Issue #1895: unsets `psdImage` (and the sibling `psdImageUrl`) on
+ * every player document whose `psdImage.asset._ref` matches PSD's
+ * "no image available" placeholder asset. Idempotent — re-runs are safe.
+ *
+ * Run against staging FIRST:
+ *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset staging --dry-run
+ *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset staging
+ */
+import {unsetPlayerPlaceholderPsdImageMigration} from '@kcvv/sanity-studio/migrations'
+
+export default unsetPlayerPlaceholderPsdImageMigration

--- a/apps/studio/migrations/unset-player-placeholder-psd-image/index.ts
+++ b/apps/studio/migrations/unset-player-placeholder-psd-image/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Production counterpart to
+ * `apps/studio-staging/migrations/unset-player-placeholder-psd-image/`.
+ * See `packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.ts`
+ * for the full contract.
+ *
+ * Issue #1895: unsets `psdImage` (and the sibling `psdImageUrl`) on
+ * every player document whose `psdImage.asset._ref` matches PSD's
+ * "no image available" placeholder asset. Idempotent — re-runs are safe.
+ *
+ * Run against production AFTER staging has been verified:
+ *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset production --dry-run
+ *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset production
+ */
+import {unsetPlayerPlaceholderPsdImageMigration} from '@kcvv/sanity-studio/migrations'
+
+export default unsetPlayerPlaceholderPsdImageMigration

--- a/apps/studio/migrations/unset-player-placeholder-psd-image/index.ts
+++ b/apps/studio/migrations/unset-player-placeholder-psd-image/index.ts
@@ -8,9 +8,15 @@
  * every player document whose `psdImage.asset._ref` matches PSD's
  * "no image available" placeholder asset. Idempotent — re-runs are safe.
  *
- * Run against production AFTER staging has been verified:
- *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset production --dry-run
+ * Run against production AFTER staging has been verified. The Sanity CLI
+ * defaults to dry-run mode; the second command MUST include `--no-dry-run`
+ * to actually apply changes.
+ *
+ *   # Preview (dry-run, default)
  *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset production
+ *
+ *   # Apply (writes changes)
+ *   npx sanity@latest migration run unset-player-placeholder-psd-image --project vhb33jaz --dataset production --no-dry-run
  */
 import {unsetPlayerPlaceholderPsdImageMigration} from '@kcvv/sanity-studio/migrations'
 

--- a/packages/sanity-studio/src/migrations/index.ts
+++ b/packages/sanity-studio/src/migrations/index.ts
@@ -60,3 +60,10 @@ export {
   migrateDropPlayerUnusedFields,
 } from './drop-player-unused-fields'
 export type {PlayerWithUnusedFieldsDoc as DropPlayerUnusedFieldsDoc} from './drop-player-unused-fields'
+
+export {
+  default as unsetPlayerPlaceholderPsdImageMigration,
+  migrateUnsetPlayerPlaceholderPsdImage,
+  PSD_PLACEHOLDER_ASSET_REF,
+} from './unset-player-placeholder-psd-image'
+export type {PlayerWithPsdImageDoc as UnsetPlayerPlaceholderPsdImageDoc} from './unset-player-placeholder-psd-image'

--- a/packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.test.ts
+++ b/packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.test.ts
@@ -1,0 +1,73 @@
+import {at, unset} from 'sanity/migrate'
+import {describe, expect, it} from 'vitest'
+import {
+  PSD_PLACEHOLDER_ASSET_REF,
+  migrateUnsetPlayerPlaceholderPsdImage,
+  type PlayerWithPsdImageDoc,
+} from './unset-player-placeholder-psd-image'
+
+describe('migrateUnsetPlayerPlaceholderPsdImage', () => {
+  it('returns undefined when psdImage is missing entirely', () => {
+    const doc: PlayerWithPsdImageDoc = {_id: 'p-1', _type: 'player'}
+    expect(migrateUnsetPlayerPlaceholderPsdImage(doc)).toBeUndefined()
+  })
+
+  it('returns undefined when psdImage.asset._ref does not match the placeholder', () => {
+    const doc: PlayerWithPsdImageDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      psdImage: {
+        _type: 'image',
+        asset: {_type: 'reference', _ref: 'image-deadbeef-350x350-jpg'},
+      },
+    }
+    expect(migrateUnsetPlayerPlaceholderPsdImage(doc)).toBeUndefined()
+  })
+
+  it('unsets psdImage when the asset ref matches the placeholder', () => {
+    const doc: PlayerWithPsdImageDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      psdImage: {
+        _type: 'image',
+        asset: {_type: 'reference', _ref: PSD_PLACEHOLDER_ASSET_REF},
+      },
+    }
+    expect(migrateUnsetPlayerPlaceholderPsdImage(doc)).toEqual([
+      at('psdImage', unset()),
+    ])
+  })
+
+  it('also unsets the sibling psdImageUrl when it exists', () => {
+    const doc: PlayerWithPsdImageDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      psdImage: {
+        _type: 'image',
+        asset: {_type: 'reference', _ref: PSD_PLACEHOLDER_ASSET_REF},
+      },
+      psdImageUrl: 'https://kcvv.prosoccerdata.com/img/placeholder.jpg?v=1',
+    }
+    expect(migrateUnsetPlayerPlaceholderPsdImage(doc)).toEqual([
+      at('psdImage', unset()),
+      at('psdImageUrl', unset()),
+    ])
+  })
+
+  it('is idempotent — re-running on an already-unset doc is a no-op', () => {
+    const original: PlayerWithPsdImageDoc = {
+      _id: 'p-1',
+      _type: 'player',
+      psdImage: {
+        _type: 'image',
+        asset: {_type: 'reference', _ref: PSD_PLACEHOLDER_ASSET_REF},
+      },
+    }
+    const patches = migrateUnsetPlayerPlaceholderPsdImage(original)
+    expect(patches).toBeDefined()
+
+    // Simulate post-migration state: psdImage gone.
+    const after: PlayerWithPsdImageDoc = {_id: 'p-1', _type: 'player'}
+    expect(migrateUnsetPlayerPlaceholderPsdImage(after)).toBeUndefined()
+  })
+})

--- a/packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.ts
+++ b/packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.ts
@@ -1,0 +1,82 @@
+import {at, defineMigration, unset} from 'sanity/migrate'
+
+/**
+ * Migration: unset `psdImage` on every player document that currently
+ * references the PSD "no image available" placeholder asset (#1895).
+ *
+ * Sanity deduplicates asset uploads by content hash, so every player
+ * whose `psdImage` resolves to the placeholder shares the same asset
+ * `_ref`. We can therefore target the whole cohort by matching on the
+ * exact asset ref — no per-player heuristics needed.
+ *
+ * The hash in the asset ref is SHA-1 of the placeholder bytes; the
+ * staging dataset stores the placeholder at
+ * `image-6607821528ffa87bb0d39b159a7a4aa81dc78683-350x350-jpg`, and the
+ * production dataset carries the same bytes → same hash → same asset id.
+ *
+ * Idempotent: docs that no longer reference the placeholder (or never
+ * did) produce zero patches and are left alone.
+ *
+ * After this migration runs, the PlayerHero illustration fallback fires
+ * for the affected players per the Phase 6.A 6.d2 lock.
+ *
+ * Exported separately from `defineMigration` so unit tests can exercise
+ * the branching against synthetic documents without a Sanity dataset.
+ */
+export const PSD_PLACEHOLDER_ASSET_REF =
+  'image-6607821528ffa87bb0d39b159a7a4aa81dc78683-350x350-jpg'
+
+export interface PlayerWithPsdImageDoc {
+  _id?: string
+  _type?: string
+  psdImage?: {
+    _type?: 'image'
+    asset?: {
+      _type?: 'reference'
+      _ref?: string
+    }
+  }
+  // The sync also writes a sibling `psdImageUrl` string used for dedup on
+  // the next run. Leaving it set would re-trigger the upload path on the
+  // next sync — but with #1895's hash-skip in place that path now bails
+  // before patching, so the lingering URL is harmless. Unset it anyway to
+  // keep the document tidy.
+  //
+  // Trade-off: unsetting `psdImageUrl` means `needsUpload` returns true on
+  // every subsequent sync for these players → the sync re-fetches the
+  // placeholder bytes from PSD just to hash + skip them, burning one
+  // PSD-counter call per affected player per sync. Acceptable at the
+  // current scale (~80 calls/sync, well under the PSD daily ceiling).
+  // A future enhancement could persist a "known-placeholder" marker so
+  // the sync short-circuits before fetching — out of scope for #1895.
+  psdImageUrl?: string
+}
+
+type Patch = ReturnType<typeof at>
+
+export function migrateUnsetPlayerPlaceholderPsdImage(
+  doc: PlayerWithPsdImageDoc,
+): Patch[] | undefined {
+  const ref = doc.psdImage?.asset?._ref
+  if (ref !== PSD_PLACEHOLDER_ASSET_REF) return undefined
+
+  const patches: Patch[] = [at('psdImage', unset())]
+  if (doc.psdImageUrl !== undefined) {
+    patches.push(at('psdImageUrl', unset()))
+  }
+  return patches
+}
+
+export default defineMigration({
+  title:
+    'Unset psdImage on players carrying the PSD "no image available" placeholder (#1895)',
+  documentTypes: ['player'],
+
+  migrate: {
+    document(doc) {
+      return migrateUnsetPlayerPlaceholderPsdImage(
+        doc as PlayerWithPsdImageDoc,
+      )
+    },
+  },
+})


### PR DESCRIPTION
Closes #1895

## Summary

Two-phase fix for the silhouette bug spotted during #1885 staging verification. PSD returns its grey \"no image available\" image as a real HTTP 200 JPEG for any player without a real photo, so the sync was uploading it as the player's \`psdImage\`. Downstream, \`<PlayerHero>\` saw a non-null \`photoUrl\` and skipped the canonical \`<PlayerFigure>\` illustration fallback locked at 6.d2.

### Phase 1 — Sync hash skip (stop the bleed)

\`apps/api/src/sanity/mutation.ts:uploadPlayerImage\` now computes SHA-1 of the fetched PSD bytes (via \`crypto.subtle.digest\`) and bails before the Sanity upload + patch when the hash matches the known placeholder. The hash constant \`PSD_PLACEHOLDER_IMAGE_SHA1\` is exported.

| | Before | After |
| --- | --- | --- |
| Player has no PSD photo | placeholder uploaded as \`psdImage\` → silhouette shown | hash detected → no upload, \`psdImage\` stays unset → \`<PlayerFigure>\` illustration fires |

Tests:
- Skip branch: spies on \`crypto.subtle.digest\` to return the placeholder hash, asserts the Sanity upload fetch + \`mockClientPatch\` are NOT called.
- Happy path: spies on \`crypto.subtle.digest\` to return a non-placeholder hash, asserts upload + patch fire as today.

### Phase 2 — Backfill migration (clean up the past)

Sanity asset deduplication means every player who currently carries the placeholder shares the **same** asset \`_ref\`. So a single GROQ-keyed migration sweeps the whole cohort.

- **Shared:** \`packages/sanity-studio/src/migrations/unset-player-placeholder-psd-image.ts\` (+ test). Exported \`PSD_PLACEHOLDER_ASSET_REF\` = \`image-6607821528ffa87bb0d39b159a7a4aa81dc78683-350x350-jpg\`. Unsets both \`psdImage\` AND the sibling \`psdImageUrl\`. Idempotent.
- **Runners:** \`apps/studio/migrations/unset-player-placeholder-psd-image/index.ts\` (prod) and \`apps/studio-staging/migrations/unset-player-placeholder-psd-image/index.ts\` (staging). Both import from \`@kcvv/sanity-studio/migrations\` per the React-free entry point (memory \`feedback_sanity_studio_migrate_leak\`).

## Staging run — already executed

\`\`\`bash
cd apps/studio-staging
npx sanity@latest migration run unset-player-placeholder-psd-image \\
  --project vhb33jaz --dataset staging --no-dry-run --no-confirm
\`\`\`

Result:
- 253 player documents processed
- **80 unique player documents patched** (~32% of the squad — the silhouette was widespread)
- 1 transaction committed
- **Idempotency verified:** immediate re-run produces 0 patches

## Production run — manual post-merge step

\`\`\`bash
cd apps/studio

# Dry-run first to confirm count + spot-check IDs
npx sanity@latest migration run unset-player-placeholder-psd-image \\
  --project vhb33jaz --dataset production --no-confirm

# Apply
npx sanity@latest migration run unset-player-placeholder-psd-image \\
  --project vhb33jaz --dataset production --no-dry-run --no-confirm
\`\`\`

The placeholder asset ref \`image-6607821528ffa87bb0d39b159a7a4aa81dc78683-350x350-jpg\` should match on production too (same placeholder bytes from PSD → same SHA-1 → same Sanity asset \`_id\`). If the dry-run shows 0 patches on production but staging had 80, something diverged — investigate before applying.

## Trade-off acknowledged

After the backfill, affected players have both \`psdImage\` AND \`psdImageUrl\` unset → on every subsequent sync, \`needsUpload\` returns true → the sync re-fetches the placeholder bytes from PSD just to hash + skip them. That's ~80 wasted PSD calls per sync at today's scale, well under the daily ceiling. A future enhancement could persist a "known-placeholder" marker so the sync short-circuits before fetching — out of scope for #1895.

## Testing

- \`pnpm --filter @kcvv/api test\` → **27 files / 321 tests pass**
- \`pnpm --filter @kcvv/sanity-studio test\` → **21 files / 165 tests pass**
- \`pnpm --filter @kcvv/api type-check\` + \`lint\` → clean
- \`pnpm turbo build --filter=@kcvv/sanity-studio\` → green

## Cross-cutting verification (post-prod migration)

After the production migration runs, re-render \`/spelers/[slug]\` for one previously-affected player (e.g. Memphis Vercammen, psdId 7305 on staging) and confirm the \`<PlayerFigure>\` illustration is now the photo column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Placeholder images are now automatically detected and prevented from being uploaded and stored as player profile images.

* **Tests**
  * Added comprehensive test coverage for placeholder detection and upload prevention behavior, including edge cases.

* **Chores**
  * Added safe, idempotent data migration to remove previously stored placeholder images and associated metadata from player records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->