### PR TITLE
docs(matches): drop "live" match state from Phase 6 docs

### DIFF
--- a/docs/design/phase-6-player-profile-brief.md
+++ b/docs/design/phase-6-player-profile-brief.md
@@ -220,7 +220,7 @@ Still in scope and needs owner sign-off (visual drill rounds):
 The player profile primitives (StatsStrip, CareerLogTable, RecentMatchesGrid, QuotesBlock) also feed:
 
 - **Team detail** (§6) — `<TeamHero>` + `<SquadGrid>` of `<PlayerCard>` (mini PlayerHero) + `<StandingsTable>` + `<MatchScheduleTable>` + `<SponsorsBlock filtered>`.
-- **Match detail** (3 states: preview, live, recap — per §6) — uses similar dark-tone scoreline + contribution-badge vocabulary from RecentMatchesGrid cards. **Inherits the cream/warm/ink/jersey-deep palette only** — no outcome-red token available.
+- **Match detail** (2 states: preview, recap — per §6; no live state, BFF surfaces no live data) — uses similar dark-tone scoreline + contribution-badge vocabulary from RecentMatchesGrid cards. **Inherits the cream/warm/ink/jersey-deep palette only** — no outcome-red token available.
 - **Events list + detail** — different vocabulary (event-card with day-block overlay, venue strip).
 - **Calendar** — list/grid of match cards.
 

--- a/docs/plans/2026-04-27-redesign-master-design.md
+++ b/docs/plans/2026-04-27-redesign-master-design.md
@@ -469,10 +469,9 @@ There is an existing `docs/prd/article-detail-redesign.md` which this work super
 
 ### 6.3 Match detail (`/wedstrijd/[matchId]`)
 
-Three hero states: upcoming (preview), live (in progress), finished (verslag).
+Two hero states: upcoming (preview) and finished (verslag). **No live state** — the BFF does not surface live match data, so the route never renders a match-in-progress view. Re-evaluate if/when a live data feed lands.
 
 - **Upcoming:** `<EditorialHero variant="match-preview">` — taped match-ticket artefact with date/venue, two club shields stacked, "VOORBESCHOUWING" mono kicker. Body: `<MatchPreviewBody>` composing tactical notes + recent form using `<TapedCardGrid>`.
-- **Live:** big mono score in the hero card, period clock in mono, possession/shots stats in `<NumberDisplay>` row, `<StatsStrip>` minute-by-minute event log with `<DashedDivider>` rows.
 - **Finished:** "MATCHVERSLAG" hero with 16:9 match photo (via `<TapedFigure aspect="landscape-16-9">`) paired with the score and final-whistle ephemera + key moments + `<PullQuote>` from coach reaction + `<RecentMatchesGrid>` of head-to-head history.
 
 Standings widget reuses the homepage's `<StandingsTable>` primitive.


### PR DESCRIPTION
## Summary

Phase 6.B kickoff housekeeping. The BFF surfaces no live match data, so \`/wedstrijd/[matchId]\` never renders a match-in-progress view. Updating the planning docs so the design-rounds work I'm about to start has the correct scope (2 states, not 3).

## Changes

| File | Before | After |
| --- | --- | --- |
| \`docs/plans/2026-04-27-redesign-master-design.md\` §6.3 | \"Three hero states: upcoming, live, finished\" + a \"Live\" bullet | \"Two hero states\" + explicit no-live note + bullet removed |
| \`docs/design/phase-6-player-profile-brief.md\` §4 | \"Match detail (3 states: preview, live, recap — per §6)\" | \"Match detail (2 states: preview, recap — per §6; no live state, BFF surfaces no live data)\" |
| GitHub epic #1528 body | \"3 states: upcoming, live, finished\" (twice) | \"2 states: upcoming, finished\" + explicit out-of-scope note (twice) |

## Next steps (out of scope for this PR)

After this lands, the Phase 6.B kickoff continues with:

1. \`/design-an-interface\` rounds for match-detail (6.B.dN), each cross-cutting component (`<MatchTeaser>` default + compact, `<MatchResultRow>`, `<MatchHeader>`, `<MatchStatusBadge>`, `<MatchStripClient>`)
2. \`/write-a-prd\` consolidating the locked designs into \`docs/prd/redesign-phase-6b-match-detail.md\`
3. \`/prd-to-issues\` to spawn implementation tickets (tracer + per-component + page assembly + cleanup, mirroring the 6.A series)

This PR is doc-only — zero code, zero schema changes, no implementation deliverables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated match detail route documentation to specify only two supported states: preview (for upcoming matches) and recap (for finished matches).
  * Clarified that the previously documented live state is not supported, as live match-in-progress rendering is not available in the current system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->