### PR TITLE
feat(matches): /wedstrijd/[matchId] page assembly + e2e (#1912)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -167,7 +167,7 @@ Every new user-facing feature or page **must** include an analytics section. Bef
 
 - [ ] **Events defined**: new user interactions have named events in the PRD event taxonomy
 - [ ] **`trackEvent` calls added**: all interactive components call `trackEvent` with the correct parameters
-- [ ] **GTM updated**: new event names not already matched by the `responsibility_|search_|organigram_|related_content_|homepage_|player_` regex need a new trigger/tag in GTM; new event parameters need a Data Layer Variable (DLV) created in GTM and mapped into the GA4 Event tag's parameter fields
+- [ ] **GTM updated**: new event names not already matched by the `responsibility_|search_|organigram_|related_content_|homepage_|player_|match_` regex need a new trigger/tag in GTM; new event parameters need a Data Layer Variable (DLV) created in GTM and mapped into the GA4 Event tag's parameter fields
 - [ ] **GA4 custom dimensions registered**: any new event parameters registered in GA4 → Admin → Data display → Custom definitions (run `node scripts/create-ga4-dimensions.mjs` or add manually)
 - [ ] **GA4 explorations updated**: existing explorations updated, or new exploration created, if the feature introduces a new funnel or metric worth tracking
 - [ ] **No PII**: no email addresses, phone numbers, names, or raw internal IDs in event parameters (hash internal IDs via `hashMemberId`)

--- a/apps/web/src/app/(main)/canonical-urls.test.ts
+++ b/apps/web/src/app/(main)/canonical-urls.test.ts
@@ -128,7 +128,6 @@ describe("Canonical URLs on dynamic routes", () => {
     mockRunPromise.mockResolvedValueOnce(matchFixture);
     const metadata = await wedstrijd.generateMetadata({
       params: Promise.resolve({ matchId: "12345" }),
-      searchParams: Promise.resolve({}),
     });
     expect(metadata).toHaveProperty(
       "alternates.canonical",

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.tsx
@@ -8,8 +8,11 @@
  */
 
 export default function MatchDetailLoading() {
+  // `min-h-screen` root preserved per the envelope-drift guard in
+  // `apps/web/src/app/__tests__/loading-envelope.test.tsx` — non-SectionStack
+  // routes pin to a contract root className.
   return (
-    <>
+    <div className="min-h-screen">
       {/* ── MatchHero skeleton — single TapedCard with stub + body ───── */}
       <section
         aria-hidden="true"
@@ -69,6 +72,6 @@ export default function MatchDetailLoading() {
           ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.tsx
@@ -1,56 +1,74 @@
 /**
- * Match Detail Page — Loading Skeleton
- * Matches the MatchDetailView layout: header with teams/score + lineup columns
+ * Match Detail Page — Loading Skeleton.
+ *
+ * Matches the Phase 6.B composition (page-composition-locked.md, 6.B.d1):
+ * cream-on-paper hero + two section skeletons (lineup grid + events
+ * timeline). Light theme to avoid the dark-bg flash that the legacy
+ * MatchDetailView skeleton produced during navigation.
  */
 
 export default function MatchDetailLoading() {
   return (
-    <div className="min-h-screen">
-      {/* Match header skeleton — dark background */}
-      <div className="bg-kcvv-dark-bg px-4 py-8 text-white">
-        <div className="mx-auto max-w-3xl">
-          {/* Competition + date */}
-          <div className="mb-6 flex flex-col items-center gap-2">
-            <div className="h-4 w-40 animate-pulse rounded bg-white/10" />
-            <div className="h-3 w-28 animate-pulse rounded bg-white/10" />
+    <>
+      {/* ── MatchHero skeleton — single TapedCard with stub + body ───── */}
+      <section
+        aria-hidden="true"
+        className="bg-cream-soft mx-auto w-full max-w-[var(--container-wide)] px-4 py-8"
+      >
+        <div className="border-ink bg-cream shadow-paper-md grid grid-cols-1 border-2 md:grid-cols-[110px_1fr]">
+          {/* Stub */}
+          <div className="bg-cream-soft border-ink space-y-2 border-b-2 border-dashed p-5 md:border-r-2 md:border-b-0">
+            <div className="bg-cream-deep h-6 w-16 animate-pulse" />
+            <div className="bg-cream-deep h-6 w-12 animate-pulse" />
+            <div className="bg-cream-deep h-4 w-10 animate-pulse" />
+            <div className="bg-cream-deep h-3 w-16 animate-pulse" />
           </div>
-
-          {/* Teams + score */}
-          <div className="flex items-center justify-center gap-6">
-            {/* Home team */}
-            <div className="flex flex-1 flex-col items-center gap-2">
-              <div className="h-16 w-16 animate-pulse rounded-full bg-white/10" />
-              <div className="h-5 w-24 animate-pulse rounded bg-white/10" />
+          {/* Body */}
+          <div className="flex flex-col gap-6 p-5 md:p-6">
+            <div className="bg-cream-soft h-3 w-32 animate-pulse" />
+            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4">
+              <div className="flex items-center gap-3">
+                <div className="bg-cream-deep h-10 w-10 animate-pulse rounded-full" />
+                <div className="bg-cream-deep h-5 w-32 animate-pulse" />
+              </div>
+              <div className="bg-cream-deep h-8 w-16 animate-pulse" />
+              <div className="flex flex-row-reverse items-center gap-3">
+                <div className="bg-cream-deep h-10 w-10 animate-pulse rounded-full" />
+                <div className="bg-cream-deep h-5 w-32 animate-pulse" />
+              </div>
             </div>
-
-            {/* Score */}
-            <div className="h-12 w-24 animate-pulse rounded bg-white/10" />
-
-            {/* Away team */}
-            <div className="flex flex-1 flex-col items-center gap-2">
-              <div className="h-16 w-16 animate-pulse rounded-full bg-white/10" />
-              <div className="h-5 w-24 animate-pulse rounded bg-white/10" />
+            <div className="border-ink border-t pt-3">
+              <div className="bg-cream-soft h-3 w-48 animate-pulse" />
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
-      {/* Lineup skeleton — two columns */}
-      <div className="mx-auto max-w-3xl px-4 py-8">
-        <div className="grid grid-cols-2 gap-6">
+      {/* ── MatchLineupSection skeleton — kicker + heading + 2-col rows ─ */}
+      <section
+        aria-hidden="true"
+        className="bg-cream mx-auto w-full max-w-[var(--container-wide)] px-4 py-10 md:py-14"
+      >
+        <div className="bg-cream-soft mb-3 h-3 w-32 animate-pulse" />
+        <div className="bg-cream-soft mb-10 h-8 w-64 animate-pulse" />
+        <div className="grid grid-cols-1 gap-x-10 gap-y-8 md:grid-cols-2">
           {Array.from({ length: 2 }).map((_, col) => (
-            <div key={col} className="animate-pulse space-y-3">
-              <div className="mb-4 h-5 w-24 rounded bg-gray-200" />
-              {Array.from({ length: 11 }).map((_, row) => (
-                <div key={row} className="flex items-center gap-3">
-                  <div className="h-6 w-6 rounded bg-gray-200" />
-                  <div className="h-4 w-32 rounded bg-gray-200" />
-                </div>
-              ))}
+            <div key={col}>
+              <div className="border-ink mb-3 border-t pt-2">
+                <div className="bg-cream-soft h-3 w-24 animate-pulse" />
+              </div>
+              <div className="space-y-2">
+                {Array.from({ length: 11 }).map((_, row) => (
+                  <div key={row} className="flex items-center gap-3 py-1.5">
+                    <div className="bg-cream-soft h-7 w-7 animate-pulse" />
+                    <div className="bg-cream-soft h-4 flex-1 animate-pulse" />
+                  </div>
+                ))}
+              </div>
             </div>
           ))}
         </div>
-      </div>
-    </div>
+      </section>
+    </>
   );
 }

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -1,6 +1,26 @@
 /**
- * Match Detail Page
- * Displays individual match details including lineups
+ * Match Detail Page — Phase 6.B composition (6.B.d1 lock).
+ *
+ * Page shape (Variant A "shared shell, per-section auto-hide"):
+ *
+ *   MatchStripSlot                 ← top only, mirrors /spelers/[slug]
+ *   <MatchHero>                    ← state-aware; never auto-hides
+ *   <StripedSeam>                  ← only when a body section will render
+ *   <MatchLineupSection>           ← auto-hides on empty (typically upcoming)
+ *   <StripedSeam>                  ← only when both Lineup + Events render
+ *   <MatchEventsSection>           ← auto-hides on empty
+ *   [reserved: <MatchArticleLinkCard>]   ← deferred to post-#1470
+ *   [reserved: <RelatedArticles>]        ← deferred to post-#1470
+ *   <FooterSafeArea>
+ *
+ * Replaces the legacy `<MatchDetailView>` consumption (now orphaned;
+ * retired by the #1913 cleanup ticket).
+ *
+ * Note: the legacy `backUrl` back-link feature (a MatchDetailView-only
+ * affordance) has no slot in the new chrome and is intentionally not
+ * carried over. Users navigate via browser back or the breadcrumb
+ * (rendered as JSON-LD only — visual breadcrumb would be a separate
+ * deliberate add).
  */
 
 import { Effect } from "effect";
@@ -10,14 +30,18 @@ import { runPromise } from "@/lib/effect/runtime";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { BffService } from "@/lib/effect/services/BffService";
 import { PlayerRepository } from "@/lib/repositories/player.repository";
-import type { MatchDetail } from "@kcvv/api-contract";
+import type { MatchDetail, MatchEvent } from "@kcvv/api-contract";
 import { JsonLd } from "@/components/seo/JsonLd";
 import {
   buildBreadcrumbJsonLd,
   buildSportsEventJsonLd,
 } from "@/lib/seo/jsonld";
-import { MatchDetailView } from "@/components/match/MatchDetailView";
-import { FooterSafeArea } from "@/components/design-system";
+import { MatchHero } from "@/components/match/MatchHero";
+import { MatchLineupSection } from "@/components/match/MatchLineupSection";
+import { MatchEventsSection } from "@/components/match/MatchEventsSection";
+import { FooterSafeArea, StripedSeam } from "@/components/design-system";
+import { MatchStripSlot } from "@/components/layout/MatchStrip/MatchStripSlot";
+import { PageViewTracker, TrackInView } from "@/components/analytics";
 import {
   transformHomeTeam,
   transformAwayTeam,
@@ -30,7 +54,6 @@ import {
 
 interface MatchPageProps {
   params: Promise<{ matchId: string }>;
-  searchParams: Promise<{ from?: string; fromTab?: string }>;
 }
 
 /**
@@ -39,9 +62,6 @@ interface MatchPageProps {
  * Fetches match details for the given `params.matchId` and produces a metadata
  * object containing a page `title`; when match data is available, also adds
  * `description` and `openGraph` fields populated from the match.
- *
- * @param params - Object containing the route params. `params.matchId` is the match identifier from the URL.
- * @returns Metadata with a page `title`. If match details are found, the metadata also includes `description` and `openGraph` (`title`, `description`, `type`). If the `matchId` is invalid or the match cannot be fetched, the returned metadata contains a "not found" title.
  */
 export async function generateMetadata({
   params,
@@ -85,11 +105,8 @@ export async function generateMetadata({
 }
 
 /**
- * Retrieve match details for the given match ID or trigger a 404 response if unavailable.
- *
- * If the match cannot be fetched, this function calls `notFound()` to produce a 404 page.
- *
- * @returns The match detail for the specified `matchId`.
+ * Retrieve match details for the given match ID or trigger a 404 response if
+ * unavailable.
  */
 async function fetchMatchOrNotFound(matchId: number): Promise<MatchDetail> {
   try {
@@ -104,29 +121,14 @@ async function fetchMatchOrNotFound(matchId: number): Promise<MatchDetail> {
   }
 }
 
-/**
- * Render the match detail page for a given route `matchId`.
- *
- * Parses `matchId` from route params, fetches match details, transforms teams and lineup data,
- * and returns the populated match detail view. If `matchId` is invalid or the match cannot be
- * retrieved, the route responds with a 404.
- *
- * @param params - Route params object containing the string `matchId`
- * @returns The MatchDetailView populated with teams, date, time, status, competition, lineups, and report flag
- */
-export default async function MatchPage({
-  params,
-  searchParams,
-}: MatchPageProps) {
+export default async function MatchPage({ params }: MatchPageProps) {
   const { matchId } = await params;
-  const { from, fromTab } = await searchParams;
   const numericId = parseInt(matchId, 10);
 
   if (isNaN(numericId)) {
     notFound();
   }
 
-  // Fetch match details via BffService
   const match = await fetchMatchOrNotFound(numericId);
 
   // Fetch keeper PSD ids from Sanity (cached for 24h in the repo's
@@ -134,9 +136,7 @@ export default async function MatchPage({
   // Used to flag KCVV-side keepers; opponent side falls back to the
   // jersey-#1 heuristic. Returns `undefined` (not an empty Set) on Sanity
   // failure so `enrichLineupWithKeeperFlag` can detect lookup failure and
-  // degrade BOTH sides to the jersey-#1 heuristic — an empty Set would be
-  // indistinguishable from "we asked Sanity and KCVV has no keeper", which
-  // would silently strip the KCVV keeper badge.
+  // degrade BOTH sides to the jersey-#1 heuristic.
   const keeperPsdIds: ReadonlySet<string> | undefined = await runPromise(
     Effect.gen(function* () {
       const repo = yield* PlayerRepository;
@@ -153,7 +153,6 @@ export default async function MatchPage({
     ),
   );
 
-  // Transform data for display
   const homeTeam = transformHomeTeam(match);
   const awayTeam = transformAwayTeam(match);
   const time = extractMatchTime(match);
@@ -168,7 +167,6 @@ export default async function MatchPage({
         ? "away"
         : undefined;
 
-  // Transform lineup data + tag keepers per side.
   const homeLineup =
     match.lineup?.home
       .map(transformLineupPlayer)
@@ -182,17 +180,20 @@ export default async function MatchPage({
         enrichLineupWithKeeperFlag(p, "away", kcvvSide, keeperPsdIds),
       ) ?? [];
 
-  // Only allow back-links to internal team paths (prevent open redirect)
-  const validFromTabs = ["info", "opstelling", "wedstrijden", "klassement"];
-  const backUrl =
-    from && /^\/ploegen\/[a-zA-Z0-9_-]+$/.test(from)
-      ? `${from}${fromTab && validFromTabs.includes(fromTab) ? `?tab=${fromTab}` : ""}`
-      : null;
+  const events: readonly MatchEvent[] = match.events ?? [];
+  const hasLineup = homeLineup.length > 0 || awayLineup.length > 0;
+  const hasEvents = events.length > 0;
 
   const matchLabel = formatMatchTitle(match);
 
+  const analyticsParams = {
+    match_id: numericId,
+    status: match.status,
+  };
+
   return (
     <>
+      <PageViewTracker eventName="match_detail_view" params={analyticsParams} />
       <h1 className="sr-only">{matchLabel}</h1>
       <JsonLd
         data={buildBreadcrumbJsonLd([
@@ -215,19 +216,66 @@ export default async function MatchPage({
           venue: match.venue,
         })}
       />
-      <MatchDetailView
+
+      <MatchStripSlot />
+
+      <MatchHero
         homeTeam={homeTeam}
         awayTeam={awayTeam}
         date={match.date}
         time={time}
+        venue={match.venue}
         status={match.status}
         competition={match.competition}
-        homeLineup={homeLineup}
-        awayLineup={awayLineup}
-        events={match.events}
-        hasReport={match.hasReport}
-        backUrl={backUrl ?? undefined}
+        kcvvTeamLabel={match.kcvv_team_label}
       />
+
+      {(hasLineup || hasEvents) && (
+        <StripedSeam colorPair="ink-cream" height="md" />
+      )}
+
+      {hasLineup && (
+        <TrackInView
+          eventName="match_lineup_section_in_view"
+          params={analyticsParams}
+        >
+          <MatchLineupSection
+            homeTeamName={match.home_team.name}
+            awayTeamName={match.away_team.name}
+            homeLineup={homeLineup}
+            awayLineup={awayLineup}
+          />
+        </TrackInView>
+      )}
+
+      {hasLineup && hasEvents && (
+        <StripedSeam colorPair="ink-cream" height="md" />
+      )}
+
+      {hasEvents && (
+        <TrackInView
+          eventName="match_events_section_in_view"
+          params={analyticsParams}
+        >
+          <MatchEventsSection
+            homeTeamName={match.home_team.name}
+            awayTeamName={match.away_team.name}
+            homeTeamLogo={match.home_team.logo}
+            awayTeamLogo={match.away_team.logo}
+            events={events}
+          />
+        </TrackInView>
+      )}
+
+      {/* TODO(#1470 follow-up): <MatchArticleLinkCard> renders here when a
+          matchPreview/matchRecap article exists for this match. Slot
+          reserved per the 6.B.d1 lock; component build deferred until the
+          article schema's `linkedMatch` field lands. */}
+
+      {/* TODO(#1470 follow-up): match-filtered <RelatedArticles> renders
+          here. Same dependency on the `linkedMatch` field — query would
+          return zero rows in v1, so the slot stays empty until #1470. */}
+
       <FooterSafeArea />
     </>
   );
@@ -235,6 +283,6 @@ export default async function MatchPage({
 
 /**
  * Enable ISR with 5 minute revalidation for match data
- * (shorter than team pages since match data changes more frequently)
+ * (shorter than team pages since match data changes more frequently).
  */
 export const revalidate = 300;

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -105,20 +105,25 @@ export async function generateMetadata({
 }
 
 /**
- * Retrieve match details for the given match ID or trigger a 404 response if
- * unavailable.
+ * Retrieve match details for the given match ID. Routes the BFF's tagged
+ * `HttpNotFound` error to Next.js's `notFound()` so an unknown matchId
+ * surfaces as a 404 page. Other BFF errors (5xx, parse failures, timeouts)
+ * bubble up — Next's error boundary handles them, which is what we want
+ * for service outages: don't silently disguise them as "not found".
  */
 async function fetchMatchOrNotFound(matchId: number): Promise<MatchDetail> {
-  try {
-    return await runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* bff.getMatchDetail(matchId);
-      }),
-    );
-  } catch {
-    notFound();
-  }
+  return runPromise(
+    Effect.gen(function* () {
+      const bff = yield* BffService;
+      return yield* bff.getMatchDetail(matchId);
+    }).pipe(
+      // `notFound()` throws Next's NEXT_NOT_FOUND sentinel; wrapping in
+      // `Effect.sync` keeps the Effect chain consistent and lets TS narrow
+      // the union (notFound returns `never`). Same pattern as the existing
+      // `apps/web/src/app/sitemap.ts` HttpNotFound handler.
+      Effect.catchTag("HttpNotFound", () => Effect.sync(() => notFound())),
+    ),
+  );
 }
 
 export default async function MatchPage({ params }: MatchPageProps) {


### PR DESCRIPTION
Closes #1912

## Summary

Phase 6.B integration — rewires `/wedstrijd/[matchId]/page.tsx` to mount the locked **Variant A** composition (one shell, per-section auto-hide) per `docs/design/mockups/phase-6-match-detail/page-composition-locked.md`. All upstream primitives shipped in earlier PRs; this PR is the integration point.

## Composition

```text
<PageViewTracker eventName="match_detail_view" />
<MatchStripSlot />                       ← top, mirrors /spelers/[slug]
<h1 sr-only> + <JsonLd> × 2              ← breadcrumb + SportsEvent
<MatchHero />                            ← always renders
<StripedSeam ink-cream md />             ← when any body section will render
<TrackInView match_lineup_section_in_view>
  <MatchLineupSection />
</TrackInView>                           ← when hasLineup
<StripedSeam ink-cream md />             ← when BOTH lineup + events render
<TrackInView match_events_section_in_view>
  <MatchEventsSection />
</TrackInView>                           ← when hasEvents
{/* TODO #1470 follow-up: <MatchArticleLinkCard> slot */}
{/* TODO #1470 follow-up: match-filtered <RelatedArticles> slot */}
<FooterSafeArea />
```

Legacy `<MatchDetailView>` consumption removed (component retirement itself happens in **#1913** — cleanup ticket).

## Analytics

Three new events in the `match_*` namespace:

| Event | Trigger |
|---|---|
| `match_detail_view` | `<PageViewTracker>` on mount |
| `match_lineup_section_in_view` | `<TrackInView>` intersection (0.4 default threshold) |
| `match_events_section_in_view` | Same |

Both intersection wrappers are gated on `hasLineup` / `hasEvents` so they **only mount when their section will actually render** — no orphan events on upcoming-match auto-hide branches.

`apps/web/CLAUDE.md` Analytics-Checklist regex extended to include `match_` so the GTM-trigger reminder doesn't false-alarm on these names.

### ⚠ GTM operator note

A **manual GTM-side trigger update is required** to fire on the new `match_*` events. The taxonomy:

- Event name pattern: `match_detail_view` / `match_lineup_section_in_view` / `match_events_section_in_view`
- Parameters: `match_id` (number), `status` (string — one of the 6 `MatchStatus` literals)

`match_id` and `status` need Data Layer Variables created in GTM and mapped into the GA4 Event tag's parameter fields, plus the GA4 Admin → Custom Definitions registration.

## Loading skeleton refresh

`loading.tsx` was modelled on the retired MatchDetailView (dark-bg hero band + gray-bg lineup columns). With the new cream-on-paper chrome live, that skeleton produced a visible dark → cream flash on every navigation. Rewritten in this PR to mirror the new shape (cream paper-card hero skeleton + cream lineup-section skeleton with mono-caps headers). Done here because the visual mismatch becomes user-visible the moment this PR merges; not deferred to #1913.

## Intentional drops

- **`backUrl` back-link feature dropped.** This was a MatchDetailView-specific affordance (a small `<Link>` at the top of the legacy view, fed by `?from=/ploegen/<slug>&fromTab=...`). The new chrome has no slot for it — users navigate via browser back or the breadcrumb (rendered as JSON-LD only). The `searchParams` prop dropped from `MatchPageProps`; the canonical-urls test that referenced it was updated.

## Out of scope

- `<MatchArticleLinkCard>` + match-filtered `<RelatedArticles>` — both deferred post-**#1470** (the article schema's `linkedMatch` field that drives them doesn't exist yet). Slots reserved with TODO comments.
- Retirement of legacy `<MatchDetailView>` / `<MatchHeader>` — handled by **#1913** (now unblocked once #1912 merges).
- VR baselines for `Pages/Matches/MatchDetail` — Pages/* stories aren't VR-tested per CLAUDE.md; e2e covers smoke.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (3159 unit tests + Next.js build green).
- Existing Playwright e2e smoke at `test/e2e/routes.spec.ts:97` exercises `/wedstrijd/[matchId]` unchanged.
- `canonical-urls.test.ts` updated to drop the unused `searchParams` in the `generateMetadata` call.

## Test plan

- [ ] Vercel preview deploy — `/wedstrijd/{any-id}` shows the assembled hero + sections (no dark-bg flash on navigation)
- [ ] Upcoming match (e.g. early in the season) → hero only; no lineup / events sections; no orphan analytics events in DevTools/GTM Preview
- [ ] Finished match → hero + lineup + events; both `match_*_section_in_view` events fire on scroll
- [ ] CI e2e suite passes against the new composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned match detail page into a component-based layout with data-aware sections and conditional rendering.
  * Improved loading skeleton with a new cream-themed, page-composition layout.

* **Bug Fixes**
  * Removed legacy back-link behavior from the match detail experience.

* **Documentation**
  * Updated PR checklist analytics pattern to include additional event-name prefixes.

* **Tests**
  * Adjusted canonical URL test to align with updated page behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->