### PR TITLE
docs(matches): Phase 6.B match-detail design series — 8 drills + PRD

### DIFF
--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
@@ -33,7 +33,7 @@ All three variants render meaningfully in both states. The score region is the o
 - **Upcoming:** "vs" (or the kickoff time, e.g. `14:30`)
 - **Finished:** numeric score (e.g. `3 — 1`) + a small status badge ("FT" / "FF" / "AFG" / "STOP")
 
-Editorial copy ("VOORBESCHOUWING" / "MATCHVERSLAG") rides as the kicker in all variants. State badge logic is the same across variants — only its placement varies (kicker vs corner stamp vs inline).
+Editorial copy ("VOORBESCHOUWING" / "MATCHVERSLAG") rides as the kicker in Variants A and C; **Variant B** uses a corner stamp instead (the full-bleed dark band leaves no natural kicker slot). Match-status badge logic is also variant-specific: A and C surface it as a small corner stamp on finished only, while B reuses the corner-stamp slot — placing the editorial kicker and the status badge in the same anchor.
 
 ## Round 2 — A+B hybrids
 

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
@@ -1,0 +1,45 @@
+# 6.B.d2 · MatchHero — primitive comparison map
+
+**Round 1.** First visual drill of Phase 6.B. Sets the structural + tonal shape of the page's hero band, which subsequent drills (lineup, events, article-link card) compose below.
+
+Visual artifact: `round-1-matchhero-comparisons.html` — three variants, each rendered in **both** the upcoming and finished states so state-handling is judged alongside layout shape.
+
+## Reference locks consumed
+
+- `data-reality-locked.md` (6.B.d0) — score/teams/date/venue/competition + status all available; no per-match photo, no editorial fields
+- `page-composition-locked.md` (6.B.d1) — Variant A; `<MatchHero state="upcoming|finished" />` is state-aware
+- Phase 5 `<EditorialHero>` vocabulary — `apps/web/src/components/article/EditorialHero/EditorialHero.tsx`
+- Phase 3.C MatchStrip's "ticket-stub" precedent
+- Phase 4.5 R9 photo-treatment system (newsprint filter + paper grain) — applies to club shields but only optionally
+
+## Variants
+
+- **A — Editorial card.** Single `<TapedCard>` hero. Mono kicker → home + score + away on one row → date/venue/competition mono row. Same shape upcoming + finished, just different score-region content (kickoff time vs final score). Reuses Phase 5 EditorialHero vocabulary directly.
+- **B — Ticket-stub band.** Full-bleed dark band with the date/venue printed along a left ticket-stub edge (perforated-line motif). Teams + score dominate the right side of the band. More distinctive, more chrome — reads like a printed matchday ticket. Differentiates strongly from article-hero vocabulary.
+- **C — Two-team polaroids.** Editorial "pair of polaroid clippings" — home + away each rendered as their own `<TapedFigure>`-style card with shield + name, big NumberDisplay score (or "vs") between them. Most graphic; leans hardest into the fanzine aesthetic. Cost: heavier visual weight on the shields, which are PSD-sourced and inconsistent in quality.
+
+## Vocabulary deltas summary
+
+| Variant | Δ count | Severity | Cost | Notes |
+| ------- | ------- | -------- | ---- | ----- |
+| **A** | 0 | Low | Pure composition of TapedCard + EditorialHeading + NumberDisplay + MonoLabelRow | Reuses every primitive we already ship. Maps 1:1 onto a `<EditorialHero variant="match">` if we ever want to merge the article + match hero into one component. |
+| **B** | 1 | Medium | New `<TicketStubBand>` primitive (perforated-edge motif, full-bleed dark band) | Distinctive but adds vocabulary. The perforated-edge geometry is non-trivial. Reusable later for transfer-window banners, season-pass-style chrome. |
+| **C** | 0 | Low | Pure composition of TapedFigure + NumberDisplay + MonoLabelRow | No new primitive, but visual weight on shields whose quality varies (PSD-sourced, some clubs have low-res or off-brand crests). Most editorial-flavored. |
+
+## Cross-state behaviour
+
+All three variants render meaningfully in both states. The score region is the only visually-state-aware element:
+
+- **Upcoming:** "vs" (or the kickoff time, e.g. `14:30`)
+- **Finished:** numeric score (e.g. `3 — 1`) + a small status badge ("FT" / "FF" / "AFG" / "STOP")
+
+Editorial copy ("VOORBESCHOUWING" / "MATCHVERSLAG") rides as the kicker in all variants. State badge logic is the same across variants — only its placement varies (kicker vs corner stamp vs inline).
+
+## Things this drill does NOT decide
+
+- Lineup + events layout — 6.B.d3
+- ArticleLinkCard visual treatment — 6.B.d4
+- `<MatchStatusBadge>` Direction-D audit — 6.B.d5
+- `<MatchTeaser>` (the match-card primitive consumed by sliders / sidebars / recent-matches grids) — 6.B.d6, separate cross-cutting drill
+- Photo treatment — 6.B.d0 already locked NO per-match photo source; this drill respects that constraint
+- Mobile collapse — variants in the mockup are desktop-only; mobile-specific drill happens in a round 2 if needed

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
@@ -35,6 +35,22 @@ All three variants render meaningfully in both states. The score region is the o
 
 Editorial copy ("VOORBESCHOUWING" / "MATCHVERSLAG") rides as the kicker in all variants. State badge logic is the same across variants — only its placement varies (kicker vs corner stamp vs inline).
 
+## Round 2 — A+B hybrids
+
+After round 1 owner direction: **C eliminated**, A and B both still on the table, with a request to explore hybrid concepts pulling B's ticket-stub identity into A's calmer paper-card chrome. Round 2 ships three hybrids in `round-2-matchhero-comparisons.html`:
+
+- **H1 — Ticket-card.** Single card split into two zones by a perforated dashed border. Left zone (~110px) is a "ticket stub" with big display date + venue. Right zone is the editorial body (kicker / teams + score / competition). Most matchday-flavored of the hybrids. **Δ: +1 small primitive** (perforated dashed line + punch-out circles).
+- **H2 — Card + matchday stamp.** A's card unchanged, with a tilted "matchday stamp" artefact in the upper-right corner carrying the big display date. Pure styled element, zero new primitive. Most A, least B. Lightest hybrid. **Δ: 0**.
+- **H3 — Card with ticket-footer.** A's body unchanged; the meta row at the bottom gets promoted to a ticket-stub footer (cream-soft tint, dashed top border, punch-out circles at the corners). Reads like the tear-strip of a printed ticket. **Δ: +1 small primitive** (perforated-edge wrapper + corner circles, narrower than H1's because it only applies to the footer).
+
+| Hybrid | Δ primitives | Where the ticket motif lives | Tradeoff vs pure A |
+| --- | --- | --- | --- |
+| **H1** | +1 (perforated line + circles) | Full left edge inside the card | Loses ~110px of horizontal space; mobile collapse non-trivial |
+| **H2** | 0 | Upper-right corner stamp | Smallest visual change; least matchday-flavored |
+| **H3** | +1 (footer perforated edge + circles) | Bottom footer of the card | Cream-on-cream tonal split is subtle; can be missed on some monitors |
+
+If none of the hybrids feel right, **fallback is pure A from round 1**.
+
 ## Things this drill does NOT decide
 
 - Lineup + events layout — 6.B.d3

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md
@@ -51,6 +51,20 @@ After round 1 owner direction: **C eliminated**, A and B both still on the table
 
 If none of the hybrids feel right, **fallback is pure A from round 1**.
 
