### PR TITLE
feat(teams): /ploegen/[slug]/wedstrijden full-season agenda route (#1943)

### DIFF
--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/AgendaScrollToNext.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/AgendaScrollToNext.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface AgendaScrollToNextProps {
+  /** data-next-match attribute value to find in the DOM */
+  nextMatchId: number | null;
+}
+
+/**
+ * Invisible client component that auto-scrolls to the next match on mount.
+ * Runs only when nextMatchId is non-null. Respects prefers-reduced-motion.
+ */
+export function AgendaScrollToNext({ nextMatchId }: AgendaScrollToNextProps) {
+  useEffect(() => {
+    if (nextMatchId === null) return;
+    const anchor = document.querySelector(`[data-match-id="${nextMatchId}"]`);
+    if (!anchor) return;
+    const prefersReduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    anchor.scrollIntoView({
+      behavior: prefersReduced ? "instant" : "smooth",
+      block: "center",
+    });
+  }, [nextMatchId]);
+
+  return null;
+}

--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
@@ -1,0 +1,194 @@
+import { Effect } from "effect";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { DateTime } from "luxon";
+import { runPromise } from "@/lib/effect/runtime";
+import { SITE_CONFIG } from "@/lib/constants";
+import { BffService } from "@/lib/effect/services/BffService";
+import type { Match } from "@kcvv/api-contract";
+import { TeamRepository } from "@/lib/repositories/team.repository";
+import { TeamAgendaRow } from "@/components/team/TeamMatchesSection/TeamAgendaRow";
+import { EditorialHeading } from "@/components/design-system/EditorialHeading";
+import { FooterSafeArea } from "@/components/design-system";
+import { transformMatchToSchedule } from "../utils";
+import type { ScheduleMatch } from "@/components/match/types";
+import { AgendaScrollToNext } from "./AgendaScrollToNext";
+
+interface WedstrijdenPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return [];
+}
+
+export async function generateMetadata({
+  params,
+}: WedstrijdenPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  try {
+    const team = await runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TeamRepository;
+        return yield* repo.findBySlug(slug);
+      }),
+    );
+    if (!team) return { title: "Team niet gevonden | KCVV Elewijt" };
+    return {
+      title: `Wedstrijden — ${team.name} | KCVV Elewijt`,
+      description: `Volledig wedstrijdschema van ${team.name}.`,
+      alternates: {
+        canonical: `${SITE_CONFIG.siteUrl}/ploegen/${slug}/wedstrijden`,
+      },
+    };
+  } catch {
+    return { title: "Wedstrijden | KCVV Elewijt" };
+  }
+}
+
+interface MonthGroup {
+  label: string;
+  monthName: string;
+  yearSuffix: string;
+  matches: ScheduleMatch[];
+}
+
+function groupByMonth(matches: ScheduleMatch[]): MonthGroup[] {
+  const sorted = [...matches].sort(
+    (a, b) => a.date.getTime() - b.date.getTime(),
+  );
+  const grouped = new Map<string, MonthGroup>();
+
+  for (const m of sorted) {
+    const dt = DateTime.fromJSDate(m.date).setLocale("nl");
+    const key = dt.toFormat("yyyy-MM");
+    if (!grouped.has(key)) {
+      const monthName =
+        dt.toFormat("LLLL").charAt(0).toUpperCase() +
+        dt.toFormat("LLLL").slice(1);
+      const yearSuffix = `'${dt.toFormat("yy")}`;
+      grouped.set(key, {
+        label: `${monthName} ${yearSuffix}.`,
+        monthName,
+        yearSuffix,
+        matches: [],
+      });
+    }
+    grouped.get(key)!.matches.push(m);
+  }
+
+  return Array.from(grouped.values());
+}
+
+function findNextMatch(
+  matches: ScheduleMatch[],
+  now: Date,
+): ScheduleMatch | undefined {
+  return matches
+    .filter((m) => m.status === "scheduled" && m.date >= now)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())[0];
+}
+
+export default async function WedstrijdenPage({
+  params,
+}: WedstrijdenPageProps) {
+  const { slug } = await params;
+
+  const team = await runPromise(
+    Effect.gen(function* () {
+      const repo = yield* TeamRepository;
+      return yield* repo.findBySlug(slug);
+    }),
+  );
+
+  if (!team) notFound();
+
+  const psdTeamId = team.psdId ? parseInt(team.psdId, 10) : NaN;
+
+  let rawMatches: readonly Match[] = [];
+  if (Number.isFinite(psdTeamId) && psdTeamId > 0) {
+    rawMatches = await runPromise(
+      Effect.gen(function* () {
+        const bff = yield* BffService;
+        return yield* bff
+          .getMatches(psdTeamId)
+          .pipe(Effect.catchAll(() => Effect.succeed([] as readonly Match[])));
+      }),
+    );
+  }
+
+  const matches = rawMatches.map(transformMatchToSchedule);
+  const monthGroups = groupByMonth(matches);
+  const now = new Date();
+  const nextMatch = findNextMatch(matches, now);
+
+  return (
+    <>
+      <AgendaScrollToNext nextMatchId={nextMatch?.id ?? null} />
+
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:py-12">
+        {/* Page header */}
+        <div className="mb-8">
+          <p className="text-ink-muted font-mono text-xs tracking-widest uppercase">
+            {team.name}
+          </p>
+          <EditorialHeading
+            level={1}
+            size="display-xl"
+            emphasis={{ text: "." }}
+          >
+            Wedstrijden
+          </EditorialHeading>
+        </div>
+
+        {matches.length === 0 ? (
+          <p
+            data-testid="wedstrijden-empty"
+            className="text-ink-muted font-mono text-sm tracking-wider uppercase"
+          >
+            Geen wedstrijden gepland.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-10">
+            {monthGroups.map((group) => (
+              <section key={group.label} aria-label={group.label}>
+                {/* Newspaper month heading — display-big, no rule beneath */}
+                <h2 className="font-display-big text-ink mb-4 text-[length:var(--text-display-xl)] leading-[var(--text-display-xl--lh)] tracking-tight">
+                  {group.monthName}{" "}
+                  <em className="text-jersey-deep italic">
+                    {group.yearSuffix}
+                  </em>
+                  .
+                </h2>
+
+                <div className="flex flex-col gap-2">
+                  {group.matches.map((m) => (
+                    <div
+                      key={m.id}
+                      data-match-id={m.id}
+                      data-testid={
+                        nextMatch?.id === m.id
+                          ? "wedstrijden-next-match"
+                          : undefined
+                      }
+                    >
+                      <TeamAgendaRow
+                        match={m}
+                        kcvvTeamId={psdTeamId}
+                        featured={nextMatch?.id === m.id}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <FooterSafeArea />
+    </>
+  );
+}
+
+export const revalidate = 3600;

--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
@@ -3,13 +3,15 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { DateTime } from "luxon";
 import { runPromise } from "@/lib/effect/runtime";
-import { SITE_CONFIG } from "@/lib/constants";
+import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { BffService } from "@/lib/effect/services/BffService";
 import type { Match } from "@kcvv/api-contract";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import { TeamAgendaRow } from "@/components/team/TeamMatchesSection/TeamAgendaRow";
 import { EditorialHeading } from "@/components/design-system/EditorialHeading";
 import { FooterSafeArea } from "@/components/design-system";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { buildBreadcrumbJsonLd, buildSportsTeamJsonLd } from "@/lib/seo/jsonld";
 import { transformMatchToSchedule } from "../utils";
 import type { ScheduleMatch } from "@/components/match/types";
 import { AgendaScrollToNext } from "./AgendaScrollToNext";
@@ -26,24 +28,32 @@ export async function generateMetadata({
   params,
 }: WedstrijdenPageProps): Promise<Metadata> {
   const { slug } = await params;
-  try {
-    const team = await runPromise(
-      Effect.gen(function* () {
-        const repo = yield* TeamRepository;
-        return yield* repo.findBySlug(slug);
-      }),
-    );
-    if (!team) return { title: "Team niet gevonden | KCVV Elewijt" };
-    return {
-      title: `Wedstrijden — ${team.name} | KCVV Elewijt`,
-      description: `Volledig wedstrijdschema van ${team.name}.`,
-      alternates: {
-        canonical: `${SITE_CONFIG.siteUrl}/ploegen/${slug}/wedstrijden`,
-      },
-    };
-  } catch {
-    return { title: "Wedstrijden | KCVV Elewijt" };
-  }
+  const team = await runPromise(
+    Effect.gen(function* () {
+      const repo = yield* TeamRepository;
+      return yield* repo.findBySlug(slug);
+    }),
+  );
+  if (!team) return { title: "Team niet gevonden | KCVV Elewijt" };
+
+  const title = `Wedstrijden — ${team.name} | KCVV Elewijt`;
+  const description = `Volledig wedstrijdschema van ${team.name}.`;
+  const url = `${SITE_CONFIG.siteUrl}/ploegen/${slug}/wedstrijden`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: "website",
+      images: team.teamImageUrl
+        ? [{ url: team.teamImageUrl, alt: `${team.name} teamfoto` }]
+        : [DEFAULT_OG_IMAGE],
+    },
+  };
 }
 
 interface MonthGroup {
@@ -104,6 +114,7 @@ export default async function WedstrijdenPage({
   if (!team) notFound();
 
   const psdTeamId = team.psdId ? parseInt(team.psdId, 10) : NaN;
+  const pageUrl = `${SITE_CONFIG.siteUrl}/ploegen/${slug}/wedstrijden`;
 
   let rawMatches: readonly Match[] = [];
   if (Number.isFinite(psdTeamId) && psdTeamId > 0) {
@@ -112,7 +123,11 @@ export default async function WedstrijdenPage({
         const bff = yield* BffService;
         return yield* bff
           .getMatches(psdTeamId)
-          .pipe(Effect.catchAll(() => Effect.succeed([] as readonly Match[])));
+          .pipe(
+            Effect.catchTag("HttpNotFound", () =>
+              Effect.sync(() => notFound()),
+            ),
+          );
       }),
     );
   }
@@ -124,6 +139,19 @@ export default async function WedstrijdenPage({
 
   return (
     <>
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: SITE_CONFIG.siteUrl },
+          { name: "Ploegen", url: `${SITE_CONFIG.siteUrl}/ploegen` },
+          {
+            name: team.name,
+            url: `${SITE_CONFIG.siteUrl}/ploegen/${slug}`,
+          },
+          { name: "Wedstrijden", url: pageUrl },
+        ])}
+      />
+      <JsonLd data={buildSportsTeamJsonLd({ name: team.name, url: pageUrl })} />
+
       <AgendaScrollToNext nextMatchId={nextMatch?.id ?? null} />
 
       <div className="mx-auto max-w-3xl px-4 py-8 sm:py-12">

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * <TeamAgendaRow> — one match row in the team matches agenda.
  *

--- a/apps/web/test/e2e/wedstrijden.spec.ts
+++ b/apps/web/test/e2e/wedstrijden.spec.ts
@@ -46,11 +46,9 @@ test.describe("/ploegen/[slug]/wedstrijden", () => {
       return;
     }
 
-    const response = await page.goto(`/ploegen/${teamSlug}/wedstrijden`);
-    expect(response?.status()).toBe(200);
-
-    // Either the empty-state message or a list of agenda rows must be present.
-    await expect(page.locator("h1").first()).toBeVisible();
+    await smokeTest(page, {
+      path: `/ploegen/${teamSlug}/wedstrijden`,
+    });
   });
 
   test("auto-scroll is skipped gracefully when no next match exists", async ({
@@ -71,11 +69,10 @@ test.describe("/ploegen/[slug]/wedstrijden", () => {
       path: `/ploegen/${teamSlug}/wedstrijden`,
     });
 
-    // Verify the scroll anchor data-attribute is either present (has next match)
-    // or absent (no next match) — both are acceptable; the test asserts no crash.
-    const nextAnchor = page.locator("[data-testid='wedstrijden-next-match']");
-    const count = await nextAnchor.count();
-    // count is 0 or 1 — no assertion on which, just that the page rendered.
-    expect(count).toBeGreaterThanOrEqual(0);
+    // At most one next-match anchor should exist (0 = no upcoming match, 1 = has next match).
+    const count = await page
+      .locator("[data-testid='wedstrijden-next-match']")
+      .count();
+    expect(count).toBeLessThanOrEqual(1);
   });
 });

--- a/apps/web/test/e2e/wedstrijden.spec.ts
+++ b/apps/web/test/e2e/wedstrijden.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * e2e smoke tests for /ploegen/[slug]/wedstrijden
+ *
+ * AC covered:
+ *  - Route renders with h1 "Wedstrijden" and no console errors
+ *  - Returns HTTP 200 (no 404/redirect) even when PSD returns no matches
+ *  - Auto-scroll is skipped when there is no next match — page must not crash
+ */
+
+import { test, expect } from "@playwright/test";
+import { discoverRouteFixtures } from "./helpers/fixtures";
+import { smokeTest } from "./helpers/smoke";
+
+test.describe("/ploegen/[slug]/wedstrijden", () => {
+  test("renders the full-season agenda page (smoke)", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("baseURL required");
+
+    const { teamSlug } = await discoverRouteFixtures(baseURL);
+
+    if (!teamSlug) {
+      test.skip(true, "No team slug discovered from sitemap — skipping");
+      return;
+    }
+
+    await smokeTest(page, {
+      path: `/ploegen/${teamSlug}/wedstrijden`,
+    });
+
+    // h1 should read "Wedstrijden."
+    await expect(page.locator("h1").first()).toContainText("Wedstrijden");
+  });
+
+  test("returns 200 (no 404) regardless of match data availability", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("baseURL required");
+
+    const { teamSlug } = await discoverRouteFixtures(baseURL);
+
+    if (!teamSlug) {
+      test.skip(true, "No team slug discovered — skipping");
+      return;
+    }
+
+    const response = await page.goto(`/ploegen/${teamSlug}/wedstrijden`);
+    expect(response?.status()).toBe(200);
+
+    // Either the empty-state message or a list of agenda rows must be present.
+    await expect(page.locator("h1").first()).toBeVisible();
+  });
+
+  test("auto-scroll is skipped gracefully when no next match exists", async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) throw new Error("baseURL required");
+
+    const { teamSlug } = await discoverRouteFixtures(baseURL);
+
+    if (!teamSlug) {
+      test.skip(true, "No team slug discovered — skipping");
+      return;
+    }
+
+    // Page must render without JS errors whether or not a next-match anchor exists.
+    await smokeTest(page, {
+      path: `/ploegen/${teamSlug}/wedstrijden`,
+    });
+
+    // Verify the scroll anchor data-attribute is either present (has next match)
+    // or absent (no next match) — both are acceptable; the test asserts no crash.
+    const nextAnchor = page.locator("[data-testid='wedstrijden-next-match']");
+    const count = await nextAnchor.count();
+    // count is 0 or 1 — no assertion on which, just that the page rendered.
+    expect(count).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Closes #1943

## Summary

New `apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx`:

- **Month-grouped newspaper agenda** — `LLLL 'yy.` display-big headings, no rule beneath, ascending Aug→Jun. Uses `<TeamAgendaRow>` with the featured (jersey-deep) variant for the next scheduled match.
- **Auto-scroll to next match** on load via `<AgendaScrollToNext>` (invisible `"use client"` component using `scrollIntoView`). Respects `prefers-reduced-motion`. Skipped gracefully when no next match exists.
- **Empty state**: "Geen wedstrijden gepland." — 200 response, no 404/redirect.
- ISR `revalidate = 3600`; `generateMetadata`; `generateStaticParams` returns `[]` (same BFF rate-limit strategy as the team detail page).

**`"use client"` on `<TeamAgendaRow>`**: `@phosphor-icons/react` is an ESM-only package (`type: "module"`) that calls `React.createContext()` at module init time. Importing it from a server component during Next.js production build's config-collection phase triggers a CJS/ESM mismatch (`(0, m.createContext) is not a function`). All other Phosphor icon consumers in the codebase (`SiteHeader`, `Alert`, `Select`, `NavTakeover`) are already `"use client"`.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (route appears in build output as `ƒ` Dynamic)
- 3 Playwright e2e smoke tests: render + h1 visible / 200 status / no-crash graceful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a matches schedule page for teams, displaying upcoming and past matches organized by month
  * Enabled automatic scrolling to the next scheduled match on page load, respecting user's motion preferences
  * Implemented SEO metadata generation for match schedule pages

* **Bug Fixes**
  * Ensured missing teams produce a proper 404 page

* **Tests**
  * Added end-to-end tests for the matches schedule page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->