### PR TITLE
docs(teams): Phase 6.C design locks + PRD (team detail + listing)

### DIFF
--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/compare.md
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/compare.md
@@ -1,0 +1,75 @@
+# 6.C.d1 · Team detail — information architecture comparison
+
+**Round 1.** First visual drill of Phase 6.C. Decides the **arrangement** of the
+team-detail page only — not the per-component look. The data box is fixed by
+`../data-reality-locked.md` (Core + editorial, auto-hide empties).
+
+Visual artifact: `round-1-detail-ia-comparisons.html` — 3 variants, single
+exemplar (KCVV A-ploeg, 3e Provinciale A). Open in a browser and scroll.
+
+## Reference locks consumed
+
+- `data-reality-locked.md` (6.C.d0) — section inventory + youth auto-hide.
+- 6.A `<PlayerHero>` / 6.B `<MatchHero>` — single-scroll + `<StripedSeam>` +
+  per-section auto-hide precedent (`phase-6-match-detail/page-composition-locked.md`).
+- Reskinned `<MatchResultRow>` / `<MatchTeaser>` (6.B) — schedule rows.
+- `<FilterTabs>` (Phase 2.B.3) — the tab-bar vocabulary used in Variant B.
+
+## Variants
+
+- **A — Single-scroll + striped seams.** Sections stacked top-to-bottom,
+  `<StripedSeam>` between. The whole team "reads" as one editorial page. Exact
+  same composition grammar as player + match detail. Empty sections vanish; a
+  U8 page is hero + squad + staff. **Δ primitives: 0.**
+- **B — Reskinned tabs.** Hero always-on; a `<FilterTabs>` bar swaps one panel
+  at a time (Info / Klassement / Wedstrijden / Spelers). Keeps today's IA,
+  repainted. Dense data stays contained, but breaks the redesign's single-scroll
+  grammar and forces a click per section. **Δ primitives: 0** (FilterTabs
+  exists) — but **Δ pattern: breaks the 6.A/6.B single-scroll convention.**
+- **C — Single-scroll + sticky section-nav.** Variant A plus a thin sticky mono
+  nav under the hero that jumps to any section. Editorial flow for casual
+  readers; quick access for standings/squad hunters. **Δ primitives: +1** (a new
+  `<SectionNav>` sticky-anchor strip).
+
+## Trade-off table
+
+| | A — Single-scroll | B — Tabs | C — Scroll + sticky nav |
+| --- | --- | --- | --- |
+| Consistency w/ 6.A/6.B | ✅ identical grammar | ❌ diverges | ✅ same + extra |
+| Clicks to reach standings | scroll | 1 click | 1 click (or scroll) |
+| Youth degradation | ✅ sections vanish | ⚠️ empty/hidden tabs | ✅ nav lists only live sections |
+| Mobile | ✅ natural | ⚠️ tab overflow / panel height | ✅ nav wraps/scrolls |
+| New vocabulary | none | none | +`<SectionNav>` |
+| SEO / deep-link to a section | native anchors | panels behind JS state | native anchors |
+| Build cost | lowest | medium (panel state) | low-medium |
+
+## Cross-state behaviour
+
+- **Senior team (full data):** all three render every section. B hides 3 of 4
+  panels behind clicks; A/C show everything inline.
+- **Youth team (empty standings/schedule):** A drops those seams silently; C's
+  sticky nav simply omits the dead anchors; B must conditionally remove tabs or
+  risk tabs that open empty panels.
+- **No squad photos (≈90% have only `psdImage`, some none):** identical across
+  variants — `<PlayerCard>` falls back to the `<PlayerFigure>` illustration
+  (shown as the cream cards with the jersey glyph).
+
+## Things this drill does NOT decide
+
+- Standings cell styling + the form (W/G/V) indicator treatment — its own later
+  drill. The mockup shows a *restrained, palette-safe* placeholder (jersey-deep /
+  cream / warm, **no red**) only so the row reads; it is not the locked look.
+- `<PlayerCard>` composition + squad grouping (by position assumed) — later drill.
+- `<TeamHero>` artefact (taped team photo, season stub, jersey-illustration
+  fallback when no `teamImage`) — later drill.
+- Listing page `/ploegen` layout — separate (hierarchy already locked in the
+  decision record; its own visual pass if needed).
+- Mobile-specific refinements.
+
+## Recommendation
+
+**C** if the page must serve both the "just read about the team" visitor and the
+"jump to the table/squad" visitor — it keeps the locked single-scroll grammar and
+only adds a cheap sticky nav. **A** if we want zero new vocabulary and maximum
+consistency with player/match. **B** is the weakest fit — it's the one IA the
+rest of the redesign has been moving *away* from. Owner decides.

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-1-detail-ia-comparisons.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-1-detail-ia-comparisons.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 1 · Team-detail IA (6.C.d1): single-scroll vs tabs</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6;
+      --color-cream-soft: #ede8da;
+      --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd;
+      --color-ink: #0a0a0a;
+      --color-ink-soft: #1f1f1f;
+      --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755;
+      --color-jersey-deep-dark: #133d28;
+      --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink);
+      --shadow-paper-md: 6px 6px 0 0 var(--color-ink);
+      --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --shadow-paper-sm-soft: 4px 4px 0 0 var(--color-ink-muted);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --pattern-seam-ink: repeating-linear-gradient(-45deg, var(--color-ink) 0 8px, var(--color-cream) 8px 16px);
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: #cfc7b0;
+      color: var(--color-ink);
+      font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 0 0 120px;
+    }
+
+    /* ---- drill chrome ---- */
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 40px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 64ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band {
+      position: sticky; top: 0; z-index: 50;
+      background: var(--color-ink); color: var(--color-cream);
+      padding: 10px 24px; margin: 56px 0 0;
+      font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px;
+      border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm);
+    }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+
+    /* ---- "device" frame ---- */
+    .frame { max-width: 760px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 26px 24px 32px; }
+
+    /* ---- primitives ---- */
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .pill { display: inline-block; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10.5px; font-weight: 600; line-height: 1; padding: 5px 8px; border: 1px solid var(--color-paper-edge); }
+    .pill.ink { background: var(--color-ink); color: var(--color-cream); border-color: var(--color-ink); }
+    .pill.cream { background: var(--color-cream-soft); color: var(--color-ink); }
+    .pill.warm { background: var(--color-warm); color: var(--color-ink); border-color: var(--color-ink); }
+    .ed { font-family: var(--font-display); font-weight: 700; letter-spacing: -.01em; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 26px; }
+    .ed-lg { font-size: 34px; }
+    .ed-2xl { font-family: var(--font-display-big); font-weight: 900; font-size: 52px; line-height: .96; }
+
+    .seam { height: 18px; background: var(--pattern-seam-ink); margin: 26px 0; border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); }
+
+    .card { border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); }
+    .card.soft { background: var(--color-cream-soft); }
+    .card.ink { background: var(--color-ink); color: var(--color-cream); }
+    .card.jersey { background: var(--color-jersey-deep); color: var(--color-cream); }
+
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 14px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+
+    /* hero */
+    .hero { display: grid; grid-template-columns: 1fr; gap: 20px; }
+    @media (min-width: 620px) { .hero { grid-template-columns: 1fr 240px; align-items: start; } }
+    .hero .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+    .hero-photo { border: 2px solid var(--color-ink); background: var(--color-cream-soft); box-shadow: var(--shadow-paper-md); transform: rotate(-1deg); padding: 8px 8px 30px; position: relative; }
+    .hero-photo .ph { aspect-ratio: 4/3; background: repeating-linear-gradient(135deg, #cdc6b2 0 10px, #c4bca6 10px 20px); display: grid; place-items: center; font-family: var(--font-mono); font-size: 10px; color: #7d7560; text-transform: uppercase; letter-spacing: .1em; }
+    .hero-photo .tape { position: absolute; top: -10px; left: 26%; width: 84px; height: 18px; background: var(--tape, var(--color-warm)); opacity: .9; transform: rotate(-3deg); border: 1px solid rgba(0,0,0,.15); }
+    .stub { margin-top: 10px; border: 2px dashed var(--color-ink); background: var(--color-cream); padding: 8px 10px; display: flex; justify-content: space-between; align-items: center; }
+
+    /* standings */
+    table.standings { width: 100%; border-collapse: collapse; font-size: 13px; }
+    table.standings th { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .06em; font-size: 10px; text-align: center; padding: 8px 6px; border-bottom: 2px solid var(--color-ink); color: var(--color-ink-soft); }
+    table.standings th:nth-child(2), table.standings td:nth-child(2) { text-align: left; }
+    table.standings td { padding: 9px 6px; text-align: center; border-bottom: 1px solid var(--color-paper-edge); }
+    table.standings td:nth-child(2) { font-family: var(--font-display); font-style: italic; font-size: 15px; }
+    table.standings .pos { font-family: var(--font-mono); color: var(--color-ink-muted); }
+    table.standings .pts { font-family: var(--font-display-big); font-weight: 900; }
+    table.standings tr.me td { background: color-mix(in srgb, var(--color-jersey-deep) 12%, var(--color-cream)); }
+    table.standings tr.me td:first-child { box-shadow: inset 3px 0 0 0 var(--color-jersey-deep); }
+    table.standings tr.me td:nth-child(2) { font-weight: 700; }
+    .form { display: inline-flex; gap: 3px; }
+    .form span { width: 16px; height: 16px; display: inline-grid; place-items: center; font-family: var(--font-mono); font-size: 9px; font-weight: 700; border: 1px solid var(--color-ink); }
+    .form .w { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .form .d { background: var(--color-cream-soft); color: var(--color-ink); }
+    .form .v { background: var(--color-warm); color: var(--color-ink); }
+
+    /* match rows */
+    .mrow { display: grid; grid-template-columns: 64px 1fr auto; gap: 12px; align-items: center; border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 0; margin-bottom: 10px; transition: all .3s; }
+    .mrow:hover { box-shadow: none; transform: translate(4px,4px); cursor: pointer; }
+    .mrow .stubd { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 10px 6px; text-align: center; }
+    .mrow .stubd .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .mrow .stubd .m { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; }
+    .mrow .body { padding: 10px 4px; display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .mrow .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .mrow .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 20px; }
+    .mrow .vs { font-family: var(--font-display); font-style: italic; color: var(--color-ink-muted); font-size: 14px; }
+    .mrow .badge { padding-right: 12px; }
+
+    /* squad */
+    .pos-head { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .1em; font-size: 11px; color: var(--color-ink-muted); margin: 18px 0 10px; border-bottom: 1px solid var(--color-paper-edge); padding-bottom: 6px; }
+    .squad { display: grid; grid-template-columns: repeat(auto-fill, minmax(132px, 1fr)); gap: 14px; }
+    .pcard { border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 6px 6px 10px; transition: all .3s; }
+    .pcard:hover { box-shadow: none; transform: translate(4px,4px); cursor: pointer; }
+    .pcard .ph { aspect-ratio: 3/4; background: repeating-linear-gradient(135deg, #d2cbb6 0 9px, #c8c0aa 9px 18px); display: grid; place-items: center; position: relative; overflow: hidden; }
+    .pcard .ph.illu { background: var(--color-cream-soft); }
+    .pcard .ph .num { position: absolute; top: 6px; left: 7px; font-family: var(--font-display-big); font-weight: 900; font-size: 22px; color: var(--color-jersey-deep); }
+    .pcard .ph .silhou { font-size: 46px; color: var(--color-jersey-deep); opacity: .55; }
+    .pcard .ph .pl { font-family: var(--font-mono); font-size: 8px; color: #7d7560; text-transform: uppercase; }
+    .pcard .nm { margin: 8px 2px 0; font-family: var(--font-display); line-height: 1.05; }
+    .pcard .nm b { font-weight: 700; }
+    .pcard .nm em { font-style: italic; font-weight: 300; }
+    .pcard .role { margin-top: 4px; }
+
+    /* staff + editorial */
+    .two { display: grid; grid-template-columns: 1fr; gap: 14px; }
+    @media (min-width: 560px){ .two { grid-template-columns: 1fr 1fr; } }
+    .scard { border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 12px; display: flex; gap: 12px; align-items: center; }
+    .scard .av { width: 52px; height: 52px; border: 2px solid var(--color-ink); background: var(--color-cream-soft); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-weight: 900; color: var(--color-jersey-deep); }
+    .prose { line-height: 1.6; color: var(--color-ink-soft); font-size: 15px; }
+    .prose p { margin: 0 0 12px; }
+
+    /* sponsors */
+    .sponsors { display: flex; flex-wrap: wrap; gap: 12px; }
+    .sponsors .logo { border: 1px solid var(--color-paper-edge); background: var(--color-cream-soft); padding: 12px 18px; font-family: var(--font-display); font-style: italic; font-size: 16px; color: #8a8270; filter: grayscale(1); }
+
+    /* tabs (variant B) */
+    .tabbar { display: flex; gap: 10px; flex-wrap: wrap; margin: 22px 0 4px; }
+    .tab { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 11px; font-weight: 600; padding: 9px 13px; border: 2px solid var(--color-ink); background: var(--color-cream-soft); box-shadow: var(--shadow-paper-sm); transition: all .3s; }
+    .tab[aria-current="page"] { background: var(--color-ink); color: var(--color-cream); box-shadow: var(--shadow-paper-sm-soft); }
+    .tab:hover { transform: translate(4px,4px); box-shadow: none; cursor: pointer; }
+    .panel-note { margin: 16px 0 4px; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: var(--color-ink-muted); }
+
+    /* sticky section nav (variant C) */
+    .secnav { position: sticky; top: 50px; z-index: 10; background: var(--color-cream); border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); display: flex; gap: 8px; flex-wrap: wrap; padding: 9px 0; margin: 22px 0 0; }
+    .secnav a { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10.5px; color: var(--color-ink-soft); text-decoration: none; padding: 4px 8px; border: 1px solid transparent; }
+    .secnav a:hover { border-color: var(--color-ink); }
+    .anchor { scroll-margin-top: 110px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 1 · Drill 6.C.d1</div>
+    <h1>One question: how do you read a team page?</h1>
+    <p>Same content, same retro vocabulary, three information architectures.
+       The data is locked (see <code>data-reality-locked.md</code>): hero,
+       standings, schedule, squad, staff, editorial, global sponsors — all
+       auto-hide when empty (youth teams). Exemplar = KCVV Elewijt A-ploeg,
+       3e&nbsp;Provinciale&nbsp;A. The only thing being decided here is the
+       <b>arrangement</b>, not the per-component look (standings cells, player
+       cards, hero artefact each get their own later drill).</p>
+  </div>
+
+  <!-- ============================ VARIANT A ============================ -->
+  <div class="variant-band">Variant <b>A</b> — Single-scroll + striped seams &nbsp;·&nbsp; the 6.A / 6.B pattern</div>
+  <div class="variant-note">Everything stacked top-to-bottom, <code>&lt;StripedSeam&gt;</code> between sections. You scroll the whole story. Empty sections simply vanish — a U8 page is just hero + squad + staff. Matches how player &amp; match detail already read.</div>
+  <div class="frame"><div class="page">
+
+    <!-- HERO -->
+    <section class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">A-PLOEG · EERSTE ELFTAL</span>
+        <h2 class="ed ed-2xl" style="margin-top:8px">KCVV <em>Elewijt.</em></h2>
+        <div class="meta-row">
+          <span class="pill cream">3e Provinciale A</span>
+          <span class="pill cream">Trainer · Koen Verbruggen</span>
+          <span class="pill cream">Seizoen 25/26</span>
+        </div>
+      </div>
+      <div>
+        <div class="hero-photo">
+          <div class="tape"></div>
+          <div class="ph">TEAMIMAGE · SQUAD PHOTO</div>
+        </div>
+        <div class="stub"><span class="mono">SEIZOEN</span><span style="font-family:var(--font-display-big);font-weight:900">25/26</span></div>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <!-- STANDINGS -->
+    <section>
+      <div class="section-kicker"><span class="mono">Stand</span><h3 class="ed ed-md">Het <em>klassement.</em></h3></div>
+      <table class="standings">
+        <thead><tr><th>#</th><th>Ploeg</th><th>M</th><th>W</th><th>G</th><th>V</th><th>+/-</th><th>Ptn</th></tr></thead>
+        <tbody>
+          <tr><td class="pos">1</td><td>KFC Eppegem</td><td>24</td><td>17</td><td>4</td><td>3</td><td>+31</td><td class="pts">55</td></tr>
+          <tr><td class="pos">2</td><td>SK Londerzeel B</td><td>24</td><td>15</td><td>5</td><td>4</td><td>+22</td><td class="pts">50</td></tr>
+          <tr><td class="pos">3</td><td>FC Perk</td><td>24</td><td>14</td><td>4</td><td>6</td><td>+15</td><td class="pts">46</td></tr>
+          <tr class="me"><td class="pos">4</td><td>KCVV Elewijt</td><td>24</td><td>13</td><td>5</td><td>6</td><td>+12</td><td class="pts">44</td></tr>
+          <tr><td class="pos">5</td><td>Eendracht Mazenzele</td><td>24</td><td>11</td><td>6</td><td>7</td><td>+4</td><td class="pts">39</td></tr>
+          <tr><td class="pos">6</td><td>KVK Wemmel</td><td>24</td><td>9</td><td>7</td><td>8</td><td>-2</td><td class="pts">34</td></tr>
+          <tr><td class="pos">7</td><td>VK Liedekerke</td><td>24</td><td>7</td><td>5</td><td>12</td><td>-14</td><td class="pts">26</td></tr>
+          <tr><td class="pos">8</td><td>Diegem Sport</td><td>24</td><td>4</td><td>4</td><td>16</td><td>-28</td><td class="pts">16</td></tr>
+        </tbody>
+      </table>
+      <div style="margin-top:12px"><span class="mono" style="color:var(--color-ink-muted)">Vorm</span>
+        <span class="form" style="margin-left:8px"><span class="w">W</span><span class="w">W</span><span class="d">G</span><span class="v">V</span><span class="w">W</span></span>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <!-- SCHEDULE -->
+    <section>
+      <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+      <div class="panel-note">Eerstvolgende</div>
+      <div class="mrow"><div class="stubd"><div class="d">31</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV Elewijt</span><span class="vs">vs</span><span class="tn">KFC Eppegem</span></div><div class="badge"><span class="pill cream">15:00 · Thuis</span></div></div>
+      <div class="mrow"><div class="stubd"><div class="d">08</div><div class="m">JUN</div></div><div class="body"><span class="tn">FC Perk</span><span class="vs">vs</span><span class="tn">KCVV Elewijt</span></div><div class="badge"><span class="pill cream">15:00 · Uit</span></div></div>
+      <div class="panel-note" style="margin-top:16px">Recent</div>
+      <div class="mrow"><div class="stubd"><div class="d">24</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">1</span><span class="tn">Liedekerke</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+      <div class="mrow"><div class="stubd"><div class="d">17</div><div class="m">MEI</div></div><div class="body"><span class="tn">Diegem</span><span class="sc">0</span><span class="vs">—</span><span class="sc">2</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    </section>
+
+    <div class="seam"></div>
+
+    <!-- SQUAD -->
+    <section>
+      <div class="section-kicker"><span class="mono">Selectie</span><h3 class="ed ed-md">De <em>kern.</em></h3></div>
+      <div class="pos-head">Doelmannen</div>
+      <div class="squad">
+        <div class="pcard"><div class="ph"><span class="num">1</span><span class="pl">psdImage</span></div><div class="nm"><b>Jonas</b> <em>Vermeer</em></div><div class="role"><span class="pill cream">Keeper</span></div></div>
+        <div class="pcard"><div class="ph illu"><span class="num">16</span><span class="silhou">&#9817;</span></div><div class="nm"><b>Lars</b> <em>De Smet</em></div><div class="role"><span class="pill cream">Keeper</span></div></div>
+      </div>
+      <div class="pos-head">Verdedigers</div>
+      <div class="squad">
+        <div class="pcard"><div class="ph"><span class="num">2</span><span class="pl">psdImage</span></div><div class="nm"><b>Bram</b> <em>Wouters</em></div><div class="role"><span class="pill cream">Verdediger</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">3</span><span class="pl">psdImage</span></div><div class="nm"><b>Senne</b> <em>Maes</em></div><div class="role"><span class="pill cream">Verdediger</span></div></div>
+        <div class="pcard"><div class="ph illu"><span class="num">4</span><span class="silhou">&#9817;</span></div><div class="nm"><b>Thibault</b> <em>Claes</em></div><div class="role"><span class="pill cream">Verdediger</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">5</span><span class="pl">psdImage</span></div><div class="nm"><b>Jens</b> <em>Peeters</em></div><div class="role"><span class="pill cream">Verdediger</span></div></div>
+      </div>
+      <div class="pos-head">Middenvelders</div>
+      <div class="squad">
+        <div class="pcard"><div class="ph"><span class="num">6</span><span class="pl">psdImage</span></div><div class="nm"><b>Milan</b> <em>Verhoeven</em></div><div class="role"><span class="pill cream">Middenvelder</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">8</span><span class="pl">psdImage</span></div><div class="nm"><b>Wout</b> <em>Janssens</em></div><div class="role"><span class="pill cream">Middenvelder</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">10</span><span class="pl">psdImage</span></div><div class="nm"><b>Daan</b> <em>Mertens</em></div><div class="role"><span class="pill cream">Middenvelder</span></div></div>
+      </div>
+      <div class="pos-head">Aanvallers</div>
+      <div class="squad">
+        <div class="pcard"><div class="ph"><span class="num">7</span><span class="pl">psdImage</span></div><div class="nm"><b>Maxim</b> <em>Breugelmans</em></div><div class="role"><span class="pill cream">Aanvaller</span></div></div>
+        <div class="pcard"><div class="ph illu"><span class="num">9</span><span class="silhou">&#9817;</span></div><div class="nm"><b>Lukas</b> <em>Dewil</em></div><div class="role"><span class="pill cream">Aanvaller</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">11</span><span class="pl">psdImage</span></div><div class="nm"><b>Stan</b> <em>Coppens</em></div><div class="role"><span class="pill cream">Aanvaller</span></div></div>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <!-- STAFF -->
+    <section>
+      <div class="section-kicker"><span class="mono">Staf</span><h3 class="ed ed-md">Begeleiding.</h3></div>
+      <div class="two">
+        <div class="scard"><div class="av">KV</div><div><div style="font-family:var(--font-display);font-size:18px"><b>Koen Verbruggen</b></div><span class="pill cream" style="margin-top:6px">Trainer</span></div></div>
+        <div class="scard"><div class="av">PL</div><div><div style="font-family:var(--font-display);font-size:18px"><b>Patrick Lauwers</b></div><span class="pill cream" style="margin-top:6px">Afgevaardigde</span></div></div>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <!-- EDITORIAL -->
+    <section>
+      <div class="section-kicker"><span class="mono">Over de ploeg</span><h3 class="ed ed-md">Info.</h3></div>
+      <div class="prose">
+        <p>De A-ploeg speelt in 3e Provinciale A en traint twee keer per week op
+           het Sportpark Driesstraat. Een hechte groep met een gezonde mix van
+           jeugd en ervaring.</p>
+      </div>
+      <div class="card soft" style="padding:12px;margin-top:8px;display:flex;gap:18px;flex-wrap:wrap">
+        <div><span class="mono" style="color:var(--color-ink-muted)">Training</span><div style="font-family:var(--font-display);font-style:italic;font-size:15px;margin-top:4px">di &amp; do · 20:00 · Driesstraat 32</div></div>
+        <div><span class="mono" style="color:var(--color-ink-muted)">Contact</span><div style="font-family:var(--font-display);font-style:italic;font-size:15px;margin-top:4px">secretariaat@kcvvelewijt.be</div></div>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <!-- SPONSORS (global) -->
+    <section>
+      <div class="section-kicker"><span class="mono">Met dank aan</span><h3 class="ed ed-md">Sponsors.</h3></div>
+      <div class="sponsors"><span class="logo">Bouwwerken</span><span class="logo">Frituur 't Pleintje</span><span class="logo">Garage Elewijt</span><span class="logo">Café De Sport</span></div>
+    </section>
+
+  </div></div>
+
+  <!-- ============================ VARIANT B ============================ -->
+  <div class="variant-band">Variant <b>B</b> — Reskinned tabs &nbsp;·&nbsp; today's IA, retro paint</div>
+  <div class="variant-note">Hero stays; below it a <code>&lt;FilterTabs&gt;</code>-style bar swaps one panel at a time. You see one section, click for the next. Dense data feels contained — but a youth team with only a squad shows tabs that lead to empty panels (or tabs must be conditionally hidden). Shown below with <b>Klassement</b> active.</div>
+  <div class="frame"><div class="page">
+
+    <section class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">A-PLOEG · EERSTE ELFTAL</span>
+        <h2 class="ed ed-2xl" style="margin-top:8px">KCVV <em>Elewijt.</em></h2>
+        <div class="meta-row">
+          <span class="pill cream">3e Provinciale A</span>
+          <span class="pill cream">Trainer · Koen Verbruggen</span>
+          <span class="pill cream">Seizoen 25/26</span>
+        </div>
+      </div>
+      <div>
+        <div class="hero-photo"><div class="tape"></div><div class="ph">TEAMIMAGE · SQUAD PHOTO</div></div>
+        <div class="stub"><span class="mono">SEIZOEN</span><span style="font-family:var(--font-display-big);font-weight:900">25/26</span></div>
+      </div>
+    </section>
+
+    <div class="tabbar">
+      <button class="tab">Info</button>
+      <button class="tab" aria-current="page">Klassement</button>
+      <button class="tab">Wedstrijden</button>
+      <button class="tab">Spelers</button>
+    </div>
+    <div class="panel-note">Actief paneel: Klassement &nbsp;—&nbsp; de andere drie verbergen hun inhoud tot je klikt</div>
+
+    <section style="margin-top:10px">
+      <table class="standings">
+        <thead><tr><th>#</th><th>Ploeg</th><th>M</th><th>W</th><th>G</th><th>V</th><th>+/-</th><th>Ptn</th></tr></thead>
+        <tbody>
+          <tr><td class="pos">1</td><td>KFC Eppegem</td><td>24</td><td>17</td><td>4</td><td>3</td><td>+31</td><td class="pts">55</td></tr>
+          <tr><td class="pos">2</td><td>SK Londerzeel B</td><td>24</td><td>15</td><td>5</td><td>4</td><td>+22</td><td class="pts">50</td></tr>
+          <tr><td class="pos">3</td><td>FC Perk</td><td>24</td><td>14</td><td>4</td><td>6</td><td>+15</td><td class="pts">46</td></tr>
+          <tr class="me"><td class="pos">4</td><td>KCVV Elewijt</td><td>24</td><td>13</td><td>5</td><td>6</td><td>+12</td><td class="pts">44</td></tr>
+          <tr><td class="pos">5</td><td>Eendracht Mazenzele</td><td>24</td><td>11</td><td>6</td><td>7</td><td>+4</td><td class="pts">39</td></tr>
+          <tr><td class="pos">6</td><td>KVK Wemmel</td><td>24</td><td>9</td><td>7</td><td>8</td><td>-2</td><td class="pts">34</td></tr>
+          <tr><td class="pos">7</td><td>VK Liedekerke</td><td>24</td><td>7</td><td>5</td><td>12</td><td>-14</td><td class="pts">26</td></tr>
+          <tr><td class="pos">8</td><td>Diegem Sport</td><td>24</td><td>4</td><td>4</td><td>16</td><td>-28</td><td class="pts">16</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+  </div></div>
+
+  <!-- ============================ VARIANT C ============================ -->
+  <div class="variant-band">Variant <b>C</b> — Single-scroll + sticky section-nav &nbsp;·&nbsp; hybrid</div>
+  <div class="variant-note">Single-scroll like A, but a thin sticky mono bar under the hero jumps you to any section. Editorial flow for casual readers, quick access for the standings/squad hunters. The nav only lists sections that exist, so it degrades cleanly for youth.</div>
+  <div class="frame"><div class="page">
+
+    <section class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">A-PLOEG · EERSTE ELFTAL</span>
+        <h2 class="ed ed-2xl" style="margin-top:8px">KCVV <em>Elewijt.</em></h2>
+        <div class="meta-row">
+          <span class="pill cream">3e Provinciale A</span>
+          <span class="pill cream">Trainer · Koen Verbruggen</span>
+          <span class="pill cream">Seizoen 25/26</span>
+        </div>
+      </div>
+      <div>
+        <div class="hero-photo"><div class="tape"></div><div class="ph">TEAMIMAGE · SQUAD PHOTO</div></div>
+        <div class="stub"><span class="mono">SEIZOEN</span><span style="font-family:var(--font-display-big);font-weight:900">25/26</span></div>
+      </div>
+    </section>
+
+    <nav class="secnav">
+      <a href="#c-stand">Klassement</a>
+      <a href="#c-wed">Wedstrijden</a>
+      <a href="#c-kern">Spelers</a>
+      <a href="#c-staf">Staf</a>
+      <a href="#c-info">Info</a>
+    </nav>
+
+    <section id="c-stand" class="anchor" style="margin-top:24px">
+      <div class="section-kicker"><span class="mono">Stand</span><h3 class="ed ed-md">Het <em>klassement.</em></h3></div>
+      <table class="standings">
+        <thead><tr><th>#</th><th>Ploeg</th><th>M</th><th>W</th><th>G</th><th>V</th><th>+/-</th><th>Ptn</th></tr></thead>
+        <tbody>
+          <tr><td class="pos">3</td><td>FC Perk</td><td>24</td><td>14</td><td>4</td><td>6</td><td>+15</td><td class="pts">46</td></tr>
+          <tr class="me"><td class="pos">4</td><td>KCVV Elewijt</td><td>24</td><td>13</td><td>5</td><td>6</td><td>+12</td><td class="pts">44</td></tr>
+          <tr><td class="pos">5</td><td>Eendracht Mazenzele</td><td>24</td><td>11</td><td>6</td><td>7</td><td>+4</td><td class="pts">39</td></tr>
+        </tbody>
+      </table>
+      <div style="margin-top:8px"><span class="mono" style="color:var(--color-ink-muted)">Volledige tabel ↓</span></div>
+    </section>
+
+    <div class="seam"></div>
+
+    <section id="c-wed" class="anchor">
+      <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+      <div class="mrow"><div class="stubd"><div class="d">31</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV Elewijt</span><span class="vs">vs</span><span class="tn">KFC Eppegem</span></div><div class="badge"><span class="pill cream">15:00</span></div></div>
+      <div class="mrow"><div class="stubd"><div class="d">24</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">1</span><span class="tn">Liedekerke</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    </section>
+
+    <div class="seam"></div>
+
+    <section id="c-kern" class="anchor">
+      <div class="section-kicker"><span class="mono">Selectie</span><h3 class="ed ed-md">De <em>kern.</em></h3></div>
+      <div class="squad">
+        <div class="pcard"><div class="ph"><span class="num">1</span><span class="pl">psdImage</span></div><div class="nm"><b>Jonas</b> <em>Vermeer</em></div><div class="role"><span class="pill cream">Keeper</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">7</span><span class="pl">psdImage</span></div><div class="nm"><b>Maxim</b> <em>Breugelmans</em></div><div class="role"><span class="pill cream">Aanvaller</span></div></div>
+        <div class="pcard"><div class="ph illu"><span class="num">9</span><span class="silhou">&#9817;</span></div><div class="nm"><b>Lukas</b> <em>Dewil</em></div><div class="role"><span class="pill cream">Aanvaller</span></div></div>
+        <div class="pcard"><div class="ph"><span class="num">10</span><span class="pl">psdImage</span></div><div class="nm"><b>Daan</b> <em>Mertens</em></div><div class="role"><span class="pill cream">Middenvelder</span></div></div>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <section id="c-staf" class="anchor">
+      <div class="section-kicker"><span class="mono">Staf</span><h3 class="ed ed-md">Begeleiding.</h3></div>
+      <div class="two">
+        <div class="scard"><div class="av">KV</div><div><div style="font-family:var(--font-display);font-size:18px"><b>Koen Verbruggen</b></div><span class="pill cream" style="margin-top:6px">Trainer</span></div></div>
+        <div class="scard"><div class="av">PL</div><div><div style="font-family:var(--font-display);font-size:18px"><b>Patrick Lauwers</b></div><span class="pill cream" style="margin-top:6px">Afgevaardigde</span></div></div>
+      </div>
+    </section>
+
+    <div class="seam"></div>
+
+    <section id="c-info" class="anchor">
+      <div class="section-kicker"><span class="mono">Over de ploeg</span><h3 class="ed ed-md">Info.</h3></div>
+      <div class="prose"><p>De A-ploeg speelt in 3e Provinciale A en traint twee keer per week op het Sportpark Driesstraat.</p></div>
+    </section>
+
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>Pick the arrangement (A / B / C). The per-component looks — standings
+       cells, player cards, the hero artefact, the season ticket-stub — are
+       <b>not</b> decided here; they get their own drills after the IA locks.
+       See <code>compare.md</code> for the trade-offs.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-10-logos-align-time.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-10-logos-align-time.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 10 · Logos + scoreboard symmetry + centred time</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame.desktop { max-width: 660px; margin: 18px auto 0; }
+    .frame.mobile { max-width: 360px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 28px; }
+    .frame.mobile .page { padding: 18px 16px 24px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 23px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; flex-wrap: wrap; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; line-height: 1; margin: 22px 0 12px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    /* placeholder crest (real PSD club logo slots in here) */
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; background: var(--color-cream-soft); flex: none; }
+    .crest.k { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; text-align: center; white-space: nowrap; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .ven { font-family: var(--font-mono); font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--color-ink-muted); text-align: center; }
+    .sq { width: 26px; height: 26px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); }
+    .comp { font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-muted); display:flex; align-items:center; gap:6px; }
+    .ctag { font-family: var(--font-mono); font-size: 8px; font-weight: 700; letter-spacing: .08em; padding: 2px 5px; border: 1px solid var(--color-ink); }
+    .ctag.beker { background: var(--color-warm); color: var(--color-ink); }
+    .ctag.oefen { background: var(--color-cream-deep); color: var(--color-ink); }
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
+    .mcard.feat .ven { color: rgba(245,241,230,.85); }
+    .mcard.feat .comp { color: rgba(245,241,230,.8); }
+    .mcard.feat .crest { background: var(--color-cream); color: var(--color-ink); border-color: var(--color-cream); }
+    .mcard.feat .crest.k { background: var(--color-jersey-deep-dark); color: var(--color-cream); border-color: rgba(245,241,230,.6); }
+
+    /* ===== A desktop — logo+name clusters at edges, score centred ===== */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr 30px 40px; }
+    .a .body { display:flex; flex-direction:column; justify-content:center; gap: 4px; padding: 9px 8px; }
+    .a .fixline { display: grid; grid-template-columns: 1fr 66px 1fr; align-items: center; gap: 6px; }
+    .a .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .a .team.home { justify-content: flex-start; }
+    .a .team.away { justify-content: flex-end; }
+    .a .comp { justify-content: center; }
+    .a .venue { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .a .result { display:flex; align-items:center; justify-content:center; padding-right: 8px; }
+    .a .mcard.feat .venue { border-left-color: rgba(245,241,230,.3); }
+
+    /* ===== B mobile — opponent (+crest) centric ===== */
+    .b .mcard { display: grid; grid-template-columns: 40px 1fr 24px 52px 32px; align-items: stretch; }
+    .b .opp { display:flex; align-items:center; gap: 8px; padding: 9px 4px 9px 10px; min-width:0; }
+    .b .opp .txt { display:flex; flex-direction:column; gap:2px; min-width:0; }
+    .b .venue { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .scorecol.wide { grid-column: 4 / 6; }   /* upcoming: time centres across score+result */
+    .b .result { display:flex; align-items:center; justify-content:center; padding-right: 6px; }
+    .b .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 10 · Drill 6.C.d1</div>
+    <h1>Crests, scoreboard symmetry, time fixed.</h1>
+    <p>Desktop: home crest+name hug the left, away crest+name hug the right,
+       score/time in a wide centred column (now clearly visible), competition
+       caption centred beneath — fully symmetric. Mobile: opponent crest+name,
+       and the kickoff time spans the score+result block so it centres. Crests
+       are placeholders; real PSD club logos slot straight in.</p>
+  </div>
+
+  <!-- ===== DESKTOP A ===== -->
+  <div class="variant-band">Desktop &nbsp;·&nbsp; <b>A symmetric + crests</b></div>
+  <div class="variant-note">Home cluster left edge, away cluster right edge, score/time centred, caption centred. KCVV bold + jersey crest wherever it plays.</div>
+  <div class="frame desktop"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="val">1–1</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest k">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="val">0–2</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest k">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val">3–1</span><span class="team away"><span class="tn">VK Liedekerke</span><span class="crest">L</span></span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val">2–2</span><span class="team away"><span class="tn">RC Mechelen</span><span class="crest">M</span></span></div><div class="comp"><span class="ctag oefen">Oefen</span> Oefenwedstrijd</div></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">15:00</span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">T</span></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">P</span><span class="tn">FC Perk</span></span><span class="val time">15:00</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest k">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">U</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">20:00</span><span class="team away"><span class="tn">VK Tildonk</span><span class="crest">T</span></span></div><div class="comp"><span class="ctag beker">Beker</span> Beker van Vlaams-Brabant · 1/2 finale</div></div><div class="venue"><span class="ven">T</span></div><div class="result"></div></div>
+  </div></div>
+
+  <!-- ===== MOBILE B ===== -->
+  <div class="variant-band">Mobile &nbsp;·&nbsp; <b>B + opponent crest</b></div>
+  <div class="variant-note">Opponent crest + name; time spans the score+result block so it centres. Played rows keep score + W/G/V square.</div>
+  <div class="frame mobile"><div class="page b">
+    <div class="section-kicker"><span class="mono">A-ploeg</span><h3 class="ed ed-md">Kalender.</h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">D</span><span class="txt"><span class="tn">Diegem Sport</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="val">0–2</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">L</span><span class="txt"><span class="tn">VK Liedekerke</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val">3–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">M</span><span class="txt"><span class="tn">RC Mechelen</span><span class="comp"><span class="ctag oefen">Oefen</span></span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val">2–2</span></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">E</span><span class="txt"><span class="tn">KFC Eppegem</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol wide"><span class="val time">15:00</span></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">P</span><span class="txt"><span class="tn">FC Perk</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol wide"><span class="val time">15:00</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">T</span><span class="txt"><span class="tn">VK Tildonk</span><span class="comp"><span class="ctag beker">Beker</span> 1/2</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol wide"><span class="val time">20:00</span></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:44px">
+    <div class="tag">Decide</div>
+    <p>Crests in, scoreboard symmetric, time centred + visible on both. If this
+       lands, 6.C.d1 locks. (KCVV's own crest shows here for balance — easy to
+       drop it on its own page if you'd rather only show the opponent's.)</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-11-meta-merge-comp.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-11-meta-merge-comp.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 11 · No empty cell + competition without redundant tag</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame.desktop { max-width: 660px; margin: 18px auto 0; }
+    .frame.mobile { max-width: 360px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 28px; }
+    .frame.mobile .page { padding: 18px 16px 24px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 23px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; flex-wrap: wrap; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; line-height: 1; margin: 22px 0 12px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; background: var(--color-cream-soft); flex: none; }
+    .crest.k { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; text-align: center; white-space: nowrap; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .ven { font-family: var(--font-mono); font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--color-ink-muted); }
+    .sq { width: 26px; height: 26px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); }
+
+    /* competition: ONE label, no redundant tag. League muted; non-league emphasised. */
+    .comp { font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-muted); }
+    .comp.special { color: var(--color-ink); font-weight: 700; }
+    .comp.special::before { content: "▪"; color: var(--color-warm); margin-right: 5px; }
+
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
+    .mcard.feat .ven { color: rgba(245,241,230,.85); }
+    .mcard.feat .comp { color: rgba(245,241,230,.85); }
+    .mcard.feat .crest { background: var(--color-cream); color: var(--color-ink); border-color: var(--color-cream); }
+    .mcard.feat .crest.k { background: var(--color-jersey-deep-dark); color: var(--color-cream); border-color: rgba(245,241,230,.6); }
+
+    /* ===== A desktop: stub | body | meta  (venue+outcome merged → no empty cell) ===== */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr auto; }
+    .a .body { display:flex; flex-direction:column; justify-content:center; gap: 4px; padding: 9px 8px; }
+    .a .fixline { display: grid; grid-template-columns: 1fr 66px 1fr; align-items: center; gap: 6px; }
+    .a .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .a .team.home { justify-content: flex-start; }
+    .a .team.away { justify-content: flex-end; }
+    .a .comp { text-align: center; }
+    .a .meta { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:6px; min-width: 58px; padding: 0 12px; border-left: 1px solid var(--color-paper-edge); }
+    .a .mcard.feat .meta { border-left-color: rgba(245,241,230,.3); }
+
+    /* ===== B mobile (unchanged structure; time spans on upcoming) ===== */
+    .b .mcard { display: grid; grid-template-columns: 40px 1fr 24px 52px 32px; align-items: stretch; }
+    .b .opp { display:flex; align-items:center; gap: 8px; padding: 9px 4px 9px 10px; min-width:0; }
+    .b .opp .txt { display:flex; flex-direction:column; gap:2px; min-width:0; }
+    .b .venue { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .scorecol.wide { grid-column: 4 / 6; }
+    .b .result { display:flex; align-items:center; justify-content:center; padding-right: 6px; }
+    .b .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 11 · Drill 6.C.d1</div>
+    <h1>No empty cell, competition without the double label.</h1>
+    <p>Right side is now one <b>meta</b> column: played = venue + W/G/V square,
+       upcoming = just the venue (no empty box). The hour stays the centred
+       headline (it was rendering in your screenshot — that empty box was the
+       separate outcome cell, now gone). Competition shows once: league muted,
+       Beker/Oefen emphasised with an accent — no redundant tag.</p>
+  </div>
+
+  <!-- ===== DESKTOP A ===== -->
+  <div class="variant-band">Desktop &nbsp;·&nbsp; <b>A</b> — merged meta column</div>
+  <div class="variant-note">Played rows: venue (T/U) above the W/G/V square. Upcoming rows: venue only. Score/time centred between the crest+name clusters.</div>
+  <div class="frame desktop"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="val">0–2</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest k">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="meta"><span class="ven">U</span><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val">3–1</span><span class="team away"><span class="tn">VK Liedekerke</span><span class="crest">L</span></span></div><div class="comp">3e Provinciale A</div></div><div class="meta"><span class="ven">T</span><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val">2–2</span><span class="team away"><span class="tn">RC Mechelen</span><span class="crest">M</span></span></div><div class="comp special">Oefenwedstrijd</div></div><div class="meta"><span class="ven">T</span><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">15:00</span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div><div class="comp">3e Provinciale A</div></div><div class="meta"><span class="ven">T</span></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">P</span><span class="tn">FC Perk</span></span><span class="val time">15:00</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest k">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="meta"><span class="ven">U</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest k">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">20:00</span><span class="team away"><span class="tn">VK Tildonk</span><span class="crest">T</span></span></div><div class="comp special">Beker van Vlaams-Brabant · 1/2 finale</div></div><div class="meta"><span class="ven">T</span></div></div>
+  </div></div>
+
+  <!-- ===== MOBILE B ===== -->
+  <div class="variant-band">Mobile &nbsp;·&nbsp; <b>B</b> — same competition rule</div>
+  <div class="variant-note">League muted, non-league emphasised (accent + ink). Time spans score+result so it centres; played keeps score + square.</div>
+  <div class="frame mobile"><div class="page b">
+    <div class="section-kicker"><span class="mono">A-ploeg</span><h3 class="ed ed-md">Kalender.</h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">L</span><span class="txt"><span class="tn">VK Liedekerke</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val">3–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">M</span><span class="txt"><span class="tn">RC Mechelen</span><span class="comp special">Oefen</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val">2–2</span></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">E</span><span class="txt"><span class="tn">KFC Eppegem</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol wide"><span class="val time">15:00</span></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">P</span><span class="txt"><span class="tn">FC Perk</span><span class="comp">3e Prov. A</span></span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol wide"><span class="val time">15:00</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">T</span><span class="txt"><span class="tn">VK Tildonk</span><span class="comp special">Beker · 1/2</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol wide"><span class="val time">20:00</span></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:44px">
+    <div class="tag">Decide</div>
+    <p>Empty cell gone, hour centred, competition shown once (Beker/Oefen
+       accented). If this lands, 6.C.d1 locks and I write the lock + 6.C PRD.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-12-simplify.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-12-simplify.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 12 · Simplified — no desktop venue, mobile home/bus icon, neutral crests</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame.desktop { max-width: 660px; margin: 18px auto 0; }
+    .frame.mobile { max-width: 360px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 28px; }
+    .frame.mobile .page { padding: 18px 16px 24px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 23px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; flex-wrap: wrap; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; line-height: 1; margin: 22px 0 12px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    /* neutral crest — ALL clubs identical placeholder (real logo drops in). No status colour. */
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); flex: none; }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; text-align: center; white-space: nowrap; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .sq { width: 26px; height: 26px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); }
+    .comp { font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-muted); }
+    .comp.special { color: var(--color-ink); font-weight: 700; }
+    .comp.special::before { content: "▪"; color: var(--color-warm); margin-right: 5px; }
+    .ha { width: 16px; height: 16px; color: var(--color-ink-muted); }
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
+    .mcard.feat .comp { color: rgba(245,241,230,.85); }
+    .mcard.feat .crest { color: var(--color-cream); border-color: rgba(245,241,230,.7); background: transparent; }
+    .mcard.feat .ha { color: rgba(245,241,230,.9); }
+
+    /* ===== A desktop: stub | body | result   (NO venue) ===== */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr 42px; }
+    .a .body { display:flex; flex-direction:column; justify-content:center; gap: 4px; padding: 9px 6px 9px 10px; }
+    .a .fixline { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; }
+    .a .fixline .val { min-width: 60px; }
+    .a .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .a .team.home { justify-content: flex-start; }
+    .a .team.away { justify-content: flex-end; }
+    .a .comp { text-align: center; }
+    .a .result { display:flex; align-items:center; justify-content:center; padding-right: 8px; }
+
+    /* ===== B mobile: stub | opp | home/away icon | score/time | result ===== */
+    .b .mcard { display: grid; grid-template-columns: 40px 1fr 26px 50px 32px; align-items: stretch; }
+    .b .opp { display:flex; align-items:center; gap: 8px; padding: 9px 4px 9px 10px; min-width:0; }
+    .b .opp .txt { display:flex; flex-direction:column; gap:2px; min-width:0; }
+    .b .ha-cell { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .scorecol.wide { grid-column: 4 / 6; }
+    .b .result { display:flex; align-items:center; justify-content:center; padding-right: 6px; }
+    .b .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 12 · Drill 6.C.d1</div>
+    <h1>Stripped back.</h1>
+    <p>Desktop: no home/away indicator (the order tells it) — just the clean
+       scoreboard + result square. Mobile: home/away as a Lucide
+       <b>house</b> / <b>bus</b> icon. All crests are one neutral placeholder
+       (real club logos slot in) so nothing reads like a colour legend.
+       Competition shows once.</p>
+  </div>
+
+  <!-- ===== DESKTOP A ===== -->
+  <div class="variant-band">Desktop &nbsp;·&nbsp; <b>A</b> — scoreboard, no venue</div>
+  <div class="variant-note">Home crest+name left, away name+crest right, score/time centred, result square at the end, competition centred beneath.</div>
+  <div class="frame desktop"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="val">0–2</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val">3–1</span><span class="team away"><span class="tn">VK Liedekerke</span><span class="crest">L</span></span></div><div class="comp">3e Provinciale A</div></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val">2–2</span><span class="team away"><span class="tn">RC Mechelen</span><span class="crest">M</span></span></div><div class="comp special">Oefenwedstrijd</div></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">15:00</span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div><div class="comp">3e Provinciale A</div></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">P</span><span class="tn">FC Perk</span></span><span class="val time">15:00</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">20:00</span><span class="team away"><span class="tn">VK Tildonk</span><span class="crest">T</span></span></div><div class="comp special">Beker van Vlaams-Brabant · 1/2 finale</div></div><div class="result"></div></div>
+  </div></div>
+
+  <!-- ===== MOBILE B ===== -->
+  <div class="variant-band">Mobile &nbsp;·&nbsp; <b>B</b> — house / bus icon for home/away</div>
+  <div class="variant-note">Opponent crest + name; a Lucide house (home) or bus (away) icon instead of T/U; score/time centred; result square for played.</div>
+  <div class="frame mobile"><div class="page b">
+    <div class="section-kicker"><span class="mono">A-ploeg</span><h3 class="ed ed-md">Kalender.</h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">D</span><span class="txt"><span class="tn">Diegem Sport</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="10" rx="2"/><path d="M3 11h18"/><path d="M7 6V4h10v2"/><circle cx="7.5" cy="18.5" r="1.4"/><circle cx="16.5" cy="18.5" r="1.4"/></svg></div><div class="scorecol"><span class="val">0–2</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">L</span><span class="txt"><span class="tn">VK Liedekerke</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol"><span class="val">3–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">M</span><span class="txt"><span class="tn">RC Mechelen</span><span class="comp special">Oefen</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol"><span class="val">2–2</span></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">E</span><span class="txt"><span class="tn">KFC Eppegem</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol wide"><span class="val time">15:00</span></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">P</span><span class="txt"><span class="tn">FC Perk</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="10" rx="2"/><path d="M3 11h18"/><path d="M7 6V4h10v2"/><circle cx="7.5" cy="18.5" r="1.4"/><circle cx="16.5" cy="18.5" r="1.4"/></svg></div><div class="scorecol wide"><span class="val time">15:00</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">T</span><span class="txt"><span class="tn">VK Tildonk</span><span class="comp special">Beker · 1/2</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol wide"><span class="val time">20:00</span></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:44px">
+    <div class="tag">Decide</div>
+    <p>Cleaner: no desktop venue, mobile house/bus icon, neutral crests, single
+       competition label. If this is the row, 6.C.d1 locks.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-13-outcome-no-column.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-13-outcome-no-column.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 13 · Outcome without a column (square + accent removed)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --tint-w: color-mix(in srgb, var(--color-jersey-deep) 20%, var(--color-cream));
+      --tint-d: color-mix(in srgb, var(--color-cream-deep) 60%, var(--color-cream));
+      --tint-v: color-mix(in srgb, var(--color-warm) 30%, var(--color-cream));
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); max-width: 620px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 26px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .legend { max-width: 620px; margin: 8px auto 0; display:flex; gap:16px; font-family: var(--font-mono); font-size:10px; text-transform:uppercase; letter-spacing:.08em; color: var(--color-ink-soft); }
+    .legend .sw { display:inline-flex; align-items:center; gap:6px; }
+    .legend i { width:14px;height:14px;display:inline-block; }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 24px; line-height: 1; margin: 16px 0 10px; }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 9px; display: grid; grid-template-columns: 46px 1fr; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .body { display:flex; flex-direction:column; justify-content:center; gap: 4px; padding: 10px 14px; }
+    .fixline { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; }
+    .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .team.home { justify-content: flex-start; }
+    .team.away { justify-content: flex-end; }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); flex: none; }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; text-align: center; white-space: nowrap; min-width: 56px; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .comp { font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-muted); text-align:center; }
+    .comp.special { color: var(--color-ink); font-weight: 700; }
+
+    /* ===== A — left edge ===== */
+    .ma .mcard.w { border-left: 6px solid var(--color-jersey-deep); }
+    .ma .mcard.d { border-left: 6px solid var(--color-ink-muted); }
+    .ma .mcard.v { border-left: 6px solid var(--color-warm); }
+
+    /* ===== B — score underline ===== */
+    .mb .val.w { box-shadow: inset 0 -7px 0 var(--tint-w); }
+    .mb .val.d { box-shadow: inset 0 -7px 0 var(--tint-d); }
+    .mb .val.v { box-shadow: inset 0 -7px 0 var(--tint-v); }
+
+    /* ===== C — score highlight wash ===== */
+    .mc .val.w, .mc .val.d, .mc .val.v { padding: 2px 8px; border-radius: 2px; }
+    .mc .val.w { background: var(--tint-w); }
+    .mc .val.d { background: var(--tint-d); }
+    .mc .val.v { background: var(--tint-v); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 13 · Drill 6.C.d1 (outcome)</div>
+    <h1>Result, without a column.</h1>
+    <p>Square column gone, ▪ gone. Three column-less ways to read win/draw/verlies
+       on a result row (palette only, no red). Upcoming rows carry nothing extra
+       — just the kickoff time. Same three KCVV results in each: 0–2 W, 1–1 G,
+       1–3 V, plus an upcoming.</p>
+  </div>
+  <div class="legend">
+    <span class="sw"><i style="background:var(--color-jersey-deep)"></i> Winst</span>
+    <span class="sw"><i style="background:var(--color-ink-muted)"></i> Gelijk</span>
+    <span class="sw"><i style="background:var(--color-warm)"></i> Verlies</span>
+  </div>
+
+  <!-- A -->
+  <div class="variant-band">A &nbsp;·&nbsp; <b>Left edge</b></div>
+  <div class="variant-note">A 6px coloured left border on the card. Reads instantly down the column; upcoming rows have a plain (ink) edge.</div>
+  <div class="frame"><div class="page ma">
+    <div class="amonth">Mei <em style="font-style:italic;color:var(--color-jersey-deep)">'26.</em></div>
+    <div class="mcard w"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="val">0–2</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+    <div class="mcard d"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="val">1–1</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+    <div class="mcard v"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val">1–3</span><span class="team away"><span class="tn">Londerzeel B</span><span class="crest">L</span></span></div><div class="comp special">Oefenwedstrijd</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">15:00</span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+  </div></div>
+
+  <!-- B -->
+  <div class="variant-band">B &nbsp;·&nbsp; <b>Score underline</b></div>
+  <div class="variant-note">A coloured highlighter swipe under the score digits. The colour lives on the result itself; nothing on upcoming.</div>
+  <div class="frame"><div class="page mb">
+    <div class="amonth">Mei <em style="font-style:italic;color:var(--color-jersey-deep)">'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="val w">0–2</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="val d">1–1</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val v">1–3</span><span class="team away"><span class="tn">Londerzeel B</span><span class="crest">L</span></span></div><div class="comp special">Oefenwedstrijd</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">15:00</span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+  </div></div>
+
+  <!-- C -->
+  <div class="variant-band">C &nbsp;·&nbsp; <b>Score highlight</b></div>
+  <div class="variant-note">A subtle coloured wash behind the score number. Compact; the result block itself is tinted.</div>
+  <div class="frame"><div class="page mc">
+    <div class="amonth">Mei <em style="font-style:italic;color:var(--color-jersey-deep)">'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="val w">0–2</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="val d">1–1</span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val v">1–3</span><span class="team away"><span class="tn">Londerzeel B</span><span class="crest">L</span></span></div><div class="comp special">Oefenwedstrijd</div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="val time">15:00</span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div><div class="comp">3e Provinciale A</div></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:40px">
+    <div class="tag">Decide</div>
+    <p>Pick A / B / C (or "none of these"). Whatever wins also drives the
+       standings form indicator, for one outcome language.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-14-underline-centered.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-14-underline-centered.html
@@ -13,10 +13,10 @@
       --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
       --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
       --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-      /* toned-down underline tints */
-      --ul-w: color-mix(in srgb, var(--color-jersey-deep) 15%, var(--color-cream));
-      --ul-d: color-mix(in srgb, var(--color-ink-muted) 15%, var(--color-cream));
-      --ul-v: color-mix(in srgb, var(--color-warm) 24%, var(--color-cream));
+      /* underline tints — less washed (a touch darker / more saturated) */
+      --ul-w: color-mix(in srgb, var(--color-jersey-deep) 28%, var(--color-cream));
+      --ul-d: color-mix(in srgb, var(--color-ink-muted) 22%, var(--color-cream));
+      --ul-v: color-mix(in srgb, var(--color-warm) 42%, var(--color-cream));
     }
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; }
@@ -96,9 +96,9 @@
     <div class="feat-label">Eerstvolgende</div>
     <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val time">15:00</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div></div></div>
 