+## Round 3 — H1 separator treatment
+
+After round 2 owner direction: **H1 (Ticket-card) picked**, with a question on whether the perforation punch-out circles are necessary. Round 3 isolates the separator treatment — same H1 shape across all three variants, only the divider between stub + body varies:
+
+- **T1 — Full perforations** (as round 2 H1): 2px dashed ink line + 18px punch-out circles top + bottom. Strongest matchday-ticket cue. +1 small primitive.
+- **T2 — Dashed only**: just `border-right: 2px dashed ink` on the stub. No punch-outs. Cleanest; zero new primitive. Reads more "two-zone card" than "ticket".
+- **T3 — Subtle perforations**: 1.5px dashed ink-muted line + 12px punch-out circles. Quieter compromise. Still +1 small primitive.
+
+| Treatment | Δ primitives | Ticket identity | Maintenance cost |
+| --- | --- | --- | --- |
+| **T1 — Full** | +1 (line + circles) | Strongest | Highest (corner geometry, breakpoints) |
+| **T2 — Dashed only** | 0 (one-line CSS) | Weakest (rests on date typography + tint alone) | Lowest |
+| **T3 — Subtle** | +1 (line + small circles) | Quiet — present but not loud | Medium |
+
 ## Things this drill does NOT decide
 
 - Lineup + events layout — 6.B.d3

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-1-matchhero-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-1-matchhero-comparisons.html
@@ -1,0 +1,802 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 1 · MatchHero (6.B.d2)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-soft: 3px 3px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page {
+        max-width: 1920px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1920px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+      }
+
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .variant > header.card code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--color-cream-deep);
+        padding: 1px 4px;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+
+      .state-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        border-top: 1px dashed var(--color-ink-muted);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+      .state-label:first-of-type { border-top: none; padding-top: 18px; }
+      .state-label .who { font-size: 9px; opacity: 0.55; }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+      .callouts .danger { color: #c93f1c; font-weight: 700; }
+
+      /* ───────── Shared mock pieces (shields / chrome) ───────── */
+      .shield {
+        width: 44px;
+        height: 50px;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 13px;
+        flex-shrink: 0;
+      }
+      .shield--opp {
+        background:
+          radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%);
+      }
+      .status-badge {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 3px 8px;
+        font-weight: 700;
+      }
+      .status-badge--ff,
+      .status-badge--afg,
+      .status-badge--stop {
+        background: var(--color-cream-deep);
+        color: var(--color-ink);
+      }
+
+      /* ═══════════ Variant A — Editorial card ═══════════ */
+      .hero-a {
+        margin: 6px 18px 18px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        padding: 22px 22px 18px;
+        position: relative;
+      }
+      .hero-a .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+        margin-bottom: 14px;
+      }
+      .hero-a .kicker::before { content: "* "; opacity: 0.6; }
+      .hero-a .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 16px;
+        align-items: center;
+      }
+      .hero-a .teams .team {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+      }
+      .hero-a .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .hero-a .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 34px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+        white-space: nowrap;
+      }
+      .hero-a .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-ink-muted);
+        text-transform: lowercase;
+      }
+      .hero-a .meta {
+        margin-top: 14px;
+        padding-top: 12px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+      .hero-a .meta .dot {
+        width: 3px;
+        height: 3px;
+        border-radius: 50%;
+        background: var(--color-ink);
+        display: inline-block;
+      }
+      .hero-a .status-corner {
+        position: absolute;
+        top: -10px;
+        right: 14px;
+      }
+
+      /* ═══════════ Variant B — Ticket-stub band ═══════════ */
+      .hero-b {
+        margin: 6px 0 18px;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 22px 22px 22px 0;
+        display: grid;
+        grid-template-columns: 130px 1fr;
+        gap: 22px;
+        position: relative;
+      }
+      .hero-b .ticket-stub {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        padding: 22px 16px;
+        border-right: 2px dashed var(--color-cream-deep);
+        position: relative;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 10px;
+      }
+      .hero-b .ticket-stub::before,
+      .hero-b .ticket-stub::after {
+        content: "";
+        position: absolute;
+        right: -10px;
+        width: 20px;
+        height: 20px;
+        background: var(--color-cream);
+        border-radius: 50%;
+      }
+      .hero-b .ticket-stub::before { top: -10px; }
+      .hero-b .ticket-stub::after { bottom: -10px; }
+      .hero-b .ticket-stub .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 22px;
+        letter-spacing: -0.025em;
+        margin-bottom: 6px;
+        line-height: 1;
+        text-transform: none;
+      }
+      .hero-b .ticket-stub .time {
+        font-size: 16px;
+        margin-bottom: 14px;
+        letter-spacing: 0.08em;
+      }
+      .hero-b .ticket-stub .venue {
+        opacity: 0.75;
+        font-size: 9px;
+        line-height: 1.4;
+      }
+      .hero-b .ticket-stub .competition {
+        margin-top: 10px;
+        padding-top: 8px;
+        border-top: 1px dashed var(--color-ink-muted);
+        font-size: 9px;
+        opacity: 0.85;
+      }
+      .hero-b .right {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 14px;
+      }
+      .hero-b .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.6;
+      }
+      .hero-b .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 14px;
+        align-items: center;
+      }
+      .hero-b .teams .team {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+      }
+      .hero-b .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .hero-b .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 40px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+      }
+      .hero-b .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-cream);
+        opacity: 0.7;
+        text-transform: lowercase;
+      }
+      .hero-b .status-corner {
+        position: absolute;
+        top: 12px;
+        right: 18px;
+        background: var(--color-jersey);
+        color: var(--color-ink);
+      }
+
+      /* ═══════════ Variant C — Two-team polaroids ═══════════ */
+      .hero-c {
+        margin: 6px 18px 18px;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        gap: 14px;
+        padding: 6px 0 18px;
+      }
+      .hero-c .polaroid {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-soft);
+        padding: 14px 12px 18px;
+        text-align: center;
+        position: relative;
+      }
+      .hero-c .polaroid--home { transform: rotate(-1deg); }
+      .hero-c .polaroid--away { transform: rotate(1deg); justify-self: end; }
+      .hero-c .polaroid .shield {
+        width: 70px;
+        height: 80px;
+        margin: 4px auto 12px;
+      }
+      .hero-c .polaroid .name {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 17px;
+        letter-spacing: -0.015em;
+        line-height: 1.1;
+      }
+      .hero-c .polaroid .tape {
+        position: absolute;
+        top: -10px;
+        left: 50%;
+        transform: translateX(-50%) rotate(-3deg);
+        width: 48px;
+        height: 14px;
+        background: rgba(0, 168, 107, 0.55);
+        border: 1px dashed rgba(0, 0, 0, 0.15);
+      }
+      .hero-c .polaroid--away .tape { transform: translateX(-50%) rotate(2deg); background: rgba(216, 118, 58, 0.5); }
+      .hero-c .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 60px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+        white-space: nowrap;
+        padding: 0 6px;
+      }
+      .hero-c .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 32px;
+        color: var(--color-ink-muted);
+        text-transform: lowercase;
+      }
+      .hero-c .meta {
+        grid-column: 1 / -1;
+        margin-top: 8px;
+        padding-top: 12px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+      .hero-c .meta .dot {
+        width: 3px;
+        height: 3px;
+        border-radius: 50%;
+        background: var(--color-ink);
+        display: inline-block;
+      }
+      .hero-c .kicker {
+        grid-column: 1 / -1;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+        margin-bottom: 6px;
+      }
+      .hero-c .kicker::before { content: "* "; opacity: 0.6; }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 1 · `&lt;MatchHero&gt;`</div>
+      <h1>How should the match-detail hero look?</h1>
+      <p>
+        Three structural shapes for the new <code>&lt;MatchHero&gt;</code>
+        component on <code>/wedstrijd/[matchId]</code>. Each variant is rendered
+        in <strong>both</strong> the upcoming and finished states so
+        state-handling is judged alongside layout shape. Data is fixed:
+        <code>KCVV Elewijt</code> vs <code>RC Mechelen</code>, <code>3e
+        Provinciale A</code>, <code>za 14 jun · 14:30 · Sportpark Elewijt</code>,
+        finished score <code>3 — 1</code>.
+      </p>
+      <p>
+        All variants respect the <strong>6.B.d0 data-reality lock</strong>: no
+        per-match photo, no editorial fields rendered inside the hero. The
+        per-match preview / recap article is surfaced separately by
+        <code>&lt;MatchArticleLinkCard&gt;</code> (drilled in 6.B.d4).
+      </p>
+      <span class="scope-banner">Pick one shape · later rounds refine within it</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ A — Editorial card ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant A</div>
+          <h2>Editorial card.</h2>
+          <p class="sub">
+            One <code>&lt;TapedCard&gt;</code> hero. Mono kicker on top, teams
+            and score on one row, date / venue / competition mono row at the
+            bottom. Same shape both states; only the score region swaps.
+            Reuses every primitive we already ship — maps 1:1 onto Phase 5's
+            <code>&lt;EditorialHero&gt;</code> if we ever consolidate.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Composes existing parts</span>
+            <span class="chip chip--cost">Less distinctive</span>
+          </div>
+        </header>
+
+        <div class="state-label">
+          <span>Upcoming · status=scheduled</span>
+          <span class="who">aftrap 14:30</span>
+        </div>
+        <section class="hero-a">
+          <div class="kicker">VOORBESCHOUWING · 3E PROVINCIALE A</div>
+          <div class="teams">
+            <div class="team team--home">
+              <span class="shield">K</span>
+              <span>KCVV Elewijt</span>
+            </div>
+            <div class="score score--vs">vs</div>
+            <div class="team team--away">
+              <span class="shield shield--opp">M</span>
+              <span>RC Mechelen</span>
+            </div>
+          </div>
+          <div class="meta">
+            <span>ZA 14 JUN</span>
+            <span class="dot"></span>
+            <span>14:30</span>
+            <span class="dot"></span>
+            <span>SPORTPARK ELEWIJT</span>
+          </div>
+        </section>
+
+        <div class="state-label">
+          <span>Finished · status=finished</span>
+          <span class="who">eindstand 3 — 1</span>
+        </div>
+        <section class="hero-a">
+          <div class="status-corner"><span class="status-badge">FT</span></div>
+          <div class="kicker">MATCHVERSLAG · 3E PROVINCIALE A</div>
+          <div class="teams">
+            <div class="team team--home">
+              <span class="shield">K</span>
+              <span>KCVV Elewijt</span>
+            </div>
+            <div class="score">3 — 1</div>
+            <div class="team team--away">
+              <span class="shield shield--opp">M</span>
+              <span>RC Mechelen</span>
+            </div>
+          </div>
+          <div class="meta">
+            <span>ZA 14 JUN</span>
+            <span class="dot"></span>
+            <span>14:30</span>
+            <span class="dot"></span>
+            <span>SPORTPARK ELEWIJT</span>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>What this gives us</h4>
+          <ul>
+            <li>Zero new design-system vocabulary — pure composition</li>
+            <li>Symmetric upcoming / finished states; one component, one test surface</li>
+            <li>Mobile collapse is trivial (teams stack, score below)</li>
+          </ul>
+          <h4>Tradeoff</h4>
+          <ul>
+            <li>Reads as "article-style hero" — quiet next to a future <code>&lt;ArticleHero&gt;</code> for the matchPreview/matchRecap article (#1470)</li>
+            <li>Status badge has nowhere ceremonial to live — corner stamp is a compromise</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ B — Ticket-stub band ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant B</div>
+          <h2>Ticket-stub band.</h2>
+          <p class="sub">
+            Full-bleed dark band with a perforated 'ticket-stub' left edge
+            carrying date / venue / competition. Teams + score dominate the
+            right side of the band. Distinctive — reads like a printed matchday
+            ticket. Introduces one new primitive (<code>&lt;TicketStubBand&gt;</code>).
+          </p>
+          <div class="chips">
+            <span class="chip chip--delta">+1 new primitive</span>
+            <span class="chip chip--good">Most distinctive</span>
+            <span class="chip chip--cost">Full-bleed dark band</span>
+          </div>
+        </header>
+
+        <div class="state-label">
+          <span>Upcoming · status=scheduled</span>
+          <span class="who">aftrap 14:30</span>
+        </div>
+        <section class="hero-b">
+          <div class="status-corner"><span class="status-badge" style="background:var(--color-jersey);color:var(--color-ink)">VOORBESCHOUWING</span></div>
+          <aside class="ticket-stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+            <div class="competition">3E PROV A</div>
+          </aside>
+          <div class="right">
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score score--vs">vs</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div class="state-label">
+          <span>Finished · status=finished</span>
+          <span class="who">eindstand 3 — 1</span>
+        </div>
+        <section class="hero-b">
+          <div class="status-corner"><span class="status-badge" style="background:var(--color-cream);color:var(--color-ink)">FT</span></div>
+          <aside class="ticket-stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+            <div class="competition">3E PROV A</div>
+          </aside>
+          <div class="right">
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>What this gives us</h4>
+          <ul>
+            <li>Strong ticket / matchday identity; differentiates from article-hero vocabulary</li>
+            <li>Dedicated home for date / venue / competition — they're the "ticket stub" data</li>
+            <li>Reusable later for season-pass chrome, transfer-window banners</li>
+          </ul>
+          <h4>Tradeoff</h4>
+          <ul>
+            <li>+1 design-system primitive (<code>&lt;TicketStubBand&gt;</code> + perforated-edge geometry)</li>
+            <li>Full-bleed dark band is a heavy chrome choice — competes with the Phase 4.5 ClubshopBanner for dark-band attention</li>
+            <li>Mobile collapse is non-trivial (ticket stub needs to either reflow or stack vertically — round 2 work)</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ C — Two-team polaroids ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant C</div>
+          <h2>Two-team polaroids.</h2>
+          <p class="sub">
+            Pair of taped polaroid clippings — home + away each rendered as
+            their own card with shield + name. Big <code>&lt;NumberDisplay&gt;</code>
+            score (or "vs") in the gap between them. Meta below. Leans hardest
+            into the fanzine aesthetic; zero new primitive.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Most editorial</span>
+            <span class="chip chip--cost">Shield quality matters</span>
+          </div>
+        </header>
+
+        <div class="state-label">
+          <span>Upcoming · status=scheduled</span>
+          <span class="who">aftrap 14:30</span>
+        </div>
+        <section class="hero-c">
+          <div class="kicker">VOORBESCHOUWING · 3E PROVINCIALE A</div>
+          <div class="polaroid polaroid--home">
+            <span class="tape"></span>
+            <span class="shield">K</span>
+            <div class="name">KCVV Elewijt</div>
+          </div>
+          <div class="score score--vs">vs</div>
+          <div class="polaroid polaroid--away">
+            <span class="tape"></span>
+            <span class="shield shield--opp">M</span>
+            <div class="name">RC Mechelen</div>
+          </div>
+          <div class="meta">
+            <span>ZA 14 JUN</span>
+            <span class="dot"></span>
+            <span>14:30</span>
+            <span class="dot"></span>
+            <span>SPORTPARK ELEWIJT</span>
+          </div>
+        </section>
+
+        <div class="state-label">
+          <span>Finished · status=finished</span>
+          <span class="who">eindstand 3 — 1</span>
+        </div>
+        <section class="hero-c">
+          <div class="kicker">MATCHVERSLAG <span class="status-badge" style="margin-left:8px">FT</span> · 3E PROVINCIALE A</div>
+          <div class="polaroid polaroid--home">
+            <span class="tape"></span>
+            <span class="shield">K</span>
+            <div class="name">KCVV Elewijt</div>
+          </div>
+          <div class="score">3 — 1</div>
+          <div class="polaroid polaroid--away">
+            <span class="tape"></span>
+            <span class="shield shield--opp">M</span>
+            <div class="name">RC Mechelen</div>
+          </div>
+          <div class="meta">
+            <span>ZA 14 JUN</span>
+            <span class="dot"></span>
+            <span>14:30</span>
+            <span class="dot"></span>
+            <span>SPORTPARK ELEWIJT</span>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>What this gives us</h4>
+          <ul>
+            <li>Most editorial-feeling option; treats the match as artefact</li>
+            <li>Reuses existing <code>&lt;TapedFigure&gt;</code> + <code>&lt;NumberDisplay&gt;</code> + <code>&lt;MonoLabelRow&gt;</code> primitives — zero net-new vocabulary</li>
+            <li>Each team gets ceremonial weight (the polaroid) — works well for cup matches, derbies, etc.</li>
+          </ul>
+          <h4>Tradeoff</h4>
+          <ul>
+            <li><span class="danger">Shield quality:</span> PSD-sourced club crests vary in quality / brand-compliance; promoting them to polaroid scale exposes that variance</li>
+            <li>More vertical real estate than A or B — pushes lineup + events further down</li>
+            <li>Three-column layout needs a strong mobile collapse story (stack vertically with score between)</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-1-matchhero-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-1-matchhero-comparisons.html
@@ -647,7 +647,7 @@
           <span class="who">aftrap 14:30</span>
         </div>
         <section class="hero-b">
-          <div class="status-corner"><span class="status-badge" style="background:var(--color-jersey);color:var(--color-ink)">VOORBESCHOUWING</span></div>
+          <div class="status-corner"><span class="hero-b-kicker" style="background:var(--color-jersey);color:var(--color-ink);font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:0.16em;font-weight:700;padding:3px 8px;display:inline-block">VOORBESCHOUWING</span></div>
           <aside class="ticket-stub">
             <div class="date">ZA 14<br />JUN</div>
             <div class="time">14:30</div>

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-2-matchhero-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-2-matchhero-comparisons.html
@@ -1,0 +1,844 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 2 · MatchHero A+B hybrids (6.B.d2)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-soft: 3px 3px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page {
+        max-width: 1920px;
+        margin: 0 auto 36px;
+      }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+      .scope-banner--note {
+        background: var(--color-warm);
+        margin-left: 8px;
+      }
+
+      .grid {
+        max-width: 1920px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+      }
+
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .variant > header.card code {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        background: var(--color-cream-deep);
+        padding: 1px 4px;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+
+      .state-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        border-top: 1px dashed var(--color-ink-muted);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+      .state-label:first-of-type { border-top: none; padding-top: 18px; }
+      .state-label .who { font-size: 9px; opacity: 0.55; }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+      .callouts .danger { color: #c93f1c; font-weight: 700; }
+
+      /* shared chrome */
+      .shield {
+        width: 44px;
+        height: 50px;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 13px;
+        flex-shrink: 0;
+      }
+      .shield--opp {
+        background:
+          radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%);
+      }
+      .status-badge {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 3px 8px;
+        font-weight: 700;
+      }
+
+      /* ═══════════ H1 — Ticket-card (card with integrated stub) ═══════════ */
+      .hero-h1 {
+        margin: 6px 18px 18px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        display: grid;
+        grid-template-columns: 112px 1fr;
+        position: relative;
+      }
+      .hero-h1 .stub {
+        padding: 16px 14px;
+        border-right: 2px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 9.5px;
+        position: relative;
+      }
+      .hero-h1 .stub::before,
+      .hero-h1 .stub::after {
+        content: "";
+        position: absolute;
+        right: -10px;
+        width: 18px;
+        height: 18px;
+        background: var(--color-cream-soft);
+        border-radius: 50%;
+        border-right: 2px solid var(--color-ink);
+      }
+      .hero-h1 .stub::before { top: -10px; }
+      .hero-h1 .stub::after  { bottom: -10px; }
+      .hero-h1 .stub .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+        margin-bottom: 6px;
+        text-transform: none;
+        font-style: normal;
+      }
+      .hero-h1 .stub .time {
+        font-size: 14px;
+        margin-bottom: 12px;
+        letter-spacing: 0.06em;
+      }
+      .hero-h1 .stub .venue {
+        opacity: 0.75;
+        line-height: 1.4;
+      }
+      .hero-h1 .body {
+        padding: 22px 22px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .hero-h1 .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+      }
+      .hero-h1 .kicker::before { content: "* "; opacity: 0.6; }
+      .hero-h1 .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 14px;
+        align-items: center;
+      }
+      .hero-h1 .teams .team {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+      }
+      .hero-h1 .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .hero-h1 .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 34px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+      }
+      .hero-h1 .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-ink-muted);
+        text-transform: lowercase;
+      }
+      .hero-h1 .competition {
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        padding-top: 10px;
+        border-top: 1px solid var(--color-ink);
+      }
+      .hero-h1 .status-corner {
+        position: absolute;
+        top: -10px;
+        right: 14px;
+      }
+
+      /* ═══════════ H2 — Editorial card + matchday stamp ═══════════ */
+      .hero-h2 {
+        margin: 6px 18px 18px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        padding: 22px 22px 18px;
+        position: relative;
+      }
+      .hero-h2 .stamp {
+        position: absolute;
+        top: 18px;
+        right: 22px;
+        background: var(--color-cream-soft);
+        border: 2px solid var(--color-ink);
+        padding: 8px 12px 6px;
+        text-align: center;
+        transform: rotate(2.5deg);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 9px;
+        line-height: 1.2;
+      }
+      .hero-h2 .stamp .date-big {
+        display: block;
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: -0.02em;
+        line-height: 1;
+        margin-bottom: 3px;
+        text-transform: none;
+        font-style: normal;
+      }
+      .hero-h2 .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+        margin-bottom: 14px;
+        max-width: calc(100% - 110px); /* avoid bumping into stamp */
+      }
+      .hero-h2 .kicker::before { content: "* "; opacity: 0.6; }
+      .hero-h2 .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 16px;
+        align-items: center;
+      }
+      .hero-h2 .teams .team {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+      }
+      .hero-h2 .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .hero-h2 .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 34px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+      }
+      .hero-h2 .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-ink-muted);
+        text-transform: lowercase;
+      }
+      .hero-h2 .meta {
+        margin-top: 14px;
+        padding-top: 12px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+      .hero-h2 .meta .dot {
+        width: 3px;
+        height: 3px;
+        border-radius: 50%;
+        background: var(--color-ink);
+        display: inline-block;
+      }
+      .hero-h2 .status-inline {
+        margin-left: auto;
+      }
+
+      /* ═══════════ H3 — Card with perforated ticket footer ═══════════ */
+      .hero-h3 {
+        margin: 6px 18px 18px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        position: relative;
+        overflow: visible;
+      }
+      .hero-h3 .body {
+        padding: 22px 22px 16px;
+      }
+      .hero-h3 .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+        margin-bottom: 14px;
+      }
+      .hero-h3 .kicker::before { content: "* "; opacity: 0.6; }
+      .hero-h3 .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 16px;
+        align-items: center;
+      }
+      .hero-h3 .teams .team {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+      }
+      .hero-h3 .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .hero-h3 .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 34px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+      }
+      .hero-h3 .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-ink-muted);
+        text-transform: lowercase;
+      }
+      .hero-h3 .ticket-footer {
+        background: var(--color-cream-soft);
+        border-top: 2px dashed var(--color-ink);
+        padding: 14px 22px 14px;
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+        position: relative;
+      }
+      .hero-h3 .ticket-footer::before,
+      .hero-h3 .ticket-footer::after {
+        content: "";
+        position: absolute;
+        top: -10px;
+        width: 18px;
+        height: 18px;
+        background: var(--color-cream-soft);
+        border-radius: 50%;
+        border-top: 2px solid var(--color-ink);
+      }
+      .hero-h3 .ticket-footer::before { left: -10px; border-left: 2px solid var(--color-ink); }
+      .hero-h3 .ticket-footer::after  { right: -10px; border-right: 2px solid var(--color-ink); }
+      .hero-h3 .ticket-footer .dot {
+        width: 3px;
+        height: 3px;
+        border-radius: 50%;
+        background: var(--color-ink);
+        display: inline-block;
+      }
+      .hero-h3 .status-corner {
+        position: absolute;
+        top: -10px;
+        right: 14px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 2 · `&lt;MatchHero&gt;` · A+B hybrids</div>
+      <h1>Combining A's calm with B's matchday identity.</h1>
+      <p>
+        Round 1 left A (editorial card) and B (ticket-stub band) in the running;
+        C is eliminated. This round explores <strong>three hybrid shapes</strong>
+        that pull B's most useful idea — ticket-stub / matchday-ticket identity —
+        into A's calm paper-card chrome <em>without</em> a full-bleed dark band.
+        Each variant is rendered in both states. Data fixed:
+        <code>KCVV Elewijt</code> vs <code>RC Mechelen</code>,
+        <code>3e Provinciale A</code>, <code>za 14 jun · 14:30 · Sportpark Elewijt</code>,
+        finished score <code>3 — 1</code>.
+      </p>
+      <span class="scope-banner">Pick one — or fall back to A from round 1</span>
+      <span class="scope-banner scope-banner--note">C eliminated · round 1 still on the table</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ H1 — Ticket-card with integrated stub ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Hybrid H1</div>
+          <h2>Ticket-card.</h2>
+          <p class="sub">
+            Single <code>&lt;TapedCard&gt;</code> hero, but the card is split
+            into two zones by a perforated dashed border. <strong>Left zone</strong>
+            (~110px) is a "ticket stub" with the big display date, time, venue.
+            <strong>Right zone</strong> is the editorial body: kicker, teams +
+            score, competition line. Brings B's ticket vocabulary inside A's
+            calm card. No full-bleed dark band.
+          </p>
+          <div class="chips">
+            <span class="chip chip--delta">+1 small primitive</span>
+            <span class="chip chip--good">Most matchday-flavored hybrid</span>
+            <span class="chip chip--cost">Slightly busier left zone</span>
+          </div>
+        </header>
+
+        <div class="state-label">
+          <span>Upcoming · status=scheduled</span>
+          <span class="who">aftrap 14:30</span>
+        </div>
+        <section class="hero-h1">
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">VOORBESCHOUWING</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score score--vs">vs</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · SEIZOEN '26/'27</div>
+          </div>
+        </section>
+
+        <div class="state-label">
+          <span>Finished · status=finished</span>
+          <span class="who">eindstand 3 — 1</span>
+        </div>
+        <section class="hero-h1">
+          <div class="status-corner"><span class="status-badge">FT</span></div>
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">MATCHVERSLAG</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · SEIZOEN '26/'27</div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>What this brings together</h4>
+          <ul>
+            <li><strong>From A:</strong> calm paper card; no dark band; reads as one editorial unit</li>
+            <li><strong>From B:</strong> big-display date + perforated dashed line — "this is a matchday ticket"</li>
+            <li>Single component (not a band wrapper) — Storybook story matches the card paradigm of every other hero</li>
+          </ul>
+          <h4>Tradeoff</h4>
+          <ul>
+            <li>+1 small primitive: the perforated dashed line + corner punch-out circles need to land somewhere reusable</li>
+            <li>Left stub eats horizontal space — the right zone gets ~110px less for teams + score</li>
+            <li>Mobile collapse needs thought (stub becomes top row or hides)</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ H2 — Editorial card + matchday stamp ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Hybrid H2</div>
+          <h2>Card + matchday stamp.</h2>
+          <p class="sub">
+            Pure A card composition — kicker → teams + score → meta row — with
+            one B-flavored addition: the date promoted to a small but bold
+            <strong>matchday stamp</strong> in the upper-right corner. Like a
+            postmark on a postcard. No perforations, no dark band, no extra
+            primitive (it's just a styled box with display typography).
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Lightest hybrid</span>
+            <span class="chip chip--cost">Most A, least B</span>
+          </div>
+        </header>
+
+        <div class="state-label">
+          <span>Upcoming · status=scheduled</span>
+          <span class="who">aftrap 14:30</span>
+        </div>
+        <section class="hero-h2">
+          <aside class="stamp">
+            <span class="date-big">14 JUN</span>
+            ZA · 14:30
+          </aside>
+          <div class="kicker">VOORBESCHOUWING · 3E PROVINCIALE A</div>
+          <div class="teams">
+            <div class="team team--home">
+              <span class="shield">K</span>
+              <span>KCVV Elewijt</span>
+            </div>
+            <div class="score score--vs">vs</div>
+            <div class="team team--away">
+              <span class="shield shield--opp">M</span>
+              <span>RC Mechelen</span>
+            </div>
+          </div>
+          <div class="meta">
+            <span>SPORTPARK ELEWIJT</span>
+            <span class="dot"></span>
+            <span>KCVV-A · '26/'27</span>
+          </div>
+        </section>
+
+        <div class="state-label">
+          <span>Finished · status=finished</span>
+          <span class="who">eindstand 3 — 1</span>
+        </div>
+        <section class="hero-h2">
+          <aside class="stamp">
+            <span class="date-big">14 JUN</span>
+            ZA · 14:30
+          </aside>
+          <div class="kicker">MATCHVERSLAG · 3E PROVINCIALE A</div>
+          <div class="teams">
+            <div class="team team--home">
+              <span class="shield">K</span>
+              <span>KCVV Elewijt</span>
+            </div>
+            <div class="score">3 — 1</div>
+            <div class="team team--away">
+              <span class="shield shield--opp">M</span>
+              <span>RC Mechelen</span>
+            </div>
+          </div>
+          <div class="meta">
+            <span>SPORTPARK ELEWIJT</span>
+            <span class="dot"></span>
+            <span>KCVV-A · '26/'27</span>
+            <span class="status-inline"><span class="status-badge">FT</span></span>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>What this brings together</h4>
+          <ul>
+            <li><strong>From A:</strong> entire card chrome unchanged — kicker / teams / meta exactly as in round 1</li>
+            <li><strong>From B:</strong> big display date promoted to a tilted stamp artefact — visual anchor without infrastructure</li>
+            <li>Zero new primitive (the stamp is just a styled <code>&lt;aside&gt;</code> with a transform rotate)</li>
+            <li>Status badge has a natural home inline in the meta row</li>
+          </ul>
+          <h4>Tradeoff</h4>
+          <ul>
+            <li>Closest to "A with a small flourish" — least matchday-flavored of the three hybrids</li>
+            <li>Stamp competes with the corner status badge for top-right attention (resolved: status inline in meta row instead)</li>
+            <li>Kicker needs to keep clearance from the stamp — the text-overflow rule is non-trivial on long competition names</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ H3 — Card with perforated ticket footer ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Hybrid H3</div>
+          <h2>Card with ticket-footer.</h2>
+          <p class="sub">
+            A's card unchanged on top (kicker + teams + score). The bottom
+            meta row gets <strong>promoted to a ticket-stub footer</strong> —
+            cream-soft tint, dashed top border, punch-out circles at the
+            corners. Reads like the perforated tear-strip at the bottom of a
+            printed ticket. Date / venue / competition live in the footer.
+          </p>
+          <div class="chips">
+            <span class="chip chip--delta">+1 small primitive</span>
+            <span class="chip chip--good">Footer-only ticket motif</span>
+            <span class="chip chip--cost">Top zone less changed than H1</span>
+          </div>
+        </header>
+
+        <div class="state-label">
+          <span>Upcoming · status=scheduled</span>
+          <span class="who">aftrap 14:30</span>
+        </div>
+        <section class="hero-h3">
+          <div class="body">
+            <div class="kicker">VOORBESCHOUWING · 3E PROVINCIALE A</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score score--vs">vs</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+          </div>
+          <footer class="ticket-footer">
+            <span>ZA 14 JUN</span>
+            <span class="dot"></span>
+            <span>14:30</span>
+            <span class="dot"></span>
+            <span>SPORTPARK ELEWIJT</span>
+          </footer>
+        </section>
+
+        <div class="state-label">
+          <span>Finished · status=finished</span>
+          <span class="who">eindstand 3 — 1</span>
+        </div>
+        <section class="hero-h3">
+          <div class="status-corner"><span class="status-badge">FT</span></div>
+          <div class="body">
+            <div class="kicker">MATCHVERSLAG · 3E PROVINCIALE A</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+          </div>
+          <footer class="ticket-footer">
+            <span>ZA 14 JUN</span>
+            <span class="dot"></span>
+            <span>14:30</span>
+            <span class="dot"></span>
+            <span>SPORTPARK ELEWIJT</span>
+          </footer>
+        </section>
+
+        <div class="callouts">
+          <h4>What this brings together</h4>
+          <ul>
+            <li><strong>From A:</strong> kicker + teams + score zone identical to round 1</li>
+            <li><strong>From B:</strong> dashed perforated edge + punch-out corner circles — clear "ticket-stub" reference at the bottom of the card</li>
+            <li>Compact — no extra primitive in the body, only in the footer treatment</li>
+            <li>Mobile collapse is trivial (footer wraps as today)</li>
+          </ul>
+          <h4>Tradeoff</h4>
+          <ul>
+            <li>Less matchday-flavored than H1 — the ticket cue lives only at the bottom edge</li>
+            <li>+1 small primitive: perforated edge + punch-out circles need to be named (could be <code>&lt;TicketFooter&gt;</code> wrapping a children slot)</li>
+            <li>Cream-on-cream tonal split between body and footer is subtle — some monitors will barely see it</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1920px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 2 of 6.B.d2 · A+B hybrids · C eliminated · round 1 variant A still on the table
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-3-matchhero-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-3-matchhero-comparisons.html
@@ -241,6 +241,15 @@
         line-height: 1;
         text-align: center;
       }
+      .h1 .score--vs {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-weight: 400;
+        font-size: 22px;
+        color: var(--color-ink-muted);
+        text-transform: lowercase;
+        letter-spacing: 0;
+      }
       .h1 .competition {
         font-family: var(--font-mono);
         font-size: 10.5px;
@@ -373,7 +382,7 @@
                 <span class="shield">K</span>
                 <span>KCVV Elewijt</span>
               </div>
-              <div class="score">vs</div>
+              <div class="score score--vs">vs</div>
               <div class="team team--away">
                 <span class="shield shield--opp">M</span>
                 <span>RC Mechelen</span>
@@ -455,7 +464,7 @@
                 <span class="shield">K</span>
                 <span>KCVV Elewijt</span>
               </div>
-              <div class="score">vs</div>
+              <div class="score score--vs">vs</div>
               <div class="team team--away">
                 <span class="shield shield--opp">M</span>
                 <span>RC Mechelen</span>
@@ -537,7 +546,7 @@
                 <span class="shield">K</span>
                 <span>KCVV Elewijt</span>
               </div>
-              <div class="score">vs</div>
+              <div class="score score--vs">vs</div>
               <div class="team team--away">
                 <span class="shield shield--opp">M</span>
                 <span>RC Mechelen</span>

--- a/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-3-matchhero-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b2-matchhero/round-3-matchhero-comparisons.html
@@ -1,0 +1,596 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 3 · MatchHero H1 separator treatment (6.B.d2)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1920px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1920px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+      }
+
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+
+      .state-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .state-label:first-of-type { border-top: none; padding-top: 18px; }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      /* ───────── Shared H1 chrome (same shape across all 3) ───────── */
+      .h1 {
+        margin: 6px 18px 18px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-md);
+        display: grid;
+        grid-template-columns: 112px 1fr;
+        position: relative;
+      }
+      .h1 .stub {
+        padding: 16px 14px;
+        background: var(--color-cream-soft);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-size: 9.5px;
+        position: relative;
+      }
+      .h1 .stub .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+        margin-bottom: 6px;
+        text-transform: none;
+        font-style: normal;
+      }
+      .h1 .stub .time {
+        font-size: 14px;
+        margin-bottom: 12px;
+        letter-spacing: 0.06em;
+      }
+      .h1 .stub .venue {
+        opacity: 0.75;
+        line-height: 1.4;
+      }
+      .h1 .body {
+        padding: 22px 22px 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .h1 .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+      }
+      .h1 .kicker::before { content: "* "; opacity: 0.6; }
+      .h1 .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 14px;
+        align-items: center;
+      }
+      .h1 .teams .team {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+        line-height: 1.05;
+      }
+      .h1 .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .h1 .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 34px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        text-align: center;
+      }
+      .h1 .competition {
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        padding-top: 10px;
+        border-top: 1px solid var(--color-ink);
+      }
+      .shield {
+        width: 44px;
+        height: 50px;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 13px;
+        flex-shrink: 0;
+      }
+      .shield--opp {
+        background:
+          radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%);
+      }
+      .status-badge {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 3px 8px;
+        font-weight: 700;
+      }
+      .status-corner {
+        position: absolute;
+        top: -10px;
+        right: 14px;
+      }
+
+      /* ═══════════ Treatment 1: full perforations (as round 2) ═══════════ */
+      .h1--perf .stub {
+        border-right: 2px dashed var(--color-ink);
+      }
+      .h1--perf .stub::before,
+      .h1--perf .stub::after {
+        content: "";
+        position: absolute;
+        right: -10px;
+        width: 18px;
+        height: 18px;
+        background: var(--color-cream-soft);
+        border-radius: 50%;
+        border-right: 2px solid var(--color-ink);
+      }
+      .h1--perf .stub::before { top: -10px; }
+      .h1--perf .stub::after  { bottom: -10px; }
+
+      /* ═══════════ Treatment 2: dashed only (no perforations) ═══════════ */
+      .h1--dashed .stub {
+        border-right: 2px dashed var(--color-ink);
+      }
+
+      /* ═══════════ Treatment 3: subtle perforations (small + muted) ═══════════ */
+      .h1--subtle .stub {
+        border-right: 1.5px dashed var(--color-ink-muted);
+      }
+      .h1--subtle .stub::before,
+      .h1--subtle .stub::after {
+        content: "";
+        position: absolute;
+        right: -6px;
+        width: 12px;
+        height: 12px;
+        background: var(--color-cream-soft);
+        border-radius: 50%;
+        border-right: 1.5px solid var(--color-ink-muted);
+      }
+      .h1--subtle .stub::before { top: -6px; }
+      .h1--subtle .stub::after  { bottom: -6px; }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 3 · `&lt;MatchHero&gt;` · H1 separator</div>
+      <h1>How loud should the ticket separator be?</h1>
+      <p>
+        Owner picked <strong>H1 (Ticket-card)</strong> in round 2, but with a
+        question on whether the perforation punch-outs are necessary. Round 3
+        compares <strong>three separator treatments of the same H1 shape</strong>
+        — everything else identical, only the divider line between stub + body
+        varies. Both states (upcoming + finished) rendered for each.
+      </p>
+      <span class="scope-banner">Pick one separator treatment → write lock</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ Treatment 1: full perforations (round 2 H1) ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Treatment 1</div>
+          <h2>Full perforations.</h2>
+          <p class="sub">
+            As shipped in round 2 H1: dashed divider line + two punch-out
+            circles at the top and bottom corners of the stub. Literally
+            reads as "this stub tears off." Strongest matchday-ticket cue.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">Strongest ticket identity</span>
+            <span class="chip chip--cost">Most chrome to maintain across breakpoints</span>
+          </div>
+        </header>
+
+        <div class="state-label">Upcoming · status=scheduled</div>
+        <section class="h1 h1--perf">
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">VOORBESCHOUWING</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">vs</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · '26/'27</div>
+          </div>
+        </section>
+
+        <div class="state-label">Finished · status=finished</div>
+        <section class="h1 h1--perf">
+          <div class="status-corner"><span class="status-badge">FT</span></div>
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">MATCHVERSLAG</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · '26/'27</div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Strongest "this is a matchday ticket" cue — the literal printed-ticket idiom</li>
+            <li>Punch-outs add visual rhythm at the corner intersections with the outer card frame</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>+1 small primitive (perforated line + circles) to ship + maintain</li>
+            <li>Risk of feeling fussy / over-detailed on smaller surfaces (MatchTeaser, mobile)</li>
+            <li>Punch-out circles need to coordinate visually with the outer card border on hover / state changes</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ Treatment 2: dashed only ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Treatment 2</div>
+          <h2>Dashed only.</h2>
+          <p class="sub">
+            Just the dashed vertical line between stub + body — no punch-out
+            circles at all. Cleaner, calmer. The ticket-ness comes from the
+            big display date + cream-soft stub tint + dashed divider; the
+            literal "tear-off" cue is dropped.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Cleanest visually</span>
+            <span class="chip chip--cost">Reads more "two-zone card" than "ticket"</span>
+          </div>
+        </header>
+
+        <div class="state-label">Upcoming · status=scheduled</div>
+        <section class="h1 h1--dashed">
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">VOORBESCHOUWING</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">vs</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · '26/'27</div>
+          </div>
+        </section>
+
+        <div class="state-label">Finished · status=finished</div>
+        <section class="h1 h1--dashed">
+          <div class="status-corner"><span class="status-badge">FT</span></div>
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">MATCHVERSLAG</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · '26/'27</div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Zero new primitive — `border-right: 2px dashed` is a one-line CSS rule</li>
+            <li>Calmer; no fiddly corner geometry across breakpoints</li>
+            <li>Mobile collapse is trivial — the stub becomes a top row, dashed line becomes bottom border</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Loses the literal ticket-stub idiom — without the punch-outs, it's just "a card with a dashed divider"</li>
+            <li>"Matchday ticket" identity rests entirely on the display-date typography + cream-soft tint</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ Treatment 3: subtle perforations ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Treatment 3</div>
+          <h2>Subtle perforations.</h2>
+          <p class="sub">
+            Compromise: the punch-out circles stay but go smaller (12px vs
+            18px) and switch to ink-muted instead of full ink. The dashed
+            line also drops to 1.5px ink-muted. The ticket idiom is still
+            present but reads as a quiet detail, not a structural element.
+          </p>
+          <div class="chips">
+            <span class="chip chip--delta">+1 small primitive</span>
+            <span class="chip chip--good">Compromise position</span>
+            <span class="chip chip--cost">Subtlety risk: barely-visible on cheap monitors</span>
+          </div>
+        </header>
+
+        <div class="state-label">Upcoming · status=scheduled</div>
+        <section class="h1 h1--subtle">
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">VOORBESCHOUWING</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">vs</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · '26/'27</div>
+          </div>
+        </section>
+
+        <div class="state-label">Finished · status=finished</div>
+        <section class="h1 h1--subtle">
+          <div class="status-corner"><span class="status-badge">FT</span></div>
+          <aside class="stub">
+            <div class="date">ZA 14<br />JUN</div>
+            <div class="time">14:30</div>
+            <div class="venue">SPORTPARK<br />ELEWIJT</div>
+          </aside>
+          <div class="body">
+            <div class="kicker">MATCHVERSLAG</div>
+            <div class="teams">
+              <div class="team team--home">
+                <span class="shield">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="competition">3E PROVINCIALE A · KCVV-A · '26/'27</div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Keeps the ticket-stub idiom but at a quieter intensity</li>
+            <li>Smaller circles + thinner dashed line reduce the "this is a heavy chrome element" feeling</li>
+            <li>Maintains visual coherence when the hero is re-used in smaller contexts (compact MatchTeaser, sidebar)</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Subtle by design — risks being lost on lower-contrast displays</li>
+            <li>Still +1 small primitive to ship</li>
+            <li>"Compromise position" — neither fully editorial-card-clean nor fully matchday-ticket-distinctive</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1920px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 3 of 6.B.d2 · H1 separator treatment · pick one to lock
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b3-lineup-events/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b3-lineup-events/compare.md
@@ -1,0 +1,47 @@
+# 6.B.d3 · `<MatchLineupSection>` + `<MatchEventsSection>` — primitive comparison map
+
+**Round 1.** First visual drill of the body content that renders below the hero on **finished** matches. Both sections auto-hide for upcoming matches per the 6.B.d1 page-composition lock (no lineup / no events data → no section).
+
+Visual artifact: `round-1-lineup-events-comparisons.html` — three variants of the lineup + events presentation. Same synthetic match data across all three (KCVV 3 — 1 RC Mechelen with realistic event timeline + 11-player rosters + 4 subs per team).
+
+## Reference locks consumed
+
+- `data-reality-locked.md` (6.B.d0) — BFF surfaces `lineup.{home, away}` (each = array of `MatchLineupPlayer` with name + number + status + card + minutesPlayed) and `events` (array of `MatchEvent` with minute + type + team + player)
+- `page-composition-locked.md` (6.B.d1) — both sections wrap existing `<MatchLineup>` / `<MatchEvents>` primitives in redesign chrome; per-section auto-hide
+- `matchhero-locked.md` (6.B.d2) — H1 + T2 hero shape sets the page's editorial-card vocabulary; body sections compose below
+- Phase 5 `<QASection>` precedent — section-level wrapper around existing per-row primitives with kicker + heading + container
+
+## Variants
+
+- **A — Classic separate sections.** Two blocks. First: "Opstellingen." with home + away as two side-by-side columns (mirrors `<MatchLineup>`'s current shape). Second: "Wedstrijdverloop." as a single timeline ordered by minute, scorer's name aligned to the correct team side. `<StripedSeam>` between them. Most conservative: maps 1:1 onto existing components, lowest implementation cost.
+- **B — Combined "Matchverslag" interleaved.** One section, heading "Matchverslag." Three columns: home lineup | events timeline | away lineup. Goals + cards stamp into the middle column at their minute, with the player name on the correct side. Most info-dense; readers see lineup + when each player acted in a single eye-sweep. Highest implementation cost (3-column-with-anchored-events layout) + hard mobile collapse.
+- **C — Events first, lineup collapsible.** Two blocks but reordered. First: a compact "Doelpunten + kaarten" summary at the top — most readers want this. Second: "Volledige opstelling." below, possibly with a default-collapsed `<details>` toggle. Optimises for the typical reading flow (scan the goals → optionally dig into the roster).
+
+## Vocabulary deltas summary
+
+| Variant | Δ count | Severity | Cost | Notes |
+| ------- | ------- | -------- | ---- | ----- |
+| **A** | 0 | Low | Pure composition of `<MatchLineup>` + `<MatchEvents>` + section-level `<EditorialHeading>` + `<StripedSeam>` | Each section is a thin wrapper around its existing primitive. Lowest implementation cost. Most conventional layout. |
+| **B** | 1 | High | New `<MatchTimelineGrid>` primitive (3-col layout with per-minute event anchoring + side-aware player labels) | Visually striking + highly informative. Significant implementation work — anchor math + mobile collapse story are both non-trivial. |
+| **C** | 0 (with native `<details>`) or 1 (with custom expand/collapse) | Medium | Composition with reordering + collapse-toggle decision | Saves vertical space; matches reading flow. Collapse mechanism needs a sub-decision (native `<details>` accessibility vs custom drawer). |
+
+## Reading-order trade-off
+
+| Variant | What the reader sees first | When that's useful |
+| --- | --- | --- |
+| A | Full home + away lineups (top-left of the body) | Reader wants to know who played |
+| B | All three columns at once (lineup + events) | Reader wants the whole story in one image (info-dense, "matchverslag" mood) |
+| C | Goals + cards summary (events first) | Reader wants the scoreboard story, may or may not care about the roster |
+
+## Cross-state behaviour
+
+All three variants render **only on finished matches**. Per the d1 lock, both sections auto-hide when their data is empty (typical for upcoming matches — PSD doesn't surface rosters until kickoff). The drill assumes finished as the rendering case; the auto-hide branch is structural, not visual.
+
+## Things this drill does NOT decide
+
+- Per-row visual treatment of individual lineup players (number badge style, captain glyph, card icon styling) — round 2 of d3 if the chosen variant needs refinement
+- Per-event visual treatment (goal icon, card icon, substitution arrows) — round 2 of d3
+- `<MatchArticleLinkCard>` — 6.B.d4
+- `<MatchStatusBadge>` — 6.B.d5
+- Tables vs cards for the lineup rows — folded into the chosen variant; not a separate decision
+- Goalkeeper vs outfield visual distinction — assumed to follow the per-row treatment decided in round 2

--- a/docs/design/mockups/phase-6-match-detail/6b3-lineup-events/round-1-lineup-events-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b3-lineup-events/round-1-lineup-events-comparisons.html
@@ -240,7 +240,6 @@
       }
       .ev-glyph--goal::before { content: "⚽"; font-size: 14px; }
       .ev-glyph--card-y { background: #f4c430; border: 1px solid #b08400; }
-      .ev-glyph--card-y::before { content: ""; }
       .ev-glyph--card-r { background: var(--color-card-red); }
       .ev-glyph--sub  { background: var(--color-cream-deep); color: var(--color-ink); }
       .ev-glyph--sub::before { content: "⇅"; font-size: 13px; }
@@ -385,7 +384,6 @@
             var(--color-ink) 0 1px,
             transparent 1px 6px
           );
-        background-size: 1px 6px;
         background-position: center top;
         background-repeat: no-repeat;
         background-size: 1px 100%;

--- a/docs/design/mockups/phase-6-match-detail/6b3-lineup-events/round-1-lineup-events-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b3-lineup-events/round-1-lineup-events-comparisons.html
@@ -1,0 +1,844 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 1 · Lineup + Events sections (6.B.d3)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-soft: #1f1f1f;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --color-card-red: #c93f1c;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-soft: 3px 3px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1920px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1920px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+        align-items: start;
+      }
+
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+      .chip--warn  { background: var(--color-warm); color: var(--color-cream); border-color: var(--color-warm); }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+      .callouts .danger { color: var(--color-card-red); font-weight: 700; }
+
+      /* ───────── Shared element vocabulary ───────── */
+      .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+        margin-bottom: 8px;
+      }
+      .kicker::before { content: "* "; opacity: 0.6; }
+      .section-heading {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 26px;
+        letter-spacing: -0.02em;
+        margin: 0 0 18px;
+        line-height: 1.05;
+      }
+      .num {
+        display: inline-flex;
+        width: 26px;
+        height: 26px;
+        align-items: center;
+        justify-content: center;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+        flex-shrink: 0;
+      }
+      .num--keeper {
+        background: var(--color-warm);
+      }
+      .player-name {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.015em;
+        line-height: 1.2;
+      }
+      .captain-mark {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        font-weight: 700;
+        background: var(--color-cream-deep);
+        padding: 1px 4px;
+        margin-left: 4px;
+        letter-spacing: 0.1em;
+      }
+      .card-mark {
+        display: inline-block;
+        width: 9px;
+        height: 12px;
+        margin-left: 4px;
+        vertical-align: -1px;
+      }
+      .card-mark--yellow { background: #f4c430; border: 1px solid #b08400; }
+      .card-mark--red    { background: var(--color-card-red); border: 1px solid #7a1f1f; }
+      .minute-mark {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        opacity: 0.7;
+        margin-left: 6px;
+        letter-spacing: 0.06em;
+      }
+
+      /* event glyphs */
+      .ev-glyph {
+        display: inline-flex;
+        width: 22px;
+        height: 22px;
+        align-items: center;
+        justify-content: center;
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 12px;
+        flex-shrink: 0;
+        background: var(--color-jersey);
+        color: var(--color-ink);
+      }
+      .ev-glyph--goal::before { content: "⚽"; font-size: 14px; }
+      .ev-glyph--card-y { background: #f4c430; border: 1px solid #b08400; }
+      .ev-glyph--card-y::before { content: ""; }
+      .ev-glyph--card-r { background: var(--color-card-red); }
+      .ev-glyph--sub  { background: var(--color-cream-deep); color: var(--color-ink); }
+      .ev-glyph--sub::before { content: "⇅"; font-size: 13px; }
+
+      /* state intro label inside each variant */
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.7;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant A — Classic separate sections
+         ═══════════════════════════════════════════ */
+      .va {
+        padding: 16px 18px 22px;
+      }
+      .va .lineup-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 22px;
+      }
+      .va .team-col {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .va .team-col h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        margin: 0 0 8px;
+        opacity: 0.7;
+      }
+      .va .player-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 0;
+        border-bottom: 1px dashed var(--color-cream-deep);
+      }
+      .va .player-row:last-child { border-bottom: none; }
+      .va .subs-divider {
+        margin-top: 10px;
+        padding-top: 6px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.6;
+        margin-bottom: 4px;
+      }
+      .va .striped-seam {
+        margin: 22px -18px;
+        height: 12px;
+        background:
+          repeating-linear-gradient(
+            -45deg,
+            var(--color-ink) 0 6px,
+            var(--color-cream) 6px 12px
+          );
+      }
+      .va .event-row {
+        display: grid;
+        grid-template-columns: 36px 22px 1fr auto;
+        gap: 10px;
+        align-items: center;
+        padding: 8px 0;
+        border-bottom: 1px dashed var(--color-cream-deep);
+      }
+      .va .event-row:last-child { border-bottom: none; }
+      .va .event-row .min {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 18px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+      }
+      .va .event-row .team {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        text-align: right;
+      }
+      .va .event-row .who {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 15px;
+        letter-spacing: -0.01em;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant B — Combined Matchverslag interleaved
+         ═══════════════════════════════════════════ */
+      .vb {
+        padding: 16px 18px 22px;
+      }
+      .vb .three-col {
+        display: grid;
+        grid-template-columns: 1fr 110px 1fr;
+        gap: 16px;
+      }
+      .vb .team-h h4,
+      .vb .team-a h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        margin: 0 0 8px;
+        opacity: 0.7;
+      }
+      .vb .team-h h4 { text-align: left; }
+      .vb .team-a h4 { text-align: right; }
+      .vb .player-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 0;
+        border-bottom: 1px dashed var(--color-cream-deep);
+        position: relative;
+      }
+      .vb .player-row:last-child { border-bottom: none; }
+      .vb .team-a .player-row { flex-direction: row-reverse; text-align: right; }
+      .vb .player-row.has-event {
+        background: var(--color-cream-soft);
+      }
+      .vb .event-anchor {
+        position: relative;
+      }
+      .vb .timeline {
+        position: relative;
+        background:
+          repeating-linear-gradient(
+            to bottom,
+            var(--color-ink) 0 1px,
+            transparent 1px 6px
+          );
+        background-size: 1px 6px;
+        background-position: center top;
+        background-repeat: no-repeat;
+        background-size: 1px 100%;
+      }
+      .vb .timeline .tick {
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        background: var(--color-cream);
+        padding: 4px 6px;
+        border: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        letter-spacing: 0.06em;
+        white-space: nowrap;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+      }
+      .vb .timeline .tick.t1  { top: 4%; }
+      .vb .timeline .tick.t2  { top: 18%; }
+      .vb .timeline .tick.t3  { top: 35%; }
+      .vb .timeline .tick.t4  { top: 50%; }
+      .vb .timeline .tick.t5  { top: 62%; }
+      .vb .timeline .tick.t6  { top: 76%; }
+      .vb .timeline .tick.t7  { top: 90%; }
+      .vb .timeline .tick.home { background: var(--color-cream); }
+      .vb .timeline .tick.away { background: var(--color-ink); color: var(--color-cream); border-color: var(--color-ink); }
+      .vb .subs-divider {
+        margin-top: 8px;
+        padding-top: 6px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.6;
+        margin-bottom: 4px;
+      }
+      .vb .team-a .subs-divider { text-align: right; }
+
+      /* ═══════════════════════════════════════════
+         Variant C — Events first, lineup collapsible
+         ═══════════════════════════════════════════ */
+      .vc {
+        padding: 16px 18px 22px;
+      }
+      .vc .events-summary {
+        background: var(--color-cream-soft);
+        border: 2px solid var(--color-ink);
+        padding: 14px 16px 12px;
+        margin-bottom: 18px;
+      }
+      .vc .events-summary h3 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 18px;
+        margin: 0 0 12px;
+        letter-spacing: -0.02em;
+      }
+      .vc .event-row {
+        display: grid;
+        grid-template-columns: 34px 22px 1fr auto;
+        gap: 10px;
+        align-items: center;
+        padding: 6px 0;
+        border-bottom: 1px dashed var(--color-cream-deep);
+      }
+      .vc .event-row:last-child { border-bottom: none; }
+      .vc .event-row .min {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 16px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+      }
+      .vc .event-row .who {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.01em;
+      }
+      .vc .event-row .team {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        text-align: right;
+      }
+      .vc details.lineup-toggle {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        padding: 14px 16px 16px;
+      }
+      .vc details.lineup-toggle > summary {
+        cursor: pointer;
+        list-style: none;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .vc details.lineup-toggle > summary::-webkit-details-marker { display: none; }
+      .vc details.lineup-toggle > summary::after {
+        content: "▾ TOON OPSTELLING";
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 700;
+      }
+      .vc details.lineup-toggle[open] > summary::after { content: "▴ VERBERG"; }
+      .vc .lineup-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 22px;
+        margin-top: 14px;
+      }
+      .vc .team-col h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        margin: 0 0 8px;
+        opacity: 0.7;
+      }
+      .vc .player-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 5px 0;
+        border-bottom: 1px dashed var(--color-cream-deep);
+      }
+      .vc .player-row:last-child { border-bottom: none; }
+      .vc .subs-divider {
+        margin-top: 10px;
+        padding-top: 6px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.6;
+        margin-bottom: 4px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 1 · Lineup + Events sections</div>
+      <h1>How should lineup + events sit below the hero?</h1>
+      <p>
+        Three structural shapes for the body content that renders below
+        <code>&lt;MatchHero&gt;</code> on <strong>finished</strong> matches.
+        Both sections auto-hide for upcoming. Data is identical across all
+        three: KCVV Elewijt 3 — 1 RC Mechelen, 7 events, 11 starters + 4 subs
+        per team.
+      </p>
+      <span class="scope-banner">Pick one structural shape · per-row refinements in round 2</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ A — Classic separate sections ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant A</div>
+          <h2>Classic separate sections.</h2>
+          <p class="sub">
+            Two blocks. <strong>Opstellingen.</strong> first (home + away as
+            two side-by-side columns), <code>&lt;StripedSeam&gt;</code>, then
+            <strong>Wedstrijdverloop.</strong> as a single timeline ordered by
+            minute. Conservative. Wraps existing <code>&lt;MatchLineup&gt;</code>
+            + <code>&lt;MatchEvents&gt;</code> primitives 1:1.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Lowest implementation cost</span>
+            <span class="chip chip--cost">Most conventional layout</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Body content (finished match — KCVV 3 — 1 RC Mech)</div>
+        <section class="va">
+          <div class="kicker">OPSTELLINGEN</div>
+          <h3 class="section-heading">Wie er stond.</h3>
+          <div class="lineup-grid">
+            <div class="team-col">
+              <h4>KCVV ELEWIJT</h4>
+              <div class="player-row"><span class="num num--keeper">1</span><span class="player-name">Ben Lievens</span></div>
+              <div class="player-row"><span class="num">2</span><span class="player-name">Niels Vermeulen</span></div>
+              <div class="player-row"><span class="num">4</span><span class="player-name">Jonas De Smet</span></div>
+              <div class="player-row"><span class="num">5</span><span class="player-name">Wim Verhoeven<span class="captain-mark">C</span></span></div>
+              <div class="player-row"><span class="num">6</span><span class="player-name">Maxim Breugelmans<span class="card-mark card-mark--yellow"></span><span class="minute-mark">67'</span></span></div>
+              <div class="player-row"><span class="num">7</span><span class="player-name">Lars De Vos<span class="minute-mark">⚽ 12'</span></span></div>
+              <div class="player-row"><span class="num">8</span><span class="player-name">Sander Peeters</span></div>
+              <div class="player-row"><span class="num">9</span><span class="player-name">Jens Vermeulen<span class="minute-mark">⚽ 45+2' (P)</span></span></div>
+              <div class="player-row"><span class="num">10</span><span class="player-name">Joris De Bock</span></div>
+              <div class="player-row"><span class="num">11</span><span class="player-name">Karel Bertels</span></div>
+              <div class="player-row"><span class="num">14</span><span class="player-name">Sven Janssens</span></div>
+              <div class="subs-divider">BANK</div>
+              <div class="player-row"><span class="num">16</span><span class="player-name">Pieter De Bondt<span class="minute-mark">⇅ 71'</span></span></div>
+              <div class="player-row"><span class="num">18</span><span class="player-name">Tom Goossens</span></div>
+              <div class="player-row"><span class="num">21</span><span class="player-name">Bram Lemmens</span></div>
+              <div class="player-row"><span class="num">23</span><span class="player-name">Davy De Meyer</span></div>
+            </div>
+            <div class="team-col">
+              <h4>RC MECHELEN</h4>
+              <div class="player-row"><span class="num num--keeper">1</span><span class="player-name">Stijn Vandenberg</span></div>
+              <div class="player-row"><span class="num">3</span><span class="player-name">Kevin Smets<span class="card-mark card-mark--yellow"></span><span class="minute-mark">28'</span></span></div>
+              <div class="player-row"><span class="num">4</span><span class="player-name">Pieter Janssens</span></div>
+              <div class="player-row"><span class="num">5</span><span class="player-name">Wouter De Greef</span></div>
+              <div class="player-row"><span class="num">6</span><span class="player-name">Tom Janssens<span class="minute-mark">⚽ 56'</span></span></div>
+              <div class="player-row"><span class="num">8</span><span class="player-name">Jeroen De Wolf</span></div>
+              <div class="player-row"><span class="num">10</span><span class="player-name">Robbie Vermeiren<span class="captain-mark">C</span></span></div>
+              <div class="player-row"><span class="num">11</span><span class="player-name">Bart De Cock</span></div>
+              <div class="player-row"><span class="num">14</span><span class="player-name">Mathias Verhoeven</span></div>
+              <div class="player-row"><span class="num">17</span><span class="player-name">Dylan Smet</span></div>
+              <div class="player-row"><span class="num">20</span><span class="player-name">Frederik De Vleeshouwer</span></div>
+              <div class="subs-divider">BANK</div>
+              <div class="player-row"><span class="num">2</span><span class="player-name">Ruben Pauwels</span></div>
+              <div class="player-row"><span class="num">9</span><span class="player-name">Lucas Adriaensen</span></div>
+              <div class="player-row"><span class="num">15</span><span class="player-name">Niels De Bondt</span></div>
+              <div class="player-row"><span class="num">19</span><span class="player-name">Bart De Klerk</span></div>
+            </div>
+          </div>
+
+          <div class="striped-seam"></div>
+
+          <div class="kicker">WEDSTRIJDVERLOOP</div>
+          <h3 class="section-heading">Hoe het ging.</h3>
+          <div>
+            <div class="event-row"><span class="min">12'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Lars De Vos</span><span class="team">KCVV</span></div>
+            <div class="event-row"><span class="min">28'</span><span class="ev-glyph ev-glyph--card-y"></span><span class="who">Kevin Smets</span><span class="team">MECH</span></div>
+            <div class="event-row"><span class="min">45+2'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Jens Vermeulen <em style="opacity:0.6">(strafschop)</em></span><span class="team">KCVV</span></div>
+            <div class="event-row"><span class="min">56'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Tom Janssens</span><span class="team">MECH</span></div>
+            <div class="event-row"><span class="min">67'</span><span class="ev-glyph ev-glyph--card-y"></span><span class="who">Maxim Breugelmans</span><span class="team">KCVV</span></div>
+            <div class="event-row"><span class="min">71'</span><span class="ev-glyph ev-glyph--sub"></span><span class="who">Pieter De Bondt ⇆ Lars De Vos</span><span class="team">KCVV</span></div>
+            <div class="event-row"><span class="min">78'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Maxim Breugelmans</span><span class="team">KCVV</span></div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Conventional reading order: lineup → events</li>
+            <li>Wraps existing <code>&lt;MatchLineup&gt;</code> + <code>&lt;MatchEvents&gt;</code> 1:1 — zero implementation surprises</li>
+            <li>Each section can ship + test independently</li>
+            <li>Mobile collapse is trivial — both blocks already work in stacked layouts</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Long page; lineup eats vertical space before the reader sees events</li>
+            <li>Events repeat per-player info that's already in the lineup (the <code>⚽ 12'</code> minute marks on Lars De Vos's row are technically duplication)</li>
+            <li>Least "redesign distinctive"</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ B — Combined Matchverslag interleaved ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant B</div>
+          <h2>Combined Matchverslag.</h2>
+          <p class="sub">
+            One section, <strong>Matchverslag.</strong>, three columns: home
+            lineup | middle timeline | away lineup. Events stamp into the middle
+            column at their minute, with the player on the correct side. Most
+            info-dense; entire story in one eye-sweep.
+          </p>
+          <div class="chips">
+            <span class="chip chip--delta">+1 new primitive</span>
+            <span class="chip chip--good">Most info-dense</span>
+            <span class="chip chip--warn">Hardest mobile collapse</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Body content (finished match — KCVV 3 — 1 RC Mech)</div>
+        <section class="vb">
+          <div class="kicker">MATCHVERSLAG</div>
+          <h3 class="section-heading">Wie speelde, wat gebeurde.</h3>
+          <div class="three-col">
+            <div class="team-h">
+              <h4>KCVV ELEWIJT</h4>
+              <div class="player-row"><span class="num num--keeper">1</span><span class="player-name">Ben Lievens</span></div>
+              <div class="player-row"><span class="num">2</span><span class="player-name">Niels Vermeulen</span></div>
+              <div class="player-row"><span class="num">4</span><span class="player-name">Jonas De Smet</span></div>
+              <div class="player-row"><span class="num">5</span><span class="player-name">Wim Verhoeven<span class="captain-mark">C</span></span></div>
+              <div class="player-row has-event"><span class="num">6</span><span class="player-name">Maxim Breugelmans<span class="card-mark card-mark--yellow"></span></span></div>
+              <div class="player-row has-event"><span class="num">7</span><span class="player-name">Lars De Vos</span></div>
+              <div class="player-row"><span class="num">8</span><span class="player-name">Sander Peeters</span></div>
+              <div class="player-row has-event"><span class="num">9</span><span class="player-name">Jens Vermeulen</span></div>
+              <div class="player-row"><span class="num">10</span><span class="player-name">Joris De Bock</span></div>
+              <div class="player-row"><span class="num">11</span><span class="player-name">Karel Bertels</span></div>
+              <div class="player-row"><span class="num">14</span><span class="player-name">Sven Janssens</span></div>
+              <div class="subs-divider">BANK</div>
+              <div class="player-row has-event"><span class="num">16</span><span class="player-name">Pieter De Bondt</span></div>
+              <div class="player-row"><span class="num">18</span><span class="player-name">Tom Goossens</span></div>
+              <div class="player-row"><span class="num">21</span><span class="player-name">Bram Lemmens</span></div>
+              <div class="player-row"><span class="num">23</span><span class="player-name">Davy De Meyer</span></div>
+            </div>
+            <div class="timeline">
+              <div class="tick t1 home">12' ⚽</div>
+              <div class="tick t2 away">28' 🟨</div>
+              <div class="tick t3 home">45+2' ⚽</div>
+              <div class="tick t4 away">56' ⚽</div>
+              <div class="tick t5 home">67' 🟨</div>
+              <div class="tick t6 home">71' ⇅</div>
+              <div class="tick t7 home">78' ⚽</div>
+            </div>
+            <div class="team-a">
+              <h4>RC MECHELEN</h4>
+              <div class="player-row"><span class="num num--keeper">1</span><span class="player-name">Stijn Vandenberg</span></div>
+              <div class="player-row has-event"><span class="num">3</span><span class="player-name">Kevin Smets<span class="card-mark card-mark--yellow"></span></span></div>
+              <div class="player-row"><span class="num">4</span><span class="player-name">Pieter Janssens</span></div>
+              <div class="player-row"><span class="num">5</span><span class="player-name">Wouter De Greef</span></div>
+              <div class="player-row has-event"><span class="num">6</span><span class="player-name">Tom Janssens</span></div>
+              <div class="player-row"><span class="num">8</span><span class="player-name">Jeroen De Wolf</span></div>
+              <div class="player-row"><span class="num">10</span><span class="player-name">Robbie Vermeiren<span class="captain-mark">C</span></span></div>
+              <div class="player-row"><span class="num">11</span><span class="player-name">Bart De Cock</span></div>
+              <div class="player-row"><span class="num">14</span><span class="player-name">Mathias Verhoeven</span></div>
+              <div class="player-row"><span class="num">17</span><span class="player-name">Dylan Smet</span></div>
+              <div class="player-row"><span class="num">20</span><span class="player-name">Frederik De Vleeshouwer</span></div>
+              <div class="subs-divider">BANK</div>
+              <div class="player-row"><span class="num">2</span><span class="player-name">Ruben Pauwels</span></div>
+              <div class="player-row"><span class="num">9</span><span class="player-name">Lucas Adriaensen</span></div>
+              <div class="player-row"><span class="num">15</span><span class="player-name">Niels De Bondt</span></div>
+              <div class="player-row"><span class="num">19</span><span class="player-name">Bart De Klerk</span></div>
+            </div>
+          </div>
+        </section>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Most info-dense — lineup + events in a single visual unit</li>
+            <li>Eliminates the "duplicate minute marks" problem from variant A</li>
+            <li>Players involved in events are highlighted (cream-soft row tint)</li>
+            <li>"Matchverslag" mood = strongest editorial identity</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li><span class="danger">+1 design-system primitive:</span> <code>&lt;MatchTimelineGrid&gt;</code> with per-minute anchoring + side-aware player labels</li>
+            <li><span class="danger">Mobile collapse is hard:</span> three columns must reflow to a single column with events interleaved — needs its own drill</li>
+            <li>Implementation cost = highest of the three variants</li>
+            <li>Long lineups (11 starters + 4 subs each side) make the timeline tall + sparse</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ C — Events first, lineup collapsible ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant C</div>
+          <h2>Events first, lineup collapsible.</h2>
+          <p class="sub">
+            Two blocks reordered. <strong>Doelpunten + kaarten.</strong> first
+            (the part most readers want to see), then a collapsible
+            <strong>Volledige opstelling.</strong> block at the bottom
+            (default-collapsed via native <code>&lt;details&gt;</code>).
+            Optimises for typical reading flow.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive (native details)</span>
+            <span class="chip chip--good">Saves vertical space</span>
+            <span class="chip chip--cost">Collapse hides a normally-visible feature</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Body content (finished match — KCVV 3 — 1 RC Mech)</div>
+        <section class="vc">
+          <div class="kicker">DOELPUNTEN + KAARTEN</div>
+          <h3 class="section-heading">Hoe het ging.</h3>
+          <div class="events-summary">
+            <div class="event-row"><span class="min">12'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Lars De Vos</span><span class="team">KCVV 1 — 0</span></div>
+            <div class="event-row"><span class="min">28'</span><span class="ev-glyph ev-glyph--card-y"></span><span class="who">Kevin Smets</span><span class="team">MECH</span></div>
+            <div class="event-row"><span class="min">45+2'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Jens Vermeulen <em style="opacity:0.6">(P)</em></span><span class="team">KCVV 2 — 0</span></div>
+            <div class="event-row"><span class="min">56'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Tom Janssens</span><span class="team">MECH 2 — 1</span></div>
+            <div class="event-row"><span class="min">67'</span><span class="ev-glyph ev-glyph--card-y"></span><span class="who">Maxim Breugelmans</span><span class="team">KCVV</span></div>
+            <div class="event-row"><span class="min">71'</span><span class="ev-glyph ev-glyph--sub"></span><span class="who">Pieter De Bondt ⇆ Lars De Vos</span><span class="team">KCVV</span></div>
+            <div class="event-row"><span class="min">78'</span><span class="ev-glyph ev-glyph--goal"></span><span class="who">Maxim Breugelmans</span><span class="team">KCVV 3 — 1</span></div>
+          </div>
+
+          <details class="lineup-toggle">
+            <summary>
+              <span>VOLLEDIGE OPSTELLING</span>
+            </summary>
+            <div class="lineup-grid">
+              <div class="team-col">
+                <h4>KCVV ELEWIJT</h4>
+                <div class="player-row"><span class="num num--keeper">1</span><span class="player-name">Ben Lievens</span></div>
+                <div class="player-row"><span class="num">2</span><span class="player-name">Niels Vermeulen</span></div>
+                <div class="player-row"><span class="num">4</span><span class="player-name">Jonas De Smet</span></div>
+                <div class="player-row"><span class="num">5</span><span class="player-name">Wim Verhoeven<span class="captain-mark">C</span></span></div>
+                <div class="player-row"><span class="num">6</span><span class="player-name">Maxim Breugelmans</span></div>
+                <div class="player-row"><span class="num">7</span><span class="player-name">Lars De Vos</span></div>
+                <div class="player-row"><span class="num">8</span><span class="player-name">Sander Peeters</span></div>
+                <div class="player-row"><span class="num">9</span><span class="player-name">Jens Vermeulen</span></div>
+                <div class="player-row"><span class="num">10</span><span class="player-name">Joris De Bock</span></div>
+                <div class="player-row"><span class="num">11</span><span class="player-name">Karel Bertels</span></div>
+                <div class="player-row"><span class="num">14</span><span class="player-name">Sven Janssens</span></div>
+                <div class="subs-divider">BANK</div>
+                <div class="player-row"><span class="num">16</span><span class="player-name">Pieter De Bondt</span></div>
+                <div class="player-row"><span class="num">18</span><span class="player-name">Tom Goossens</span></div>
+                <div class="player-row"><span class="num">21</span><span class="player-name">Bram Lemmens</span></div>
+                <div class="player-row"><span class="num">23</span><span class="player-name">Davy De Meyer</span></div>
+              </div>
+              <div class="team-col">
+                <h4>RC MECHELEN</h4>
+                <div class="player-row"><span class="num num--keeper">1</span><span class="player-name">Stijn Vandenberg</span></div>
+                <div class="player-row"><span class="num">3</span><span class="player-name">Kevin Smets</span></div>
+                <div class="player-row"><span class="num">4</span><span class="player-name">Pieter Janssens</span></div>
+                <div class="player-row"><span class="num">5</span><span class="player-name">Wouter De Greef</span></div>
+                <div class="player-row"><span class="num">6</span><span class="player-name">Tom Janssens</span></div>
+                <div class="player-row"><span class="num">8</span><span class="player-name">Jeroen De Wolf</span></div>
+                <div class="player-row"><span class="num">10</span><span class="player-name">Robbie Vermeiren<span class="captain-mark">C</span></span></div>
+                <div class="player-row"><span class="num">11</span><span class="player-name">Bart De Cock</span></div>
+                <div class="player-row"><span class="num">14</span><span class="player-name">Mathias Verhoeven</span></div>
+                <div class="player-row"><span class="num">17</span><span class="player-name">Dylan Smet</span></div>
+                <div class="player-row"><span class="num">20</span><span class="player-name">Frederik De Vleeshouwer</span></div>
+                <div class="subs-divider">BANK</div>
+                <div class="player-row"><span class="num">2</span><span class="player-name">Ruben Pauwels</span></div>
+                <div class="player-row"><span class="num">9</span><span class="player-name">Lucas Adriaensen</span></div>
+                <div class="player-row"><span class="num">15</span><span class="player-name">Niels De Bondt</span></div>
+                <div class="player-row"><span class="num">19</span><span class="player-name">Bart De Klerk</span></div>
+              </div>
+            </div>
+          </details>
+        </section>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Matches typical reading flow: scoreboard story first, roster on demand</li>
+            <li>Saves significant vertical space (lineup is ~30 rows tall — hidden by default)</li>
+            <li>Zero new design-system primitive (native <code>&lt;details&gt;</code> is accessible by default + ships with all browsers)</li>
+            <li>Event-row entries can carry running score ("KCVV 2 — 0") — at-a-glance progress</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Default-collapsing the lineup hides a feature most readers expect to see — surprise factor</li>
+            <li>Lose the per-player context for events (Lars De Vos's goal at 12' loses the "and he was subbed off at 71'" continuity unless you expand)</li>
+            <li>Native <code>&lt;details&gt;</code> animation is minimal — can feel abrupt</li>
+            <li>Less "redesign-distinctive" — uses a convention familiar from any web form</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1920px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 1 of 6.B.d3 · structural shape · per-row refinements in round 2
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b4-article-link-card/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b4-article-link-card/compare.md
@@ -1,0 +1,49 @@
+# 6.B.d4 · `<MatchArticleLinkCard>` — primitive comparison map
+
+**Round 1.** The new card surfaces an editorial article about this match (a `matchPreview` for upcoming, a `matchRecap` for finished) as a single link element on `/wedstrijd/[matchId]`. Auto-hides when no such article exists.
+
+Visual artifact: `round-1-article-link-card-comparisons.html` — three variants of treatment. Renders the **finished** state (linking to a `matchRecap`); the upcoming state is identical in shape, only the badge / kicker copy differs.
+
+## Reference locks consumed
+
+- `data-reality-locked.md` (6.B.d0) — articles surface via the `matchPreview` / `matchRecap` articleType (per #1470); each article has cover image + title + kicker + publishedAt + author
+- `page-composition-locked.md` (6.B.d1) — card mounts between `<MatchEventsSection>` and `<RelatedArticlesSection>`; auto-hides if no article exists
+- `matchhero-locked.md` (6.B.d2) + `lineup-events-locked.md` (6.B.d3) — sets the page's editorial paper-card vocabulary
+- Phase 5 `<EditorialHero>` / `<NewsCard>` precedents — these define the article-presentation vocabulary; the card should feel cousinly to them
+- Phase 4.5 R10 card structure — flush-edge cards with outer `<TapedCard>` + image bleed + 1px ink rule between zones
+
+## Variants
+
+- **A — Compact one-line link.** Single inline row: kicker `LEES OOK` → article title → ellipsis arrow. No image. Sits like an "in-text" call-out — minimum visual weight; the focus stays on the lineup + events above.
+- **B — Hero-style cover card.** Full-width `<TapedCard>` with the article cover image bleeding to the top edge, kicker + heading below, optional one-line lead. Same shape as `<NewsCard>` on the homepage — most prominent of the three options. Strongest "go read this" CTA.
+- **C — Inline magazine banner.** Mid-weight horizontal card — small square cover image on the left (square aspect, ~120px), article kicker + title + lead on the right, arrow at the far right. Reads like a magazine sidebar callout. Compromise between A's restraint and B's prominence.
+
+## Vocabulary deltas summary
+
+| Variant | Δ count | Severity | Cost | Notes |
+| ------- | ------- | -------- | ---- | ----- |
+| **A** | 0 | Low | Pure styled link with mono caps kicker | Maps 1:1 onto any "see also" / "lees ook" pattern; reusable elsewhere |
+| **B** | 0 | Low | Composes `<TapedCard>` + `<TapedFigure>` + `<EditorialHeading>` exactly like `<NewsCard>` | Visually identical to a homepage news card — owner may want to differentiate |
+| **C** | 1 (small) | Medium | New small primitive: horizontal card layout with square cover on the left | Reusable pattern (could power related-articles, sponsor banners) |
+
+## Reading-intent trade-off
+
+| Variant | Reader's signal | Reader's likely action |
+| --- | --- | --- |
+| A | "There's an article" — quiet pointer | Click if curious; easy to scroll past |
+| B | "There's an article and you should read it" — strong CTA | High click intent; lineup + events feel less central |
+| C | "There's an article" — visible but doesn't dominate | Click-through likely; lineup + events stay central |
+
+## Cross-state behaviour
+
+- **Finished match + `matchRecap` exists** → card renders linking to the recap (kicker: `LEES HET VERSLAG`)
+- **Upcoming match + `matchPreview` exists** → card renders linking to the preview (kicker: `LEES DE VOORBESCHOUWING`)
+- **No matching article** → component returns `null`. Per the 6.B.d1 auto-hide rule.
+- **Both `matchPreview` AND `matchRecap` exist on a finished match** → render recap only (preview is stale post-kickoff)
+
+## Things this drill does NOT decide
+
+- Article-side schema for `articleMatch` reference field — that's a #1470 concern
+- Whether `<RelatedArticles>` below the card also surfaces the preview/recap (likely de-duplicated by the page query, but settled when implementation lands)
+- `<MatchStatusBadge>` Direction-D audit — 6.B.d5
+- Cross-cutting components (`<MatchTeaser>` / `<MatchResultRow>` / `<MatchStripClient>`) — 6.B.d6 / d7 / d8

--- a/docs/design/mockups/phase-6-match-detail/6b4-article-link-card/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b4-article-link-card/compare.md
@@ -36,10 +36,20 @@ Visual artifact: `round-1-article-link-card-comparisons.html` — three variants
 
 ## Cross-state behaviour
 
-- **Finished match + `matchRecap` exists** → card renders linking to the recap (kicker: `LEES HET VERSLAG`)
-- **Upcoming match + `matchPreview` exists** → card renders linking to the preview (kicker: `LEES DE VOORBESCHOUWING`)
-- **No matching article** → component returns `null`. Per the 6.B.d1 auto-hide rule.
-- **Both `matchPreview` AND `matchRecap` exist on a finished match** → render recap only (preview is stale post-kickoff)
+Exhaustive truth table — every combination of match status × article presence. "Render X" picks the linked article; "hide" returns `null` per the 6.B.d1 auto-hide rule.
+
+| Match status | `matchRecap` exists? | `matchPreview` exists? | Behaviour | Kicker |
+| --- | --- | --- | --- | --- |
+| `finished` (or any edge state: `forfeited` / `postponed` / `cancelled` / `stopped`) | yes | yes | Render **recap** (preview is stale post-kickoff) | `LEES HET VERSLAG · MATCHVERSLAG` |
+| `finished` (or edge) | yes | no  | Render **recap** | `LEES HET VERSLAG · MATCHVERSLAG` |
+| `finished` (or edge) | no  | yes | Render **preview** as a fallback (rare but useful — e.g. recap unwritten, preview still on file) | `LEES DE VOORBESCHOUWING · MATCHPREVIEW` |
+| `finished` (or edge) | no  | no  | Hide (`null`) | — |
+| `scheduled` (upcoming) | yes | yes | Render **preview** (recap exists but is anomalous on an upcoming match — log a warning in dev) | `LEES DE VOORBESCHOUWING · MATCHPREVIEW` |
+| `scheduled` | yes | no  | Render **recap** as a fallback (rare; usually a data anomaly — log a warning in dev) | `LEES HET VERSLAG · MATCHVERSLAG` |
+| `scheduled` | no  | yes | Render **preview** | `LEES DE VOORBESCHOUWING · MATCHPREVIEW` |
+| `scheduled` | no  | no  | Hide (`null`) | — |
+
+Rule summary: **recap wins on finished/edge states; preview wins on scheduled**. Fallbacks ship for asymmetric data — if the dominant article is missing, render the other rather than hide outright. Anomalous combinations (recap on a scheduled match, etc.) render in dev-warning mode but ship live without error.
 
 ## Things this drill does NOT decide
 

--- a/docs/design/mockups/phase-6-match-detail/6b4-article-link-card/round-1-article-link-card-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b4-article-link-card/round-1-article-link-card-comparisons.html
@@ -1,0 +1,496 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 1 · MatchArticleLinkCard (6.B.d4)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-soft: 3px 3px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1920px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1920px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+        align-items: start;
+      }
+
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.7;
+      }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      /* mocked cover image (synthetic) */
+      .cover {
+        background:
+          linear-gradient(135deg, var(--color-jersey-deep) 0%, var(--color-ink) 60%),
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0%, transparent 50%);
+        background-blend-mode: screen;
+        display: flex;
+        align-items: flex-end;
+        padding: 12px;
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant A — Compact one-line link
+         ═══════════════════════════════════════════ */
+      .va-wrap {
+        padding: 22px 18px;
+      }
+      .va-link {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 18px;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        box-shadow: var(--shadow-paper-soft);
+        text-decoration: none;
+        color: var(--color-ink);
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 17px;
+        letter-spacing: -0.015em;
+      }
+      .va-link .kicker {
+        font-family: var(--font-mono);
+        font-style: normal;
+        font-size: 9.5px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        background: var(--color-cream-deep);
+        padding: 4px 7px;
+        flex-shrink: 0;
+      }
+      .va-link .title {
+        flex: 1;
+        line-height: 1.25;
+      }
+      .va-link .arrow {
+        font-family: var(--font-mono);
+        font-size: 14px;
+        flex-shrink: 0;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant B — Hero-style cover card
+         ═══════════════════════════════════════════ */
+      .vb-wrap {
+        padding: 22px 18px;
+      }
+      .vb-card {
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        box-shadow: var(--shadow-paper-md);
+        transform: rotate(-0.3deg);
+        display: flex;
+        flex-direction: column;
+        text-decoration: none;
+        color: var(--color-ink);
+        overflow: hidden;
+      }
+      .vb-card .cover {
+        aspect-ratio: 16 / 9;
+        border-bottom: 2px solid var(--color-ink);
+      }
+      .vb-card .body {
+        padding: 16px 18px 18px;
+      }
+      .vb-card .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+        margin-bottom: 8px;
+      }
+      .vb-card .kicker::before { content: "* "; opacity: 0.6; }
+      .vb-card .title {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 24px;
+        letter-spacing: -0.025em;
+        line-height: 1.1;
+        margin: 0 0 10px;
+      }
+      .vb-card .lead {
+        font-size: 13.5px;
+        line-height: 1.5;
+        margin: 0 0 14px;
+      }
+      .vb-card .cta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant C — Inline magazine banner
+         ═══════════════════════════════════════════ */
+      .vc-wrap {
+        padding: 22px 18px;
+      }
+      .vc-card {
+        display: grid;
+        grid-template-columns: 120px 1fr auto;
+        gap: 16px;
+        align-items: center;
+        padding: 14px 18px;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        box-shadow: var(--shadow-paper-soft);
+        text-decoration: none;
+        color: var(--color-ink);
+      }
+      .vc-card .cover {
+        aspect-ratio: 1 / 1;
+        border: 1px solid var(--color-ink);
+      }
+      .vc-card .text {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .vc-card .kicker {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.85;
+      }
+      .vc-card .kicker::before { content: "* "; opacity: 0.6; }
+      .vc-card .title {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 18px;
+        letter-spacing: -0.02em;
+        line-height: 1.15;
+      }
+      .vc-card .lead {
+        font-size: 12.5px;
+        line-height: 1.4;
+        opacity: 0.8;
+      }
+      .vc-card .arrow {
+        font-family: var(--font-mono);
+        font-size: 18px;
+        align-self: center;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 1 · `&lt;MatchArticleLinkCard&gt;`</div>
+      <h1>How should the article link sit between the events and the related-articles?</h1>
+      <p>
+        Three treatment levels for the new
+        <code>&lt;MatchArticleLinkCard&gt;</code>. Auto-hides if no
+        <code>matchPreview</code> / <code>matchRecap</code> article exists for
+        the match. All three render the finished state (linking to a recap);
+        the upcoming state is identical in shape, only the badge / kicker copy
+        differs.
+      </p>
+      <span class="scope-banner">Pick one treatment level → write d4 lock</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ A — Compact one-line link ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant A</div>
+          <h2>Compact one-line link.</h2>
+          <p class="sub">
+            Single inline row: kicker pill on the left, article title in the
+            middle, ellipsis arrow on the right. No image. Minimum visual
+            weight; reads as an in-text pointer. Focus stays on lineup +
+            events above.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Quietest treatment</span>
+            <span class="chip chip--cost">Low click affordance</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Body slot (finished — links to matchRecap article)</div>
+        <div class="va-wrap">
+          <a class="va-link" href="#">
+            <span class="kicker">LEES HET VERSLAG</span>
+            <span class="title">Drie keer Maxim, één keer pech: KCVV wint thuis tegen RC Mechelen.</span>
+            <span class="arrow">↗</span>
+          </a>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Smallest possible footprint — reader's attention stays on the match facts</li>
+            <li>Zero new primitive (one styled link + a small mono kicker pill)</li>
+            <li>Works identically on mobile without layout changes</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Low click affordance — easy to scroll past</li>
+            <li>Doesn't sell the editorial content; the article author's effort gets less visual weight than the BFF lineup data</li>
+            <li>Title-only — no lead to preview the recap content</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ B — Hero-style cover card ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant B</div>
+          <h2>Hero-style cover card.</h2>
+          <p class="sub">
+            Full-width <code>&lt;TapedCard&gt;</code> with the article cover
+            image bleeding to the top edge. Kicker + heading + one-line lead
+            below the image. Same shape as <code>&lt;NewsCard&gt;</code> on
+            the homepage — the strongest CTA of the three options.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Strongest CTA</span>
+            <span class="chip chip--cost">Identical to NewsCard — may confuse</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Body slot (finished — links to matchRecap article)</div>
+        <div class="vb-wrap">
+          <a class="vb-card" href="#">
+            <div class="cover">[ matchRecap cover · 16:9 ]</div>
+            <div class="body">
+              <div class="kicker">LEES HET VERSLAG · MATCHVERSLAG</div>
+              <h3 class="title">Drie keer Maxim, één keer pech.</h3>
+              <p class="lead">KCVV wint thuis tegen RC Mechelen na een
+                tweedehelftshow van Maxim Breugelmans. Tom Janssens corrigeert
+                even, maar de bezoekers vinden geen antwoord.</p>
+              <div class="cta">LEES HET HELE VERHAAL <span>→</span></div>
+            </div>
+          </a>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Strongest "go read this" affordance — image + kicker + heading + lead + CTA</li>
+            <li>Surfaces editorial work prominently; rewards article authors</li>
+            <li>Composes existing primitives 1:1 (<code>&lt;TapedCard&gt;</code> + <code>&lt;TapedFigure&gt;</code> + <code>&lt;EditorialHeading&gt;</code>)</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Visually indistinguishable from a homepage <code>&lt;NewsCard&gt;</code> — may confuse readers ("why is there a news card in the middle of the match page?")</li>
+            <li>Dominates the body — competes with the match content for attention</li>
+            <li>Mobile: adds a full-width image block, more scroll</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ C — Inline magazine banner ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant C</div>
+          <h2>Inline magazine banner.</h2>
+          <p class="sub">
+            Mid-weight horizontal card. Small square cover image (~120px) on
+            the left, kicker + title + lead on the right, arrow at the far
+            right. Reads like a magazine sidebar callout — compromise between
+            A's restraint and B's prominence.
+          </p>
+          <div class="chips">
+            <span class="chip chip--delta">+1 small primitive</span>
+            <span class="chip chip--good">Compromise position</span>
+            <span class="chip chip--cost">Square image crop ≠ news cover crop</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Body slot (finished — links to matchRecap article)</div>
+        <div class="vc-wrap">
+          <a class="vc-card" href="#">
+            <div class="cover">[ cover · square ]</div>
+            <div class="text">
+              <div class="kicker">LEES HET VERSLAG</div>
+              <h3 class="title">Drie keer Maxim, één keer pech.</h3>
+              <p class="lead">Maxim Breugelmans tekent voor twee tweede-helftgoals
+                en KCVV pakt de drie punten.</p>
+            </div>
+            <span class="arrow">↗</span>
+          </a>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Visible but doesn't dominate — lineup + events stay central</li>
+            <li>Cover image gives editorial work weight without competing with the hero</li>
+            <li>Click affordance higher than A; lower than B</li>
+            <li>Distinct visual shape from <code>&lt;NewsCard&gt;</code> — readers recognise it as a different element</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>+1 small primitive: the square-cover-left-with-text-right horizontal layout (could be a generic <code>&lt;SidebarLinkCard&gt;</code>)</li>
+            <li>Article cover images are typically 16:9 — square crop means a derived crop is needed in the GROQ image transform</li>
+            <li>Mobile collapse needs the image to either stack on top or shrink (still solvable, not as automatic as A)</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1920px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 1 of 6.B.d4 · article link card · pick treatment level
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/compare.md
@@ -44,20 +44,41 @@ Consumers: `<BrandedTabs>`, `<FilterTabs>`, `<HorizontalSlider>` arrows. **NOT a
 
 ## Audit findings
 
-### Finding 1 — Coverage gap vs `matchhero-locked.md`
+### Finding 1 — Coverage gap vs `matchhero-locked.md` (also: cancelled/postponed data-model bug)
 
-`matchhero-locked.md` spec (d2) says the corner stamp renders on **finished** matches with text **"FT"** (plus the existing FF / AFG / STOP for edge states). The current component:
+`matchhero-locked.md` spec (d2) says the corner stamp renders on **finished** matches with text **"FT"**. The current component:
 
 - **Returns `null` for `finished`** — no badge at all
-- Uses long-form Dutch ("Uitgesteld" / "Gestopt") for postponed / stopped — doesn't match d2's abbreviations ("AFG" / "STOP")
-- Uses "FF" for forfeited — matches d2
+- Uses long-form Dutch ("Uitgesteld" / "Gestopt") for postponed / stopped — doesn't match the locked-abbreviations spec
+- Uses "FF" for forfeited — matches the spec
 
-This is a real spec gap from d2. The hero needs the badge to handle `finished` (the dominant case for any post-kickoff page render). Either:
+**Also discovered during the audit:** the current `MatchStatus` literal **conflates `cancelled` with `postponed`**. From `apps/api/src/psd/transforms.ts:100`:
 
-- **(a)** Extend `<MatchStatusBadge>` to cover `finished` + render "FT", OR
-- **(b)** Have `<MatchHero>` render the FT stamp itself via a plain `<MonoLabel>` and only delegate to `<MatchStatusBadge>` for the edge states
+```typescript
+if (cancelled) return "postponed";
+if (status === 0) return goalsScored.length > 0 || ... ? "finished" : "scheduled";
+if (status === 1) return "forfeited";
+if (status === 2) return "postponed";   // PSD code 2 = afgelast
+if (status === 3) return "stopped";
+return "scheduled";
+```
 
-(a) is more consistent (one component owns all status-stamp rendering); (b) is more separated (the badge's API stays narrow — only "this match needs special attention").
+PSD's `cancelled: boolean` is a separate field that signals "definitively dead — won't be played", semantically distinct from `postponed` (PSD code 2 = afgelast = held, may reschedule). The BFF collapses both into `"postponed"`, hiding the distinction.
+
+**BFF schema delta required** — Phase 6.B owns it (per owner direction):
+
+| Touch point | Change |
+| --- | --- |
+| `packages/api-contract/src/schemas/match.ts` | Add `"cancelled"` to `MatchStatus` literal |
+| `apps/api/src/psd/transforms.ts` | Return `"cancelled"` (not `"postponed"`) when `cancelled === true`; preserve PSD code 2 → `"postponed"` |
+| `apps/api/src/psd/service.test.ts` + `apps/api/src/handlers/matches.test.ts` | Cover the new branch |
+| All consumers branching on `status === "postponed"` | Decide per-consumer whether `cancelled` shares the branch or splits |
+
+Resulting full set: **6 normalised statuses** (`scheduled`, `finished`, `forfeited`, `postponed`, `cancelled`, `stopped`); **5 render badges** (FT, FF, PP, CANC, STOP); `scheduled` doesn't render (kickoff time IS the status).
+
+### Coverage decision: extend `<MatchStatusBadge>` to cover all 5 badge states
+
+**(a)** wins. One component owns all status-stamp rendering. Easier to migrate the visual treatment in one place if/when Direction D evolves. The `<MatchHero>` simply mounts `<MatchStatusBadge status={match.status} />` and the badge decides whether to render and how.
 
 ### Finding 2 — Visual treatment vs Direction D
 
@@ -73,31 +94,36 @@ The bright-jersey pill diverges from Direction D. It's also a colour choice the 
 
 **Recommended migration:** swap `pill-jersey` → Direction D paper-chrome treatment. Either as a NEW MonoLabel variant (`pill-paper-chrome` or similar) reusable elsewhere, OR baked into `<MatchStatusBadge>` directly (component-level styling, no new primitive).
 
-### Finding 3 — Copy: long-form Dutch vs abbreviations
+### Finding 3 — Copy: long-form Dutch vs abbreviations (owner-corrected)
 
-The d2 spec uses abbreviations ("FT", "FF", "AFG", "STOP") for the corner stamp; the current component uses long-form Dutch ("Uitgesteld", "Gestopt"). Trade-off:
+The d2 spec uses abbreviations for the corner stamp; the current component uses long-form Dutch ("Uitgesteld", "Gestopt"). Owner direction during the audit:
 
-- **Abbreviations** read like printed-matchday-programme codes — fit the editorial-paper-fanzine vocabulary. Saves horizontal space on the corner stamp. Less accessible (readers don't always know "AFG" = afgelast).
-- **Long-form Dutch** is clear and accessible. Risks looking like a generic UI badge (which it currently does).
+- Abbreviations win
+- Specifically: **FT** (finished), **FF** (forfeit), **PP** (postponed), **CANC** (cancelled), **STOP** (stopped)
+- `title=` tooltip carries the long-form Dutch for accessibility
 
-Worth noting: PSD's own data uses the numeric status codes (0/1/2/3) which we already normalise to English literals (`scheduled`/`finished`/`forfeited`/`postponed`/`stopped`). The user-facing copy is fully our call.
+Reasoning: abbreviations read like printed-matchday-programme codes — fit the editorial-paper-fanzine vocabulary, save horizontal space on the corner stamp, distinct enough at a glance that readers learn them quickly.
 
-## Sub-decisions for the owner
+## Owner direction (after the audit conversation)
 
-| # | Decision | Recommendation | Why |
+- **Coverage**: extend `<MatchStatusBadge>` to render all 5 badge states (FT / FF / PP / CANC / STOP). `<MatchHero>` just mounts the badge; the badge owns whether-and-how to render.
+- **BFF schema delta**: **Phase 6.B owns it.** The `cancelled` literal extension + transform fix + downstream cascade is part of the eventual Phase 6.B implementation tickets that `/prd-to-issues` will spawn.
+- **Copy**: abbreviations. FT / FF / PP / CANC / STOP. `title=` tooltip carries the long-form Dutch for accessibility.
+- **Visual treatment**: Direction D paper-chrome base (`border-2 ink + shadow-paper-sm + bg-cream + mono caps`) with **per-status tint** signalling severity. Four tints across five statuses:
+
+| Status | Tint token | Severity tier | Why |
 | --- | --- | --- | --- |
-| **1** | Coverage: extend the badge to render `finished` ("FT") inside `<MatchStatusBadge>` (a) OR have `<MatchHero>` render FT itself via plain `<MonoLabel>` and delegate to the badge for edge states only (b) | **(a)** — extend the badge | One component owns all status-stamp rendering. Easier to migrate the visual treatment in one place if/when Direction D evolves. |
-| **2** | Visual treatment: keep current `pill-jersey` / `pill-cream` MonoLabel chrome (i) OR migrate to Direction D paper-chrome (ii) | **(ii)** — migrate to Direction D | `pill-jersey` uses the retired bright-jersey colour (see `[[feedback_no_bright_jersey]]`). Direction D matches `<MatchHero>`'s editorial-paper vocabulary directly. |
-| **3** | Copy: long-form Dutch ("Uitgesteld" / "Gestopt") (i) OR abbreviations ("AFG" / "STOP") (ii) | **(ii)** — abbreviations | Fits the matchday-printed-programme vocabulary. Saves space on the corner stamp. Tooltip on hover can give the long-form for accessibility. |
+| FT | `cream` | Normal | Game played to full time |
+| PP | `cream-deep` | No game today (held) | May reschedule |
+| FF | `cream-deep` | No game today (dead) | Won't be played; result imposed. Owner-grouped with PP — both read as "no game today" |
+| STOP | `warm` | Notice (abnormal) | Game started + ended weird — incomplete result |
+| CANC | `card-red` (new token) | Alert (dead) | Definitively dead, won't play, may have no result |
 
-If owner agrees with all three recommendations, the d5 lock captures:
+A small HTML mockup confirming the visual treatment lives at `round-1-statusbadge-comparisons.html` — all 5 statuses rendered in 3 treatments (current `pill-jersey`, uniform Direction D, Direction D + status tint).
 
-- `<MatchStatusBadge>` extended to cover `finished` (renders "FT")
-- New visual chrome on the badge: `border-2 border-ink shadow-paper-sm bg-cream` + mono caps (Direction D)
-- Edge state copy: "FF" / "AFG" / "STOP" abbreviations + `title=` long-form for tooltip accessibility
-- Component-level styling (no new MonoLabel variant; baked into MatchStatusBadge directly to keep the surface area narrow)
+## Open sub-decision
 
-If owner disagrees with any of (1) / (2) / (3), a small HTML mockup can render the alternatives for visual confirmation in a round 2.
+- **`--color-card-red` token introduction**: CANC's red would be the first redesign use of card-red. Acceptable to introduce, OR downgrade CANC to a desaturated warm-tint variant. Owner picks at d5 lock time.
 
 ## Cross-references
 

--- a/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/compare.md
@@ -1,0 +1,108 @@
+# 6.B.d5 · `<MatchStatusBadge>` — audit drill
+
+**Audit, not a design comparison.** The component already exists (shipped during the MonoLabel pill migration). This drill confirms whether it's in shape for the Phase 6.B `<MatchHero>` corner-stamp use case OR needs refinement.
+
+No HTML mockup file — three sub-decisions surface from the audit; each can be settled in text + a small mockup if owner wants visual confirmation.
+
+## Current state (as shipped)
+
+`apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.tsx`:
+
+```typescript
+// Renders ONLY for these three statuses; returns null for everything else
+type BadgeStatus = Extract<MatchStatus, "postponed" | "stopped" | "forfeited">;
+
+const statusLabels: Record<BadgeStatus, string> = {
+  postponed: "Uitgesteld",   // long-form Dutch
+  stopped: "Gestopt",
+  forfeited: "FF",            // abbreviation (the one exception)
+};
+
+// Visual: thin wrapper around <MonoLabel variant="pill-…">
+//   color "orange" (postponed/stopped) → variant "pill-jersey"
+//   color "gray" (no match status uses this today) → variant "pill-cream"
+```
+
+`<MonoLabel>` pill variant specs (from `apps/web/src/components/design-system/MonoLabel/MonoLabel.tsx:27-29`):
+
+```text
+pill-jersey: bg-jersey text-ink                                     (no border, no shadow)
+pill-ink:    bg-ink text-cream                                      (no border, no shadow)
+pill-cream:  bg-cream-soft text-ink border border-paper-edge        (1px paper-edge border, no shadow)
+```
+
+## Direction D reference
+
+Phase 2 Track B locked Direction D ("Paper chrome, ink emphasis"):
+
+```text
+border-2 ink + shadow-paper-sm + bg-cream (or cream-soft) + mono caps + sharp corners
+Active state inversion: bg-ink text-cream + shadow-paper-sm-soft
+```
+
+Consumers: `<BrandedTabs>`, `<FilterTabs>`, `<HorizontalSlider>` arrows. **NOT a global mandate** — MonoLabel pills carry their own visual language inherited from earlier phases.
+
+## Audit findings
+
+### Finding 1 — Coverage gap vs `matchhero-locked.md`
+
+`matchhero-locked.md` spec (d2) says the corner stamp renders on **finished** matches with text **"FT"** (plus the existing FF / AFG / STOP for edge states). The current component:
+
+- **Returns `null` for `finished`** — no badge at all
+- Uses long-form Dutch ("Uitgesteld" / "Gestopt") for postponed / stopped — doesn't match d2's abbreviations ("AFG" / "STOP")
+- Uses "FF" for forfeited — matches d2
+
+This is a real spec gap from d2. The hero needs the badge to handle `finished` (the dominant case for any post-kickoff page render). Either:
+
+- **(a)** Extend `<MatchStatusBadge>` to cover `finished` + render "FT", OR
+- **(b)** Have `<MatchHero>` render the FT stamp itself via a plain `<MonoLabel>` and only delegate to `<MatchStatusBadge>` for the edge states
+
+(a) is more consistent (one component owns all status-stamp rendering); (b) is more separated (the badge's API stays narrow — only "this match needs special attention").
+
+### Finding 2 — Visual treatment vs Direction D
+
+Current MonoLabel pill chrome:
+
+| State | Current visual | Direction D equivalent |
+| --- | --- | --- |
+| `postponed`, `stopped` | `pill-jersey` — bright jersey-green bg, no border, no shadow | `border-2 ink + shadow-paper-sm + bg-cream + mono caps` |
+| `forfeited` (today via `pill-jersey` too) | Same as above | Same as above |
+| `finished` (per d2 — net-new) | n/a today | `border-2 ink + shadow-paper-sm + bg-cream` (or jersey-deep for "FT" emphasis) |
+
+The bright-jersey pill diverges from Direction D. It's also a colour choice the redesign has otherwise dialled down (per `[[feedback_no_bright_jersey]]` — `--color-jersey` retired in favour of `--color-jersey-deep`).
+
+**Recommended migration:** swap `pill-jersey` → Direction D paper-chrome treatment. Either as a NEW MonoLabel variant (`pill-paper-chrome` or similar) reusable elsewhere, OR baked into `<MatchStatusBadge>` directly (component-level styling, no new primitive).
+
+### Finding 3 — Copy: long-form Dutch vs abbreviations
+
+The d2 spec uses abbreviations ("FT", "FF", "AFG", "STOP") for the corner stamp; the current component uses long-form Dutch ("Uitgesteld", "Gestopt"). Trade-off:
+
+- **Abbreviations** read like printed-matchday-programme codes — fit the editorial-paper-fanzine vocabulary. Saves horizontal space on the corner stamp. Less accessible (readers don't always know "AFG" = afgelast).
+- **Long-form Dutch** is clear and accessible. Risks looking like a generic UI badge (which it currently does).
+
+Worth noting: PSD's own data uses the numeric status codes (0/1/2/3) which we already normalise to English literals (`scheduled`/`finished`/`forfeited`/`postponed`/`stopped`). The user-facing copy is fully our call.
+
+## Sub-decisions for the owner
+
+| # | Decision | Recommendation | Why |
+| --- | --- | --- | --- |
+| **1** | Coverage: extend the badge to render `finished` ("FT") inside `<MatchStatusBadge>` (a) OR have `<MatchHero>` render FT itself via plain `<MonoLabel>` and delegate to the badge for edge states only (b) | **(a)** — extend the badge | One component owns all status-stamp rendering. Easier to migrate the visual treatment in one place if/when Direction D evolves. |
+| **2** | Visual treatment: keep current `pill-jersey` / `pill-cream` MonoLabel chrome (i) OR migrate to Direction D paper-chrome (ii) | **(ii)** — migrate to Direction D | `pill-jersey` uses the retired bright-jersey colour (see `[[feedback_no_bright_jersey]]`). Direction D matches `<MatchHero>`'s editorial-paper vocabulary directly. |
+| **3** | Copy: long-form Dutch ("Uitgesteld" / "Gestopt") (i) OR abbreviations ("AFG" / "STOP") (ii) | **(ii)** — abbreviations | Fits the matchday-printed-programme vocabulary. Saves space on the corner stamp. Tooltip on hover can give the long-form for accessibility. |
+
+If owner agrees with all three recommendations, the d5 lock captures:
+
+- `<MatchStatusBadge>` extended to cover `finished` (renders "FT")
+- New visual chrome on the badge: `border-2 border-ink shadow-paper-sm bg-cream` + mono caps (Direction D)
+- Edge state copy: "FF" / "AFG" / "STOP" abbreviations + `title=` long-form for tooltip accessibility
+- Component-level styling (no new MonoLabel variant; baked into MatchStatusBadge directly to keep the surface area narrow)
+
+If owner disagrees with any of (1) / (2) / (3), a small HTML mockup can render the alternatives for visual confirmation in a round 2.
+
+## Cross-references
+
+- Existing component: `apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.tsx`
+- d2 lock (where "FT" corner stamp originates): `docs/design/mockups/phase-6-match-detail/matchhero-locked.md`
+- Direction D source-of-record: `docs/prd/redesign-phase-2.md` §6.5 + `docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html`
+- MonoLabel pill specs: `apps/web/src/components/design-system/MonoLabel/MonoLabel.tsx`
+- Memory: `[[feedback_no_bright_jersey]]` (bright `--color-jersey` retired)

--- a/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/round-1-statusbadge-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/round-1-statusbadge-comparisons.html
@@ -253,14 +253,17 @@
       .t3--ft   { /* finished — neutral cream */
         background: var(--color-cream);
       }
-      .t3--ff   { /* forfeit — warm accent */
+      .t3--ff   { /* forfeit — muted (no game played; result imposed) */
+        background: var(--color-cream-deep);
+      }
+      .t3--pp   { /* postponed — muted (may reschedule) */
+        background: var(--color-cream-deep);
+      }
+      .t3--stop { /* stopped — notice (game ended weird) */
         background: var(--color-warm);
         color: var(--color-cream);
       }
-      .t3--pp   { /* postponed — muted cream-deep */
-        background: var(--color-cream-deep);
-      }
-      .t3--stop { /* stopped — alert red */
+      .t3--canc { /* cancelled — alert (definitively dead) */
         background: var(--color-card-red);
         color: var(--color-cream);
       }
@@ -272,18 +275,24 @@
       <div class="meta">Phase 6.B · Drill round 1 · `&lt;MatchStatusBadge&gt;`</div>
       <h1>How should the status corner stamp look?</h1>
       <p>
-        Four status values render a badge: <code>finished</code> (FT),
+        Five status values render a badge: <code>finished</code> (FT),
         <code>forfeited</code> (FF), <code>postponed</code> (PP),
-        <code>stopped</code> (STOP). <code>scheduled</code> renders no
-        badge (the kickoff time in the hero IS the status).
+        <code>cancelled</code> (CANC), <code>stopped</code> (STOP).
+        <code>scheduled</code> renders no badge (the kickoff time in the
+        hero IS the status). <strong>Requires a BFF schema delta</strong>:
+        today's <code>MatchStatus</code> literal collapses
+        <code>cancelled</code> into <code>postponed</code>; Phase 6.B
+        implementation adds <code>"cancelled"</code> to the literal and
+        stops the override in <code>transforms.ts</code>.
       </p>
       <p>
-        Three visual treatments compared. Each variant shows the four badges
-        (a) in isolation as a horizontal row + (b) in-context as a corner
-        stamp on a tiny hero card so the size + visual weight read
-        realistically.
+        Three visual treatments compared. Each variant shows the five
+        badges (a) in isolation as a horizontal row + (b) in-context as
+        corner stamps on tiny hero cards. T3 uses the severity tiers
+        agreed during the audit: FT = cream (normal), PP + FF = cream-deep
+        (no game today), STOP = warm (notice), CANC = card-red (alert).
       </p>
-      <span class="scope-banner">Pick one treatment · all 4 statuses ship with it</span>
+      <span class="scope-banner">Pick one treatment · all 5 statuses ship with it</span>
     </header>
 
     <div class="grid">
@@ -312,6 +321,7 @@
             <span class="t1 t1--cream">FT</span>
             <span class="t1">FF</span>
             <span class="t1">PP</span>
+            <span class="t1">CANC</span>
             <span class="t1">STOP</span>
           </div>
           <div class="demo-row-label">On a hero corner</div>
@@ -326,6 +336,10 @@
           <div class="hero-mini">
             <div class="status-corner"><span class="t1">PP</span></div>
             KCVV — Mech · postponed
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t1">CANC</span></div>
+            KCVV — Mech · cancelled
           </div>
           <div class="hero-mini">
             <div class="status-corner"><span class="t1">STOP</span></div>
@@ -368,6 +382,7 @@
             <span class="t2">FT</span>
             <span class="t2">FF</span>
             <span class="t2">PP</span>
+            <span class="t2">CANC</span>
             <span class="t2">STOP</span>
           </div>
           <div class="demo-row-label">On a hero corner</div>
@@ -382,6 +397,10 @@
           <div class="hero-mini">
             <div class="status-corner"><span class="t2">PP</span></div>
             KCVV — Mech · postponed
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t2">CANC</span></div>
+            KCVV — Mech · cancelled
           </div>
           <div class="hero-mini">
             <div class="status-corner"><span class="t2">STOP</span></div>
@@ -408,10 +427,12 @@
           <p class="sub">
             Same Direction D chrome as T2 (border-2 ink + shadow-paper-sm
             + mono caps), but the background tints differ per status to
-            signal severity: <strong>FT</strong> = cream (neutral),
-            <strong>FF</strong> = warm (notice), <strong>PP</strong> =
-            cream-deep (muted, on hold), <strong>STOP</strong> = card-red
-            (alert).
+            signal severity. Four visual flavours across five statuses:
+            <strong>FT</strong> = cream (normal),
+            <strong>PP + FF</strong> = cream-deep (no game today; PP may
+            reschedule, FF won't be played but result imposed),
+            <strong>STOP</strong> = warm (notice — game ended weird),
+            <strong>CANC</strong> = card-red (alert — definitively dead).
           </p>
           <div class="chips">
             <span class="chip chip--good">Per-status severity signal</span>
@@ -426,6 +447,7 @@
             <span class="t3 t3--ft">FT</span>
             <span class="t3 t3--ff">FF</span>
             <span class="t3 t3--pp">PP</span>
+            <span class="t3 t3--canc">CANC</span>
             <span class="t3 t3--stop">STOP</span>
           </div>
           <div class="demo-row-label">On a hero corner</div>
@@ -442,6 +464,10 @@
             KCVV — Mech · postponed
           </div>
           <div class="hero-mini">
+            <div class="status-corner"><span class="t3 t3--canc">CANC</span></div>
+            KCVV — Mech · cancelled
+          </div>
+          <div class="hero-mini">
             <div class="status-corner"><span class="t3 t3--stop">STOP</span></div>
             KCVV — Mech · stopped
           </div>
@@ -450,11 +476,11 @@
         <div class="callouts">
           <h4>Notes</h4>
           <ul>
-            <li>Reader sees severity at a glance — FF / PP / STOP stand out from the routine FT</li>
+            <li>Reader sees severity at a glance — STOP and CANC stand out as the abnormal-and-dramatic states; PP + FF read as muted "no game today"; FT reads as routine</li>
             <li>Same chrome geometry as T2 (border + shadow + mono caps); only the bg tint differs per status</li>
-            <li>Tints use existing tokens: warm (already shipped for kicker variants), cream-deep (existing neutral fallback), card-red (would need a token — currently only used in test status colouring)</li>
-            <li>Risk: adding red to the redesign palette where it wasn't before. <code>--color-card-red</code> doesn't exist as a token today; STOP is so rare that a token decision for one badge may be over-engineered</li>
-            <li>Could downgrade STOP to use the warm tint (shared with FF) — STOP is rare enough that distinguishing it from FF visually may not matter</li>
+            <li>Tints use existing tokens: cream (shipped), cream-deep (shipped), warm (shipped for kicker variants), card-red (would need a new token — does not exist today)</li>
+            <li>Trade-off: introducing <code>--color-card-red</code> for CANC means red enters the redesign palette where it wasn't before. CANC is rare enough that a dedicated token may feel heavy; could downgrade to a desaturated warm-tint variant. Owner call.</li>
+            <li>FF and PP share the cream-deep treatment per owner direction — both are "no game today" semantically (PP may resume, FF won't but is routinely-resolved). Readers don't need to distinguish them visually.</li>
           </ul>
         </div>
       </article>

--- a/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/round-1-statusbadge-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b5-matchstatusbadge/round-1-statusbadge-comparisons.html
@@ -1,0 +1,467 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 1 · MatchStatusBadge (6.B.d5)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --color-card-red: #c93f1c;
+        --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --shadow-paper-sm-soft: 2px 2px 0 0 var(--color-ink-muted);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1600px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1600px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+        align-items: start;
+      }
+
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.7;
+      }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      /* ───── Badge demo: in-context (on a tiny hero corner) + isolated row ───── */
+      .demo {
+        padding: 6px 18px 22px;
+      }
+      .demo .demo-row-label {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.55;
+        margin: 12px 0 6px;
+      }
+      .demo .hero-mini {
+        position: relative;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        padding: 12px 14px;
+        margin: 6px 0 10px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 13px;
+      }
+      .hero-mini .status-corner {
+        position: absolute;
+        top: -10px;
+        right: 14px;
+      }
+      .demo .badge-row {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        padding: 6px 0;
+      }
+
+      /* ───────── Treatment 1: current pill-jersey (as shipped) ───────── */
+      .t1 {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 500;
+        line-height: 1;
+        padding: 5px 7px;
+        background: var(--color-jersey);
+        color: var(--color-ink);
+      }
+      /* (current code uses pill-jersey for postponed/stopped/forfeited; pill-cream is
+         the gray fallback when status colour isn't recognised — extra-rare). */
+      .t1--cream {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        border: 1px solid var(--color-cream-deep);
+      }
+
+      /* ───────── Treatment 2: Direction D paper-chrome, uniform ───────── */
+      .t2 {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+        line-height: 1;
+        padding: 5px 8px;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+
+      /* ───────── Treatment 3: Direction D paper-chrome, per-status tint ───────── */
+      .t3 {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+        line-height: 1;
+        padding: 5px 8px;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .t3--ft   { /* finished — neutral cream */
+        background: var(--color-cream);
+      }
+      .t3--ff   { /* forfeit — warm accent */
+        background: var(--color-warm);
+        color: var(--color-cream);
+      }
+      .t3--pp   { /* postponed — muted cream-deep */
+        background: var(--color-cream-deep);
+      }
+      .t3--stop { /* stopped — alert red */
+        background: var(--color-card-red);
+        color: var(--color-cream);
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 1 · `&lt;MatchStatusBadge&gt;`</div>
+      <h1>How should the status corner stamp look?</h1>
+      <p>
+        Four status values render a badge: <code>finished</code> (FT),
+        <code>forfeited</code> (FF), <code>postponed</code> (PP),
+        <code>stopped</code> (STOP). <code>scheduled</code> renders no
+        badge (the kickoff time in the hero IS the status).
+      </p>
+      <p>
+        Three visual treatments compared. Each variant shows the four badges
+        (a) in isolation as a horizontal row + (b) in-context as a corner
+        stamp on a tiny hero card so the size + visual weight read
+        realistically.
+      </p>
+      <span class="scope-banner">Pick one treatment · all 4 statuses ship with it</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ Treatment 1: current pill-jersey ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Treatment 1</div>
+          <h2>Current pill-jersey.</h2>
+          <p class="sub">
+            As shipped today: <code>&lt;MonoLabel variant="pill-jersey"&gt;</code>
+            — solid bright-green pill, ink text. Used for postponed +
+            stopped + forfeited; finished is unimplemented (returns null).
+            Bright <code>--color-jersey</code> is the colour the redesign
+            otherwise retired in favour of jersey-deep.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 work</span>
+            <span class="chip chip--cost">Uses retired bright-jersey</span>
+            <span class="chip chip--cost">No FT yet</span>
+          </div>
+        </header>
+
+        <div class="demo">
+          <div class="demo-row-label">In isolation</div>
+          <div class="badge-row">
+            <span class="t1 t1--cream">FT</span>
+            <span class="t1">FF</span>
+            <span class="t1">PP</span>
+            <span class="t1">STOP</span>
+          </div>
+          <div class="demo-row-label">On a hero corner</div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t1 t1--cream">FT</span></div>
+            KCVV — Mech · finished
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t1">FF</span></div>
+            KCVV — Mech · forfeit
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t1">PP</span></div>
+            KCVV — Mech · postponed
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t1">STOP</span></div>
+            KCVV — Mech · stopped
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Notes</h4>
+          <ul>
+            <li>All three edge statuses look identical — bright-green pill, no severity differentiation</li>
+            <li>FT shown as <code>pill-cream</code> approximation; current code returns null for finished so there's no real precedent</li>
+            <li>Diverges from the editorial paper-card vocabulary of the rest of the page</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ Treatment 2: Direction D paper-chrome, uniform ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Treatment 2</div>
+          <h2>Direction D — uniform.</h2>
+          <p class="sub">
+            Migrate every badge to the locked Phase 2 Direction D paper
+            chrome: <code>border-2 ink + shadow-paper-sm + bg-cream + mono
+            caps</code>. Same vocabulary as <code>&lt;BrandedTabs&gt;</code>
+            and <code>&lt;FilterTabs&gt;</code>. All 4 statuses look identical
+            — only the text varies.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">Matches editorial paper vocab</span>
+            <span class="chip chip--good">Aligns with locked Direction D</span>
+            <span class="chip chip--cost">No per-status severity signal</span>
+          </div>
+        </header>
+
+        <div class="demo">
+          <div class="demo-row-label">In isolation</div>
+          <div class="badge-row">
+            <span class="t2">FT</span>
+            <span class="t2">FF</span>
+            <span class="t2">PP</span>
+            <span class="t2">STOP</span>
+          </div>
+          <div class="demo-row-label">On a hero corner</div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t2">FT</span></div>
+            KCVV — Mech · finished
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t2">FF</span></div>
+            KCVV — Mech · forfeit
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t2">PP</span></div>
+            KCVV — Mech · postponed
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t2">STOP</span></div>
+            KCVV — Mech · stopped
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Notes</h4>
+          <ul>
+            <li>One visual language across all 4 statuses; reader differentiates via the letters alone</li>
+            <li>Matches Phase 2 Direction D — same chrome as the locked Tab + Arrow primitives</li>
+            <li>Slight ink-rectangle weight on every hero card corner; less visual noise overall than coloured pills</li>
+            <li>No "this needs special attention" signal — FF feels visually equivalent to a routine FT</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ Treatment 3: Direction D + per-status tint ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Treatment 3</div>
+          <h2>Direction D + status tint.</h2>
+          <p class="sub">
+            Same Direction D chrome as T2 (border-2 ink + shadow-paper-sm
+            + mono caps), but the background tints differ per status to
+            signal severity: <strong>FT</strong> = cream (neutral),
+            <strong>FF</strong> = warm (notice), <strong>PP</strong> =
+            cream-deep (muted, on hold), <strong>STOP</strong> = card-red
+            (alert).
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">Per-status severity signal</span>
+            <span class="chip chip--good">Direction D base preserved</span>
+            <span class="chip chip--cost">+1 tint vocabulary to maintain</span>
+          </div>
+        </header>
+
+        <div class="demo">
+          <div class="demo-row-label">In isolation</div>
+          <div class="badge-row">
+            <span class="t3 t3--ft">FT</span>
+            <span class="t3 t3--ff">FF</span>
+            <span class="t3 t3--pp">PP</span>
+            <span class="t3 t3--stop">STOP</span>
+          </div>
+          <div class="demo-row-label">On a hero corner</div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t3 t3--ft">FT</span></div>
+            KCVV — Mech · finished
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t3 t3--ff">FF</span></div>
+            KCVV — Mech · forfeit
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t3 t3--pp">PP</span></div>
+            KCVV — Mech · postponed
+          </div>
+          <div class="hero-mini">
+            <div class="status-corner"><span class="t3 t3--stop">STOP</span></div>
+            KCVV — Mech · stopped
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Notes</h4>
+          <ul>
+            <li>Reader sees severity at a glance — FF / PP / STOP stand out from the routine FT</li>
+            <li>Same chrome geometry as T2 (border + shadow + mono caps); only the bg tint differs per status</li>
+            <li>Tints use existing tokens: warm (already shipped for kicker variants), cream-deep (existing neutral fallback), card-red (would need a token — currently only used in test status colouring)</li>
+            <li>Risk: adding red to the redesign palette where it wasn't before. <code>--color-card-red</code> doesn't exist as a token today; STOP is so rare that a token decision for one badge may be over-engineered</li>
+            <li>Could downgrade STOP to use the warm tint (shared with FF) — STOP is rare enough that distinguishing it from FF visually may not matter</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1600px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 1 of 6.B.d5 · status badge treatment · pick one
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
@@ -66,6 +66,24 @@ After round 1 owner direction: **A (mini-hero) picked**, with feedback that the 
 
 Visual artifact: `round-2-matchteaser-A-stub-iterations.html`.
 
+## Round 3 — A2-italic mix + compact correction
+
+After round 2 owner direction: **A2 base picked**, with one refinement (month label in italic display, not mono caps) and one clarification ("where is compact used? — there is no date indication in compact"). Production consumer audit corrects an earlier mistake:
+
+| Consumer | Surface | Variant | Theme |
+| --- | --- | --- | --- |
+| `<MatchesSlider>` (homepage + team pages) | Homepage slider band; sidebar widgets | **`variant="compact"`** | dark (homepage) + light (sidebars) |
+| `<CalendarMonth>` | `/kalender` selected-day list | `variant="default"` | light |
+
+Compact is therefore the **most-consumed surface** (homepage slider is the site's busiest match-discovery surface). The round-2 A2 compact had the date too small (17px) on a cream-soft stub against a cream card — visually getting lost. Round 3 fixes this:
+
+- Stub widths: **76px** default (was 72px), **64px** compact (was 54px)
+- Date typography: **30px** default (was 24px), **22px** compact (was 17px) — display-big weight 900
+- Month label switches from mono caps to italic display ("juni") — owner's mix request
+- Compact rendered in BOTH light (sidebar) AND dark (homepage slider) contexts so the production look is verifiable
+
+Visual artifact: `round-3-matchteaser-A2-italic.html` — three panels (default-light, compact-light, compact-dark) with same A2-italic chrome across all.
+
 ## Things this drill does NOT decide
 
 - Highlight treatment (round 2)

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
@@ -84,6 +84,18 @@ Compact is therefore the **most-consumed surface** (homepage slider is the site'
 
 Visual artifact: `round-3-matchteaser-A2-italic.html` — three panels (default-light, compact-light, compact-dark) with same A2-italic chrome across all.
 
+## Scope slim-down (LOCKED at round 3 close)
+
+After round 3, a consumer-audit correction surfaces: **`<MatchesSlider>` was retired from the homepage by Phase 4.B.2** (replaced by `<UpcomingMatches>`, which doesn't use `<MatchTeaser>` at all). The actual non-legacy production consumer map for `<MatchTeaser>` is:
+
+| Consumer | Variant | Status |
+| --- | --- | --- |
+| `<CalendarMonth>` (day-detail list at `/kalender`) | default | ✅ Live |
+| `<MatchesSlider>` (orphan; no app route mounts it) | compact | 💀 Retire as dead code |
+| `<UpcomingMatches>` (new homepage block) | n/a | Renders its own primitives — doesn't use MatchTeaser |
+
+The `compact` variant has **zero active consumers**. Owner direction: slim d6 to the default variant only. Compact + `<MatchesSlider>` retire as dead code in Phase 6.B implementation. Full decision captured in `../matchteaser-locked.md`.
+
 ## Things this drill does NOT decide
 
 - Highlight treatment (round 2)

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
@@ -1,0 +1,63 @@
+# 6.B.d6 · `<MatchTeaser>` — primitive comparison map
+
+**Round 1.** The most cross-cutting drill in Phase 6.B. `<MatchTeaser>` is consumed by `<MatchesSlider>` (homepage), `<CalendarMonth>`, sidebar widgets, recent-matches grids on player profiles, and the slider stories at `HorizontalSlider.stories.tsx`. Two variants today: `default` and `compact`. Both in scope per Phase 6 epic #1528.
+
+Visual artifact: `round-1-matchteaser-comparisons.html` — three structural shapes, each showing **default + compact size side-by-side** in the same panel so the relationship between sizes is judged together. Same finished match across all variants (KCVV 3 — 1 RC Mech, KCVV-home).
+
+Theme (light vs dark), states (upcoming / edge) and per-status badge integration are settled in round 2 after the structural shape locks.
+
+## Reference locks consumed
+
+- `matchhero-locked.md` (6.B.d2) — H1 + T2 ticket-card sets the page-level match-card vocabulary; teaser should be a smaller relative
+- `matchstatusbadge-locked.md` (6.B.d5) — `<MatchStatusBadge>` is the corner stamp; teaser mounts it for edge states
+- `lineup-events-locked.md` (6.B.d3) — wraps existing primitives; teaser already exists and gets reskinned (no greenfield rebuild)
+- Phase 4.5 R10 card structure — flush-edge cards + outer `<TapedCard>` + 1px ink rule between zones
+- The `HorizontalSlider.stories.tsx` PR #1594 inline mock — starting reference, NOT a contract (per #1528 explicit note)
+
+## Variants
+
+- **A — Mini-hero (ticket-card descendant).** Apply d2's ticket-card shape at teaser scale. Left stub (~80px) with the big display date + kickoff time. Right body with teams + score, mono caps. Same dashed-divider chrome as `<MatchHero>` (no perforations per d2 T2). Most vocabulary-consistent with the page hero.
+- **B — Vertical stacked card.** Date kicker on top, teams stacked vertically (home above away) with score on the right column, venue/competition mono row at the bottom. Different shape from the hero but matchday-card-flavored. Maps naturally to a slider card aspect ratio (taller than wide).
+- **C — Horizontal fixture row.** Date | home shield + name | score | away name + shield | venue. Reads like a fixture-list row. Most compact, most list-friendly — but loses the matchday-card identity at default size.
+
+## Vocabulary deltas summary
+
+| Variant | Δ count | Severity | Cost | Notes |
+| --- | --- | --- | --- | --- |
+| **A** | 0 | Low | Reuses d2's ticket-card layout (stub + body + dashed divider); just smaller | Strongest visual coherence with `<MatchHero>`. Same component family reads up + down the size scale. |
+| **B** | 0 | Low | Composes `<TapedCard>` + stacked team rows + `<NumberDisplay>` score | Slider-natural aspect ratio. Differentiates from hero (intentional — hero is the page anchor, teaser is the navigation). |
+| **C** | 0 | Low | Pure horizontal row layout | Most space-efficient. Compact variant becomes trivial — just shrink the heights. Loses card identity though; reads as a table row, not a teaser. |
+
+## Default + compact relationship
+
+Each variant must scale **down** cleanly to a compact size used by `<CalendarMonth>` rows and tight sidebar contexts. Per epic, compact stays a separate variant — not a CSS media-query collapse. So compact has its own layout decisions, but it should be a clear shrink of the default.
+
+| Variant | Default → Compact relationship |
+| --- | --- |
+| **A — Mini-hero** | Stub width shrinks from ~80px → ~64px; team names abbreviate (e.g. "KCVV Elewijt" → "KCVV E."); score size drops; venue line dropped |
+| **B — Vertical stacked** | Team rows tighten; score column narrows; venue/competition row dropped entirely; minimum height ~60% of default |
+| **C — Horizontal row** | Already row-shaped — compact is a height + padding shrink only. Trivially smaller. |
+
+## Highlight + theme caveats (deferred to round 2)
+
+- **Highlight rule:** the KCVV team gets visually emphasised (italic display, jersey-deep tint, or a side stripe). All three variants support this — the exact treatment is round 2.
+- **Light vs dark theme:** consumers like `MatchesSlider` (homepage) need a dark theme for the ink-band placement. Round 2 mockup renders the chosen shape in both themes.
+- **Edge states** (FF / PP / CANC / STOP): all three variants render `<MatchStatusBadge>` per d5; placement on the teaser is round 2.
+
+## Cross-cutting consumer audit
+
+| Consumer | Surface | Currently uses | Implication for the chosen shape |
+| --- | --- | --- | --- |
+| `<MatchesSlider>` (homepage) | Dark ink band | `<MatchTeaser theme="dark" variant="default">` | Variant A's stub doesn't darken-friendly without thinking about ticket-stub tint reversal; B + C cleaner under dark |
+| `<CalendarMonth>` | Light cream rows | `<MatchTeaser variant="compact">` | C's row layout is the natural fit; A + B work but compact-shrink is more invasive |
+| Sidebar widgets / recent-matches grids on player profiles | Light cream cards | `<MatchTeaser variant="default">` | All three work; A reinforces the page hero on player profiles; B + C feel more like a generic card |
+| `HorizontalSlider.stories.tsx` inline mock | Storybook only | The PR-#1594 mock | Migrate the stories to render the real component once d6 locks; delete the inline mock per #1528 follow-up cleanup |
+
+## Things this drill does NOT decide
+
+- Highlight treatment (round 2)
+- Light vs dark theme (round 2)
+- Edge-state visual layout (round 2)
+- Score row typography sizing — flows from the chosen shape; locked in round 2
+- The `HorizontalSlider.stories.tsx` mock migration — separate cleanup ticket per #1528
+- Mobile collapse — teasers already work on mobile via stacking; tightened in round 2 if needed

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/compare.md
@@ -53,6 +53,19 @@ Each variant must scale **down** cleanly to a compact size used by `<CalendarMon
 | Sidebar widgets / recent-matches grids on player profiles | Light cream cards | `<MatchTeaser variant="default">` | All three work; A reinforces the page hero on player profiles; B + C feel more like a generic card |
 | `HorizontalSlider.stories.tsx` inline mock | Storybook only | The PR-#1594 mock | Migrate the stories to render the real component once d6 locks; delete the inline mock per #1528 follow-up cleanup |
 
+## Round 2 — A stub iterations
+
+After round 1 owner direction: **A (mini-hero) picked**, with feedback that the left stub feels too dense. Round 2 explores three thinning iterations — same overall A shape, only the stub varies. Round-1 A is included as reference.
+
+| Iteration | Change to stub | Δ horizontal space | Tradeoff |
+| --- | --- | --- | --- |
+| **A0 — Reference** | Round 1 as shipped: weekday + day + month + time + display-big weight in 80px column | 80px / 64px | Baseline ("too dense") |
+| **A1 — Drop weekday** | Single-line "14 JUN" + time; same widths; display-big stays | 80px / 64px | Smallest change; one fewer info unit; day-of-week lost from the card |
+| **A2 — Date-only stub** | Big date number + mono month label only; centred; time moves to body kicker row | 72px / 54px | Most calendar-page identity; loses time from the stub |
+| **A3 — Wider, mono date** | Wider stub (~100px); display-big dropped entirely; day name spelled out ("ZATERDAG") + mono date + mono time | 100px / 80px | Calmest typography; loses display-big stamp; eats more horizontal space |
+
+Visual artifact: `round-2-matchteaser-A-stub-iterations.html`.
+
 ## Things this drill does NOT decide
 
 - Highlight treatment (round 2)

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/round-1-matchteaser-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/round-1-matchteaser-comparisons.html
@@ -1,0 +1,786 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 1 · MatchTeaser (6.B.d6)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1600px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1600px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+        align-items: start;
+      }
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.7;
+      }
+
+      .demo { padding: 6px 18px 22px; }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      .shield {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        flex-shrink: 0;
+      }
+      .shield--opp {
+        background:
+          radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%);
+      }
+      .shield--lg { width: 36px; height: 42px; font-size: 12px; }
+      .shield--sm { width: 24px; height: 28px; font-size: 9px; }
+
+      /* ═══════════════════════════════════════════
+         Variant A — Mini-hero (ticket-card descendant)
+         ═══════════════════════════════════════════ */
+      .a-default {
+        display: grid;
+        grid-template-columns: 80px 1fr;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        margin-bottom: 16px;
+      }
+      .a-default .stub {
+        padding: 12px 10px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 8.5px;
+      }
+      .a-default .stub .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 16px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+        margin-bottom: 4px;
+        text-transform: none;
+        font-style: normal;
+      }
+      .a-default .stub .time {
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        opacity: 0.75;
+      }
+      .a-default .body {
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .a-default .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 10px;
+        align-items: center;
+      }
+      .a-default .teams .team {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.015em;
+        line-height: 1.1;
+      }
+      .a-default .teams .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .a-default .teams .team--highlight {
+        font-weight: 600;
+      }
+      .a-default .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+      .a-default .meta {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        opacity: 0.6;
+      }
+
+      .a-compact {
+        display: grid;
+        grid-template-columns: 64px 1fr;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .a-compact .stub {
+        padding: 8px 8px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 7.5px;
+      }
+      .a-compact .stub .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 12px;
+        line-height: 1;
+        margin-bottom: 2px;
+        text-transform: none;
+        font-style: normal;
+        letter-spacing: -0.02em;
+      }
+      .a-compact .body {
+        padding: 8px 10px;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 6px;
+        align-items: center;
+      }
+      .a-compact .team {
+        display: flex;
+        gap: 5px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 11px;
+        line-height: 1.1;
+      }
+      .a-compact .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .a-compact .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 16px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant B — Vertical stacked
+         ═══════════════════════════════════════════ */
+      .b-default {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 14px 16px;
+        margin-bottom: 16px;
+      }
+      .b-default .kicker {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+        margin-bottom: 10px;
+      }
+      .b-default .teams-grid {
+        display: grid;
+        grid-template-columns: 1fr 40px;
+        gap: 8px 12px;
+        align-items: center;
+      }
+      .b-default .team-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 16px;
+        letter-spacing: -0.02em;
+        line-height: 1.1;
+      }
+      .b-default .team-row--highlight {
+        font-weight: 600;
+      }
+      .b-default .score-col {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 22px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+        text-align: right;
+        grid-row: 1 / 3;
+        align-self: center;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 4px;
+      }
+      .b-default .meta {
+        margin-top: 12px;
+        padding-top: 8px;
+        border-top: 1px solid var(--color-ink);
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        opacity: 0.65;
+      }
+
+      .b-compact {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 10px 12px;
+      }
+      .b-compact .kicker {
+        font-family: var(--font-mono);
+        font-size: 8.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        opacity: 0.65;
+        margin-bottom: 6px;
+      }
+      .b-compact .teams-grid {
+        display: grid;
+        grid-template-columns: 1fr 30px;
+        gap: 4px 8px;
+        align-items: center;
+      }
+      .b-compact .team-row {
+        display: flex;
+        gap: 7px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 12px;
+        line-height: 1.1;
+      }
+      .b-compact .team-row--highlight { font-weight: 600; }
+      .b-compact .score-col {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 15px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+        text-align: right;
+        grid-row: 1 / 3;
+        align-self: center;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 2px;
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant C — Horizontal fixture row
+         ═══════════════════════════════════════════ */
+      .c-default {
+        display: grid;
+        grid-template-columns: 78px 1fr auto 1fr;
+        align-items: center;
+        gap: 10px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 10px 14px;
+        margin-bottom: 16px;
+      }
+      .c-default .date-col {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 9px;
+        line-height: 1.2;
+        opacity: 0.75;
+        border-right: 1px dashed var(--color-ink-muted);
+        padding-right: 8px;
+      }
+      .c-default .date-col .date-strong {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 13px;
+        letter-spacing: -0.02em;
+        line-height: 1;
+        margin-bottom: 2px;
+        text-transform: none;
+        font-style: normal;
+        opacity: 1;
+      }
+      .c-default .home-col {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.015em;
+      }
+      .c-default .away-col {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-direction: row-reverse;
+        text-align: right;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.015em;
+      }
+      .c-default .team--highlight { font-weight: 600; }
+      .c-default .score-col {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        line-height: 1;
+        letter-spacing: -0.04em;
+        padding: 0 6px;
+      }
+
+      .c-compact {
+        display: grid;
+        grid-template-columns: 60px 1fr auto 1fr;
+        align-items: center;
+        gap: 8px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 6px 10px;
+      }
+      .c-compact .date-col {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 8px;
+        line-height: 1.2;
+        opacity: 0.7;
+        border-right: 1px dashed var(--color-ink-muted);
+        padding-right: 6px;
+      }
+      .c-compact .date-col .date-strong {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 11px;
+        letter-spacing: -0.02em;
+        line-height: 1;
+        margin-bottom: 1px;
+        text-transform: none;
+        font-style: normal;
+      }
+      .c-compact .home-col,
+      .c-compact .away-col {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 11px;
+      }
+      .c-compact .away-col { flex-direction: row-reverse; text-align: right; }
+      .c-compact .team--highlight { font-weight: 600; }
+      .c-compact .score-col {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 14px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+        padding: 0 5px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 1 · `&lt;MatchTeaser&gt;`</div>
+      <h1>How should the teaser card look at default + compact?</h1>
+      <p>
+        Three structural shapes. Each variant renders the
+        <strong>default + compact size side-by-side</strong> in the same
+        panel so the relationship between the two sizes is visible.
+        Same finished match across all variants — KCVV Elewijt 3 — 1
+        RC Mechelen, KCVV-home, played 14 June 14:30 at Sportpark Elewijt.
+        Theme (light/dark), edge states + highlight treatment all
+        deferred to round 2.
+      </p>
+      <span class="scope-banner">Pick one structural shape · round 2 covers theme + states</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ A — Mini-hero (ticket-card descendant) ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant A</div>
+          <h2>Mini-hero.</h2>
+          <p class="sub">
+            d2's ticket-card shape at smaller scale. Left stub (~80px) =
+            big display date + kickoff time. Right body = teams + score
+            + competition mono row. Same dashed-divider chrome as the
+            page hero (no perforations per d2 T2). Strongest vocabulary
+            coherence with <code>&lt;MatchHero&gt;</code>.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Matches MatchHero vocab</span>
+            <span class="chip chip--cost">Stub eats horizontal space</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="a-default">
+            <aside class="stub">
+              <div class="date">ZA 14<br />JUN</div>
+              <div class="time">14:30</div>
+            </aside>
+            <div class="body">
+              <div class="teams">
+                <div class="team team--highlight">
+                  <span class="shield shield--lg">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score">3 — 1</div>
+                <div class="team team--away">
+                  <span class="shield shield--lg shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+              <div class="meta">3E PROVINCIALE A · SPORTPARK ELEWIJT</div>
+            </div>
+          </div>
+
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="a-compact">
+            <aside class="stub">
+              <div class="date">14<br />JUN</div>
+              <span>14:30</span>
+            </aside>
+            <div class="body">
+              <div class="team team--highlight">
+                <span class="shield shield--sm">K</span>
+                <span>KCVV E.</span>
+              </div>
+              <div class="score">3 — 1</div>
+              <div class="team team--away">
+                <span class="shield shield--sm shield--opp">M</span>
+                <span>RC Mech.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Same component family as <code>&lt;MatchHero&gt;</code> — reads up + down the size scale as one vocabulary</li>
+            <li>Dashed-divider stub motif is distinctive at all sizes</li>
+            <li>Date stays prominent — readers scan slider/calendar rows by date</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Stub width (~80px default, ~64px compact) eats horizontal space — fewer characters for team names</li>
+            <li>On dark theme (homepage slider): stub tint needs to invert/adapt — not free</li>
+            <li>Compact loses venue + competition — venue drop is unavoidable for any compact variant though</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ B — Vertical stacked ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant B</div>
+          <h2>Vertical stacked.</h2>
+          <p class="sub">
+            Date kicker on top, teams stacked vertically (home above away)
+            with score on the right column. Venue / competition mono row
+            at the bottom. Different shape from
+            <code>&lt;MatchHero&gt;</code> — intentional, the teaser plays a
+            different role (navigation, not page anchor).
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Slider-natural aspect ratio</span>
+            <span class="chip chip--cost">Less direct visual link to hero</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="b-default">
+            <div class="kicker">ZA 14 JUN · 14:30</div>
+            <div class="teams-grid">
+              <div class="team-row team-row--highlight">
+                <span class="shield shield--lg">K</span>
+                <span>KCVV Elewijt</span>
+              </div>
+              <div class="score-col">3<br />1</div>
+              <div class="team-row">
+                <span class="shield shield--lg shield--opp">M</span>
+                <span>RC Mechelen</span>
+              </div>
+            </div>
+            <div class="meta">3E PROVINCIALE A · SPORTPARK ELEWIJT</div>
+          </div>
+
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="b-compact">
+            <div class="kicker">ZA 14 JUN · 14:30</div>
+            <div class="teams-grid">
+              <div class="team-row team-row--highlight">
+                <span class="shield shield--sm">K</span>
+                <span>KCVV E.</span>
+              </div>
+              <div class="score-col">3<br />1</div>
+              <div class="team-row">
+                <span class="shield shield--sm shield--opp">M</span>
+                <span>RC Mech.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Aspect ratio natural for the homepage slider — taller cards read as cards, not as rows</li>
+            <li>Highlighted team (home in this case) reads top-down — natural eye flow</li>
+            <li>Score-column stacking (3 over 1) mirrors the team rows; reads naturally</li>
+            <li>Dark theme is straightforward — invert text + bg, no special chrome adaptation</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Most different from <code>&lt;MatchHero&gt;</code> — readers have to learn two card shapes for the same domain</li>
+            <li>Compact still has decent height; not the most space-efficient for calendar rows</li>
+            <li>Score-column stacking can read as "3 — 1" vertical OR as two separate digits — risk of misread on edge cases</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ C — Horizontal fixture row ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">Variant C</div>
+          <h2>Horizontal fixture row.</h2>
+          <p class="sub">
+            Date column on the left | home (shield + name) | score |
+            away (name + shield) | optional venue/competition strip
+            below. Reads like a fixture-list row. Most space-efficient;
+            compact is just a smaller padding + smaller font.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">0 new primitive</span>
+            <span class="chip chip--good">Most space-efficient</span>
+            <span class="chip chip--cost">Loses card identity at default</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="c-default">
+            <div class="date-col">
+              <div class="date-strong">14 JUN</div>
+              ZA · 14:30
+            </div>
+            <div class="home-col team--highlight">
+              <span class="shield shield--lg">K</span>
+              <span>KCVV Elewijt</span>
+            </div>
+            <div class="score-col">3 — 1</div>
+            <div class="away-col">
+              <span class="shield shield--lg shield--opp">M</span>
+              <span>RC Mechelen</span>
+            </div>
+          </div>
+
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="c-compact">
+            <div class="date-col">
+              <div class="date-strong">14 JUN</div>
+              14:30
+            </div>
+            <div class="home-col team--highlight">
+              <span class="shield shield--sm">K</span>
+              <span>KCVV E.</span>
+            </div>
+            <div class="score-col">3 — 1</div>
+            <div class="away-col">
+              <span class="shield shield--sm shield--opp">M</span>
+              <span>RC Mech.</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Most space-efficient at both default + compact sizes</li>
+            <li>Compact variant is trivial — same layout, smaller; trivial CSS difference</li>
+            <li>Reads naturally in <code>&lt;CalendarMonth&gt;</code> rows — calendar entries are inherently row-like</li>
+            <li>Date column on the left mirrors A's stub motif (lighter weight version)</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Default doesn't feel like a "card" — reads as a list row, not a card. Loses matchday-card identity on the slider</li>
+            <li>The homepage slider (dark band) currently expects card-shaped teasers — rows feel uncanny there</li>
+            <li>Venue / competition needs a 2nd row below; this mockup shows the chrome-only version</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1600px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 1 of 6.B.d6 · structural shape · pick one
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/round-2-matchteaser-A-stub-iterations.html
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/round-2-matchteaser-A-stub-iterations.html
@@ -1,0 +1,774 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 2 · MatchTeaser A stub iterations (6.B.d6)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1920px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1920px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 22px;
+        align-items: start;
+      }
+      .variant {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .variant > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .variant--reference > header.card {
+        background: var(--color-cream-deep);
+      }
+      .variant > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .variant > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .variant > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .chips {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-top: 10px;
+      }
+      .chip {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        padding: 3px 7px;
+        border: 1px solid var(--color-ink);
+        background: var(--color-cream);
+      }
+      .chip--good { background: var(--color-cream); }
+      .chip--cost { background: var(--color-cream-deep); }
+      .chip--delta { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+      .chip--reference { background: var(--color-cream-deep); }
+
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.7;
+      }
+      .demo { padding: 6px 18px 22px; }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      .shield {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        flex-shrink: 0;
+      }
+      .shield--opp {
+        background:
+          radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%);
+      }
+      .shield--lg { width: 36px; height: 42px; font-size: 12px; }
+      .shield--sm { width: 24px; height: 28px; font-size: 9px; }
+
+      /* Shared card chrome */
+      .card-default,
+      .card-compact {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .card-default { margin-bottom: 16px; }
+      .body-d {
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .body-c {
+        padding: 8px 10px;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 6px;
+        align-items: center;
+      }
+      .teams-d {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 10px;
+        align-items: center;
+      }
+      .team-d {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.015em;
+        line-height: 1.1;
+      }
+      .team-d--away { justify-self: end; flex-direction: row-reverse; text-align: right; }
+      .team-d--highlight { font-weight: 600; }
+      .team-c {
+        display: flex;
+        gap: 5px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 11px;
+        line-height: 1.1;
+      }
+      .team-c--away { justify-self: end; flex-direction: row-reverse; text-align: right; }
+      .team-c--highlight { font-weight: 600; }
+      .score-d {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+      .score-c {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 16px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+      }
+      .meta-d {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        opacity: 0.6;
+      }
+      .kicker-d {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        opacity: 0.6;
+        margin-bottom: 4px;
+      }
+
+      /* ───────── A0 — original (for reference) ───────── */
+      .a0-default { display: grid; grid-template-columns: 80px 1fr; }
+      .a0-default .stub-d {
+        padding: 12px 10px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 8.5px;
+      }
+      .a0-default .stub-d .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 16px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+        margin-bottom: 4px;
+        text-transform: none;
+        font-style: normal;
+      }
+      .a0-default .stub-d .time {
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        opacity: 0.75;
+      }
+      .a0-compact { display: grid; grid-template-columns: 64px 1fr; }
+      .a0-compact .stub-c {
+        padding: 8px 8px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 7.5px;
+      }
+      .a0-compact .stub-c .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 12px;
+        line-height: 1;
+        margin-bottom: 2px;
+        text-transform: none;
+        font-style: normal;
+        letter-spacing: -0.02em;
+      }
+
+      /* ───────── A1 — drop weekday ───────── */
+      .a1-default { display: grid; grid-template-columns: 80px 1fr; }
+      .a1-default .stub-d {
+        padding: 14px 12px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+      }
+      .a1-default .stub-d .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 18px;
+        letter-spacing: -0.025em;
+        line-height: 1;
+        margin-bottom: 5px;
+      }
+      .a1-default .stub-d .time {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      .a1-compact { display: grid; grid-template-columns: 64px 1fr; }
+      .a1-compact .stub-c {
+        padding: 9px 9px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+      }
+      .a1-compact .stub-c .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 13px;
+        line-height: 1;
+        margin-bottom: 3px;
+        letter-spacing: -0.02em;
+      }
+      .a1-compact .stub-c .time {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+
+      /* ───────── A2 — date-only stub (time in body) ───────── */
+      .a2-default { display: grid; grid-template-columns: 72px 1fr; }
+      .a2-default .stub-d {
+        padding: 14px 10px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        text-align: center;
+      }
+      .a2-default .stub-d .date-big {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 24px;
+        letter-spacing: -0.03em;
+        line-height: 1;
+      }
+      .a2-default .stub-d .month {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        margin-top: 3px;
+        opacity: 0.7;
+      }
+      .a2-default .body-d .kicker-d { margin-bottom: 6px; }
+      .a2-compact { display: grid; grid-template-columns: 54px 1fr; }
+      .a2-compact .stub-c {
+        padding: 9px 6px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        text-align: center;
+      }
+      .a2-compact .stub-c .date-big {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 17px;
+        letter-spacing: -0.02em;
+        line-height: 1;
+      }
+      .a2-compact .stub-c .month {
+        font-family: var(--font-mono);
+        font-size: 8px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        margin-top: 2px;
+        opacity: 0.7;
+      }
+
+      /* ───────── A3 — wider + lighter (~100px, mono caps date) ───────── */
+      .a3-default { display: grid; grid-template-columns: 100px 1fr; }
+      .a3-default .stub-d {
+        padding: 14px 14px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+      }
+      .a3-default .stub-d .day {
+        font-family: var(--font-mono);
+        font-size: 9.5px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.65;
+        margin-bottom: 4px;
+      }
+      .a3-default .stub-d .date {
+        font-family: var(--font-mono);
+        font-size: 14px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        font-weight: 700;
+        line-height: 1;
+        margin-bottom: 8px;
+      }
+      .a3-default .stub-d .time {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.75;
+      }
+      .a3-compact { display: grid; grid-template-columns: 80px 1fr; }
+      .a3-compact .stub-c {
+        padding: 9px 10px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+      }
+      .a3-compact .stub-c .date {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-weight: 700;
+        line-height: 1;
+        margin-bottom: 4px;
+      }
+      .a3-compact .stub-c .time {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 2 · `&lt;MatchTeaser&gt;` · A stub iterations</div>
+      <h1>How dense should the left stub be?</h1>
+      <p>
+        Owner picked Variant A (mini-hero) but flagged the left stub as too
+        dense. Three iterations explore different ways to thin it out.
+        Round-1 A is included on the left as the reference baseline.
+      </p>
+      <span class="scope-banner">Pick one stub treatment · falls back to A0 if none feel right</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ A0 — original reference ═════════════ -->
+      <article class="variant variant--reference">
+        <header class="card">
+          <div class="label">A0 — Reference</div>
+          <h2>Original (round 1).</h2>
+          <p class="sub">
+            What round 1 shipped. Stub width 80px / 64px (default / compact).
+            Content: <strong>ZA 14</strong>, <strong>JUN</strong>, time.
+            Display-big weight at default. The "too dense" baseline.
+          </p>
+          <div class="chips">
+            <span class="chip chip--reference">For comparison only</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="a0-default card-default">
+            <aside class="stub-d">
+              <div class="date">ZA 14<br />JUN</div>
+              <div class="time">14:30</div>
+            </aside>
+            <div class="body-d">
+              <div class="teams-d">
+                <div class="team-d team-d--highlight">
+                  <span class="shield shield--lg">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score-d">3 — 1</div>
+                <div class="team-d team-d--away">
+                  <span class="shield shield--lg shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+              <div class="meta-d">3E PROVINCIALE A · SPORTPARK ELEWIJT</div>
+            </div>
+          </div>
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="a0-compact card-compact">
+            <aside class="stub-c">
+              <div class="date">14<br />JUN</div>
+              <span>14:30</span>
+            </aside>
+            <div class="body-c">
+              <div class="team-c team-c--highlight">
+                <span class="shield shield--sm">K</span>
+                <span>KCVV E.</span>
+              </div>
+              <div class="score-c">3 — 1</div>
+              <div class="team-c team-c--away">
+                <span class="shield shield--sm shield--opp">M</span>
+                <span>RC Mech.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Why "too dense"</h4>
+          <ul>
+            <li>4 information units (weekday / day / month / time) in a narrow column</li>
+            <li>Display-big weight makes the date typographically heavy</li>
+            <li>Two lines of date stack on top of the time — visual stack feels crowded</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ A1 — drop weekday ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">A1</div>
+          <h2>Drop weekday.</h2>
+          <p class="sub">
+            Smallest change: drop the <code>ZA</code> prefix. Day-of-week is
+            already implied by context (slider rows are sorted; calendar
+            rows live under a day header). One fewer info unit in the stub,
+            slightly more breathing room around the date.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">Smallest change</span>
+            <span class="chip chip--cost">Day-of-week lost from card itself</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="a1-default card-default">
+            <aside class="stub-d">
+              <div class="date">14 JUN</div>
+              <div class="time">14:30</div>
+            </aside>
+            <div class="body-d">
+              <div class="teams-d">
+                <div class="team-d team-d--highlight">
+                  <span class="shield shield--lg">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score-d">3 — 1</div>
+                <div class="team-d team-d--away">
+                  <span class="shield shield--lg shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+              <div class="meta-d">3E PROVINCIALE A · SPORTPARK ELEWIJT</div>
+            </div>
+          </div>
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="a1-compact card-compact">
+            <aside class="stub-c">
+              <div class="date">14 JUN</div>
+              <div class="time">14:30</div>
+            </aside>
+            <div class="body-c">
+              <div class="team-c team-c--highlight">
+                <span class="shield shield--sm">K</span>
+                <span>KCVV E.</span>
+              </div>
+              <div class="score-c">3 — 1</div>
+              <div class="team-c team-c--away">
+                <span class="shield shield--sm shield--opp">M</span>
+                <span>RC Mech.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Minimal change to A — same widths, same chrome, one fewer line of text</li>
+            <li>Date reads as one continuous unit ("14 JUN") instead of split across lines</li>
+            <li>Weekday is contextual data — calendar / slider rows usually provide it elsewhere</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>If the teaser appears in a non-grouped context (e.g. team page recent matches), losing the weekday means the reader has to derive it</li>
+            <li>Doesn't address the visual-weight density (display-big stays)</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ A2 — date-only stub (time in body) ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">A2</div>
+          <h2>Date-only stub.</h2>
+          <p class="sub">
+            Stub becomes <strong>one display-big date number stacked over a
+            mono month label</strong>. Time moves to a kicker row in the
+            body. Stub looks like a torn-off calendar page; body owns
+            scheduling chrome. Centred typography.
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">Most calendar-page feel</span>
+            <span class="chip chip--cost">Time loses stub prominence</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="a2-default card-default">
+            <aside class="stub-d">
+              <div class="date-big">14</div>
+              <div class="month">JUN</div>
+            </aside>
+            <div class="body-d">
+              <div class="kicker-d">ZA · 14:30 · SPORTPARK ELEWIJT</div>
+              <div class="teams-d">
+                <div class="team-d team-d--highlight">
+                  <span class="shield shield--lg">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score-d">3 — 1</div>
+                <div class="team-d team-d--away">
+                  <span class="shield shield--lg shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="a2-compact card-compact">
+            <aside class="stub-c">
+              <div class="date-big">14</div>
+              <div class="month">JUN</div>
+            </aside>
+            <div class="body-c">
+              <div class="team-c team-c--highlight">
+                <span class="shield shield--sm">K</span>
+                <span>KCVV E.</span>
+              </div>
+              <div class="score-c">3 — 1</div>
+              <div class="team-c team-c--away">
+                <span class="shield shield--sm shield--opp">M</span>
+                <span>RC Mech.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Stub is the single most uncluttered of the four — one big number + a mono label</li>
+            <li>Most "torn calendar page" identity — leans into the editorial-paper vocabulary</li>
+            <li>Body can carry richer scheduling chrome (day + time + venue all in one mono row) without crowding</li>
+            <li>Compact reads tightly — date number stays prominent at small scale</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Time is no longer in the stub — readers scanning slider/calendar for kickoff time have to look at the body row</li>
+            <li>Body grows a kicker row to absorb the time/venue — slightly taller default card</li>
+            <li>Compact loses the kicker row entirely (no room) — time is implicit at small scale</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ A3 — wider + lighter ═════════════ -->
+      <article class="variant">
+        <header class="card">
+          <div class="label">A3</div>
+          <h2>Wider stub, mono date.</h2>
+          <p class="sub">
+            Wider stub (~100px / 80px) but the display-big date drops out
+            entirely. Stub becomes <strong>mono caps day on top, mono caps
+            date, mono caps time</strong> — calmer typography, more
+            breathing room. Stub reads as a "mono tag" instead of a
+            "ticket-stub date stamp".
+          </p>
+          <div class="chips">
+            <span class="chip chip--good">Calmest typography</span>
+            <span class="chip chip--cost">Loses display-date impact</span>
+          </div>
+        </header>
+
+        <div class="stage-label">Default</div>
+        <div class="demo">
+          <div class="a3-default card-default">
+            <aside class="stub-d">
+              <div class="day">ZATERDAG</div>
+              <div class="date">14 JUN</div>
+              <div class="time">14:30</div>
+            </aside>
+            <div class="body-d">
+              <div class="teams-d">
+                <div class="team-d team-d--highlight">
+                  <span class="shield shield--lg">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score-d">3 — 1</div>
+                <div class="team-d team-d--away">
+                  <span class="shield shield--lg shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+              <div class="meta-d">3E PROVINCIALE A · SPORTPARK ELEWIJT</div>
+            </div>
+          </div>
+          <div class="stage-label" style="padding-left:0">Compact</div>
+          <div class="a3-compact card-compact">
+            <aside class="stub-c">
+              <div class="date">14 JUN</div>
+              <div class="time">14:30</div>
+            </aside>
+            <div class="body-c">
+              <div class="team-c team-c--highlight">
+                <span class="shield shield--sm">K</span>
+                <span>KCVV E.</span>
+              </div>
+              <div class="score-c">3 — 1</div>
+              <div class="team-c team-c--away">
+                <span class="shield shield--sm shield--opp">M</span>
+                <span>RC Mech.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Wider stub allows full day name ("ZATERDAG") at default</li>
+            <li>Mono-only typography reads as a calmer tag — no display-big punch competing with the score</li>
+            <li>Compact drops the day name automatically (no room) — natural simplification</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Loses the display-big date — the stub no longer "stamps" the date the way the page hero does</li>
+            <li>Wider stub eats more horizontal space — body has fewer chars for team names at default</li>
+            <li>Drifts away from the ticket-card identity that originally won round 2 of d2</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1920px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 2 of 6.B.d6 · A stub iterations · pick one
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/round-3-matchteaser-A2-italic.html
+++ b/docs/design/mockups/phase-6-match-detail/6b6-matchteaser/round-3-matchteaser-A2-italic.html
@@ -1,0 +1,526 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 3 · MatchTeaser A2-italic (6.B.d6)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-sm-soft: 2px 2px 0 0 var(--color-ink-muted);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1440px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1440px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+        align-items: start;
+      }
+      .panel {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .panel > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .panel > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .panel > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .panel > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .panel--dark {
+        background: var(--color-cream-deep);
+      }
+      .panel--dark > header.card {
+        background: var(--color-cream-soft);
+      }
+
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.75;
+      }
+      .stage-sub {
+        font-size: 11px;
+        padding: 0 18px;
+        opacity: 0.55;
+        margin-bottom: 8px;
+      }
+      .demo-light {
+        padding: 16px 18px 22px;
+      }
+      .demo-dark {
+        padding: 22px 18px 22px;
+        background: var(--color-ink);
+        margin-top: 8px;
+      }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      .shield {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        flex-shrink: 0;
+      }
+      .shield--opp {
+        background:
+          radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%);
+      }
+      .shield--lg { width: 36px; height: 42px; font-size: 12px; }
+      .shield--sm { width: 28px; height: 32px; font-size: 10px; }
+
+      /* ═══════════════════════════════════════════
+         A2-italic — shared rules across light + dark
+         ═══════════════════════════════════════════ */
+      .teaser-default {
+        display: grid;
+        grid-template-columns: 76px 1fr;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .teaser-default .stub {
+        padding: 14px 12px 12px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        justify-content: center;
+      }
+      .teaser-default .stub .date-big {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 30px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+      .teaser-default .stub .month {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.01em;
+        line-height: 1;
+        opacity: 0.85;
+      }
+      .teaser-default .body {
+        padding: 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .teaser-default .kicker {
+        font-family: var(--font-mono);
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        opacity: 0.6;
+      }
+      .teaser-default .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 10px;
+        align-items: center;
+      }
+      .teaser-default .team {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 14px;
+        letter-spacing: -0.015em;
+        line-height: 1.1;
+      }
+      .teaser-default .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .teaser-default .team--highlight { font-weight: 600; }
+      .teaser-default .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 20px;
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+
+      /* Compact — the homepage slider workhorse */
+      .teaser-compact {
+        display: grid;
+        grid-template-columns: 64px 1fr;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .teaser-compact .stub {
+        padding: 10px 8px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        justify-content: center;
+      }
+      .teaser-compact .stub .date-big {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 22px;
+        letter-spacing: -0.03em;
+        line-height: 1;
+      }
+      .teaser-compact .stub .month {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 11px;
+        letter-spacing: -0.01em;
+        line-height: 1;
+        opacity: 0.85;
+      }
+      .teaser-compact .body {
+        padding: 10px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .teaser-compact .kicker {
+        font-family: var(--font-mono);
+        font-size: 8.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        opacity: 0.6;
+      }
+      .teaser-compact .teams {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 8px;
+        align-items: center;
+      }
+      .teaser-compact .team {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.1;
+      }
+      .teaser-compact .team--away {
+        justify-self: end;
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+      .teaser-compact .team--highlight { font-weight: 600; }
+      .teaser-compact .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 17px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+      }
+
+      /* Dark theme — homepage slider context */
+      .demo-dark .teaser-default,
+      .demo-dark .teaser-compact {
+        background: var(--color-cream);
+        box-shadow: var(--shadow-paper-sm-soft);
+      }
+      .demo-dark .teaser-default .stub,
+      .demo-dark .teaser-compact .stub {
+        background: var(--color-cream-soft);
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 3 · `&lt;MatchTeaser&gt;` · A2-italic mix</div>
+      <h1>A2 with italic-display month.</h1>
+      <p>
+        Owner picked A2 base (big-date stamp + month label, time moves to
+        body kicker) with one refinement: the month label in italic display
+        instead of mono caps. Plus a clarification on the compact variant —
+        which is in fact the homepage slider workhorse, not a niche calendar
+        thing — so the date needs to be visually unmissable there.
+      </p>
+      <p>
+        Three panels: <strong>Default (light)</strong>,
+        <strong>Compact (light — calendar)</strong>, and
+        <strong>Compact (dark — homepage slider)</strong>. Same A2-italic
+        layout across all three; only the surrounding context varies.
+      </p>
+      <span class="scope-banner">Confirm to lock · or flag any sizing issues</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ Default — light ═════════════ -->
+      <article class="panel">
+        <header class="card">
+          <div class="label">Default — light</div>
+          <h2>The card variant.</h2>
+          <p class="sub">
+            Used by <code>&lt;CalendarMonth&gt;</code> in the day-detail
+            view. 76px stub (slightly wider than before to breathe).
+            Big-display date "14" stacked over italic display "juni" —
+            torn-calendar-page feel with editorial typography.
+          </p>
+        </header>
+
+        <div class="stage-label">/kalender · selected day</div>
+        <div class="stage-sub">Cream paper card on a cream-soft page</div>
+        <div class="demo-light">
+          <div class="teaser-default">
+            <aside class="stub">
+              <div class="date-big">14</div>
+              <div class="month">juni</div>
+            </aside>
+            <div class="body">
+              <div class="kicker">ZA · 14:30 · SPORTPARK ELEWIJT</div>
+              <div class="teams">
+                <div class="team team--highlight">
+                  <span class="shield shield--lg">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score">3 — 1</div>
+                <div class="team team--away">
+                  <span class="shield shield--lg shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Notes</h4>
+          <ul>
+            <li>Stub widened 72 → 76px to give the italic month label horizontal breathing room</li>
+            <li>Display-big "14" at 30px reads as the dominant date stamp</li>
+            <li>Body kicker carries weekday + time + venue in a single mono row</li>
+            <li>This is the <em>default</em> variant — currently consumed only by <code>&lt;CalendarMonth&gt;</code></li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ Compact — light (calendar) ═════════════ -->
+      <article class="panel">
+        <header class="card">
+          <div class="label">Compact — light</div>
+          <h2>The compact variant.</h2>
+          <p class="sub">
+            64px stub. Same A2 chrome as default but tighter typography.
+            Date "14" + italic "juni" still prominent — no longer
+            blending with the background. Kicker keeps weekday + time
+            (no venue on compact).
+          </p>
+        </header>
+
+        <div class="stage-label">Compact on a light surface</div>
+        <div class="stage-sub">Sidebar widgets, recent-matches grids</div>
+        <div class="demo-light">
+          <div class="teaser-compact">
+            <aside class="stub">
+              <div class="date-big">14</div>
+              <div class="month">juni</div>
+            </aside>
+            <div class="body">
+              <div class="kicker">ZA · 14:30</div>
+              <div class="teams">
+                <div class="team team--highlight">
+                  <span class="shield shield--sm">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score">3 — 1</div>
+                <div class="team team--away">
+                  <span class="shield shield--sm shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Notes</h4>
+          <ul>
+            <li>Date "14" now 22px display-big (was 17px in round 2) — unmissable at compact scale</li>
+            <li>Italic "juni" at 11px sits below the date number</li>
+            <li>Shield sized up 24 → 28px for proportionality with the larger date</li>
+            <li>Full team names fit at compact width without abbreviation</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ Compact — dark (homepage slider) ═════════════ -->
+      <article class="panel panel--dark">
+        <header class="card">
+          <div class="label">Compact — dark (HOMEPAGE SLIDER)</div>
+          <h2>Where it actually ships.</h2>
+          <p class="sub">
+            The same compact variant rendered on the ink-band homepage
+            slider context. <code>&lt;MatchesSlider theme="dark"&gt;</code>
+            in <code>MatchesSlider.tsx:81</code> consumes
+            <code>variant="compact"</code> — this is the production
+            workhorse.
+          </p>
+        </header>
+
+        <div class="stage-label">/ (homepage) · MatchesSliderSection</div>
+        <div class="stage-sub">Cream paper card on ink-band — soft shadow</div>
+        <div class="demo-dark">
+          <div class="teaser-compact">
+            <aside class="stub">
+              <div class="date-big">14</div>
+              <div class="month">juni</div>
+            </aside>
+            <div class="body">
+              <div class="kicker">ZA · 14:30</div>
+              <div class="teams">
+                <div class="team team--highlight">
+                  <span class="shield shield--sm">K</span>
+                  <span>KCVV Elewijt</span>
+                </div>
+                <div class="score">3 — 1</div>
+                <div class="team team--away">
+                  <span class="shield shield--sm shield--opp">M</span>
+                  <span>RC Mechelen</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Notes</h4>
+          <ul>
+            <li>Dark theme = ink panel background; teaser card itself stays cream paper (matches Phase 2 Direction D for dark contexts)</li>
+            <li>Shadow swaps to <code>--shadow-paper-sm-soft</code> (ink-muted offset) so the cream card has a visible drop-shadow against ink</li>
+            <li>Same chrome geometry as light — no separate component, just CSS context</li>
+            <li>Date "14" punches off the cream-soft stub regardless of surrounding panel colour</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1440px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 3 of 6.B.d6 · A2-italic + compact rendering · confirm to lock
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b7-matchresultrow/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b7-matchresultrow/compare.md
@@ -1,0 +1,47 @@
+# 6.B.d7 · `<MatchResultRow>` — primitive comparison map
+
+**Round 1.** Reskin of the finished-match table row used by `<TeamSchedule>` on `<TeamDetail>` (`/ploegen/[slug]`). Current implementation predates Phase 4.5 — uses pre-redesign tokens (`kcvv-green-bright`, `kcvv-success`, `kcvv-alert`, `rounded-card`) and doesn't compose with the editorial paper-card vocabulary locked in d2/d6.
+
+Visual artifact: `round-1-matchresultrow-comparisons.html` — two structural shapes. The decision space is narrower than d6: owner consistently picked ticket-card descendants (d2 H1, d6 A2), so this round contrasts a **ticket-card row variant** against a **result-anchored row variant** rather than re-exploring the whole shape space.
+
+## Consumer reality
+
+Single non-legacy consumer: `<TeamSchedule>` inside `<TeamDetail>` on `/ploegen/[slug]`. Light theme. The pre-redesign component supports a dark theme; in the redesigned `<TeamDetail>` (Phase 6.C scope) the dark theme has no consumer either — same logic that retired `<MatchTeaser variant="compact">` in d6. **Dark theme is dropped** in this drill; if Phase 6.C surfaces a dark consumer it spawns a follow-up.
+
+## Reference locks consumed
+
+- `matchhero-locked.md` (d2) — ticket-card stub vocabulary
+- `matchteaser-locked.md` (d6) — A2-italic + display-big date number + italic month label
+- `matchstatusbadge-locked.md` (d5) — corner stamp integration
+- Phase 2 Direction D — paper chrome (`border-2 ink + shadow-paper-sm + bg-cream`)
+
+## Variants
+
+- **A — Mini-teaser row (ticket-card descendant).** Same stub + body shape as `<MatchTeaser>` from d6, scaled DOWN to row height. Date stub on the left (~64px), teams + score in the body. Result indicated by a small coloured pill at the row end (W/L/G — same vocabulary as today, restyled to MonoLabel pill). Strongest visual coherence with the rest of the page.
+- **B — Result-anchored row.** Date column → home (shield + name) → score (big display-big) → away (name + shield) → result indicator pill at the far right. No ticket-card stub. The score IS the visual anchor; result colour reinforces it via subtle row-bg tint (win = cream, draw = cream-soft, loss = warm-tint). Reads as a results table.
+
+## Vocabulary deltas summary
+
+| Variant | Δ count | Severity | Cost | Notes |
+| --- | --- | --- | --- | --- |
+| **A — Mini-teaser row** | 0 | Low | Pure composition of d6 vocabulary at row scale | Vocabulary coherence; reads as "fixture card at row scale". |
+| **B — Result-anchored row** | 0 | Low | New layout but composes existing primitives | More table-like; score is the dominant element. |
+
+## Result-pill vocabulary
+
+Both variants render a small W/L/G result indicator. Today's pre-redesign component uses bg-coloured spans with green/red/yellow tints. The reskin uses MonoLabel pill variants:
+
+| Result | Today (pre-redesign) | Reskinned |
+| --- | --- | --- |
+| **W** (win) | `bg-kcvv-green-bright/15 text-kcvv-green-bright` | `<MonoLabel variant="pill-jersey">W</MonoLabel>` |
+| **G** (draw / gelijkspel) | `bg-yellow-500/15 text-yellow-400` | `<MonoLabel variant="pill-cream">G</MonoLabel>` |
+| **L** (loss) | `bg-red-500/15 text-red-400` | New `pill-warm` variant OR a bordered-cream pill — minor decision deferred to round 2 |
+
+The result-coloured left border in today's component is **dropped** — it doesn't compose with the 2px ink card frame used elsewhere. Result lives in the pill at the row end.
+
+## Things this drill does NOT decide
+
+- Pill colour for "L" — round 2 sub-decision (either a new `pill-warm` variant or a bordered-cream pill matching MatchStatusBadge's STOP tier from d5)
+- Light-only theme behaviour (dropped from scope; revisit if Phase 6.C surfaces a dark consumer)
+- Row-bg tint by result (variant B floats this; if A wins, the tint is moot)
+- Mobile collapse — both variants stack naturally; locked at implementation time

--- a/docs/design/mockups/phase-6-match-detail/6b7-matchresultrow/round-1-matchresultrow-comparisons.html
+++ b/docs/design/mockups/phase-6-match-detail/6b7-matchresultrow/round-1-matchresultrow-comparisons.html
@@ -1,0 +1,499 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 6.B · Round 1 · MatchResultRow (6.B.d7)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --font-display:
+          "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big:
+          "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono:
+          "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+          Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+
+      header.page { max-width: 1280px; margin: 0 auto 36px; }
+      header.page .meta {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 40px;
+        margin: 6px 0 10px;
+        letter-spacing: -0.02em;
+      }
+      header.page p {
+        margin: 0 0 8px;
+        max-width: 90ch;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      header.page code {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        background: var(--color-cream-deep);
+        padding: 1px 5px;
+      }
+      .scope-banner {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 6px 12px;
+        background: var(--color-jersey-deep);
+        color: var(--color-cream);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-weight: 700;
+      }
+
+      .grid {
+        max-width: 1280px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 22px;
+        align-items: start;
+      }
+      .panel {
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-lift);
+        display: flex;
+        flex-direction: column;
+      }
+      .panel > header.card {
+        padding: 16px 18px 14px;
+        border-bottom: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .panel > header.card .label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        opacity: 0.7;
+      }
+      .panel > header.card h2 {
+        margin: 4px 0 6px;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 22px;
+        letter-spacing: -0.015em;
+      }
+      .panel > header.card .sub {
+        font-size: 12.5px;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .stage-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        padding: 14px 18px 6px;
+        opacity: 0.7;
+      }
+      .demo { padding: 6px 18px 22px; }
+      .demo .row-stack > * + * { margin-top: 8px; }
+
+      .callouts {
+        padding: 14px 18px 18px;
+        border-top: 1px dashed var(--color-ink-muted);
+      }
+      .callouts h4 {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        margin: 0 0 6px;
+      }
+      .callouts ul {
+        margin: 0 0 12px;
+        padding-left: 16px;
+        font-size: 12.5px;
+        line-height: 1.55;
+      }
+      .callouts ul:last-child { margin-bottom: 0; }
+
+      .shield {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background:
+          radial-gradient(circle at 30% 30%, var(--color-jersey) 0 60%, var(--color-jersey-deep) 60% 100%);
+        clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+        color: var(--color-cream);
+        font-family: var(--font-display);
+        font-weight: 700;
+        flex-shrink: 0;
+        width: 22px; height: 25px; font-size: 9px;
+      }
+      .shield--opp { background: radial-gradient(circle at 70% 35%, #c34, #7a1f1f 65%); }
+
+      .result-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+      .result-pill--w { background: var(--color-jersey); color: var(--color-ink); }
+      .result-pill--g { background: var(--color-cream-soft); color: var(--color-ink); border: 1px solid var(--color-ink); }
+      .result-pill--l { background: var(--color-warm); color: var(--color-cream); }
+
+      /* ═══════════════════════════════════════════
+         Variant A — Mini-teaser row
+         ═══════════════════════════════════════════ */
+      .a-row {
+        display: grid;
+        grid-template-columns: 64px 1fr auto;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .a-row .stub {
+        padding: 8px 6px;
+        background: var(--color-cream-soft);
+        border-right: 2px dashed var(--color-ink);
+        text-align: center;
+      }
+      .a-row .stub .date {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 18px;
+        line-height: 1;
+        letter-spacing: -0.025em;
+      }
+      .a-row .stub .month {
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 10px;
+        opacity: 0.85;
+        margin-top: 2px;
+        line-height: 1;
+      }
+      .a-row .body {
+        padding: 10px 12px;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 8px;
+        align-items: center;
+      }
+      .a-row .body .team {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 12.5px;
+        line-height: 1.1;
+      }
+      .a-row .body .team--away { justify-self: end; flex-direction: row-reverse; text-align: right; }
+      .a-row .body .team--highlight { font-weight: 600; }
+      .a-row .body .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 16px;
+        line-height: 1;
+        letter-spacing: -0.03em;
+      }
+      .a-row .result {
+        padding: 0 12px;
+        display: flex;
+        align-items: center;
+        border-left: 1px dashed var(--color-ink-muted);
+      }
+
+      /* ═══════════════════════════════════════════
+         Variant B — Result-anchored row
+         ═══════════════════════════════════════════ */
+      .b-row {
+        display: grid;
+        grid-template-columns: 64px 1fr 56px 1fr auto;
+        gap: 10px;
+        background: var(--color-cream);
+        border: 2px solid var(--color-ink);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 10px 14px;
+        align-items: center;
+      }
+      .b-row--win { background: var(--color-cream); }
+      .b-row--draw { background: var(--color-cream-soft); }
+      .b-row--loss { background: var(--color-cream-deep); }
+      .b-row .date-col {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 8.5px;
+        line-height: 1.2;
+        opacity: 0.7;
+        border-right: 1px dashed var(--color-ink-muted);
+        padding-right: 8px;
+      }
+      .b-row .date-col .date-strong {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 14px;
+        line-height: 1;
+        letter-spacing: -0.02em;
+        text-transform: none;
+        font-style: normal;
+        opacity: 1;
+        margin-bottom: 2px;
+      }
+      .b-row .home {
+        display: flex;
+        gap: 7px;
+        align-items: center;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.1;
+      }
+      .b-row .away {
+        display: flex;
+        gap: 7px;
+        align-items: center;
+        flex-direction: row-reverse;
+        text-align: right;
+        font-family: var(--font-display);
+        font-style: italic;
+        font-size: 13px;
+        line-height: 1.1;
+      }
+      .b-row .team--highlight { font-weight: 600; }
+      .b-row .score {
+        font-family: var(--font-display-big);
+        font-weight: 900;
+        font-size: 22px;
+        line-height: 1;
+        letter-spacing: -0.04em;
+        text-align: center;
+        padding: 0 6px;
+      }
+      .b-row .result {
+        padding-left: 10px;
+        border-left: 1px dashed var(--color-ink-muted);
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="page">
+      <div class="meta">Phase 6.B · Drill round 1 · `&lt;MatchResultRow&gt;`</div>
+      <h1>Two row shapes for the team-schedule list.</h1>
+      <p>
+        Sole consumer is <code>&lt;TeamSchedule&gt;</code> on <code>/ploegen/[slug]</code>
+        (light theme). Each variant rendered as a vertical stack of 5
+        match rows — recent results for KCVV with mixed W / G / L
+        outcomes — so the per-row visual at list scale reads.
+      </p>
+      <span class="scope-banner">Pick one structural shape · round 2 covers result-pill colour for L + any tints</span>
+    </header>
+
+    <div class="grid">
+      <!-- ═════════════ A — Mini-teaser row ═════════════ -->
+      <article class="panel">
+        <header class="card">
+          <div class="label">Variant A</div>
+          <h2>Mini-teaser row.</h2>
+          <p class="sub">
+            Same shape as <code>&lt;MatchTeaser&gt;</code> from d6 (A2-italic
+            stub + body), scaled down to row height. Date stamp on the
+            left, teams + score in the body, result pill at the row end.
+            Strongest visual coherence with the rest of the page.
+          </p>
+        </header>
+
+        <div class="stage-label">5 results — KCVV recent (TeamSchedule)</div>
+        <div class="demo">
+          <div class="row-stack">
+            <!-- WIN -->
+            <div class="a-row">
+              <aside class="stub"><div class="date">14</div><div class="month">jun</div></aside>
+              <div class="body">
+                <div class="team team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+                <div class="score">3 — 1</div>
+                <div class="team team--away"><span class="shield shield--opp">M</span>RC Mechelen</div>
+              </div>
+              <div class="result"><span class="result-pill result-pill--w">W</span></div>
+            </div>
+
+            <!-- DRAW -->
+            <div class="a-row">
+              <aside class="stub"><div class="date">07</div><div class="month">jun</div></aside>
+              <div class="body">
+                <div class="team"><span class="shield shield--opp">T</span>FC Tielen</div>
+                <div class="score">1 — 1</div>
+                <div class="team team--away team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              </div>
+              <div class="result"><span class="result-pill result-pill--g">G</span></div>
+            </div>
+
+            <!-- LOSS -->
+            <div class="a-row">
+              <aside class="stub"><div class="date">31</div><div class="month">mei</div></aside>
+              <div class="body">
+                <div class="team team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+                <div class="score">0 — 2</div>
+                <div class="team team--away"><span class="shield shield--opp">H</span>HO Heist</div>
+              </div>
+              <div class="result"><span class="result-pill result-pill--l">L</span></div>
+            </div>
+
+            <!-- WIN -->
+            <div class="a-row">
+              <aside class="stub"><div class="date">24</div><div class="month">mei</div></aside>
+              <div class="body">
+                <div class="team"><span class="shield shield--opp">D</span>SK Drongen</div>
+                <div class="score">0 — 4</div>
+                <div class="team team--away team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              </div>
+              <div class="result"><span class="result-pill result-pill--w">W</span></div>
+            </div>
+
+            <!-- WIN -->
+            <div class="a-row">
+              <aside class="stub"><div class="date">17</div><div class="month">mei</div></aside>
+              <div class="body">
+                <div class="team team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+                <div class="score">2 — 0</div>
+                <div class="team team--away"><span class="shield shield--opp">P</span>SC Pulle</div>
+              </div>
+              <div class="result"><span class="result-pill result-pill--w">W</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Strongest vocabulary coherence — same shape as the teaser + hero</li>
+            <li>Date stamp on the left makes scrolling through results scannable by date</li>
+            <li>Result pill is small, sits at the row end, doesn't compete with the score</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Row height (~60px) is taller than a pure list row — longer schedules feel heavy</li>
+            <li>Stub eats horizontal space — team names + score share less width than B</li>
+          </ul>
+        </div>
+      </article>
+
+      <!-- ═════════════ B — Result-anchored row ═════════════ -->
+      <article class="panel">
+        <header class="card">
+          <div class="label">Variant B</div>
+          <h2>Result-anchored row.</h2>
+          <p class="sub">
+            Date column → home → score → away → result pill. Score is
+            the visual anchor (display-big 22px). Result reinforced
+            by a subtle row-bg tint (win = cream, draw = cream-soft,
+            loss = cream-deep). Reads as a results table.
+          </p>
+        </header>
+
+        <div class="stage-label">5 results — KCVV recent (TeamSchedule)</div>
+        <div class="demo">
+          <div class="row-stack">
+            <!-- WIN -->
+            <div class="b-row b-row--win">
+              <div class="date-col"><div class="date-strong">14 JUN</div>ZA</div>
+              <div class="home team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              <div class="score">3 — 1</div>
+              <div class="away"><span class="shield shield--opp">M</span>RC Mechelen</div>
+              <div class="result"><span class="result-pill result-pill--w">W</span></div>
+            </div>
+
+            <!-- DRAW -->
+            <div class="b-row b-row--draw">
+              <div class="date-col"><div class="date-strong">07 JUN</div>ZA</div>
+              <div class="home"><span class="shield shield--opp">T</span>FC Tielen</div>
+              <div class="score">1 — 1</div>
+              <div class="away team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              <div class="result"><span class="result-pill result-pill--g">G</span></div>
+            </div>
+
+            <!-- LOSS -->
+            <div class="b-row b-row--loss">
+              <div class="date-col"><div class="date-strong">31 MEI</div>ZA</div>
+              <div class="home team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              <div class="score">0 — 2</div>
+              <div class="away"><span class="shield shield--opp">H</span>HO Heist</div>
+              <div class="result"><span class="result-pill result-pill--l">L</span></div>
+            </div>
+
+            <!-- WIN -->
+            <div class="b-row b-row--win">
+              <div class="date-col"><div class="date-strong">24 MEI</div>ZA</div>
+              <div class="home"><span class="shield shield--opp">D</span>SK Drongen</div>
+              <div class="score">0 — 4</div>
+              <div class="away team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              <div class="result"><span class="result-pill result-pill--w">W</span></div>
+            </div>
+
+            <!-- WIN -->
+            <div class="b-row b-row--win">
+              <div class="date-col"><div class="date-strong">17 MEI</div>ZA</div>
+              <div class="home team--highlight"><span class="shield">K</span>KCVV Elewijt</div>
+              <div class="score">2 — 0</div>
+              <div class="away"><span class="shield shield--opp">P</span>SC Pulle</div>
+              <div class="result"><span class="result-pill result-pill--w">W</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="callouts">
+          <h4>Pros</h4>
+          <ul>
+            <li>Most space-efficient — shorter row height; long schedules read as a clean table</li>
+            <li>Score is dominant — reader's eye lands on results at a glance</li>
+            <li>Row-bg tint adds a second severity signal beyond the pill</li>
+          </ul>
+          <h4>Cons</h4>
+          <ul>
+            <li>Diverges from the ticket-card vocabulary — three card shapes for the same domain (hero / teaser / row)</li>
+            <li>Row-bg tint risks a "trafic light" feel if the season has lots of losses (cream-deep stripe)</li>
+            <li>Date column without the dashed-ticket motif feels generic</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+
+    <footer style="max-width:1280px;margin:36px auto 0;font-family:var(--font-mono);font-size:11px;letter-spacing:0.14em;text-transform:uppercase;opacity:0.65">
+      Round 1 of 6.B.d7 · row shape · pick one
+    </footer>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-match-detail/6b8-matchstrip-audit/compare.md
+++ b/docs/design/mockups/phase-6-match-detail/6b8-matchstrip-audit/compare.md
@@ -1,0 +1,88 @@
+# 6.B.d8 · `<MatchStrip>` — audit drill
+
+**Audit only.** Per Phase 6 epic, `<MatchStrip>` was flagged for "audit alongside the match-detail checkpoint to decide whether it shares vocabulary with `<MatchTeaser>` or stays distinct". Phase 3.C already locked the strip design (`docs/design/mockups/phase-3-c-header-and-matchstrip/matchstrip-locked.md`); d8's job is to **verify the lock is still authoritative** + flag any drift between spec and current implementation.
+
+No HTML mockup. Text-only audit.
+
+## Components in scope
+
+`apps/web/src/components/layout/MatchStrip/`:
+
+| File | Role |
+| --- | --- |
+| `MatchStripSlot.tsx` | Suspense + skeleton wrapper; the mount point for all consumers |
+| `MatchStrip.tsx` | Async server component that fetches the next-fixture data from BFF |
+| `MatchStripView.tsx` | Pure presentational component — given a match, renders the strip |
+| `MatchStripSkeleton.tsx` | Loading state |
+| (epic mentioned `<MatchStripClient>` — does not exist; appears to be outdated naming) |
+
+## Production mount points
+
+| Mount | Surface | Mounted via | Theme |
+| --- | --- | --- | --- |
+| `(landing)/layout.tsx` | All landing surfaces (homepage, section indexes) | `<MatchStripSlot />` | Light (cream-on-cream-soft) |
+| `(main)/spelers/[slug]/page.tsx` | Player detail | `<MatchStripSlot />` inline (per d2 opt-in) | Light |
+| `(main)/wedstrijd/[matchId]/page.tsx` | Match detail (Phase 6.B implementation) | `<MatchStripSlot />` inline (per d1 lock) | Light |
+| `(main)/layout.tsx` | All other detail pages | NOT mounted (per Phase 3.C "detail pages omit" rule) | n/a |
+
+## Direction D conformance check
+
+Reading `MatchStripView.tsx`:
+
+| Element | Current implementation | Direction D expectation | Drift? |
+| --- | --- | --- | --- |
+| Background | `bg-cream border-t-jersey-deep/35 border-b-ink/15` | `bg-cream` ✓; ink/35 borders are tonal-only, no Direction D mandate on borders for chrome | None |
+| Layout | Grid: `auto_1fr_auto` (fixture / meta / CTA) on desktop, stacked on mobile | Phase 3.C lock spec | Matches |
+| TeamMark + TeamName components | Italic Freight Display for KCVV; body sans for opponents | Phase 3.C lock | Matches |
+| Score / vs separator | `font-display italic text-ink/50` for "vs." | Phase 3.C lock | Matches |
+| Aftrap (date + time) | Mono semibold | Phase 3.C lock | Matches |
+| CTA "Wedstrijddetails →" | `getButtonClasses(...)` — canonical button at small size | Phase 3.C lock | Matches |
+| Mono caption / value cells | `lg:divide-x divide-ink/15` | Phase 3.C lock | Matches |
+
+**Verdict:** no drift. The current `<MatchStripView>` implementation matches the Phase 3.C lock. No Direction D migration needed — the strip was built post-Direction-D and conforms to it natively.
+
+## Cross-cutting vocabulary check
+
+Per the epic: "audit alongside the match-detail checkpoint to decide whether it shares vocabulary with `<MatchTeaser>` or stays distinct".
+
+After d6 locked `<MatchTeaser>` to A2-italic (ticket-card stub + body), the comparison:
+
+| Element | `<MatchStrip>` (Phase 3.C lock) | `<MatchTeaser>` (d6 A2-italic) |
+| --- | --- | --- |
+| Card chrome | Full-bleed band, no card border, ink/35 + jersey-deep/35 hairlines | TapedCard frame: `border-2 ink + shadow-paper-sm` |
+| Date treatment | Mono semibold inline | Display-big stamp in left stub + italic month label |
+| Teams | Italic Freight Display KCVV + body sans opponent | Both italic Freight Display |
+| Layout | Horizontal full-width band | Card with internal grid |
+| Purpose | Always-on next-fixture orientation chrome | Discrete fixture card in a list |
+
+**Vocabulary intentionally distinct.** The strip is chrome (always-on, dense); the teaser is content (a card in a list). The Phase 3.C lock explicitly notes: "**Always-on, dense** — different mood again". Trying to unify the two would weaken both. The audit confirms keeping them separate.
+
+## Decision (locked)
+
+- **No changes to `<MatchStrip*>` for Phase 6.B.** Phase 3.C's lock remains authoritative.
+- `<MatchStripClient>` reference in the Phase 6 epic was outdated naming — actual components are `<MatchStripSlot>` / `<MatchStrip>` / `<MatchStripView>`. No work to do.
+- The component is mounted inline on `/wedstrijd/[matchId]` per the d1 page composition lock — that's consumer code, not a strip change.
+- If a future drift between Phase 3.C lock and implementation surfaces, it spawns a Phase 3.C follow-up, not Phase 6.B work.
+
+## Cross-references
+
+- Phase 3.C lock source-of-record: `docs/design/mockups/phase-3-c-header-and-matchstrip/matchstrip-locked.md`
+- Existing components: `apps/web/src/components/layout/MatchStrip/`
+- 6.B.d1 page composition (where the strip mounts on `/wedstrijd/[matchId]`): `../page-composition-locked.md`
+- 6.B.d6 MatchTeaser lock (vocabulary comparison): `../matchteaser-locked.md`
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ LOCKED |
+| 6.B.d4 | `<MatchArticleLinkCard>` | ✅ LOCKED (build deferred to post-#1470) |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D + tint | ✅ LOCKED |
+| 6.B.d6 | `<MatchTeaser>` | ✅ LOCKED (default only; compact + MatchesSlider retired) |
+| 6.B.d7 | `<MatchResultRow>` reskin | round 1 in-flight |
+| 6.B.d8 | `<MatchStrip>` audit | ✅ **LOCKED (this doc — no changes; Phase 3.C lock authoritative)** |
+| 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
+| 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |

--- a/docs/design/mockups/phase-6-match-detail/article-link-card-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/article-link-card-locked.md
@@ -1,0 +1,81 @@
+# 6.B.d4 · `<MatchArticleLinkCard>` — LOCKED + DEFERRED
+
+**Decision:** **Variant B — Hero-style cover card**, design locked 2026-05-22. **Implementation deferred to the post-#1470 timeline.**
+
+The component design is settled so that when `matchPreview` / `matchRecap` article variants eventually ship (per #1470), the implementation can follow the locked spec without re-litigating visual direction. **It is NOT built in Phase 6.B implementation issues** — Phase 6.B's match-detail page renders without this card until #1470 lands.
+
+## Why the deferral
+
+The component **auto-hides on every match today**. No `matchPreview` / `matchRecap` articles exist in the dataset, the article schema's `articleMatch` reference is not yet implemented, and #1470 (the issue that would ship those variants) is not on the near-term roadmap. Building `<MatchArticleLinkCard>` as part of Phase 6.B implementation would mean shipping dormant code: tests + Storybook + page wiring all for a branch that returns `null` 100% of the time in production.
+
+The right move is to lock the design (so the future PR has a starting point) and skip the implementation. When #1470 lands, a follow-up issue spawns the build.
+
+## What this locks (when it eventually ships)
+
+| Decision | Locked value |
+| --- | --- |
+| Shape | Full-width `<TapedCard>` with cover image bleeding to the top edge |
+| Cover image | 16:9 aspect, derived from the article's `coverImage` field via the standard Sanity image transform |
+| Image bleed | Flush to the card's `border-2 border-ink` outline; 2px ink rule between image + body |
+| Card rotation | Slight (~-0.3°) tilt, matching the page's editorial-paper-card vocabulary |
+| Body padding | `padding-lg` (16px 18px 18px) |
+| Kicker | `<MonoLabelRow>` — copy varies by state (see "Per-state behaviour" below) |
+| Heading | `<EditorialHeading size="display-md">` — italic display, period suffix, pulled from the article title |
+| Lead | One-line article description (max ~140 chars; the article's `excerpt` field) |
+| CTA row | Mono caps `LEES HET HELE VERHAAL →` with arrow |
+| Container | Centered, `max-w-[var(--container-wide)]` |
+| Hover | Canonical press-down (per `[[feedback_canonical_press_down_hover]]`) — translates 1px + shadow disappears |
+| New primitives | **None** — pure composition of `<TapedCard>` + `<TapedFigure>` + `<EditorialHeading>` + `<MonoLabelRow>` |
+
+## Per-state behaviour
+
+| Match state | Article variant linked | Kicker copy | Auto-hide rule |
+| --- | --- | --- | --- |
+| `scheduled` (upcoming) | `matchPreview` | `LEES DE VOORBESCHOUWING · MATCHPREVIEW` | No matching article → `null` |
+| `finished` | `matchRecap` | `LEES HET VERSLAG · MATCHVERSLAG` | No matching article → `null` |
+| `forfeited` / `postponed` / `stopped` | `matchRecap` if exists, otherwise `matchPreview` | "LEES OOK" (generic) | Both missing → `null` |
+| Both `matchPreview` AND `matchRecap` exist on a finished match | `matchRecap` (preview is stale post-kickoff) | `LEES HET VERSLAG · MATCHVERSLAG` | n/a |
+
+## Rejected alternatives
+
+- **A — Compact one-line link**: rejected. Low click affordance. Hides the editorial work — the journalist's article gets less visual weight than the BFF lineup data. Owner picked B partly because B sells the article properly when it does exist.
+- **C — Inline magazine banner**: rejected. Mid-weight compromise without a clear win. Square cover crop is non-standard (article covers are 16:9), and the `+1 small primitive` cost has no upside when B already composes existing parts cleanly.
+
+## Implementation guard rails
+
+When the follow-up PR ships (paired with #1470):
+
+- Component file: `apps/web/src/components/match/MatchArticleLinkCard/MatchArticleLinkCard.tsx`
+- Story title: `Features/Matches/MatchArticleLinkCard` with `tags: ["autodocs", "vr"]`
+- Stories: one per state (Preview / Recap / Hidden) — `Hidden` ships as a blank-snapshot VR baseline mirroring how Phase 6.A's `BioBlock.Empty` story is structured
+- Test coverage: auto-hide branches (no article, both articles, preview-only, recap-only) explicitly covered
+- Page-level wiring: the page's GROQ query for `/wedstrijd/[matchId]` fans out to `*[_type == "article" && articleMatch._ref == $matchId && type in ["matchPreview", "matchRecap"]]` — picks one per the per-state rule above
+- Auto-hide is enforced at the page level, not just inside the component (`null` is OK but Phase 6.A's `findNthPullquoteText`-style pre-compute pattern is preferred)
+
+## Cross-references
+
+- 6.B.d0 data reality: `data-reality-locked.md`
+- 6.B.d1 page composition: `page-composition-locked.md` — `<MatchArticleLinkCard>` slot is reserved; renders nothing pre-#1470
+- 6.B.d2 MatchHero lock: `matchhero-locked.md`
+- 6.B.d3 lineup + events lock: `lineup-events-locked.md`
+- d4 drill artifacts:
+  - `6b4-article-link-card/compare.md`
+  - `round-1-article-link-card-comparisons.html`
+- Dependency: **#1470** (`feat(news): match preview/recap article variant`)
+- Phase 5 `<NewsCard>` precedent: `apps/web/src/components/news/NewsCard/`
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ LOCKED |
+| 6.B.d4 | `<MatchArticleLinkCard>` | ✅ **LOCKED + DEFERRED to post-#1470** |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D audit | next |
+| 6.B.d6 | `<MatchTeaser>` reskin (default + compact) | queued — cross-cutting per #1528 |
+| 6.B.d7 | `<MatchResultRow>` reskin | queued — cross-cutting per #1528 |
+| 6.B.d8 | `<MatchStripClient>` audit | queued — cross-cutting per #1528 |
+| 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
+| 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |

--- a/docs/design/mockups/phase-6-match-detail/article-link-card-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/article-link-card-locked.md
@@ -6,7 +6,7 @@ The component design is settled so that when `matchPreview` / `matchRecap` artic
 
 ## Why the deferral
 
-The component **auto-hides on every match today**. No `matchPreview` / `matchRecap` articles exist in the dataset, the article schema's `articleMatch` reference is not yet implemented, and #1470 (the issue that would ship those variants) is not on the near-term roadmap. Building `<MatchArticleLinkCard>` as part of Phase 6.B implementation would mean shipping dormant code: tests + Storybook + page wiring all for a branch that returns `null` 100% of the time in production.
+The component **auto-hides on every match today**. No `matchPreview` / `matchRecap` articles exist in the dataset, the article schema has no `linkedMatch` field yet (the actual field name from #1470's spec — it stores the PSD match ID, not a Sanity reference, since matches aren't Sanity-managed), and #1470 (the issue that would ship both the variants and the field) is not on the near-term roadmap. Building `<MatchArticleLinkCard>` as part of Phase 6.B implementation would mean shipping dormant code: tests + Storybook + page wiring all for a branch that returns `null` 100% of the time in production.
 
 The right move is to lock the design (so the future PR has a starting point) and skip the implementation. When #1470 lands, a follow-up issue spawns the build.
 
@@ -49,7 +49,7 @@ When the follow-up PR ships (paired with #1470):
 - Story title: `Features/Matches/MatchArticleLinkCard` with `tags: ["autodocs", "vr"]`
 - Stories: one per state (Preview / Recap / Hidden) — `Hidden` ships as a blank-snapshot VR baseline mirroring how Phase 6.A's `BioBlock.Empty` story is structured
 - Test coverage: auto-hide branches (no article, both articles, preview-only, recap-only) explicitly covered
-- Page-level wiring: the page's GROQ query for `/wedstrijd/[matchId]` fans out to `*[_type == "article" && articleMatch._ref == $matchId && type in ["matchPreview", "matchRecap"]]` — picks one per the per-state rule above
+- Page-level wiring: the page's GROQ query for `/wedstrijd/[matchId]` fans out to `*[_type == "article" && linkedMatch == $matchId && articleType in ["matchPreview", "matchRecap"]]` — picks one per the per-state rule above
 - Auto-hide is enforced at the page level, not just inside the component (`null` is OK but Phase 6.A's `findNthPullquoteText`-style pre-compute pattern is preferred)
 
 ## Cross-references

--- a/docs/design/mockups/phase-6-match-detail/lineup-events-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/lineup-events-locked.md
@@ -144,10 +144,10 @@ The events-first reading order has merit on mobile where vertical space is tight
 | 6.B.d1 | Page composition | ✅ LOCKED |
 | 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
 | 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ **LOCKED (this doc — Variant A)** |
-| 6.B.d4 | `<MatchArticleLinkCard>` | next |
-| 6.B.d5 | `<MatchStatusBadge>` Direction-D audit | queued |
-| 6.B.d6 | `<MatchTeaser>` reskin (default + compact) | queued — cross-cutting per #1528 |
-| 6.B.d7 | `<MatchResultRow>` reskin | queued — cross-cutting per #1528 |
-| 6.B.d8 | `<MatchStripClient>` audit | queued — cross-cutting per #1528 |
+| 6.B.d4 | `<MatchArticleLinkCard>` | ✅ LOCKED (Variant B — build deferred to post-#1470) |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D audit | ✅ LOCKED (T3 paper-chrome + per-status tint; 5-status set; BFF schema delta) |
+| 6.B.d6 | `<MatchTeaser>` | ✅ LOCKED (A2-italic default; compact + `<MatchesSlider>` retired) |
+| 6.B.d7 | `<MatchResultRow>` | ✅ LOCKED (Variant A mini-teaser row) |
+| 6.B.d8 | `<MatchStrip>` audit | ✅ LOCKED (no-op — Phase 3.C lock authoritative) |
 | 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
 | 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |

--- a/docs/design/mockups/phase-6-match-detail/lineup-events-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/lineup-events-locked.md
@@ -1,0 +1,153 @@
+# 6.B.d3 · `<MatchLineupSection>` + `<MatchEventsSection>` — LOCKED
+
+**Decision:** **Variant A — Classic separate sections**, locked 2026-05-22.
+
+Two distinct sections render below the hero on **finished** matches. Both auto-hide for upcoming matches per the 6.B.d1 page-composition lock.
+
+1. **`<MatchLineupSection>`** — kicker `OPSTELLINGEN` + heading "Wie er stond." + two-column home/away rosters wrapping the existing `<MatchLineup>` primitive.
+2. **`<StripedSeam>`** between the two sections.
+3. **`<MatchEventsSection>`** — kicker `WEDSTRIJDVERLOOP` + heading "Hoe het ging." + single timeline ordered by minute, wrapping the existing `<MatchEvents>` primitive.
+
+Zero new design-system primitives. Both sections are thin chrome wrappers around their existing per-row primitives.
+
+## What this locks
+
+| Decision | Locked value |
+| --- | --- |
+| Section count | Two separate sections (lineup + events) |
+| Section order | Lineup first, then events |
+| Inter-section divider | `<StripedSeam colorPair="ink-cream" height="md" />` |
+| Lineup layout | Two columns (home left, away right), each = list of player rows |
+| Events layout | Single timeline ordered chronologically by minute, scorer's team shown as a mono caps label on the right |
+| Sub presentation | Below starters, separated by a `BANK` divider line + section heading style |
+| Per-row primitive | `<MatchLineup>` + `<MatchEvents>` (existing) — section wrappers add chrome, not row geometry |
+| New primitives | **None** (round 1 mockup uses existing per-row vocabulary; round 2 may refine if owner wants) |
+| Auto-hide rule | Each section returns `null` when its data is empty (typically upcoming matches) |
+
+## Composition
+
+```text
+─── MatchHero (locked in 6.B.d2) ─────────────────────────────────
+
+* OPSTELLINGEN
+Wie er stond.
+
+┌────────────────────────────┬────────────────────────────┐
+│ KCVV ELEWIJT               │ RC MECHELEN                │
+├────────────────────────────┼────────────────────────────┤
+│  1  Ben Lievens     (GK)   │  1  Stijn Vandenberg (GK)  │
+│  2  Niels Vermeulen        │  3  Kevin Smets   🟨 28'   │
+│  4  Jonas De Smet          │  …                         │
+│  5  Wim Verhoeven    [C]   │ 10  Robbie Vermeiren  [C]  │
+│  6  Maxim Breugelmans 🟨   │  …                         │
+│  7  Lars De Vos    ⚽ 12'  │                            │
+│  …                         │                            │
+├── BANK ────────────────────┼── BANK ────────────────────┤
+│ 16  Pieter De Bondt ⇅ 71'  │  2  Ruben Pauwels          │
+│  …                         │  …                         │
+└────────────────────────────┴────────────────────────────┘
+
+═══════════════════════════════════════════════════════════════
+                   ⌷⌷⌷ StripedSeam ⌷⌷⌷
+═══════════════════════════════════════════════════════════════
+
+* WEDSTRIJDVERLOOP
+Hoe het ging.
+
+  12'    ⚽   Lars De Vos                          KCVV
+  28'    🟨   Kevin Smets                          MECH
+  45+2'  ⚽   Jens Vermeulen (strafschop)          KCVV
+  56'    ⚽   Tom Janssens                         MECH
+  67'    🟨   Maxim Breugelmans                    KCVV
+  71'    ⇅   Pieter De Bondt ⇆ Lars De Vos       KCVV
+  78'    ⚽   Maxim Breugelmans                    KCVV
+
+─── <MatchArticleLinkCard> (drilled in 6.B.d4) ──────────────────
+─── RelatedArticles ─────────────────────────────────────────────
+─── FooterSafeArea ──────────────────────────────────────────────
+```
+
+### `<MatchLineupSection>` chrome
+
+| Element | Treatment |
+| --- | --- |
+| Kicker | `<MonoLabelRow>` `OPSTELLINGEN` (10px mono caps, 0.18em tracking, `* ` prefix) |
+| Heading | `<EditorialHeading size="display-md">Wie er stond.</EditorialHeading>` — italic display, period suffix |
+| Container | Centered, `max-w-[var(--container-wide)]`, paper bg (`bg-cream`) |
+| Grid | `grid-template-columns: 1fr 1fr` desktop; stack to single column at < 768px (mobile collapse follows existing `<MatchLineup>` rules) |
+| Team column header | Mono caps team name (10px, 0.16em tracking, opacity 0.7) above the player rows |
+| Per-row | `<MatchLineup>` row primitive: number badge + italic display name + status icons inline (captain `[C]`, card `🟨/🟥`, minute mark `⚽ 12'`) |
+| Subs separator | "BANK" divider line (1px ink top border + mono caps label) separates starters from subs |
+| Goalkeeper distinction | Number badge gets `bg-warm` instead of `bg-ink` for keepers — see round-1 mockup; round 2 may refine |
+
+### `<MatchEventsSection>` chrome
+
+| Element | Treatment |
+| --- | --- |
+| Kicker | `<MonoLabelRow>` `WEDSTRIJDVERLOOP` |
+| Heading | `<EditorialHeading size="display-md">Hoe het ging.</EditorialHeading>` |
+| Container | Centered, `max-w-[var(--container-wide)]`, paper bg |
+| Row layout | 4-column grid: minute (36px) / event glyph (22px) / player name (`1fr`) / team mono label (auto, right-aligned) |
+| Minute typography | `font-display-big`, weight 900, ~18px, letter-spacing -0.025em |
+| Event glyph | 22px square — goal `⚽` on jersey-green bg; yellow card `🟨`; red card `🟥`; substitution `⇅` on cream-deep bg |
+| Player name | `font-display` italic, ~15px — for substitutions: `<in> ⇆ <out>` form |
+| Team label | Mono caps right-aligned ("KCVV" / "MECH" or whatever opponent's short code is) |
+| Row separator | 1px dashed cream-deep between rows |
+| Sort | Chronological by `minute` ascending; first-half stoppage time (`45+2'`) sorts before `46'` |
+
+## Rejected alternatives
+
+### B — Combined Matchverslag interleaved (3-column)
+
+Rejected for three reasons:
+1. **+1 new primitive** (`<MatchTimelineGrid>` with per-minute anchoring + side-aware player labels) — implementation cost is the highest of the three options
+2. **Mobile collapse is hard** — three columns must reflow to a single column with events interleaved by minute, which is its own design problem requiring a dedicated drill
+3. The "redesign distinctiveness" win doesn't justify the cost when Variant A already meets the "matchverslag" reading intent via the kicker + heading
+
+The variant remains valuable design reference and is documented in the round-1 mockup. A future drill can revisit if the page feels under-distinctive after implementation.
+
+### C — Events first, lineup collapsible
+
+Rejected for two reasons:
+1. **Default-collapsing the lineup hides a feature most readers expect to see** — the editorial intent of "matchverslag" includes the rosters, and hiding them by default reads as a UX anti-pattern (not a deliberate choice)
+2. **Lose per-player event context** — the lineup row showing "Lars De Vos ⚽ 12'" + "subbed off ⇅ 71'" is a useful at-a-glance, which is broken when the events live in a separate top block
+
+The events-first reading order has merit on mobile where vertical space is tight — round 2 could revisit a mobile-specific reordering if needed, but the desktop default stays lineup-first per A.
+
+## Knock-on resolutions
+
+**`<MatchLineup>` + `<MatchEvents>` primitives stay as-is.** The redesign work happens at the SECTION wrapper layer, not the row-rendering layer. Per-row visual refinements (number badge style, captain glyph treatment, card icon set) are deferred to a round-2 drill IF owner pushback during implementation flags any of them.
+
+**`<MatchDetailView>` retires alongside `<MatchHeader>`.** The current `MatchDetailView` composes header + lineup + events in a single component; the new shape splits these into hero + two sections at the page level. Implementation issue covers the migration.
+
+**Goalkeeper visual distinction.** Round-1 mockup uses `bg-warm` for the keeper number badge to differentiate from outfielders. This is a small treatment decision that ships as-is unless flagged.
+
+**Mobile collapse plan.** Both sections stack to single column at < 768px (the team columns sit one above the other). The events table stays as-is — minute / glyph / player / team grid scales down without restructuring. Deferred to implementation-time sanity check, not a separate drill.
+
+## Cross-references
+
+- 6.B.d0 data reality: `docs/design/mockups/phase-6-match-detail/data-reality-locked.md`
+- 6.B.d1 page composition: `docs/design/mockups/phase-6-match-detail/page-composition-locked.md`
+- 6.B.d2 MatchHero lock: `docs/design/mockups/phase-6-match-detail/matchhero-locked.md`
+- d3 drill artifacts:
+  - `docs/design/mockups/phase-6-match-detail/6b3-lineup-events/compare.md`
+  - `round-1-lineup-events-comparisons.html`
+- Existing primitives wrapped:
+  - `apps/web/src/components/match/MatchLineup/`
+  - `apps/web/src/components/match/MatchEvents/`
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ **LOCKED (this doc — Variant A)** |
+| 6.B.d4 | `<MatchArticleLinkCard>` | next |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D audit | queued |
+| 6.B.d6 | `<MatchTeaser>` reskin (default + compact) | queued — cross-cutting per #1528 |
+| 6.B.d7 | `<MatchResultRow>` reskin | queued — cross-cutting per #1528 |
+| 6.B.d8 | `<MatchStripClient>` audit | queued — cross-cutting per #1528 |
+| 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
+| 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |

--- a/docs/design/mockups/phase-6-match-detail/matchhero-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/matchhero-locked.md
@@ -1,0 +1,126 @@
+# 6.B.d2 · `<MatchHero>` — LOCKED
+
+**Decision:** Round 2 **H1 (Ticket-card)** + Round 3 **T2 (dashed-only separator)**, locked 2026-05-22.
+
+The hero is a single `<TapedCard>` split into two zones by a 2px dashed ink divider:
+
+- **Left zone** (~110px wide): "ticket stub" with the big display date, kickoff time, and venue. Cream-soft tint background.
+- **Right zone**: editorial body — mono kicker → teams + score row → competition meta row.
+
+No perforation punch-out circles. Zero new design-system primitives — pure composition + one-line `border-right: 2px dashed var(--color-ink)` rule.
+
+## What this locks
+
+| Decision | Locked value |
+| --- | --- |
+| Overall shape | Single `<TapedCard>` hero, two zones via internal grid |
+| Left zone (stub) | ~110px wide, `bg="cream-soft"`, display-big date + time + venue (mono caps) |
+| Right zone (body) | `bg="cream"`, kicker + teams/score + competition meta |
+| Divider between zones | 2px dashed ink line (`border-right` on the stub element) — **no** punch-out circles |
+| States | Same shape upcoming + finished; only score region + kicker copy swap |
+| Status badge placement | Finished state only; renders as a corner stamp top-right, slightly overlapping the card top border |
+| New primitives introduced | **None** |
+| Photo treatment | None — per 6.B.d0 data-reality lock, no per-match photo source exists |
+
+## Composition
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ ┌──────────┐ ╎  * VOORBESCHOUWING / MATCHVERSLAG            │
+│ │  ZA 14   │ ╎                                              │
+│ │  JUN     │ ╎  [K] KCVV Elewijt  vs / 3 — 1  RC Mech [M]   │
+│ │  14:30   │ ╎                                              │
+│ │          │ ╎  ──────────────────────────────────────────  │
+│ │ SPORTPARK│ ╎  3E PROVINCIALE A · KCVV-A · '26/'27         │
+│ │ ELEWIJT  │ ╎                                              │
+│ └──────────┘ ╎                                              │
+│   (stub)    (dashed)        (body)                          │
+└──────────────────────────────────────────────────────────────┘
+                                              [FT stamp on finished only]
+```
+
+### Stub (left zone)
+
+| Element | Typography | Notes |
+| --- | --- | --- |
+| Date | `font-display-big`, weight 900, 20–24px, line-height 1, two lines (`ZA 14 / JUN`) | Upright Black display — same weight family as `<EditorialHeading size="display-2xl">` (no font-subset re-cut needed) |
+| Time | `font-mono`, 14px, letter-spacing 0.06em | Single line e.g. `14:30` |
+| Venue | `font-mono` caps, 9.5px, opacity 0.75, line-height 1.4 | Two lines OK |
+| Background | `bg-cream-soft` (var `--color-cream-soft`) | Distinguishes from body zone visually |
+| Divider | `border-right: 2px dashed var(--color-ink)` | The only chrome between zones |
+
+### Body (right zone)
+
+| Element | Typography | Notes |
+| --- | --- | --- |
+| Kicker | `<MonoLabelRow>` style, 10px, letter-spacing 0.18em, prefix `* ` | Copy = `VOORBESCHOUWING` (upcoming) or `MATCHVERSLAG` (finished); may append competition name |
+| Teams row | 3-column grid (home `1fr` / score `auto` / away `1fr`) | Each team = `<shield>` + italic display name; away mirrors home (reverse direction, right-aligned) |
+| Score region | `font-display-big` weight 900, 34px when numeric; italic display 22px lowercase when "vs" | The only visually state-aware element inside the hero |
+| Competition meta | `font-mono` caps, 10.5px, separated by `·` dots; sits above a 1px ink top border | One line e.g. `3E PROVINCIALE A · KCVV-A · '26/'27` |
+
+### State-aware element table
+
+| Element | Upcoming (`scheduled`) | Finished (`finished`) |
+| --- | --- | --- |
+| Kicker text | `VOORBESCHOUWING` | `MATCHVERSLAG` |
+| Score region | `vs` (italic display lowercase) | `3 — 1` (display-big) |
+| Status badge | None | Corner stamp (`FT` / `FF` / `AFG` / `STOP`) top-right |
+| Everything else | Identical | Identical |
+
+Edge states (`forfeited` / `postponed` / `stopped`) render as finished with the appropriate status badge — they're not separate visual treatments.
+
+## Rejected alternatives
+
+### Round 1 (structural shape)
+
+- **B — Ticket-stub band** (full-bleed dark band): rejected for being too heavy chrome. Owner picked A but flagged B's ticket motif as desirable → resolved by round 2 hybrids.
+- **C — Two-team polaroids**: eliminated entirely by owner. Shield quality varies (PSD-sourced), and polaroid-scale promotion exposed that variance.
+
+### Round 2 (A+B hybrid concepts)
+
+- **H2 — Card + matchday stamp**: rejected. Stamp competed with the corner status badge for top-right attention; status-inline-in-meta-row workaround wasn't worth the complexity.
+- **H3 — Card with ticket-footer**: rejected. Ticket motif at the bottom edge was less prominent than H1's left-stub treatment.
+
+### Round 3 (separator treatment)
+
+- **T1 — Full perforations**: rejected. Punch-out corner circles added fiddly geometry to maintain across breakpoints + competed with the outer card frame's ink border. The ticket-stub idiom comes through enough via the dashed line + display-date typography + cream-soft tint.
+- **T3 — Subtle perforations**: rejected. Compromise position with no compelling argument over T2's full elimination of the circles.
+
+## Knock-on resolutions
+
+**`<MatchHeader>` retires when `<MatchHero>` ships.** The existing `<MatchHeader>` consumed by `MatchDetailView` is superseded. Implementation issue covers the migration (likely: a separate cleanup ticket spawned by `/prd-to-issues` after the PRD is written).
+
+**`<MatchStatusBadge>` Direction-D audit (6.B.d5)** is independent — the badge already exists; d5 just confirms it aligns with the Phase 4.5/5 Direction D treatment for use as the corner stamp in `<MatchHero>` (and elsewhere).
+
+**Mobile collapse (round 4, deferred):**
+
+At narrow widths (<~640px) the two-zone grid stacks vertically: stub becomes a top row spanning the full card width, body sits below, divider rotates from vertical-right to horizontal-bottom (`border-bottom: 2px dashed ink` on the stub). Status badge stays top-right.
+
+This is straightforward but worth a small round-4 sanity-check mockup before implementation — deferred to a sub-drill when 6.B.d2 implementation kicks off, not blocking the rest of the design series.
+
+## Cross-references
+
+- 6.B.d0 data reality: `docs/design/mockups/phase-6-match-detail/data-reality-locked.md`
+- 6.B.d1 page composition: `docs/design/mockups/phase-6-match-detail/page-composition-locked.md`
+- d2 drill artifacts:
+  - `docs/design/mockups/phase-6-match-detail/6b2-matchhero/compare.md`
+  - `round-1-matchhero-comparisons.html`
+  - `round-2-matchhero-comparisons.html`
+  - `round-3-matchhero-comparisons.html`
+- Phase 5 `<EditorialHero>` vocabulary (for primitive references): `apps/web/src/components/article/EditorialHero/EditorialHero.tsx`
+- Phase 4.5 `<TapedCard>` precedent
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ **LOCKED (this doc — H1 + T2)** |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` visual treatment | next |
+| 6.B.d4 | `<MatchArticleLinkCard>` | queued |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D audit | queued |
+| 6.B.d6 | `<MatchTeaser>` reskin (default + compact) | queued — cross-cutting per #1528 |
+| 6.B.d7 | `<MatchResultRow>` reskin | queued — cross-cutting per #1528 |
+| 6.B.d8 | `<MatchStripClient>` audit | queued — cross-cutting per #1528 |
+| 6.B.d2 round 4 | Mobile collapse (deferred to implementation kickoff) | queued |

--- a/docs/design/mockups/phase-6-match-detail/matchhero-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/matchhero-locked.md
@@ -18,7 +18,7 @@ No perforation punch-out circles. Zero new design-system primitives — pure com
 | Right zone (body) | `bg="cream"`, kicker + teams/score + competition meta |
 | Divider between zones | 2px dashed ink line (`border-right` on the stub element) — **no** punch-out circles |
 | States | Same shape upcoming + finished; only score region + kicker copy swap |
-| Status badge placement | Finished state only; renders as a corner stamp top-right, slightly overlapping the card top border |
+| Status badge placement | Renders as a corner stamp top-right, slightly overlapping the card top border. `<MatchStatusBadge>` owns whether-and-how to render — see `matchstatusbadge-locked.md` (6.B.d5) for the 5-status set + tints |
 | New primitives introduced | **None** |
 | Photo treatment | None — per 6.B.d0 data-reality lock, no per-match photo source exists |
 
@@ -60,14 +60,14 @@ No perforation punch-out circles. Zero new design-system primitives — pure com
 
 ### State-aware element table
 
-| Element | Upcoming (`scheduled`) | Finished (`finished`) |
+| Element | Upcoming (`scheduled`) | Finished / edge states |
 | --- | --- | --- |
 | Kicker text | `VOORBESCHOUWING` | `MATCHVERSLAG` |
-| Score region | `vs` (italic display lowercase) | `3 — 1` (display-big) |
-| Status badge | None | Corner stamp (`FT` / `FF` / `AFG` / `STOP`) top-right |
+| Score region | `vs` (italic display lowercase) | `3 — 1` (display-big) — score reflects whatever value the BFF surfaces; FF / PP / CANC / STOP states typically show `—` or `0 — 0` per upstream data |
+| Status badge | None | Corner stamp per `matchstatusbadge-locked.md` (6.B.d5) — `FT` / `FF` / `PP` / `CANC` / `STOP` with severity tint |
 | Everything else | Identical | Identical |
 
-Edge states (`forfeited` / `postponed` / `stopped`) render as finished with the appropriate status badge — they're not separate visual treatments.
+Edge states (`forfeited` / `postponed` / `cancelled` / `stopped`) render the same hero shape as finished — they're differentiated only by the corner status badge, not by hero geometry.
 
 ## Rejected alternatives
 

--- a/docs/design/mockups/phase-6-match-detail/matchresultrow-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/matchresultrow-locked.md
@@ -1,0 +1,81 @@
+# 6.B.d7 · `<MatchResultRow>` — LOCKED
+
+**Decision:** **Variant A — Mini-teaser row**, locked 2026-05-22.
+
+`<MatchResultRow>` reskinned as a scaled-down `<MatchTeaser>` (per d6 A2-italic vocabulary). Date stub + body + result pill, all in row height. Strongest vocabulary coherence with the rest of the page; same ticket-card family across hero → teaser → row.
+
+## What this locks
+
+| Decision | Locked value |
+| --- | --- |
+| Overall shape | Single row card — `border-2 ink + shadow-paper-sm + bg-cream`. Three zones: left stub (~64px) → body (teams + score) → result pill at the right edge |
+| Stub | `bg-cream-soft`, centred. Display-big date number (18px, weight 900) over italic display month label ("jun", lowercase Dutch). 2px dashed ink right border. No time in the stub. |
+| Body | Mono kicker dropped (date stamp is the marker; rows live under date-grouped section headers when needed). 3-col grid: home (`1fr`) / score (`auto`) / away (`1fr`). Italic display team names; KCVV gets `font-weight: 600`. Score `display-big` weight 900, 16px |
+| Result pill | At the row end, separated by a 1px dashed ink-muted vertical divider. 22×22 square pill. Three variants: W (jersey green bg, ink text) / G (cream-soft bg, ink border, ink text) / L (warm bg, cream text — per round 2 deferral) |
+| Theme | Light only (dark dropped — single consumer `<TeamSchedule>` is light) |
+| Hover | Canonical press-down per `[[feedback_canonical_press_down_hover]]` |
+| Link wrap | Whole row is a `<Link>` to `/wedstrijd/[matchId]` (matches today's behaviour) |
+| New primitives | **None** — pure composition of d6 vocabulary at row scale |
+
+## Composition
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ ┌────┐ ╎ [K] KCVV Elewijt    3 — 1    RC Mechelen [M] ╎ W │
+│ │ 14 │ ╎                                              ╎    │
+│ │ jun│ ╎                                              ╎    │
+│ └────┘ ╎                                              ╎    │
+│ (stub) (dashed)        (body)                  (dashed)(pill)
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Result pill colours
+
+| Result | Pill | Notes |
+| --- | --- | --- |
+| **W** (winst) | `bg-jersey text-ink` (effectively `pill-jersey`) | Existing MonoLabel pill variant |
+| **G** (gelijkspel / draw) | `bg-cream-soft text-ink border border-ink` | Neutral; matches MatchStatusBadge T3's cream-deep no-game tier in spirit |
+| **L** (verlies) | `bg-warm text-cream` | Round 2 sub-decision; warm reads as "abnormal but match concluded". Owner can downgrade to a bordered-cream pill if warm feels too loud across many losses in a season |
+
+## Rejected alternatives
+
+- **B — Result-anchored row**: rejected. Diverges from the ticket-card vocabulary; introducing a third card shape for the same domain (hero / teaser / row) when A delivers vocabulary coherence at near-equivalent space efficiency. Row-bg tint risked a "traffic light" feel across a difficult season.
+
+## Knock-on resolutions
+
+**`<MatchResultRow>` is rewritten — not migrated.** The pre-redesign component (`apps/web/src/components/match/MatchResultRow/MatchResultRow.tsx`) uses retired tokens (`kcvv-green-bright`, `kcvv-success`, `kcvv-alert`, `kcvv-warning`, `rounded-card`) + a result-coloured left border that conflicts with the 2px ink card frame. The implementation ticket replaces the component file entirely; downstream consumer `<TeamSchedule>` keeps the same API and shouldn't need changes beyond a re-test against the new visual.
+
+**`getResultColor` utility stays as-is.** `apps/web/src/lib/utils/match-display.ts:getResultColor` still works — it returns `"win" | "loss" | "draw"`, which maps to the new pill variants in the rewrite.
+
+**Storybook + VR coverage required.** New stories per result type (W / G / L) + per state (finished, edge states via MatchStatusBadge); meta `tags: ["autodocs", "vr"]`.
+
+**Mobile collapse.** Rows stack naturally in the parent `<TeamSchedule>` — no row-internal collapse needed (the stub stays ~64px even on mobile; teams abbreviate via CSS truncation, score stays prominent).
+
+## Cross-references
+
+- 6.B.d2 MatchHero lock — ticket-card vocabulary source
+- 6.B.d5 MatchStatusBadge lock — corner stamp integration (rows render the badge in the same corner-stamp slot when applicable)
+- 6.B.d6 MatchTeaser lock — A2-italic source for the scaled-down stub + body
+- d7 drill artifacts:
+  - `6b7-matchresultrow/compare.md`
+  - `round-1-matchresultrow-comparisons.html` (A vs B)
+- Existing component to rewrite: `apps/web/src/components/match/MatchResultRow/`
+- Sole consumer: `apps/web/src/components/team/TeamSchedule/` (in `<TeamDetail>` at `/ploegen/[slug]`)
+
+## Drill state after this lock — ALL DRILLS COMPLETE
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ LOCKED |
+| 6.B.d4 | `<MatchArticleLinkCard>` | ✅ LOCKED (build deferred to post-#1470) |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D + tint | ✅ LOCKED |
+| 6.B.d6 | `<MatchTeaser>` | ✅ LOCKED (default only; compact + MatchesSlider retired) |
+| 6.B.d7 | `<MatchResultRow>` | ✅ **LOCKED (this doc — Variant A mini-teaser row)** |
+| 6.B.d8 | `<MatchStrip>` audit | ✅ LOCKED (no-op — Phase 3.C lock authoritative) |
+| 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
+| 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |
+
+**Next step: `/write-a-prd`** consolidating all 8 drill decisions + the BFF schema delta + the cleanup deliverables into `docs/prd/redesign-phase-6b-match-detail.md`. Then `/prd-to-issues` to spawn the implementation tickets.

--- a/docs/design/mockups/phase-6-match-detail/matchstatusbadge-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/matchstatusbadge-locked.md
@@ -1,0 +1,99 @@
+# 6.B.d5 · `<MatchStatusBadge>` — LOCKED
+
+**Decision:** **Treatment 3** (Direction D paper-chrome + per-status tint), locked 2026-05-22.
+
+The component is extended to cover all 5 badge-rendering statuses (FT / FF / PP / CANC / STOP). It uses the locked Phase 2 Direction D paper-chrome base (`border-2 ink + shadow-paper-sm + bg-cream + mono caps`) with a per-status background tint that signals severity. Phase 6.B implementation owns the BFF schema delta required to surface `cancelled` as distinct from `postponed`.
+
+## What this locks
+
+| Decision | Locked value |
+| --- | --- |
+| Badge-rendering statuses | 5 — `finished`, `forfeited`, `postponed`, `cancelled`, `stopped` |
+| Non-rendering statuses | 1 — `scheduled` (kickoff time in `<MatchHero>` IS the status) |
+| Visual base | Direction D paper-chrome: `border-2 border-ink shadow-paper-sm` + mono caps + sharp corners + small padding (`5px 8px`) |
+| Per-status tint | See severity table below |
+| Copy | Abbreviations: `FT` / `FF` / `PP` / `CANC` / `STOP` |
+| Accessibility | `title=` attribute carries long-form Dutch on every badge (`"Voltijd"` / `"Forfait"` / `"Uitgesteld"` / `"Geannuleerd"` / `"Gestopt"`) |
+| API | `<MatchStatusBadge status={match.status} />` — the badge owns whether-and-how to render. `<MatchHero>` mounts it unconditionally. |
+| Placement on `<MatchHero>` | Corner stamp, top-right, slight overlap with the card top border (per `matchhero-locked.md`) |
+| New design-system primitive | **None** — chrome is styled inline on the existing `<MatchStatusBadge>` (no new `<MonoLabel>` variant; keeps the surface narrow) |
+| BFF schema delta | **In Phase 6.B scope** — extend `MatchStatus` literal + update `transforms.ts` to stop collapsing `cancelled` into `postponed`. See "BFF schema delta" below. |
+| `--color-card-red` token | **Introduced** as part of this lock — new design-system token for the CANC severity tier. Reusable elsewhere if a system-alert vocabulary lands later. |
+
+## Severity table
+
+| Status | Abbreviation | Tint token | Severity tier | Why |
+| --- | --- | --- | --- | --- |
+| `finished` | **FT** | `cream` | Normal | Game played to full time |
+| `postponed` | **PP** | `cream-deep` | No game today (held) | May reschedule |
+| `forfeited` | **FF** | `cream-deep` | No game today (dead-end) | Won't be played; result imposed. Owner-grouped with PP — both read as "no game today" |
+| `stopped` | **STOP** | `warm` | Notice (abnormal) | Game started + ended weird — incomplete result |
+| `cancelled` | **CANC** | `card-red` | Alert (dead) | Definitively dead, won't play, may have no result |
+| `scheduled` | — (no badge) | — | — | Upcoming — kickoff time in hero conveys the state |
+
+Four tints across five statuses. Reader sees severity at a glance.
+
+## BFF schema delta (in Phase 6.B scope)
+
+Today's `MatchStatus` literal lumps `cancelled` into `postponed` (see `apps/api/src/psd/transforms.ts:100`):
+
+```typescript
+if (cancelled) return "postponed";
+```
+
+This hides a real semantic distinction — PSD's `cancelled: boolean` means "definitively dead" while PSD code 2 (`afgelast`) means "held, may reschedule". The d5 lock requires the distinction to survive into the normalised type.
+
+**Implementation tickets (spawned by `/prd-to-issues` when the PRD lands):**
+
+| File | Change |
+| --- | --- |
+| `packages/api-contract/src/schemas/match.ts` | Add `"cancelled"` to the `MatchStatus` literal: `"scheduled" \| "finished" \| "forfeited" \| "postponed" \| "cancelled" \| "stopped"` |
+| `apps/api/src/psd/transforms.ts` | Return `"cancelled"` when `cancelled === true`; preserve PSD code 2 → `"postponed"`. Update the JSDoc comment block. |
+| `apps/api/src/psd/service.test.ts` | Add a test case: `cancelled: true` + PSD code 0 → status === `"cancelled"` |
+| `apps/api/src/handlers/matches.test.ts` | Update fixtures that exercise the postponed branch — confirm cancelled now flows separately |
+| `apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.tsx` | Extend `BadgeStatus` from 3 → 5 statuses; add the per-status tint logic |
+| `apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.test.tsx` | Branch test per status |
+| `apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.stories.tsx` | Story per status; meta `tags: ["autodocs", "vr"]` |
+| `apps/web/src/app/globals.css` (or wherever tokens live) | Introduce `--color-card-red` |
+
+## Rejected alternatives
+
+- **T1 — Current `pill-jersey`**: rejected. Uses the retired bright-jersey colour (`feedback_no_bright_jersey`). All edge statuses look visually identical. Doesn't align with the editorial paper-card vocabulary that the rest of `<MatchHero>` uses.
+- **T2 — Direction D uniform**: rejected. Aligns with the editorial vocabulary but provides no per-status severity signal. The CANC alert would visually equal the routine FT — loses an important reader signal.
+
+## Knock-on resolutions
+
+**`<MatchHero>` simplifies.** The hero now just mounts `<MatchStatusBadge status={match.status} />`. No per-state special-casing; the badge owns rendering decisions. `matchhero-locked.md` status table updates to 5 statuses + reference this lock.
+
+**`<MatchTeaser>` / `<MatchResultRow>` / `<MatchStripClient>` cross-cutting components** (drills 6.B.d6 / d7 / d8) inherit the same badge. If they currently render status differently, they migrate to `<MatchStatusBadge>` in their own implementation tickets.
+
+**`<MonoLabel>` pill variants stay untouched.** No new variant added; chrome is local to `<MatchStatusBadge>`. Other consumers of `pill-jersey` / `pill-ink` / `pill-cream` are unaffected.
+
+**`title=` Dutch tooltip** on each badge for accessibility — abbreviations read as printed-matchday-programme codes but tooltips preserve the full meaning for screen readers + new readers.
+
+## Cross-references
+
+- 6.B.d2 MatchHero lock (badge consumer): `matchhero-locked.md` — needs an update for the 5-status set; tracked in this same drill commit
+- Direction D source-of-record: `docs/prd/redesign-phase-2.md` §6.5 + `docs/design/mockups/phase-2-track-b/option-d-paper-chrome-ink-emphasis.html`
+- BFF source files: `packages/api-contract/src/schemas/match.ts`, `apps/api/src/psd/transforms.ts`
+- Existing component: `apps/web/src/components/match/MatchStatusBadge/`
+- d5 drill artifacts:
+  - `6b5-matchstatusbadge/compare.md`
+  - `round-1-statusbadge-comparisons.html`
+- Memory: `[[feedback_no_bright_jersey]]` (bright `--color-jersey` retired)
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ LOCKED |
+| 6.B.d4 | `<MatchArticleLinkCard>` | ✅ LOCKED (build deferred to post-#1470) |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D + tint | ✅ **LOCKED (this doc — T3, 5 statuses, severity tint)** |
+| 6.B.d6 | `<MatchTeaser>` reskin (default + compact) | next — cross-cutting per #1528 |
+| 6.B.d7 | `<MatchResultRow>` reskin | queued — cross-cutting per #1528 |
+| 6.B.d8 | `<MatchStripClient>` audit | queued — cross-cutting per #1528 |
+| 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
+| 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |

--- a/docs/design/mockups/phase-6-match-detail/matchteaser-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/matchteaser-locked.md
@@ -1,0 +1,121 @@
+# 6.B.d6 · `<MatchTeaser>` — LOCKED + scope slim-down
+
+**Decision:** **Variant A2-italic** (mini-hero ticket-card descendant, date-only stub, italic-display month label) locked 2026-05-22. **Scope slimmed**: only the `default` variant ships. The `compact` variant is **retired** alongside `<MatchesSlider>` (both have zero active production consumers since Phase 4.B.2 retired `<MatchesSliderSection>` from the homepage in favour of `<UpcomingMatches>`).
+
+## Why the slim-down
+
+The Phase 6 epic (#1528) listed both `default` and `compact` variants as in-scope cross-cutting, written before Phase 4.B.2 swapped the homepage `<MatchesSliderSection>` for `<UpcomingMatches>` (a different component that renders its own primitives directly from `<TapedCard>` + `<EditorialHeading>` + `<MonoLabel>`, not via `<MatchTeaser>`). After that swap, the actual production consumer map for `<MatchTeaser>` is:
+
+| Consumer | Variant | Status |
+| --- | --- | --- |
+| `<CalendarMonth>` (day-detail list at `/kalender`) | default | ✅ Live — only real consumer |
+| `<MatchesSlider>` (component file at `apps/web/src/components/match/MatchesSlider/`) | compact | 💀 Orphaned — exists but no app route mounts it |
+| `<UpcomingMatches>` (new homepage block, Phase 4.B.2) | n/a | Does NOT use `<MatchTeaser>` — composes its own internal rendering |
+
+Designing a compact variant for surfaces that don't exist is shipping dormant code. Same reasoning as the d4 article-link-card deferral (where matchPreview/matchRecap doesn't exist yet either): don't ship the design until the consumer ships.
+
+## What this locks
+
+### `<MatchTeaser variant="default">` (the only variant that ships)
+
+| Decision | Locked value |
+| --- | --- |
+| Shape | Single card, 2 zones: left stub (~76px) + right body, divided by a 2px dashed ink line (no perforation circles — per d2 T2) |
+| Left stub | `bg-cream-soft`, centred typography. Big display-big date number (30px, weight 900) + italic display month label ("juni" — lowercase, Dutch). No time in the stub. |
+| Right body | `bg-cream`, mono kicker (weekday + time + venue) → teams + score → no separate competition row at default (folded into the kicker for space) |
+| Kicker copy | `ZA · 14:30 · SPORTPARK ELEWIJT` — mono caps, opacity 0.6, no `* ` prefix (the stub is the dominant marker) |
+| Teams row | 3-col grid (home `1fr` / score `auto` / away `1fr`), italic display, shield-left for home, shield-right for away |
+| Score | `display-big` weight 900, 20px, dash separator (`3 — 1`) |
+| Highlighted team | KCVV team gets `font-weight: 600` italic display — visually emphasises which side is "us" |
+| Status badge | When `<MatchStatusBadge>` returns non-null (per 6.B.d5), placed as a corner stamp at top-right of the card |
+| Hover | Canonical press-down per `[[feedback_canonical_press_down_hover]]` |
+| Theme | Light only (no dark theme — the only consumer `<CalendarMonth>` is a light surface) |
+
+### `<MatchTeaser variant="compact">` (RETIRED)
+
+Component file's `variant?: "default" | "compact"` prop is **simplified to `default` only** (or the prop is dropped entirely if the API becomes uniform — flagged in the implementation issue). All `compact` story/test references retired in the cleanup.
+
+### `<MatchesSlider>` (RETIRED — orphan code)
+
+`apps/web/src/components/match/MatchesSlider/` is dead code after Phase 4.B.2's homepage rework. Retirement is in Phase 6.B implementation scope:
+
+- `apps/web/src/components/match/MatchesSlider/MatchesSlider.tsx` + `.stories.tsx` + `.test.tsx` + `index.ts` → delete
+- Barrel exports cleaned
+- `<HorizontalSlider>` stories at `HorizontalSlider.stories.tsx` (the PR #1594 inline `MatchCard` mock) — already flagged in #1528 follow-up cleanup; not in 6.B implementation scope unless owner pulls forward
+
+## Composition (default only)
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ ┌────────┐ ╎ * ZA · 14:30 · SPORTPARK ELEWIJT             │
+│ │   14   │ ╎                                              │
+│ │  juni  │ ╎ [K] KCVV Elewijt   3 — 1   RC Mechelen [M]  │
+│ └────────┘ ╎                                              │
+│  (stub)  (dashed)        (body)                           │
+└─────────────────────────────────────────────────────────────┘
+                                          ┌──── corner stamp
+                                          │  (when MatchStatusBadge
+                                          │   returns non-null per d5)
+```
+
+## Rejected alternatives
+
+### Round 1 (structural shape)
+
+- **B — Vertical stacked**: rejected. Less vocabulary coherence with `<MatchHero>`. Slider-natural aspect was the main argument; with the slider retired that argument disappears.
+- **C — Horizontal fixture row**: rejected. Loses card identity; reads as a table row.
+
+### Round 2 (A stub iterations)
+
+- **A0 — Round 1 baseline**: rejected. "Too dense" per owner — too many info units in the narrow column.
+- **A1 — Drop weekday**: rejected in favour of A2 — dropping the weekday alone didn't free enough density.
+- **A3 — Wider mono date**: rejected. Loses display-big stamp identity; eats more horizontal space.
+
+### Round 3 (A2-italic refinement)
+
+- The "month in mono caps" variation (A2 as originally drafted): rejected. Italic display "juni" reads as more editorial, ties the stub typography back to the page hero's italic display name.
+- Compact variant rendered for completeness: **retired**, not chosen — see scope slim-down above.
+
+## Knock-on resolutions
+
+**Phase 6.B implementation work tracked (will be spawned by `/prd-to-issues` once the PRD lands):**
+
+1. Reskin `<MatchTeaser>` to the locked A2-italic default
+2. Migrate `<CalendarMonth>` to render the new teaser (likely zero changes since the API stays the same)
+3. Delete `<MatchTeaser variant="compact">` code + tests + stories
+4. Delete `<MatchesSlider>` directory + tests + stories + barrel export
+5. Storybook story coverage: one story per relevant state (upcoming, finished, edge — using `<MatchStatusBadge>` integration)
+6. VR baselines for the new teaser stories
+
+**`<MatchHero>` and `<MatchTeaser>` share the ticket-card vocabulary.** The hero uses the d2 ticket-card at full size; the teaser is the same shape at smaller scale with a centred date stamp. Vocabulary coherence across the page hero + the calendar fixture cards.
+
+**No dark theme.** `<CalendarMonth>` is a light-surface consumer. If a future dark-surface consumer appears, that's a follow-up drill (round 4 of d6).
+
+## Cross-references
+
+- 6.B.d2 MatchHero lock: `matchhero-locked.md` — sets the ticket-card vocabulary
+- 6.B.d5 MatchStatusBadge lock: `matchstatusbadge-locked.md` — corner-stamp integration
+- d6 drill artifacts:
+  - `6b6-matchteaser/compare.md`
+  - `round-1-matchteaser-comparisons.html` (A vs B vs C)
+  - `round-2-matchteaser-A-stub-iterations.html` (A0 / A1 / A2 / A3)
+  - `round-3-matchteaser-A2-italic.html` (final A2-italic at default + retired compact panels)
+- Phase 4.B.2 homepage rework that retired `<MatchesSliderSection>`: `<UpcomingMatches>` at `apps/web/src/components/home/UpcomingMatches/`
+- Existing component (to be reskinned): `apps/web/src/components/match/MatchTeaser/`
+- Dead code to be retired: `apps/web/src/components/match/MatchesSlider/`
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ LOCKED |
+| 6.B.d2 | `<MatchHero>` shape | ✅ LOCKED |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | ✅ LOCKED |
+| 6.B.d4 | `<MatchArticleLinkCard>` | ✅ LOCKED (build deferred to post-#1470) |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D + tint | ✅ LOCKED |
+| 6.B.d6 | `<MatchTeaser>` (default only; compact retired) | ✅ **LOCKED (this doc — A2-italic + scope slim-down)** |
+| 6.B.d7 | `<MatchResultRow>` reskin — needs consumer audit | next |
+| 6.B.d8 | `<MatchStripClient>` audit — needs consumer audit | queued |
+| 6.B.d2 round 4 | MatchHero mobile collapse | deferred to implementation kickoff |
+| 6.B.d3 round 2 | Per-row visual refinements | deferred unless flagged |

--- a/docs/design/mockups/phase-6-match-detail/page-composition-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/page-composition-locked.md
@@ -15,7 +15,7 @@ The "minimal" Variant C (push lineup + events to the article system) is **reject
 | Page shape | One composition; sections auto-hide based on data availability |
 | State branching | Hero is state-aware (one `<MatchHero state="upcoming\|finished" />`); body sections gate on data, not state |
 | MatchStrip placement | Top only (`<MatchStripSlot />` inline at the top, mirroring `/spelers/[slug]`'s post-6.A resolution) |
-| RelatedArticles | Always renders below the body sections (queries by `articleMatch` ref — schema delta tracked separately, dependency on #1470) |
+| RelatedArticles | Slot reserved below the body sections; **DEFERRED to post-#1470** for the same reason as `<MatchArticleLinkCard>` — without the `linkedMatch` field that #1470 introduces on the article schema, no structured article↔match linkage exists in the dataset and the query would always return zero rows |
 
 ## Page composition
 
@@ -27,7 +27,7 @@ StripedSeam
 <MatchLineupSection>                      (auto-hides if no lineup → typically upcoming)
 <MatchEventsSection>                      (auto-hides if no events → typically upcoming)
 <MatchArticleLinkCard>                    (DEFERRED to post-#1470; slot reserved, renders nothing in v1)
-RelatedArticles                           (queries by articleMatch ref — also depends on #1470 schema; render-empty fallback OK in v1)
+RelatedArticles                           (DEFERRED to post-#1470; depends on the linkedMatch field that #1470 introduces — no article↔match linkage exists in the dataset until then)
 FooterSafeArea
 ```
 
@@ -61,7 +61,7 @@ Top-only mounting matches the precedent set by /spelers/[slug] (Phase 6.A) — t
 
 **`<MatchArticleLinkCard>` is a new design-system component** introduced by this lock. Its visual treatment is settled in 6.B.d4 (Variant B — hero-style cover card). The component is **OPTIONAL** — when no `matchPreview` / `matchRecap` article exists, it returns `null` (auto-hide).
 
-**Implementation deferred per the d4 lock.** Since no `matchPreview` / `matchRecap` articles exist in the dataset today (they ship with #1470, not on the near-term roadmap), the component would auto-hide on every match in v1. The card is therefore **not** built in Phase 6.B implementation tickets — the slot in the page composition is reserved but renders nothing pre-#1470. A follow-up issue spawned alongside #1470 implements the component to the locked design.
+**Implementation deferred per the d4 lock.** The `linkedMatch` field on the article schema (which is how an article points at a match per #1470's spec) doesn't exist today. No `matchPreview` / `matchRecap` articles exist either. Both `<MatchArticleLinkCard>` AND a match-filtered `<RelatedArticles>` would auto-hide on every match in v1 — they're shipped as dormant code or skipped entirely. The card is **not** built in Phase 6.B implementation tickets — the slot in the page composition is reserved but renders nothing pre-#1470. A follow-up issue spawned alongside #1470 implements both pieces (the link card + the related-articles match query) to the locked designs.
 
 **`<MatchLineupSection>` and `<MatchEventsSection>`** are new section-level wrappers around the existing `<MatchLineup>` + `<MatchEvents>` primitives, adding redesign chrome (kicker, heading, striped seam, container). The wrapped primitives keep their tested behaviour.
 

--- a/docs/design/mockups/phase-6-match-detail/page-composition-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/page-composition-locked.md
@@ -26,8 +26,8 @@ MatchStripSlot                            (top — inline, like /spelers/[slug])
 StripedSeam
 <MatchLineupSection>                      (auto-hides if no lineup → typically upcoming)
 <MatchEventsSection>                      (auto-hides if no events → typically upcoming)
-<MatchArticleLinkCard>                    (auto-hides if no matchPreview/matchRecap article)
-RelatedArticles                           (queries by articleMatch ref)
+<MatchArticleLinkCard>                    (DEFERRED to post-#1470; slot reserved, renders nothing in v1)
+RelatedArticles                           (queries by articleMatch ref — also depends on #1470 schema; render-empty fallback OK in v1)
 FooterSafeArea
 ```
 
@@ -59,7 +59,9 @@ Top-only mounting matches the precedent set by /spelers/[slug] (Phase 6.A) — t
 
 **`<MatchHero>` is a new design-system component** introduced by this lock. It supersedes the existing `<MatchHeader>` consumed by `MatchDetailView`. `<MatchHeader>` retirement is in scope for 6.B; the per-component drill (6.B.d2) settles the visual treatment.
 
-**`<MatchArticleLinkCard>` is a new design-system component** introduced by this lock. Its visual treatment is settled in 6.B.d4. The component is **OPTIONAL** — when no `matchPreview` / `matchRecap` article exists, it returns `null` (auto-hide).
+**`<MatchArticleLinkCard>` is a new design-system component** introduced by this lock. Its visual treatment is settled in 6.B.d4 (Variant B — hero-style cover card). The component is **OPTIONAL** — when no `matchPreview` / `matchRecap` article exists, it returns `null` (auto-hide).
+
+**Implementation deferred per the d4 lock.** Since no `matchPreview` / `matchRecap` articles exist in the dataset today (they ship with #1470, not on the near-term roadmap), the component would auto-hide on every match in v1. The card is therefore **not** built in Phase 6.B implementation tickets — the slot in the page composition is reserved but renders nothing pre-#1470. A follow-up issue spawned alongside #1470 implements the component to the locked design.
 
 **`<MatchLineupSection>` and `<MatchEventsSection>`** are new section-level wrappers around the existing `<MatchLineup>` + `<MatchEvents>` primitives, adding redesign chrome (kicker, heading, striped seam, container). The wrapped primitives keep their tested behaviour.
 

--- a/docs/design/mockups/phase-6-match-detail/page-composition-locked.md
+++ b/docs/design/mockups/phase-6-match-detail/page-composition-locked.md
@@ -1,0 +1,85 @@
+# 6.B.d1 · Page Composition — LOCKED
+
+**Decision:** Variant **A — Shared shell, per-section auto-hide**, locked 2026-05-22.
+
+The match-detail page renders one composition for both states. `<MatchHero>` is state-aware; structural sections (`<MatchLineupSection>`, `<MatchEventsSection>`, `<MatchArticleLinkCard>`) auto-hide when their data isn't available. Mirrors the Phase 6.A pattern (BioBlock / QuotesBlock auto-hide when bio lacks the right span marks).
+
+The "hard fork" Variant B (separate UpcomingMatchPage / FinishedMatchPage components) is **rejected** in favour of one composition — reduces code duplication and matches the BioBlock / QuotesBlock vocabulary established in 6.A.
+
+The "minimal" Variant C (push lineup + events to the article system) is **rejected** in favour of keeping lineup + events on `/wedstrijd/[matchId]` — they're already-available BFF data and provide value independent of editorial coverage.
+
+## What this locks
+
+| Decision | Locked value |
+| --- | --- |
+| Page shape | One composition; sections auto-hide based on data availability |
+| State branching | Hero is state-aware (one `<MatchHero state="upcoming\|finished" />`); body sections gate on data, not state |
+| MatchStrip placement | Top only (`<MatchStripSlot />` inline at the top, mirroring `/spelers/[slug]`'s post-6.A resolution) |
+| RelatedArticles | Always renders below the body sections (queries by `articleMatch` ref — schema delta tracked separately, dependency on #1470) |
+
+## Page composition
+
+```text
+SiteHeader                                (from layout)
+MatchStripSlot                            (top — inline, like /spelers/[slug])
+<MatchHero state="upcoming|finished">     (state-aware; never auto-hides)
+StripedSeam
+<MatchLineupSection>                      (auto-hides if no lineup → typically upcoming)
+<MatchEventsSection>                      (auto-hides if no events → typically upcoming)
+<MatchArticleLinkCard>                    (auto-hides if no matchPreview/matchRecap article)
+RelatedArticles                           (queries by articleMatch ref)
+FooterSafeArea
+```
+
+### Per-state render shape
+
+**Upcoming** (status = `scheduled`):
+- Hero (upcoming variant — score region shows kickoff time or "vs")
+- `<MatchArticleLinkCard>` if a `matchPreview` article exists for this match
+- `RelatedArticles`
+- (Lineup + Events auto-hidden — no data)
+
+**Finished** (status = `finished`):
+- Hero (finished variant — score region shows final score + status badge)
+- `<MatchLineupSection>` (BFF surfaces lineup for finished matches)
+- `<MatchEventsSection>` (BFF surfaces events for finished matches)
+- `<MatchArticleLinkCard>` if a `matchRecap` article exists for this match
+- `RelatedArticles`
+
+**Edge states** (`forfeited` / `postponed` / `stopped`):
+- Hero renders the finished variant with the appropriate `MatchStatus` badge ("FF" / "AFG" / "STOP")
+- Lineup / events typically empty → auto-hide
+- ArticleLinkCard renders if any related article exists
+
+## MatchStrip placement rationale
+
+Top-only mounting matches the precedent set by /spelers/[slug] (Phase 6.A) — the strip gives the visitor next-fixture orientation before they engage with detail content. Bottom mounting (originally hinted at in the 6.d8 player-profile spec) is rejected as visual noise the rest of the site doesn't repeat. The Phase 3.C lock's "detail pages omit" rule is opted out of for `/wedstrijd/[matchId]` and `/spelers/[slug]` only — both are match-context surfaces where the next-fixture strip enhances rather than distracts.
+
+## Knock-on resolutions
+
+**`<MatchHero>` is a new design-system component** introduced by this lock. It supersedes the existing `<MatchHeader>` consumed by `MatchDetailView`. `<MatchHeader>` retirement is in scope for 6.B; the per-component drill (6.B.d2) settles the visual treatment.
+
+**`<MatchArticleLinkCard>` is a new design-system component** introduced by this lock. Its visual treatment is settled in 6.B.d4. The component is **OPTIONAL** — when no `matchPreview` / `matchRecap` article exists, it returns `null` (auto-hide).
+
+**`<MatchLineupSection>` and `<MatchEventsSection>`** are new section-level wrappers around the existing `<MatchLineup>` + `<MatchEvents>` primitives, adding redesign chrome (kicker, heading, striped seam, container). The wrapped primitives keep their tested behaviour.
+
+## Cross-references
+
+- Phase 6.B.d0 data-reality lock: `docs/design/mockups/phase-6-match-detail/data-reality-locked.md`
+- Phase 6.A precedent (one-composition-with-auto-hide): `docs/design/mockups/phase-6-player-profile/quotesblock-locked.md`
+- Phase 3.C MatchStrip rule: `docs/design/mockups/phase-3-c-header-and-matchstrip/matchstrip-locked.md`
+- Article variant dependency: #1470
+
+## Drill state after this lock
+
+| Drill | Subject | Status |
+| --- | --- | --- |
+| 6.B.d0 | Data reality | ✅ LOCKED |
+| 6.B.d1 | Page composition | ✅ **LOCKED (this doc)** |
+| 6.B.d2 | `<MatchHero>` shape (upcoming + finished variants) | round 1 in-flight |
+| 6.B.d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | queued |
+| 6.B.d4 | `<MatchArticleLinkCard>` | queued |
+| 6.B.d5 | `<MatchStatusBadge>` Direction-D audit | queued |
+| 6.B.d6 | `<MatchTeaser>` reskin (default + compact) | queued — cross-cutting per #1528 |
+| 6.B.d7 | `<MatchResultRow>` reskin | queued — cross-cutting per #1528 |
+| 6.B.d8 | `<MatchStripClient>` audit | queued — cross-cutting per #1528 |

--- a/docs/prd/redesign-phase-6b-match-detail.md
+++ b/docs/prd/redesign-phase-6b-match-detail.md
@@ -1,0 +1,275 @@
+# PRD — Phase 6.B · Match Detail Redesign
+
+**Status:** ready for `/prd-to-issues`. All 8 design drills (6.B.d0 → 6.B.d8) locked 2026-05-22.
+**Authored:** 2026-05-22.
+**Owner:** @climacon.
+**Tracker:** #1528 (Phase 6 master).
+**Lock docs (authoritative for design decisions):** `docs/design/mockups/phase-6-match-detail/*-locked.md` — 8 per-element locks. Do not re-derive in any sub-issue; quote the lock docs.
+**Master plan:** `docs/plans/2026-04-27-redesign-master-design.md` §6.3 (updated 2026-05-22 to drop the live state).
+**Drill artefacts:** `docs/design/mockups/phase-6-match-detail/6b{0..8}-*/` — comparisons HTML + `compare.md` per drill. Historical record; lock docs supersede.
+
+---
+
+## 1. Problem statement
+
+`/wedstrijd/[matchId]` ships in pre-redesign vocabulary while the rest of the site is moving to the retro-terrace-fanzine system locked across Phases 0–5. Three cross-cutting match components carry visible drift:
+
+- `<MatchResultRow>` (consumed by `<TeamSchedule>` on `/ploegen/[slug]`) uses retired tokens (`kcvv-green-bright`, `kcvv-success`, `kcvv-alert`, `rounded-card`) plus a result-coloured left border that conflicts with the new 2px ink card frame.
+- `<MatchTeaser>` (consumed by `<CalendarMonth>` on `/kalender`) predates the editorial paper-card vocabulary.
+- `<MatchStatusBadge>` uses the retired bright `--color-jersey` colour (see `[[feedback_no_bright_jersey]]`) and is missing coverage for the `finished` state required by the new `<MatchHero>`.
+
+Plus a data-model gap surfaced during the audit: the BFF normalises PSD's `cancelled: boolean` flag and PSD code 2 (`afgelast`) into the same `MatchStatus` literal `"postponed"`, hiding a meaningful semantic distinction (cancelled = definitively dead, postponed = may reschedule).
+
+Phase 6.B closes the match-detail gap, brings the cross-cutting components into Direction D / editorial-paper vocabulary, and adds `"cancelled"` to `MatchStatus` so the new badge tier system can express the correct severity. The scope is deliberately lean: **ONE BFF schema delta, ZERO new BFF endpoints, ZERO new editorial backlog**. Editorial-derived sections (match preview/recap article surfacing) are design-locked but build-deferred until #1470 ships the `linkedMatch` reference field on the article schema.
+
+---
+
+## 2. Scope
+
+### In scope (packages touched)
+
+- **`packages/api-contract`** — add `"cancelled"` to the `MatchStatus` literal in `src/schemas/match.ts`
+- **`apps/api`** — `src/psd/transforms.ts` returns `"cancelled"` when PSD's `cancelled === true` (stops collapsing into `"postponed"`); test fixtures updated
+- **`apps/web`** —
+  - Rewire `src/app/(main)/wedstrijd/[matchId]/page.tsx` to the locked composition (`<MatchHero>` → `<StripedSeam>` → `<MatchLineupSection>` → `<MatchEventsSection>` → footer)
+  - New `<MatchHero>` component (`src/components/match/MatchHero/`)
+  - New `<MatchLineupSection>` + `<MatchEventsSection>` wrappers around existing `<MatchLineup>` + `<MatchEvents>` primitives
+  - Extend `<MatchStatusBadge>` to render 5 statuses (FT/FF/PP/CANC/STOP) with Direction D paper-chrome + per-status severity tints
+  - Reskin `<MatchTeaser>` to A2-italic (default variant only)
+  - Reskin `<MatchResultRow>` to mini-teaser-row vocabulary
+  - Introduce `--color-card-red` token for the CANC severity tier
+- **Cleanup** (Phase 3 of this PRD):
+  - Retire `<MatchesSlider>` component (orphan after Phase 4.B.2)
+  - Retire `<MatchTeaser variant="compact">` (zero active consumers)
+  - Retire legacy `<MatchDetailView>` + `<MatchHeader>` (superseded by `<MatchHero>` + sections)
+
+### Out of scope — explicit, named
+
+These surfaces ARE on the match-detail page today (or are mentioned in the Phase 6 epic) but are NOT touched in Phase 6.B. Mixed-state styling acceptable per master plan §7:
+
+- **`<MatchArticleLinkCard>`** — design-locked (Variant B hero-style cover card) but **build deferred to post-#1470**. The `linkedMatch: string` field that #1470 introduces is the only way to query articles tied to a specific match; without it, the card auto-hides on every match. The locked-but-deferred spec lives at `docs/design/mockups/phase-6-match-detail/article-link-card-locked.md` for the future implementer to follow.
+- **`<RelatedArticles>` match-filtered surfacing** — same #1470 dependency. The page composition reserves the slot; Phase 6.B implementation renders nothing in it pre-#1470.
+- **`<MatchStrip>`** — no changes. Phase 3.C lock (`docs/design/mockups/phase-3-c-header-and-matchstrip/matchstrip-locked.md`) remains authoritative; the d8 audit confirmed no drift between spec and current implementation.
+- **Live match data + the live page state** — confirmed no BFF source; not in scope. Master plan §6.3 updated to a 2-state surface (upcoming + finished).
+- **`<MatchHero>` mobile collapse** — straightforward stacked-stub-on-top layout; design sanity-check deferred to implementation kickoff (round 4 of d2).
+- **Per-row visual refinements in `<MatchLineupSection>` / `<MatchEventsSection>`** — number badge style, captain glyph, card icon set inherit from existing primitives. Refinements deferred unless flagged in implementation review.
+- **`<MatchResultRow>` round 2** — the L (loss) pill colour (warm vs bordered-cream) is open per the d7 lock. Phase 6.B implementation ships with warm; round 2 happens only if owner flags during PR review.
+- **Phase 6.C surfaces** (`/ploegen/[slug]` team detail), **Phase 6.D** (`/kalender`), **Phase 6.E** (`/events`) — separate re-plans after Phase 6.B retrospective.
+
+---
+
+## 3. Tracer bullet
+
+**Phase 1 (the BFF schema delta PR) is the tracer.** It crosses every layer end-to-end — Effect Schema literal → BFF transform → handler tests → downstream consumer types in apps/web — without touching UI. If the schema delta ships clean (api-contract types regenerate, BFF tests pass, no surprise downstream breakage), the data flow for the new `"cancelled"` literal is proven before any component work begins.
+
+Thinnest possible end-to-end change: **the single Effect Schema literal addition plus the one-line transform change**, with the supporting test fixtures + downstream type adjustments. Validates the schema chain.
+
+---
+
+## 4. Phases
+
+Three phases. Each = one deployable unit, runnable tests, no broken state.
+
+```text
+Phase 1: BFF schema delta — TRACER. Backend + contract only, no UI change.
+         → chore(api): add "cancelled" to MatchStatus + fix transforms.ts
+
+Phase 2: UI rebuild — parallel sub-issues for components, then integration via
+         page assembly. Plus the cross-cutting reskins.
+         → feat(matches): <MatchHero> new component
+         → feat(matches): <MatchLineupSection> + <MatchEventsSection> wrappers
+         → feat(matches): extend <MatchStatusBadge> to 5 statuses + Direction-D tints
+         → feat(matches): reskin <MatchTeaser> to A2-italic (default only)
+         → feat(matches): reskin <MatchResultRow> to mini-teaser-row
+         → feat(matches): /wedstrijd/[matchId] page assembly + e2e
+
+Phase 3: Legacy cleanup + doc audit closeout.
+         → chore(matches): retire <MatchesSlider>, <MatchTeaser variant="compact">,
+            legacy <MatchDetailView> + <MatchHeader>
+```
+
+**Milestone:** `redesign-retro-terrace-fanzine` (the Phase 6 umbrella).
+
+**Dependency graph:**
+
+```text
+Phase 1 (tracer)
+   ├─ blocks → <MatchHero>            (consumes MatchStatus literal in corner stamp)
+   ├─ blocks → <MatchStatusBadge> ext  (renders 5 statuses incl. cancelled)
+   ├─ blocks → <MatchLineupSection>   (auto-hide branch depends on status)
+   ├─ blocks → <MatchEventsSection>   (auto-hide branch depends on status)
+   ├─ blocks → <MatchTeaser> reskin   (consumes MatchStatus literal)
+   ├─ blocks → <MatchResultRow> reskin (consumes MatchStatus literal)
+   └─ blocks → page assembly + e2e   (consumes all above)
+                  ↑
+                  └─ blocks → Phase 3 cleanup
+```
+
+---
+
+## 5. Acceptance criteria per phase
+
+### Phase 1 — BFF schema delta (tracer)
+
+- [ ] `packages/api-contract/src/schemas/match.ts` — `MatchStatus` literal expanded to `"scheduled" | "finished" | "forfeited" | "postponed" | "cancelled" | "stopped"`; JSDoc updated
+- [ ] `apps/api/src/psd/transforms.ts` — return `"cancelled"` when `cancelled === true`; PSD code 2 still returns `"postponed"`; JSDoc updated
+- [ ] `apps/api/src/psd/service.test.ts` — new test case: `cancelled: true` + PSD code 0 → status === `"cancelled"`; existing postponed tests still pass
+- [ ] `apps/api/src/handlers/matches.test.ts` — fixtures or assertions updated wherever they branched on `"postponed"` (audit each)
+- [ ] `apps/web/src/components/match/MatchStatusBadge/MatchStatusBadge.tsx` (and any other web-side consumer) — accept the new literal in its `MatchStatus` import; render path may temporarily delegate to `null` until Phase 2 extends the badge — fine, just don't crash
+- [ ] `pnpm --filter @kcvv/api check-all` passes
+- [ ] `pnpm --filter @kcvv/web check-all` passes
+- [ ] `pnpm turbo build --filter=@kcvv/api-contract` passes
+
+### Phase 2 — UI rebuild
+
+#### `<MatchHero>` new component
+
+- [ ] Component shipped at `apps/web/src/components/match/MatchHero/` with `MatchHero.tsx`, `MatchHero.stories.tsx`, `MatchHero.test.tsx`, `index.ts`
+- [ ] Story title `Features/Matches/MatchHero`; meta tags include `vr`
+- [ ] Single `<TapedCard>` split into 2 zones by a 2px dashed ink divider (no perforation circles per d2 T2)
+- [ ] Left stub (~110px) — `bg-cream-soft`, display-big date + time + venue (mono caps); typography per `matchhero-locked.md`
+- [ ] Right body — kicker (`VOORBESCHOUWING` / `MATCHVERSLAG`), teams + score row, competition meta row
+- [ ] Score region state-aware: `vs` (italic display lowercase) for `scheduled`; numeric score (display-big) for everything else
+- [ ] Mounts `<MatchStatusBadge>` as a corner stamp top-right
+- [ ] Stories cover: upcoming, finished, edge states (FF / PP / CANC / STOP)
+- [ ] VR baselines captured + committed
+- [ ] Unit tests cover state branching + edge-state badge rendering
+
+#### `<MatchLineupSection>` + `<MatchEventsSection>` new wrappers
+
+- [ ] Two wrappers at `apps/web/src/components/match/MatchLineupSection/` + `MatchEventsSection/`
+- [ ] Each auto-hides (`return null`) when its data is empty (typically upcoming)
+- [ ] `<MatchLineupSection>` — kicker `OPSTELLINGEN` + heading "Wie er stond." + 2-col home/away wrapping existing `<MatchLineup>`; `BANK` divider separates starters from subs
+- [ ] `<MatchEventsSection>` — kicker `WEDSTRIJDVERLOOP` + heading "Hoe het ging." + single chronological timeline wrapping existing `<MatchEvents>`; 4-col grid (minute / glyph / player / team mono)
+- [ ] `<StripedSeam>` between the two sections (`colorPair="ink-cream"`, `height="md"`)
+- [ ] Stories per section cover: full data (finished match), empty data (auto-hide branch)
+- [ ] VR baselines captured for the populated stories; auto-hide stories ship blank baselines per Phase 6.A `BioBlock.Empty` precedent
+- [ ] Unit tests cover the auto-hide branch + the wrapper composition
+
+#### `<MatchStatusBadge>` extension (Direction-D + per-status tint)
+
+- [ ] `BadgeStatus` extended from 3 → 5 statuses (`finished` + `forfeited` + `postponed` + `cancelled` + `stopped`); `scheduled` still returns `null`
+- [ ] Visual chrome migrated from `<MonoLabel variant="pill-jersey">` to Direction D paper-chrome (`border-2 border-ink shadow-paper-sm bg-cream` + mono caps + sharp corners) — styled inline on the component, no new `<MonoLabel>` variant
+- [ ] Per-status tint applied: FT → `cream`, PP + FF → `cream-deep`, STOP → `warm`, CANC → `card-red`
+- [ ] Copy: abbreviations only (`FT` / `FF` / `PP` / `CANC` / `STOP`); `title=` attribute carries long-form Dutch (`Voltijd` / `Forfait` / `Uitgesteld` / `Geannuleerd` / `Gestopt`) for accessibility
+- [ ] New token `--color-card-red` introduced wherever Phase 4.5 / Phase 5 tokens live (likely `apps/web/src/app/globals.css`)
+- [ ] Stories cover each of the 5 statuses + the `scheduled` null branch
+- [ ] VR baselines captured
+- [ ] Unit tests: one assertion per status (render text, tint class, tooltip title)
+
+#### `<MatchTeaser>` reskin (default only)
+
+- [ ] Component rewritten to A2-italic: stub (~76px, `bg-cream-soft`, 30px display-big date number + 14px italic display month label) + body (mono kicker + teams + score)
+- [ ] `variant` prop simplified — drop `compact` from the union, simplify the API
+- [ ] Highlighted team (KCVV) gets `font-weight: 600`
+- [ ] Mounts `<MatchStatusBadge>` as a corner stamp when applicable
+- [ ] Light theme only — the dark `theme` prop is dropped
+- [ ] Stories cover: upcoming, finished, edge states; existing `<CalendarMonth>` integration confirmed via the consumer's tests
+- [ ] VR baselines captured + committed
+- [ ] Unit tests for each rendered state
+
+#### `<MatchResultRow>` reskin (mini-teaser row)
+
+- [ ] Component rewritten to a scaled-down mini-teaser shape: 64px stub (display-big date + italic month) + body (italic display teams + display-big score) + result pill at the row end
+- [ ] Result pill: W → `pill-jersey`, G → cream-soft + ink border, L → `warm` (round-2 sub-decision; can downgrade to bordered-cream if owner flags during PR review)
+- [ ] Result-coloured left border from the legacy component **dropped** — conflicts with the new 2px ink card frame
+- [ ] Light theme only — `theme="dark"` prop dropped (no current dark consumer)
+- [ ] Mounts `<MatchStatusBadge>` as a corner stamp when applicable
+- [ ] Whole row is a `<Link>` to `/wedstrijd/[matchId]` (matches legacy behaviour)
+- [ ] Stories cover W / G / L + edge states
+- [ ] VR baselines captured + committed
+- [ ] Unit tests for each result state + status integration
+
+#### Page assembly + e2e
+
+- [ ] `apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx` rewired to the locked composition: `<MatchHero>` → `<StripedSeam>` → `<MatchLineupSection>` → `<MatchEventsSection>` → `<FooterSafeArea>`
+- [ ] `<MatchStripSlot>` mounted inline once at the top (per d1 — same opt-in as `/spelers/[slug]`)
+- [ ] Reserved (unrendered) slots in the composition for `<MatchArticleLinkCard>` + `<RelatedArticles>` documented with a TODO comment pointing at the post-#1470 follow-up
+- [ ] Legacy `<MatchDetailView>` consumption removed (component retirement in Phase 3)
+- [ ] `getMatchDetail` BFF call shape unchanged; lineup + events flow through the new sections directly
+- [ ] `generateMetadata` preserved; OG image unchanged
+- [ ] `<JsonLd>` preserved (breadcrumb + `SportsEvent` per existing builder; no scope creep on the schema-dts side)
+- [ ] Analytics: `match_detail_view` page-view event fires on mount (pattern from Phase 6.A `<PageViewTracker>`); `match_lineup_section_in_view` + `match_events_section_in_view` intersection events fire when each section enters view (pattern from Phase 6.A `<TrackInView>`); only mount the wrappers when the section will actually render (no orphan events on auto-hide)
+- [ ] GTM regex update: extend the existing `responsibility_|search_|organigram_|related_content_|homepage_|player_` regex to include `match_` (CLAUDE.md analytics-checklist line update + manual GTM trigger change documented in PR body)
+- [ ] Playwright e2e smoke test for `/wedstrijd/[matchId]` still passes (no broken images, `<h1>` visible, console clean)
+- [ ] `pnpm --filter @kcvv/web check-all` passes
+- [ ] `pnpm --filter @kcvv/web run test:e2e` passes locally against this route family
+
+#### Cross-cutting
+
+- [ ] `apps/web/CLAUDE.md` "Redesign primitives (Phase 0+)" section updated with `<MatchHero>`, `<MatchLineupSection>`, `<MatchEventsSection>`, extended `<MatchStatusBadge>`, reworked `<MatchTeaser>`, reworked `<MatchResultRow>`
+- [ ] `--color-card-red` token registered in the Foundation/Colors Storybook reference
+- [ ] No staging seed matrix required — match data is BFF-synced (no per-record fixtures to author). E2e smoke validates the page assembly against staging data
+
+### Phase 3 — Cleanup
+
+- [ ] `apps/web/src/components/match/MatchesSlider/` deleted entirely (component file + tests + stories + index)
+- [ ] `<MatchTeaser variant="compact">` code path removed; `variant` prop simplified per Phase 2 lock
+- [ ] Legacy `<MatchDetailView>` + `<MatchHeader>` deleted (`apps/web/src/components/match/MatchDetailView/`, `apps/web/src/components/match/MatchHeader/`); barrel exports cleaned; no remaining consumers (`rg` confirms)
+- [ ] `apps/web/src/components/design-system/HorizontalSlider/HorizontalSlider.stories.tsx` inline `MatchCard*` mock + `mockMatches` array — **out of scope** per #1528's own follow-up cleanup note; flag if it surfaces in review but defer to a separate ticket
+- [ ] `pnpm --filter @kcvv/web check-all` passes
+
+---
+
+## 6. Effect Schema / api-contract changes
+
+One literal expansion; no new shapes.
+
+```typescript
+// packages/api-contract/src/schemas/match.ts
+export const MatchStatus = S.Literal(
+  "scheduled",
+  "finished",
+  "forfeited",
+  "postponed",
+  "cancelled",   // NEW (#6.B.d5)
+  "stopped",
+);
+```
+
+```typescript
+// apps/api/src/psd/transforms.ts — BEFORE
+if (cancelled) return "postponed";
+
+// AFTER
+if (cancelled) return "cancelled";
+```
+
+**No other api-contract changes.** No new endpoints. No new Schema classes. The PSD response schemas (`apps/api/src/psd/schemas-*.ts`) stay untouched — PSD's `cancelled: boolean` is already in them; the transform just stops collapsing it.
+
+---
+
+## 7. Open questions
+
+These do NOT block the PRD. They surface during implementation and resolve via tracer feedback, audit at PR time, or owner direction.
+
+- [ ] **`--color-card-red` token reusability.** Phase 6.B introduces it for CANC. If a future system-alert / error / destructive-action vocabulary needs a red, this token covers it. Worth registering in Foundation/Colors story; worth a sentence in CLAUDE.md flagging "this is the redesign's alert-red — reuse, don't re-introduce a sibling". **Resolved by**: design-system review at Phase 2 PR time.
+- [ ] **L pill colour on `<MatchResultRow>`.** Current spec: warm. Risk: a difficult season → many warm pills in a row → "traffic light" feel. Fallback: downgrade to bordered-cream (same as G). **Resolved by**: implementer renders a screenful of mixed results in Storybook + owner sanity-checks at PR review.
+- [ ] **`<MatchArticleLinkCard>` follow-up issue.** Design-locked + build-deferred. A follow-up issue should be filed alongside #1470 (when it lands) so the link card ships as part of #1470's implementation or as an immediate follow-up. **Resolved by**: file the follow-up issue when this Phase 6.B PRD's `/prd-to-issues` run completes — title it `feat(matches): implement <MatchArticleLinkCard> per locked design (post-#1470)` and add `blocked-by: #1470` via GraphQL.
+- [ ] **`<MatchHero>` mobile collapse.** Two-zone stub stacks vertically; design is straightforward but unverified at production scale. **Resolved by**: implementer renders the hero at narrow widths in Storybook; if the stack feels broken, a small round-4 mockup in `6b2-matchhero/` sub-folder + owner sign-off.
+- [ ] **`<MatchStripClient>` epic reference.** The Phase 6 epic (#1528) mentioned `<MatchStripClient>` as a cross-cutting deliverable, but no such component exists in the current codebase — actual files are `<MatchStripSlot>` / `<MatchStrip>` / `<MatchStripView>`. d8 audit closed this as no-op (Phase 3.C lock authoritative). **Resolved by**: nothing to do; this PRD acknowledges the epic's reference is outdated.
+
+---
+
+## 8. Discovered unknowns
+
+Surfaced during the 8 drills, not blockers, no owner direction needed at PRD-authoring time. Captured for the implementer.
+
+- The current `<MatchStripView>` already conforms to Phase 3.C locked Direction D. No drift between spec and implementation; d8 audit returned a clean no-op.
+- `<HorizontalSlider>`'s inline `MatchCard*` mock from PR #1594 is unrelated to Phase 6.B's MatchTeaser reskin — they're separate components living in different folders. The #1528 follow-up cleanup that swaps the slider stories to render the real reskinned MatchTeaser still applies but stays its own ticket (not bundled with Phase 6.B).
+- `<UpcomingMatches>` on the homepage (the post-Phase-4.B.2 successor of `<MatchesSliderSection>`) does NOT use `<MatchTeaser>` — it composes its own primitives (`<TapedCard>` + `<EditorialHeading>` + `<MonoLabel>`) via `<UpcomingMatchesClient>`. No knock-on impact from Phase 6.B's teaser reskin.
+- `<TeamSchedule>` is in `apps/web/src/components/team/` (Phase 6.C scope), but its sole reskin requirement (the per-row `<MatchResultRow>` component) lands in Phase 6.B per the Phase 6 epic's cross-cutting designation. When Phase 6.C drills `<TeamDetail>`, the rows already use the locked vocabulary.
+
+---
+
+## 9. Implementation order suggestion
+
+Not a hard requirement (sub-issues are written to be parallel-executable after Phase 1), but a pragmatic order for one-engineer execution:
+
+1. **Phase 1** ships first (tracer) — every Phase 2 component depends on the cancelled literal landing in the shared types.
+2. **`<MatchStatusBadge>` extension** ships second — it's the smallest of the Phase 2 components and unblocks visual review of the badge across every other component's stories.
+3. **`<MatchHero>` + `<MatchLineupSection>` + `<MatchEventsSection>`** ship in parallel — they're independent components, each with its own story + test suite, all consumed only by the page assembly.
+4. **`<MatchTeaser>` reskin** ships in parallel with the above — the only consumer (`<CalendarMonth>`) doesn't change its API call.
+5. **`<MatchResultRow>` reskin** ships in parallel — same reasoning (`<TeamSchedule>` is the sole consumer; API unchanged).
+6. **Page assembly + e2e** ships last in Phase 2 — depends on all of the above.
+7. **Phase 3 cleanup** rides with the page-assembly PR or ships immediately after at the implementer's choice. Per Phase 6.A precedent (where #1886 was a separate cleanup PR after #1885), separate-ship is the cleaner default.


### PR DESCRIPTION
Phase 6.B design series for the match-detail redesign. All 8 drills locked, PRD authored, ready for `/prd-to-issues` review (implementation tickets already spawned — see "Spawned issues" below).

## What's in this PR

### Lock docs (`docs/design/mockups/phase-6-match-detail/`)

| Drill | Subject | Lock doc |
| --- | --- | --- |
| d0 | Data reality | `data-reality-locked.md` |
| d1 | Page composition | `page-composition-locked.md` |
| d2 | `<MatchHero>` shape | `matchhero-locked.md` |
| d3 | `<MatchLineupSection>` + `<MatchEventsSection>` | `lineup-events-locked.md` |
| d4 | `<MatchArticleLinkCard>` (design locked, build deferred) | `article-link-card-locked.md` |
| d5 | `<MatchStatusBadge>` Direction-D + tint | `matchstatusbadge-locked.md` |
| d6 | `<MatchTeaser>` (compact + `<MatchesSlider>` retired) | `matchteaser-locked.md` |
| d7 | `<MatchResultRow>` | `matchresultrow-locked.md` |
| d8 | `<MatchStrip>` audit (no-op) | `6b8-matchstrip-audit/compare.md` |

### Drill artefacts

Each drill folder `6b{0..8}-*/` carries the `compare.md` + one or more `round-N-*-comparisons.html` mockups documenting the iteration trail. Open the HTMLs in a browser to see the visual rounds.

### PRD

`docs/prd/redesign-phase-6b-match-detail.md` — 275 lines consolidating all 8 drill decisions + the BFF schema delta (add `"cancelled"` to `MatchStatus`) + cleanup deliverables into a `/prd-to-issues`-ready spec. Mirrors the Phase 6.A PRD structure.

### Master plan + epic updates

- `docs/plans/2026-04-27-redesign-master-design.md` §6.3 — dropped the live state (already merged in #1901)
- `docs/design/phase-6-player-profile-brief.md` §4 — same correction (already merged)
- #1528 epic body — updated to reflect the 2-state surface

## Headline decisions

- **`<MatchHero>`**: H1 ticket-card + T2 dashed-only separator (no perforation circles). Same shape both states; only score region + kicker copy swap.
- **Page composition**: shared shell, per-section auto-hide (mirrors Phase 6.A BioBlock/QuotesBlock). `<MatchStripSlot>` mounted top-only inline (same opt-in as `/spelers/[slug]`).
- **Lineup + events**: classic separate sections (Opstellingen → StripedSeam → Wedstrijdverloop), wraps existing `<MatchLineup>` + `<MatchEvents>` primitives.
- **`<MatchArticleLinkCard>`**: Variant B (hero-style cover card) design-locked, build deferred to post-#1470 — without the `linkedMatch` field, the card auto-hides on every match.
- **`<MatchStatusBadge>`**: Direction D paper-chrome + per-status severity tints. 5 statuses ship (FT/FF/PP/CANC/STOP). New `--color-card-red` token introduced. Requires BFF schema delta to surface `cancelled` distinctly from `postponed`.
- **`<MatchTeaser>`**: A2-italic default variant only. Compact + orphaned `<MatchesSlider>` retired in Phase 3 cleanup.
- **`<MatchResultRow>`**: mini-teaser-row vocabulary at row scale.
- **`<MatchStrip>`**: no changes. Phase 3.C lock remains authoritative.

## Spawned implementation issues

`/prd-to-issues` ran during this PR. Phase 6.B implementation tickets:

- **#1906** — `chore(api): Phase 6.B tracer — add "cancelled" to MatchStatus + fix transforms.ts` (tracer; blocks every other ticket)
- **#1907** — `feat(matches): <MatchHero> new component for Phase 6.B`
- **#1908** — `feat(matches): <MatchLineupSection> + <MatchEventsSection> wrappers`
- **#1909** — `feat(matches): extend <MatchStatusBadge> to 5 statuses + Direction-D tints`
- **#1910** — `feat(matches): reskin <MatchTeaser> to A2-italic (default only)`
- **#1911** — `feat(matches): reskin <MatchResultRow> to mini-teaser-row`
- **#1912** — `feat(matches): /wedstrijd/[matchId] page assembly + e2e` (blocked by all Phase 2 components)
- **#1913** — `chore(matches): retire <MatchesSlider>, <MatchTeaser variant="compact">, legacy <MatchDetailView> + <MatchHeader>` (blocked by page assembly)
- **#1914** — `feat(matches): implement <MatchArticleLinkCard> per locked design (post-#1470)` (blocked by #1470; not `ready`)

All blockedBy relationships wired via GraphQL. Ralph will pick them up in dependency order once this PR merges.

## CI review

Seven CI findings from earlier rounds addressed in commit `b2bfcb35`; one finding skipped as invalid (round-2 mockup already had the score--vs modifier). See commit message for the full breakdown.

## Doc-only PR

Zero code changes. Implementation work happens in the spawned issues #1906–#1913 (plus follow-up #1914).