### PR TITLE
fix(config): set Sanity client perspective to "published"

### DIFF
--- a/apps/web/src/lib/sanity/client.ts
+++ b/apps/web/src/lib/sanity/client.ts
@@ -6,4 +6,10 @@ export const sanityClient = createClient({
   apiVersion: "2024-01-01",
   useCdn: true,
   token: process.env.SANITY_API_READ_TOKEN,
+  // Published-only: with a token and no perspective, @sanity/client v7 defaults
+  // to "raw", which returns BOTH drafts and published documents. That leaks
+  // unpublished edits into the live site — e.g. an in-progress Studio draft of a
+  // team surfaced as a duplicate nav entry. The public site must never render
+  // drafts; there is no draft-preview route that relies on them.
+  perspective: "published",
 });


### PR DESCRIPTION
## Problem

The site navigation showed a **duplicate "A-Ploeg" entry**. Root cause: an unpublished Studio draft of the A-team (`drafts.team-psd-1`) was being returned by the Sanity client alongside its published counterpart (`team-psd-1`).

With a `token` set and no `perspective`, `@sanity/client` v7 defaults to `"raw"` — which returns **both** draft and published documents. Every GROQ query in the app inherited that, so any document with an in-progress draft leaked the draft into the live site.

## Fix

Set `perspective: "published"` on the shared client. Drafts are now filtered site-wide.

Verified no draft-preview dependency: no `draftMode`, `previewDrafts`, or `drafts.`-path usage anywhere in `apps/web/src`.

## Note (data)

There is also an unpublished draft of "Eerste Elftallen A" sitting in Studio (staging). Publishing or discarding it removes the stale draft; this code fix prevents drafts from leaking regardless.

## Testing

- `pnpm --filter @kcvv/web check-all` passes