-    <div class="amonth">Stress test <em>·</em> lange namen / competities</div>
-    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV Elewijt</span></span><span class="center"><span class="val w">3–0</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">KSK Steenokkerzeel</span><span class="crest">S</span></span></div></div></div>
-    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val time">20:00</span><span class="comp special">Beker van Vlaams-Brabant · halve finale</span></span><span class="team away"><span class="tn">VK Tildonk</span><span class="crest">T</span></span></div></div></div>
+    <div class="amonth">Stress test <em>·</em> lange naam + lange competitie tegelijk</div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val w">2–1</span><span class="comp">Beker van België · 1/16 finale</span></span><span class="team away"><span class="tn">KSV Schoonbeek-Beverst A</span><span class="crest">S</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">S</span><span class="tn">KSV Schoonbeek-Beverst A</span></span><span class="center"><span class="val time">20:00</span><span class="comp">Beker van België</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
   </div></div>
 
   <div class="drill-head" style="padding-top:40px">

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-14-underline-centered.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-14-underline-centered.html
@@ -13,10 +13,10 @@
       --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
       --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
       --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-      /* underline tints — less washed (a touch darker / more saturated) */
-      --ul-w: color-mix(in srgb, var(--color-jersey-deep) 28%, var(--color-cream));
-      --ul-d: color-mix(in srgb, var(--color-ink-muted) 22%, var(--color-cream));
-      --ul-v: color-mix(in srgb, var(--color-warm) 42%, var(--color-cream));
+      /* underline tints — darker / more saturated swipe */
+      --ul-w: color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream));
+      --ul-d: color-mix(in srgb, var(--color-ink-muted) 32%, var(--color-cream));
+      --ul-v: color-mix(in srgb, var(--color-warm) 58%, var(--color-cream));
     }
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; }
@@ -67,6 +67,7 @@
     .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
     .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
     .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .stub .mo { color: rgba(245,241,230,.82); }
     .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
     .mcard.feat .comp { color: rgba(245,241,230,.85); }
     .mcard.feat .crest { color: var(--color-cream); border-color: rgba(245,241,230,.7); background: transparent; }

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-14-underline-centered.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-14-underline-centered.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 14 · Underline (toned down) + reliable vertical centering</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      /* toned-down underline tints */
+      --ul-w: color-mix(in srgb, var(--color-jersey-deep) 15%, var(--color-cream));
+      --ul-d: color-mix(in srgb, var(--color-ink-muted) 15%, var(--color-cream));
+      --ul-v: color-mix(in srgb, var(--color-warm) 24%, var(--color-cream));
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 40px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); max-width: 640px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 26px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 25px; line-height: 1; margin: 14px 0 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+    .section-kicker { display:flex; align-items:baseline; gap:10px; margin-bottom: 6px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; font-size: 23px; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 9px; display: grid; grid-template-columns: 46px 1fr; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow:none; transform: translate(3px,3px); cursor:pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+
+    /* fixline: comp lives INSIDE the centre column → grid align-items:center keeps
+       the team names centred against the score+caption block, reliably */
+    .body { padding: 11px 14px; }
+    .fixline { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px; }
+    .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .team.home { justify-content: flex-start; }
+    .team.away { justify-content: flex-end; }
+    .team .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; line-height: 1.15; }
+    .team.home .tn { text-align: left; }
+    .team.away .tn { text-align: right; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); flex: none; }
+    .center { display:flex; flex-direction:column; align-items:center; gap: 3px; }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; white-space: nowrap; line-height: 1.1; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .val.w { box-shadow: inset 0 -6px 0 var(--ul-w); }
+    .val.d { box-shadow: inset 0 -6px 0 var(--ul-d); }
+    .val.v { box-shadow: inset 0 -6px 0 var(--ul-v); }
+    /* one treatment for ALL competitions: ink, same weight, no bullet, no special-case */
+    .comp { font-family: var(--font-mono); font-size: 8.5px; font-weight: 500; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-soft); text-align:center; max-width: 160px; }
+
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
+    .mcard.feat .comp { color: rgba(245,241,230,.85); }
+    .mcard.feat .crest { color: var(--color-cream); border-color: rgba(245,241,230,.7); background: transparent; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 14 · Drill 6.C.d1</div>
+    <h1>Underline, toned down + centred reliably.</h1>
+    <p>Score underline is lighter now. Competition caption moved into the centre
+       column, so the team names always centre against the score+caption block —
+       try the long-name and long-competition rows at the bottom; they stay
+       balanced.</p>
+  </div>
+
+  <div class="variant-band">B &nbsp;·&nbsp; <b>Score underline (subtle)</b> + reliable vertical centering</div>
+  <div class="variant-note">Win green / draw grey / verlies warm — fainter swipe under the score. Long names &amp; competitions don't break the rhythm.</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">D</span><span class="tn">Diegem</span></span><span class="center"><span class="val w">0–2</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="center"><span class="val d">1–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val v">1–3</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">Londerzeel B</span><span class="crest">L</span></span></div></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val time">15:00</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div></div></div>
+
+    <div class="amonth">Stress test <em>·</em> lange namen / competities</div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV Elewijt</span></span><span class="center"><span class="val w">3–0</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">KSK Steenokkerzeel</span><span class="crest">S</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val time">20:00</span><span class="comp special">Beker van Vlaams-Brabant · halve finale</span></span><span class="team away"><span class="tn">VK Tildonk</span><span class="crest">T</span></span></div></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:40px">
+    <div class="tag">Decide</div>
+    <p>Underline subtlety OK? Vertical rhythm fixed (centre column holds
+       score+comp; teams centre against it)? If yes, 6.C.d1 locks.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-15-highlighterstroke-loss-names.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-15-highlighterstroke-loss-names.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 15 · HighlighterStroke marker · loss colour · long-name handling</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264; --color-alert: #b84a3a;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 30px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 40px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); max-width: 600px; margin: 18px auto 0; }
+    .frame .page { padding: 20px 20px 24px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 9px; display: grid; grid-template-columns: 46px 1fr; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .body { padding: 11px 14px; }
+    .fixline { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px; }
+    .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .team.home { justify-content: flex-start; }
+    .team.away { justify-content: flex-end; }
+    .team .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; line-height: 1.15; }
+    .team.home .tn { text-align: left; }
+    .team.away .tn { text-align: right; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); flex: none; }
+    .center { display:flex; flex-direction:column; align-items:center; gap: 3px; }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; white-space: nowrap; line-height: 1.1; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .comp { font-family: var(--font-mono); font-size: 8.5px; font-weight: 500; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-soft); text-align:center; max-width: 160px; }
+
+    /* === REAL HighlighterStroke marker (same path + technique as the component) === */
+    .hs { background-repeat: no-repeat; background-position: 0 88%; background-size: 100% 0.42em; padding-bottom: 0.08em; -webkit-box-decoration-break: clone; box-decoration-break: clone; }
+    .hs.jd   { background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='%23008755' opacity='0.85'/></svg>"); }
+    .hs.ink  { background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='%230a0a0a' opacity='0.85'/></svg>"); }
+    .hs.brick{ background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='%23b84a3a' opacity='0.85'/></svg>"); }
+
+    .crest.sm { } /* placeholder */
+    .legend { max-width: 600px; margin: 6px auto 0; display:flex; gap:14px; font-family: var(--font-mono); font-size:9.5px; text-transform:uppercase; letter-spacing:.07em; color: var(--color-ink-soft); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 15 · Drill 6.C.d1</div>
+    <h1>Real marker, loss colour, long names.</h1>
+    <p>The mark below is the actual <code>&lt;HighlighterStroke&gt;</code> texture
+       (same SVG path the component ships). Win = jersey-deep, draw = no mark.
+       The open question is the loss mark — pick a scheme — and how long names
+       behave.</p>
+  </div>
+
+  <!-- ===== LOSS COLOUR ===== -->
+  <div class="variant-band">Loss mark &nbsp;·&nbsp; <b>A — ink</b> (no new colour)</div>
+  <div class="variant-note">Win = jersey-deep marker, draw = unmarked, loss = ink (dark) marker. Stays entirely within the existing HighlighterStroke colours.</div>
+  <div class="frame"><div class="page">
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs jd">3–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">Liedekerke</span><span class="crest">L</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="center"><span class="val">1–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs ink">1–3</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">Londerzeel B</span><span class="crest">L</span></span></div></div></div>
+  </div></div>
+
+  <div class="variant-band">Loss mark &nbsp;·&nbsp; <b>C — muted brick</b> (small palette delta)</div>
+  <div class="variant-note">Same, but loss = a muted retro brick (--color-alert #b84a3a, NOT bright red). Reads as a loss instantly; cost = adding one colour to HighlighterStroke + bending the "no outcome red" lock.</div>
+  <div class="frame"><div class="page">
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs jd">3–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">Liedekerke</span><span class="crest">L</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">Wemmel</span></span><span class="center"><span class="val">1–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs brick">1–3</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">Londerzeel B</span><span class="crest">L</span></span></div></div></div>
+  </div></div>
+
+  <!-- ===== LONG NAMES ===== -->
+  <div class="variant-band">Long names &nbsp;·&nbsp; <b>1 — wrap to 2 lines</b></div>
+  <div class="variant-note">Full name always visible; row grows taller, the score+caption stay centred against it.</div>
+  <div class="frame"><div class="page">
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs jd">2–1</span><span class="comp">Beker van België · 1/16 finale</span></span><span class="team away"><span class="tn" style="white-space:normal">KSV Schoonbeek-Beverst A</span><span class="crest">S</span></span></div></div></div>
+  </div></div>
+
+  <div class="variant-band">Long names &nbsp;·&nbsp; <b>2 — ellipsis + title tooltip</b></div>
+  <div class="variant-note">Single-line height stays constant; the name truncates with … and the full name shows on hover (title attr). Hover "KSV Schoonbeek-Bever…" to see it.</div>
+  <div class="frame"><div class="page">
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs jd">2–1</span><span class="comp">Beker van België · 1/16 finale</span></span><span class="team away"><span class="tn" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis" title="KSV Schoonbeek-Beverst A">KSV Schoonbeek-Beverst A</span><span class="crest">S</span></span></div></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:40px">
+    <div class="tag">Decide</div>
+    <p>Loss mark: A (ink) or C (brick)? &nbsp; Long names: wrap (1) or ellipsis+title (2)?
+       Then 6.C.d1 locks.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-16-final-assembled.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-16-final-assembled.html
@@ -55,8 +55,8 @@
        (HighlighterStroke stays reserved for large headline text.) */
     .hs { padding: 0 8px 1px; }   /* underline runs a touch wider than the score */
     /* band climbs higher up the digits — closer to the "–", per round 13 */
-    .hs.win  { box-shadow: inset 0 -9px 0 color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream)); }
-    .hs.loss { box-shadow: inset 0 -9px 0 color-mix(in srgb, var(--color-alert) 46%, var(--color-cream)); }
+    .hs.win  { box-shadow: inset 0 -9px 0 color-mix(in srgb, var(--color-jersey-deep) 34%, var(--color-cream)); }
+    .hs.loss { box-shadow: inset 0 -9px 0 color-mix(in srgb, var(--color-alert) 38%, var(--color-cream)); }
     /* draw = no underline */
 
     .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
@@ -102,9 +102,9 @@
        Desktop = symmetric A; mobile = KCVV-centric B with a house/bus icon.</p>
   </div>
   <div class="legend">
-    <span class="sw"><i style="background: color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream))"></i> Winst</span>
+    <span class="sw"><i style="background: color-mix(in srgb, var(--color-jersey-deep) 34%, var(--color-cream))"></i> Winst</span>
     <span class="sw">Gelijk = geen markering</span>
-    <span class="sw"><i style="background: color-mix(in srgb, var(--color-alert) 46%, var(--color-cream))"></i> Verlies (brick)</span>
+    <span class="sw"><i style="background: color-mix(in srgb, var(--color-alert) 38%, var(--color-cream))"></i> Verlies (brick)</span>
   </div>
 
   <!-- DESKTOP -->

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-16-final-assembled.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-16-final-assembled.html
@@ -54,8 +54,9 @@
     /* clean flat underline — reads better than the textured stroke at score size.
        (HighlighterStroke stays reserved for large headline text.) */
     .hs { padding: 0 8px 1px; }   /* underline runs a touch wider than the score */
-    .hs.win  { box-shadow: inset 0 -6px 0 color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream)); }
-    .hs.loss { box-shadow: inset 0 -6px 0 color-mix(in srgb, var(--color-alert) 46%, var(--color-cream)); }
+    /* band climbs higher up the digits — closer to the "–", per round 13 */
+    .hs.win  { box-shadow: inset 0 -9px 0 color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream)); }
+    .hs.loss { box-shadow: inset 0 -9px 0 color-mix(in srgb, var(--color-alert) 46%, var(--color-cream)); }
     /* draw = no underline */
 
     .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-16-final-assembled.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-16-final-assembled.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 16 · FINAL assembled matches row (desktop A / mobile B)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264; --color-alert: #b84a3a;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 30px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 68ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 40px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .legend { max-width: 920px; margin: 8px auto 0; padding: 0 24px; display:flex; gap:16px; font-family: var(--font-mono); font-size:9.5px; text-transform:uppercase; letter-spacing:.07em; color: var(--color-ink-soft); }
+    .legend .sw { display:inline-flex; align-items:center; gap:6px; }
+    .legend i { width:18px;height:9px;display:inline-block; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame.desktop { max-width: 640px; margin: 18px auto 0; }
+    .frame.mobile { max-width: 358px; margin: 18px auto 0; }
+    .frame .page { padding: 20px 20px 26px; }
+    .frame.mobile .page { padding: 16px 14px 22px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; font-size: 22px; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .section-kicker { display:flex; align-items:baseline; gap:10px; margin-bottom: 4px; flex-wrap:wrap; }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 25px; line-height: 1; margin: 20px 0 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 9px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow:none; transform: translate(3px,3px); cursor:pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; line-height: 1.15; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .crest { width: 22px; height: 22px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-size: 9px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); flex: none; }
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; white-space: nowrap; line-height: 1.1; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 18px; }
+    .comp { font-family: var(--font-mono); font-size: 8.5px; font-weight: 500; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-soft); text-align:center; max-width: 170px; }
+
+    /* clean flat underline — reads better than the textured stroke at score size.
+       (HighlighterStroke stays reserved for large headline text.) */
+    .hs { padding: 0 8px 1px; }   /* underline runs a touch wider than the score */
+    .hs.win  { box-shadow: inset 0 -6px 0 color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream)); }
+    .hs.loss { box-shadow: inset 0 -6px 0 color-mix(in srgb, var(--color-alert) 46%, var(--color-cream)); }
+    /* draw = no underline */
+
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .stub .mo { color: rgba(245,241,230,.82); }
+    .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
+    .mcard.feat .comp { color: rgba(245,241,230,.85); }
+    .mcard.feat .crest { color: var(--color-cream); border-color: rgba(245,241,230,.7); background: transparent; }
+    .mcard.feat .ha { color: rgba(245,241,230,.9); }
+
+    /* ===== A desktop: stub | body  (no venue, no result column) ===== */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr; }
+    .a .body { padding: 11px 14px; }
+    .a .fixline { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px; }
+    .a .team { display:flex; align-items:center; gap: 7px; min-width:0; }
+    .a .team.home { justify-content: flex-start; }
+    .a .team.away { justify-content: flex-end; }
+    .a .team.home .tn { text-align:left; }
+    .a .team.away .tn { text-align:right; }
+    .a .center { display:flex; flex-direction:column; align-items:center; gap: 3px; }
+
+    /* ===== B mobile: stub | opp | home/away icon | score (no result column) ===== */
+    .b .mcard { display: grid; grid-template-columns: 40px 1fr 26px 58px; align-items: stretch; }
+    .b .opp { display:flex; align-items:center; gap: 8px; padding: 9px 4px 9px 10px; min-width:0; }
+    .b .opp .txt { display:flex; flex-direction:column; gap:2px; min-width:0; }
+    .b .ha-cell { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+    .ha { width: 16px; height: 16px; color: var(--color-ink-muted); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 16 · Drill 6.C.d1 — assembled</div>
+    <h1>The matches row, assembled.</h1>
+    <p>Everything together: month-grouped agenda, card rows, crests (placeholder →
+       real logos), score/time centred (display font), competition in ink under
+       the score, outcome as a <code>&lt;HighlighterStroke&gt;</code> on the
+       score (win jersey-deep, draw none, loss brick), featured next in
+       jersey-deep, ellipsis+title for long names, no separate outcome column.
+       Desktop = symmetric A; mobile = KCVV-centric B with a house/bus icon.</p>
+  </div>
+  <div class="legend">
+    <span class="sw"><i style="background: color-mix(in srgb, var(--color-jersey-deep) 42%, var(--color-cream))"></i> Winst</span>
+    <span class="sw">Gelijk = geen markering</span>
+    <span class="sw"><i style="background: color-mix(in srgb, var(--color-alert) 46%, var(--color-cream))"></i> Verlies (brick)</span>
+  </div>
+
+  <!-- DESKTOP -->
+  <div class="variant-band">Desktop &nbsp;·&nbsp; <b>A</b></div>
+  <div class="frame desktop"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs win">2–1</span><span class="comp" title="Beker van België · 1/16 finale">Beker van België · 1/16 finale</span></span><span class="team away"><span class="tn" title="KSV Schoonbeek-Beverst A">KSV Schoonbeek-Beverst A</span><span class="crest">S</span></span></div></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs loss">1–3</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">SK Londerzeel B</span><span class="crest">L</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">W</span><span class="tn">KVK Wemmel</span></span><span class="center"><span class="val">1–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val hs win">3–1</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">VK Liedekerke</span><span class="crest">L</span></span></div></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">K</span><span class="tn kcvv">KCVV</span></span><span class="center"><span class="val time">15:00</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn">KFC Eppegem</span><span class="crest">E</span></span></div></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="team home"><span class="crest">P</span><span class="tn">FC Perk</span></span><span class="center"><span class="val time">15:00</span><span class="comp">3e Provinciale A</span></span><span class="team away"><span class="tn kcvv">KCVV</span><span class="crest">K</span></span></div></div></div>
+  </div></div>
+
+  <!-- MOBILE -->
+  <div class="variant-band">Mobile &nbsp;·&nbsp; <b>B</b></div>
+  <div class="frame mobile"><div class="page b">
+    <div class="section-kicker"><span class="mono">A-ploeg</span><h3 class="ed">Kalender.</h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">L</span><span class="txt"><span class="tn">SK Londerzeel B</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol"><span class="val hs loss">1–3</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">W</span><span class="txt"><span class="tn">KVK Wemmel</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="10" rx="2"/><path d="M3 11h18"/><path d="M7 6V4h10v2"/><circle cx="7.5" cy="18.5" r="1.4"/><circle cx="16.5" cy="18.5" r="1.4"/></svg></div><div class="scorecol"><span class="val">1–1</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">L</span><span class="txt"><span class="tn">VK Liedekerke</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol"><span class="val hs win">3–1</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="crest">E</span><span class="txt"><span class="tn">KFC Eppegem</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/><path d="M10 20v-5h4v5"/></svg></div><div class="scorecol"><span class="val time">15:00</span></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="crest">P</span><span class="txt"><span class="tn">FC Perk</span><span class="comp">3e Prov. A</span></span></div><div class="ha-cell"><svg class="ha" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="10" rx="2"/><path d="M3 11h18"/><path d="M7 6V4h10v2"/><circle cx="7.5" cy="18.5" r="1.4"/><circle cx="16.5" cy="18.5" r="1.4"/></svg></div><div class="scorecol"><span class="val time">15:00</span></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:40px">
+    <div class="tag">Decide</div>
+    <p>This is the assembled matches row. If it lands, I lock 6.C.d1 and write the
+       lock doc + the 6.C PRD.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-2-matches-section.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-2-matches-section.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 2 · Wedstrijden-section treatments (6.C.d1)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink);
+      --shadow-paper-lift: 8px 8px 0 0 var(--color-ink); --shadow-paper-sm-soft: 4px 4px 0 0 var(--color-ink-muted);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --pattern-seam-ink: repeating-linear-gradient(-45deg, var(--color-ink) 0 8px, var(--color-cream) 8px 16px);
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 38px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 52px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+
+    .frame { max-width: 720px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 22px 28px; }
+
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .pill { display: inline-block; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10px; font-weight: 600; line-height: 1; padding: 5px 8px; border: 1px solid var(--color-paper-edge); }
+    .pill.ink { background: var(--color-ink); color: var(--color-cream); border-color: var(--color-ink); }
+    .pill.cream { background: var(--color-cream-soft); color: var(--color-ink); }
+    .pill.warm { background: var(--color-warm); color: var(--color-ink); border-color: var(--color-ink); }
+    .pill.jersey { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 26px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 14px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .secnav { position: sticky; top: 50px; z-index: 10; background: var(--color-cream); border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); display: flex; gap: 8px; flex-wrap: wrap; padding: 8px 0; margin: 0 0 18px; }
+    .secnav span { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10px; color: var(--color-ink-soft); padding: 4px 8px; }
+    .secnav span.on { border: 1px solid var(--color-ink); background: var(--color-cream-soft); }
+    .panel-note { margin: 14px 0 8px; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: var(--color-ink-muted); }
+
+    /* card match rows (variants 1/2/3) */
+    .mrow { display: grid; grid-template-columns: 58px 1fr auto; gap: 12px; align-items: center; border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); margin-bottom: 9px; transition: all .25s; }
+    .mrow:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .mrow .stubd { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 9px 4px; text-align: center; }
+    .mrow .stubd .d { font-family: var(--font-display-big); font-weight: 900; font-size: 17px; line-height: 1; }
+    .mrow .stubd .m { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; }
+    .mrow .body { padding: 9px 4px; display: flex; align-items: center; gap: 7px; min-width: 0; }
+    .mrow .tn { font-family: var(--font-display); font-style: italic; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .mrow .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; }
+    .mrow .vs { font-family: var(--font-display); font-style: italic; color: var(--color-ink-muted); font-size: 13px; }
+    .mrow .badge { padding-right: 10px; }
+    .cta { display:block; text-align:center; border:2px solid var(--color-ink); background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 12px; margin-top: 10px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .1em; font-size: 12px; transition: all .25s; }
+    .cta:hover { box-shadow:none; transform: translate(3px,3px); cursor:pointer; }
+    .dest { margin-top: 14px; border: 2px dashed var(--color-ink-muted); padding: 14px; background: color-mix(in srgb, var(--color-cream-soft) 70%, var(--color-cream)); }
+    .dest .lbl { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; letter-spacing: .12em; color: var(--color-ink-muted); margin-bottom: 10px; }
+
+    /* accordion */
+    details.acc { border-bottom: 2px solid var(--color-ink); }
+    details.acc > summary { list-style: none; cursor: pointer; display: flex; justify-content: space-between; align-items: center; padding: 12px 4px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 12px; }
+    details.acc > summary::-webkit-details-marker { display:none; }
+    details.acc > summary .cnt { color: var(--color-ink-muted); font-size: 10px; }
+    details.acc > summary::before { content: "▸"; margin-right: 8px; color: var(--color-jersey-deep); }
+    details.acc[open] > summary::before { content: "▾"; }
+    details.acc .acc-body { padding: 6px 0 12px; }
+
+    /* segmented */
+    .seg { display: inline-flex; border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); margin-bottom: 14px; }
+    .seg span { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 11px; font-weight: 600; padding: 8px 16px; }
+    .seg span.on { background: var(--color-ink); color: var(--color-cream); }
+    .seg span:not(.on) { background: var(--color-cream-soft); }
+    details.more > summary { list-style:none; cursor:pointer; text-align:center; font-family: var(--font-mono); text-transform: uppercase; letter-spacing:.1em; font-size: 11px; color: var(--color-jersey-deep); padding: 12px; border: 1px dashed var(--color-ink); }
+    details.more > summary::-webkit-details-marker { display:none; }
+
+    /* newspaper agenda */
+    .agenda-month { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; margin: 20px 0 4px; line-height: 1; }
+    .agenda-month em { font-style: italic; color: var(--color-jersey-deep); }
+    .agenda-row { display: grid; grid-template-columns: 84px 1fr 64px; gap: 14px; align-items: baseline; padding: 11px 2px; border-bottom: 1px dashed var(--color-ink); }
+    .agenda-row .date { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; color: var(--color-ink-soft); line-height: 1.3; }
+    .agenda-row .fix { font-family: var(--font-display); font-style: italic; font-size: 16px; line-height: 1.25; }
+    .agenda-row .fix .meta { display:block; font-family: var(--font-mono); font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .08em; color: var(--color-ink-muted); margin-top: 2px; }
+    .agenda-row .res { font-family: var(--font-display-big); font-weight: 900; font-size: 17px; text-align: right; }
+    .agenda-row .res.up { font-family: var(--font-mono); font-weight: 600; font-size: 10px; text-transform: uppercase; color: var(--color-jersey-deep); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 2 · Drill 6.C.d1 (continued)</div>
+    <h1>The Wedstrijden problem: 40–50 matches a season.</h1>
+    <p>IA stays <b>single-scroll + sticky nav</b> (the A/C blend you liked). An
+       A-team season runs 40–50 fixtures (league + beker + oefenmatchen), so this
+       section is the real stress test. The
+       only open piece is how the <b>Wedstrijden</b> section holds a full season
+       without burying the squad/staff below it. Four treatments below, each the
+       same KCVV A-ploeg season. The fourth is the <b>§6.6 newspaper-agenda</b>
+       style — which also previews the parked 6.D kalender direction.</p>
+  </div>
+
+  <!-- ===================== VARIANT 1: TEASER + DEDICATED ===================== -->
+  <div class="variant-band">Treatment <b>1</b> — Teaser on page &nbsp;→&nbsp; dedicated full-schedule view</div>
+  <div class="variant-note">Team page carries only next + recent + a big "Volledige kalender" link. The full season lives on its own scrollable page (shown dashed below). Team page stays lean; full matches becomes its own destination.</div>
+  <div class="frame"><div class="page">
+    <nav class="secnav"><span>Klassement</span><span class="on">Wedstrijden</span><span>Spelers</span><span>Staf</span><span>Info</span></nav>
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="panel-note">Eerstvolgende</div>
+    <div class="mrow"><div class="stubd"><div class="d">31</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV Elewijt</span><span class="vs">vs</span><span class="tn">KFC Eppegem</span></div><div class="badge"><span class="pill cream">15:00 · Thuis</span></div></div>
+    <div class="mrow"><div class="stubd"><div class="d">08</div><div class="m">JUN</div></div><div class="body"><span class="tn">FC Perk</span><span class="vs">vs</span><span class="tn">KCVV Elewijt</span></div><div class="badge"><span class="pill cream">15:00 · Uit</span></div></div>
+    <div class="panel-note">Laatste uitslagen</div>
+    <div class="mrow"><div class="stubd"><div class="d">24</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">1</span><span class="tn">Liedekerke</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <div class="mrow"><div class="stubd"><div class="d">17</div><div class="m">MEI</div></div><div class="body"><span class="tn">Diegem</span><span class="sc">0</span><span class="vs">—</span><span class="sc">2</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <div class="mrow"><div class="stubd"><div class="d">10</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">0</span><span class="tn">Wemmel</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <a class="cta">Volledige kalender (46) →</a>
+
+    <div class="dest">
+      <div class="lbl">→ /ploegen/elewijt-a/wedstrijden · the dedicated full-season page</div>
+      <div class="mrow"><div class="stubd"><div class="d">06</div><div class="m">SEP</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">1</span><span class="tn">Kampenhout</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+      <div class="mrow"><div class="stubd"><div class="d">13</div><div class="m">SEP</div></div><div class="body"><span class="tn">Zemst</span><span class="sc">1</span><span class="vs">—</span><span class="sc">3</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+      <div class="mrow"><div class="stubd"><div class="d">20</div><div class="m">SEP</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">0</span><span class="vs">—</span><span class="sc">0</span><span class="tn">Weerde</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+      <div style="text-align:center;font-family:var(--font-mono);font-size:10px;color:var(--color-ink-muted);padding:8px">… 25 more rows …</div>
+    </div>
+  </div></div>
+
+  <!-- ===================== VARIANT 2: MONTH ACCORDION ===================== -->
+  <div class="variant-band">Treatment <b>2</b> — Month-grouped accordion, inline</div>
+  <div class="variant-note">All ~46 stay on the team page. Grouped by month (Aug→Jun); past months collapsed (click to open), current + upcoming open by default. Try clicking the months — note how many months a full A-team season spans.</div>
+  <div class="frame"><div class="page">
+    <nav class="secnav"><span>Klassement</span><span class="on">Wedstrijden</span><span>Spelers</span><span>Staf</span><span>Info</span></nav>
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+
+    <details class="acc"><summary>Augustus <span class="cnt">3 oefenwedstrijden</span></summary></details>
+    <details class="acc"><summary>September <span class="cnt">5 wedstrijden</span></summary></details>
+    <details class="acc"><summary>Oktober <span class="cnt">4 wedstrijden</span></summary></details>
+    <details class="acc"><summary>November <span class="cnt">5 wedstrijden</span></summary></details>
+    <details class="acc"><summary>December <span class="cnt">3 wedstrijden</span></summary></details>
+    <details class="acc"><summary>Januari <span class="cnt">4 wedstrijden</span></summary></details>
+    <details class="acc"><summary>Februari <span class="cnt">4 wedstrijden</span></summary></details>
+    <details class="acc"><summary>Maart <span class="cnt">5 wedstrijden</span></summary></details>
+    <details class="acc"><summary>April <span class="cnt">5 wedstrijden</span></summary></details>
+    <details class="acc" open><summary>Mei <span class="cnt">4 wedstrijden</span></summary>
+      <div class="acc-body">
+        <div class="mrow"><div class="stubd"><div class="d">10</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">0</span><span class="tn">Wemmel</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+        <div class="mrow"><div class="stubd"><div class="d">17</div><div class="m">MEI</div></div><div class="body"><span class="tn">Diegem</span><span class="sc">0</span><span class="vs">—</span><span class="sc">2</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+        <div class="mrow"><div class="stubd"><div class="d">24</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">1</span><span class="tn">Liedekerke</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+        <div class="mrow"><div class="stubd"><div class="d">31</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV Elewijt</span><span class="vs">vs</span><span class="tn">KFC Eppegem</span></div><div class="badge"><span class="pill cream">15:00</span></div></div>
+      </div>
+    </details>
+    <details class="acc" open><summary>Juni <span class="cnt">1 wedstrijd</span></summary>
+      <div class="acc-body">
+        <div class="mrow"><div class="stubd"><div class="d">08</div><div class="m">JUN</div></div><div class="body"><span class="tn">FC Perk</span><span class="vs">vs</span><span class="tn">KCVV Elewijt</span></div><div class="badge"><span class="pill cream">15:00</span></div></div>
+      </div>
+    </details>
+  </div></div>
+
+  <!-- ===================== VARIANT 3: SEGMENTED + EXPAND ===================== -->
+  <div class="variant-band">Treatment <b>3</b> — Segmented (Komend / Uitslagen) + "toon alle"</div>
+  <div class="variant-note">A toggle splits upcoming vs results; ~4 rows shown, the rest behind "Toon alle". Compact default even at 40–50 fixtures, full list one click away. Try the "toon alle" row.</div>
+  <div class="frame"><div class="page">
+    <nav class="secnav"><span>Klassement</span><span class="on">Wedstrijden</span><span>Spelers</span><span>Staf</span><span>Info</span></nav>
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="seg"><span>Komend</span><span class="on">Uitslagen</span></div>
+    <div class="mrow"><div class="stubd"><div class="d">24</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">1</span><span class="tn">Liedekerke</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <div class="mrow"><div class="stubd"><div class="d">17</div><div class="m">MEI</div></div><div class="body"><span class="tn">Diegem</span><span class="sc">0</span><span class="vs">—</span><span class="sc">2</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <div class="mrow"><div class="stubd"><div class="d">10</div><div class="m">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">0</span><span class="tn">Wemmel</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <div class="mrow"><div class="stubd"><div class="d">22</div><div class="m">NOV</div></div><div class="body"><span class="tn">Liedekerke</span><span class="sc">0</span><span class="vs">—</span><span class="sc">2</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+    <details class="more"><summary>Toon alle 42 uitslagen ↓</summary>
+      <div style="padding-top:10px">
+        <div class="mrow"><div class="stubd"><div class="d">15</div><div class="m">NOV</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">2</span><span class="tn">Wemmel</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+        <div class="mrow"><div class="stubd"><div class="d">08</div><div class="m">NOV</div></div><div class="body"><span class="tn">Mazenzele</span><span class="sc">1</span><span class="vs">—</span><span class="sc">1</span><span class="tn">KCVV</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+        <div class="mrow"><div class="stubd"><div class="d">01</div><div class="m">NOV</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">0</span><span class="tn">Perk</span></div><div class="badge"><span class="pill ink">FT</span></div></div>
+      </div>
+    </details>
+  </div></div>
+
+  <!-- ===================== VARIANT 4: NEWSPAPER AGENDA ===================== -->
+  <div class="variant-band">Treatment <b>4</b> — §6.6 newspaper agenda &nbsp;·&nbsp; (also previews 6.D kalender)</div>
+  <div class="variant-note">No cards. Month headings + dashed-divider rows: date · fixture (+ competition/venue) · result. Tabular, dense, editorial — a whole season reads compactly. This is the master-plan §6.6 vocabulary; seeing it here is a free taste of the kalender direction.</div>
+  <div class="frame"><div class="page">
+    <nav class="secnav"><span>Klassement</span><span class="on">Wedstrijden</span><span>Spelers</span><span>Staf</span><span>Info</span></nav>
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+
+    <div class="agenda-month">Mei <em>'26.</em></div>
+    <div class="agenda-row"><div class="date">ZA 31<br>15:00</div><div class="fix">KCVV Elewijt — KFC Eppegem<span class="meta">3e Prov. A · Driesstraat · Thuis</span></div><div class="res up">Komend</div></div>
+    <div class="agenda-row"><div class="date">ZA 24</div><div class="fix">KCVV Elewijt — VK Liedekerke<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res">3–1</div></div>
+    <div class="agenda-row"><div class="date">ZA 17</div><div class="fix">Diegem Sport — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res">0–2</div></div>
+    <div class="agenda-row"><div class="date">ZA 10</div><div class="fix">KCVV Elewijt — KVK Wemmel<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res">2–0</div></div>
+
+    <div class="agenda-month">April <em>'26.</em></div>
+    <div class="agenda-row"><div class="date">ZA 26</div><div class="fix">KCVV Elewijt — FC Perk<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res">2–0</div></div>
+    <div class="agenda-row"><div class="date">ZA 19</div><div class="fix">Eendracht Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="res">1–1</div></div>
+    <div class="agenda-row"><div class="date">ZA 12</div><div class="fix">KCVV Elewijt — SK Londerzeel B<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res">1–3</div></div>
+
+    <div class="agenda-month">Maart <em>'26.</em></div>
+    <div class="agenda-row"><div class="date">ZA 29</div><div class="fix">KFC Eppegem — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res">1–1</div></div>
+    <div class="agenda-row"><div class="date">ZA 22</div><div class="fix">KCVV Elewijt — Machelen<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res">2–1</div></div>
+    <div style="text-align:center;font-family:var(--font-mono);font-size:10px;color:var(--color-ink-muted);padding:12px">… september → februari volgen, zelfde ritme …</div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>Pick a Wedstrijden treatment (1 / 2 / 3 / 4). They're not mutually
+       exclusive with the agenda question for 6.D — if you love treatment 4 here,
+       that's a strong signal the kalender should go agenda too. Per-row styling
+       (shields, result emphasis) is a later detail; this is about structure.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-3-agenda-refined.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-3-agenda-refined.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 3 · Refined 1+4 agenda (next-highlight + W/G/V tints)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      /* palette-safe outcome tints (NO red — jersey-deep / neutral / warm) */
+      --tint-win: color-mix(in srgb, var(--color-jersey-deep) 8%, var(--color-cream));
+      --tint-draw: color-mix(in srgb, var(--color-cream-deep) 55%, var(--color-cream));
+      --tint-loss: color-mix(in srgb, var(--color-warm) 14%, var(--color-cream));
+      --tint-next: color-mix(in srgb, var(--color-jersey-deep) 14%, var(--color-cream));
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 36px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .legend { max-width: 920px; margin: 10px auto 0; padding: 0 24px; display: flex; gap: 14px; flex-wrap: wrap; align-items: center; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--color-ink-soft); }
+    .legend .sw { display: inline-flex; align-items: center; gap: 6px; }
+    .legend .chip { width: 26px; height: 16px; border: 1px solid var(--color-paper-edge); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 48px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 700px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 22px 28px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .pill { display: inline-block; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10px; font-weight: 600; line-height: 1; padding: 5px 8px; border: 1px solid var(--color-paper-edge); }
+    .pill.cream { background: var(--color-cream-soft); color: var(--color-ink); }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 26px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 14px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .secnav { position: sticky; top: 50px; z-index: 10; background: var(--color-cream); border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); display: flex; gap: 8px; flex-wrap: wrap; padding: 8px 0; margin: 0 0 18px; }
+    .secnav span { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10px; color: var(--color-ink-soft); padding: 4px 8px; }
+    .secnav span.on { border: 1px solid var(--color-ink); background: var(--color-cream-soft); }
+    .cta { display:block; text-align:center; border:2px solid var(--color-ink); background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 12px; margin-top: 14px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .1em; font-size: 12px; transition: all .25s; }
+    .cta:hover { box-shadow:none; transform: translate(3px,3px); cursor:pointer; }
+    .empty { border: 2px dashed var(--color-paper-edge); padding: 16px; text-align: center; font-family: var(--font-display); font-style: italic; color: var(--color-ink-muted); margin-top: 8px; }
+
+    /* ----- shared agenda row vocabulary (teaser AND full page) ----- */
+    .agenda-month { font-family: var(--font-display-big); font-weight: 900; font-size: 24px; margin: 20px 0 2px; line-height: 1; }
+    .agenda-month em { font-style: italic; color: var(--color-jersey-deep); }
+    .arow { display: grid; grid-template-columns: 78px 1fr 58px; gap: 12px; align-items: center; padding: 11px 8px 11px 10px; border-bottom: 1px dashed var(--color-ink); border-left: 4px solid transparent; }
+    .arow .date { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; color: var(--color-ink-soft); line-height: 1.3; }
+    .arow .fix { font-family: var(--font-display); font-style: italic; font-size: 16px; line-height: 1.25; }
+    .arow .fix .meta { display:block; font-family: var(--font-mono); font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-muted); margin-top: 3px; }
+    .arow .res { text-align: right; }
+    .arow .res .score { font-family: var(--font-display-big); font-weight: 900; font-size: 17px; }
+    .arow .res .time { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-soft); }
+    .rp { display:inline-grid; place-items:center; width:18px; height:18px; font-family: var(--font-mono); font-size:9px; font-weight:700; border:1px solid var(--color-ink); margin-top: 4px; }
+    .rp.w { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .rp.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .rp.v { background: var(--color-warm); color: var(--color-ink); }
+
+    /* outcome tints (subtle, palette-only) */
+    .arow.win  { background: var(--tint-win);  border-left-color: var(--color-jersey-deep); }
+    .arow.draw { background: var(--tint-draw); border-left-color: var(--color-ink-muted); }
+    .arow.loss { background: var(--tint-loss); border-left-color: var(--color-warm); }
+
+    /* the featured "next match" row */
+    .arow.next { background: var(--tint-next); border-left: 4px solid var(--color-jersey-deep); border-bottom: 2px solid var(--color-ink); padding-top: 14px; padding-bottom: 14px; }
+    .arow.next .fix { font-size: 19px; }
+    .arow.next .badge-next { display:inline-block; background: var(--color-jersey-deep); color: var(--color-cream); font-family: var(--font-mono); font-size: 8.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .1em; padding: 3px 6px; margin-bottom: 6px; }
+    .arow.next .res .time { font-family: var(--font-display-big); font-weight: 900; font-size: 15px; color: var(--color-ink); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 3 · Refined 1+4</div>
+    <h1>Agenda, refined: featured next match + palette-safe W/G/V.</h1>
+    <p>One row vocabulary shared by the team-page teaser <b>and</b> the full
+       schedule (your consistency ask). The <b>eerstvolgende</b> match is a
+       featured row (works even when the whole season is still upcoming).
+       Played matches carry a subtle outcome tint — <b>no red</b>, only
+       jersey-deep / neutral / warm from the palette.</p>
+  </div>
+  <div class="legend">
+    <span class="sw"><span class="chip" style="background:var(--tint-win);border-left:4px solid var(--color-jersey-deep)"></span> Winst</span>
+    <span class="sw"><span class="chip" style="background:var(--tint-draw);border-left:4px solid var(--color-ink-muted)"></span> Gelijk</span>
+    <span class="sw"><span class="chip" style="background:var(--tint-loss);border-left:4px solid var(--color-warm)"></span> Verlies</span>
+    <span class="sw"><span class="chip" style="background:var(--tint-next);border-left:4px solid var(--color-jersey-deep)"></span> Eerstvolgende</span>
+  </div>
+
+  <!-- ================= A: TEAM-PAGE TEASER (mid-season) ================= -->
+  <div class="variant-band">A &nbsp;·&nbsp; Team page <b>teaser</b> — mid-season</div>
+  <div class="variant-note">On the team page itself: the featured next match + the last few results in the SAME agenda rows as the full page (consistent), then "Volledige kalender →".</div>
+  <div class="frame"><div class="page">
+    <nav class="secnav"><span>Klassement</span><span class="on">Wedstrijden</span><span>Spelers</span><span>Staf</span><span>Info</span></nav>
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="arow next">
+      <div class="date">ZA 31 MEI</div>
+      <div class="fix"><span class="badge-next">Eerstvolgende</span><br>KCVV Elewijt — KFC Eppegem<span class="meta">3e Prov. A · Driesstraat · Thuis</span></div>
+      <div class="res"><span class="time">15:00</span></div>
+    </div>
+    <div class="arow win"><div class="date">ZA 24 MEI</div><div class="fix">KCVV Elewijt — VK Liedekerke<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="score">3–1</span><br><span class="rp w">W</span></div></div>
+    <div class="arow win"><div class="date">ZA 17 MEI</div><div class="fix">Diegem Sport — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="score">0–2</span><br><span class="rp w">W</span></div></div>
+    <div class="arow draw"><div class="date">ZA 10 MEI</div><div class="fix">KVK Wemmel — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="score">1–1</span><br><span class="rp d">G</span></div></div>
+    <a class="cta">Volledige kalender (46) →</a>
+  </div></div>
+
+  <!-- ================= B: TEAM-PAGE TEASER (season start) ================= -->
+  <div class="variant-band">B &nbsp;·&nbsp; Team page <b>teaser</b> — season start (your question)</div>
+  <div class="variant-note">At the start of the season there are no results yet — the featured next match (the opener) carries the section on its own; the results slot says so honestly rather than rendering empty.</div>
+  <div class="frame"><div class="page">
+    <nav class="secnav"><span>Klassement</span><span class="on">Wedstrijden</span><span>Spelers</span><span>Staf</span><span>Info</span></nav>
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="arow next">
+      <div class="date">ZA 30 AUG</div>
+      <div class="fix"><span class="badge-next">Seizoensopener</span><br>KCVV Elewijt — FC Kampenhout<span class="meta">3e Prov. A · Driesstraat · Thuis</span></div>
+      <div class="res"><span class="time">15:00</span></div>
+    </div>
+    <div class="arow"><div class="date">ZA 06 SEP</div><div class="fix">SK Zemst — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="time">15:00</span></div></div>
+    <div class="arow"><div class="date">ZA 13 SEP</div><div class="fix">KCVV Elewijt — Weerde<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="time">15:00</span></div></div>
+    <div class="empty">Nog geen uitslagen — het seizoen moet nog beginnen.</div>
+    <a class="cta">Volledige kalender (44) →</a>
+  </div></div>
+
+  <!-- ================= C: FULL SCHEDULE AGENDA (mid-season) ================= -->
+  <div class="variant-band">C &nbsp;·&nbsp; <b>Volledige kalender</b> page — full season agenda (mid-season)</div>
+  <div class="variant-note">"Volledige kalender →" opens this: the whole season as the §6.6 newspaper agenda, same rows, month-grouped, next featured, results tinted. Dense + scannable at 40–50 fixtures. (This is also your 6.D kalender preview.)</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="arow next"><div class="date">ZA 31 MEI</div><div class="fix"><span class="badge-next">Eerstvolgende</span><br>KCVV Elewijt — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div><div class="res"><span class="time">15:00</span></div></div>
+
+    <div class="agenda-month">Mei <em>'26.</em></div>
+    <div class="arow win"><div class="date">ZA 24</div><div class="fix">KCVV Elewijt — VK Liedekerke<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="score">3–1</span><br><span class="rp w">W</span></div></div>
+    <div class="arow win"><div class="date">ZA 17</div><div class="fix">Diegem Sport — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="score">0–2</span><br><span class="rp w">W</span></div></div>
+    <div class="arow draw"><div class="date">ZA 10</div><div class="fix">KVK Wemmel — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="score">1–1</span><br><span class="rp d">G</span></div></div>
+
+    <div class="agenda-month">April <em>'26.</em></div>
+    <div class="arow win"><div class="date">ZA 26</div><div class="fix">KCVV Elewijt — FC Perk<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="score">2–0</span><br><span class="rp w">W</span></div></div>
+    <div class="arow draw"><div class="date">ZA 19</div><div class="fix">Eendracht Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="score">1–1</span><br><span class="rp d">G</span></div></div>
+    <div class="arow loss"><div class="date">ZA 12</div><div class="fix">KCVV Elewijt — SK Londerzeel B<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="score">1–3</span><br><span class="rp v">V</span></div></div>
+    <div class="arow win"><div class="date">WO 09</div><div class="fix">KCVV Elewijt — VK Tildonk<span class="meta">Beker · 1/4 finale</span></div><div class="res"><span class="score">2–1</span><br><span class="rp w">W</span></div></div>
+
+    <div class="agenda-month">Maart <em>'26.</em></div>
+    <div class="arow draw"><div class="date">ZA 29</div><div class="fix">KFC Eppegem — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="score">1–1</span><br><span class="rp d">G</span></div></div>
+    <div class="arow win"><div class="date">ZA 22</div><div class="fix">KCVV Elewijt — Machelen<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="score">2–1</span><br><span class="rp w">W</span></div></div>
+    <div style="text-align:center;font-family:var(--font-mono);font-size:10px;color:var(--color-ink-muted);padding:12px">… augustus → februari volgen, zelfde ritme (44 wedstrijden totaal) …</div>
+  </div></div>
+
+  <!-- ================= D: FULL SCHEDULE AGENDA (season start) ================= -->
+  <div class="variant-band">D &nbsp;·&nbsp; <b>Volledige kalender</b> page — season start (all upcoming)</div>
+  <div class="variant-note">Same agenda, opening day of the season: every row is upcoming, the opener is featured, nothing renders empty or broken. As results come in, rows simply gain a score + tint.</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="arow next"><div class="date">ZA 30 AUG</div><div class="fix"><span class="badge-next">Seizoensopener</span><br>KCVV Elewijt — FC Kampenhout<span class="meta">3e Prov. A · Thuis</span></div><div class="res"><span class="time">15:00</span></div></div>
+
+    <div class="agenda-month">Augustus <em>'25.</em></div>
+    <div class="arow"><div class="date">ZA 16</div><div class="fix">KCVV Elewijt — KV Woluwe<span class="meta">Oefenwedstrijd · Driesstraat</span></div><div class="res"><span class="time">19:00</span></div></div>
+    <div class="arow"><div class="date">WO 20</div><div class="fix">Tervuren — KCVV Elewijt<span class="meta">Beker · 1/16 · Uit</span></div><div class="res"><span class="time">20:00</span></div></div>
+
+    <div class="agenda-month">September <em>'25.</em></div>
+    <div class="arow"><div class="date">ZA 06</div><div class="fix">SK Zemst — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="time">15:00</span></div></div>
+    <div class="arow"><div class="date">ZA 13</div><div class="fix">KCVV Elewijt — Weerde<span class="meta">3e Prov. A · Driesstraat</span></div><div class="res"><span class="time">15:00</span></div></div>
+    <div class="arow"><div class="date">ZA 20</div><div class="fix">Hofstade — KCVV Elewijt<span class="meta">3e Prov. A · Uit</span></div><div class="res"><span class="time">15:00</span></div></div>
+    <div style="text-align:center;font-family:var(--font-mono);font-size:10px;color:var(--color-ink-muted);padding:12px">… de rest van het seizoen volgt, allemaal "komend" tot de eerste fluit …</div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>If this resolves the season-start + outcome-tint + consistency questions,
+       we lock 6.C.d1 as <b>single-scroll + sticky nav</b>, Wedstrijden =
+       <b>1+4</b> (agenda teaser → full agenda page). Tints, the featured-row
+       marker, and "no red" carry into the standings form indicator too, for
+       one consistent outcome language across the team page.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-4-row-styles.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-4-row-styles.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 4 · Agenda row styles (minimal colour)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264;
+      --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 34px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 48px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 660px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 24px 28px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 25px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 6px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .grp { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 10px; color: var(--color-ink-muted); margin: 22px 0 4px; padding-bottom: 6px; border-bottom: 2px solid var(--color-ink); }
+    .grp:first-of-type { margin-top: 12px; }
+    .nextlabel { display:inline-block; font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; color: var(--color-jersey-deep); margin-bottom: 3px; }
+
+    /* ============ V1 — end square ============ */
+    .v1 .row { display: grid; grid-template-columns: 64px 1fr auto 22px; gap: 12px; align-items: center; padding: 10px 2px; border-bottom: 1px dashed var(--color-paper-edge); }
+    .v1 .row .date { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; color: var(--color-ink-muted); }
+    .v1 .row .fix { font-family: var(--font-display); font-style: italic; font-size: 16px; }
+    .v1 .row .fix .meta { display:block; font-family: var(--font-mono); font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; color: var(--color-ink-muted); margin-top: 2px; }
+    .v1 .row .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; }
+    .v1 .row .tm { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-soft); }
+    .v1 .sq { width: 20px; height: 20px; display: inline-grid; place-items: center; font-family: var(--font-mono); font-size: 9px; font-weight: 700; border: 1px solid var(--color-ink); }
+    .v1 .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .v1 .sq.d { background: transparent; color: var(--color-ink); }
+    .v1 .sq.v { background: var(--color-warm); color: var(--color-ink); border-color: var(--color-warm); }
+    .v1 .row.feat { border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); padding: 13px 2px; }
+    .v1 .row.feat .fix { font-size: 18px; }
+    .v1 .row.feat .tm { font-family: var(--font-display-big); font-weight: 900; font-size: 15px; color: var(--color-ink); }
+
+    /* ============ V2 — left edge only ============ */
+    .v2 .row { display: grid; grid-template-columns: 64px 1fr auto; gap: 12px; align-items: center; padding: 10px 2px 10px 12px; border-bottom: 1px dashed var(--color-paper-edge); border-left: 3px solid transparent; }
+    .v2 .row.w { border-left-color: var(--color-jersey-deep); }
+    .v2 .row.d { border-left-color: var(--color-ink-muted); }
+    .v2 .row.v { border-left-color: var(--color-warm); }
+    .v2 .row .date { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; color: var(--color-ink-muted); }
+    .v2 .row .fix { font-family: var(--font-display); font-style: italic; font-size: 16px; }
+    .v2 .row .fix .meta { display:block; font-family: var(--font-mono); font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; color: var(--color-ink-muted); margin-top: 2px; }
+    .v2 .row .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; }
+    .v2 .row .tm { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-soft); }
+    .v2 .row.feat { border-left: 4px solid var(--color-jersey-deep); padding-top: 13px; padding-bottom: 13px; }
+    .v2 .row.feat .fix { font-size: 18px; }
+    .v2 .row.feat .tm { font-family: var(--font-display-big); font-weight: 900; font-size: 15px; color: var(--color-ink); }
+
+    /* ============ V3 — score-led, dot marker ============ */
+    .v3 .row { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: baseline; padding: 11px 2px; border-bottom: 1px solid var(--color-paper-edge); }
+    .v3 .row .left { display:flex; gap: 12px; align-items: baseline; min-width: 0; }
+    .v3 .row .date { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; color: var(--color-ink-muted); white-space: nowrap; }
+    .v3 .row .fix { font-family: var(--font-display); font-style: italic; font-size: 17px; }
+    .v3 .row .fix .meta { display:block; font-family: var(--font-mono); font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; color: var(--color-ink-muted); margin-top: 2px; }
+    .v3 .row .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; white-space: nowrap; }
+    .v3 .row .sc .dot { display:inline-block; width: 8px; height: 8px; border-radius: 50%; margin-left: 7px; vertical-align: middle; }
+    .v3 .dot.w { background: var(--color-jersey-deep); }
+    .v3 .dot.d { background: var(--color-ink-muted); }
+    .v3 .dot.v { background: var(--color-warm); }
+    .v3 .row .tm { font-family: var(--font-mono); font-size: 12px; color: var(--color-ink-soft); }
+    .v3 .row.feat { border-bottom: 2px solid var(--color-ink); border-top: 2px solid var(--color-ink); padding: 14px 2px; }
+    .v3 .row.feat .fix { font-size: 19px; }
+    .v3 .row.feat .tm { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; color: var(--color-ink); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 4 · Drill 6.C.d1 (row style)</div>
+    <h1>Pick the row. Minimal colour, multiple upcoming shown.</h1>
+    <p>Three restrained row treatments for the agenda, each on the same
+       mid-season state: a <b>Komend</b> group (featured next + 4 more upcoming)
+       then an <b>Uitslagen</b> group (7 played, mixed). No row fills. Outcome
+       shown only by a small end-square (V1), a thin left edge (V2), or a dot by
+       the score (V3). Same structure works on the team-page teaser and the full
+       schedule page.</p>
+  </div>
+
+  <!-- ===== V1: END SQUARE ===== -->
+  <div class="variant-band">V1 &nbsp;·&nbsp; <b>End square</b> — W/G/V chip at the row's end</div>
+  <div class="variant-note">Cleanest "fixtures column" feel. Colour lives only in the 20px square: Winst = jersey-deep, Gelijk = outline, Verlies = warm.</div>
+  <div class="frame"><div class="page v1">
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="grp">Komend</div>
+    <div class="row feat"><div class="date">ZA 31/5</div><div class="fix"><span class="nextlabel">Eerstvolgende</span><br>KCVV — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div><div></div></div>
+    <div class="row"><div class="date">ZA 7/6</div><div class="fix">FC Perk — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="tm">15:00</div><div></div></div>
+    <div class="row"><div class="date">WO 11/6</div><div class="fix">KCVV — VK Tildonk<span class="meta">Beker · 1/2 finale</span></div><div class="tm">20:00</div><div></div></div>
+    <div class="row"><div class="date">ZA 14/6</div><div class="fix">KCVV — Diegem Sport<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div><div></div></div>
+    <div class="row"><div class="date">ZA 21/6</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="tm">15:00</div><div></div></div>
+    <div class="grp">Uitslagen</div>
+    <div class="row"><div class="date">ZA 24/5</div><div class="fix">KCVV — VK Liedekerke<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">3–1</div><div class="sq w">W</div></div>
+    <div class="row"><div class="date">ZA 17/5</div><div class="fix">Diegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">0–2</div><div class="sq w">W</div></div>
+    <div class="row"><div class="date">ZA 10/5</div><div class="fix">KVK Wemmel — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div><div class="sq d">G</div></div>
+    <div class="row"><div class="date">ZA 3/5</div><div class="fix">KCVV — SK Londerzeel B<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">1–3</div><div class="sq v">V</div></div>
+    <div class="row"><div class="date">ZA 26/4</div><div class="fix">KCVV — FC Perk<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">2–0</div><div class="sq w">W</div></div>
+    <div class="row"><div class="date">ZA 19/4</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div><div class="sq d">G</div></div>
+    <div class="row"><div class="date">ZA 12/4</div><div class="fix">KFC Eppegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">2–1</div><div class="sq v">V</div></div>
+  </div></div>
+
+  <!-- ===== V2: LEFT EDGE ===== -->
+  <div class="variant-band">V2 &nbsp;·&nbsp; <b>Left edge</b> — thin coloured border, no chip</div>
+  <div class="variant-note">Even quieter. The only colour is a 3px left edge: jersey-deep (W), grey (G), warm (V). Score stays ink. Featured next = thicker jersey-deep edge.</div>
+  <div class="frame"><div class="page v2">
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="grp">Komend</div>
+    <div class="row feat"><div class="date">ZA 31/5</div><div class="fix"><span class="nextlabel">Eerstvolgende</span><br>KCVV — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="date">ZA 7/6</div><div class="fix">FC Perk — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="date">WO 11/6</div><div class="fix">KCVV — VK Tildonk<span class="meta">Beker · 1/2 finale</span></div><div class="tm">20:00</div></div>
+    <div class="row"><div class="date">ZA 14/6</div><div class="fix">KCVV — Diegem Sport<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="date">ZA 21/6</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="tm">15:00</div></div>
+    <div class="grp">Uitslagen</div>
+    <div class="row w"><div class="date">ZA 24/5</div><div class="fix">KCVV — VK Liedekerke<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">3–1</div></div>
+    <div class="row w"><div class="date">ZA 17/5</div><div class="fix">Diegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">0–2</div></div>
+    <div class="row d"><div class="date">ZA 10/5</div><div class="fix">KVK Wemmel — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div></div>
+    <div class="row v"><div class="date">ZA 3/5</div><div class="fix">KCVV — SK Londerzeel B<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">1–3</div></div>
+    <div class="row w"><div class="date">ZA 26/4</div><div class="fix">KCVV — FC Perk<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">2–0</div></div>
+    <div class="row d"><div class="date">ZA 19/4</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div></div>
+    <div class="row v"><div class="date">ZA 12/4</div><div class="fix">KFC Eppegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">2–1</div></div>
+  </div></div>
+
+  <!-- ===== V3: SCORE-LED DOT ===== -->
+  <div class="variant-band">V3 &nbsp;·&nbsp; <b>Score-led</b> — big score + a small outcome dot</div>
+  <div class="variant-note">Most editorial/typographic. Score is the hero; a tiny dot beside it carries the outcome (green/grey/warm). No borders, no chips, hairline dividers.</div>
+  <div class="frame"><div class="page v3">
+    <div class="section-kicker"><span class="mono">Kalender</span><h3 class="ed ed-md">Wedstrijden.</h3></div>
+    <div class="grp">Komend</div>
+    <div class="row feat"><div class="left"><div class="date">ZA 31/5</div><div class="fix"><span class="nextlabel">Eerstvolgende</span><br>KCVV — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="left"><div class="date">ZA 7/6</div><div class="fix">FC Perk — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="left"><div class="date">WO 11/6</div><div class="fix">KCVV — VK Tildonk<span class="meta">Beker · 1/2 finale</span></div></div><div class="tm">20:00</div></div>
+    <div class="row"><div class="left"><div class="date">ZA 14/6</div><div class="fix">KCVV — Diegem Sport<span class="meta">3e Prov. A · Thuis</span></div></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="left"><div class="date">ZA 21/6</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="tm">15:00</div></div>
+    <div class="grp">Uitslagen</div>
+    <div class="row"><div class="left"><div class="date">ZA 24/5</div><div class="fix">KCVV — VK Liedekerke<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">3–1<span class="dot w"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 17/5</div><div class="fix">Diegem — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">0–2<span class="dot w"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 10/5</div><div class="fix">KVK Wemmel — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">1–1<span class="dot d"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 3/5</div><div class="fix">KCVV — SK Londerzeel B<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">1–3<span class="dot v"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 26/4</div><div class="fix">KCVV — FC Perk<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">2–0<span class="dot w"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 19/4</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">1–1<span class="dot d"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 12/4</div><div class="fix">KFC Eppegem — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">2–1<span class="dot v"></span></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>Pick a row style (V1 / V2 / V3) and an outcome marker. Mix-and-match is
+       fine (e.g. "V3 rows but with V1's end-square"). The featured-next
+       treatment shown is restrained — tell me if it should be even quieter or a
+       touch louder.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-5-month-agenda-rows.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-5-month-agenda-rows.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 5 · Month-grouped agenda × row styles</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264;
+      --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 33px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 48px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 640px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 24px 30px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 25px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+
+    /* the signature month heading (newspaper agenda) */
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 30px; line-height: 1; margin: 26px 0 2px; border-bottom: 2px solid var(--color-ink); padding-bottom: 8px; }
+    .amonth:first-of-type { margin-top: 14px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); font-weight: 900; }
+    .amonth .cnt { float: right; font-family: var(--font-mono); font-size: 10px; font-weight: 400; text-transform: uppercase; letter-spacing: .08em; color: var(--color-ink-muted); margin-top: 14px; }
+    .nextlabel { display:inline-block; font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; color: var(--color-jersey-deep); margin-bottom: 3px; }
+
+    /* shared row bits */
+    .date { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; color: var(--color-ink-muted); white-space: nowrap; }
+    .fix { font-family: var(--font-display); font-style: italic; font-size: 16px; }
+    .fix .meta { display:block; font-family: var(--font-mono); font-style: normal; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; color: var(--color-ink-muted); margin-top: 2px; }
+    .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; }
+    .tm { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-soft); }
+
+    /* ===== V1: end square ===== */
+    .v1 .row { display: grid; grid-template-columns: 56px 1fr auto 22px; gap: 12px; align-items: center; padding: 10px 2px; border-bottom: 1px dashed var(--color-paper-edge); }
+    .v1 .sq { width: 20px; height: 20px; display: inline-grid; place-items: center; font-family: var(--font-mono); font-size: 9px; font-weight: 700; border: 1px solid var(--color-ink); }
+    .v1 .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .v1 .sq.d { background: transparent; color: var(--color-ink); }
+    .v1 .sq.v { background: var(--color-warm); color: var(--color-ink); border-color: var(--color-warm); }
+    .v1 .row.feat { border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); padding: 13px 2px; }
+    .v1 .row.feat .fix { font-size: 18px; }
+    .v1 .row.feat .tm { font-family: var(--font-display-big); font-weight: 900; font-size: 15px; color: var(--color-ink); }
+
+    /* ===== V2: left edge ===== */
+    .v2 .row { display: grid; grid-template-columns: 56px 1fr auto; gap: 12px; align-items: center; padding: 10px 2px 10px 12px; border-bottom: 1px dashed var(--color-paper-edge); border-left: 3px solid transparent; }
+    .v2 .row.w { border-left-color: var(--color-jersey-deep); }
+    .v2 .row.d { border-left-color: var(--color-ink-muted); }
+    .v2 .row.v { border-left-color: var(--color-warm); }
+    .v2 .row.feat { border-left: 4px solid var(--color-jersey-deep); padding-top: 13px; padding-bottom: 13px; border-bottom: 1px dashed var(--color-paper-edge); }
+    .v2 .row.feat .fix { font-size: 18px; }
+    .v2 .row.feat .tm { font-family: var(--font-display-big); font-weight: 900; font-size: 15px; color: var(--color-ink); }
+
+    /* ===== V3: score-led dot ===== */
+    .v3 .row { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: baseline; padding: 11px 2px; border-bottom: 1px solid var(--color-paper-edge); }
+    .v3 .row .left { display:flex; gap: 12px; align-items: baseline; min-width: 0; }
+    .v3 .sc .dot { display:inline-block; width: 8px; height: 8px; border-radius: 50%; margin-left: 7px; vertical-align: middle; }
+    .v3 .dot.w { background: var(--color-jersey-deep); }
+    .v3 .dot.d { background: var(--color-ink-muted); }
+    .v3 .dot.v { background: var(--color-warm); }
+    .v3 .row.feat { border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); padding: 14px 2px; }
+    .v3 .row.feat .fix { font-size: 18px; }
+    .v3 .row.feat .tm { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; color: var(--color-ink); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 5 · Drill 6.C.d1 (corrected)</div>
+    <h1>Month-grouped agenda — kept. Now pick the row.</h1>
+    <p>The §6.6 newspaper month grouping is back (it's the signature). Each row
+       style below renders inside it across three months — <b>April</b> (played),
+       <b>Mei</b> (played + the featured next match), <b>Juni</b> (all upcoming,
+       so multiple upcoming games show naturally). Full season = same, ascending
+       Aug→Jun, on the dedicated schedule page. No row fills; outcome marker
+       differs per variant.</p>
+  </div>
+
+  <!-- ===== V1 ===== -->
+  <div class="variant-band">V1 &nbsp;·&nbsp; month agenda + <b>end square</b></div>
+  <div class="variant-note">W/G/V chip (20px) at the row end. Played rows carry score + chip; upcoming rows carry time. Featured next = top/bottom rule.</div>
+  <div class="frame"><div class="page v1">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em><span class="cnt">4 gespeeld</span></div>
+    <div class="row"><div class="date">ZA 5/4</div><div class="fix">KCVV — Steenokkerzeel<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">4–1</div><div class="sq w">W</div></div>
+    <div class="row"><div class="date">ZA 12/4</div><div class="fix">KFC Eppegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">2–1</div><div class="sq v">V</div></div>
+    <div class="row"><div class="date">ZA 19/4</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div><div class="sq d">G</div></div>
+    <div class="row"><div class="date">ZA 26/4</div><div class="fix">KCVV — FC Perk<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">2–0</div><div class="sq w">W</div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="row"><div class="date">ZA 3/5</div><div class="fix">KCVV — SK Londerzeel B<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">1–3</div><div class="sq v">V</div></div>
+    <div class="row"><div class="date">ZA 10/5</div><div class="fix">KVK Wemmel — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div><div class="sq d">G</div></div>
+    <div class="row"><div class="date">ZA 17/5</div><div class="fix">Diegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">0–2</div><div class="sq w">W</div></div>
+    <div class="row"><div class="date">ZA 24/5</div><div class="fix">KCVV — VK Liedekerke<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">3–1</div><div class="sq w">W</div></div>
+    <div class="row feat"><div class="date">ZA 31/5</div><div class="fix"><span class="nextlabel">Eerstvolgende</span><br>KCVV — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div><div></div></div>
+
+    <div class="amonth">Juni <em>'26.</em><span class="cnt">3 komend</span></div>
+    <div class="row"><div class="date">ZA 7/6</div><div class="fix">FC Perk — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="tm">15:00</div><div></div></div>
+    <div class="row"><div class="date">WO 11/6</div><div class="fix">KCVV — VK Tildonk<span class="meta">Beker · 1/2 finale</span></div><div class="tm">20:00</div><div></div></div>
+    <div class="row"><div class="date">ZA 14/6</div><div class="fix">KCVV — Diegem Sport<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div><div></div></div>
+  </div></div>
+
+  <!-- ===== V2 ===== -->
+  <div class="variant-band">V2 &nbsp;·&nbsp; month agenda + <b>left edge</b></div>
+  <div class="variant-note">Outcome = a 3px coloured left edge only. Quietest. Upcoming rows have no edge; featured next has a thicker jersey edge.</div>
+  <div class="frame"><div class="page v2">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em><span class="cnt">4 gespeeld</span></div>
+    <div class="row w"><div class="date">ZA 5/4</div><div class="fix">KCVV — Steenokkerzeel<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">4–1</div></div>
+    <div class="row v"><div class="date">ZA 12/4</div><div class="fix">KFC Eppegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">2–1</div></div>
+    <div class="row d"><div class="date">ZA 19/4</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div></div>
+    <div class="row w"><div class="date">ZA 26/4</div><div class="fix">KCVV — FC Perk<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">2–0</div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="row v"><div class="date">ZA 3/5</div><div class="fix">KCVV — SK Londerzeel B<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">1–3</div></div>
+    <div class="row d"><div class="date">ZA 10/5</div><div class="fix">KVK Wemmel — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">1–1</div></div>
+    <div class="row w"><div class="date">ZA 17/5</div><div class="fix">Diegem — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="sc">0–2</div></div>
+    <div class="row w"><div class="date">ZA 24/5</div><div class="fix">KCVV — VK Liedekerke<span class="meta">3e Prov. A · Thuis</span></div><div class="sc">3–1</div></div>
+    <div class="row feat"><div class="date">ZA 31/5</div><div class="fix"><span class="nextlabel">Eerstvolgende</span><br>KCVV — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div></div>
+
+    <div class="amonth">Juni <em>'26.</em><span class="cnt">3 komend</span></div>
+    <div class="row"><div class="date">ZA 7/6</div><div class="fix">FC Perk — KCVV<span class="meta">3e Prov. A · Uit</span></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="date">WO 11/6</div><div class="fix">KCVV — VK Tildonk<span class="meta">Beker · 1/2 finale</span></div><div class="tm">20:00</div></div>
+    <div class="row"><div class="date">ZA 14/6</div><div class="fix">KCVV — Diegem Sport<span class="meta">3e Prov. A · Thuis</span></div><div class="tm">15:00</div></div>
+  </div></div>
+
+  <!-- ===== V3 ===== -->
+  <div class="variant-band">V3 &nbsp;·&nbsp; month agenda + <b>score-led dot</b></div>
+  <div class="variant-note">Score is the hero with a small outcome dot. Most typographic. Upcoming rows show time on the right.</div>
+  <div class="frame"><div class="page v3">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em><span class="cnt">4 gespeeld</span></div>
+    <div class="row"><div class="left"><div class="date">ZA 5/4</div><div class="fix">KCVV — Steenokkerzeel<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">4–1<span class="dot w"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 12/4</div><div class="fix">KFC Eppegem — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">2–1<span class="dot v"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 19/4</div><div class="fix">Mazenzele — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">1–1<span class="dot d"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 26/4</div><div class="fix">KCVV — FC Perk<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">2–0<span class="dot w"></span></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="row"><div class="left"><div class="date">ZA 3/5</div><div class="fix">KCVV — SK Londerzeel B<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">1–3<span class="dot v"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 10/5</div><div class="fix">KVK Wemmel — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">1–1<span class="dot d"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 17/5</div><div class="fix">Diegem — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="sc">0–2<span class="dot w"></span></div></div>
+    <div class="row"><div class="left"><div class="date">ZA 24/5</div><div class="fix">KCVV — VK Liedekerke<span class="meta">3e Prov. A · Thuis</span></div></div><div class="sc">3–1<span class="dot w"></span></div></div>
+    <div class="row feat"><div class="left"><div class="date">ZA 31/5</div><div class="fix"><span class="nextlabel">Eerstvolgende</span><br>KCVV — KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></div></div><div class="tm">15:00</div></div>
+
+    <div class="amonth">Juni <em>'26.</em><span class="cnt">3 komend</span></div>
+    <div class="row"><div class="left"><div class="date">ZA 7/6</div><div class="fix">FC Perk — KCVV<span class="meta">3e Prov. A · Uit</span></div></div><div class="tm">15:00</div></div>
+    <div class="row"><div class="left"><div class="date">WO 11/6</div><div class="fix">KCVV — VK Tildonk<span class="meta">Beker · 1/2 finale</span></div></div><div class="tm">20:00</div></div>
+    <div class="row"><div class="left"><div class="date">ZA 14/6</div><div class="fix">KCVV — Diegem Sport<span class="meta">3e Prov. A · Thuis</span></div></div><div class="tm">15:00</div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>Month grouping stays (the agenda signature). Pick the row marker:
+       V1 end-square / V2 left-edge / V3 score-dot — or a blend. This is the last
+       open piece of 6.C.d1; once it's picked I'll write the lock and move to the
+       6.C PRD.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-6-card-agenda.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-6-card-agenda.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 6 · Card rows + month agenda + colour squares + auto-scroll</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .demo-banner { position: fixed; top: 0; left: 0; right: 0; z-index: 100; background: var(--color-warm); color: var(--color-ink); text-align: center; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .1em; font-size: 11px; padding: 7px; border-bottom: 2px solid var(--color-ink); }
+    .demo-banner a { color: var(--color-ink); }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 56px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 33px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .frame { max-width: 640px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 24px 30px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 25px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .legend { display:flex; gap:14px; flex-wrap:wrap; margin: 6px 0 4px; font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-soft); }
+    .legend .sw { display:inline-flex; align-items:center; gap:6px; }
+    .legend .b { width:16px;height:16px;border:1px solid var(--color-ink); }
+
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 30px; line-height: 1; margin: 26px 0 12px; border-bottom: 2px solid var(--color-ink); padding-bottom: 8px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+    .amonth .cnt { float: right; font-family: var(--font-mono); font-size: 10px; font-weight: 400; text-transform: uppercase; letter-spacing: .08em; color: var(--color-ink-muted); margin-top: 14px; }
+
+    /* round-2 card row */
+    .mcard { display: grid; grid-template-columns: 52px 1fr auto; align-items: stretch; border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .mcard .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; text-align: center; display:flex; flex-direction:column; justify-content:center; }
+    .mcard .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .mcard .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; letter-spacing: .05em; margin-top: 2px; }
+    .mcard .body { padding: 10px 12px; display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .mcard .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .mcard .tn.away { text-align: right; }
+    .mcard .grow { flex: 1; }
+    .mcard .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 19px; }
+    .mcard .vs { font-family: var(--font-display); font-style: italic; color: var(--color-ink-muted); font-size: 14px; }
+    .mcard .meta { display:block; font-family: var(--font-mono); font-style:normal; font-size: 8.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--color-ink-muted); margin-top: 2px; }
+    .mcard .end { display: flex; align-items: center; justify-content: center; padding: 0 12px; border-left: 1px solid var(--color-paper-edge); }
+    .mcard .tm { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-soft); white-space: nowrap; }
+
+    /* the W/G/V square (replaces the old "FT" pill) */
+    .sq { width: 28px; height: 28px; display: inline-grid; place-items: center; font-family: var(--font-mono); font-size: 12px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-jersey-deep); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); border-color: var(--color-warm); }
+
+    /* featured next = jersey-deep filled card */
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); border-color: var(--color-ink); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn { color: var(--color-cream); }
+    .mcard.feat .vs { color: rgba(245,241,230,.7); }
+    .mcard.feat .end { border-left-color: rgba(245,241,230,.3); }
+    .mcard.feat .tm { color: var(--color-cream); font-family: var(--font-display-big); font-weight: 900; font-size: 15px; }
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin-bottom: 7px; }
+
+    .alt { max-width: 640px; margin: 26px auto 0; padding: 16px 24px; background: var(--color-cream-soft); border: 2px dashed var(--color-ink-muted); }
+    .alt .lbl { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: var(--color-ink-muted); margin-bottom: 12px; }
+    .mcard.feat-outline { background: var(--color-cream); color: var(--color-ink); border: 3px solid var(--color-jersey-deep); box-shadow: var(--shadow-paper-sm); }
+    .mcard.feat-outline .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-jersey-deep); }
+    .mcard.feat-outline .tn { color: var(--color-ink); }
+  </style>
+</head>
+<body>
+  <div class="demo-banner">DEMO · auto-gescrolld naar de eerstvolgende match — <a href="#top">scroll omhoog voor uitleg ↑</a></div>
+
+  <div class="drill-head" id="top">
+    <div class="tag">Phase 6.C · Team detail · Round 6 · Drill 6.C.d1</div>
+    <h1>Card rows in the month agenda + colour squares + auto-scroll.</h1>
+    <p>Your blend: round-2 ticket-card rows, inside the §6.6 month grouping, with
+       the old "FT" pill replaced by a <b>W/G/V square in the outcome colour</b>.
+       The <b>eerstvolgende</b> match is the jersey-deep filled card. On load the
+       page auto-scrolls to it (try reloading) — recent results sit above,
+       upcoming below. A restrained alternative for the featured card is shown at
+       the very bottom.</p>
+  </div>
+
+  <div class="legend" style="max-width:640px;margin:0 auto;padding:0 24px">
+    <span class="sw"><span class="b" style="background:var(--color-jersey-deep)"></span> Winst</span>
+    <span class="sw"><span class="b" style="background:var(--color-cream-deep)"></span> Gelijk</span>
+    <span class="sw"><span class="b" style="background:var(--color-warm)"></span> Verlies</span>
+    <span class="sw"><span class="b" style="background:var(--color-jersey-deep)"></span> Eerstvolgende (gevulde kaart)</span>
+  </div>
+
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">Maart <em>'26.</em><span class="cnt">5 gespeeld</span></div>
+    <div class="mcard"><div class="stub"><div class="d">8</div><div class="mo">MRT</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">Machelen</span></div><div class="end"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">15</div><div class="mo">MRT</div></div><div class="body"><span class="tn">Eppegem</span><span class="sc">1</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">KCVV</span></div><div class="end"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">22</div><div class="mo">MRT</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">0</span><span class="tn away grow">Weerde</span></div><div class="end"><span class="sq w">W</span></div></div>
+
+    <div class="amonth">April <em>'26.</em><span class="cnt">4 gespeeld</span></div>
+    <div class="mcard"><div class="stub"><div class="d">5</div><div class="mo">APR</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">4</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">Steenokkerzeel</span></div><div class="end"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">12</div><div class="mo">APR</div></div><div class="body"><span class="tn">Eppegem</span><span class="sc">2</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">KCVV</span></div><div class="end"><span class="sq v">V</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">19</div><div class="mo">APR</div></div><div class="body"><span class="tn">Mazenzele</span><span class="sc">1</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">KCVV</span></div><div class="end"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">2</span><span class="vs">—</span><span class="sc">0</span><span class="tn away grow">FC Perk</span></div><div class="end"><span class="sq w">W</span></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">3</div><div class="mo">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">1</span><span class="vs">—</span><span class="sc">3</span><span class="tn away grow">Londerzeel B</span></div><div class="end"><span class="sq v">V</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><span class="tn">Wemmel</span><span class="sc">1</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">KCVV</span></div><div class="end"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><span class="tn">Diegem</span><span class="sc">0</span><span class="vs">—</span><span class="sc">2</span><span class="tn away grow">KCVV</span></div><div class="end"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="sc">3</span><span class="vs">—</span><span class="sc">1</span><span class="tn away grow">Liedekerke</span></div><div class="end"><span class="sq w">W</span></div></div>
+
+    <!-- FEATURED NEXT (jersey-deep) -->
+    <div id="next" style="scroll-margin-top: 70px">
+      <div class="feat-label">Eerstvolgende</div>
+      <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="vs">vs</span><span class="tn away grow">KFC Eppegem<span class="meta" style="color:rgba(245,241,230,.75)">3e Prov. A · Thuis</span></span></div><div class="end"><span class="tm">15:00</span></div></div>
+    </div>
+
+    <div class="amonth">Juni <em>'26.</em><span class="cnt">3 komend</span></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><span class="tn">FC Perk</span><span class="vs">vs</span><span class="tn away grow">KCVV<span class="meta">3e Prov. A · Uit</span></span></div><div class="end"><span class="tm">15:00</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><span class="tn">KCVV</span><span class="vs">vs</span><span class="tn away grow">VK Tildonk<span class="meta">Beker · 1/2 finale</span></span></div><div class="end"><span class="tm">20:00</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">14</div><div class="mo">JUN</div></div><div class="body"><span class="tn">KCVV</span><span class="vs">vs</span><span class="tn away grow">Diegem Sport<span class="meta">3e Prov. A · Thuis</span></span></div><div class="end"><span class="tm">15:00</span></div></div>
+  </div></div>
+
+  <div class="alt">
+    <div class="lbl">Alternatief voor de eerstvolgende-kaart (i.p.v. gevuld jersey-groen): omlijnd</div>
+    <div class="feat-label" style="background:var(--color-jersey-deep);color:var(--color-cream)">Eerstvolgende</div>
+    <div class="mcard feat-outline"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><span class="tn">KCVV</span><span class="vs">vs</span><span class="tn away grow">KFC Eppegem<span class="meta">3e Prov. A · Thuis</span></span></div><div class="end"><span class="tm">15:00</span></div></div>
+  </div>
+
+  <div class="drill-head" style="padding-top:40px">
+    <div class="tag">Decide</div>
+    <p>If this is it: card rows + month agenda + colour W/G/V squares, featured
+       next as the <b>jersey-deep filled</b> card (or the outlined alternative),
+       auto-scroll to next on the full-schedule page. Then I lock 6.C.d1 and
+       write the 6.C PRD.</p>
+  </div>
+
+  <script>
+    // demo of the "auto-scroll to next match on load" behaviour
+    window.addEventListener("load", function () {
+      var el = document.getElementById("next");
+      if (!el) return;
+      var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      el.scrollIntoView({ behavior: reduce ? "auto" : "smooth", block: "center" });
+    });
+  </script>
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-7-row-alignment.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-7-row-alignment.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 7 · Row alignment fixed (symmetric vs KCVV-centric)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 32px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 640px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 24px 30px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 25px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 28px; line-height: 1; margin: 24px 0 12px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    /* shared card chrome */
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; align-items: stretch; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .score { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; text-align: center; white-space: nowrap; }
+    .tm { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-soft); text-align: center; white-space: nowrap; }
+    .ven { font-family: var(--font-mono); font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--color-ink-muted); text-align: center; }
+    .sq { width: 26px; height: 26px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); }
+
+    /* ===== Approach A: symmetric scoreboard ===== */
+    /* card columns: stub | body | venue | result  (fixed except body) */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr 30px 40px; }
+    .a .body { display: grid; grid-template-columns: 1fr 52px 1fr; align-items: center; gap: 8px; padding: 10px 4px 10px 10px; }
+    .a .body .home { text-align: right; }
+    .a .body .away { text-align: left; }
+    .a .venue { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .a .result { display:flex; align-items:center; justify-content:center; padding-right: 8px; }
+
+    /* ===== Approach B: KCVV-centric column ===== */
+    /* card columns: stub | opponent | venue | score | result */
+    .b .mcard { display: grid; grid-template-columns: 46px 1fr 34px 50px 40px; }
+    .b .opp { display:flex; flex-direction:column; justify-content:center; padding: 10px 4px 10px 12px; min-width:0; }
+    .b .opp .comp { font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing:.05em; color: var(--color-ink-muted); margin-top: 2px; }
+    .b .venue { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .result { display:flex; align-items:center; justify-content:center; padding-right: 8px; }
+
+    /* featured next (jersey-deep) — works in both */
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .score, .mcard.feat .tm { color: var(--color-cream); }
+    .mcard.feat .tn.kcvv { color: var(--color-cream); }
+    .mcard.feat .ven { color: rgba(245,241,230,.8); }
+    .mcard.feat .venue, .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 7 · Drill 6.C.d1 (alignment fix)</div>
+    <h1>Aligned columns. Two framings.</h1>
+    <p>Same card + month agenda, but the row internals are now a real grid so the
+       score / venue / result columns line up down the page. Compare the two
+       framings — symmetric (both teams, real H/A order) vs KCVV-centric
+       (opponent always one column, our score first). Long names ellipsis
+       cleanly.</p>
+  </div>
+
+  <!-- ============ APPROACH A ============ -->
+  <div class="variant-band">A &nbsp;·&nbsp; <b>Symmetric scoreboard</b> — home (right) · score (centre) · away (left)</div>
+  <div class="variant-note">Real home/away order; KCVV bold so the eye finds it. Score column is fixed-centre so all scores align. Tiny T/U venue tag + result square at the right.</div>
+  <div class="frame"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">5</div><div class="mo">APR</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">4–1</span><span class="tn away">Steenokkerzeel</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">12</div><div class="mo">APR</div></div><div class="body"><span class="tn away">KFC Eppegem</span><span class="score">2–1</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq v">V</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">19</div><div class="mo">APR</div></div><div class="body"><span class="tn away">Mazenzele</span><span class="score">1–1</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">2–0</span><span class="tn away">FC Perk</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><span class="tn away">Diegem</span><span class="score">0–2</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">3–1</span><span class="tn away">VK Liedekerke</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">vs</span><span class="tn away">KFC Eppegem</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="tm">15:00</span></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><span class="tn away">FC Perk</span><span class="score">vs</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="tm">15:00</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">vs</span><span class="tn away">VK Tildonk</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="tm">20:00</span></div></div>
+  </div></div>
+
+  <!-- ============ APPROACH B ============ -->
+  <div class="variant-band">B &nbsp;·&nbsp; <b>KCVV-centric</b> — opponent · venue · our score · result</div>
+  <div class="variant-note">You're on KCVV's page, so KCVV isn't repeated. Opponent always left, then T/U, then OUR score first, then result. Every column aligns; the whole season scans as one clean table.</div>
+  <div class="frame"><div class="page b">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">5</div><div class="mo">APR</div></div><div class="opp"><span class="tn">Steenokkerzeel</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="score">4–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">12</div><div class="mo">APR</div></div><div class="opp"><span class="tn">KFC Eppegem</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="score">1–2</span></div><div class="result"><span class="sq v">V</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">19</div><div class="mo">APR</div></div><div class="opp"><span class="tn">Mazenzele</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="score">1–1</span></div><div class="result"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="opp"><span class="tn">FC Perk</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="score">2–0</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">Diegem Sport</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="score">2–0</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">VK Liedekerke</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="score">3–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">KFC Eppegem</span><span class="comp" style="color:rgba(245,241,230,.75)">3e Prov. A</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="tm">15:00</span></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">FC Perk</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="tm">15:00</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">VK Tildonk</span><span class="comp">Beker · 1/2</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="tm">20:00</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">14</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">Diegem Sport</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="tm">15:00</span></div><div class="result"></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:44px">
+    <div class="tag">Decide</div>
+    <p>Pick the framing (A symmetric / B KCVV-centric). Both now have real column
+       alignment. Then any last tweak (venue tag style, score size, comp line
+       only-when-not-league) and I lock 6.C.d1.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-8-responsive-a-desktop-b-mobile.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-8-responsive-a-desktop-b-mobile.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 8 · A on desktop / B on mobile + display-font time</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame.desktop { max-width: 660px; margin: 18px auto 0; }
+    .frame.mobile { max-width: 360px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 28px; }
+    .frame.mobile .page { padding: 18px 16px 24px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 23px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; flex-wrap: wrap; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; line-height: 1; margin: 22px 0 12px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    /* shared card chrome */
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    .score { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; text-align: center; white-space: nowrap; }
+    /* kickoff time now in the STYLISH display font (was mono) */
+    .tm { font-family: var(--font-display); font-style: italic; font-size: 16px; color: var(--color-ink-soft); text-align: center; white-space: nowrap; }
+    .ven { font-family: var(--font-mono); font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--color-ink-muted); text-align: center; }
+    .sq { width: 26px; height: 26px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); }
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .score, .mcard.feat .tm { color: var(--color-cream); }
+    .mcard.feat .ven { color: rgba(245,241,230,.8); }
+
+    /* ===== A — symmetric (desktop) ===== */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr 30px 40px; }
+    .a .body { display: grid; grid-template-columns: 1fr 52px 1fr; align-items: center; gap: 8px; padding: 10px 4px 10px 10px; }
+    .a .body .home { text-align: right; }
+    .a .body .away { text-align: left; }
+    .a .venue { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .a .result { display:flex; align-items:center; justify-content:center; padding-right: 8px; }
+    .a .mcard.feat .venue { border-left-color: rgba(245,241,230,.3); }
+
+    /* ===== B — KCVV-centric (mobile) ===== */
+    .b .mcard { display: grid; grid-template-columns: 44px 1fr 28px 48px 38px; }
+    .b .opp { display:flex; flex-direction:column; justify-content:center; padding: 9px 4px 9px 10px; min-width:0; }
+    .b .opp .comp { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; letter-spacing:.05em; color: var(--color-ink-muted); margin-top: 2px; }
+    .b .venue { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .result { display:flex; align-items:center; justify-content:center; padding-right: 7px; }
+    .b .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 8 · Drill 6.C.d1</div>
+    <h1>A on desktop, B on mobile — one component, one breakpoint.</h1>
+    <p>Same fixtures, same data. At ≥ ~640px the row lays out as the symmetric
+       scoreboard (A); below that it collapses to the KCVV-centric column (B),
+       where two names + a centred score won't fit. Kickoff times are now in the
+       display font (no more mono/serif clash). Left = desktop frame, right/below
+       = a 360px phone frame.</p>
+  </div>
+
+  <!-- ===== DESKTOP (A) ===== -->
+  <div class="variant-band">Desktop &nbsp;·&nbsp; ≥ ~640px &nbsp;·&nbsp; <b>A symmetric scoreboard</b></div>
+  <div class="variant-note">Both names, real home/away order, KCVV bold, score centred. Upcoming shows kickoff time in the display font.</div>
+  <div class="frame desktop"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">April <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">5</div><div class="mo">APR</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">4–1</span><span class="tn away">Steenokkerzeel</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">12</div><div class="mo">APR</div></div><div class="body"><span class="tn away">KFC Eppegem</span><span class="score">2–1</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq v">V</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">2–0</span><span class="tn away">FC Perk</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><span class="tn away">Diegem</span><span class="score">0–2</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="score">3–1</span><span class="tn away">VK Liedekerke</span></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="tm">15:00</span><span class="tn away">KFC Eppegem</span></div><div class="venue"><span class="ven">T</span></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><span class="tn away">FC Perk</span><span class="tm">15:00</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="venue"><span class="ven">U</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><span class="tn kcvv">KCVV</span><span class="tm">20:00</span><span class="tn away">VK Tildonk</span></div><div class="venue"><span class="ven">T</span></div><div class="result"></div></div>
+  </div></div>
+
+  <!-- ===== MOBILE (B) ===== -->
+  <div class="variant-band">Mobile &nbsp;·&nbsp; &lt; ~640px &nbsp;·&nbsp; <b>B KCVV-centric</b></div>
+  <div class="variant-note">Opponent · T/U · our score first · result. KCVV dropped (you're on its page). Kickoff time in the display font.</div>
+  <div class="frame mobile"><div class="page b">
+    <div class="section-kicker"><span class="mono">A-ploeg</span><h3 class="ed ed-md">Kalender.</h3></div>
+
+    <div class="amonth">April <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">5</div><div class="mo">APR</div></div><div class="opp"><span class="tn">Steenokkerzeel</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="score">4–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">12</div><div class="mo">APR</div></div><div class="opp"><span class="tn">KFC Eppegem</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="score">1–2</span></div><div class="result"><span class="sq v">V</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">26</div><div class="mo">APR</div></div><div class="opp"><span class="tn">FC Perk</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="score">2–0</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">Diegem Sport</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="score">2–0</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">VK Liedekerke</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="score">3–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">KFC Eppegem</span><span class="comp" style="color:rgba(245,241,230,.75)">3e Prov. A</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="tm">15:00</span></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">FC Perk</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="tm">15:00</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">VK Tildonk</span><span class="comp">Beker · 1/2</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="tm">20:00</span></div><div class="result"></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:44px">
+    <div class="tag">Decide</div>
+    <p>If this lands — A desktop / B mobile, display-font times — I'll lock
+       6.C.d1 (the whole IA: single-scroll + sticky nav, month-grouped card
+       agenda, W/G/V squares, jersey featured next, auto-scroll, responsive A/B
+       rows) and write the lock + 6.C PRD.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-9-competition-and-time.html
+++ b/docs/design/mockups/phase-6-team/6cd1-detail-ia/round-9-competition-and-time.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 9 · Competition type + centred display-font time</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #006e47; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { position: sticky; top: 0; z-index: 50; background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame.desktop { max-width: 660px; margin: 18px auto 0; }
+    .frame.mobile { max-width: 360px; margin: 18px auto 0; }
+    .frame .page { padding: 22px 22px 28px; }
+    .frame.mobile .page { padding: 18px 16px 24px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .ed-md { font-size: 23px; }
+    .section-kicker { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; flex-wrap: wrap; }
+    .section-kicker .mono { color: var(--color-ink-muted); }
+    .amonth { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; line-height: 1; margin: 22px 0 12px; }
+    .amonth:first-of-type { margin-top: 12px; }
+    .amonth em { font-style: italic; color: var(--color-jersey-deep); }
+
+    /* card chrome */
+    .mcard { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); background: var(--color-cream); margin-bottom: 10px; transition: transform .25s, box-shadow .25s; }
+    .mcard:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .stub { background: var(--color-cream-soft); border-right: 2px dashed var(--color-ink); padding: 8px 4px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+    .stub .d { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; line-height: 1; }
+    .stub .mo { font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; margin-top: 2px; color: var(--color-ink-soft); }
+    .tn { font-family: var(--font-display); font-style: italic; font-size: 15px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tn.kcvv { font-weight: 700; font-style: normal; }
+    /* the single centre "score-or-time" slot */
+    .val { font-family: var(--font-display-big); font-weight: 900; font-size: 18px; text-align: center; white-space: nowrap; }
+    .val.time { font-family: var(--font-display); font-weight: 400; font-style: italic; font-size: 17px; }
+    .ven { font-family: var(--font-mono); font-size: 9px; font-weight: 700; text-transform: uppercase; color: var(--color-ink-muted); text-align: center; }
+    .sq { width: 26px; height: 26px; display: grid; place-items: center; font-family: var(--font-mono); font-size: 11px; font-weight: 700; border: 2px solid var(--color-ink); }
+    .sq.w { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .sq.d { background: var(--color-cream-deep); color: var(--color-ink); }
+    .sq.v { background: var(--color-warm); color: var(--color-ink); }
+
+    /* competition caption */
+    .comp { font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--color-ink-muted); display:flex; align-items:center; gap:6px; }
+    .ctag { font-family: var(--font-mono); font-size: 8px; font-weight: 700; letter-spacing: .08em; padding: 2px 5px; border: 1px solid var(--color-ink); }
+    .ctag.beker { background: var(--color-warm); color: var(--color-ink); }
+    .ctag.oefen { background: var(--color-cream-deep); color: var(--color-ink); }
+
+    /* featured */
+    .feat-label { display:inline-block; background: var(--color-warm); color: var(--color-ink); font-family: var(--font-mono); font-size: 8.5px; font-weight:700; text-transform: uppercase; letter-spacing: .12em; padding: 4px 7px; margin: 4px 0 7px; }
+    .mcard.feat { background: var(--color-jersey-deep); color: var(--color-cream); box-shadow: 6px 6px 0 0 var(--color-ink); }
+    .mcard.feat .stub { background: var(--color-jersey-deep-dark); border-right-color: rgba(245,241,230,.4); color: var(--color-cream); }
+    .mcard.feat .tn, .mcard.feat .val { color: var(--color-cream); }
+    .mcard.feat .ven { color: rgba(245,241,230,.85); }
+    .mcard.feat .comp { color: rgba(245,241,230,.8); }
+
+    /* ===== A — desktop symmetric ===== */
+    .a .mcard { display: grid; grid-template-columns: 46px 1fr 30px 40px; }
+    .a .body { display:flex; flex-direction:column; justify-content:center; gap: 4px; padding: 9px 4px 9px 10px; }
+    .a .fixline { display: grid; grid-template-columns: 1fr 54px 1fr; align-items: center; gap: 8px; }
+    .a .fixline .home { text-align: right; }
+    .a .fixline .away { text-align: left; }
+    .a .comp { justify-content: center; }
+    .a .venue { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .a .result { display:flex; align-items:center; justify-content:center; padding-right: 8px; }
+    .a .mcard.feat .venue { border-left-color: rgba(245,241,230,.3); }
+
+    /* ===== B — mobile KCVV-centric ===== */
+    .b .mcard { display: grid; grid-template-columns: 44px 1fr 26px 46px 36px; }
+    .b .opp { display:flex; flex-direction:column; justify-content:center; gap: 3px; padding: 9px 4px 9px 10px; min-width:0; }
+    .b .venue { display:flex; align-items:center; justify-content:center; }
+    .b .scorecol { display:flex; align-items:center; justify-content:center; border-left: 1px solid var(--color-paper-edge); }
+    .b .result { display:flex; align-items:center; justify-content:center; padding-right: 6px; }
+    .b .mcard.feat .scorecol { border-left-color: rgba(245,241,230,.3); }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 9 · Drill 6.C.d1</div>
+    <h1>Competition shown + the time fixed.</h1>
+    <p>Each card is now two lines: the fixture, then a competition caption.
+       League games show the division muted; <b>Beker</b> and <b>Oefen</b>
+       (and any non-league type) get a tag so they stand out. The centre slot
+       holds the score (played) or the kickoff time (upcoming) — always centred,
+       in the display font. Desktop = A, phone = B.</p>
+  </div>
+
+  <!-- ===== DESKTOP A ===== -->
+  <div class="variant-band">Desktop &nbsp;·&nbsp; <b>A symmetric</b> + competition caption</div>
+  <div class="variant-note">Centre column = score or kickoff time (centred, display font). Competition caption centred beneath; Beker/Oefen tagged.</div>
+  <div class="frame desktop"><div class="page a">
+    <div class="section-kicker"><span class="mono">KCVV Elewijt · A-ploeg</span><h3 class="ed ed-md">Volledige <em>kalender.</em></h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">10</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="tn away">Wemmel</span><span class="val">1–1</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq d">G</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="tn away">Diegem</span><span class="val">0–2</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">U</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="tn kcvv">KCVV</span><span class="val">3–1</span><span class="tn away">VK Liedekerke</span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="tn kcvv">KCVV</span><span class="val">2–2</span><span class="tn away">RC Mechelen</span></div><div class="comp"><span class="ctag oefen">Oefen</span> Oefenwedstrijd</div></div><div class="venue"><span class="ven">T</span></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="body"><div class="fixline"><span class="tn kcvv">KCVV</span><span class="val time">15:00</span><span class="tn away">KFC Eppegem</span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">T</span></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="tn away">FC Perk</span><span class="val time">15:00</span><span class="tn kcvv" style="text-align:left">KCVV</span></div><div class="comp">3e Provinciale A</div></div><div class="venue"><span class="ven">U</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="body"><div class="fixline"><span class="tn kcvv">KCVV</span><span class="val time">20:00</span><span class="tn away">VK Tildonk</span></div><div class="comp"><span class="ctag beker">Beker</span> Beker van Vlaams-Brabant · 1/2 finale</div></div><div class="venue"><span class="ven">T</span></div><div class="result"></div></div>
+  </div></div>
+
+  <!-- ===== MOBILE B ===== -->
+  <div class="variant-band">Mobile &nbsp;·&nbsp; <b>B KCVV-centric</b> + competition caption</div>
+  <div class="variant-note">Competition caption sits under the opponent. Score/time in the centred score column (display font). Beker/Oefen tagged.</div>
+  <div class="frame mobile"><div class="page b">
+    <div class="section-kicker"><span class="mono">A-ploeg</span><h3 class="ed ed-md">Kalender.</h3></div>
+
+    <div class="amonth">Mei <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">17</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">Diegem Sport</span><span class="comp">3e Prov. A</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="val">0–2</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">24</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">VK Liedekerke</span><span class="comp">3e Prov. A</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val">3–1</span></div><div class="result"><span class="sq w">W</span></div></div>
+    <div class="mcard"><div class="stub"><div class="d">28</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">RC Mechelen</span><span class="comp"><span class="ctag oefen">Oefen</span></span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val">2–2</span></div><div class="result"><span class="sq d">G</span></div></div>
+
+    <div class="feat-label">Eerstvolgende</div>
+    <div class="mcard feat"><div class="stub"><div class="d">31</div><div class="mo">MEI</div></div><div class="opp"><span class="tn">KFC Eppegem</span><span class="comp">3e Prov. A</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val time">15:00</span></div><div class="result"></div></div>
+
+    <div class="amonth">Juni <em>'26.</em></div>
+    <div class="mcard"><div class="stub"><div class="d">7</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">FC Perk</span><span class="comp">3e Prov. A</span></div><div class="venue"><span class="ven">U</span></div><div class="scorecol"><span class="val time">15:00</span></div><div class="result"></div></div>
+    <div class="mcard"><div class="stub"><div class="d">11</div><div class="mo">JUN</div></div><div class="opp"><span class="tn">VK Tildonk</span><span class="comp"><span class="ctag beker">Beker</span> 1/2 finale</span></div><div class="venue"><span class="ven">T</span></div><div class="scorecol"><span class="val time">20:00</span></div><div class="result"></div></div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:44px">
+    <div class="tag">Decide</div>
+    <p>Competition now reads on every row (Beker/Oefen tagged); the centre slot
+       carries score-or-time, centred, display font. If this lands, 6.C.d1
+       locks. Tell me if the comp caption should only show for non-league
+       (hide "3e Prov. A" on league rows to reduce repetition) — easy switch.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd2-teamhero/round-1-teamhero-comparisons.html
+++ b/docs/design/mockups/phase-6-team/6cd2-teamhero/round-1-teamhero-comparisons.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 1 · TeamHero identity (6.C.d2)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #133d28; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 32px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 760px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 30px 28px; }
+
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .pill { display: inline-block; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10.5px; font-weight: 600; line-height: 1; padding: 6px 9px; border: 1px solid var(--color-paper-edge); background: var(--color-cream-soft); color: var(--color-ink); }
+    .ed { font-family: var(--font-display); font-weight: 700; letter-spacing: -.01em; line-height: 1.05; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+
+    .hero { display: grid; grid-template-columns: 1fr; gap: 26px; align-items: start; }
+    @media (min-width: 640px) { .hero { grid-template-columns: 1fr 280px; } }
+    .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+    .lead { font-family: var(--font-display); font-style: italic; font-size: 17px; color: var(--color-ink-soft); margin-top: 16px; max-width: 42ch; line-height: 1.4; }
+
+    /* right artefact: taped squad polaroid + season stub */
+    .artefact { }
+    .polaroid { border: 2px solid var(--color-ink); background: var(--color-cream-soft); box-shadow: var(--shadow-paper-md); transform: rotate(-1.5deg); padding: 10px 10px 16px; position: relative; }
+    .polaroid .tape { position: absolute; top: -11px; left: 30%; width: 92px; height: 20px; background: var(--color-warm); opacity: .9; transform: rotate(-3deg); border: 1px solid rgba(0,0,0,.15); }
+    .polaroid .ph { aspect-ratio: 4/3; background: repeating-linear-gradient(135deg, #cdc6b2 0 11px, #c4bca6 11px 22px); display: grid; place-items: center; font-family: var(--font-mono); font-size: 10px; color: #7d7560; text-transform: uppercase; letter-spacing: .1em; }
+    .stub { margin-top: 12px; border: 2px dashed var(--color-ink); background: var(--color-cream); padding: 9px 11px; display: flex; justify-content: space-between; align-items: center; transform: rotate(.5deg); }
+    .stub .mono { color: var(--color-ink-muted); }
+    .stub b { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; }
+
+    /* C — category badge (parallels PlayerHero number disc) */
+    .badge { display: inline-grid; place-items: center; width: 92px; height: 92px; background: var(--color-jersey-deep); color: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); margin-bottom: 16px; }
+    .badge span { font-family: var(--font-display-big); font-weight: 900; font-size: 46px; line-height: 1; }
+    .badge.u span { font-size: 30px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 1 · Drill 6.C.d2 (TeamHero)</div>
+    <h1>What does the team hero lead with?</h1>
+    <p>Every team is "KCVV Elewijt", so the <b>category</b> (A-ploeg / U17) is the
+       distinguishing identity. Left = words, right = a taped squad polaroid +
+       season stub (JerseyShirt illustration when no <code>teamImage</code>).
+       Three ways to frame the identity; data is what the team doc + ranking
+       actually provide.</p>
+  </div>
+
+  <!-- A -->
+  <div class="variant-band">A &nbsp;·&nbsp; <b>Category-forward</b></div>
+  <div class="variant-note">The category is the big headline; "KCVV Elewijt" is the kicker. Instantly says which team you're on. Scales to youth ("U17.").</div>
+  <div class="frame"><div class="page">
+    <div class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">KCVV Elewijt</span>
+        <h2 class="ed" style="font-family:var(--font-display-big);font-weight:900;font-size:60px;margin-top:8px">A-ploeg<em>.</em></h2>
+        <div class="meta-row">
+          <span class="pill">3e Provinciale A</span>
+          <span class="pill">Trainer · Koen Verbruggen</span>
+          <span class="pill">Seizoen 25/26</span>
+        </div>
+        <p class="lead">Een hechte groep met een gezonde mix van jeugd en ervaring, thuis op het Sportpark Driesstraat.</p>
+      </div>
+      <div class="artefact">
+        <div class="polaroid"><div class="tape"></div><div class="ph">TEAMIMAGE · SQUAD PHOTO</div></div>
+        <div class="stub"><span class="mono">Seizoen</span><b>25/26</b></div>
+      </div>
+    </div>
+  </div></div>
+
+  <!-- B -->
+  <div class="variant-band">B &nbsp;·&nbsp; <b>Club-forward</b> (split name)</div>
+  <div class="variant-note">Club name is the headline (KCVV black + Elewijt italic, the 6.A split rhythm); the category rides in the kicker. More brand-forward; the category is smaller.</div>
+  <div class="frame"><div class="page">
+    <div class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">A-ploeg · 3e Provinciale A</span>
+        <h2 class="ed" style="margin-top:8px">
+          <span style="font-family:var(--font-display-big);font-weight:900;font-size:52px;display:block">KCVV</span>
+          <span style="font-style:italic;font-size:44px;display:block">Elewijt.</span>
+        </h2>
+        <div class="meta-row">
+          <span class="pill">Trainer · Koen Verbruggen</span>
+          <span class="pill">Seizoen 25/26</span>
+        </div>
+        <p class="lead">Een hechte groep met een gezonde mix van jeugd en ervaring.</p>
+      </div>
+      <div class="artefact">
+        <div class="polaroid"><div class="tape"></div><div class="ph">TEAMIMAGE · SQUAD PHOTO</div></div>
+        <div class="stub"><span class="mono">Seizoen</span><b>25/26</b></div>
+      </div>
+    </div>
+  </div></div>
+
+  <!-- C -->
+  <div class="variant-band">C &nbsp;·&nbsp; <b>Category badge</b> (parallels the player number disc)</div>
+  <div class="variant-note">A jersey-deep category badge anchors the hero — the team-page echo of PlayerHero's number disc — with the club name beside it. Strong system rhyme; the badge holds "A" or "U17".</div>
+  <div class="frame"><div class="page">
+    <div class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">KCVV Elewijt · 3e Provinciale A</span>
+        <div class="badge"><span>A</span></div>
+        <h2 class="ed" style="font-size:40px">A-ploeg<em>.</em></h2>
+        <div class="meta-row">
+          <span class="pill">Trainer · Koen Verbruggen</span>
+          <span class="pill">Seizoen 25/26</span>
+        </div>
+      </div>
+      <div class="artefact">
+        <div class="polaroid"><div class="tape"></div><div class="ph">TEAMIMAGE · SQUAD PHOTO</div></div>
+        <div class="stub"><span class="mono">Seizoen</span><b>25/26</b></div>
+      </div>
+    </div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>Pick A / B / C for the hero identity. Then later d2 rounds settle the
+       artefact (photo treatment + JerseyShirt fallback + stub), the meta-row
+       field set, and the tagline/lead. Cross-age: the youth version swaps the
+       category ("U13.") and drops division/coach/photo when absent.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd2-teamhero/round-2-teamhero-states.html
+++ b/docs/design/mockups/phase-6-team/6cd2-teamhero/round-2-teamhero-states.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 2 · TeamHero A — artefact + states (6.C.d2)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #133d28; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 46px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 760px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 30px 28px; }
+
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; }
+    .pill { display: inline-block; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 10.5px; font-weight: 600; line-height: 1; padding: 6px 9px; border: 1px solid var(--color-paper-edge); background: var(--color-cream-soft); color: var(--color-ink); }
+    .ed { font-family: var(--font-display-big); font-weight: 900; letter-spacing: -.01em; line-height: 1.02; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); font-weight: 900; }
+
+    .hero { display: grid; grid-template-columns: 1fr; gap: 26px; align-items: start; }
+    @media (min-width: 640px) { .hero { grid-template-columns: 1fr 280px; } }
+    .meta-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+    .lead { font-family: var(--font-display); font-style: italic; font-size: 17px; color: var(--color-ink-soft); margin-top: 16px; max-width: 42ch; line-height: 1.4; }
+
+    .polaroid { border: 2px solid var(--color-ink); background: var(--color-cream-soft); box-shadow: var(--shadow-paper-md); transform: rotate(-1.5deg); padding: 10px 10px 16px; position: relative; }
+    .polaroid .tape { position: absolute; top: -11px; left: 30%; width: 92px; height: 20px; background: var(--color-warm); opacity: .9; transform: rotate(-3deg); border: 1px solid rgba(0,0,0,.15); }
+    .ph { aspect-ratio: 4/3; display: grid; place-items: center; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .1em; position: relative; overflow: hidden; }
+    /* newsprint photo treatment (consistent with the player photo system R9) */
+    .ph.photo { background: repeating-linear-gradient(135deg, #b9b09a 0 11px, #ada590 11px 22px); color: #5f5847; filter: grayscale(1) contrast(1.06); }
+    .ph.photo::after { content:""; position:absolute; inset:0; background-image: radial-gradient(rgba(0,0,0,.18) 0.5px, transparent 0.5px); background-size: 3px 3px; mix-blend-mode: multiply; opacity:.5; }
+    /* JerseyShirt illustration fallback (jersey-deep underprint + ink overprint, stripes) */
+    .ph.jersey { background: var(--color-cream); }
+    .stub { margin-top: 12px; border: 2px dashed var(--color-ink); background: var(--color-cream); padding: 9px 11px; display: flex; justify-content: space-between; align-items: center; transform: rotate(.5deg); }
+    .stub .mono { color: var(--color-ink-muted); }
+    .stub b { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 2 · Drill 6.C.d2 (TeamHero A)</div>
+    <h1>TeamHero A, assembled — photo, fallback, youth.</h1>
+    <p>Identity locked as category-forward (A). Here's the full hero in its real
+       states: squad photo (newsprint-treated like player photos), the no-photo
+       <b>JerseyShirt</b> fallback, and a youth team where division + coach are
+       absent. Meta = division · trainer · season, each auto-hiding when missing.
+       Tagline (team.tagline) renders as an italic lead, auto-hides when empty.</p>
+  </div>
+
+  <!-- senior + photo -->
+  <div class="variant-band">State 1 &nbsp;·&nbsp; <b>A-ploeg, with squad photo</b></div>
+  <div class="frame"><div class="page">
+    <div class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">KCVV Elewijt</span>
+        <h2 class="ed" style="font-size:60px;margin-top:8px">A-ploeg<em>.</em></h2>
+        <div class="meta-row">
+          <span class="pill">3e Provinciale A</span>
+          <span class="pill">Trainer · Koen Verbruggen</span>
+          <span class="pill">Seizoen 25/26</span>
+        </div>
+        <p class="lead">Een hechte groep met een gezonde mix van jeugd en ervaring, thuis op het Sportpark Driesstraat.</p>
+      </div>
+      <div>
+        <div class="polaroid"><div class="tape"></div><div class="ph photo">TEAMIMAGE · NEWSPRINT</div></div>
+        <div class="stub"><span class="mono">Seizoen</span><b>25/26</b></div>
+      </div>
+    </div>
+  </div></div>
+
+  <!-- senior, no photo -> JerseyShirt fallback -->
+  <div class="variant-band">State 2 &nbsp;·&nbsp; <b>No teamImage → JerseyShirt fallback</b></div>
+  <div class="variant-note">When the team has no squad photo, the polaroid holds the canonical jersey illustration instead (jersey-deep underprint + ink stripes) — same frame + stub.</div>
+  <div class="frame"><div class="page">
+    <div class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">KCVV Elewijt</span>
+        <h2 class="ed" style="font-size:60px;margin-top:8px">B-ploeg<em>.</em></h2>
+        <div class="meta-row">
+          <span class="pill">4e Provinciale C</span>
+          <span class="pill">Trainer · Dirk Aerts</span>
+          <span class="pill">Seizoen 25/26</span>
+        </div>
+      </div>
+      <div>
+        <div class="polaroid"><div class="tape"></div><div class="ph jersey">
+          <svg viewBox="0 0 120 110" width="80%" style="display:block">
+            <g fill="none" stroke="var(--color-ink)" stroke-width="2.5" stroke-linejoin="round">
+              <path d="M40 22 L20 34 L30 52 L40 46 L40 92 L80 92 L80 46 L90 52 L100 34 L80 22 L70 30 Q60 38 50 30 Z" fill="var(--color-jersey-deep)"/>
+              <path d="M52 24 Q60 34 68 24" />
+              <line x1="52" y1="46" x2="52" y2="92" stroke="var(--color-ink)" stroke-width="2" opacity=".5"/>
+              <line x1="68" y1="46" x2="68" y2="92" stroke="var(--color-ink)" stroke-width="2" opacity=".5"/>
+            </g>
+          </svg>
+        </div></div>
+        <div class="stub"><span class="mono">Seizoen</span><b>25/26</b></div>
+      </div>
+    </div>
+  </div></div>
+
+  <!-- youth, degraded -->
+  <div class="variant-band">State 3 &nbsp;·&nbsp; <b>Youth (U13) — division + coach absent</b></div>
+  <div class="variant-note">Cross-age degrade: category swaps to "U13."; no PSD division/standings; the meta row shows only what exists (here: jeugd category + season). Photo or fallback as available.</div>
+  <div class="frame"><div class="page">
+    <div class="hero">
+      <div>
+        <span class="mono" style="color:var(--color-ink-muted)">KCVV Elewijt · Jeugd</span>
+        <h2 class="ed" style="font-size:60px;margin-top:8px">U13<em>.</em></h2>
+        <div class="meta-row">
+          <span class="pill">Middenbouw</span>
+          <span class="pill">Seizoen 25/26</span>
+        </div>
+      </div>
+      <div>
+        <div class="polaroid"><div class="tape"></div><div class="ph photo">TEAMIMAGE · NEWSPRINT</div></div>
+        <div class="stub"><span class="mono">Seizoen</span><b>25/26</b></div>
+      </div>
+    </div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:48px">
+    <div class="tag">Decide</div>
+    <p>Lock TeamHero, or tweak: the artefact (photo treatment / rotation / stub),
+       the meta-row fields + order, the tagline lead, or the youth degrade. Next
+       6.C drill after this = StandingsTable.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd2-teamhero/round-2-teamhero-states.html
+++ b/docs/design/mockups/phase-6-team/6cd2-teamhero/round-2-teamhero-states.html
@@ -71,7 +71,6 @@
         <h2 class="ed" style="font-size:60px;margin-top:8px">A-ploeg<em>.</em></h2>
         <div class="meta-row">
           <span class="pill">3e Provinciale A</span>
-          <span class="pill">Trainer · Koen Verbruggen</span>
           <span class="pill">Seizoen 25/26</span>
         </div>
         <p class="lead">Een hechte groep met een gezonde mix van jeugd en ervaring, thuis op het Sportpark Driesstraat.</p>
@@ -93,7 +92,6 @@
         <h2 class="ed" style="font-size:60px;margin-top:8px">B-ploeg<em>.</em></h2>
         <div class="meta-row">
           <span class="pill">4e Provinciale C</span>
-          <span class="pill">Trainer · Dirk Aerts</span>
           <span class="pill">Seizoen 25/26</span>
         </div>
       </div>

--- a/docs/design/mockups/phase-6-team/6cd3-standings/round-1-standings.html
+++ b/docs/design/mockups/phase-6-team/6cd3-standings/round-1-standings.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 1 · StandingsTable (6.C.d3)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264; --color-alert: #b84a3a;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --tint-kcvv: color-mix(in srgb, var(--color-jersey-deep) 12%, var(--color-cream));
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 660px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 22px 28px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; font-size: 24px; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .section-kicker { display:flex; align-items:baseline; gap:10px; margin-bottom: 14px; }
+
+    table.st { width: 100%; border-collapse: collapse; }
+    table.st th { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .05em; font-size: 9.5px; color: var(--color-ink-muted); padding: 8px 5px; border-bottom: 2px solid var(--color-ink); text-align: center; }
+    table.st th.l, table.st td.l { text-align: left; }
+    table.st td { padding: 9px 5px; text-align: center; border-bottom: 1px solid var(--color-paper-edge); font-size: 13px; }
+    table.st td.pos { font-family: var(--font-mono); color: var(--color-ink-muted); width: 26px; }
+    table.st td.team { font-family: var(--font-display); font-style: italic; font-size: 15px; }
+    table.st td.pts { font-family: var(--font-display-big); font-weight: 900; }
+    table.st .crest { width: 19px; height: 19px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: inline-grid; place-items: center; font-family: var(--font-display-big); font-size: 8px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); vertical-align: middle; margin-right: 7px; }
+    table.st tr.me td { background: var(--tint-kcvv); }
+    table.st tr.me td.pos { box-shadow: inset 3px 0 0 0 var(--color-jersey-deep); }
+    table.st tr.me td.team { font-style: normal; font-weight: 700; }
+
+    /* form indicators (using the locked outcome language: win jersey-deep / draw neutral / loss brick) */
+    .form { display: inline-flex; gap: 3px; align-items:center; justify-content:center; }
+    /* A — dots */
+    .fdot { width: 9px; height: 9px; border-radius: 50%; border: 1.5px solid var(--color-ink); }
+    .fdot.w { background: var(--color-jersey-deep); border-color: var(--color-jersey-deep); }
+    .fdot.d { background: transparent; border-color: var(--color-ink-muted); }
+    .fdot.v { background: var(--color-alert); border-color: var(--color-alert); }
+    /* B — letters */
+    .fl { font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
+    .fl.w { color: var(--color-jersey-deep); }
+    .fl.d { color: var(--color-ink-muted); }
+    .fl.v { color: var(--color-alert); }
+    /* C — bars */
+    .fbar { width: 5px; height: 14px; }
+    .fbar.w { background: var(--color-jersey-deep); }
+    .fbar.d { background: var(--color-cream-deep); border: 1px solid var(--color-ink-muted); }
+    .fbar.v { background: var(--color-alert); }
+
+    .compare { max-width: 660px; margin: 16px auto 0; background: var(--color-cream); border: 2px dashed var(--color-ink-muted); padding: 16px 20px; }
+    .compare .row { display:flex; align-items:center; gap: 16px; padding: 6px 0; }
+    .compare .lbl { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing:.08em; color: var(--color-ink-muted); width: 90px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 1 · Drill 6.C.d3 (StandingsTable)</div>
+    <h1>Standings — retro table, this team highlighted.</h1>
+    <p>Classic table in the paper vocabulary: mono headers, hairline rows, KCVV's
+       row tinted jersey-deep with a left accent + bold. Data = the BFF
+       `RankingEntry`. The open visual choice is the <b>Vorm</b> (form) indicator,
+       which must use the locked outcome language (win jersey-deep / draw neutral
+       / loss brick — no green-yellow-red badges from the legacy table). Three
+       form treatments compared below the table.</p>
+  </div>
+
+  <div class="variant-band">StandingsTable &nbsp;·&nbsp; full division, KCVV highlighted</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">Stand</span><h3 class="ed">Het <em>klassement.</em></h3></div>
+    <table class="st">
+      <thead><tr><th>#</th><th class="l">Ploeg</th><th>M</th><th>W</th><th>G</th><th>V</th><th>+/-</th><th>Ptn</th><th>Vorm</th></tr></thead>
+      <tbody>
+        <tr><td class="pos">1</td><td class="l team"><span class="crest">E</span>KFC Eppegem</td><td>24</td><td>17</td><td>4</td><td>3</td><td>+31</td><td class="pts">55</td><td><span class="form"><span class="fdot w"></span><span class="fdot w"></span><span class="fdot w"></span><span class="fdot d"></span><span class="fdot w"></span></span></td></tr>
+        <tr><td class="pos">2</td><td class="l team"><span class="crest">L</span>SK Londerzeel B</td><td>24</td><td>15</td><td>5</td><td>4</td><td>+22</td><td class="pts">50</td><td><span class="form"><span class="fdot w"></span><span class="fdot v"></span><span class="fdot w"></span><span class="fdot w"></span><span class="fdot d"></span></span></td></tr>
+        <tr><td class="pos">3</td><td class="l team"><span class="crest">P</span>FC Perk</td><td>24</td><td>14</td><td>4</td><td>6</td><td>+15</td><td class="pts">46</td><td><span class="form"><span class="fdot d"></span><span class="fdot w"></span><span class="fdot v"></span><span class="fdot w"></span><span class="fdot w"></span></span></td></tr>
+        <tr class="me"><td class="pos">4</td><td class="l team"><span class="crest">K</span>KCVV Elewijt</td><td>24</td><td>13</td><td>5</td><td>6</td><td>+12</td><td class="pts">44</td><td><span class="form"><span class="fdot w"></span><span class="fdot w"></span><span class="fdot d"></span><span class="fdot v"></span><span class="fdot w"></span></span></td></tr>
+        <tr><td class="pos">5</td><td class="l team"><span class="crest">M</span>Eendracht Mazenzele</td><td>24</td><td>11</td><td>6</td><td>7</td><td>+4</td><td class="pts">39</td><td><span class="form"><span class="fdot v"></span><span class="fdot d"></span><span class="fdot w"></span><span class="fdot d"></span><span class="fdot w"></span></span></td></tr>
+        <tr><td class="pos">6</td><td class="l team"><span class="crest">W</span>KVK Wemmel</td><td>24</td><td>9</td><td>7</td><td>8</td><td>-2</td><td class="pts">34</td><td><span class="form"><span class="fdot d"></span><span class="fdot v"></span><span class="fdot d"></span><span class="fdot w"></span><span class="fdot v"></span></span></td></tr>
+        <tr><td class="pos">7</td><td class="l team"><span class="crest">L</span>VK Liedekerke</td><td>24</td><td>7</td><td>5</td><td>12</td><td>-14</td><td class="pts">26</td><td><span class="form"><span class="fdot v"></span><span class="fdot v"></span><span class="fdot d"></span><span class="fdot v"></span><span class="fdot w"></span></span></td></tr>
+        <tr><td class="pos">8</td><td class="l team"><span class="crest">D</span>Diegem Sport</td><td>24</td><td>4</td><td>4</td><td>16</td><td>-28</td><td class="pts">16</td><td><span class="form"><span class="fdot v"></span><span class="fdot v"></span><span class="fdot v"></span><span class="fdot d"></span><span class="fdot v"></span></span></td></tr>
+      </tbody>
+    </table>
+    <p class="mono" style="margin-top:12px">Mobiel: W · G · V kolommen vallen weg → #, Ploeg, M, +/-, Ptn, Vorm.</p>
+  </div></div>
+
+  <div class="compare">
+    <div class="mono" style="margin-bottom:10px;color:var(--color-ink-soft)">Vorm — drie opties (laatste 5: W W G V W)</div>
+    <div class="row"><span class="lbl">A · dots</span><span class="form"><span class="fdot w"></span><span class="fdot w"></span><span class="fdot d"></span><span class="fdot v"></span><span class="fdot w"></span></span></div>
+    <div class="row"><span class="lbl">B · letters</span><span class="form" style="gap:5px"><span class="fl w">W</span><span class="fl w">W</span><span class="fl d">G</span><span class="fl v">V</span><span class="fl w">W</span></span></div>
+    <div class="row"><span class="lbl">C · bars</span><span class="form"><span class="fbar w"></span><span class="fbar w"></span><span class="fbar d"></span><span class="fbar v"></span><span class="fbar w"></span></span></div>
+  </div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>Table treatment OK (classic retro, KCVV highlighted)? Pick the Vorm
+       indicator (A dots / B letters / C bars). Also: full division inline, or a
+       window around KCVV + "volledige stand →"? Next 6.C drill = SquadGrid /
+       PlayerCard.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd3-standings/round-2-no-form.html
+++ b/docs/design/mockups/phase-6-team/6cd3-standings/round-2-no-form.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 2 · StandingsTable — Vorm dropped (6.C.d3)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --tint-kcvv: color-mix(in srgb, var(--color-jersey-deep) 12%, var(--color-cream));
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 560px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 22px 28px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; font-size: 24px; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .section-kicker { display:flex; align-items:baseline; gap:10px; margin-bottom: 14px; }
+
+    table.st { width: 100%; border-collapse: collapse; }
+    table.st th { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .05em; font-size: 9.5px; color: var(--color-ink-muted); padding: 8px 6px; border-bottom: 2px solid var(--color-ink); text-align: center; }
+    table.st th.l, table.st td.l { text-align: left; }
+    table.st td { padding: 10px 6px; text-align: center; border-bottom: 1px solid var(--color-paper-edge); font-size: 13px; }
+    table.st td.pos { font-family: var(--font-mono); color: var(--color-ink-muted); width: 26px; }
+    table.st td.team { font-family: var(--font-display); font-style: italic; font-size: 15px; }
+    table.st td.pts { font-family: var(--font-display-big); font-weight: 900; }
+    table.st .crest { width: 19px; height: 19px; border: 1.5px solid var(--color-ink-muted); border-radius: 50%; display: inline-grid; place-items: center; font-family: var(--font-display-big); font-size: 8px; font-weight: 900; color: var(--color-ink-muted); background: var(--color-cream-soft); vertical-align: middle; margin-right: 7px; }
+    table.st tr.me td { background: var(--tint-kcvv); }
+    table.st tr.me td.pos { box-shadow: inset 3px 0 0 0 var(--color-jersey-deep); }
+    table.st tr.me td.team { font-style: normal; font-weight: 700; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 2 · Drill 6.C.d3 (StandingsTable)</div>
+    <h1>Standings — Vorm column dropped.</h1>
+    <p>`RankingEntry.form` isn't reliably available for the other teams in the
+       division, so the Vorm column is gone (a half-empty column reads worse than
+       none). Clean classic table: mono headers, hairline rows, KCVV's row tinted
+       jersey-deep with a left accent + bold name.</p>
+  </div>
+
+  <div class="variant-band">StandingsTable &nbsp;·&nbsp; no Vorm</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">Stand</span><h3 class="ed">Het <em>klassement.</em></h3></div>
+    <table class="st">
+      <thead><tr><th>#</th><th class="l">Ploeg</th><th>M</th><th>W</th><th>G</th><th>V</th><th>+/-</th><th>Ptn</th></tr></thead>
+      <tbody>
+        <tr><td class="pos">1</td><td class="l team"><span class="crest">E</span>KFC Eppegem</td><td>24</td><td>17</td><td>4</td><td>3</td><td>+31</td><td class="pts">55</td></tr>
+        <tr><td class="pos">2</td><td class="l team"><span class="crest">L</span>SK Londerzeel B</td><td>24</td><td>15</td><td>5</td><td>4</td><td>+22</td><td class="pts">50</td></tr>
+        <tr><td class="pos">3</td><td class="l team"><span class="crest">P</span>FC Perk</td><td>24</td><td>14</td><td>4</td><td>6</td><td>+15</td><td class="pts">46</td></tr>
+        <tr class="me"><td class="pos">4</td><td class="l team"><span class="crest">K</span>KCVV Elewijt</td><td>24</td><td>13</td><td>5</td><td>6</td><td>+12</td><td class="pts">44</td></tr>
+        <tr><td class="pos">5</td><td class="l team"><span class="crest">M</span>Eendracht Mazenzele</td><td>24</td><td>11</td><td>6</td><td>7</td><td>+4</td><td class="pts">39</td></tr>
+        <tr><td class="pos">6</td><td class="l team"><span class="crest">W</span>KVK Wemmel</td><td>24</td><td>9</td><td>7</td><td>8</td><td>-2</td><td class="pts">34</td></tr>
+        <tr><td class="pos">7</td><td class="l team"><span class="crest">L</span>VK Liedekerke</td><td>24</td><td>7</td><td>5</td><td>12</td><td>-14</td><td class="pts">26</td></tr>
+        <tr><td class="pos">8</td><td class="l team"><span class="crest">D</span>Diegem Sport</td><td>24</td><td>4</td><td>4</td><td>16</td><td>-28</td><td class="pts">16</td></tr>
+      </tbody>
+    </table>
+    <p class="mono" style="margin-top:12px">Mobiel: W · G · V kolommen vallen weg → #, Ploeg, M, +/-, Ptn.</p>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>Lock the standings, or tweak (KCVV highlight, columns, crests, density)?
+       Also: full division inline (shown), or a window around KCVV + "volledige
+       stand →"? Next 6.C drill = SquadGrid / PlayerCard.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd4-squadgrid/round-1-playercard.html
+++ b/docs/design/mockups/phase-6-team/6cd4-squadgrid/round-1-playercard.html
@@ -67,7 +67,7 @@
     <div class="tag">Phase 6.C · Team detail · Round 1 · Drill 6.C.d4 (SquadGrid / PlayerCard)</div>
     <h1>The squad grid + the player card.</h1>
     <p>Grouped by position (Doelmannen / Verdedigers / Middenvelders /
-       Aanvallers). Each card composes the locked `<PlayerFigure>` (newsprint
+       Aanvallers). Each card composes the locked <code>&lt;PlayerFigure&gt;</code> (newsprint
        photo, illustration fallback when no <code>psdImage</code>) + name +
        jersey number + position, linking to <code>/spelers/[slug]</code>. The
        open choice is the <b>number treatment</b> — compared at the bottom. Grid

--- a/docs/design/mockups/phase-6-team/6cd4-squadgrid/round-1-playercard.html
+++ b/docs/design/mockups/phase-6-team/6cd4-squadgrid/round-1-playercard.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 1 · SquadGrid / PlayerCard (6.C.d4)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #133d28; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 720px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 22px 28px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+
+    .pos-head { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .1em; font-size: 11px; color: var(--color-ink-muted); margin: 20px 0 12px; border-bottom: 1px solid var(--color-paper-edge); padding-bottom: 6px; }
+    .pos-head:first-of-type { margin-top: 4px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 16px; }
+
+    /* base card */
+    .pc { border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 8px 8px 12px; transition: transform .25s, box-shadow .25s; }
+    .pc:hover { box-shadow: none; transform: translate(3px,3px); cursor: pointer; }
+    .photo { aspect-ratio: 3/4; position: relative; overflow: hidden; border: 1px solid var(--color-paper-edge); }
+    .photo.has { background: repeating-linear-gradient(135deg, #b9b09a 0 10px, #ada590 10px 20px); filter: grayscale(1) contrast(1.05); }
+    .photo .pl { position:absolute; inset:0; display:grid; place-items:center; font-family: var(--font-mono); font-size:8px; color:#5f5847; text-transform:uppercase; }
+    .photo.illu { background: var(--color-cream-soft); display:grid; place-items:center; }
+    .photo.illu .fig { font-size: 52px; color: var(--color-jersey-deep); opacity:.5; }
+    .name { font-family: var(--font-display); line-height: 1.05; margin-top: 8px; }
+    .name b { font-weight: 700; } .name em { font-style: italic; font-weight: 300; }
+    .pos { font-family: var(--font-mono); text-transform: uppercase; letter-spacing:.06em; font-size: 9px; color: var(--color-ink-muted); margin-top: 4px; }
+    .numdisc { width: 26px; height: 26px; background: var(--color-jersey-deep); color: var(--color-cream); display:grid; place-items:center; font-family: var(--font-display-big); font-weight:900; font-size:14px; border: 1.5px solid var(--color-ink); }
+
+    /* A — number disc overlaid on photo */
+    .a .numdisc { position:absolute; top:6px; left:6px; }
+
+    /* B — number inline before name */
+    .b .name-row { display:flex; align-items:baseline; gap:7px; margin-top:8px; }
+    .b .num-inline { font-family: var(--font-display-big); font-weight:900; font-size:18px; color: var(--color-jersey-deep); }
+
+    /* C — number big beside name row at bottom */
+    .c .foot { display:flex; align-items:center; gap:10px; margin-top:8px; }
+    .c .numbig { font-family: var(--font-display-big); font-weight:900; font-size:30px; color: var(--color-jersey-deep); line-height:1; }
+
+    .single { max-width: 720px; margin: 16px auto 0; background: var(--color-cream); border: 2px dashed var(--color-ink-muted); padding: 18px; display:flex; gap: 22px; flex-wrap:wrap; }
+    .single .col { width: 150px; }
+    .single .lbl { font-family: var(--font-mono); font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:var(--color-ink-muted); margin-bottom:8px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 1 · Drill 6.C.d4 (SquadGrid / PlayerCard)</div>
+    <h1>The squad grid + the player card.</h1>
+    <p>Grouped by position (Doelmannen / Verdedigers / Middenvelders /
+       Aanvallers). Each card composes the locked `<PlayerFigure>` (newsprint
+       photo, illustration fallback when no <code>psdImage</code>) + name +
+       jersey number + position, linking to <code>/spelers/[slug]</code>. The
+       open choice is the <b>number treatment</b> — compared at the bottom. Grid
+       below uses A.</p>
+  </div>
+
+  <div class="variant-band">SquadGrid &nbsp;·&nbsp; position-grouped (card style A)</div>
+  <div class="frame"><div class="page">
+    <div class="pos-head">Doelmannen</div>
+    <div class="grid a">
+      <div class="pc"><div class="photo has"><span class="numdisc">1</span><span class="pl">psdImage</span></div><div class="name"><b>Jonas</b> <em>Vermeer</em></div><div class="pos">Keeper</div></div>
+      <div class="pc"><div class="photo illu"><span class="numdisc">16</span><span class="fig">&#9917;</span></div><div class="name"><b>Lars</b> <em>De Smet</em></div><div class="pos">Keeper</div></div>
+    </div>
+    <div class="pos-head">Verdedigers</div>
+    <div class="grid a">
+      <div class="pc"><div class="photo has"><span class="numdisc">2</span><span class="pl">psdImage</span></div><div class="name"><b>Bram</b> <em>Wouters</em></div><div class="pos">Verdediger</div></div>
+      <div class="pc"><div class="photo has"><span class="numdisc">3</span><span class="pl">psdImage</span></div><div class="name"><b>Senne</b> <em>Maes</em></div><div class="pos">Verdediger</div></div>
+      <div class="pc"><div class="photo illu"><span class="numdisc">4</span><span class="fig">&#9917;</span></div><div class="name"><b>Thibault</b> <em>Claes</em></div><div class="pos">Verdediger</div></div>
+      <div class="pc"><div class="photo has"><span class="numdisc">5</span><span class="pl">psdImage</span></div><div class="name"><b>Jens</b> <em>Peeters</em></div><div class="pos">Verdediger</div></div>
+    </div>
+    <div class="pos-head">Aanvallers</div>
+    <div class="grid a">
+      <div class="pc"><div class="photo has"><span class="numdisc">7</span><span class="pl">psdImage</span></div><div class="name"><b>Maxim</b> <em>Breugelmans</em></div><div class="pos">Aanvaller</div></div>
+      <div class="pc"><div class="photo has"><span class="numdisc">9</span><span class="pl">psdImage</span></div><div class="name"><b>Lukas</b> <em>Dewil</em></div><div class="pos">Aanvaller</div></div>
+      <div class="pc"><div class="photo has"><span class="numdisc">11</span><span class="pl">psdImage</span></div><div class="name"><b>Stan</b> <em>Coppens</em></div><div class="pos">Aanvaller</div></div>
+    </div>
+  </div></div>
+
+  <div class="single">
+    <div class="col a"><div class="lbl">A · disc on photo</div><div class="pc"><div class="photo has"><span class="numdisc">7</span><span class="pl">psdImage</span></div><div class="name"><b>Maxim</b> <em>Breugelmans</em></div><div class="pos">Aanvaller</div></div></div>
+    <div class="col b"><div class="lbl">B · number before name</div><div class="pc"><div class="photo has"><span class="pl">psdImage</span></div><div class="name-row"><span class="num-inline">7</span><span class="name"><b>Maxim</b> <em>Breugelmans</em></span></div><div class="pos">Aanvaller</div></div></div>
+    <div class="col c"><div class="lbl">C · number big at foot</div><div class="pc"><div class="photo has"><span class="pl">psdImage</span></div><div class="foot"><span class="numbig">7</span><div><div class="name"><b>Maxim</b> <em>Breugelmans</em></div><div class="pos">Aanvaller</div></div></div></div></div>
+  </div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>Grid grouping OK (by position)? Pick the number treatment (A disc-on-photo
+       / B inline / C big-at-foot). Keeper, captain glyph, and youth privacy
+       (minors reuse PlayerFigure's locked treatment) are follow-ups. Next 6.C
+       drill = Staff cards.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd5-staff/round-1-staff.html
+++ b/docs/design/mockups/phase-6-team/6cd5-staff/round-1-staff.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 1 · Staff (6.C.d5)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 660px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 24px 22px 28px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .ed { font-family: var(--font-display); font-weight: 700; line-height: 1.1; margin: 0; font-size: 24px; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .section-kicker { display:flex; align-items:baseline; gap:10px; margin-bottom: 14px; }
+
+    .func { font-family: var(--font-mono); text-transform: uppercase; letter-spacing:.06em; font-size: 9px; color: var(--color-ink-muted); margin-top: 4px; }
+    .nm { font-family: var(--font-display); line-height: 1.1; }
+    .nm b { font-weight: 700; } .nm em { font-style: italic; font-weight: 300; }
+    .avatar { background: var(--color-cream-soft); border: 1.5px solid var(--color-ink); display:grid; place-items:center; font-family: var(--font-display-big); font-weight:900; color: var(--color-jersey-deep); }
+    .avatar.photo { background: repeating-linear-gradient(135deg, #b9b09a 0 9px, #ada590 9px 18px); filter: grayscale(1) contrast(1.05); color: transparent; }
+
+    /* A — compact cards */
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 14px; }
+    .scard { border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 10px; text-align:center; }
+    .scard .avatar { width: 64px; height: 64px; border-radius: 50%; margin: 0 auto 10px; font-size: 20px; }
+
+    /* B — list rows */
+    .list { display:flex; flex-direction:column; gap: 8px; }
+    .srow { display:flex; align-items:center; gap: 12px; border: 2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 10px 14px; }
+    .srow .avatar { width: 44px; height: 44px; border-radius: 50%; font-size: 15px; flex:none; }
+    .srow .func { margin-top: 2px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team detail · Round 1 · Drill 6.C.d5 (Staff)</div>
+    <h1>The staff section.</h1>
+    <p>A small support group: head/assistant/keeper trainer + afgevaardigde.
+       Photo (monogram fallback when absent) + name + function. The function
+       shows the readable PSD title (Hoofdtrainer / Keeperstrainer / …); codes
+       like "T1"/"T2"/"TK" map to readable labels, falling back to the role
+       bucket (Trainer / Afgevaardigde) when functionTitle is empty. Two
+       treatments — pick one.</p>
+  </div>
+
+  <!-- A -->
+  <div class="variant-band">A &nbsp;·&nbsp; <b>Compact cards</b></div>
+  <div class="variant-note">Mirrors the PlayerCard rhythm at a smaller scale; centred photo/monogram + name + function.</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">Staf</span><h3 class="ed">Begeleiding.</h3></div>
+    <div class="grid">
+      <div class="scard"><div class="avatar photo">KV</div><div class="nm"><b>Koen</b> <em>Verbruggen</em></div><div class="func">Hoofdtrainer</div></div>
+      <div class="scard"><div class="avatar">TP</div><div class="nm"><b>Tom</b> <em>Peeters</em></div><div class="func">Assistent-trainer</div></div>
+      <div class="scard"><div class="avatar photo">DJ</div><div class="nm"><b>Dirk</b> <em>Janssens</em></div><div class="func">Keeperstrainer</div></div>
+      <div class="scard"><div class="avatar">PL</div><div class="nm"><b>Patrick</b> <em>Lauwers</em></div><div class="func">Afgevaardigde</div></div>
+    </div>
+  </div></div>
+
+  <!-- B -->
+  <div class="variant-band">B &nbsp;·&nbsp; <b>List rows</b></div>
+  <div class="variant-note">More compact / secondary feel — appropriate since staff sit below the squad. Small round photo + name + function in a row.</div>
+  <div class="frame"><div class="page">
+    <div class="section-kicker"><span class="mono">Staf</span><h3 class="ed">Begeleiding.</h3></div>
+    <div class="list">
+      <div class="srow"><div class="avatar photo">KV</div><div><div class="nm"><b>Koen</b> <em>Verbruggen</em></div><div class="func">Hoofdtrainer</div></div></div>
+      <div class="srow"><div class="avatar">TP</div><div><div class="nm"><b>Tom</b> <em>Peeters</em></div><div class="func">Assistent-trainer</div></div></div>
+      <div class="srow"><div class="avatar photo">DJ</div><div><div class="nm"><b>Dirk</b> <em>Janssens</em></div><div class="func">Keeperstrainer</div></div></div>
+      <div class="srow"><div class="avatar">PL</div><div><div class="nm"><b>Patrick</b> <em>Lauwers</em></div><div class="func">Afgevaardigde</div></div></div>
+    </div>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>Pick A (compact cards) or B (list rows). Last 6.C drill after this = the
+       listing page `/ploegen` layout (the editorial body/training/contact block
+       reuses article-prose primitives — no separate drill needed).</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd6-listing/round-1-ploegen.html
+++ b/docs/design/mockups/phase-6-team/6cd6-listing/round-1-ploegen.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 1 · /ploegen listing (6.C.d6)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #133d28; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .frame { max-width: 780px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 30px 28px 36px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .ed { font-family: var(--font-display-big); font-weight: 900; line-height: 1.02; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .seam { height: 16px; background: repeating-linear-gradient(-45deg, var(--color-ink) 0 8px, var(--color-cream) 8px 16px); margin: 28px 0; border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); }
+    .crest { border: 2px solid var(--color-ink); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-weight: 900; background: var(--color-cream-soft); color: var(--color-ink); flex: none; }
+
+    /* page hero */
+    .pagehero { margin-bottom: 6px; }
+    .pagehero .ed { font-size: 56px; }
+    .lead { font-family: var(--font-display); font-style: italic; font-size: 17px; color: var(--color-ink-soft); margin-top: 12px; max-width: 46ch; }
+
+    /* A-team featured (flagship) */
+    .feat { display:grid; grid-template-columns: 1fr; gap:0; border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); background: var(--color-jersey-deep); color: var(--color-cream); }
+    @media (min-width:600px){ .feat { grid-template-columns: 1.3fr 1fr; } }
+    .feat .body { padding: 24px 22px; }
+    .feat .kick { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.14em; font-size:10px; color: rgba(245,241,230,.8); }
+    .feat h3 { font-family: var(--font-display-big); font-weight:900; font-size: 44px; margin: 8px 0 0; }
+    .feat .meta { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.07em; font-size:10px; color: rgba(245,241,230,.85); margin-top: 12px; }
+    .feat .cta { display:inline-block; margin-top:18px; font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.1em; font-size:11px; border:2px solid var(--color-cream); padding:9px 14px; }
+    .feat .photo { background: repeating-linear-gradient(135deg, #0a3d2a 0 12px, #0c4a32 12px 24px); display:grid; place-items:center; font-family:var(--font-mono); font-size:10px; color: rgba(245,241,230,.6); text-transform:uppercase; min-height: 150px; }
+    .feat .crest { background: var(--color-cream); }
+
+    /* featured row (B + others) */
+    .duo { display:grid; grid-template-columns:1fr; gap:14px; margin-top:14px; }
+    @media (min-width:600px){ .duo { grid-template-columns:1fr 1fr; } }
+    .tcard { border:2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 16px; display:flex; align-items:center; gap:14px; transition: transform .25s, box-shadow .25s; }
+    .tcard:hover { box-shadow:none; transform: translate(3px,3px); cursor:pointer; }
+    .tcard .crest { width:46px; height:46px; font-size:16px; }
+    .tcard h4 { font-family: var(--font-display-big); font-weight:900; font-size:22px; margin:0; }
+    .tcard .meta { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.06em; font-size:9px; color:var(--color-ink-muted); margin-top:4px; }
+    .tcard .arrow { margin-left:auto; font-family:var(--font-mono); font-size:14px; }
+
+    /* youth directory */
+    .ydir { }
+    .yband { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.1em; font-size:11px; color:var(--color-ink-muted); margin: 18px 0 10px; border-bottom:1px solid var(--color-paper-edge); padding-bottom:6px; }
+    .ygrid { display:grid; grid-template-columns: repeat(auto-fill, minmax(120px,1fr)); gap:10px; }
+    .ycard { border:2px solid var(--color-ink); background:var(--color-cream); box-shadow: var(--shadow-paper-sm); padding:12px; display:flex; align-items:center; gap:10px; transition: transform .25s, box-shadow .25s; }
+    .ycard:hover { box-shadow:none; transform: translate(2px,2px); cursor:pointer; }
+    .ycard .crest { width:32px;height:32px;font-size:11px; }
+    .ycard b { font-family: var(--font-display-big); font-weight:900; font-size:18px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team listing · Round 1 · Drill 6.C.d6 (/ploegen)</div>
+    <h1>The teams listing — A-team-featured hierarchy.</h1>
+    <p>Locked direction: A-ploeg flagship + B-ploeg featured + youth directory
+       grouped Bovenbouw / Middenbouw / Onderbouw. Page-header + retro cards;
+       every card links to its team detail.</p>
+  </div>
+
+  <div class="variant-band">/ploegen &nbsp;·&nbsp; assembled</div>
+  <div class="frame"><div class="page">
+
+    <div class="pagehero">
+      <span class="mono">KCVV Elewijt</span>
+      <h2 class="ed" style="margin-top:8px">Onze <em>ploegen.</em></h2>
+      <p class="lead">Van de A-kern tot de jongste Onderbouw — alle ploegen van de club.</p>
+    </div>
+
+    <div class="seam"></div>
+
+    <!-- A flagship -->
+    <div class="feat">
+      <div class="body">
+        <span class="kick">Eerste elftal</span>
+        <h3>A-ploeg.</h3>
+        <div class="meta">3e Provinciale A · Seizoen 25/26 · 22 spelers</div>
+        <span class="cta">Bekijk ploeg →</span>
+      </div>
+      <div class="photo">TEAMIMAGE</div>
+    </div>
+
+    <!-- B + reserves -->
+    <div class="duo">
+      <div class="tcard"><span class="crest">K</span><div><h4>B-ploeg.</h4><div class="meta">4e Provinciale C</div></div><span class="arrow">→</span></div>
+      <div class="tcard"><span class="crest">K</span><div><h4>Dames.</h4><div class="meta">2e Provinciale</div></div><span class="arrow">→</span></div>
+    </div>
+
+    <div class="seam"></div>
+
+    <!-- youth directory -->
+    <div class="ydir">
+      <span class="mono">Jeugdwerking</span>
+      <h2 class="ed" style="font-size:30px;margin-top:6px">De <em>jeugd.</em></h2>
+
+      <div class="yband">Bovenbouw</div>
+      <div class="ygrid">
+        <div class="ycard"><span class="crest">K</span><b>U21</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U17</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U15</b><span class="arrow" style="margin-left:auto">→</span></div>
+      </div>
+
+      <div class="yband">Middenbouw</div>
+      <div class="ygrid">
+        <div class="ycard"><span class="crest">K</span><b>U13</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U12</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U11</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U10</b><span class="arrow" style="margin-left:auto">→</span></div>
+      </div>
+
+      <div class="yband">Onderbouw</div>
+      <div class="ygrid">
+        <div class="ycard"><span class="crest">K</span><b>U9</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U8</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U7</b><span class="arrow" style="margin-left:auto">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U6</b><span class="arrow" style="margin-left:auto">→</span></div>
+      </div>
+    </div>
+
+  </div></div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>Lock the listing, or tweak: the A-flagship treatment (jersey-deep block
+       shown), the B/Dames featured row, or the youth directory cards. This is
+       the last 6.C component drill — after it, 6.C is fully designed and ready
+       for the PRD.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd6-listing/round-2-flagship-variants.html
+++ b/docs/design/mockups/phase-6-team/6cd6-listing/round-2-flagship-variants.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 2 · /ploegen A-flagship variants (6.C.d6)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #133d28; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .variant-band b { color: var(--color-warm); }
+    .variant-note { max-width: 920px; margin: 0 auto; padding: 14px 24px 0; font-size: 13px; color: var(--color-ink-soft); line-height: 1.45; }
+    .frame { max-width: 780px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 28px 26px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .crest { border: 2px solid var(--color-ink); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-weight: 900; background: var(--color-cream-soft); color: var(--color-ink); flex: none; }
+    .cta { display:inline-block; font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.1em; font-size:11px; }
+
+    /* V1 — jersey-deep block */
+    .v1 { display:grid; grid-template-columns: 1.3fr 1fr; border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); background: var(--color-jersey-deep); color: var(--color-cream); }
+    .v1 .body { padding: 26px 24px; }
+    .v1 .kick { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.14em; font-size:10px; color: rgba(245,241,230,.8); }
+    .v1 h3 { font-family: var(--font-display-big); font-weight:900; font-size: 46px; margin: 8px 0 0; }
+    .v1 .meta { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.07em; font-size:10px; color: rgba(245,241,230,.85); margin-top: 12px; }
+    .v1 .cta { margin-top:18px; border:2px solid var(--color-cream); padding:9px 14px; }
+    .v1 .photo { background: repeating-linear-gradient(135deg, #0a3d2a 0 12px, #0c4a32 12px 24px); display:grid; place-items:center; font-family:var(--font-mono); font-size:10px; color: rgba(245,241,230,.55); text-transform:uppercase; }
+
+    /* V2 — cream, photo-led */
+    .v2 { border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); background: var(--color-cream); display:grid; grid-template-columns: 1fr 1.1fr; }
+    .v2 .photo { background: repeating-linear-gradient(135deg, #b9b09a 0 12px, #ada590 12px 24px); filter: grayscale(1) contrast(1.05); display:grid; place-items:center; font-family:var(--font-mono); font-size:10px; color:#5f5847; text-transform:uppercase; min-height:200px; }
+    .v2 .body { padding: 26px 24px; display:flex; flex-direction:column; justify-content:center; }
+    .v2 .kick { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.14em; font-size:10px; color: var(--color-ink-muted); }
+    .v2 h3 { font-family: var(--font-display-big); font-weight:900; font-size: 46px; margin: 8px 0 0; }
+    .v2 h3 em { font-style:italic; color: var(--color-jersey-deep); }
+    .v2 .meta { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.07em; font-size:10px; color: var(--color-ink-muted); margin-top: 12px; }
+    .v2 .cta { margin-top:18px; border:2px solid var(--color-ink); padding:9px 14px; box-shadow: var(--shadow-paper-sm); }
+
+    /* V3 — editorial mini-hero (no card fill) */
+    .v3 { display:grid; grid-template-columns: 1fr 240px; gap: 26px; align-items:center; padding: 8px 4px; }
+    .v3 .kick { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.14em; font-size:11px; color: var(--color-ink-muted); }
+    .v3 h3 { font-family: var(--font-display-big); font-weight:900; font-size: 58px; margin: 8px 0 0; }
+    .v3 h3 em { font-style:italic; color: var(--color-jersey-deep); }
+    .v3 .meta-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:16px; }
+    .v3 .pill { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.08em; font-size:10px; font-weight:600; padding:6px 9px; border:1px solid var(--color-paper-edge); background:var(--color-cream-soft); }
+    .v3 .cta { margin-top:18px; color: var(--color-jersey-deep); border-bottom:2px solid var(--color-jersey-deep); padding-bottom:2px; }
+    .v3 .polaroid { border:2px solid var(--color-ink); background:var(--color-cream-soft); box-shadow: var(--shadow-paper-md); transform: rotate(-1.5deg); padding:9px 9px 16px; }
+    .v3 .polaroid .ph { aspect-ratio:4/3; background: repeating-linear-gradient(135deg, #b9b09a 0 11px, #ada590 11px 22px); filter:grayscale(1); display:grid; place-items:center; font-family:var(--font-mono); font-size:9px; color:#5f5847; text-transform:uppercase; }
+
+    /* corrected B row */
+    .tcard { border:2px solid var(--color-ink); background: var(--color-cream); box-shadow: var(--shadow-paper-sm); padding: 16px; display:flex; align-items:center; gap:14px; max-width: 360px; }
+    .tcard .crest { width:46px; height:46px; font-size:16px; }
+    .tcard h4 { font-family: var(--font-display-big); font-weight:900; font-size:22px; margin:0; }
+    .tcard .meta { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.06em; font-size:9px; color:var(--color-ink-muted); margin-top:4px; }
+    .tcard .arrow { margin-left:auto; font-family:var(--font-mono); font-size:14px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team listing · Round 2 · Drill 6.C.d6 (A-flagship)</div>
+    <h1>Three A-flagship treatments.</h1>
+    <p>Pick how the A-ploeg leads the listing. (No Dames team — senior side is
+       A-ploeg + B-ploeg; the corrected B card is shown once at the bottom.)
+       Squad-count dropped unless we reliably have it.</p>
+  </div>
+
+  <!-- V1 -->
+  <div class="variant-band">V1 &nbsp;·&nbsp; <b>Jersey-deep block</b></div>
+  <div class="variant-note">Bold filled card, content + photo panel. Loudest / most "flagship".</div>
+  <div class="frame"><div class="page">
+    <div class="v1">
+      <div class="body"><span class="kick">Eerste elftal</span><h3>A-ploeg.</h3><div class="meta">3e Provinciale A · Seizoen 25/26</div><span class="cta">Bekijk ploeg →</span></div>
+      <div class="photo">TEAMIMAGE</div>
+    </div>
+  </div></div>
+
+  <!-- V2 -->
+  <div class="variant-band">V2 &nbsp;·&nbsp; <b>Cream, photo-led</b></div>
+  <div class="variant-note">Newsprint squad photo leads; cream body beside it. Lighter, photographic, sits closer to the rest of the page.</div>
+  <div class="frame"><div class="page">
+    <div class="v2">
+      <div class="photo">TEAMIMAGE · NEWSPRINT</div>
+      <div class="body"><span class="kick">Eerste elftal</span><h3>A-<em>ploeg.</em></h3><div class="meta">3e Provinciale A · Seizoen 25/26</div><span class="cta">Bekijk ploeg →</span></div>
+    </div>
+  </div></div>
+
+  <!-- V3 -->
+  <div class="variant-band">V3 &nbsp;·&nbsp; <b>Editorial mini-hero</b> (no card fill)</div>
+  <div class="variant-note">No filled card — big editorial headline + meta pills + a taped polaroid. Echoes the TeamHero; most "paper", least boxy.</div>
+  <div class="frame"><div class="page">
+    <div class="v3">
+      <div>
+        <span class="kick">Eerste elftal</span>
+        <h3>A-<em>ploeg.</em></h3>
+        <div class="meta-row"><span class="pill">3e Provinciale A</span><span class="pill">Seizoen 25/26</span></div>
+        <div><span class="cta">Bekijk ploeg →</span></div>
+      </div>
+      <div class="polaroid"><div class="ph">TEAMIMAGE</div></div>
+    </div>
+  </div></div>
+
+  <!-- corrected B -->
+  <div class="variant-band" style="background:var(--color-cream);color:var(--color-ink-soft);border-color:var(--color-paper-edge)">Corrected B row &nbsp;·&nbsp; B-ploeg only (no Dames)</div>
+  <div class="frame"><div class="page">
+    <div class="tcard"><span class="crest">K</span><div><h4>B-ploeg.</h4><div class="meta">4e Provinciale C · Seizoen 25/26</div></div><span class="arrow">→</span></div>
+    <p class="mono" style="margin-top:12px">Youth directory (Bovenbouw / Middenbouw / Onderbouw) follows unchanged from round 1.</p>
+  </div></div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>Pick V1 / V2 / V3 for the A-flagship. Then the listing locks and 6.C is
+       fully designed → ready for the PRD.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/6cd6-listing/round-3-ab-paired.html
+++ b/docs/design/mockups/phase-6-team/6cd6-listing/round-3-ab-paired.html
@@ -49,7 +49,7 @@
     .flag.a .photo { background: repeating-linear-gradient(135deg, #0a3d2a 0 12px, #0c4a32 12px 24px); color: rgba(245,241,230,.55); }
 
     /* B — cream, MIRRORED: photo left / content right */
-    .flag.b { background: var(--color-cream); color: var(--color-ink); grid-template-columns: 1fr 1.25fr; }
+    .flag.b { background: var(--color-cream); color: var(--color-ink); grid-template-columns: 1fr 1.25fr; margin-top: 32px; }
     .flag.b .photo { grid-column: 1; background: repeating-linear-gradient(135deg, #b9b09a 0 12px, #ada590 12px 24px); filter: grayscale(1) contrast(1.05); color:#5f5847; }
     .flag.b .body { grid-column: 2; }
     .flag.b .kick, .flag.b .meta { color: var(--color-ink-muted); }

--- a/docs/design/mockups/phase-6-team/6cd6-listing/round-3-ab-paired.html
+++ b/docs/design/mockups/phase-6-team/6cd6-listing/round-3-ab-paired.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 6.C · Round 3 · /ploegen A+B paired flagships (6.C.d6)</title>
+  <style>
+    :root {
+      --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+      --color-paper-edge: #d9d2bd; --color-ink: #0a0a0a; --color-ink-soft: #1f1f1f; --color-ink-muted: #6b6b6b;
+      --color-jersey-deep: #008755; --color-jersey-deep-dark: #133d28; --color-warm: #f0c264;
+      --shadow-paper-sm: 4px 4px 0 0 var(--color-ink); --shadow-paper-md: 6px 6px 0 0 var(--color-ink); --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
+      --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+      --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+      --font-mono: "Quasimoda", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: #cfc7b0; color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; padding: 0 0 120px; }
+    .drill-head { max-width: 920px; margin: 0 auto; padding: 40px 24px 8px; }
+    .drill-head .tag { font-family: var(--font-mono); font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--color-ink-soft); }
+    .drill-head h1 { font-family: var(--font-display-big); font-weight: 900; font-size: 31px; line-height: 1.05; margin: 8px 0 6px; }
+    .drill-head p { max-width: 66ch; line-height: 1.5; color: var(--color-ink-soft); }
+    .variant-band { background: var(--color-ink); color: var(--color-cream); padding: 10px 24px; margin: 44px 0 0; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .12em; font-size: 13px; border-top: 3px solid var(--color-warm); border-bottom: 3px solid var(--color-warm); }
+    .frame { max-width: 800px; margin: 18px auto 0; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); }
+    .frame .page { padding: 30px 28px 36px; }
+    .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .14em; font-size: 11px; color: var(--color-ink-muted); }
+    .ed { font-family: var(--font-display-big); font-weight: 900; line-height: 1.02; margin: 0; }
+    .ed em { font-style: italic; color: var(--color-jersey-deep); }
+    .lead { font-family: var(--font-display); font-style: italic; font-size: 17px; color: var(--color-ink-soft); margin-top: 12px; max-width: 46ch; }
+    .seam { height: 16px; background: repeating-linear-gradient(-45deg, var(--color-ink) 0 8px, var(--color-cream) 8px 16px); margin: 28px 0; border-top: 2px solid var(--color-ink); border-bottom: 2px solid var(--color-ink); }
+    .crest { border: 2px solid var(--color-ink); border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display-big); font-weight: 900; background: var(--color-cream-soft); color: var(--color-ink); flex: none; }
+
+    .pagehero .ed { font-size: 56px; }
+
+    /* paired flagships */
+    .flag { display:grid; grid-template-columns: 1.25fr 1fr; border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); margin-top: 16px; min-height: 180px; }
+    .flag .body { padding: 26px 24px; display:flex; flex-direction:column; justify-content:center; }
+    .flag .kick { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.14em; font-size:10px; }
+    .flag h3 { font-family: var(--font-display-big); font-weight:900; font-size: 44px; margin: 8px 0 0; }
+    .flag .meta { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.07em; font-size:10px; margin-top: 12px; }
+    .flag .cta { display:inline-block; width:max-content; margin-top:18px; font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.1em; font-size:11px; padding:9px 14px; border:2px solid; }
+    .flag .photo { display:grid; place-items:center; font-family:var(--font-mono); font-size:10px; text-transform:uppercase; }
+
+    /* A — jersey-deep, content left / photo right */
+    .flag.a { background: var(--color-jersey-deep); color: var(--color-cream); }
+    .flag.a .kick, .flag.a .meta { color: rgba(245,241,230,.82); }
+    .flag.a .cta { border-color: var(--color-cream); color: var(--color-cream); }
+    .flag.a .photo { background: repeating-linear-gradient(135deg, #0a3d2a 0 12px, #0c4a32 12px 24px); color: rgba(245,241,230,.55); }
+
+    /* B — cream, MIRRORED: photo left / content right */
+    .flag.b { background: var(--color-cream); color: var(--color-ink); grid-template-columns: 1fr 1.25fr; }
+    .flag.b .photo { grid-column: 1; background: repeating-linear-gradient(135deg, #b9b09a 0 12px, #ada590 12px 24px); filter: grayscale(1) contrast(1.05); color:#5f5847; }
+    .flag.b .body { grid-column: 2; }
+    .flag.b .kick, .flag.b .meta { color: var(--color-ink-muted); }
+    .flag.b h3 em { font-style:italic; color: var(--color-jersey-deep); }
+    .flag.b .cta { border-color: var(--color-ink); color: var(--color-ink); box-shadow: var(--shadow-paper-sm); }
+
+    .yband { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:.1em; font-size:11px; color:var(--color-ink-muted); margin: 18px 0 10px; border-bottom:1px solid var(--color-paper-edge); padding-bottom:6px; }
+    .ygrid { display:grid; grid-template-columns: repeat(auto-fill, minmax(120px,1fr)); gap:10px; }
+    .ycard { border:2px solid var(--color-ink); background:var(--color-cream); box-shadow: var(--shadow-paper-sm); padding:12px; display:flex; align-items:center; gap:10px; }
+    .ycard .crest { width:32px;height:32px;font-size:11px; }
+    .ycard b { font-family: var(--font-display-big); font-weight:900; font-size:18px; }
+    .ycard .arrow { margin-left:auto; font-family:var(--font-mono); font-size:13px; }
+  </style>
+</head>
+<body>
+
+  <div class="drill-head">
+    <div class="tag">Phase 6.C · Team listing · Round 3 · Drill 6.C.d6</div>
+    <h1>A + B as a matched pair.</h1>
+    <p>A-ploeg = jersey-deep flagship (content left / photo right). B-ploeg =
+       the same block <b>mirrored</b> (photo left / content right) in <b>cream</b>
+       — equal weight, opposite hand, B clearly the lighter sibling. Youth
+       directory below.</p>
+  </div>
+
+  <div class="variant-band">/ploegen &nbsp;·&nbsp; A green + B cream (mirrored)</div>
+  <div class="frame"><div class="page">
+
+    <div class="pagehero">
+      <span class="mono">KCVV Elewijt</span>
+      <h2 class="ed" style="margin-top:8px">Onze <em>ploegen.</em></h2>
+      <p class="lead">Van de A-kern tot de jongste Onderbouw — alle ploegen van de club.</p>
+    </div>
+
+    <div class="seam"></div>
+
+    <!-- A flagship -->
+    <div class="flag a">
+      <div class="body"><span class="kick">Eerste elftal</span><h3>A-ploeg.</h3><div class="meta">3e Provinciale A · Seizoen 25/26</div><span class="cta">Bekijk ploeg →</span></div>
+      <div class="photo">TEAMIMAGE</div>
+    </div>
+
+    <!-- B flagship, mirrored + cream -->
+    <div class="flag b">
+      <div class="photo">TEAMIMAGE · NEWSPRINT</div>
+      <div class="body"><span class="kick">Tweede elftal</span><h3>B-<em>ploeg.</em></h3><div class="meta">4e Provinciale C · Seizoen 25/26</div><span class="cta">Bekijk ploeg →</span></div>
+    </div>
+
+    <div class="seam"></div>
+
+    <div>
+      <span class="mono">Jeugdwerking</span>
+      <h2 class="ed" style="font-size:30px;margin-top:6px">De <em>jeugd.</em></h2>
+      <div class="yband">Bovenbouw</div>
+      <div class="ygrid">
+        <div class="ycard"><span class="crest">K</span><b>U21</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U17</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U15</b><span class="arrow">→</span></div>
+      </div>
+      <div class="yband">Middenbouw</div>
+      <div class="ygrid">
+        <div class="ycard"><span class="crest">K</span><b>U13</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U12</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U11</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U10</b><span class="arrow">→</span></div>
+      </div>
+      <div class="yband">Onderbouw</div>
+      <div class="ygrid">
+        <div class="ycard"><span class="crest">K</span><b>U9</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U8</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U7</b><span class="arrow">→</span></div>
+        <div class="ycard"><span class="crest">K</span><b>U6</b><span class="arrow">→</span></div>
+      </div>
+    </div>
+
+  </div></div>
+
+  <div class="drill-head" style="padding-top:36px">
+    <div class="tag">Decide</div>
+    <p>A green + B cream mirrored — lock the listing? Then 6.C is fully designed.</p>
+  </div>
+
+</body>
+</html>

--- a/docs/design/mockups/phase-6-team/data-reality-locked.md
+++ b/docs/design/mockups/phase-6-team/data-reality-locked.md
@@ -1,0 +1,97 @@
+# 6.C.d0 · Team listing + detail — Data Reality LOCKED
+
+**Drill round 0.** First drill of the Phase 6.C (team) design series.
+Establishes which data the redesign can render today so subsequent visual
+drills compose within a known data-truth box. Mirrors 6.A.d0 / 6.B.d0.
+
+**Status:** LOCKED 2026-05-28. Variant C — design within today's data; auto-hide
+sections whose data is absent (esp. youth teams). No new BFF endpoints; no new
+editorial backlog beyond what already exists on the `team` document.
+
+---
+
+## Surfaces
+
+- Listing: `/ploegen` — ISR 1h. Today renders legacy `InteriorPageHero` +
+  `TeamFeaturedCard` + `YouthTeamsDirectory`.
+- Detail: `/ploegen/[slug]` — ISR 1h. Today renders legacy `<TeamDetail>` with
+  tabs (Info / Spelers / Wedstrijden / Klassement).
+
+## Data source map
+
+### Sanity `team` document (`TEAM_BY_SLUG_QUERY`)
+
+| Field | Type | Availability | Notes |
+| --- | --- | --- | --- |
+| `name` | string | ✓ (PSD-synced) | e.g. "KCVV Elewijt" |
+| `slug` | slug | ✓ | route key |
+| `age` | string | ✓ (PSD-synced) | "A", "U17", … |
+| `division` / `divisionFull` | string | ✓ editorial | "3NA" / "Eerste Elftal A – 3e Nat. A" |
+| `season` | string | ✓ (PSD-synced) | "25/26" |
+| `tagline` | string | optional editorial | |
+| `body` | Portable Text | optional editorial | team description |
+| `contactInfo` | Portable Text | optional editorial | |
+| `teamImage` | image (hotspot) | optional | squad photo |
+| `trainingSchedule` | `trainingSession[]` | optional editorial | day/time/location/type |
+| `players` | ref[] → player | ✓ (PSD-synced) | squad (forward refs) |
+| `staff` | `{ member→staffMember, role }[]` | ✓ (PSD-synced refs) | role = trainer \| afgevaardigde |
+
+`player` fields available via the team query: `firstName`, `lastName`,
+`jerseyNumber`, `keeper`, `positionPsd`, `position` (Keeper / Verdediger /
+Middenvelder / Aanvaller / Speler), `psdImage` (≈90% of players) OR
+`transparentImage` (editorial, rare). **Dropped in 6.A:** nationality, height,
+weight — do not render.
+
+`staffMember` fields: `firstName`, `lastName`, `functionTitle` (PSD-synced),
+`photo`.
+
+### BFF (PSD)
+
+| Call | Returns | Availability |
+| --- | --- | --- |
+| `getRanking(psdId)` → `/ranking/:teamId` | `RankingEntry[]` | ✓ seniors; **empty `[]` for most youth** |
+| `getMatches(psdId)` → `/matches/:teamId` | `Match[]` | ✓ seniors; **empty `[]` for most youth** |
+
+`RankingEntry`: position, team_id, team_name, team_logo?, played, won, drawn,
+lost, goals_for, goals_against, goal_difference, points, form?. The team's
+**own** row already carries season W/D/L + GF/GA — so a standalone `StatsStrip`
+is redundant (dropped, see decision record).
+
+`Match` rows reuse the already-reskinned `<MatchResultRow>` (finished) /
+`<MatchTeaser>` (upcoming) — no new row vocabulary needed in 6.C.
+
+## NOT available today
+
+- **Team-filtered sponsors** — sponsor docs don't reference teams. 6.C renders
+  the **global** `<SponsorsBlock>` at the foot, not a per-team set.
+- **Per-team statistics endpoint** consumed on the page — not used; the team's
+  ranking row covers W/D/L + GF/GA.
+- **Youth competitive data** — PSD frequently returns empty standings/schedule
+  for U-teams. Those sections **auto-hide**; a U-team page can degrade to
+  hero + squad + staff (+ training/body when present).
+
+## Locked composition (direction, per decision record)
+
+`TeamHero` → `StandingsTable` (this team highlighted) → `MatchSchedule`
+(upcoming + past) → `SquadGrid` of `PlayerCard` → Staff → `team.body` /
+`trainingSchedule` / `contactInfo` when present → **global** `SponsorsBlock`.
+No standalone `StatsStrip`. All non-hero sections auto-hide on empty data.
+
+**Open (this is 6.C.d1):** is the detail IA a **single-scroll** stack (6.A/6.B
+precedent) or **reskinned tabs**? Resolved by the side-by-side in
+`6cd1-detail-ia/`.
+
+## Constraints inherited
+
+- Locked palette only (cream / warm / ink / jersey-deep) — **no outcome
+  colours** in standings/form. The legacy `TeamStandings` green/yellow/red W/D/L
+  badges are a violation and must not carry over.
+- `<PlayerCard>` composes `<PlayerFigure>` → inherits the 6.A photo treatment +
+  minor-privacy rules (see `project_player_profile_all_ages`).
+- Cross-age: every section answers "does this render for a U8?" — most → hide.
+
+## Cross-references
+
+- Decision record: `project_phase_6cde_remainder_decisions` memory + #1528.
+- 6.A precedent: `docs/design/mockups/phase-6-player-profile/data-reality-locked.md`.
+- 6.B precedent: `docs/design/mockups/phase-6-match-detail/data-reality-locked.md`.

--- a/docs/design/mockups/phase-6-team/detail-ia-locked.md
+++ b/docs/design/mockups/phase-6-team/detail-ia-locked.md
@@ -45,7 +45,9 @@ one colour (on the jersey-deep featured card both are cream — earlier bug fixe
   KCVV bold wherever it plays. **No venue indicator** (the order conveys home/away).
 - **B · mobile = KCVV-centric column:** `[stub] [opponent crest+name+comp]
   [home/away icon] [score/time]`. KCVV is **not** repeated (you're on its page);
-  **our score first**. Home/away shown as a **Lucide `house` / `bus`** icon.
+  **our score first**. Home/away shown as a **Phosphor Fill `House` / `Bus`**
+  icon (`weight="fill"`, via `@/lib/icons.redesign` — the redesign's canonical
+  icon set; not Lucide).
 
 **Crests:** real PSD club logos (`home_team.logo` / `away_team.logo`). One
 **neutral** placeholder for all clubs (no KCVV-green — it read as a colour
@@ -84,12 +86,16 @@ wrapping to 2 lines was rejected (uneven rhythm).
 ## 4. Palette / vocabulary deltas (must be addressed in the PRD)
 
 - **Deliberate exception to the "no outcome colours / no loss-red" lock:** the
-  matches/standings outcome language is **win = jersey-deep · draw = none · loss
+  **matches-agenda** outcome language is **win = jersey-deep · draw = none · loss
   = `--color-alert` (#b84a3a) brick** (an existing token; not bright red). This
   is the single semantic-outcome-colour pair in the redesign — justify it in the
-  PRD and apply the SAME language to the `<StandingsTable>` form indicator for
-  consistency. (Supersedes the blanket "no semantic outcome colours" note in the
-  earlier palette lock for this specific case.)
+  PRD. (Supersedes the blanket "no semantic outcome colours" note in the earlier
+  palette lock for this specific case.)
+  **NOTE (superseded):** an earlier draft also applied this language to a
+  `<StandingsTable>` **form indicator** — that is dropped. `RankingEntry.form` is
+  optional/unreliable for the other teams in the division, so the standings table
+  has **no Vorm column**; the colour language applies to the **matches agenda
+  only**. See `standings-locked.md`.
 - New route: **`/ploegen/[slug]/wedstrijden`** (full-season agenda).
 - No new design-system colour token (reuses jersey-deep + alert).
 
@@ -97,7 +103,7 @@ wrapping to 2 lines was rejected (uneven rhythm).
 
 - `<TeamHero>` artefact (taped team photo / jersey-illustration fallback, season
   ticket-stub, MonoLabelRow).
-- `<StandingsTable>` layout (uses the §3 outcome language; KCVV row highlighted;
+- `<StandingsTable>` layout (KCVV row highlighted; no Vorm column — see `standings-locked.md`;
   no green/yellow/red badges from the legacy table).
 - `<SquadGrid>` + `<PlayerCard>` (position grouping; reuses `<PlayerFigure>`).
 - Staff cards; editorial section; **listing `/ploegen`** layout (hierarchy

--- a/docs/design/mockups/phase-6-team/detail-ia-locked.md
+++ b/docs/design/mockups/phase-6-team/detail-ia-locked.md
@@ -1,0 +1,111 @@
+# 6.C.d1 · Team-detail IA + matches agenda row — LOCKED
+
+**Decision:** Single-scroll + sticky section-nav; matches = month-grouped card
+agenda (teaser on the team page → full-season agenda on its own route);
+responsive scoreboard row (A desktop / B mobile); outcome as a flat underline on
+the score. Locked 2026-05-28 across 16 drill rounds
+(`6cd1-detail-ia/round-1` → `round-16`).
+
+---
+
+## 1. Page IA (team detail)
+
+- **Single-scroll** stack with `<StripedSeam>` section breaks + per-section
+  auto-hide — consistent with 6.A (player) / 6.B (match). Tabs **rejected**.
+- A thin **sticky section-nav** under the hero jumps to: Klassement ·
+  Wedstrijden · Spelers · Staf · Info. Nav lists only sections that exist
+  (cross-age / data-thin youth teams degrade cleanly).
+- Section order (from `data-reality-locked.md`): TeamHero → StandingsTable →
+  **Wedstrijden** → SquadGrid → Staff → editorial (body / training / contact
+  when present) → global SponsorsBlock.
+
+## 2. Wedstrijden (matches) section
+
+- **On the team page:** a *teaser* — the featured next match + a few recent
+  results, same row vocabulary as the full page, then **"Volledige kalender →"**.
+- **Full schedule = its own route** (`/ploegen/[slug]/wedstrijden`), rendered as
+  the **§6.6 newspaper agenda**: big month headings (`Mei '26.`, display-big,
+  jersey-deep italic year, **no rule beneath**) → card rows.
+- The full-schedule page **auto-scrolls to the featured next match on load**
+  (`scrollIntoView`, `block:center`, reduced-motion safe) so the visitor lands
+  on "now" — recent results above, upcoming below. Season order ascending.
+- Handles a realistic **40–50-fixture** A-team season (league + beker + oefen).
+
+## 3. The agenda row (the heavily-drilled bit)
+
+**Card chrome:** `border-2 border-ink` + `shadow-paper-sm` + cream bg +
+canonical press-down hover. Left **date stub** (cream-soft, `border-r-2 border-dashed`):
+day in `font-display-big` (≈18px), month in mono (≈8px). Date + month must share
+one colour (on the jersey-deep featured card both are cream — earlier bug fixed).
+
+**Responsive — one component, one breakpoint (~640px):**
+
+- **A · desktop = symmetric scoreboard:** `[stub] [home crest+name] [score/time]
+  [away name+crest]`. Home cluster hugs left, away hugs right, score/time centred.
+  KCVV bold wherever it plays. **No venue indicator** (the order conveys home/away).
+- **B · mobile = KCVV-centric column:** `[stub] [opponent crest+name+comp]
+  [home/away icon] [score/time]`. KCVV is **not** repeated (you're on its page);
+  **our score first**. Home/away shown as a **Lucide `house` / `bus`** icon.
+
+**Crests:** real PSD club logos (`home_team.logo` / `away_team.logo`). One
+**neutral** placeholder for all clubs (no KCVV-green — it read as a colour
+legend). Desktop shows both (home-left / away-right); mobile shows the opponent's
+only.
+
+**Score / time (centred headline, display font):** played → score
+(`font-display-big`); upcoming → **kickoff time** in `font-display` italic
+(no "vs", no mono — mono clashed). Always centred in the score slot.
+
+**Competition caption:** sits **inside the centre column, under the score**, so
+the team names centre against the score+caption block reliably (stress-tested:
+`KSV Schoonbeek-Beverst A` + `Beker van België` on one row). One treatment for
+**all** competitions — mono, ink, same weight, **no tag, no bullet**. The name
+itself ("Beker van België" vs "3e Provinciale A") distinguishes the type.
+
+**Outcome indicator — flat underline on the score (NOT a column):**
+- A **flat colour underline** (`box-shadow: inset 0 -9px 0 <tint>`), padded
+  **wider than the score** (`padding: 0 8px`), climbing **up toward the "–"**.
+- **Win** = jersey-deep tint `color-mix(jersey-deep 34%, cream)`.
+- **Draw** = **no underline**.
+- **Loss** = **brick** `color-mix(--color-alert 38%, cream)` (`#b84a3a`, muted
+  terracotta).
+- `<HighlighterStroke>` was evaluated (owner asked to reuse it) but its textured
+  slab reads as noise at score-size — **reserve HighlighterStroke for large
+  headline text only**; the score outcome uses this flat underline.
+- **No separate W/G/V result column** on desktop *or* mobile — putting the
+  outcome on the score removed the empty-cell / misalignment problems for good.
+
+**Featured "Eerstvolgende":** the next match renders as a **jersey-deep filled
+card** with a warm "Eerstvolgende" / "Seizoensopener" label above it.
+
+**Long team names:** **ellipsis + `title="<full name>"`** (constant row height) —
+wrapping to 2 lines was rejected (uneven rhythm).
+
+## 4. Palette / vocabulary deltas (must be addressed in the PRD)
+
+- **Deliberate exception to the "no outcome colours / no loss-red" lock:** the
+  matches/standings outcome language is **win = jersey-deep · draw = none · loss
+  = `--color-alert` (#b84a3a) brick** (an existing token; not bright red). This
+  is the single semantic-outcome-colour pair in the redesign — justify it in the
+  PRD and apply the SAME language to the `<StandingsTable>` form indicator for
+  consistency. (Supersedes the blanket "no semantic outcome colours" note in the
+  earlier palette lock for this specific case.)
+- New route: **`/ploegen/[slug]/wedstrijden`** (full-season agenda).
+- No new design-system colour token (reuses jersey-deep + alert).
+
+## 5. NOT locked here (later 6.C drills)
+
+- `<TeamHero>` artefact (taped team photo / jersey-illustration fallback, season
+  ticket-stub, MonoLabelRow).
+- `<StandingsTable>` layout (uses the §3 outcome language; KCVV row highlighted;
+  no green/yellow/red badges from the legacy table).
+- `<SquadGrid>` + `<PlayerCard>` (position grouping; reuses `<PlayerFigure>`).
+- Staff cards; editorial section; **listing `/ploegen`** layout (hierarchy
+  locked in the decision record; visual pass if needed).
+- Exact sticky-nav styling; exact breakpoint px; per-row crest sizing.
+
+## Cross-references
+
+- `data-reality-locked.md` (6.C.d0).
+- Round artifacts: `6cd1-detail-ia/round-1…round-16-final-assembled.html`.
+- Decision record: `project_phase_6cde_remainder_decisions` memory + #1528.

--- a/docs/design/mockups/phase-6-team/listing-locked.md
+++ b/docs/design/mockups/phase-6-team/listing-locked.md
@@ -1,0 +1,28 @@
+# 6.C.d6 · /ploegen listing — LOCKED
+
+**Decision:** A-team-featured hierarchy; A + B as a **matched pair of mirrored
+flagships**. Locked 2026-05-28 (`6cd6-listing/round-3-ab-paired.html`).
+
+- **Page header:** MonoLabel kicker `KCVV Elewijt` + `<EditorialHeading>` display
+  `Onze ploegen.` + italic lead. (No `<EditorialHero variant="generic">` — that
+  variant doesn't exist; a plain editorial page-header is used.)
+- **A-ploeg flagship:** 2-column **jersey-deep filled** block (cream text),
+  **content left / photo right** — kicker `Eerste elftal`, big `A-ploeg.`, meta
+  `division · season`, cream-bordered `Bekijk ploeg →`, team-photo panel.
+- **B-ploeg flagship:** the **same block mirrored** — **photo left / content
+  right** — in **cream** (not jersey-deep). Equal block dimensions (photo = the
+  `1fr` column in both; content `1.25fr`), a larger gap between A and B; B reads
+  as the lighter sibling. **No Dames team** (removed). Extra senior teams
+  (veterans) would reuse the same paired-flagship pattern.
+- **Youth directory:** `Jeugdwerking` heading, grouped **Bovenbouw / Middenbouw /
+  Onderbouw** (per [[project_youth_divisions]]), grid of compact crest + age-code
+  cards (U21…U6), each linking to its detail.
+- **Squad count dropped** from cards unless reliably available.
+- Every card → its `/ploegen/[slug]` detail.
+
+## Cross-references
+
+- Decision record: [[project_phase_6cde_remainder_decisions]].
+- Artifacts: `6cd6-listing/round-1-ploegen.html`,
+  `round-2-flagship-variants.html` (flagship V1 chosen),
+  `round-3-ab-paired.html` (A+B paired, **locked**).

--- a/docs/design/mockups/phase-6-team/squadgrid-locked.md
+++ b/docs/design/mockups/phase-6-team/squadgrid-locked.md
@@ -1,0 +1,25 @@
+# 6.C.d4 · SquadGrid / PlayerCard — LOCKED
+
+**Decision:** Position-grouped grid; PlayerCard = photo polaroid with a
+jersey-deep **number disc overlaid top-left** + name + position. Locked
+2026-05-28 (`6cd4-squadgrid/round-1-playercard.html`, treatment A).
+
+- **Grouping:** by position — Doelmannen / Verdedigers / Middenvelders /
+  Aanvallers (mono group headers + hairline rule). Derived from
+  `player.position` (editorial) || `positionPsd`.
+- **PlayerCard:** `<TapedCard>`-framed; `<PlayerFigure>` photo (3:4, newsprint
+  treatment) with the **number disc** (jersey-deep, cream numeral, ink border)
+  top-left; below: name (first semibold + last italic, the 6.A rhythm) + position
+  (MonoLabel/mono). Press-down hover; whole card links to `/spelers/[slug]`.
+- **No-`psdImage` fallback:** `<PlayerFigure>` canonical illustration in the same
+  frame (inherits [[project_playerfigure_illustration_canonical]]).
+- **Cross-age / minors:** reuses `<PlayerFigure>`'s locked minor treatment
+  ([[project_player_profile_all_ages]]) — no extra work here.
+- **Follow-ups (implementation):** keeper is already conveyed by the Doelmannen
+  group + "Keeper" position; captain glyph is match-level (not squad) — omit;
+  responsive grid `auto-fill minmax(~140px)`.
+
+## Cross-references
+
+- Inherits `<PlayerFigure>` (locked photo + illustration states).
+- Artifact: `6cd4-squadgrid/round-1-playercard.html`.

--- a/docs/design/mockups/phase-6-team/staff-locked.md
+++ b/docs/design/mockups/phase-6-team/staff-locked.md
@@ -1,0 +1,19 @@
+# 6.C.d5 · Staff — LOCKED
+
+**Decision:** Compact centred cards. Locked 2026-05-28
+(`6cd5-staff/round-1-staff.html`, treatment A).
+
+- **Card:** `<TapedCard>`-framed, centred — round photo (newsprint) **or
+  monogram fallback** (initials, jersey-deep on cream-soft) + name (first
+  semibold + last italic) + **function** (mono caption).
+- **Function label:** show `staffMember.functionTitle` (PSD) rendered readable —
+  map known codes `T1→Hoofdtrainer`, `T2→Assistent-trainer`, `TK→Keeperstrainer`,
+  `TVJO→Jeugdcoördinator`; pass through already-readable values; **fall back to
+  the role bucket** (`Trainer` / `Afgevaardigde`) when `functionTitle` is null.
+- **Grid:** `auto-fill minmax(~150px)`. Section auto-hides when `staff` is empty.
+- Smaller scale than `<PlayerCard>` (staff sit below the squad).
+
+## Cross-references
+
+- Artifact: `6cd5-staff/round-1-staff.html`.
+- Function-code mapping mirrors the organigram role codes (T1/T2/TK/TVJO).

--- a/docs/design/mockups/phase-6-team/standings-locked.md
+++ b/docs/design/mockups/phase-6-team/standings-locked.md
@@ -1,0 +1,26 @@
+# 6.C.d3 · StandingsTable — LOCKED
+
+**Decision:** Classic retro table, full division inline, KCVV highlighted, **no
+Vorm column.** Locked 2026-05-28 (`6cd3-standings/round-2-no-form.html`).
+
+- **Source:** BFF `RankingEntry`. Columns: `# · Ploeg · M · W · G · V · +/- · Ptn`.
+- **Treatment:** mono uppercase headers; `border-b-2 ink` header rule; hairline
+  (`border-b 1px paper-edge`) row rules; team name display italic; points
+  display-big black; small neutral crest before each team name (real PSD logo).
+- **KCVV row highlight:** `color-mix(jersey-deep 12%, cream)` tint band +
+  `inset 3px 0 jersey-deep` left accent + team name non-italic bold. (This is a
+  "this team" highlight — distinct from the matches win/loss colour language.)
+- **Vorm DROPPED:** `RankingEntry.form` is optional and not reliably populated
+  for the other teams in the division — a half-empty column reads worse than
+  none. **Consequence:** the win/draw/loss colour language (jersey-deep / brick)
+  applies to the **matches agenda only** — there is no standings form indicator.
+  (Supersedes the "also drives the standings form" note in `detail-ia-locked.md`.)
+- **Scope:** full division shown inline on the team page (compact enough).
+- **Mobile:** drop `W · G · V` → `# · Ploeg · M · +/- · Ptn`.
+- Auto-hides entirely for teams with no PSD ranking (most youth).
+
+## Cross-references
+
+- `detail-ia-locked.md` (6.C.d1) — outcome colour language (matches only).
+- Artifacts: `6cd3-standings/round-1-standings.html` (form options, rejected),
+  `round-2-no-form.html` (locked).

--- a/docs/design/mockups/phase-6-team/teamhero-locked.md
+++ b/docs/design/mockups/phase-6-team/teamhero-locked.md
@@ -1,0 +1,50 @@
+# 6.C.d2 · TeamHero — LOCKED
+
+**Decision:** Category-forward identity, left-words / right-taped-polaroid.
+Locked 2026-05-28 (`6cd2-teamhero/round-1` identity → `round-2` assembled).
+
+## Composition
+
+- Two-column: **left words / right artefact**; stacks on mobile (artefact moves
+  **above** the headline per master-plan §5.4).
+- **Kicker** (MonoLabel, ink-muted): `KCVV Elewijt` (youth: `KCVV Elewijt · Jeugd`).
+- **Headline** (`<EditorialHeading>`, display-big black ~60px): the **category**
+  — `A-ploeg.` / `B-ploeg.` / `U13.` — with a jersey-deep italic period. The
+  category is the page's distinguishing identity (every team is KCVV Elewijt).
+- **Meta row** (MonoLabel pills): **division + season only.**
+  - **Coach dropped** — `staff[]` is unbounded and the only head-coach signal is
+    PSD `functionTitle` (`T1`/`Hoofdtrainer`, free-text, often null), so no
+    reliable single value for the hero. Coaches surface in the **Staff section**
+    with their function titles.
+  - Pills auto-hide when absent. Youth (no PSD division) shows the youth band
+    (`Bovenbouw`/`Middenbouw`/`Onderbouw`) + season.
+- **Tagline** (`team.tagline`): italic display **lead** under the meta;
+  auto-hides when empty.
+
+## Artefact (right column)
+
+- Taped **squad polaroid**: `border-2 ink` + `shadow-paper-md`, slight rotation
+  (~-1.5°), warm `<TapeStrip>` at top. Photo gets the **newsprint treatment**
+  (grayscale + grain) consistent with the player photo system (R9).
+- **Season ticket-stub** below: dashed-border (`border-2 border-dashed`), cream,
+  slight rotation (~+0.5°), `MonoLabel "Seizoen"` + `25/26` in display-big.
+- **No-`teamImage` fallback:** the canonical **`<JerseyShirt>`** illustration
+  (jersey-deep underprint + ink stripes) fills the same polaroid frame.
+
+## Cross-age
+
+Youth: category headline swaps (`U13.`), division/coach/standings absent →
+meta degrades to youth band + season; photo or JerseyShirt fallback as available.
+
+## NOT locked here
+
+StandingsTable, SquadGrid/PlayerCard, Staff cards, listing `/ploegen`. Exact
+polaroid rotation degrees + stub copy are implementation-tunable.
+
+## Cross-references
+
+- `detail-ia-locked.md` (6.C.d1), `data-reality-locked.md` (6.C.d0).
+- Artifacts: `6cd2-teamhero/round-1-teamhero-comparisons.html`,
+  `round-2-teamhero-states.html`.
+- Inherits `<JerseyShirt>` ([[project_jersey_illustration_vocabulary]]),
+  player photo system R9.

--- a/docs/plans/2026-04-27-redesign-master-design.md
+++ b/docs/plans/2026-04-27-redesign-master-design.md
@@ -482,17 +482,25 @@ Hero: `<EditorialHero variant="generic">` `Onze ploegen.` Body: `<TapedCardGrid 
 
 Existing `docs/prd/teams-landing-page.md` is superseded — restate in Phase 6.
 
+> **STATUS (2026-05-28) — direction locked (6.C).** Listing IS in Phase 6 scope. The uniform `<TapedCardGrid>` above is **rejected** — keep the A-team-featured **hierarchy** (A hero + B featured + youth directory), reskinned. See #1528 + the Phase 6 remainder decision record.
+
 ### 6.5 Team detail (`/ploegen/[slug]`)
 
 `<TeamHero>` — kicker (A-PLOEG / U21 / etc.), `<EditorialHeading>` team name, `<MonoLabelRow>` (classification, coach, season), right-column taped polaroid with team-photo or jersey illustration + `<TicketStub>SEIZOEN 25/26</TicketStub>`. Sections: `<StatsStrip>` season W/D/L + GF/GA, `<StandingsTable>` with this team highlighted, `<MatchScheduleTable>` upcoming + past, `<SquadGrid>` of `<PlayerCard>` instances (each composes `<TapedCard>` + `<PlayerFigure>` + name + position), staff section, `<SponsorsBlock>` filtered by team.
+
+> **STATUS (2026-05-28) — direction locked (6.C).** Composition trimmed to **Core + editorial, auto-hide empties**: TeamHero + StandingsTable + MatchSchedule + SquadGrid + staff + `team.body`/`trainingSchedule`/`contactInfo` when present. **Dropped:** standalone `<StatsStrip>` (redundant with the highlighted standings row) and **team-filtered `<SponsorsBlock>`** (sponsor docs don't reference teams — a **global** `<SponsorsBlock>` renders at the foot instead). Detail IA (tabs vs single-scroll) is parked for a 6.C.d1 visual A/B. See #1528.
 
 ### 6.6 Calendar (`/kalender`)
 
 Hero: `<EditorialHero variant="generic">` `Kalender.` Body: cream paper page with month-by-month sections. Each month: `<EditorialHeading size="display-md">April '26.</EditorialHeading>` followed by a `<DashedDivider>`-separated list of events — date column (mono), title column (display), location column (mono), tag column (`<MonoLabel>` for type). No card treatment — it's a tabular agenda. Filter row reskins `<FilterTabs>` (matches / events / training / supporter activities).
 
+> **STATUS (2026-05-28) — direction locked (6.D).** `/kalender` is **already built** as an interactive month/week/list widget + iCal subscribe; the tabular agenda above is one of two candidates. **Reskin-the-widget vs rebuild-to-this-agenda is parked for a 6.D.d1 visual A/B** (owner wants to see both side-by-side). Filters are **by type** — Wedstrijden + Clubevent + Supporters + Jeugdwerking + Andere — not matches/events/training/supporter (training has no standalone data source). Feed merges 3 sources: PSD matches + `event` docs + `articleType:event` articles. See #1528.
+
 ### 6.7 Events list + detail (`/events`, `/events/[slug]`)
 
 List: `<TapedCardGrid columns={3}>` of `<EventCard>` (composes `<TapedCard>` + landscape `<TapedFigure aspect="landscape-16-9">` cover image + date `<TicketStub>` overlay + title + location + `<MonoLabel>` tag). Detail: `<EditorialHero variant="event">` with date ticket-stub artefact paired with the event hero image at 16:9; body in `--container-prose` + inline `<TapedFigure>` photos for any in-line imagery + RSVP CTA + sponsor/credit footer. Event imagery is overwhelmingly 16:9 today and renders at native aspect inside the polaroid frame.
+
+> **STATUS (2026-05-28) — direction locked (6.E).** Route renamed **`/events` → `/evenementen`** (301 from `/events/*`). Detail uses a new **`<EventHero>` sibling**, NOT `<EditorialHero variant="event">` (per §5.4 sibling-per-surface lock). Schema gains **`location` + `eventType` enum** (Clubevent / Supportersactiviteit / Jeugdwerking / Andere) only — **no body PT, no RSVP**; external link stays the CTA, plus a per-event "Zet in agenda" (iCal) + "Andere events" grid. List is **upcoming-only**. The RSVP CTA + sponsor/credit footer above are dropped. `eventType` is also added to the `eventFact` block so `articleType:event` articles join the merged calendar/list feed. See #1528.
 
 ### 6.8 Sponsors (`/sponsors`)
 

--- a/docs/plans/2026-04-27-redesign-master-design.md
+++ b/docs/plans/2026-04-27-redesign-master-design.md
@@ -482,13 +482,13 @@ Hero: `<EditorialHero variant="generic">` `Onze ploegen.` Body: `<TapedCardGrid 
 
 Existing `docs/prd/teams-landing-page.md` is superseded — restate in Phase 6.
 
-> **STATUS (2026-05-28) — direction locked (6.C).** Listing IS in Phase 6 scope. The uniform `<TapedCardGrid>` above is **rejected** — keep the A-team-featured **hierarchy** (A hero + B featured + youth directory), reskinned. See #1528 + the Phase 6 remainder decision record.
+> **STATUS (2026-05-28) — direction locked (6.C).** Listing IS in Phase 6 scope. The uniform `<TapedCardGrid>` above is **rejected** — A and B are **paired mirrored flagships** (A jersey-deep, content-left/photo-right; B cream, mirrored — equal weight, not a hero/sub-feature hierarchy) + a youth directory grouped Bovenbouw/Middenbouw/Onderbouw, reskinned. See #1528 + `docs/design/mockups/phase-6-team/listing-locked.md`.
 
 ### 6.5 Team detail (`/ploegen/[slug]`)
 
 `<TeamHero>` — kicker (A-PLOEG / U21 / etc.), `<EditorialHeading>` team name, `<MonoLabelRow>` (classification, coach, season), right-column taped polaroid with team-photo or jersey illustration + `<TicketStub>SEIZOEN 25/26</TicketStub>`. Sections: `<StatsStrip>` season W/D/L + GF/GA, `<StandingsTable>` with this team highlighted, `<MatchScheduleTable>` upcoming + past, `<SquadGrid>` of `<PlayerCard>` instances (each composes `<TapedCard>` + `<PlayerFigure>` + name + position), staff section, `<SponsorsBlock>` filtered by team.
 
-> **STATUS (2026-05-28) — direction locked (6.C).** Composition trimmed to **Core + editorial, auto-hide empties**: TeamHero + StandingsTable + MatchSchedule + SquadGrid + staff + `team.body`/`trainingSchedule`/`contactInfo` when present. **Dropped:** standalone `<StatsStrip>` (redundant with the highlighted standings row) and **team-filtered `<SponsorsBlock>`** (sponsor docs don't reference teams — a **global** `<SponsorsBlock>` renders at the foot instead). Detail IA (tabs vs single-scroll) is parked for a 6.C.d1 visual A/B. See #1528.
+> **STATUS (2026-05-28) — direction locked (6.C).** Composition trimmed to **Core + editorial, auto-hide empties**: TeamHero + StandingsTable + MatchSchedule + SquadGrid + staff + `team.body`/`trainingSchedule`/`contactInfo` when present. **Dropped:** standalone `<StatsStrip>` (redundant with the highlighted standings row) and **team-filtered `<SponsorsBlock>`** (sponsor docs don't reference teams — a **global** `<SponsorsBlock>` renders at the foot instead). Detail IA locked to **single-scroll + sticky-nav** (visual A/B completed). See #1528 + `docs/design/mockups/phase-6-team/detail-ia-locked.md` + the PRD `docs/prd/redesign-phase-6c-team.md`.
 
 ### 6.6 Calendar (`/kalender`)
 

--- a/docs/prd/redesign-phase-6c-team.md
+++ b/docs/prd/redesign-phase-6c-team.md
@@ -146,7 +146,7 @@ Phase 1 (tracer: <TeamHero>)
 - [ ] Agenda row component (`components/team/TeamMatchRow/` or shared) — **responsive: A symmetric scoreboard (desktop ≥~640px) / B KCVV-centric column (mobile)**, one component + one breakpoint
 - [ ] Date stub; club crests (real PSD `home_team.logo`/`away_team.logo`; neutral placeholder fallback); centred score-or-time headline in the display font (kickoff time, no `vs`); competition caption (ink, one weight, no tag) inside the centre column under the score
 - [ ] **Outcome = flat colour underline on the score**, wider than the digits, climbing toward the "–": **win = `color-mix(jersey-deep 34%, cream)` · draw = none · loss = `color-mix(--color-alert 38%, cream)`** (brick). NOT a separate column; NOT `<HighlighterStroke>`.
-- [ ] Long team names: ellipsis + `title="<full name>"`. Mobile home/away = Lucide `house`/`bus` icon
+- [ ] Long team names: ellipsis + `title="<full name>"`. Mobile home/away = **Phosphor Fill** `House`/`Bus` (`weight="fill"`, via `@/lib/icons.redesign` — the redesign's canonical icon set; **not** Lucide)
 - [ ] `<TeamMatchesSection>` (teaser on the detail page): featured next match (jersey-deep filled card) + a few recent rows (same vocabulary) + **"Volledige kalender →"** linking to `/ploegen/[slug]/wedstrijden`
 - [ ] Section auto-hides when `bff.getMatches` empty. Stories: mid-season (W/D/L mix), season-start (all upcoming), empty. VR + unit tests
 
@@ -155,8 +155,10 @@ Phase 1 (tracer: <TeamHero>)
 - [ ] New route `apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx`; ISR like the detail page; `generateMetadata`
 - [ ] Renders the full season as a **month-grouped newspaper agenda** (display-big month headings, no rule beneath; agenda rows) ascending Aug→Jun
 - [ ] **Auto-scrolls to the next match on load** (`scrollIntoView`, `block:center`, `prefers-reduced-motion` safe)
+- [ ] **No next match (end / off-season):** render the full season and **skip auto-scroll** (or scroll to top) — never crash on a missing anchor
+- [ ] **`bff.getMatches` returns empty:** render a localized empty state (e.g. "Geen wedstrijden gepland") — **no 404, no redirect**
 - [ ] Handles a 40–50-fixture season; Beker/Oefen distinguished by the competition caption text
-- [ ] Playwright e2e smoke: route renders, next-match anchor present, console clean
+- [ ] Playwright e2e smoke: route renders + console clean; asserts the **empty-state UI** when there are no fixtures, and that **auto-scroll is skipped** when there is no next match
 
 #### `<TeamEditorial>` (body / training / contact)
 
@@ -236,4 +238,3 @@ Not a hard requirement (Phase 2 sub-issues are parallel-executable), but pragmat
 5. **Page assembly + e2e** ships last in Phase 2 — consumes everything above.
 6. **Phase 3 listing** after the detail page is live (shares `<TeamHero>`/crest vocabulary; flagship reuses the hero's jersey-deep treatment).
 7. **Phase 4 cleanup** rides after, once `rg` confirms no legacy consumers — separate-ship is the cleaner default (per Phase 6.A #1886).
-```

--- a/docs/prd/redesign-phase-6c-team.md
+++ b/docs/prd/redesign-phase-6c-team.md
@@ -1,9 +1,10 @@
 # PRD — Phase 6.C · Team Detail + Listing Redesign
 
-**Status:** ready for `/prd-to-issues`. All 7 design drills (6.C.d0 → 6.C.d6) locked 2026-05-28/29.
+**Status:** issues cut — #1938–#1947, milestone `redesign-retro-terrace-fanzine`. PR #1937 (draft until merge).
 **Authored:** 2026-05-29.
 **Owner:** @climacon.
 **Tracker:** #1528 (Phase 6 master).
+**Issues:** #1938 (tracer) · #1939–#1945 (detail) · #1946 (listing) · #1947 (cleanup). Dependencies wired via GitHub blockedBy.
 **Lock docs (authoritative for design decisions):** `docs/design/mockups/phase-6-team/*-locked.md` — `data-reality`, `detail-ia`, `teamhero`, `standings`, `squadgrid`, `staff`, `listing`. Do not re-derive in any sub-issue; quote the lock docs.
 **Decision record:** memory `project_phase_6cde_remainder_decisions` (direction + cross-surface deltas).
 **Master plan:** `docs/plans/2026-04-27-redesign-master-design.md` §6.4 (listing) + §6.5 (detail) — both carry status-notes pointing here.
@@ -58,22 +59,22 @@ Four phases. Each = one deployable unit, runnable tests, no broken state. **Mile
 
 ```text
 Phase 1: <TeamHero> live on /ploegen/[slug] — TRACER (new component + real Sanity wiring, legacy body below).
-         → feat(teams): <TeamHero> + tracer mount on /ploegen/[slug]
+         → #1938 feat(teams): <TeamHero> + tracer mount on /ploegen/[slug]
 
 Phase 2: Team-detail rebuild — parallel component sub-issues, then page assembly.
-         → feat(teams): <StandingsTable> (redesigned; KCVV row highlighted; no Vorm)
-         → feat(teams): <SquadGrid> + <PlayerCard> reskin (position-grouped; number disc)
-         → feat(teams): <TeamStaff> section (compact cards; functionTitle→label)
-         → feat(teams): match agenda row + <TeamMatchesSection> teaser
-         → feat(teams): /ploegen/[slug]/wedstrijden full-season agenda route (auto-scroll)
-         → feat(teams): <TeamEditorial> (body / trainingSchedule / contactInfo)
-         → feat(teams): /ploegen/[slug] page assembly (single-scroll + sticky-nav, auto-hide) + e2e + analytics
+         → #1939 feat(teams): <StandingsTable> (redesigned; KCVV row highlighted; no Vorm)
+         → #1940 feat(teams): <SquadGrid> + <PlayerCard> reskin (position-grouped; number disc)
+         → #1941 feat(teams): <TeamStaff> section (compact cards; functionTitle→label)
+         → #1942 feat(teams): match agenda row + <TeamMatchesSection> teaser
+         → #1943 feat(teams): /ploegen/[slug]/wedstrijden full-season agenda route (auto-scroll)
+         → #1944 feat(teams): <TeamEditorial> (body / trainingSchedule / contactInfo)
+         → #1945 feat(teams): /ploegen/[slug] page assembly (single-scroll + sticky-nav, auto-hide) + e2e + analytics
 
 Phase 3: Team-listing rebuild.
-         → feat(teams): <TeamFlagship> (A+B paired) + youth directory + /ploegen assembly + e2e
+         → #1946 feat(teams): <TeamFlagship> (A+B paired) + youth directory + /ploegen assembly + e2e
 
 Phase 4: Legacy cleanup + doc audit.
-         → chore(teams): retire legacy team components + CLAUDE.md + master-plan §6.4/6.5 closeout
+         → #1947 chore(teams): retire legacy team components + CLAUDE.md + master-plan §6.4/6.5 closeout
 ```
 
 **Dependency graph:**

--- a/docs/prd/redesign-phase-6c-team.md
+++ b/docs/prd/redesign-phase-6c-team.md
@@ -1,0 +1,236 @@
+# PRD — Phase 6.C · Team Detail + Listing Redesign
+
+**Status:** ready for `/prd-to-issues`. All 7 design drills (6.C.d0 → 6.C.d6) locked 2026-05-28/29.
+**Authored:** 2026-05-29.
+**Owner:** @climacon.
+**Tracker:** #1528 (Phase 6 master).
+**Lock docs (authoritative for design decisions):** `docs/design/mockups/phase-6-team/*-locked.md` — `data-reality`, `detail-ia`, `teamhero`, `standings`, `squadgrid`, `staff`, `listing`. Do not re-derive in any sub-issue; quote the lock docs.
+**Decision record:** memory `project_phase_6cde_remainder_decisions` (direction + cross-surface deltas).
+**Master plan:** `docs/plans/2026-04-27-redesign-master-design.md` §6.4 (listing) + §6.5 (detail) — both carry status-notes pointing here.
+**Precedent:** `docs/prd/redesign-phase-6b-match-detail.md` (structure, AC style, analytics + VR + CLAUDE.md conventions).
+**Drill artefacts:** `docs/design/mockups/phase-6-team/6cd{1..6}-*/` — comparison HTML per drill. Historical record; lock docs supersede.
+
+---
+
+## 1. Problem statement
+
+`/ploegen` (team listing) and `/ploegen/[slug]` (team detail) ship entirely in pre-redesign vocabulary — the detail page is a tabbed `<TeamDetail>` (Info / Spelers / Wedstrijden / Klassement) with a legacy `InteriorPageHero` and a `<TeamStandings>` table that uses **banned outcome colours** (green/yellow/red W-D-L badges), while the listing renders `InteriorPageHero` + `<TeamFeaturedCard>` + `<YouthTeamsDirectory>`. Both diverge from the retro-terrace-fanzine system locked across Phases 0–6.B. The detail page is also the most variant-dense surface in the redesign (A-team with full data → a U6 with only a squad), so it needs an IA that degrades gracefully. Phase 6.C rebuilds both surfaces to the locked single-scroll + sticky-nav composition, introduces a full-season match agenda on its own route, and aligns the squad/standings/staff to the design system — with **no new BFF endpoints, no new Effect schemas, no new editorial backlog beyond fields the `team` doc already has**.
+
+---
+
+## 2. Scope
+
+### In scope (packages touched)
+
+- **`apps/web`** — the whole of Phase 6.C lives here. No `apps/api`, no `packages/api-contract`, no `apps/studio` changes (all data already exists; see §6).
+  - **New route** `src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx` — full-season month-grouped agenda, auto-scroll to the next match on load. Uses the existing `bff.getMatches(psdId)`.
+  - **Rebuild** `src/app/(main)/ploegen/[slug]/page.tsx` to the locked single-scroll composition (sticky section-nav; sections auto-hide on empty data).
+  - **Rebuild** `src/app/(main)/ploegen/page.tsx` to the A+B paired-flagship + youth-directory listing.
+  - **New components:** `<TeamHero>`, `<StandingsTable>` (redesigned, replaces legacy `<TeamStandings>`), `<SquadGrid>`, the match **agenda row + `<TeamMatchesSection>` teaser + full-schedule view**, `<TeamFlagship>` (listing A/B block), reskinned `<PlayerCard>`, reskinned staff card, reskinned youth-directory.
+  - **Reuse:** already-reskinned `<MatchResultRow>` / `<MatchTeaser>` (Phase 6.B) where the agenda or schedule needs a match row; `<TapedCard>`, `<MonoLabel>`, `<EditorialHeading>`, `<StripedSeam>`, `<PlayerFigure>`, `<JerseyShirt>`, `<TapedFigure>`, `<SponsorsBlock>` (global), `<FilterTabs>`.
+  - **Retire (Phase 4 cleanup):** legacy `<TeamDetail>`, `<TeamStandings>`, `<TeamSchedule>`, `<TeamRoster>`, `<StaffCard>`, `<TeamOverview>`, `<TeamCard>`, `<TeamFeaturedCard>`, `<YouthTeamsDirectory>` once no consumers remain.
+
+### Out of scope — explicit, named
+
+- **Team-filtered sponsors.** Sponsor docs don't reference teams; the detail page renders the **global** `<SponsorsBlock>` at the foot. No sponsor-schema work. (Per `listing`/decision record.)
+- **Coach in the TeamHero.** Dropped — `staff[]` is unbounded and the only head-coach signal (`functionTitle` = `T1`/`Hoofdtrainer`, free-text, often null) is unreliable. Coaches appear in the Staff section only.
+- **Dames / women's team.** No such team exists; the listing's senior side is A-ploeg + B-ploeg only.
+- **Standings form (Vorm) column.** `RankingEntry.form` is optional and not populated for the other teams in the division — dropped. The win/draw/loss colour language applies to the **matches agenda only**, not standings.
+- **`StatsStrip` on the detail page.** Redundant with the team's own highlighted standings row — dropped (matches the lock).
+- **`getStatistics` / any new BFF endpoint.** The team's ranking row covers W/D/L + GF/GA. No statistics endpoint consumed.
+- **Youth match/standings data sourcing.** Where PSD returns empty ranking/matches for a youth team, those sections auto-hide. No effort to source youth competitive data.
+- **Player profile content** (`/spelers/[slug]`) — Phase 6.A, shipped. PlayerCard only links to it.
+- **6.E events / 6.D kalender** — separate re-plans (sequence: this 6.C, then 6.E, then 6.D).
+
+---
+
+## 3. Tracer bullet
+
+**Phase 1 = `<TeamHero>` rendered live on `/ploegen/[slug]` from real Sanity data, above the existing (legacy) page body.** Mixed-state is acceptable per master plan §7.
+
+This is the thinnest slice that crosses every layer the redesign actually touches: a new design-system component → the `(main)/ploegen/[slug]/page.tsx` server component → `TeamRepository.findBySlug` → Sanity. It proves the sibling-per-surface hero pattern wires onto a team route with real data (name → category headline, division/season meta, `teamImage` → newsprint polaroid, `tagline` → lead, **no-photo → `<JerseyShirt>` fallback**) before any of the heavier sections are built. No data-layer change, no caching change, legacy tabs still render below it until Phase 2 rebuilds the shell.
+
+---
+
+## 4. Phases
+
+Four phases. Each = one deployable unit, runnable tests, no broken state. **Milestone:** `redesign-retro-terrace-fanzine`.
+
+```text
+Phase 1: <TeamHero> live on /ploegen/[slug] — TRACER (new component + real Sanity wiring, legacy body below).
+         → feat(teams): <TeamHero> + tracer mount on /ploegen/[slug]
+
+Phase 2: Team-detail rebuild — parallel component sub-issues, then page assembly.
+         → feat(teams): <StandingsTable> (redesigned; KCVV row highlighted; no Vorm)
+         → feat(teams): <SquadGrid> + <PlayerCard> reskin (position-grouped; number disc)
+         → feat(teams): <TeamStaff> section (compact cards; functionTitle→label)
+         → feat(teams): match agenda row + <TeamMatchesSection> teaser
+         → feat(teams): /ploegen/[slug]/wedstrijden full-season agenda route (auto-scroll)
+         → feat(teams): <TeamEditorial> (body / trainingSchedule / contactInfo)
+         → feat(teams): /ploegen/[slug] page assembly (single-scroll + sticky-nav, auto-hide) + e2e + analytics
+
+Phase 3: Team-listing rebuild.
+         → feat(teams): <TeamFlagship> (A+B paired) + youth directory + /ploegen assembly + e2e
+
+Phase 4: Legacy cleanup + doc audit.
+         → chore(teams): retire legacy team components + CLAUDE.md + master-plan §6.4/6.5 closeout
+```
+
+**Dependency graph:**
+
+```text
+Phase 1 (tracer: <TeamHero>)
+   └─ informs → Phase 2 components (all independent; parallel after the agenda-row settles)
+        ├─ <StandingsTable>
+        ├─ <SquadGrid> + <PlayerCard>
+        ├─ <TeamStaff>
+        ├─ agenda row ──┬─ <TeamMatchesSection> teaser
+        │               └─ /ploegen/[slug]/wedstrijden route
+        ├─ <TeamEditorial>
+        └─ page assembly + e2e  ← consumes all Phase 2 components
+              ↓
+        Phase 3 (listing: <TeamFlagship> + youth directory + /ploegen assembly)
+              ↓
+        Phase 4 (cleanup — retire legacy once no consumers remain)
+```
+
+---
+
+## 5. Acceptance criteria per phase
+
+### Phase 1 — `<TeamHero>` tracer
+
+- [ ] `<TeamHero>` at `apps/web/src/components/team/TeamHero/` (`.tsx`, `.stories.tsx`, `.test.tsx`, `index.ts`); story `Features/Teams/TeamHero`, meta tagged `vr`
+- [ ] Category-forward: kicker `KCVV Elewijt` (`· Jeugd` for youth) + display-big headline = category (`A-ploeg.` / `U13.`) with jersey-deep italic period
+- [ ] Meta row (MonoLabel pills): **division + season only**; pills auto-hide when absent; youth shows the youth band (Bovenbouw/Middenbouw/Onderbouw) + season
+- [ ] `tagline` renders as italic display lead, auto-hides when empty
+- [ ] Right artefact: taped squad polaroid (`<TapedFigure>` newsprint treatment) + dashed season ticket-stub; **no-`teamImage` → `<JerseyShirt>` fallback** in the same frame
+- [ ] Two-column desktop; mobile stacks with the artefact above the headline (§5.4)
+- [ ] Mounted at the top of `apps/web/src/app/(main)/ploegen/[slug]/page.tsx` using existing `TeamRepository.findBySlug` data; legacy body still renders below (temporary mixed state)
+- [ ] Stories cover: A-team (photo), no-photo (JerseyShirt), youth (degraded meta)
+- [ ] VR baselines captured + committed; unit tests cover headline/meta/fallback branches
+- [ ] `pnpm --filter @kcvv/web check-all` passes
+
+### Phase 2 — Team-detail rebuild
+
+#### `<StandingsTable>` (redesigned)
+
+- [ ] New component `apps/web/src/components/team/StandingsTable/` (replaces legacy `<TeamStandings>`); story `Features/Teams/StandingsTable`, `vr`
+- [ ] Classic retro table: mono uppercase headers, `border-b-2 ink` header rule, hairline row rules; columns `# · Ploeg · M · W · G · V · +/- · Ptn`
+- [ ] KCVV row: `color-mix(jersey-deep 12%, cream)` tint + `inset 3px 0 jersey-deep` left accent + non-italic bold name
+- [ ] Small neutral crest before each team name (real PSD `team_logo`; neutral placeholder fallback)
+- [ ] **No Vorm column.** No green/yellow/red badges.
+- [ ] Mobile: drop `W · G · V`
+- [ ] Section auto-hides when `bff.getRanking` returns empty (most youth)
+- [ ] Stories: full division (KCVV mid-table), empty (auto-hide). VR baselines. Unit tests for the highlight + auto-hide branch
+
+#### `<SquadGrid>` + `<PlayerCard>` reskin
+
+- [ ] `<SquadGrid>` at `components/team/SquadGrid/`; `<PlayerCard>` reskin at `components/player/PlayerCard/` (or `components/team/`); stories `vr`
+- [ ] Position-grouped (Doelmannen / Verdedigers / Middenvelders / Aanvallers) from `player.position || positionPsd`; mono group headers + hairline rule
+- [ ] PlayerCard = `<TapedCard>` + `<PlayerFigure>` photo (3:4 newsprint) with **jersey-deep number disc overlaid top-left** + name (first semibold + last italic) + position; whole card links to `/spelers/[slug]`; press-down hover
+- [ ] No-`psdImage` → `<PlayerFigure>` illustration fallback; minors reuse PlayerFigure's locked treatment
+- [ ] Stories cover: photo, illustration-fallback, a full position-grouped grid. VR baselines. Unit tests
+
+#### `<TeamStaff>` section
+
+- [ ] New section component (reskins/retires legacy `<StaffCard>`); story `vr`
+- [ ] Compact centred cards: round photo (newsprint) **or monogram fallback** + name + function
+- [ ] Function = `staffMember.functionTitle` rendered readable via a code→label map (`T1→Hoofdtrainer`, `T2→Assistent-trainer`, `TK→Keeperstrainer`, `TVJO→Jeugdcoördinator`); pass through already-readable values; **fall back to the role bucket** (`Trainer`/`Afgevaardigde`) when null
+- [ ] Section auto-hides when `staff` empty. Stories: with photos, with monograms. VR + unit tests
+
+#### Match agenda row + `<TeamMatchesSection>` teaser
+
+- [ ] Agenda row component (`components/team/TeamMatchRow/` or shared) — **responsive: A symmetric scoreboard (desktop ≥~640px) / B KCVV-centric column (mobile)**, one component + one breakpoint
+- [ ] Date stub; club crests (real PSD `home_team.logo`/`away_team.logo`; neutral placeholder fallback); centred score-or-time headline in the display font (kickoff time, no `vs`); competition caption (ink, one weight, no tag) inside the centre column under the score
+- [ ] **Outcome = flat colour underline on the score**, wider than the digits, climbing toward the "–": **win = `color-mix(jersey-deep 34%, cream)` · draw = none · loss = `color-mix(--color-alert 38%, cream)`** (brick). NOT a separate column; NOT `<HighlighterStroke>`.
+- [ ] Long team names: ellipsis + `title="<full name>"`. Mobile home/away = Lucide `house`/`bus` icon
+- [ ] `<TeamMatchesSection>` (teaser on the detail page): featured next match (jersey-deep filled card) + a few recent rows (same vocabulary) + **"Volledige kalender →"** linking to `/ploegen/[slug]/wedstrijden`
+- [ ] Section auto-hides when `bff.getMatches` empty. Stories: mid-season (W/D/L mix), season-start (all upcoming), empty. VR + unit tests
+
+#### `/ploegen/[slug]/wedstrijden` full-schedule route
+
+- [ ] New route `apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx`; ISR like the detail page; `generateMetadata`
+- [ ] Renders the full season as a **month-grouped newspaper agenda** (display-big month headings, no rule beneath; agenda rows) ascending Aug→Jun
+- [ ] **Auto-scrolls to the next match on load** (`scrollIntoView`, `block:center`, `prefers-reduced-motion` safe)
+- [ ] Handles a 40–50-fixture season; Beker/Oefen distinguished by the competition caption text
+- [ ] Playwright e2e smoke: route renders, next-match anchor present, console clean
+
+#### `<TeamEditorial>` (body / training / contact)
+
+- [ ] Renders `team.body` (Portable Text) via a prose serializer, `team.trainingSchedule[]` (day/time/location/type) as a compact list/table, `team.contactInfo` (PT); each block auto-hides when empty
+- [ ] Uses article-prose primitives (`<EditorialHeading>` subheads + prose width); no new PT block types. Story + unit test for the empty/auto-hide path
+
+#### `/ploegen/[slug]` page assembly + e2e
+
+- [ ] Page rewired to locked composition: SiteHeader → `<MatchStripSlot>` (top, per the /spelers + /wedstrijd opt-in) → `<TeamHero>` → sticky **section-nav** → `<StandingsTable>` → `<TeamMatchesSection>` → `<SquadGrid>` → `<TeamStaff>` → `<TeamEditorial>` → global `<SponsorsBlock>` → footer; `<StripedSeam>` between sections
+- [ ] Sticky section-nav lists only sections that render (auto-hide aware); native anchors
+- [ ] Every non-hero section auto-hides on empty data → a U6 page = hero + squad + staff
+- [ ] Legacy tabbed `<TeamDetail>` consumption removed (component retired in Phase 4)
+- [ ] `generateMetadata` + `<JsonLd>` (`SportsTeam` / breadcrumb per existing builder) preserved
+- [ ] Analytics: `team_detail_view` page-view on mount; `team_standings_in_view` / `team_squad_in_view` / `team_matches_in_view` intersection events (Phase 6.A `<TrackInView>` pattern); mount trackers only when the section renders
+- [ ] GTM regex: extend the existing `responsibility_|search_|…|match_` regex to include `team_` (CLAUDE.md analytics-checklist line + manual GTM trigger change documented in PR body)
+- [ ] Playwright e2e for `/ploegen/[slug]` passes (h1 visible, no broken images, console clean); `pnpm --filter @kcvv/web check-all` + `run test:e2e` pass
+
+### Phase 3 — Team-listing rebuild
+
+- [ ] `<TeamFlagship>` component (A+B paired): A = jersey-deep block (content left / photo right); B = same block **mirrored** (photo left / content right) in **cream**; equal block dims; story `vr`
+- [ ] `apps/web/src/app/(main)/ploegen/page.tsx` rebuilt: editorial page-header (`Onze ploegen.`) → A flagship → B flagship (larger gap between) → youth directory grouped **Bovenbouw / Middenbouw / Onderbouw** (compact crest + age-code cards) → footer
+- [ ] Youth directory reskinned (retires `<YouthTeamsDirectory>`); each card links to its detail
+- [ ] No Dames team; squad count omitted unless reliably available
+- [ ] Uses existing `TeamRepository.findAllForLanding()` data shape (extend the VM only if a needed field is missing — flag as a discovered unknown, don't pre-add)
+- [ ] Analytics `team_list_view` page-view; Playwright e2e for `/ploegen`; VR baselines for `<TeamFlagship>`
+- [ ] `pnpm --filter @kcvv/web check-all` passes
+
+### Phase 4 — Cleanup + doc audit
+
+- [ ] Retire (delete file + tests + stories + barrel exports, `rg` confirms no consumers): `<TeamDetail>`, `<TeamStandings>`, `<TeamSchedule>`, `<TeamRoster>`, `<StaffCard>`, `<TeamOverview>`, `<TeamCard>`, `<TeamFeaturedCard>`, `<YouthTeamsDirectory>`
+- [ ] `apps/web/CLAUDE.md` "Redesign primitives (Phase 0+)" updated with the new team components
+- [ ] Master plan §6.4 + §6.5 status-notes updated to "shipped"; decision-record memory updated
+- [ ] `pnpm --filter @kcvv/web check-all` passes
+
+---
+
+## 6. Effect Schema / api-contract changes
+
+**None.** Phase 6.C is `apps/web`-only. All data already flows: Sanity `team` (name, slug, age, division/divisionFull, season, tagline, body, contactInfo, teamImage, trainingSchedule, `players[]→player`, `staff[]→staffMember`) via `TeamRepository`; BFF `getRanking(psdId)→RankingEntry[]` and `getMatches(psdId)→Match[]` (both already consumed by the current detail page). The matches outcome underline reuses existing tokens `--color-jersey-deep` + `--color-alert` (#b84a3a, already in `globals.css`) — **no new token**. The new `/ploegen/[slug]/wedstrijden` route is a Next.js page reusing `bff.getMatches`, not an api-contract change.
+
+**Documented palette exception:** the matches outcome language (win jersey-deep / draw none / loss brick) is a deliberate, single exception to the redesign's "no outcome colours / no loss-red" lock — it applies to the matches agenda only (standings has no form indicator). `--color-alert` is a muted retro terracotta, not bright red.
+
+---
+
+## 7. Open questions
+
+Not blockers. Resolve via tracer feedback, audit at PR time, or owner direction.
+
+- [ ] **Club crest coverage/quality.** Standings + agenda rows want real PSD logos (`RankingEntry.team_logo?`, `MatchTeam.logo`). Coverage may be partial. **Resolved by:** implementer renders with real data; neutral monogram/placeholder fallback already specced.
+- [ ] **`functionTitle` value set.** The code→label map assumes `T1/T2/TK/TVJO` + readable strings. Live staff data may contain other codes. **Resolved by:** inspect live staff at impl; unmapped values pass through verbatim, role-bucket fallback covers null.
+- [ ] **PT serializer for `team.body` / `team.contactInfo`.** Reuse the article `ArticleBody` serializers or a lighter team-local renderer? **Resolved by:** implementer audits the existing serializer's coupling; default to reusing it.
+- [ ] **Extra senior teams (veterans).** Does the club have a senior team beyond A/B that needs a flagship/row slot? **Resolved by:** owner / `TeamRepository` data at Phase 3.
+- [ ] **Staging seed.** Editorial team fields (tagline/body/trainingSchedule/contactInfo) are manual — a representative seeded team (full data + a no-photo + a youth) is likely needed to VR/e2e the editorial + fallback paths. **Resolved by:** author + run a team seed in Phase 2 page-assembly issue (per Phase 6.A seed precedent), or confirm staging already has one.
+- [ ] **`<TeamHero>` mobile artefact-above order** — straightforward; sanity-check at impl.
+
+---
+
+## 8. Discovered unknowns
+
+Filled during implementation.
+
+```text
+- [date] Discovered: ... → [new issue #N / PRD updated / resolved inline]
+```
+
+---
+
+## 9. Implementation order suggestion
+
+Not a hard requirement (Phase 2 sub-issues are parallel-executable), but pragmatic for one-engineer execution:
+
+1. **Phase 1** (TeamHero tracer) ships first — proves the new-component + Sanity wiring.
+2. **Agenda row** ships next within Phase 2 — it's the most-drilled, highest-risk component and gates both `<TeamMatchesSection>` and the `/wedstrijden` route.
+3. **`<StandingsTable>` + `<SquadGrid>`/`<PlayerCard>` + `<TeamStaff>` + `<TeamEditorial>`** ship in parallel — independent, each its own story/test suite.
+4. **`/ploegen/[slug]/wedstrijden` route** ships once the agenda row lands.
+5. **Page assembly + e2e** ships last in Phase 2 — consumes everything above.
+6. **Phase 3 listing** after the detail page is live (shares `<TeamHero>`/crest vocabulary; flagship reuses the hero's jersey-deep treatment).
+7. **Phase 4 cleanup** rides after, once `rg` confirms no legacy consumers — separate-ship is the cleaner default (per Phase 6.A #1886).
+```

--- a/docs/prd/redesign-phase-6c-team.md
+++ b/docs/prd/redesign-phase-6c-team.md
@@ -23,7 +23,8 @@
 
 ### In scope (packages touched)
 
-- **`apps/web`** — the whole of Phase 6.C lives here. No `apps/api`, no `packages/api-contract`, no `apps/studio` changes (all data already exists; see §6).
+- **`apps/web`** — the bulk of Phase 6.C.
+- **`packages/sanity-schemas`** — **one additive delta:** add the existing `pullquote` Portable-Text decorator (introduced for `player.bio` in 6.A) to `team.body` block marks, so `<TeamEditorial>` can render an optional styled coach/team pull-quote ("Het verhaal"). Additive; no migration; reuses the 6.A web-side serializer. No `apps/api` / `packages/api-contract` / `apps/studio` changes.
   - **New route** `src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx` — full-season month-grouped agenda, auto-scroll to the next match on load. Uses the existing `bff.getMatches(psdId)`.
   - **Rebuild** `src/app/(main)/ploegen/[slug]/page.tsx` to the locked single-scroll composition (sticky section-nav; sections auto-hide on empty data).
   - **Rebuild** `src/app/(main)/ploegen/page.tsx` to the A+B paired-flagship + youth-directory listing.
@@ -159,8 +160,9 @@ Phase 1 (tracer: <TeamHero>)
 
 #### `<TeamEditorial>` (body / training / contact)
 
-- [ ] Renders `team.body` (Portable Text) via a prose serializer, `team.trainingSchedule[]` (day/time/location/type) as a compact list/table, `team.contactInfo` (PT); each block auto-hides when empty
-- [ ] Uses article-prose primitives (`<EditorialHeading>` subheads + prose width); no new PT block types. Story + unit test for the empty/auto-hide path
+- [ ] **Schema (additive):** add the 6.A `pullquote` decorator to `team.body` block marks in `packages/sanity-schemas/src/team.ts` (reuse the existing decorator + web serializer; no migration)
+- [ ] Renders `team.body` (Portable Text) via a prose serializer **incl. the `pullquote` decorator → a styled "Het verhaal" pull-quote** (reuse the 6.A `<BioBlock>` serializer), `team.trainingSchedule[]` (day/time/location/type) as a compact list/table, `team.contactInfo` (PT); each block auto-hides when empty
+- [ ] Uses article-prose primitives (`<EditorialHeading>` subheads + prose width); no new PT block types beyond reusing the pullquote decorator. Story + unit test for the empty/auto-hide path + the pull-quote render
 
 #### `/ploegen/[slug]` page assembly + e2e
 
@@ -194,7 +196,7 @@ Phase 1 (tracer: <TeamHero>)
 
 ## 6. Effect Schema / api-contract changes
 
-**None.** Phase 6.C is `apps/web`-only. All data already flows: Sanity `team` (name, slug, age, division/divisionFull, season, tagline, body, contactInfo, teamImage, trainingSchedule, `players[]→player`, `staff[]→staffMember`) via `TeamRepository`; BFF `getRanking(psdId)→RankingEntry[]` and `getMatches(psdId)→Match[]` (both already consumed by the current detail page). The matches outcome underline reuses existing tokens `--color-jersey-deep` + `--color-alert` (#b84a3a, already in `globals.css`) — **no new token**. The new `/ploegen/[slug]/wedstrijden` route is a Next.js page reusing `bff.getMatches`, not an api-contract change.
+**One additive Sanity-schema delta** (the `pullquote` decorator on `team.body`, reused verbatim from 6.A's `player.bio` — same decorator + same `<BioBlock>` serializer; additive, no migration). No api-contract / endpoint changes. Everything else already flows: Sanity `team` (name, slug, age, division/divisionFull, season, tagline, body, contactInfo, teamImage, trainingSchedule, `players[]→player`, `staff[]→staffMember`) via `TeamRepository`; BFF `getRanking(psdId)→RankingEntry[]` and `getMatches(psdId)→Match[]` (both already consumed by the current detail page). The matches outcome underline reuses existing tokens `--color-jersey-deep` + `--color-alert` (#b84a3a, already in `globals.css`) — **no new token**. The new `/ploegen/[slug]/wedstrijden` route is a Next.js page reusing `bff.getMatches`, not an api-contract change.
 
 **Documented palette exception:** the matches outcome language (win jersey-deep / draw none / loss brick) is a deliberate, single exception to the redesign's "no outcome colours / no loss-red" lock — it applies to the matches agenda only (standings has no form indicator). `--color-alert` is a muted retro terracotta, not bright red.
 


### PR DESCRIPTION
**Draft** — kept as draft so the Phase 6.C issue numbers (from `/prd-to-issues`) can be linked into the PRD before merge.

Docs-only. Closes the design phase for **6.C (team detail + listing)** and records the broader Phase 6 remainder direction.

## Contents
- **Decision record** for the Phase 6 remainder (6.C/6.E/6.D) — master-plan §6.4–6.7 status-notes.
- **7 locked design drills** for 6.C: `docs/design/mockups/phase-6-team/*-locked.md` (data-reality, detail-IA + matches agenda, TeamHero, StandingsTable, SquadGrid/PlayerCard, Staff, listing) + the drill comparison HTML (`6cd{1..6}-*/`).
- **PRD:** `docs/prd/redesign-phase-6c-team.md` (4-phase build plan; `apps/web`-only, no api-contract change).

## Notable locked decisions
- Single-scroll + sticky-nav detail IA; new `/ploegen/[slug]/wedstrijden` full-season agenda route (auto-scroll to next).
- Matches outcome language = win jersey-deep / draw none / **loss brick** (`--color-alert`) flat underline — a deliberate, documented exception to "no outcome red".
- Coach dropped from hero; global SponsorsBlock (no team-filtered sponsors); StandingsTable without a Vorm column; no Dames team; A+B paired mirrored flagships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added extensive Phase 6.C design specs and locked decisions for team listing (/ploegen) and team detail (/ploegen/[slug]), including PRD and planning updates.
  * Added 20+ static mockup pages demonstrating IA/layout variants (team hero, standings, matches agenda, squad grid, staff, listings) and multiple round-specific explorations.
  * Documented finalised behaviors (single-scroll + sticky nav, match agenda rules, auto-hide on empty data, visual row/crest fallbacks).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soniCaH/www.kcvvelewijt.be/pull/1937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->