### PR TITLE
docs(events): Phase 6.E /evenementen design checkpoint + implementation PRD

### DIFF
--- a/docs/design/mockups/phase-6-events/6e-design-summary-locked.md
+++ b/docs/design/mockups/phase-6-events/6e-design-summary-locked.md
@@ -24,13 +24,13 @@ Both are part of the retro-terrace-fanzine redesign and reuse the locked design-
 
 **Filters:** a row of **colour-coded chips** that double as the legend (no separate legend):
 
-| Chip | Colour |
-| ---- | ------ |
-| Alles (default, no filter) | cream |
-| Clubevent | `jersey-deep` |
-| Supportersactiviteit | `warm` |
-| Jeugdwerking | `jersey-bright` |
-| Andere | `ink` |
+| Chip                       | Colour          |
+| -------------------------- | --------------- |
+| Alles (default, no filter) | cream           |
+| Clubevent                  | `jersey-deep`   |
+| Supportersactiviteit       | `warm`          |
+| Jeugdwerking               | `jersey-bright` |
+| Andere                     | `ink`           |
 
 Selected = filled with the type colour; unselected = dimmed cream outline. Single-select in v1.
 Each chip keeps its text label (type is never colour-only — WCAG 1.4.1).
@@ -49,7 +49,7 @@ its header**.
 - **Whole ticket is a link** to `/evenementen/[slug]`.
 - **Hover / focus-visible:** tilt + scale + a **"Meer details →"** reveal — the `EditorialHero`
   featured-image idiom: `transition-transform duration-300 group-hover:scale-[1.02]
-  group-hover:-rotate-1` (+ `group-focus-visible`, + `motion-reduce` resets); reveal is mono /
+group-hover:-rotate-1` (+ `group-focus-visible`, + `motion-reduce` resets); reveal is mono /
   uppercase / jersey-deep, `opacity-0 → group-hover:opacity-100`.
 - **No** list CTA, **no** cover thumbnail (text-forward).
 
@@ -97,7 +97,7 @@ footer (per §6.7).
   to the `event` delta, or show **`location` only** on the detail page for root events. (Do not
   fabricate an address.)
 - The `/evenementen` list is **events-only** (`event` docs + `articleType:event` articles), upcoming
-  only. The 3-source feed *including PSD matches* is the separate **`/kalender`** surface (§6.6), out
+  only. The 3-source feed _including PSD matches_ is the separate **`/kalender`** surface (§6.6), out
   of scope here.
 
 ## 6. Component deltas (`apps/web`)

--- a/docs/design/mockups/phase-6-events/6e-design-summary-locked.md
+++ b/docs/design/mockups/phase-6-events/6e-design-summary-locked.md
@@ -1,0 +1,130 @@
+# Phase 6.E · Events (`/evenementen`) — Consolidated Design Lock
+
+**Date:** 2026-06-02
+**Branch:** `design/phase-6e-events`
+**Drill rounds:** `6e1`–`6e5` (each with its own `*-locked.md`)
+**Supersedes for 6.E:** master-design `§6.7` decisions (route, EventHero, schema deltas) — this doc
+is the visual contract for the implementation PRD.
+
+---
+
+## 1. Surfaces
+
+- **`/evenementen`** — upcoming-only events list (renamed from `/events`; **301** from `/events/*`).
+- **`/evenementen/[slug]`** — event detail page.
+
+Both are part of the retro-terrace-fanzine redesign and reuse the locked design-system primitives.
+
+## 2. List page (`/evenementen`)
+
+**Voice:** ticket-stub poster wall on a **dark `jersey-deep-dark` field**.
+
+**Header:** `EditorialHeading` "Evenementen." (display serif, cream) + mono kicker
+("KCVV ELEWIJT · AGENDA").
+
+**Filters:** a row of **colour-coded chips** that double as the legend (no separate legend):
+
+| Chip | Colour |
+| ---- | ------ |
+| Alles (default, no filter) | cream |
+| Clubevent | `jersey-deep` |
+| Supportersactiviteit | `warm` |
+| Jeugdwerking | `jersey-bright` |
+| Andere | `ink` |
+
+Selected = filled with the type colour; unselected = dimmed cream outline. Single-select in v1.
+Each chip keeps its text label (type is never colour-only — WCAG 1.4.1).
+
+**Layout:** **single column, grouped by month.** Each month = display-serif month name +
+`StripedSeam` rule, then that month's tickets chronologically. Year shown on the header only when
+the list crosses into the next calendar year. A month whose tickets are all filtered out **hides
+its header**.
+
+**Ticket (`<TicketStub>` — NEW component):**
+
+- Left **tear-off date block** (dashed divider, no punch-holes), **colour = `eventType`** (table
+  above). Shows weekday (ZA) / big serif **day** / **month** (SEP). The 2px ink ticket border
+  frames every stub colour, so all four read against the dark field.
+- Body: `eventType` **pill** · display-serif **title** · mono **meta** (`time · location`).
+- **Whole ticket is a link** to `/evenementen/[slug]`.
+- **Hover / focus-visible:** tilt + scale + a **"Meer details →"** reveal — the `EditorialHero`
+  featured-image idiom: `transition-transform duration-300 group-hover:scale-[1.02]
+  group-hover:-rotate-1` (+ `group-focus-visible`, + `motion-reduce` resets); reveal is mono /
+  uppercase / jersey-deep, `opacity-0 → group-hover:opacity-100`.
+- **No** list CTA, **no** cover thumbnail (text-forward).
+
+## 3. Detail page (`/evenementen/[slug]`)
+
+**Voice:** **editorial, cream page** — a calm contrast to the dark list (dark index → light detail).
+
+**`<EventHero>` (NEW component), centred:**
+
+1. `eventType` pill (jersey-deep).
+2. Mono date/location kicker — full date (`ZATERDAG 14 SEPTEMBER · 18:00`).
+3. Display-serif title with italic jersey-deep emphasis on the accent word.
+4. Mono location line.
+5. **CTAs** (centred):
+   - **Reserveer ↗** — warm filled; **only when `externalLink` is set** (label =
+     `externalLink.label`, fallback "Reserveer"); opens external in a new tab.
+   - **＋ Zet in agenda** — outline; **always present**; downloads an **iCal** (`.ics`) for the event.
+6. **Cover** — `TapedFigure` (tilted + taped) below the CTAs, **only when `coverImage` exists**.
+
+**Below hero:** **"Andere events"** — `StripedSeam` heading + the locked `<TicketStub>` in a grid
+(upcoming events, excluding the current one). **No** body Portable Text, **no** RSVP, **no** sponsor
+footer (per §6.7).
+
+## 4. States
+
+- **Empty list** (no upcoming events): centred message on the dark field — e.g. _"Geen evenementen
+  gepland — kom snel terug."_ (mono kicker + serif line). No month headers, no filter row.
+- **Filtered-to-zero** (a type has no upcoming events): _"Geen [type] gepland."_ + a **"Toon alles"**
+  reset chip. Filter row stays visible.
+- **Multi-day** (`dateStart` + `dateEnd`): stub shows the **start** day; the meta/kicker shows the
+  **range** (list meta: `14–15 SEP`; hero kicker: `ZA 14 – ZO 15 SEPTEMBER`).
+- **Time-less / all-day** (`dateStart` time is `00:00`, or `eventFact.startTime` absent): **omit the
+  time**, show the date only.
+- **No cover** (`coverImage` absent — the common case): detail hero omits the `TapedFigure` (just the
+  centred text + CTAs). List is unaffected (no thumbs).
+- **No externalLink:** the **Reserveer** CTA is hidden; only **＋ Zet in agenda** shows.
+
+## 5. Schema deltas (`packages/sanity-schemas`)
+
+- **`event`** (root doc): add **`location`** (string) + **`eventType`** enum
+  (`Clubevent` | `Supportersactiviteit` | `Jeugdwerking` | `Andere`).
+- **`eventFact`** (block): add the same **`eventType`** enum, so `articleType:event` articles join the
+  merged feed.
+- **OPEN for PRD:** root `event` has **no `address`** (only `eventFact` does). Decide: add `address`
+  to the `event` delta, or show **`location` only** on the detail page for root events. (Do not
+  fabricate an address.)
+- The `/evenementen` list is **events-only** (`event` docs + `articleType:event` articles), upcoming
+  only. The 3-source feed *including PSD matches* is the separate **`/kalender`** surface (§6.6), out
+  of scope here.
+
+## 6. Component deltas (`apps/web`)
+
+- **NEW `<TicketStub>`** — the type-coloured tear-off ticket; consumed by the list and the detail
+  "Andere events" grid. Both `default` (list, full-width) and a denser grid use.
+- **NEW `<EventHero>`** — editorial detail hero (NOT a variant of `<EditorialHero>`).
+- **Reskin** `<EventCard>` / `<EventsList>` → replace with `<TicketStub>` + the month-grouped list, or
+  retire them.
+- **Route:** add `/evenementen` + `/evenementen/[slug]`; 301 redirect `/events/*` → `/evenementen/*`.
+- **iCal:** a `.ics` generator for "Zet in agenda" (title, start/end, location, description).
+
+## 7. Primitives reused (no net-new beyond §6)
+
+`EditorialHeading`, `MonoLabel`/pill, `StripedSeam`, `TapedFigure` (tilted+taped cover), the
+`EditorialHero` hover idiom. Tokens: `cream`, `jersey-deep`, `jersey-deep-dark`, `jersey-bright`,
+`warm`, `ink`.
+
+## 8. Analytics (per repo policy — confirm in PRD)
+
+- `event_view` (detail) — `event_slug`, `event_type`.
+- `event_cta_click` — `event_slug`, `cta` (`reserveer` | `agenda`).
+- List filter usage — `event_filter` with `event_type`.
+
+## 9. Open questions for the PRD
+
+1. `address` on `event` delta vs `location`-only on detail (see §5).
+2. Single- vs multi-select filters (locked single for v1 — confirm).
+3. iCal: client-side `.ics` blob vs a BFF endpoint.
+4. Empty/filtered-zero copy wording (Dutch) — final strings.

--- a/docs/design/mockups/phase-6-events/6e1-list-voice-compare.html
+++ b/docs/design/mockups/phase-6-events/6e1-list-voice-compare.html
@@ -284,8 +284,9 @@
     <div class="harness-head">
       <h1>Phase 6.E · /evenementen — Round 1: VOICE</h1>
       <p>
-        Four chrome registers for the <b>events list</b> (upcoming-only). Same
-        six placeholder events in every direction — only the
+        Four chrome registers for the <b>events list</b> (upcoming-only), drawn
+        from one shared placeholder set — each register shows a representative
+        slice at its natural density (counts differ per layout), so only the
         <b>voice</b> differs. Pick the register; IA (real fields/order) and
         per-element details come in later rounds. Type filters = the locked
         <b>eventType</b> enum (Clubevent · Supportersactiviteit · Jeugdwerking ·

--- a/docs/design/mockups/phase-6-events/6e1-list-voice-compare.html
+++ b/docs/design/mockups/phase-6-events/6e1-list-voice-compare.html
@@ -1,0 +1,451 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.E — /evenementen list · Round 1: VOICE compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Freight is Typekit-only; Fraunces is the closest free editorial serif for mockup fidelity -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6;
+        --cream-soft: #ede8da;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c;
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, "Times New Roman", serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: var(--font-body);
+        /* subtle newsprint grain */
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+
+      /* ---------- compare-harness chrome (NOT part of the design) ---------- */
+      .harness-head {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 22px 28px;
+        font-family: var(--font-mono);
+      }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 70ch; line-height: 1.5; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar {
+        position: sticky; top: 0; z-index: 50;
+        background: var(--jersey-deep); color: var(--cream);
+        padding: 10px 28px; font-family: var(--font-mono);
+        font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline;
+        border-bottom: 2px solid var(--ink);
+      }
+      .direction-bar .tag {
+        background: var(--warm); color: var(--ink); padding: 2px 9px;
+        font-weight: 700; border: 1.5px solid var(--ink);
+      }
+      .direction-bar .says { color: #cfe9d8; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .maps {
+        font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-muted);
+        padding: 8px 28px; background: var(--cream-soft); border-bottom: 1px dashed var(--paper-edge);
+      }
+      .maps b { color: var(--ink-soft); }
+      .stage { padding: 40px 28px 64px; }
+
+      /* ---------- shared design-system approximations ---------- */
+      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
+      .pill {
+        display: inline-flex; align-items: center; gap: 5px;
+        font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.08em;
+        font-size: 10.5px; font-weight: 600; padding: 3px 9px; border: 1.5px solid var(--ink);
+        background: var(--cream); color: var(--ink); white-space: nowrap;
+      }
+      .pill.jersey { background: var(--jersey-deep); color: var(--cream); border-color: var(--ink); }
+      .pill.warm { background: var(--warm); color: var(--ink); }
+      .pill.ink { background: var(--ink); color: var(--cream); }
+      .pill.brick { background: var(--brick); color: var(--cream); border-color: var(--ink); }
+
+      .display { font-family: var(--font-display); font-weight: 900; line-height: 0.95; letter-spacing: -0.01em; }
+      .display .em { font-style: italic; font-weight: 500; color: var(--jersey-deep); }
+
+      /* paper card */
+      .card { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 var(--ink); }
+      .card.soft { box-shadow: 5px 5px 0 rgba(10,10,10,0.18); }
+      .rot-a { transform: rotate(-1.4deg); }
+      .rot-b { transform: rotate(1.1deg); }
+      .rot-c { transform: rotate(-0.6deg); }
+      .rot-d { transform: rotate(0.8deg); }
+      .tape {
+        position: absolute; width: 84px; height: 26px; top: -13px; left: 22px;
+        background: rgba(240,194,100,0.78); border: 1px solid rgba(10,10,10,0.25);
+        transform: rotate(-4deg); box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+      }
+      .tape.r { left: auto; right: 22px; transform: rotate(3deg); background: rgba(74,207,82,0.6); }
+      .photo {
+        background: var(--cream-deep) center/cover no-repeat; position: relative;
+        filter: saturate(0.85) contrast(1.05); border-bottom: 2px solid var(--ink);
+      }
+      .photo::after { /* newsprint dot tint */
+        content:""; position:absolute; inset:0;
+        background-image: radial-gradient(rgba(10,10,10,0.10) 1px, transparent 1.4px);
+        background-size: 4px 4px; mix-blend-mode: multiply;
+      }
+      .ph1 { background-color:#3a5a47; background-image:linear-gradient(135deg,#15543a,#2f7d56); }
+      .ph2 { background-color:#6b6b6b; background-image:linear-gradient(135deg,#444,#7a7a7a); }
+      .ph3 { background-color:#8a5a2b; background-image:linear-gradient(135deg,#6b3d18,#b07a3c); }
+      .ph4 { background-color:#1f6b46; background-image:linear-gradient(135deg,#0a3a26,#1f8a57); }
+      .ph5 { background-color:#7a2f22; background-image:linear-gradient(135deg,#5a1f15,#a8472f); }
+      .ph6 { background-color:#2a3550; background-image:linear-gradient(135deg,#1a2438,#3a4a70); }
+
+      .seam { height: 14px; background:
+        repeating-linear-gradient(-45deg, var(--ink) 0 8px, var(--cream) 8px 16px, var(--jersey-deep) 16px 24px, var(--cream) 24px 32px);
+        border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); }
+      .dashed { border-top: 2px dashed var(--ink); }
+
+      .filters { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+      .container { max-width: 1080px; margin: 0 auto; }
+      h2,h3 { margin: 0; }
+      .muted { color: var(--ink-muted); }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.E · /evenementen — Round 1: VOICE</h1>
+      <p>
+        Four chrome registers for the <b>events list</b> (upcoming-only). Same six placeholder events in every
+        direction — only the <b>voice</b> differs. Pick the register; IA (real fields/order) and per-element details
+        come in later rounds. Type filters = the locked <b>eventType</b> enum (Clubevent · Supportersactiviteit ·
+        Jeugdwerking · Andere). Matches live on /kalender, not here.
+      </p>
+    </div>
+
+    <!-- ============================== DIRECTION A ============================== -->
+    <div class="direction-bar">
+      <span class="tag">A</span> Prikbord
+      <span class="says">— the kantine corkboard: pinned flyers, taped &amp; tilted, communal and warm</span>
+    </div>
+    <div class="maps">
+      maps to: <b>TapedCard</b> (rotation a–d) + <b>TapeStrip</b> + <b>TapedFigure</b> cover · <b>MonoLabel</b> pills for eventType · masonry-ish scatter
+    </div>
+    <div class="stage" style="background: var(--cream);">
+      <div class="container">
+        <div style="margin-bottom: 26px;">
+          <div class="mono muted" style="margin-bottom: 8px;">KCVV ELEWIJT · WAT IS ER TE DOEN</div>
+          <h2 class="display" style="font-size: clamp(40px, 6vw, 68px);">Evenementen<span class="em">.</span></h2>
+        </div>
+        <div class="filters" style="margin-bottom: 30px;">
+          <span class="pill ink">Alles</span>
+          <span class="pill">Clubevent</span>
+          <span class="pill">Supportersactiviteit</span>
+          <span class="pill">Jeugdwerking</span>
+          <span class="pill">Andere</span>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 30px 26px;">
+          <!-- card -->
+          <div class="card rot-a" style="align-self:start;">
+            <span class="tape"></span>
+            <div class="photo ph1" style="aspect-ratio: 4/3;"></div>
+            <div style="padding: 16px 16px 18px;">
+              <span class="pill warm" style="margin-bottom:10px;">Clubevent</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Mosselfeest</h3>
+              <div class="mono muted">ZA 14 SEP · 18:00 · KANTINE</div>
+            </div>
+          </div>
+          <div class="card rot-b" style="align-self:start; margin-top: 18px;">
+            <span class="tape r"></span>
+            <div class="photo ph2" style="aspect-ratio: 4/3;"></div>
+            <div style="padding: 16px 16px 18px;">
+              <span class="pill warm" style="margin-bottom:10px;">Jeugdwerking</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Jeugdtornooi U10–U13</h3>
+              <div class="mono muted">ZO 22 SEP · SPORTPARK ELEWIJT</div>
+            </div>
+          </div>
+          <div class="card rot-c" style="align-self:start;">
+            <span class="tape"></span>
+            <div class="photo ph3" style="aspect-ratio: 4/3;"></div>
+            <div style="padding: 16px 16px 18px;">
+              <span class="pill warm" style="margin-bottom:10px;">Supportersactiviteit</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Busreis naar de uitwedstrijd</h3>
+              <div class="mono muted">ZA 5 OKT · VERTREK KANTINE</div>
+            </div>
+          </div>
+          <div class="card rot-b" style="align-self:start; margin-top: 14px;">
+            <span class="tape r"></span>
+            <div class="photo ph6" style="aspect-ratio: 4/3;"></div>
+            <div style="padding: 16px 16px 18px;">
+              <span class="pill warm" style="margin-bottom:10px;">Supportersactiviteit</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Quiz van de Compagnie</h3>
+              <div class="mono muted">VR 18 OKT · 20:00 · KANTINE</div>
+            </div>
+          </div>
+          <div class="card rot-a" style="align-self:start;">
+            <span class="tape"></span>
+            <div class="photo ph5" style="aspect-ratio: 4/3;"></div>
+            <div style="padding: 16px 16px 18px;">
+              <span class="pill warm" style="margin-bottom:10px;">Andere</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Bloedinzameling Rode Kruis</h3>
+              <div class="mono muted">DI 8 OKT · PAROCHIEZAAL</div>
+            </div>
+          </div>
+          <div class="card rot-c" style="align-self:start; margin-top: 20px;">
+            <span class="tape r"></span>
+            <div class="photo ph4" style="aspect-ratio: 4/3;"></div>
+            <div style="padding: 16px 16px 18px;">
+              <span class="pill warm" style="margin-bottom:10px;">Clubevent</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Kampioenenviering</h3>
+              <div class="mono muted">VR 30 MEI · KANTINE</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================== DIRECTION B ============================== -->
+    <div class="direction-bar">
+      <span class="tag">B</span> Programmablad
+      <span class="says">— newspaper "what's on" listings: big serif date, dashed rules, dense &amp; scannable</span>
+    </div>
+    <div class="maps">
+      maps to: <b>NumberDisplay</b> date block + <b>EditorialHeading</b> rows + dashed dividers + <b>MonoLabelRow</b> filters · image optional thumb
+    </div>
+    <div class="stage">
+      <div class="container" style="max-width: 820px;">
+        <div style="border-bottom: 3px solid var(--ink); padding-bottom: 14px; margin-bottom: 6px; display:flex; justify-content:space-between; align-items:flex-end;">
+          <h2 class="display" style="font-size: clamp(36px, 5vw, 56px);">Agenda<span class="em">.</span></h2>
+          <span class="mono muted">SEIZOEN 2025–26 · KOMENDE EVENTS</span>
+        </div>
+        <div class="filters" style="margin: 18px 0 8px;">
+          <span class="mono" style="color:var(--ink-muted); margin-right:4px;">FILTER:</span>
+          <span class="pill ink">Alles</span><span class="pill">Clubevent</span><span class="pill">Supporters</span><span class="pill">Jeugd</span><span class="pill">Andere</span>
+        </div>
+
+        <!-- listing row -->
+        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
+          <div style="text-align:center; line-height:1;">
+            <div class="display" style="font-size: 46px;">14</div>
+            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">SEP</div>
+          </div>
+          <div>
+            <span class="pill warm" style="margin-bottom:8px;">Clubevent</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Mosselfeest</h3>
+            <div class="mono muted">18:00 · KANTINE KCVV</div>
+          </div>
+          <span class="mono" style="color:var(--ink); border:1.5px solid var(--ink); padding:8px 12px;">RESERVEER →</span>
+        </div>
+
+        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
+          <div style="text-align:center; line-height:1;">
+            <div class="display" style="font-size: 46px;">22</div>
+            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">SEP</div>
+          </div>
+          <div>
+            <span class="pill warm" style="margin-bottom:8px;">Jeugdwerking</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Jeugdtornooi U10–U13</h3>
+            <div class="mono muted">SPORTPARK ELEWIJT</div>
+          </div>
+          <span class="mono muted">DETAILS →</span>
+        </div>
+
+        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
+          <div style="text-align:center; line-height:1;">
+            <div class="display" style="font-size: 46px;">05</div>
+            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">OKT</div>
+          </div>
+          <div>
+            <span class="pill warm" style="margin-bottom:8px;">Supportersactiviteit</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Busreis naar de uitwedstrijd</h3>
+            <div class="mono muted">VERTREK KANTINE</div>
+          </div>
+          <span class="mono muted">DETAILS →</span>
+        </div>
+
+        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
+          <div style="text-align:center; line-height:1;">
+            <div class="display" style="font-size: 46px;">08</div>
+            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">OKT</div>
+          </div>
+          <div>
+            <span class="pill warm" style="margin-bottom:8px;">Andere</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Bloedinzameling Rode Kruis</h3>
+            <div class="mono muted">PAROCHIEZAAL</div>
+          </div>
+          <span class="mono muted">DETAILS →</span>
+        </div>
+
+        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
+          <div style="text-align:center; line-height:1;">
+            <div class="display" style="font-size: 46px;">18</div>
+            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">OKT</div>
+          </div>
+          <div>
+            <span class="pill warm" style="margin-bottom:8px;">Supportersactiviteit</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Quiz van de Compagnie</h3>
+            <div class="mono muted">20:00 · KANTINE KCVV</div>
+          </div>
+          <span class="mono muted">DETAILS →</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================== DIRECTION C ============================== -->
+    <div class="direction-bar">
+      <span class="tag">C</span> Toegangsbewijs
+      <span class="says">— gig-poster ticket stubs: perforated tear-off date, bold, energetic, jersey-deep</span>
+    </div>
+    <div class="maps">
+      maps to: <b>TicketStub</b> (NEW primitive, to build) + <b>NumberDisplay</b> on the stub + <b>MonoLabel</b> · poster-weight headings
+    </div>
+    <div class="stage" style="background: var(--jersey-deep-dark);">
+      <div class="container">
+        <div style="margin-bottom: 26px;">
+          <div class="mono" style="color: var(--warm); margin-bottom: 8px;">TOEGANG · KCVV ELEWIJT</div>
+          <h2 class="display" style="font-size: clamp(40px, 6vw, 66px); color: var(--cream);">
+            Evenementen<span class="em" style="color: var(--warm);">.</span>
+          </h2>
+        </div>
+        <div class="filters" style="margin-bottom: 30px;">
+          <span class="pill warm">Alles</span>
+          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Clubevent</span>
+          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Supporters</span>
+          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Jeugd</span>
+          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Andere</span>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px;">
+          <!-- ticket -->
+          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
+            <div style="flex: 0 0 110px; background: var(--brick); color: var(--cream); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px; position:relative;">
+              <div class="display" style="font-size: 50px; line-height:0.9;">14</div>
+              <div class="mono">SEP</div>
+              <div class="mono" style="margin-top:6px; font-size:9px;">ZA</div>
+            </div>
+            <div style="padding: 16px 18px;">
+              <span class="pill ink" style="margin-bottom:8px;">Clubevent</span>
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Mosselfeest</h3>
+              <div class="mono muted">18:00 · KANTINE</div>
+            </div>
+          </div>
+          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
+            <div style="flex: 0 0 110px; background: var(--jersey-deep); color: var(--cream); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px;">
+              <div class="display" style="font-size: 50px; line-height:0.9;">22</div>
+              <div class="mono">SEP</div>
+              <div class="mono" style="margin-top:6px; font-size:9px;">ZO</div>
+            </div>
+            <div style="padding: 16px 18px;">
+              <span class="pill ink" style="margin-bottom:8px;">Jeugdwerking</span>
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Jeugdtornooi U10–U13</h3>
+              <div class="mono muted">SPORTPARK ELEWIJT</div>
+            </div>
+          </div>
+          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
+            <div style="flex: 0 0 110px; background: var(--jersey-deep); color: var(--cream); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px;">
+              <div class="display" style="font-size: 50px; line-height:0.9;">05</div>
+              <div class="mono">OKT</div>
+              <div class="mono" style="margin-top:6px; font-size:9px;">ZA</div>
+            </div>
+            <div style="padding: 16px 18px;">
+              <span class="pill ink" style="margin-bottom:8px;">Supporters</span>
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Busreis uitwedstrijd</h3>
+              <div class="mono muted">VERTREK KANTINE</div>
+            </div>
+          </div>
+          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
+            <div style="flex: 0 0 110px; background: var(--warm); color: var(--ink); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px;">
+              <div class="display" style="font-size: 50px; line-height:0.9;">18</div>
+              <div class="mono">OKT</div>
+              <div class="mono" style="margin-top:6px; font-size:9px;">VR</div>
+            </div>
+            <div style="padding: 16px 18px;">
+              <span class="pill ink" style="margin-bottom:8px;">Supporters</span>
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Quiz van de Compagnie</h3>
+              <div class="mono muted">20:00 · KANTINE</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================== DIRECTION D ============================== -->
+    <div class="direction-bar">
+      <span class="tag">D</span> Uitgelicht + raster
+      <span class="says">— featured band hero for the next event, then a calm taped grid (closest to locked vocab)</span>
+    </div>
+    <div class="maps">
+      maps to: <b>FeaturedEventBand</b> hero (already locked, Phase 4) + <b>TapedCard</b> grid below · maximum continuity, least net-new
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="mono muted" style="margin-bottom: 14px;">EVENEMENTEN · EERSTVOLGENDE</div>
+        <!-- featured band -->
+        <div style="background: var(--jersey-deep); color: var(--cream); border: 2px solid var(--ink); box-shadow: 7px 7px 0 var(--ink); display:grid; grid-template-columns: 1.1fr 1fr; overflow:hidden; margin-bottom: 40px;">
+          <div style="padding: 34px 34px 36px;">
+            <span class="pill warm" style="margin-bottom: 16px;">Clubevent</span>
+            <h2 class="display" style="font-size: clamp(34px, 5vw, 54px); color: var(--cream);">
+              Mossel<span class="em" style="color: var(--warm); -webkit-text-fill-color: var(--warm);">feest</span>
+            </h2>
+            <div class="mono" style="color:#cfe9d8; margin: 14px 0 22px;">ZA 14 SEP · 18:00 · KANTINE KCVV</div>
+            <span class="mono" style="background: var(--warm); color: var(--ink); border: 2px solid var(--ink); padding: 10px 16px;">RESERVEER JE TAFEL →</span>
+          </div>
+          <div class="photo ph1" style="min-height: 240px; border-bottom: none; border-left: 2px solid var(--ink);"></div>
+        </div>
+
+        <div style="display:flex; align-items:center; gap: 14px; margin-bottom: 22px;">
+          <h3 class="display" style="font-size: 28px;">Ook op de agenda</h3>
+          <div style="flex:1;" class="seam"></div>
+        </div>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px;">
+          <div class="card soft">
+            <div class="photo ph2" style="aspect-ratio: 16/10;"></div>
+            <div style="padding: 14px 15px 16px;">
+              <span class="pill jersey" style="margin-bottom:8px;">Jeugdwerking</span>
+              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px;">Jeugdtornooi U10–U13</h3>
+              <div class="mono muted">ZO 22 SEP</div>
+            </div>
+          </div>
+          <div class="card soft">
+            <div class="photo ph3" style="aspect-ratio: 16/10;"></div>
+            <div style="padding: 14px 15px 16px;">
+              <span class="pill jersey" style="margin-bottom:8px;">Supporters</span>
+              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px;">Busreis uitwedstrijd</h3>
+              <div class="mono muted">ZA 5 OKT</div>
+            </div>
+          </div>
+          <div class="card soft">
+            <div class="photo ph6" style="aspect-ratio: 16/10;"></div>
+            <div style="padding: 14px 15px 16px;">
+              <span class="pill jersey" style="margin-bottom:8px;">Supporters</span>
+              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px;">Quiz van de Compagnie</h3>
+              <div class="mono muted">VR 18 OKT</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="harness-head" style="background: var(--ink-soft);">
+      <p>
+        Round 1 locks the <b>voice</b> only. Placeholder data is intentional. Next rounds: <b>IA</b> (real field order,
+        filter behaviour, empty state, what a card must show) → <b>per-element details</b> (date format, image
+        treatment, CTA rules, the new <code>&lt;EventHero&gt;</code> for the detail page).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-events/6e1-list-voice-compare.html
+++ b/docs/design/mockups/phase-6-events/6e1-list-voice-compare.html
@@ -30,7 +30,9 @@
         --font-mono: "IBM Plex Mono", monospace;
       }
 
-      * { box-sizing: border-box; }
+      * {
+        box-sizing: border-box;
+      }
 
       body {
         margin: 0;
@@ -48,170 +50,360 @@
         padding: 22px 28px;
         font-family: var(--font-mono);
       }
-      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
-      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 70ch; line-height: 1.5; }
-      .harness-head a { color: var(--warm); }
+      .harness-head h1 {
+        margin: 0 0 6px;
+        font-size: 15px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .harness-head p {
+        margin: 0;
+        font-size: 13px;
+        color: #b9b9b9;
+        max-width: 70ch;
+        line-height: 1.5;
+      }
+      .harness-head a {
+        color: var(--warm);
+      }
       .direction-bar {
-        position: sticky; top: 0; z-index: 50;
-        background: var(--jersey-deep); color: var(--cream);
-        padding: 10px 28px; font-family: var(--font-mono);
-        font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
-        display: flex; gap: 14px; align-items: baseline;
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: var(--jersey-deep);
+        color: var(--cream);
+        padding: 10px 28px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
         border-bottom: 2px solid var(--ink);
       }
       .direction-bar .tag {
-        background: var(--warm); color: var(--ink); padding: 2px 9px;
-        font-weight: 700; border: 1.5px solid var(--ink);
+        background: var(--warm);
+        color: var(--ink);
+        padding: 2px 9px;
+        font-weight: 700;
+        border: 1.5px solid var(--ink);
       }
-      .direction-bar .says { color: #cfe9d8; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .direction-bar .says {
+        color: #cfe9d8;
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 12px;
+      }
       .maps {
-        font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-muted);
-        padding: 8px 28px; background: var(--cream-soft); border-bottom: 1px dashed var(--paper-edge);
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+        color: var(--ink-muted);
+        padding: 8px 28px;
+        background: var(--cream-soft);
+        border-bottom: 1px dashed var(--paper-edge);
       }
-      .maps b { color: var(--ink-soft); }
-      .stage { padding: 40px 28px 64px; }
+      .maps b {
+        color: var(--ink-soft);
+      }
+      .stage {
+        padding: 40px 28px 64px;
+      }
 
       /* ---------- shared design-system approximations ---------- */
-      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
-      .pill {
-        display: inline-flex; align-items: center; gap: 5px;
-        font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.08em;
-        font-size: 10.5px; font-weight: 600; padding: 3px 9px; border: 1.5px solid var(--ink);
-        background: var(--cream); color: var(--ink); white-space: nowrap;
+      .mono {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        font-size: 11px;
       }
-      .pill.jersey { background: var(--jersey-deep); color: var(--cream); border-color: var(--ink); }
-      .pill.warm { background: var(--warm); color: var(--ink); }
-      .pill.ink { background: var(--ink); color: var(--cream); }
-      .pill.brick { background: var(--brick); color: var(--cream); border-color: var(--ink); }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 10.5px;
+        font-weight: 600;
+        padding: 3px 9px;
+        border: 1.5px solid var(--ink);
+        background: var(--cream);
+        color: var(--ink);
+        white-space: nowrap;
+      }
+      .pill.jersey {
+        background: var(--jersey-deep);
+        color: var(--cream);
+        border-color: var(--ink);
+      }
+      .pill.warm {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .pill.ink {
+        background: var(--ink);
+        color: var(--cream);
+      }
+      .pill.brick {
+        background: var(--brick);
+        color: var(--cream);
+        border-color: var(--ink);
+      }
 
-      .display { font-family: var(--font-display); font-weight: 900; line-height: 0.95; letter-spacing: -0.01em; }
-      .display .em { font-style: italic; font-weight: 500; color: var(--jersey-deep); }
+      .display {
+        font-family: var(--font-display);
+        font-weight: 900;
+        line-height: 0.95;
+        letter-spacing: -0.01em;
+      }
+      .display .em {
+        font-style: italic;
+        font-weight: 500;
+        color: var(--jersey-deep);
+      }
 
       /* paper card */
-      .card { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 var(--ink); }
-      .card.soft { box-shadow: 5px 5px 0 rgba(10,10,10,0.18); }
-      .rot-a { transform: rotate(-1.4deg); }
-      .rot-b { transform: rotate(1.1deg); }
-      .rot-c { transform: rotate(-0.6deg); }
-      .rot-d { transform: rotate(0.8deg); }
+      .card {
+        position: relative;
+        background: var(--cream);
+        border: 2px solid var(--ink);
+        box-shadow: 6px 6px 0 var(--ink);
+      }
+      .card.soft {
+        box-shadow: 5px 5px 0 rgba(10, 10, 10, 0.18);
+      }
+      .rot-a {
+        transform: rotate(-1.4deg);
+      }
+      .rot-b {
+        transform: rotate(1.1deg);
+      }
+      .rot-c {
+        transform: rotate(-0.6deg);
+      }
+      .rot-d {
+        transform: rotate(0.8deg);
+      }
       .tape {
-        position: absolute; width: 84px; height: 26px; top: -13px; left: 22px;
-        background: rgba(240,194,100,0.78); border: 1px solid rgba(10,10,10,0.25);
-        transform: rotate(-4deg); box-shadow: 0 1px 2px rgba(0,0,0,0.12);
+        position: absolute;
+        width: 84px;
+        height: 26px;
+        top: -13px;
+        left: 22px;
+        background: rgba(240, 194, 100, 0.78);
+        border: 1px solid rgba(10, 10, 10, 0.25);
+        transform: rotate(-4deg);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
       }
-      .tape.r { left: auto; right: 22px; transform: rotate(3deg); background: rgba(74,207,82,0.6); }
+      .tape.r {
+        left: auto;
+        right: 22px;
+        transform: rotate(3deg);
+        background: rgba(74, 207, 82, 0.6);
+      }
       .photo {
-        background: var(--cream-deep) center/cover no-repeat; position: relative;
-        filter: saturate(0.85) contrast(1.05); border-bottom: 2px solid var(--ink);
+        background: var(--cream-deep) center/cover no-repeat;
+        position: relative;
+        filter: saturate(0.85) contrast(1.05);
+        border-bottom: 2px solid var(--ink);
       }
-      .photo::after { /* newsprint dot tint */
-        content:""; position:absolute; inset:0;
-        background-image: radial-gradient(rgba(10,10,10,0.10) 1px, transparent 1.4px);
-        background-size: 4px 4px; mix-blend-mode: multiply;
+      .photo::after {
+        /* newsprint dot tint */
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: radial-gradient(
+          rgba(10, 10, 10, 0.1) 1px,
+          transparent 1.4px
+        );
+        background-size: 4px 4px;
+        mix-blend-mode: multiply;
       }
-      .ph1 { background-color:#3a5a47; background-image:linear-gradient(135deg,#15543a,#2f7d56); }
-      .ph2 { background-color:#6b6b6b; background-image:linear-gradient(135deg,#444,#7a7a7a); }
-      .ph3 { background-color:#8a5a2b; background-image:linear-gradient(135deg,#6b3d18,#b07a3c); }
-      .ph4 { background-color:#1f6b46; background-image:linear-gradient(135deg,#0a3a26,#1f8a57); }
-      .ph5 { background-color:#7a2f22; background-image:linear-gradient(135deg,#5a1f15,#a8472f); }
-      .ph6 { background-color:#2a3550; background-image:linear-gradient(135deg,#1a2438,#3a4a70); }
+      .ph1 {
+        background-color: #3a5a47;
+        background-image: linear-gradient(135deg, #15543a, #2f7d56);
+      }
+      .ph2 {
+        background-color: #6b6b6b;
+        background-image: linear-gradient(135deg, #444, #7a7a7a);
+      }
+      .ph3 {
+        background-color: #8a5a2b;
+        background-image: linear-gradient(135deg, #6b3d18, #b07a3c);
+      }
+      .ph4 {
+        background-color: #1f6b46;
+        background-image: linear-gradient(135deg, #0a3a26, #1f8a57);
+      }
+      .ph5 {
+        background-color: #7a2f22;
+        background-image: linear-gradient(135deg, #5a1f15, #a8472f);
+      }
+      .ph6 {
+        background-color: #2a3550;
+        background-image: linear-gradient(135deg, #1a2438, #3a4a70);
+      }
 
-      .seam { height: 14px; background:
-        repeating-linear-gradient(-45deg, var(--ink) 0 8px, var(--cream) 8px 16px, var(--jersey-deep) 16px 24px, var(--cream) 24px 32px);
-        border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); }
-      .dashed { border-top: 2px dashed var(--ink); }
+      .seam {
+        height: 14px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--ink) 0 8px,
+          var(--cream) 8px 16px,
+          var(--jersey-deep) 16px 24px,
+          var(--cream) 24px 32px
+        );
+        border-top: 2px solid var(--ink);
+        border-bottom: 2px solid var(--ink);
+      }
+      .dashed {
+        border-top: 2px dashed var(--ink);
+      }
 
-      .filters { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
-      .container { max-width: 1080px; margin: 0 auto; }
-      h2,h3 { margin: 0; }
-      .muted { color: var(--ink-muted); }
+      .filters {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .container {
+        max-width: 1080px;
+        margin: 0 auto;
+      }
+      h2,
+      h3 {
+        margin: 0;
+      }
+      .muted {
+        color: var(--ink-muted);
+      }
     </style>
   </head>
   <body>
     <div class="harness-head">
       <h1>Phase 6.E · /evenementen — Round 1: VOICE</h1>
       <p>
-        Four chrome registers for the <b>events list</b> (upcoming-only). Same six placeholder events in every
-        direction — only the <b>voice</b> differs. Pick the register; IA (real fields/order) and per-element details
-        come in later rounds. Type filters = the locked <b>eventType</b> enum (Clubevent · Supportersactiviteit ·
-        Jeugdwerking · Andere). Matches live on /kalender, not here.
+        Four chrome registers for the <b>events list</b> (upcoming-only). Same
+        six placeholder events in every direction — only the
+        <b>voice</b> differs. Pick the register; IA (real fields/order) and
+        per-element details come in later rounds. Type filters = the locked
+        <b>eventType</b> enum (Clubevent · Supportersactiviteit · Jeugdwerking ·
+        Andere). Matches live on /kalender, not here.
       </p>
     </div>
 
     <!-- ============================== DIRECTION A ============================== -->
     <div class="direction-bar">
       <span class="tag">A</span> Prikbord
-      <span class="says">— the kantine corkboard: pinned flyers, taped &amp; tilted, communal and warm</span>
+      <span class="says"
+        >— the kantine corkboard: pinned flyers, taped &amp; tilted, communal
+        and warm</span
+      >
     </div>
     <div class="maps">
-      maps to: <b>TapedCard</b> (rotation a–d) + <b>TapeStrip</b> + <b>TapedFigure</b> cover · <b>MonoLabel</b> pills for eventType · masonry-ish scatter
+      maps to: <b>TapedCard</b> (rotation a–d) + <b>TapeStrip</b> +
+      <b>TapedFigure</b> cover · <b>MonoLabel</b> pills for eventType ·
+      masonry-ish scatter
     </div>
-    <div class="stage" style="background: var(--cream);">
+    <div class="stage" style="background: var(--cream)">
       <div class="container">
-        <div style="margin-bottom: 26px;">
-          <div class="mono muted" style="margin-bottom: 8px;">KCVV ELEWIJT · WAT IS ER TE DOEN</div>
-          <h2 class="display" style="font-size: clamp(40px, 6vw, 68px);">Evenementen<span class="em">.</span></h2>
+        <div style="margin-bottom: 26px">
+          <div class="mono muted" style="margin-bottom: 8px">
+            KCVV ELEWIJT · WAT IS ER TE DOEN
+          </div>
+          <h2 class="display" style="font-size: clamp(40px, 6vw, 68px)">
+            Evenementen<span class="em">.</span>
+          </h2>
         </div>
-        <div class="filters" style="margin-bottom: 30px;">
+        <div class="filters" style="margin-bottom: 30px">
           <span class="pill ink">Alles</span>
           <span class="pill">Clubevent</span>
           <span class="pill">Supportersactiviteit</span>
           <span class="pill">Jeugdwerking</span>
           <span class="pill">Andere</span>
         </div>
-        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 30px 26px;">
+        <div
+          style="
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 30px 26px;
+          "
+        >
           <!-- card -->
-          <div class="card rot-a" style="align-self:start;">
+          <div class="card rot-a" style="align-self: start">
             <span class="tape"></span>
-            <div class="photo ph1" style="aspect-ratio: 4/3;"></div>
-            <div style="padding: 16px 16px 18px;">
-              <span class="pill warm" style="margin-bottom:10px;">Clubevent</span>
-              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Mosselfeest</h3>
+            <div class="photo ph1" style="aspect-ratio: 4/3"></div>
+            <div style="padding: 16px 16px 18px">
+              <span class="pill warm" style="margin-bottom: 10px"
+                >Clubevent</span
+              >
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px">
+                Mosselfeest
+              </h3>
               <div class="mono muted">ZA 14 SEP · 18:00 · KANTINE</div>
             </div>
           </div>
-          <div class="card rot-b" style="align-self:start; margin-top: 18px;">
+          <div class="card rot-b" style="align-self: start; margin-top: 18px">
             <span class="tape r"></span>
-            <div class="photo ph2" style="aspect-ratio: 4/3;"></div>
-            <div style="padding: 16px 16px 18px;">
-              <span class="pill warm" style="margin-bottom:10px;">Jeugdwerking</span>
-              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Jeugdtornooi U10–U13</h3>
+            <div class="photo ph2" style="aspect-ratio: 4/3"></div>
+            <div style="padding: 16px 16px 18px">
+              <span class="pill warm" style="margin-bottom: 10px"
+                >Jeugdwerking</span
+              >
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px">
+                Jeugdtornooi U10–U13
+              </h3>
               <div class="mono muted">ZO 22 SEP · SPORTPARK ELEWIJT</div>
             </div>
           </div>
-          <div class="card rot-c" style="align-self:start;">
+          <div class="card rot-c" style="align-self: start">
             <span class="tape"></span>
-            <div class="photo ph3" style="aspect-ratio: 4/3;"></div>
-            <div style="padding: 16px 16px 18px;">
-              <span class="pill warm" style="margin-bottom:10px;">Supportersactiviteit</span>
-              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Busreis naar de uitwedstrijd</h3>
+            <div class="photo ph3" style="aspect-ratio: 4/3"></div>
+            <div style="padding: 16px 16px 18px">
+              <span class="pill warm" style="margin-bottom: 10px"
+                >Supportersactiviteit</span
+              >
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px">
+                Busreis naar de uitwedstrijd
+              </h3>
               <div class="mono muted">ZA 5 OKT · VERTREK KANTINE</div>
             </div>
           </div>
-          <div class="card rot-b" style="align-self:start; margin-top: 14px;">
+          <div class="card rot-b" style="align-self: start; margin-top: 14px">
             <span class="tape r"></span>
-            <div class="photo ph6" style="aspect-ratio: 4/3;"></div>
-            <div style="padding: 16px 16px 18px;">
-              <span class="pill warm" style="margin-bottom:10px;">Supportersactiviteit</span>
-              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Quiz van de Compagnie</h3>
+            <div class="photo ph6" style="aspect-ratio: 4/3"></div>
+            <div style="padding: 16px 16px 18px">
+              <span class="pill warm" style="margin-bottom: 10px"
+                >Supportersactiviteit</span
+              >
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px">
+                Quiz van de Compagnie
+              </h3>
               <div class="mono muted">VR 18 OKT · 20:00 · KANTINE</div>
             </div>
           </div>
-          <div class="card rot-a" style="align-self:start;">
+          <div class="card rot-a" style="align-self: start">
             <span class="tape"></span>
-            <div class="photo ph5" style="aspect-ratio: 4/3;"></div>
-            <div style="padding: 16px 16px 18px;">
-              <span class="pill warm" style="margin-bottom:10px;">Andere</span>
-              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Bloedinzameling Rode Kruis</h3>
+            <div class="photo ph5" style="aspect-ratio: 4/3"></div>
+            <div style="padding: 16px 16px 18px">
+              <span class="pill warm" style="margin-bottom: 10px">Andere</span>
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px">
+                Bloedinzameling Rode Kruis
+              </h3>
               <div class="mono muted">DI 8 OKT · PAROCHIEZAAL</div>
             </div>
           </div>
-          <div class="card rot-c" style="align-self:start; margin-top: 20px;">
+          <div class="card rot-c" style="align-self: start; margin-top: 20px">
             <span class="tape r"></span>
-            <div class="photo ph4" style="aspect-ratio: 4/3;"></div>
-            <div style="padding: 16px 16px 18px;">
-              <span class="pill warm" style="margin-bottom:10px;">Clubevent</span>
-              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px;">Kampioenenviering</h3>
+            <div class="photo ph4" style="aspect-ratio: 4/3"></div>
+            <div style="padding: 16px 16px 18px">
+              <span class="pill warm" style="margin-bottom: 10px"
+                >Clubevent</span
+              >
+              <h3 class="display" style="font-size: 26px; margin: 8px 0 6px">
+                Kampioenenviering
+              </h3>
               <div class="mono muted">VR 30 MEI · KANTINE</div>
             </div>
           </div>
@@ -222,83 +414,196 @@
     <!-- ============================== DIRECTION B ============================== -->
     <div class="direction-bar">
       <span class="tag">B</span> Programmablad
-      <span class="says">— newspaper "what's on" listings: big serif date, dashed rules, dense &amp; scannable</span>
+      <span class="says"
+        >— newspaper "what's on" listings: big serif date, dashed rules, dense
+        &amp; scannable</span
+      >
     </div>
     <div class="maps">
-      maps to: <b>NumberDisplay</b> date block + <b>EditorialHeading</b> rows + dashed dividers + <b>MonoLabelRow</b> filters · image optional thumb
+      maps to: <b>NumberDisplay</b> date block + <b>EditorialHeading</b> rows +
+      dashed dividers + <b>MonoLabelRow</b> filters · image optional thumb
     </div>
     <div class="stage">
-      <div class="container" style="max-width: 820px;">
-        <div style="border-bottom: 3px solid var(--ink); padding-bottom: 14px; margin-bottom: 6px; display:flex; justify-content:space-between; align-items:flex-end;">
-          <h2 class="display" style="font-size: clamp(36px, 5vw, 56px);">Agenda<span class="em">.</span></h2>
+      <div class="container" style="max-width: 820px">
+        <div
+          style="
+            border-bottom: 3px solid var(--ink);
+            padding-bottom: 14px;
+            margin-bottom: 6px;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+          "
+        >
+          <h2 class="display" style="font-size: clamp(36px, 5vw, 56px)">
+            Agenda<span class="em">.</span>
+          </h2>
           <span class="mono muted">SEIZOEN 2025–26 · KOMENDE EVENTS</span>
         </div>
-        <div class="filters" style="margin: 18px 0 8px;">
-          <span class="mono" style="color:var(--ink-muted); margin-right:4px;">FILTER:</span>
-          <span class="pill ink">Alles</span><span class="pill">Clubevent</span><span class="pill">Supporters</span><span class="pill">Jeugd</span><span class="pill">Andere</span>
+        <div class="filters" style="margin: 18px 0 8px">
+          <span class="mono" style="color: var(--ink-muted); margin-right: 4px"
+            >FILTER:</span
+          >
+          <span class="pill ink">Alles</span><span class="pill">Clubevent</span
+          ><span class="pill">Supporters</span><span class="pill">Jeugd</span
+          ><span class="pill">Andere</span>
         </div>
 
         <!-- listing row -->
-        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
-          <div style="text-align:center; line-height:1;">
-            <div class="display" style="font-size: 46px;">14</div>
-            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">SEP</div>
+        <div
+          class="dashed"
+          style="
+            display: grid;
+            grid-template-columns: 92px 1fr auto;
+            gap: 20px;
+            align-items: center;
+            padding: 20px 0;
+          "
+        >
+          <div style="text-align: center; line-height: 1">
+            <div class="display" style="font-size: 46px">14</div>
+            <div
+              class="mono"
+              style="color: var(--jersey-deep); margin-top: 2px"
+            >
+              SEP
+            </div>
           </div>
           <div>
-            <span class="pill warm" style="margin-bottom:8px;">Clubevent</span>
-            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Mosselfeest</h3>
+            <span class="pill warm" style="margin-bottom: 8px">Clubevent</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px">
+              Mosselfeest
+            </h3>
             <div class="mono muted">18:00 · KANTINE KCVV</div>
           </div>
-          <span class="mono" style="color:var(--ink); border:1.5px solid var(--ink); padding:8px 12px;">RESERVEER →</span>
+          <span
+            class="mono"
+            style="
+              color: var(--ink);
+              border: 1.5px solid var(--ink);
+              padding: 8px 12px;
+            "
+            >RESERVEER →</span
+          >
         </div>
 
-        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
-          <div style="text-align:center; line-height:1;">
-            <div class="display" style="font-size: 46px;">22</div>
-            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">SEP</div>
+        <div
+          class="dashed"
+          style="
+            display: grid;
+            grid-template-columns: 92px 1fr auto;
+            gap: 20px;
+            align-items: center;
+            padding: 20px 0;
+          "
+        >
+          <div style="text-align: center; line-height: 1">
+            <div class="display" style="font-size: 46px">22</div>
+            <div
+              class="mono"
+              style="color: var(--jersey-deep); margin-top: 2px"
+            >
+              SEP
+            </div>
           </div>
           <div>
-            <span class="pill warm" style="margin-bottom:8px;">Jeugdwerking</span>
-            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Jeugdtornooi U10–U13</h3>
+            <span class="pill warm" style="margin-bottom: 8px"
+              >Jeugdwerking</span
+            >
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px">
+              Jeugdtornooi U10–U13
+            </h3>
             <div class="mono muted">SPORTPARK ELEWIJT</div>
           </div>
           <span class="mono muted">DETAILS →</span>
         </div>
 
-        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
-          <div style="text-align:center; line-height:1;">
-            <div class="display" style="font-size: 46px;">05</div>
-            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">OKT</div>
+        <div
+          class="dashed"
+          style="
+            display: grid;
+            grid-template-columns: 92px 1fr auto;
+            gap: 20px;
+            align-items: center;
+            padding: 20px 0;
+          "
+        >
+          <div style="text-align: center; line-height: 1">
+            <div class="display" style="font-size: 46px">05</div>
+            <div
+              class="mono"
+              style="color: var(--jersey-deep); margin-top: 2px"
+            >
+              OKT
+            </div>
           </div>
           <div>
-            <span class="pill warm" style="margin-bottom:8px;">Supportersactiviteit</span>
-            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Busreis naar de uitwedstrijd</h3>
+            <span class="pill warm" style="margin-bottom: 8px"
+              >Supportersactiviteit</span
+            >
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px">
+              Busreis naar de uitwedstrijd
+            </h3>
             <div class="mono muted">VERTREK KANTINE</div>
           </div>
           <span class="mono muted">DETAILS →</span>
         </div>
 
-        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
-          <div style="text-align:center; line-height:1;">
-            <div class="display" style="font-size: 46px;">08</div>
-            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">OKT</div>
+        <div
+          class="dashed"
+          style="
+            display: grid;
+            grid-template-columns: 92px 1fr auto;
+            gap: 20px;
+            align-items: center;
+            padding: 20px 0;
+          "
+        >
+          <div style="text-align: center; line-height: 1">
+            <div class="display" style="font-size: 46px">08</div>
+            <div
+              class="mono"
+              style="color: var(--jersey-deep); margin-top: 2px"
+            >
+              OKT
+            </div>
           </div>
           <div>
-            <span class="pill warm" style="margin-bottom:8px;">Andere</span>
-            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Bloedinzameling Rode Kruis</h3>
+            <span class="pill warm" style="margin-bottom: 8px">Andere</span>
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px">
+              Bloedinzameling Rode Kruis
+            </h3>
             <div class="mono muted">PAROCHIEZAAL</div>
           </div>
           <span class="mono muted">DETAILS →</span>
         </div>
 
-        <div class="dashed" style="display:grid; grid-template-columns: 92px 1fr auto; gap: 20px; align-items:center; padding: 20px 0;">
-          <div style="text-align:center; line-height:1;">
-            <div class="display" style="font-size: 46px;">18</div>
-            <div class="mono" style="color:var(--jersey-deep); margin-top:2px;">OKT</div>
+        <div
+          class="dashed"
+          style="
+            display: grid;
+            grid-template-columns: 92px 1fr auto;
+            gap: 20px;
+            align-items: center;
+            padding: 20px 0;
+          "
+        >
+          <div style="text-align: center; line-height: 1">
+            <div class="display" style="font-size: 46px">18</div>
+            <div
+              class="mono"
+              style="color: var(--jersey-deep); margin-top: 2px"
+            >
+              OKT
+            </div>
           </div>
           <div>
-            <span class="pill warm" style="margin-bottom:8px;">Supportersactiviteit</span>
-            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px;">Quiz van de Compagnie</h3>
+            <span class="pill warm" style="margin-bottom: 8px"
+              >Supportersactiviteit</span
+            >
+            <h3 class="display" style="font-size: 27px; margin: 6px 0 4px">
+              Quiz van de Compagnie
+            </h3>
             <div class="mono muted">20:00 · KANTINE KCVV</div>
           </div>
           <span class="mono muted">DETAILS →</span>
@@ -309,73 +614,220 @@
     <!-- ============================== DIRECTION C ============================== -->
     <div class="direction-bar">
       <span class="tag">C</span> Toegangsbewijs
-      <span class="says">— gig-poster ticket stubs: perforated tear-off date, bold, energetic, jersey-deep</span>
+      <span class="says"
+        >— gig-poster ticket stubs: perforated tear-off date, bold, energetic,
+        jersey-deep</span
+      >
     </div>
     <div class="maps">
-      maps to: <b>TicketStub</b> (NEW primitive, to build) + <b>NumberDisplay</b> on the stub + <b>MonoLabel</b> · poster-weight headings
+      maps to: <b>TicketStub</b> (NEW primitive, to build) +
+      <b>NumberDisplay</b> on the stub + <b>MonoLabel</b> · poster-weight
+      headings
     </div>
-    <div class="stage" style="background: var(--jersey-deep-dark);">
+    <div class="stage" style="background: var(--jersey-deep-dark)">
       <div class="container">
-        <div style="margin-bottom: 26px;">
-          <div class="mono" style="color: var(--warm); margin-bottom: 8px;">TOEGANG · KCVV ELEWIJT</div>
-          <h2 class="display" style="font-size: clamp(40px, 6vw, 66px); color: var(--cream);">
-            Evenementen<span class="em" style="color: var(--warm);">.</span>
+        <div style="margin-bottom: 26px">
+          <div class="mono" style="color: var(--warm); margin-bottom: 8px">
+            TOEGANG · KCVV ELEWIJT
+          </div>
+          <h2
+            class="display"
+            style="font-size: clamp(40px, 6vw, 66px); color: var(--cream)"
+          >
+            Evenementen<span class="em" style="color: var(--warm)">.</span>
           </h2>
         </div>
-        <div class="filters" style="margin-bottom: 30px;">
+        <div class="filters" style="margin-bottom: 30px">
           <span class="pill warm">Alles</span>
-          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Clubevent</span>
-          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Supporters</span>
-          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Jeugd</span>
-          <span class="pill" style="background:transparent;color:var(--cream);border-color:var(--cream);">Andere</span>
+          <span
+            class="pill"
+            style="
+              background: transparent;
+              color: var(--cream);
+              border-color: var(--cream);
+            "
+            >Clubevent</span
+          >
+          <span
+            class="pill"
+            style="
+              background: transparent;
+              color: var(--cream);
+              border-color: var(--cream);
+            "
+            >Supporters</span
+          >
+          <span
+            class="pill"
+            style="
+              background: transparent;
+              color: var(--cream);
+              border-color: var(--cream);
+            "
+            >Jeugd</span
+          >
+          <span
+            class="pill"
+            style="
+              background: transparent;
+              color: var(--cream);
+              border-color: var(--cream);
+            "
+            >Andere</span
+          >
         </div>
-        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px;">
+        <div
+          style="
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 22px;
+          "
+        >
           <!-- ticket -->
-          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
-            <div style="flex: 0 0 110px; background: var(--brick); color: var(--cream); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px; position:relative;">
-              <div class="display" style="font-size: 50px; line-height:0.9;">14</div>
+          <div
+            style="
+              display: flex;
+              background: var(--cream);
+              border: 2px solid var(--ink);
+              box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.5);
+            "
+          >
+            <div
+              style="
+                flex: 0 0 110px;
+                background: var(--brick);
+                color: var(--cream);
+                border-right: 2px dashed var(--ink);
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                padding: 16px 8px;
+                position: relative;
+              "
+            >
+              <div class="display" style="font-size: 50px; line-height: 0.9">
+                14
+              </div>
               <div class="mono">SEP</div>
-              <div class="mono" style="margin-top:6px; font-size:9px;">ZA</div>
+              <div class="mono" style="margin-top: 6px; font-size: 9px">ZA</div>
             </div>
-            <div style="padding: 16px 18px;">
-              <span class="pill ink" style="margin-bottom:8px;">Clubevent</span>
-              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Mosselfeest</h3>
+            <div style="padding: 16px 18px">
+              <span class="pill ink" style="margin-bottom: 8px">Clubevent</span>
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px">
+                Mosselfeest
+              </h3>
               <div class="mono muted">18:00 · KANTINE</div>
             </div>
           </div>
-          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
-            <div style="flex: 0 0 110px; background: var(--jersey-deep); color: var(--cream); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px;">
-              <div class="display" style="font-size: 50px; line-height:0.9;">22</div>
+          <div
+            style="
+              display: flex;
+              background: var(--cream);
+              border: 2px solid var(--ink);
+              box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.5);
+            "
+          >
+            <div
+              style="
+                flex: 0 0 110px;
+                background: var(--jersey-deep);
+                color: var(--cream);
+                border-right: 2px dashed var(--ink);
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                padding: 16px 8px;
+              "
+            >
+              <div class="display" style="font-size: 50px; line-height: 0.9">
+                22
+              </div>
               <div class="mono">SEP</div>
-              <div class="mono" style="margin-top:6px; font-size:9px;">ZO</div>
+              <div class="mono" style="margin-top: 6px; font-size: 9px">ZO</div>
             </div>
-            <div style="padding: 16px 18px;">
-              <span class="pill ink" style="margin-bottom:8px;">Jeugdwerking</span>
-              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Jeugdtornooi U10–U13</h3>
+            <div style="padding: 16px 18px">
+              <span class="pill ink" style="margin-bottom: 8px"
+                >Jeugdwerking</span
+              >
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px">
+                Jeugdtornooi U10–U13
+              </h3>
               <div class="mono muted">SPORTPARK ELEWIJT</div>
             </div>
           </div>
-          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
-            <div style="flex: 0 0 110px; background: var(--jersey-deep); color: var(--cream); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px;">
-              <div class="display" style="font-size: 50px; line-height:0.9;">05</div>
+          <div
+            style="
+              display: flex;
+              background: var(--cream);
+              border: 2px solid var(--ink);
+              box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.5);
+            "
+          >
+            <div
+              style="
+                flex: 0 0 110px;
+                background: var(--jersey-deep);
+                color: var(--cream);
+                border-right: 2px dashed var(--ink);
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                padding: 16px 8px;
+              "
+            >
+              <div class="display" style="font-size: 50px; line-height: 0.9">
+                05
+              </div>
               <div class="mono">OKT</div>
-              <div class="mono" style="margin-top:6px; font-size:9px;">ZA</div>
+              <div class="mono" style="margin-top: 6px; font-size: 9px">ZA</div>
             </div>
-            <div style="padding: 16px 18px;">
-              <span class="pill ink" style="margin-bottom:8px;">Supporters</span>
-              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Busreis uitwedstrijd</h3>
+            <div style="padding: 16px 18px">
+              <span class="pill ink" style="margin-bottom: 8px"
+                >Supporters</span
+              >
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px">
+                Busreis uitwedstrijd
+              </h3>
               <div class="mono muted">VERTREK KANTINE</div>
             </div>
           </div>
-          <div style="display:flex; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 rgba(0,0,0,0.5);">
-            <div style="flex: 0 0 110px; background: var(--warm); color: var(--ink); border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 16px 8px;">
-              <div class="display" style="font-size: 50px; line-height:0.9;">18</div>
+          <div
+            style="
+              display: flex;
+              background: var(--cream);
+              border: 2px solid var(--ink);
+              box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.5);
+            "
+          >
+            <div
+              style="
+                flex: 0 0 110px;
+                background: var(--warm);
+                color: var(--ink);
+                border-right: 2px dashed var(--ink);
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                padding: 16px 8px;
+              "
+            >
+              <div class="display" style="font-size: 50px; line-height: 0.9">
+                18
+              </div>
               <div class="mono">OKT</div>
-              <div class="mono" style="margin-top:6px; font-size:9px;">VR</div>
+              <div class="mono" style="margin-top: 6px; font-size: 9px">VR</div>
             </div>
-            <div style="padding: 16px 18px;">
-              <span class="pill ink" style="margin-bottom:8px;">Supporters</span>
-              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px;">Quiz van de Compagnie</h3>
+            <div style="padding: 16px 18px">
+              <span class="pill ink" style="margin-bottom: 8px"
+                >Supporters</span
+              >
+              <h3 class="display" style="font-size: 25px; margin: 6px 0 6px">
+                Quiz van de Compagnie
+              </h3>
               <div class="mono muted">20:00 · KANTINE</div>
             </div>
           </div>
@@ -386,53 +838,120 @@
     <!-- ============================== DIRECTION D ============================== -->
     <div class="direction-bar">
       <span class="tag">D</span> Uitgelicht + raster
-      <span class="says">— featured band hero for the next event, then a calm taped grid (closest to locked vocab)</span>
+      <span class="says"
+        >— featured band hero for the next event, then a calm taped grid
+        (closest to locked vocab)</span
+      >
     </div>
     <div class="maps">
-      maps to: <b>FeaturedEventBand</b> hero (already locked, Phase 4) + <b>TapedCard</b> grid below · maximum continuity, least net-new
+      maps to: <b>FeaturedEventBand</b> hero (already locked, Phase 4) +
+      <b>TapedCard</b> grid below · maximum continuity, least net-new
     </div>
     <div class="stage">
       <div class="container">
-        <div class="mono muted" style="margin-bottom: 14px;">EVENEMENTEN · EERSTVOLGENDE</div>
+        <div class="mono muted" style="margin-bottom: 14px">
+          EVENEMENTEN · EERSTVOLGENDE
+        </div>
         <!-- featured band -->
-        <div style="background: var(--jersey-deep); color: var(--cream); border: 2px solid var(--ink); box-shadow: 7px 7px 0 var(--ink); display:grid; grid-template-columns: 1.1fr 1fr; overflow:hidden; margin-bottom: 40px;">
-          <div style="padding: 34px 34px 36px;">
-            <span class="pill warm" style="margin-bottom: 16px;">Clubevent</span>
-            <h2 class="display" style="font-size: clamp(34px, 5vw, 54px); color: var(--cream);">
-              Mossel<span class="em" style="color: var(--warm); -webkit-text-fill-color: var(--warm);">feest</span>
+        <div
+          style="
+            background: var(--jersey-deep);
+            color: var(--cream);
+            border: 2px solid var(--ink);
+            box-shadow: 7px 7px 0 var(--ink);
+            display: grid;
+            grid-template-columns: 1.1fr 1fr;
+            overflow: hidden;
+            margin-bottom: 40px;
+          "
+        >
+          <div style="padding: 34px 34px 36px">
+            <span class="pill warm" style="margin-bottom: 16px">Clubevent</span>
+            <h2
+              class="display"
+              style="font-size: clamp(34px, 5vw, 54px); color: var(--cream)"
+            >
+              Mossel<span
+                class="em"
+                style="color: var(--warm); -webkit-text-fill-color: var(--warm)"
+                >feest</span
+              >
             </h2>
-            <div class="mono" style="color:#cfe9d8; margin: 14px 0 22px;">ZA 14 SEP · 18:00 · KANTINE KCVV</div>
-            <span class="mono" style="background: var(--warm); color: var(--ink); border: 2px solid var(--ink); padding: 10px 16px;">RESERVEER JE TAFEL →</span>
+            <div class="mono" style="color: #cfe9d8; margin: 14px 0 22px">
+              ZA 14 SEP · 18:00 · KANTINE KCVV
+            </div>
+            <span
+              class="mono"
+              style="
+                background: var(--warm);
+                color: var(--ink);
+                border: 2px solid var(--ink);
+                padding: 10px 16px;
+              "
+              >RESERVEER JE TAFEL →</span
+            >
           </div>
-          <div class="photo ph1" style="min-height: 240px; border-bottom: none; border-left: 2px solid var(--ink);"></div>
+          <div
+            class="photo ph1"
+            style="
+              min-height: 240px;
+              border-bottom: none;
+              border-left: 2px solid var(--ink);
+            "
+          ></div>
         </div>
 
-        <div style="display:flex; align-items:center; gap: 14px; margin-bottom: 22px;">
-          <h3 class="display" style="font-size: 28px;">Ook op de agenda</h3>
-          <div style="flex:1;" class="seam"></div>
+        <div
+          style="
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            margin-bottom: 22px;
+          "
+        >
+          <h3 class="display" style="font-size: 28px">Ook op de agenda</h3>
+          <div style="flex: 1" class="seam"></div>
         </div>
-        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px;">
+        <div
+          style="
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 24px;
+          "
+        >
           <div class="card soft">
-            <div class="photo ph2" style="aspect-ratio: 16/10;"></div>
-            <div style="padding: 14px 15px 16px;">
-              <span class="pill jersey" style="margin-bottom:8px;">Jeugdwerking</span>
-              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px;">Jeugdtornooi U10–U13</h3>
+            <div class="photo ph2" style="aspect-ratio: 16/10"></div>
+            <div style="padding: 14px 15px 16px">
+              <span class="pill jersey" style="margin-bottom: 8px"
+                >Jeugdwerking</span
+              >
+              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px">
+                Jeugdtornooi U10–U13
+              </h3>
               <div class="mono muted">ZO 22 SEP</div>
             </div>
           </div>
           <div class="card soft">
-            <div class="photo ph3" style="aspect-ratio: 16/10;"></div>
-            <div style="padding: 14px 15px 16px;">
-              <span class="pill jersey" style="margin-bottom:8px;">Supporters</span>
-              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px;">Busreis uitwedstrijd</h3>
+            <div class="photo ph3" style="aspect-ratio: 16/10"></div>
+            <div style="padding: 14px 15px 16px">
+              <span class="pill jersey" style="margin-bottom: 8px"
+                >Supporters</span
+              >
+              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px">
+                Busreis uitwedstrijd
+              </h3>
               <div class="mono muted">ZA 5 OKT</div>
             </div>
           </div>
           <div class="card soft">
-            <div class="photo ph6" style="aspect-ratio: 16/10;"></div>
-            <div style="padding: 14px 15px 16px;">
-              <span class="pill jersey" style="margin-bottom:8px;">Supporters</span>
-              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px;">Quiz van de Compagnie</h3>
+            <div class="photo ph6" style="aspect-ratio: 16/10"></div>
+            <div style="padding: 14px 15px 16px">
+              <span class="pill jersey" style="margin-bottom: 8px"
+                >Supporters</span
+              >
+              <h3 class="display" style="font-size: 21px; margin: 6px 0 5px">
+                Quiz van de Compagnie
+              </h3>
               <div class="mono muted">VR 18 OKT</div>
             </div>
           </div>
@@ -440,11 +959,13 @@
       </div>
     </div>
 
-    <div class="harness-head" style="background: var(--ink-soft);">
+    <div class="harness-head" style="background: var(--ink-soft)">
       <p>
-        Round 1 locks the <b>voice</b> only. Placeholder data is intentional. Next rounds: <b>IA</b> (real field order,
-        filter behaviour, empty state, what a card must show) → <b>per-element details</b> (date format, image
-        treatment, CTA rules, the new <code>&lt;EventHero&gt;</code> for the detail page).
+        Round 1 locks the <b>voice</b> only. Placeholder data is intentional.
+        Next rounds: <b>IA</b> (real field order, filter behaviour, empty state,
+        what a card must show) → <b>per-element details</b> (date format, image
+        treatment, CTA rules, the new <code>&lt;EventHero&gt;</code> for the
+        detail page).
       </p>
     </div>
   </body>

--- a/docs/design/mockups/phase-6-events/6e1-list-voice-locked.md
+++ b/docs/design/mockups/phase-6-events/6e1-list-voice-locked.md
@@ -1,0 +1,34 @@
+# Phase 6.E · /evenementen — Round 1 (VOICE) — LOCKED
+
+**Date:** 2026-06-02
+**Mockup:** `6e1-list-voice-compare.html`
+
+## Decision
+
+**Voice = Direction C "Toegangsbewijs" (ticket stubs).**
+
+The `/evenementen` list adopts a gig-poster **ticket-stub** register:
+
+- Dark **jersey-deep** field (not cream) for the list surface — events read as a poster wall.
+- Each event is a **ticket** with a perforated **tear-off date block** (dashed edge) + a body panel.
+- Bold poster-weight **display headings**; `eventType` shown as a `MonoLabel` pill.
+
+## Implied delta
+
+- Requires building the **`<TicketStub>`** primitive (already flagged as missing in the
+  Phase 6.E audit). The list ticket and the detail "Andere events" grid both consume it.
+
+## Rejected (and why)
+
+- **A · Prikbord** — too photo-dependent (most events have no cover) and too informal for the
+  primary events index.
+- **B · Programmablad** — clean and scannable, but too quiet/utilitarian for an events surface
+  meant to generate turnout. (Worth borrowing its big-serif-date discipline into the stub.)
+- **D · Uitgelicht + raster** — safest continuity choice, but least distinctive; the featured
+  band is already used on the homepage, so reusing it here adds little.
+
+## Carry-forward into IA round
+
+- Borrow B's **big-serif date** treatment for the tear-off block.
+- Open IA questions for Round 2: stub anatomy (fields carried), whether the date block color
+  **encodes eventType**, and whether the list stub surfaces a **CTA** or defers to detail.

--- a/docs/design/mockups/phase-6-events/6e2-stub-anatomy-compare.html
+++ b/docs/design/mockups/phase-6-events/6e2-stub-anatomy-compare.html
@@ -12,140 +12,574 @@
     />
     <style>
       :root {
-        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
-        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
-        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
-        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
-        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+        --cream: #f5f1e6;
+        --cream-soft: #ede8da;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-bright: #22c55e;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c;
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
       }
-      * { box-sizing: border-box; }
-      body { margin: 0; background: var(--jersey-deep-dark); color: var(--cream); font-family: var(--font-body);
-        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E"); }
-      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
-      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
-      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 78ch; line-height: 1.55; }
-      .harness-head code { color: var(--warm); }
-      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--warm); color: var(--ink);
-        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
-        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
-      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
-      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
-      .note { font-family: var(--font-mono); font-size: 11.5px; color: #cfe9d8; padding: 9px 28px; background: rgba(0,0,0,0.25); border-bottom: 1px dashed rgba(255,255,255,0.18); }
-      .note b { color: var(--warm); }
-      .hint { text-align:center; font-family: var(--font-mono); font-size: 11px; color: var(--warm); padding: 12px; letter-spacing: 0.05em; }
-      .stage { padding: 30px 28px 50px; }
-      .container { max-width: 1000px; margin: 0 auto; }
-      .grid2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
-      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
-      .pill { display: inline-flex; align-items: center; font-family: var(--font-mono); text-transform: uppercase;
-        letter-spacing: 0.08em; font-size: 10px; font-weight: 600; padding: 3px 8px; border: 1.5px solid var(--ink);
-        background: var(--cream); color: var(--ink); white-space: nowrap; }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--jersey-deep-dark);
+        color: var(--cream);
+        font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+      }
+      .harness-head {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 22px 28px;
+        font-family: var(--font-mono);
+      }
+      .harness-head h1 {
+        margin: 0 0 6px;
+        font-size: 15px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .harness-head p {
+        margin: 0;
+        font-size: 13px;
+        color: #b9b9b9;
+        max-width: 78ch;
+        line-height: 1.55;
+      }
+      .harness-head code {
+        color: var(--warm);
+      }
+      .direction-bar {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: var(--warm);
+        color: var(--ink);
+        padding: 11px 28px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
+        border-bottom: 2px solid var(--ink);
+      }
+      .direction-bar .tag {
+        background: var(--ink);
+        color: var(--warm);
+        padding: 2px 9px;
+        font-weight: 700;
+      }
+      .direction-bar .says {
+        color: var(--ink-soft);
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .note {
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+        color: #cfe9d8;
+        padding: 9px 28px;
+        background: rgba(0, 0, 0, 0.25);
+        border-bottom: 1px dashed rgba(255, 255, 255, 0.18);
+      }
+      .note b {
+        color: var(--warm);
+      }
+      .hint {
+        text-align: center;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--warm);
+        padding: 12px;
+        letter-spacing: 0.05em;
+      }
+      .stage {
+        padding: 30px 28px 50px;
+      }
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+      .grid2 {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 24px;
+      }
+      .mono {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        font-size: 11px;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 3px 8px;
+        border: 1.5px solid var(--ink);
+        background: var(--cream);
+        color: var(--ink);
+        white-space: nowrap;
+      }
 
       /* ===== clickable ticket — whole card links to /evenementen/[slug] ===== */
-      .ticket { display: flex; background: var(--cream); color: var(--ink); border: 2px solid var(--ink);
-        box-shadow: 6px 6px 0 rgba(0,0,0,0.5); text-decoration: none; cursor: pointer;
-        transition: transform .3s ease, box-shadow .3s ease; }
-      .ticket:hover, .ticket:focus-visible { transform: rotate(-1deg) scale(1.02); box-shadow: 9px 9px 0 rgba(0,0,0,0.55); outline: none; }
-      @media (prefers-reduced-motion: reduce) { .ticket { transition: none; } .ticket:hover, .ticket:focus-visible { transform: none; } }
-      .stub { flex: 0 0 104px; border-right: 2px dashed var(--ink); display: flex; flex-direction: column;
-        align-items: center; justify-content: center; padding: 16px 8px; color: var(--cream); }
-      .stub .day { font-family: var(--font-display); font-weight: 900; font-size: 48px; line-height: 0.85; }
-      .stub .mon { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; font-size: 12px; margin-top: 3px; }
-      .stub .wd { font-family: var(--font-mono); text-transform: uppercase; font-size: 9px; margin-top: 6px; opacity: 0.85; }
-      .s-jersey { background: var(--jersey-deep); } .s-warm { background: var(--warm); color: var(--ink); }
-      .s-bright { background: var(--jersey-bright); color: var(--ink); } .s-ink { background: var(--ink); }
-      .body { padding: 15px 17px; flex: 1; display: flex; flex-direction: column; }
-      .body h3 { margin: 7px 0 6px; font-family: var(--font-display); font-weight: 900; font-size: 23px; }
-      .meta { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10.5px; color: var(--ink-muted); }
+      .ticket {
+        display: flex;
+        background: var(--cream);
+        color: var(--ink);
+        border: 2px solid var(--ink);
+        box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.5);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          transform 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+      .ticket:hover,
+      .ticket:focus-visible {
+        transform: rotate(-1deg) scale(1.02);
+        box-shadow: 9px 9px 0 rgba(0, 0, 0, 0.55);
+        outline: none;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .ticket {
+          transition: none;
+        }
+        .ticket:hover,
+        .ticket:focus-visible {
+          transform: none;
+        }
+      }
+      .stub {
+        flex: 0 0 104px;
+        border-right: 2px dashed var(--ink);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 16px 8px;
+        color: var(--cream);
+      }
+      .stub .day {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 48px;
+        line-height: 0.85;
+      }
+      .stub .mon {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 12px;
+        margin-top: 3px;
+      }
+      .stub .wd {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        font-size: 9px;
+        margin-top: 6px;
+        opacity: 0.85;
+      }
+      .s-jersey {
+        background: var(--jersey-deep);
+      }
+      .s-warm {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .s-bright {
+        background: var(--jersey-bright);
+        color: var(--ink);
+      }
+      .s-ink {
+        background: var(--ink);
+      }
+      .body {
+        padding: 15px 17px;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+      .body h3 {
+        margin: 7px 0 6px;
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 23px;
+      }
+      .meta {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10.5px;
+        color: var(--ink-muted);
+      }
       /* hover reveal — same idiom as EditorialHero "★ Lees verder →" */
-      .reveal { margin-top: 11px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em;
-        font-size: 10.5px; font-weight: 700; color: var(--jersey-deep); opacity: 0; transition: opacity .3s ease; }
-      .ticket:hover .reveal, .ticket:focus-visible .reveal { opacity: 1; }
+      .reveal {
+        margin-top: 11px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10.5px;
+        font-weight: 700;
+        color: var(--jersey-deep);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+      .ticket:hover .reveal,
+      .ticket:focus-visible .reveal {
+        opacity: 1;
+      }
       /* secondary external chip (V3) — stops propagation; distinct from the card link */
-      .chip { align-self: flex-start; margin-top: 11px; font-family: var(--font-mono); text-transform: uppercase;
-        letter-spacing: 0.06em; font-size: 10.5px; font-weight: 700; padding: 7px 12px; border: 1.5px solid var(--ink);
-        background: var(--warm); color: var(--ink); text-decoration: none; }
-      .thumb { flex: 0 0 92px; background: var(--cream-deep) center/cover; border-left: 2px solid var(--ink); filter: saturate(0.85) contrast(1.05); }
-      .t-mossel { background-image: linear-gradient(135deg,#15543a,#2f7d56); }
-      .t-jeugd { background-image: linear-gradient(135deg,#444,#7a7a7a); }
-      .legend { display:flex; gap:16px; flex-wrap:wrap; font-family: var(--font-mono); font-size: 10.5px; text-transform:uppercase; letter-spacing:0.07em; color:#cfe9d8; margin-top:18px; }
-      .legend span { display:inline-flex; align-items:center; gap:7px; }
-      .sw { width:14px; height:14px; border:1.5px solid var(--ink); display:inline-block; }
+      .chip {
+        align-self: flex-start;
+        margin-top: 11px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10.5px;
+        font-weight: 700;
+        padding: 7px 12px;
+        border: 1.5px solid var(--ink);
+        background: var(--warm);
+        color: var(--ink);
+        text-decoration: none;
+      }
+      .thumb {
+        flex: 0 0 92px;
+        background: var(--cream-deep) center/cover;
+        border-left: 2px solid var(--ink);
+        filter: saturate(0.85) contrast(1.05);
+      }
+      .t-mossel {
+        background-image: linear-gradient(135deg, #15543a, #2f7d56);
+      }
+      .t-jeugd {
+        background-image: linear-gradient(135deg, #444, #7a7a7a);
+      }
+      .legend {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: #cfe9d8;
+        margin-top: 18px;
+      }
+      .legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+      }
+      .sw {
+        width: 14px;
+        height: 14px;
+        border: 1.5px solid var(--ink);
+        display: inline-block;
+      }
     </style>
   </head>
   <body>
     <div class="harness-head">
       <h1>Phase 6.E · /evenementen — Round 2: IA · ticket-stub anatomy</h1>
       <p>
-        Voice locked (ticket stubs). <b>NEW this round:</b> the whole ticket is a <b>link to the detail page</b> —
-        hover it for the <b>tilt + "Meer details →"</b> reveal (the same idiom as the homepage EditorialHero featured
-        image). All real fields: <code>dateStart</code> (day/month/weekday + time), <code>eventType</code>,
-        <code>title</code>, <code>location</code>, <code>externalLink {url,label}</code>. Pick the anatomy; we can graft.
+        Voice locked (ticket stubs). <b>NEW this round:</b> the whole ticket is
+        a <b>link to the detail page</b> — hover it for the
+        <b>tilt + "Meer details →"</b> reveal (the same idiom as the homepage
+        EditorialHero featured image). All real fields:
+        <code>dateStart</code> (day/month/weekday + time),
+        <code>eventType</code>, <code>title</code>, <code>location</code>,
+        <code>externalLink {url,label}</code>. Pick the anatomy; we can graft.
       </p>
     </div>
-    <div class="hint">↳ hover any ticket to see the tilt + "Meer details →" reveal</div>
+    <div class="hint">
+      ↳ hover any ticket to see the tilt + "Meer details →" reveal
+    </div>
 
     <!-- V1 -->
-    <div class="direction-bar"><span class="tag">1</span> Eén merkkleur <span class="says">— every stub jersey-deep; type only in the pill. Whole card → detail. No CTA on the list.</span></div>
-    <div class="note">carries: <b>date · pill · title · location · time</b> · whole-card link + hover reveal. Reserveer/CTA lives on the detail page.</div>
-    <div class="stage"><div class="container"><div class="grid2">
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
-        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div></a>
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
-        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div></a>
-    </div></div></div>
+    <div class="direction-bar">
+      <span class="tag">1</span> Eén merkkleur
+      <span class="says"
+        >— every stub jersey-deep; type only in the pill. Whole card → detail.
+        No CTA on the list.</span
+      >
+    </div>
+    <div class="note">
+      carries: <b>date · pill · title · location · time</b> · whole-card link +
+      hover reveal. Reserveer/CTA lives on the detail page.
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="grid2">
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZA</div>
+            </div>
+            <div class="body">
+              <span class="pill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="meta">18:00 · Kantine KCVV</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZO</div>
+            </div>
+            <div class="body">
+              <span class="pill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="meta">Sportpark Elewijt</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+        </div>
+      </div>
+    </div>
 
     <!-- V2 -->
-    <div class="direction-bar"><span class="tag">2</span> Type-gecodeerd <span class="says">— date-block COLOUR encodes eventType. Scannable; needs a legend.</span></div>
-    <div class="note">V1 + <b>stub colour = eventType</b> (Clubevent=jersey · Supporters=warm · Jeugd=bright · Andere=ink)</div>
-    <div class="stage"><div class="container"><div class="grid2">
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
-        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div></a>
-      <a class="ticket" href="#"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
-        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div></a>
-      <a class="ticket" href="#"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div><div class="wd">ZA</div></div>
-        <div class="body"><span class="pill">Supportersactiviteit</span><h3>Busreis uitwedstrijd</h3><div class="meta">Vertrek Kantine</div><div class="reveal">Meer details →</div></div></a>
-      <a class="ticket" href="#"><div class="stub s-ink"><div class="day">08</div><div class="mon">OKT</div><div class="wd">DI</div></div>
-        <div class="body"><span class="pill">Andere</span><h3>Bloedinzameling</h3><div class="meta">Parochiezaal</div><div class="reveal">Meer details →</div></div></a>
+    <div class="direction-bar">
+      <span class="tag">2</span> Type-gecodeerd
+      <span class="says"
+        >— date-block COLOUR encodes eventType. Scannable; needs a legend.</span
+      >
     </div>
-    <div class="legend">
-      <span><i class="sw s-jersey"></i> Clubevent</span><span><i class="sw s-warm"></i> Supporters</span>
-      <span><i class="sw s-bright"></i> Jeugd</span><span><i class="sw s-ink"></i> Andere</span>
-    </div></div></div>
+    <div class="note">
+      V1 + <b>stub colour = eventType</b> (Clubevent=jersey · Supporters=warm ·
+      Jeugd=bright · Andere=ink)
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="grid2">
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZA</div>
+            </div>
+            <div class="body">
+              <span class="pill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="meta">18:00 · Kantine KCVV</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+          <a class="ticket" href="#"
+            ><div class="stub s-bright">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZO</div>
+            </div>
+            <div class="body">
+              <span class="pill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="meta">Sportpark Elewijt</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+          <a class="ticket" href="#"
+            ><div class="stub s-warm">
+              <div class="day">05</div>
+              <div class="mon">OKT</div>
+              <div class="wd">ZA</div>
+            </div>
+            <div class="body">
+              <span class="pill">Supportersactiviteit</span>
+              <h3>Busreis uitwedstrijd</h3>
+              <div class="meta">Vertrek Kantine</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+          <a class="ticket" href="#"
+            ><div class="stub s-ink">
+              <div class="day">08</div>
+              <div class="mon">OKT</div>
+              <div class="wd">DI</div>
+            </div>
+            <div class="body">
+              <span class="pill">Andere</span>
+              <h3>Bloedinzameling</h3>
+              <div class="meta">Parochiezaal</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+        </div>
+        <div class="legend">
+          <span><i class="sw s-jersey"></i> Clubevent</span
+          ><span><i class="sw s-warm"></i> Supporters</span>
+          <span><i class="sw s-bright"></i> Jeugd</span
+          ><span><i class="sw s-ink"></i> Andere</span>
+        </div>
+      </div>
+    </div>
 
     <!-- V3 -->
-    <div class="direction-bar"><span class="tag">3</span> + Reserveer-chip <span class="says">— whole card → detail, PLUS a secondary external chip when externalLink is set.</span></div>
-    <div class="note">V1 + a <b>"Reserveer" chip</b> (= <code>externalLink.label</code>) for events that have an externalLink — a second click target that opens the external link (stops propagation). Events without one show only the hover reveal.</div>
-    <div class="stage"><div class="container"><div class="grid2">
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
-        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div>
-          <a class="chip" href="#" onclick="event.stopPropagation();return false;">Reserveer ↗</a></div></a>
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
-        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div></a>
-    </div></div></div>
+    <div class="direction-bar">
+      <span class="tag">3</span> + Reserveer-chip
+      <span class="says"
+        >— whole card → detail, PLUS a secondary external chip when externalLink
+        is set.</span
+      >
+    </div>
+    <div class="note">
+      V1 + a <b>"Reserveer" chip</b> (= <code>externalLink.label</code>) for
+      events that have an externalLink — a second click target that opens the
+      external link (stops propagation). Events without one show only the hover
+      reveal.
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="grid2">
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZA</div>
+            </div>
+            <div class="body">
+              <span class="pill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="meta">18:00 · Kantine KCVV</div>
+              <a
+                class="chip"
+                href="#"
+                onclick="
+                  event.stopPropagation();
+                  return false;
+                "
+                >Reserveer ↗</a
+              >
+            </div></a
+          >
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZO</div>
+            </div>
+            <div class="body">
+              <span class="pill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="meta">Sportpark Elewijt</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+        </div>
+      </div>
+    </div>
 
     <!-- V4 -->
-    <div class="direction-bar"><span class="tag">4</span> + Mini-foto <span class="says">— optional cover thumb when coverImage exists, gracefully omitted when not.</span></div>
-    <div class="note">V1 + <b>optional cover thumb</b> (rendered only when <code>coverImage</code> is set)</div>
-    <div class="stage"><div class="container"><div class="grid2">
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
-        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div>
-        <div class="thumb t-mossel"></div></a>
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
-        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div>
-        <div class="thumb t-jeugd"></div></a>
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">05</div><div class="mon">OKT</div><div class="wd">ZA</div></div>
-        <div class="body"><span class="pill">Supportersactiviteit</span><h3>Busreis uitwedstrijd</h3><div class="meta">Vertrek Kantine</div><div class="reveal">Meer details →</div></div></a>
-      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">18</div><div class="mon">OKT</div><div class="wd">VR</div></div>
-        <div class="body"><span class="pill">Supportersactiviteit</span><h3>Quiz van de Compagnie</h3><div class="meta">20:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div></a>
+    <div class="direction-bar">
+      <span class="tag">4</span> + Mini-foto
+      <span class="says"
+        >— optional cover thumb when coverImage exists, gracefully omitted when
+        not.</span
+      >
     </div>
-    <div class="legend"><span>↑ rows 1–2 have a cover; rows 3–4 don't — the thumb column just collapses</span></div>
-    </div></div>
+    <div class="note">
+      V1 + <b>optional cover thumb</b> (rendered only when
+      <code>coverImage</code> is set)
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="grid2">
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZA</div>
+            </div>
+            <div class="body">
+              <span class="pill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="meta">18:00 · Kantine KCVV</div>
+              <div class="reveal">Meer details →</div>
+            </div>
+            <div class="thumb t-mossel"></div
+          ></a>
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+              <div class="wd">ZO</div>
+            </div>
+            <div class="body">
+              <span class="pill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="meta">Sportpark Elewijt</div>
+              <div class="reveal">Meer details →</div>
+            </div>
+            <div class="thumb t-jeugd"></div
+          ></a>
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">05</div>
+              <div class="mon">OKT</div>
+              <div class="wd">ZA</div>
+            </div>
+            <div class="body">
+              <span class="pill">Supportersactiviteit</span>
+              <h3>Busreis uitwedstrijd</h3>
+              <div class="meta">Vertrek Kantine</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+          <a class="ticket" href="#"
+            ><div class="stub s-jersey">
+              <div class="day">18</div>
+              <div class="mon">OKT</div>
+              <div class="wd">VR</div>
+            </div>
+            <div class="body">
+              <span class="pill">Supportersactiviteit</span>
+              <h3>Quiz van de Compagnie</h3>
+              <div class="meta">20:00 · Kantine KCVV</div>
+              <div class="reveal">Meer details →</div>
+            </div></a
+          >
+        </div>
+        <div class="legend">
+          <span
+            >↑ rows 1–2 have a cover; rows 3–4 don't — the thumb column just
+            collapses</span
+          >
+        </div>
+      </div>
+    </div>
 
-    <div class="harness-head" style="background: var(--ink-soft);">
-      <p>Next IA rounds after anatomy locks: <b>list layout</b> (1- vs 2-column, month grouping, sort) ·
-      <b>filters</b> (eventType row + "Alles" default) · <b>empty / multi-day / time-less</b> states · then the
-      <code>&lt;EventHero&gt;</code> <b>detail page</b> (hero + iCal "Zet in agenda" + "Andere events" grid).</p>
+    <div class="harness-head" style="background: var(--ink-soft)">
+      <p>
+        Next IA rounds after anatomy locks: <b>list layout</b> (1- vs 2-column,
+        month grouping, sort) · <b>filters</b> (eventType row + "Alles" default)
+        · <b>empty / multi-day / time-less</b> states · then the
+        <code>&lt;EventHero&gt;</code> <b>detail page</b> (hero + iCal "Zet in
+        agenda" + "Andere events" grid).
+      </p>
     </div>
   </body>
 </html>

--- a/docs/design/mockups/phase-6-events/6e2-stub-anatomy-compare.html
+++ b/docs/design/mockups/phase-6-events/6e2-stub-anatomy-compare.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.E — /evenementen · Round 2: IA (ticket-stub anatomy)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--jersey-deep-dark); color: var(--cream); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 78ch; line-height: 1.55; }
+      .harness-head code { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--warm); color: var(--ink);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
+      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
+      .note { font-family: var(--font-mono); font-size: 11.5px; color: #cfe9d8; padding: 9px 28px; background: rgba(0,0,0,0.25); border-bottom: 1px dashed rgba(255,255,255,0.18); }
+      .note b { color: var(--warm); }
+      .hint { text-align:center; font-family: var(--font-mono); font-size: 11px; color: var(--warm); padding: 12px; letter-spacing: 0.05em; }
+      .stage { padding: 30px 28px 50px; }
+      .container { max-width: 1000px; margin: 0 auto; }
+      .grid2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
+      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
+      .pill { display: inline-flex; align-items: center; font-family: var(--font-mono); text-transform: uppercase;
+        letter-spacing: 0.08em; font-size: 10px; font-weight: 600; padding: 3px 8px; border: 1.5px solid var(--ink);
+        background: var(--cream); color: var(--ink); white-space: nowrap; }
+
+      /* ===== clickable ticket — whole card links to /evenementen/[slug] ===== */
+      .ticket { display: flex; background: var(--cream); color: var(--ink); border: 2px solid var(--ink);
+        box-shadow: 6px 6px 0 rgba(0,0,0,0.5); text-decoration: none; cursor: pointer;
+        transition: transform .3s ease, box-shadow .3s ease; }
+      .ticket:hover, .ticket:focus-visible { transform: rotate(-1deg) scale(1.02); box-shadow: 9px 9px 0 rgba(0,0,0,0.55); outline: none; }
+      @media (prefers-reduced-motion: reduce) { .ticket { transition: none; } .ticket:hover, .ticket:focus-visible { transform: none; } }
+      .stub { flex: 0 0 104px; border-right: 2px dashed var(--ink); display: flex; flex-direction: column;
+        align-items: center; justify-content: center; padding: 16px 8px; color: var(--cream); }
+      .stub .day { font-family: var(--font-display); font-weight: 900; font-size: 48px; line-height: 0.85; }
+      .stub .mon { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; font-size: 12px; margin-top: 3px; }
+      .stub .wd { font-family: var(--font-mono); text-transform: uppercase; font-size: 9px; margin-top: 6px; opacity: 0.85; }
+      .s-jersey { background: var(--jersey-deep); } .s-warm { background: var(--warm); color: var(--ink); }
+      .s-bright { background: var(--jersey-bright); color: var(--ink); } .s-ink { background: var(--ink); }
+      .body { padding: 15px 17px; flex: 1; display: flex; flex-direction: column; }
+      .body h3 { margin: 7px 0 6px; font-family: var(--font-display); font-weight: 900; font-size: 23px; }
+      .meta { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10.5px; color: var(--ink-muted); }
+      /* hover reveal — same idiom as EditorialHero "★ Lees verder →" */
+      .reveal { margin-top: 11px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em;
+        font-size: 10.5px; font-weight: 700; color: var(--jersey-deep); opacity: 0; transition: opacity .3s ease; }
+      .ticket:hover .reveal, .ticket:focus-visible .reveal { opacity: 1; }
+      /* secondary external chip (V3) — stops propagation; distinct from the card link */
+      .chip { align-self: flex-start; margin-top: 11px; font-family: var(--font-mono); text-transform: uppercase;
+        letter-spacing: 0.06em; font-size: 10.5px; font-weight: 700; padding: 7px 12px; border: 1.5px solid var(--ink);
+        background: var(--warm); color: var(--ink); text-decoration: none; }
+      .thumb { flex: 0 0 92px; background: var(--cream-deep) center/cover; border-left: 2px solid var(--ink); filter: saturate(0.85) contrast(1.05); }
+      .t-mossel { background-image: linear-gradient(135deg,#15543a,#2f7d56); }
+      .t-jeugd { background-image: linear-gradient(135deg,#444,#7a7a7a); }
+      .legend { display:flex; gap:16px; flex-wrap:wrap; font-family: var(--font-mono); font-size: 10.5px; text-transform:uppercase; letter-spacing:0.07em; color:#cfe9d8; margin-top:18px; }
+      .legend span { display:inline-flex; align-items:center; gap:7px; }
+      .sw { width:14px; height:14px; border:1.5px solid var(--ink); display:inline-block; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.E · /evenementen — Round 2: IA · ticket-stub anatomy</h1>
+      <p>
+        Voice locked (ticket stubs). <b>NEW this round:</b> the whole ticket is a <b>link to the detail page</b> —
+        hover it for the <b>tilt + "Meer details →"</b> reveal (the same idiom as the homepage EditorialHero featured
+        image). All real fields: <code>dateStart</code> (day/month/weekday + time), <code>eventType</code>,
+        <code>title</code>, <code>location</code>, <code>externalLink {url,label}</code>. Pick the anatomy; we can graft.
+      </p>
+    </div>
+    <div class="hint">↳ hover any ticket to see the tilt + "Meer details →" reveal</div>
+
+    <!-- V1 -->
+    <div class="direction-bar"><span class="tag">1</span> Eén merkkleur <span class="says">— every stub jersey-deep; type only in the pill. Whole card → detail. No CTA on the list.</span></div>
+    <div class="note">carries: <b>date · pill · title · location · time</b> · whole-card link + hover reveal. Reserveer/CTA lives on the detail page.</div>
+    <div class="stage"><div class="container"><div class="grid2">
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
+        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div></a>
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
+        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div></a>
+    </div></div></div>
+
+    <!-- V2 -->
+    <div class="direction-bar"><span class="tag">2</span> Type-gecodeerd <span class="says">— date-block COLOUR encodes eventType. Scannable; needs a legend.</span></div>
+    <div class="note">V1 + <b>stub colour = eventType</b> (Clubevent=jersey · Supporters=warm · Jeugd=bright · Andere=ink)</div>
+    <div class="stage"><div class="container"><div class="grid2">
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
+        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div></a>
+      <a class="ticket" href="#"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
+        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div></a>
+      <a class="ticket" href="#"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div><div class="wd">ZA</div></div>
+        <div class="body"><span class="pill">Supportersactiviteit</span><h3>Busreis uitwedstrijd</h3><div class="meta">Vertrek Kantine</div><div class="reveal">Meer details →</div></div></a>
+      <a class="ticket" href="#"><div class="stub s-ink"><div class="day">08</div><div class="mon">OKT</div><div class="wd">DI</div></div>
+        <div class="body"><span class="pill">Andere</span><h3>Bloedinzameling</h3><div class="meta">Parochiezaal</div><div class="reveal">Meer details →</div></div></a>
+    </div>
+    <div class="legend">
+      <span><i class="sw s-jersey"></i> Clubevent</span><span><i class="sw s-warm"></i> Supporters</span>
+      <span><i class="sw s-bright"></i> Jeugd</span><span><i class="sw s-ink"></i> Andere</span>
+    </div></div></div>
+
+    <!-- V3 -->
+    <div class="direction-bar"><span class="tag">3</span> + Reserveer-chip <span class="says">— whole card → detail, PLUS a secondary external chip when externalLink is set.</span></div>
+    <div class="note">V1 + a <b>"Reserveer" chip</b> (= <code>externalLink.label</code>) for events that have an externalLink — a second click target that opens the external link (stops propagation). Events without one show only the hover reveal.</div>
+    <div class="stage"><div class="container"><div class="grid2">
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
+        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div>
+          <a class="chip" href="#" onclick="event.stopPropagation();return false;">Reserveer ↗</a></div></a>
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
+        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div></a>
+    </div></div></div>
+
+    <!-- V4 -->
+    <div class="direction-bar"><span class="tag">4</span> + Mini-foto <span class="says">— optional cover thumb when coverImage exists, gracefully omitted when not.</span></div>
+    <div class="note">V1 + <b>optional cover thumb</b> (rendered only when <code>coverImage</code> is set)</div>
+    <div class="stage"><div class="container"><div class="grid2">
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div><div class="wd">ZA</div></div>
+        <div class="body"><span class="pill">Clubevent</span><h3>Mosselfeest</h3><div class="meta">18:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div>
+        <div class="thumb t-mossel"></div></a>
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">22</div><div class="mon">SEP</div><div class="wd">ZO</div></div>
+        <div class="body"><span class="pill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="meta">Sportpark Elewijt</div><div class="reveal">Meer details →</div></div>
+        <div class="thumb t-jeugd"></div></a>
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">05</div><div class="mon">OKT</div><div class="wd">ZA</div></div>
+        <div class="body"><span class="pill">Supportersactiviteit</span><h3>Busreis uitwedstrijd</h3><div class="meta">Vertrek Kantine</div><div class="reveal">Meer details →</div></div></a>
+      <a class="ticket" href="#"><div class="stub s-jersey"><div class="day">18</div><div class="mon">OKT</div><div class="wd">VR</div></div>
+        <div class="body"><span class="pill">Supportersactiviteit</span><h3>Quiz van de Compagnie</h3><div class="meta">20:00 · Kantine KCVV</div><div class="reveal">Meer details →</div></div></a>
+    </div>
+    <div class="legend"><span>↑ rows 1–2 have a cover; rows 3–4 don't — the thumb column just collapses</span></div>
+    </div></div>
+
+    <div class="harness-head" style="background: var(--ink-soft);">
+      <p>Next IA rounds after anatomy locks: <b>list layout</b> (1- vs 2-column, month grouping, sort) ·
+      <b>filters</b> (eventType row + "Alles" default) · <b>empty / multi-day / time-less</b> states · then the
+      <code>&lt;EventHero&gt;</code> <b>detail page</b> (hero + iCal "Zet in agenda" + "Andere events" grid).</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-events/6e2-stub-anatomy-compare.html
+++ b/docs/design/mockups/phase-6-events/6e2-stub-anatomy-compare.html
@@ -455,8 +455,10 @@
     <div class="stage">
       <div class="container">
         <div class="grid2">
-          <a class="ticket" href="#"
-            ><div class="stub s-jersey">
+          <!-- whole-card click is wired in code (router push); the card is NOT an
+               <a> here so the secondary Reserveer link can be a real, non-nested anchor -->
+          <div class="ticket">
+            <div class="stub s-jersey">
               <div class="day">14</div>
               <div class="mon">SEP</div>
               <div class="wd">ZA</div>
@@ -465,17 +467,9 @@
               <span class="pill">Clubevent</span>
               <h3>Mosselfeest</h3>
               <div class="meta">18:00 · Kantine KCVV</div>
-              <a
-                class="chip"
-                href="#"
-                onclick="
-                  event.stopPropagation();
-                  return false;
-                "
-                >Reserveer ↗</a
-              >
-            </div></a
-          >
+              <a class="chip" href="#">Reserveer ↗</a>
+            </div>
+          </div>
           <a class="ticket" href="#"
             ><div class="stub s-jersey">
               <div class="day">22</div>

--- a/docs/design/mockups/phase-6-events/6e2-stub-anatomy-locked.md
+++ b/docs/design/mockups/phase-6-events/6e2-stub-anatomy-locked.md
@@ -1,0 +1,43 @@
+# Phase 6.E · /evenementen — Round 2 (IA · ticket-stub anatomy) — LOCKED
+
+**Date:** 2026-06-02
+**Mockup:** `6e2-stub-anatomy-compare.html`
+
+## Decision — Variant 2 "Type-gecodeerd" + whole-card interaction
+
+### Interaction (applies to every ticket)
+
+- The **whole ticket is a link** to `/evenementen/[slug]`.
+- **Hover / focus-visible** → small **tilt + scale** and a **"Meer details →"** reveal, reusing the
+  established `EditorialHero` featured-image idiom:
+  `transition-transform duration-300 group-hover:scale-[1.02] group-hover:-rotate-1`
+  (+ `group-focus-visible` equivalents, + `motion-reduce` resets). The reveal label is mono /
+  uppercase / jersey-deep, `opacity-0 → group-hover:opacity-100`.
+
+### Anatomy
+
+- Tear-off **date block** colour **encodes `eventType`**:
+  - Clubevent → `jersey-deep`
+  - Supportersactiviteit → `warm`
+  - Jeugdwerking → `jersey-bright`
+  - Andere → `ink`
+- **`eventType` pill is retained** as the accessible text label. Colour is a redundant fast-scan
+  cue only — it is **not** the sole means of conveying type (WCAG 1.4.1). A **legend** explains the
+  colour system on the list.
+- Fields carried per ticket: **date** (day / MON / weekday + time, from `dateStart`) · **eventType
+  pill** · **title** · **location**.
+
+### Rejected
+
+- **V1** (single brand colour) — chosen interaction adopted, but type-colour added on top.
+- **V3** (+ Reserveer chip on the list) — second click target rejected; the external "Reserveer"
+  CTA stays on the **detail page** (per master-design §6.7 "external link stays the CTA").
+- **V4** (+ mini cover thumb) — list stays text-forward; no list imagery.
+
+## Open refinements for the details round
+
+- **Stub colour values must clear contrast on the `jersey-deep-dark` list field** — `jersey-deep`
+  (Clubevent) and `ink` (Andere) risk blending into the dark background; tune values / add a hairline
+  or cream inset so all four read distinctly. (Per-element detail — deferred per drill order.)
+- Confirm whether the **legend** is always shown or only when >1 type is present.
+- Weekday abbreviation format (ZA / ZO / …) and time display when an event is **time-less**.

--- a/docs/design/mockups/phase-6-events/6e3-list-layout-compare.html
+++ b/docs/design/mockups/phase-6-events/6e3-list-layout-compare.html
@@ -12,93 +12,408 @@
     />
     <style>
       :root {
-        --cream: #f5f1e6; --cream-deep: #e1d7bf; --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
-        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
-        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
-        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+        --cream: #f5f1e6;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-bright: #22c55e;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c;
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
       }
-      * { box-sizing: border-box; }
-      body { margin: 0; background: var(--jersey-deep-dark); color: var(--cream); font-family: var(--font-body); }
-      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
-      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
-      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 78ch; line-height: 1.55; }
-      .harness-head code { color: var(--warm); }
-      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--warm); color: var(--ink);
-        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
-        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
-      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
-      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
-      .stage { padding: 30px 28px 50px; }
-      .container { max-width: 1000px; margin: 0 auto; }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--jersey-deep-dark);
+        color: var(--cream);
+        font-family: var(--font-body);
+      }
+      .harness-head {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 22px 28px;
+        font-family: var(--font-mono);
+      }
+      .harness-head h1 {
+        margin: 0 0 6px;
+        font-size: 15px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .harness-head p {
+        margin: 0;
+        font-size: 13px;
+        color: #b9b9b9;
+        max-width: 78ch;
+        line-height: 1.55;
+      }
+      .harness-head code {
+        color: var(--warm);
+      }
+      .direction-bar {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: var(--warm);
+        color: var(--ink);
+        padding: 11px 28px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
+        border-bottom: 2px solid var(--ink);
+      }
+      .direction-bar .tag {
+        background: var(--ink);
+        color: var(--warm);
+        padding: 2px 9px;
+        font-weight: 700;
+      }
+      .direction-bar .says {
+        color: var(--ink-soft);
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .stage {
+        padding: 30px 28px 50px;
+      }
+      .container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
 
-      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
-      .pill { display: inline-flex; align-items: center; font-family: var(--font-mono); text-transform: uppercase;
-        letter-spacing: 0.08em; font-size: 10px; font-weight: 600; padding: 3px 8px; border: 1.5px solid var(--ink);
-        background: var(--cream); color: var(--ink); white-space: nowrap; }
+      .mono {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        font-size: 11px;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 3px 8px;
+        border: 1.5px solid var(--ink);
+        background: var(--cream);
+        color: var(--ink);
+        white-space: nowrap;
+      }
 
-      .ticket { display: flex; background: var(--cream); color: var(--ink); border: 2px solid var(--ink);
-        box-shadow: 6px 6px 0 rgba(0,0,0,0.5); text-decoration: none; cursor: pointer;
-        transition: transform .3s ease, box-shadow .3s ease; }
-      .ticket:hover, .ticket:focus-visible { transform: rotate(-1deg) scale(1.02); box-shadow: 9px 9px 0 rgba(0,0,0,0.55); outline: none; }
-      @media (prefers-reduced-motion: reduce) { .ticket { transition: none; } .ticket:hover { transform: none; } }
-      .stub { flex: 0 0 100px; border-right: 2px dashed var(--ink); display: flex; flex-direction: column;
-        align-items: center; justify-content: center; padding: 14px 8px; color: var(--cream); }
-      .stub .day { font-family: var(--font-display); font-weight: 900; font-size: 44px; line-height: 0.85; }
-      .stub .mon { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; font-size: 11px; margin-top: 3px; }
-      .stub .wd { font-family: var(--font-mono); text-transform: uppercase; font-size: 9px; margin-top: 5px; opacity: 0.85; }
-      .s-jersey { background: var(--jersey-deep); } .s-warm { background: var(--warm); color: var(--ink); }
-      .s-bright { background: var(--jersey-bright); color: var(--ink); } .s-ink { background: var(--ink); }
-      .body { padding: 14px 16px; flex: 1; display: flex; flex-direction: column; }
-      .body h3 { margin: 6px 0 5px; font-family: var(--font-display); font-weight: 900; font-size: 22px; }
-      .meta { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10.5px; color: var(--ink-muted); }
-      .reveal { margin-top: 10px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em;
-        font-size: 10.5px; font-weight: 700; color: var(--jersey-deep); opacity: 0; transition: opacity .3s ease; }
-      .ticket:hover .reveal, .ticket:focus-visible .reveal { opacity: 1; }
+      .ticket {
+        display: flex;
+        background: var(--cream);
+        color: var(--ink);
+        border: 2px solid var(--ink);
+        box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.5);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          transform 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+      .ticket:hover,
+      .ticket:focus-visible {
+        transform: rotate(-1deg) scale(1.02);
+        box-shadow: 9px 9px 0 rgba(0, 0, 0, 0.55);
+        outline: none;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .ticket {
+          transition: none;
+        }
+        .ticket:hover {
+          transform: none;
+        }
+      }
+      .stub {
+        flex: 0 0 100px;
+        border-right: 2px dashed var(--ink);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 8px;
+        color: var(--cream);
+      }
+      .stub .day {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 44px;
+        line-height: 0.85;
+      }
+      .stub .mon {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+        margin-top: 3px;
+      }
+      .stub .wd {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        font-size: 9px;
+        margin-top: 5px;
+        opacity: 0.85;
+      }
+      .s-jersey {
+        background: var(--jersey-deep);
+      }
+      .s-warm {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .s-bright {
+        background: var(--jersey-bright);
+        color: var(--ink);
+      }
+      .s-ink {
+        background: var(--ink);
+      }
+      .body {
+        padding: 14px 16px;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+      .body h3 {
+        margin: 6px 0 5px;
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 22px;
+      }
+      .meta {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10.5px;
+        color: var(--ink-muted);
+      }
+      .reveal {
+        margin-top: 10px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10.5px;
+        font-weight: 700;
+        color: var(--jersey-deep);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
+      .ticket:hover .reveal,
+      .ticket:focus-visible .reveal {
+        opacity: 1;
+      }
 
-      .col1 { display: flex; flex-direction: column; gap: 20px; max-width: 680px; }
-      .col2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px; }
-      .month { display: flex; align-items: center; gap: 16px; margin: 30px 0 18px; }
-      .month:first-child { margin-top: 4px; }
-      .month h2 { margin: 0; font-family: var(--font-display); font-weight: 900; font-size: 30px; color: var(--cream); }
-      .seam { flex: 1; height: 12px; background:
-        repeating-linear-gradient(-45deg, var(--cream) 0 8px, var(--jersey-deep) 8px 16px, var(--cream) 16px 24px, var(--ink) 24px 32px); }
-      .legend { display:flex; gap:16px; flex-wrap:wrap; font-family: var(--font-mono); font-size: 10.5px; text-transform:uppercase; letter-spacing:0.07em; color:#cfe9d8; margin: 0 0 24px; }
-      .legend span { display:inline-flex; align-items:center; gap:7px; }
-      .sw { width:14px; height:14px; border:1.5px solid var(--ink); display:inline-block; }
+      .col1 {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        max-width: 680px;
+      }
+      .col2 {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 22px;
+      }
+      .month {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin: 30px 0 18px;
+      }
+      .month:first-child {
+        margin-top: 4px;
+      }
+      .month h2 {
+        margin: 0;
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 30px;
+        color: var(--cream);
+      }
+      .seam {
+        flex: 1;
+        height: 12px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--cream) 0 8px,
+          var(--jersey-deep) 8px 16px,
+          var(--cream) 16px 24px,
+          var(--ink) 24px 32px
+        );
+      }
+      .legend {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        font-family: var(--font-mono);
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: #cfe9d8;
+        margin: 0 0 24px;
+      }
+      .legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+      }
+      .sw {
+        width: 14px;
+        height: 14px;
+        border: 1.5px solid var(--ink);
+        display: inline-block;
+      }
     </style>
   </head>
   <body>
     <div class="harness-head">
       <h1>Phase 6.E · /evenementen — Round 3: list LAYOUT</h1>
       <p>
-        Voice + anatomy locked (type-coloured clickable ticket stubs, hover tilt + "Meer details →"). This round picks
-        how the list is <b>arranged</b>: columns (1 vs 2) × grouping (flat chronological vs month sections). Same six
-        upcoming events in each. Note: an amateur club often has only a handful of upcoming events at once — weigh
-        whether month headers earn their space.
+        Voice + anatomy locked (type-coloured clickable ticket stubs, hover tilt
+        + "Meer details →"). This round picks how the list is <b>arranged</b>:
+        columns (1 vs 2) × grouping (flat chronological vs month sections). Same
+        six upcoming events in each. Note: an amateur club often has only a
+        handful of upcoming events at once — weigh whether month headers earn
+        their space.
       </p>
     </div>
 
-    <div class="direction-bar"><span class="tag">A</span> Eén kolom · doorlopend <span class="says">— one ticket per row, flat chronological. Calmest, most readable, mobile-native.</span></div>
-    <div class="stage"><div class="container"><div class="legend" id="lg-a"></div><div class="col1" id="la"></div></div></div>
+    <div class="direction-bar">
+      <span class="tag">A</span> Eén kolom · doorlopend
+      <span class="says"
+        >— one ticket per row, flat chronological. Calmest, most readable,
+        mobile-native.</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="legend" id="lg-a"></div>
+        <div class="col1" id="la"></div>
+      </div>
+    </div>
 
-    <div class="direction-bar"><span class="tag">B</span> Twee kolommen · doorlopend <span class="says">— 2-col grid, flat chronological. Denser, more poster-wall.</span></div>
-    <div class="stage"><div class="container"><div class="legend" id="lg-b"></div><div class="col2" id="lb"></div></div></div>
+    <div class="direction-bar">
+      <span class="tag">B</span> Twee kolommen · doorlopend
+      <span class="says"
+        >— 2-col grid, flat chronological. Denser, more poster-wall.</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="legend" id="lg-b"></div>
+        <div class="col2" id="lb"></div>
+      </div>
+    </div>
 
-    <div class="direction-bar"><span class="tag">C</span> Twee kolommen · per maand <span class="says">— month headers (striped seam) + 2-col grid under each. Editorial structure.</span></div>
-    <div class="stage"><div class="container"><div class="legend" id="lg-c"></div><div id="lc"></div></div></div>
+    <div class="direction-bar">
+      <span class="tag">C</span> Twee kolommen · per maand
+      <span class="says"
+        >— month headers (striped seam) + 2-col grid under each. Editorial
+        structure.</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="legend" id="lg-c"></div>
+        <div id="lc"></div>
+      </div>
+    </div>
 
-    <div class="direction-bar"><span class="tag">D</span> Eén kolom · per maand <span class="says">— month headers + single column. Agenda-like, most "what's on next".</span></div>
-    <div class="stage"><div class="container"><div class="legend" id="lg-d"></div><div id="ld"></div></div></div>
+    <div class="direction-bar">
+      <span class="tag">D</span> Eén kolom · per maand
+      <span class="says"
+        >— month headers + single column. Agenda-like, most "what's on
+        next".</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="legend" id="lg-d"></div>
+        <div id="ld"></div>
+      </div>
+    </div>
 
     <script>
-      const COLOR = { Clubevent: "s-jersey", Supportersactiviteit: "s-warm", Jeugdwerking: "s-bright", Andere: "s-ink" };
+      const COLOR = {
+        Clubevent: "s-jersey",
+        Supportersactiviteit: "s-warm",
+        Jeugdwerking: "s-bright",
+        Andere: "s-ink",
+      };
       const EVENTS = [
-        { day:"14", mon:"SEP", wd:"ZA", type:"Clubevent",           title:"Mosselfeest",            meta:"18:00 · Kantine KCVV",  month:"September" },
-        { day:"22", mon:"SEP", wd:"ZO", type:"Jeugdwerking",        title:"Jeugdtornooi U10–U13",   meta:"Sportpark Elewijt",     month:"September" },
-        { day:"05", mon:"OKT", wd:"ZA", type:"Supportersactiviteit", title:"Busreis uitwedstrijd",   meta:"Vertrek Kantine",       month:"Oktober" },
-        { day:"08", mon:"OKT", wd:"DI", type:"Andere",              title:"Bloedinzameling Rode Kruis", meta:"Parochiezaal",      month:"Oktober" },
-        { day:"18", mon:"OKT", wd:"VR", type:"Supportersactiviteit", title:"Quiz van de Compagnie",  meta:"20:00 · Kantine KCVV",  month:"Oktober" },
-        { day:"09", mon:"NOV", wd:"ZA", type:"Clubevent",           title:"Eetfestijn",             meta:"18:30 · Kantine KCVV",  month:"November" },
+        {
+          day: "14",
+          mon: "SEP",
+          wd: "ZA",
+          type: "Clubevent",
+          title: "Mosselfeest",
+          meta: "18:00 · Kantine KCVV",
+          month: "September",
+        },
+        {
+          day: "22",
+          mon: "SEP",
+          wd: "ZO",
+          type: "Jeugdwerking",
+          title: "Jeugdtornooi U10–U13",
+          meta: "Sportpark Elewijt",
+          month: "September",
+        },
+        {
+          day: "05",
+          mon: "OKT",
+          wd: "ZA",
+          type: "Supportersactiviteit",
+          title: "Busreis uitwedstrijd",
+          meta: "Vertrek Kantine",
+          month: "Oktober",
+        },
+        {
+          day: "08",
+          mon: "OKT",
+          wd: "DI",
+          type: "Andere",
+          title: "Bloedinzameling Rode Kruis",
+          meta: "Parochiezaal",
+          month: "Oktober",
+        },
+        {
+          day: "18",
+          mon: "OKT",
+          wd: "VR",
+          type: "Supportersactiviteit",
+          title: "Quiz van de Compagnie",
+          meta: "20:00 · Kantine KCVV",
+          month: "Oktober",
+        },
+        {
+          day: "09",
+          mon: "NOV",
+          wd: "ZA",
+          type: "Clubevent",
+          title: "Eetfestijn",
+          meta: "18:30 · Kantine KCVV",
+          month: "November",
+        },
       ];
       const ticket = (e) => `
         <a class="ticket" href="#">
@@ -108,15 +423,24 @@
       const legend = `
         <span><i class="sw s-jersey"></i> Clubevent</span><span><i class="sw s-warm"></i> Supporters</span>
         <span><i class="sw s-bright"></i> Jeugd</span><span><i class="sw s-ink"></i> Andere</span>`;
-      ["lg-a","lg-b","lg-c","lg-d"].forEach(id => document.getElementById(id).innerHTML = legend);
+      ["lg-a", "lg-b", "lg-c", "lg-d"].forEach(
+        (id) => (document.getElementById(id).innerHTML = legend),
+      );
 
       document.getElementById("la").innerHTML = EVENTS.map(ticket).join("");
       document.getElementById("lb").innerHTML = EVENTS.map(ticket).join("");
 
-      const months = [...new Set(EVENTS.map(e => e.month))];
-      const grouped = (wrapClass) => months.map(m => `
+      const months = [...new Set(EVENTS.map((e) => e.month))];
+      const grouped = (wrapClass) =>
+        months
+          .map(
+            (m) => `
         <div class="month"><h2>${m}</h2><div class="seam"></div></div>
-        <div class="${wrapClass}">${EVENTS.filter(e => e.month === m).map(ticket).join("")}</div>`).join("");
+        <div class="${wrapClass}">${EVENTS.filter((e) => e.month === m)
+          .map(ticket)
+          .join("")}</div>`,
+          )
+          .join("");
       document.getElementById("lc").innerHTML = grouped("col2");
       document.getElementById("ld").innerHTML = grouped("col1");
     </script>

--- a/docs/design/mockups/phase-6-events/6e3-list-layout-compare.html
+++ b/docs/design/mockups/phase-6-events/6e3-list-layout-compare.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.E — /evenementen · Round 3: list layout</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,500&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-deep: #e1d7bf; --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--jersey-deep-dark); color: var(--cream); font-family: var(--font-body); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 78ch; line-height: 1.55; }
+      .harness-head code { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--warm); color: var(--ink);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
+      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
+      .stage { padding: 30px 28px 50px; }
+      .container { max-width: 1000px; margin: 0 auto; }
+
+      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
+      .pill { display: inline-flex; align-items: center; font-family: var(--font-mono); text-transform: uppercase;
+        letter-spacing: 0.08em; font-size: 10px; font-weight: 600; padding: 3px 8px; border: 1.5px solid var(--ink);
+        background: var(--cream); color: var(--ink); white-space: nowrap; }
+
+      .ticket { display: flex; background: var(--cream); color: var(--ink); border: 2px solid var(--ink);
+        box-shadow: 6px 6px 0 rgba(0,0,0,0.5); text-decoration: none; cursor: pointer;
+        transition: transform .3s ease, box-shadow .3s ease; }
+      .ticket:hover, .ticket:focus-visible { transform: rotate(-1deg) scale(1.02); box-shadow: 9px 9px 0 rgba(0,0,0,0.55); outline: none; }
+      @media (prefers-reduced-motion: reduce) { .ticket { transition: none; } .ticket:hover { transform: none; } }
+      .stub { flex: 0 0 100px; border-right: 2px dashed var(--ink); display: flex; flex-direction: column;
+        align-items: center; justify-content: center; padding: 14px 8px; color: var(--cream); }
+      .stub .day { font-family: var(--font-display); font-weight: 900; font-size: 44px; line-height: 0.85; }
+      .stub .mon { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; font-size: 11px; margin-top: 3px; }
+      .stub .wd { font-family: var(--font-mono); text-transform: uppercase; font-size: 9px; margin-top: 5px; opacity: 0.85; }
+      .s-jersey { background: var(--jersey-deep); } .s-warm { background: var(--warm); color: var(--ink); }
+      .s-bright { background: var(--jersey-bright); color: var(--ink); } .s-ink { background: var(--ink); }
+      .body { padding: 14px 16px; flex: 1; display: flex; flex-direction: column; }
+      .body h3 { margin: 6px 0 5px; font-family: var(--font-display); font-weight: 900; font-size: 22px; }
+      .meta { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10.5px; color: var(--ink-muted); }
+      .reveal { margin-top: 10px; font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em;
+        font-size: 10.5px; font-weight: 700; color: var(--jersey-deep); opacity: 0; transition: opacity .3s ease; }
+      .ticket:hover .reveal, .ticket:focus-visible .reveal { opacity: 1; }
+
+      .col1 { display: flex; flex-direction: column; gap: 20px; max-width: 680px; }
+      .col2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px; }
+      .month { display: flex; align-items: center; gap: 16px; margin: 30px 0 18px; }
+      .month:first-child { margin-top: 4px; }
+      .month h2 { margin: 0; font-family: var(--font-display); font-weight: 900; font-size: 30px; color: var(--cream); }
+      .seam { flex: 1; height: 12px; background:
+        repeating-linear-gradient(-45deg, var(--cream) 0 8px, var(--jersey-deep) 8px 16px, var(--cream) 16px 24px, var(--ink) 24px 32px); }
+      .legend { display:flex; gap:16px; flex-wrap:wrap; font-family: var(--font-mono); font-size: 10.5px; text-transform:uppercase; letter-spacing:0.07em; color:#cfe9d8; margin: 0 0 24px; }
+      .legend span { display:inline-flex; align-items:center; gap:7px; }
+      .sw { width:14px; height:14px; border:1.5px solid var(--ink); display:inline-block; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.E · /evenementen — Round 3: list LAYOUT</h1>
+      <p>
+        Voice + anatomy locked (type-coloured clickable ticket stubs, hover tilt + "Meer details →"). This round picks
+        how the list is <b>arranged</b>: columns (1 vs 2) × grouping (flat chronological vs month sections). Same six
+        upcoming events in each. Note: an amateur club often has only a handful of upcoming events at once — weigh
+        whether month headers earn their space.
+      </p>
+    </div>
+
+    <div class="direction-bar"><span class="tag">A</span> Eén kolom · doorlopend <span class="says">— one ticket per row, flat chronological. Calmest, most readable, mobile-native.</span></div>
+    <div class="stage"><div class="container"><div class="legend" id="lg-a"></div><div class="col1" id="la"></div></div></div>
+
+    <div class="direction-bar"><span class="tag">B</span> Twee kolommen · doorlopend <span class="says">— 2-col grid, flat chronological. Denser, more poster-wall.</span></div>
+    <div class="stage"><div class="container"><div class="legend" id="lg-b"></div><div class="col2" id="lb"></div></div></div>
+
+    <div class="direction-bar"><span class="tag">C</span> Twee kolommen · per maand <span class="says">— month headers (striped seam) + 2-col grid under each. Editorial structure.</span></div>
+    <div class="stage"><div class="container"><div class="legend" id="lg-c"></div><div id="lc"></div></div></div>
+
+    <div class="direction-bar"><span class="tag">D</span> Eén kolom · per maand <span class="says">— month headers + single column. Agenda-like, most "what's on next".</span></div>
+    <div class="stage"><div class="container"><div class="legend" id="lg-d"></div><div id="ld"></div></div></div>
+
+    <script>
+      const COLOR = { Clubevent: "s-jersey", Supportersactiviteit: "s-warm", Jeugdwerking: "s-bright", Andere: "s-ink" };
+      const EVENTS = [
+        { day:"14", mon:"SEP", wd:"ZA", type:"Clubevent",           title:"Mosselfeest",            meta:"18:00 · Kantine KCVV",  month:"September" },
+        { day:"22", mon:"SEP", wd:"ZO", type:"Jeugdwerking",        title:"Jeugdtornooi U10–U13",   meta:"Sportpark Elewijt",     month:"September" },
+        { day:"05", mon:"OKT", wd:"ZA", type:"Supportersactiviteit", title:"Busreis uitwedstrijd",   meta:"Vertrek Kantine",       month:"Oktober" },
+        { day:"08", mon:"OKT", wd:"DI", type:"Andere",              title:"Bloedinzameling Rode Kruis", meta:"Parochiezaal",      month:"Oktober" },
+        { day:"18", mon:"OKT", wd:"VR", type:"Supportersactiviteit", title:"Quiz van de Compagnie",  meta:"20:00 · Kantine KCVV",  month:"Oktober" },
+        { day:"09", mon:"NOV", wd:"ZA", type:"Clubevent",           title:"Eetfestijn",             meta:"18:30 · Kantine KCVV",  month:"November" },
+      ];
+      const ticket = (e) => `
+        <a class="ticket" href="#">
+          <div class="stub ${COLOR[e.type]}"><div class="day">${e.day}</div><div class="mon">${e.mon}</div><div class="wd">${e.wd}</div></div>
+          <div class="body"><span class="pill">${e.type}</span><h3>${e.title}</h3><div class="meta">${e.meta}</div><div class="reveal">Meer details →</div></div>
+        </a>`;
+      const legend = `
+        <span><i class="sw s-jersey"></i> Clubevent</span><span><i class="sw s-warm"></i> Supporters</span>
+        <span><i class="sw s-bright"></i> Jeugd</span><span><i class="sw s-ink"></i> Andere</span>`;
+      ["lg-a","lg-b","lg-c","lg-d"].forEach(id => document.getElementById(id).innerHTML = legend);
+
+      document.getElementById("la").innerHTML = EVENTS.map(ticket).join("");
+      document.getElementById("lb").innerHTML = EVENTS.map(ticket).join("");
+
+      const months = [...new Set(EVENTS.map(e => e.month))];
+      const grouped = (wrapClass) => months.map(m => `
+        <div class="month"><h2>${m}</h2><div class="seam"></div></div>
+        <div class="${wrapClass}">${EVENTS.filter(e => e.month === m).map(ticket).join("")}</div>`).join("");
+      document.getElementById("lc").innerHTML = grouped("col2");
+      document.getElementById("ld").innerHTML = grouped("col1");
+    </script>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-events/6e3-list-layout-compare.html
+++ b/docs/design/mockups/phase-6-events/6e3-list-layout-compare.html
@@ -139,7 +139,8 @@
         .ticket {
           transition: none;
         }
-        .ticket:hover {
+        .ticket:hover,
+        .ticket:focus-visible {
           transform: none;
         }
       }

--- a/docs/design/mockups/phase-6-events/6e3-list-layout-locked.md
+++ b/docs/design/mockups/phase-6-events/6e3-list-layout-locked.md
@@ -1,0 +1,27 @@
+# Phase 6.E · /evenementen — Round 3 (IA · list layout) — LOCKED
+
+**Date:** 2026-06-02
+**Mockup:** `6e3-list-layout-compare.html`
+
+## Decision — Variant D "Eén kolom, per maand"
+
+- **Single column** of full-width ticket stubs (same as the mobile layout — one responsive rule).
+- **Grouped by month**: each month is introduced by a header = month name (display serif) +
+  a **`StripedSeam`** rule. Tickets sit chronologically within each month.
+- List is **upcoming-only**, chronological.
+
+### Why
+
+Most agenda-like "what's on next" reading; clearest chronology; combines single-column
+readability with light temporal structure. Beat B/C (2-col) on clarity and A (flat) on
+wayfinding.
+
+## Open refinements (later rounds / details)
+
+- **Filter × month interaction**: when a type filter empties a month, hide that month's header
+  (don't render an empty section). — covered in the filter round.
+- **Month header seam**: exact `StripedSeam` height + colour order to confirm in details.
+- **Year boundary**: show the year on the month header only when the list spans into the next
+  calendar year (e.g. "Januari 2027").
+- **Few-events case**: with only 1–2 upcoming events the month headers are sparse but still read
+  as an agenda — accepted.

--- a/docs/design/mockups/phase-6-events/6e4-filterbar-compare.html
+++ b/docs/design/mockups/phase-6-events/6e4-filterbar-compare.html
@@ -12,154 +12,605 @@
     />
     <style>
       :root {
-        --cream: #f5f1e6; --cream-deep: #e1d7bf; --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
-        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
-        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
-        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+        --cream: #f5f1e6;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-bright: #22c55e;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c;
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
       }
-      * { box-sizing: border-box; }
-      body { margin: 0; background: var(--jersey-deep-dark); color: var(--cream); font-family: var(--font-body); }
-      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
-      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
-      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 78ch; line-height: 1.55; }
-      .harness-head code { color: var(--warm); }
-      .direction-bar { background: var(--warm); color: var(--ink);
-        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
-        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top: 2px solid var(--ink); }
-      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
-      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
-      .stage { padding: 26px 28px 44px; }
-      .container { max-width: 880px; margin: 0 auto; }
-      .pagetitle { font-family: var(--font-display); font-weight: 900; font-size: 46px; color: var(--cream); margin: 0 0 4px; letter-spacing: -0.01em; }
-      .kicker { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; font-size: 11px; color: var(--warm); margin-bottom: 8px; }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--jersey-deep-dark);
+        color: var(--cream);
+        font-family: var(--font-body);
+      }
+      .harness-head {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 22px 28px;
+        font-family: var(--font-mono);
+      }
+      .harness-head h1 {
+        margin: 0 0 6px;
+        font-size: 15px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .harness-head p {
+        margin: 0;
+        font-size: 13px;
+        color: #b9b9b9;
+        max-width: 78ch;
+        line-height: 1.55;
+      }
+      .harness-head code {
+        color: var(--warm);
+      }
+      .direction-bar {
+        background: var(--warm);
+        color: var(--ink);
+        padding: 11px 28px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
+        border-bottom: 2px solid var(--ink);
+        border-top: 2px solid var(--ink);
+      }
+      .direction-bar .tag {
+        background: var(--ink);
+        color: var(--warm);
+        padding: 2px 9px;
+        font-weight: 700;
+      }
+      .direction-bar .says {
+        color: var(--ink-soft);
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .stage {
+        padding: 26px 28px 44px;
+      }
+      .container {
+        max-width: 880px;
+        margin: 0 auto;
+      }
+      .pagetitle {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 46px;
+        color: var(--cream);
+        margin: 0 0 4px;
+        letter-spacing: -0.01em;
+      }
+      .kicker {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 11px;
+        color: var(--warm);
+        margin-bottom: 8px;
+      }
 
       /* filter atoms */
-      .pill { display: inline-flex; align-items: center; gap:6px; font-family: var(--font-mono); text-transform: uppercase;
-        letter-spacing: 0.07em; font-size: 11px; font-weight: 600; padding: 7px 13px; border: 1.5px solid var(--cream);
-        background: transparent; color: var(--cream); white-space: nowrap; cursor: pointer; }
-      .pill.on { background: var(--cream); color: var(--ink); }
-      .row { display: flex; gap: 9px; flex-wrap: wrap; align-items: center; }
-      .dot { width: 11px; height: 11px; border: 1.5px solid var(--ink); display:inline-block; }
-      .d-jersey { background: var(--jersey-deep); } .d-warm { background: var(--warm); } .d-bright { background: var(--jersey-bright); } .d-ink { background: var(--ink); }
-      .legend { display:flex; gap:15px; flex-wrap:wrap; font-family: var(--font-mono); font-size: 10px; text-transform:uppercase; letter-spacing:0.07em; color:#cfe9d8; margin-top:14px; }
-      .legend span { display:inline-flex; align-items:center; gap:6px; }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        font-size: 11px;
+        font-weight: 600;
+        padding: 7px 13px;
+        border: 1.5px solid var(--cream);
+        background: transparent;
+        color: var(--cream);
+        white-space: nowrap;
+        cursor: pointer;
+      }
+      .pill.on {
+        background: var(--cream);
+        color: var(--ink);
+      }
+      .row {
+        display: flex;
+        gap: 9px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .dot {
+        width: 11px;
+        height: 11px;
+        border: 1.5px solid var(--ink);
+        display: inline-block;
+      }
+      .d-jersey {
+        background: var(--jersey-deep);
+      }
+      .d-warm {
+        background: var(--warm);
+      }
+      .d-bright {
+        background: var(--jersey-bright);
+      }
+      .d-ink {
+        background: var(--ink);
+      }
+      .legend {
+        display: flex;
+        gap: 15px;
+        flex-wrap: wrap;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: #cfe9d8;
+        margin-top: 14px;
+      }
+      .legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
 
       /* colour-coded filter chips (B) */
-      .cpill { display:inline-flex; align-items:center; gap:7px; font-family: var(--font-mono); text-transform:uppercase;
-        letter-spacing:0.07em; font-size:11px; font-weight:600; padding:7px 13px; border:1.5px solid var(--ink); cursor:pointer; }
-      .cpill .dot { border-color: rgba(0,0,0,0.35); }
-      .cp-all { background: var(--cream); color: var(--ink); }
-      .cp-jersey { background: var(--jersey-deep); color: var(--cream); }
-      .cp-warm { background: var(--warm); color: var(--ink); }
-      .cp-bright { background: var(--jersey-bright); color: var(--ink); }
-      .cp-ink { background: var(--ink); color: var(--cream); }
-      .cpill.off { background: transparent; color: var(--cream); border-color: var(--cream); opacity: 0.6; }
+      .cpill {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        font-size: 11px;
+        font-weight: 600;
+        padding: 7px 13px;
+        border: 1.5px solid var(--ink);
+        cursor: pointer;
+      }
+      .cpill .dot {
+        border-color: rgba(0, 0, 0, 0.35);
+      }
+      .cp-all {
+        background: var(--cream);
+        color: var(--ink);
+      }
+      .cp-jersey {
+        background: var(--jersey-deep);
+        color: var(--cream);
+      }
+      .cp-warm {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .cp-bright {
+        background: var(--jersey-bright);
+        color: var(--ink);
+      }
+      .cp-ink {
+        background: var(--ink);
+        color: var(--cream);
+      }
+      .cpill.off {
+        background: transparent;
+        color: var(--cream);
+        border-color: var(--cream);
+        opacity: 0.6;
+      }
 
       /* tabs (C) */
-      .tabs { display:flex; gap: 24px; border-bottom: 2px solid rgba(245,241,230,0.25); padding-bottom: 0; flex-wrap: wrap; }
-      .tab { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.08em; font-size: 12px; font-weight: 600;
-        color: rgba(245,241,230,0.7); padding: 0 2px 10px; border-bottom: 3px solid transparent; cursor: pointer; }
-      .tab.on { color: var(--cream); border-bottom-color: var(--warm); }
+      .tabs {
+        display: flex;
+        gap: 24px;
+        border-bottom: 2px solid rgba(245, 241, 230, 0.25);
+        padding-bottom: 0;
+        flex-wrap: wrap;
+      }
+      .tab {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 12px;
+        font-weight: 600;
+        color: rgba(245, 241, 230, 0.7);
+        padding: 0 2px 10px;
+        border-bottom: 3px solid transparent;
+        cursor: pointer;
+      }
+      .tab.on {
+        color: var(--cream);
+        border-bottom-color: var(--warm);
+      }
 
       /* dropdown (D) */
-      .select { display:inline-flex; align-items:center; gap:10px; font-family: var(--font-mono); text-transform:uppercase;
-        letter-spacing:0.06em; font-size:12px; font-weight:600; padding: 10px 16px; border:1.5px solid var(--cream); background: transparent; color: var(--cream); cursor:pointer; }
+      .select {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 12px;
+        font-weight: 600;
+        padding: 10px 16px;
+        border: 1.5px solid var(--cream);
+        background: transparent;
+        color: var(--cream);
+        cursor: pointer;
+      }
 
       /* mini list context */
-      .month { display: flex; align-items: center; gap: 14px; margin: 22px 0 14px; }
-      .month h2 { margin: 0; font-family: var(--font-display); font-weight: 900; font-size: 24px; color: var(--cream); }
-      .seam { flex: 1; height: 11px; background: repeating-linear-gradient(-45deg, var(--cream) 0 7px, var(--jersey-deep) 7px 14px, var(--cream) 14px 21px, var(--ink) 21px 28px); }
-      .col1 { display:flex; flex-direction:column; gap: 16px; }
-      .ticket { display: flex; background: var(--cream); color: var(--ink); border: 2px solid var(--ink); box-shadow: 5px 5px 0 rgba(0,0,0,0.5); text-decoration: none; }
-      .stub { flex: 0 0 86px; border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 12px 6px; color: var(--cream); }
-      .stub .day { font-family: var(--font-display); font-weight: 900; font-size: 36px; line-height: 0.85; }
-      .stub .mon { font-family: var(--font-mono); text-transform: uppercase; font-size: 10px; margin-top: 3px; }
-      .s-jersey { background: var(--jersey-deep); } .s-warm { background: var(--warm); color: var(--ink); } .s-bright { background: var(--jersey-bright); color: var(--ink); } .s-ink { background: var(--ink); }
-      .tbody { padding: 11px 15px; }
-      .tpill { display:inline-flex; font-family: var(--font-mono); text-transform:uppercase; letter-spacing:0.07em; font-size:9.5px; font-weight:600; padding:2px 7px; border:1.5px solid var(--ink); background: var(--cream); color: var(--ink); }
-      .tbody h3 { margin: 6px 0 4px; font-family: var(--font-display); font-weight: 900; font-size: 19px; }
-      .tmeta { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10px; color: var(--ink-muted); }
+      .month {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin: 22px 0 14px;
+      }
+      .month h2 {
+        margin: 0;
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 24px;
+        color: var(--cream);
+      }
+      .seam {
+        flex: 1;
+        height: 11px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--cream) 0 7px,
+          var(--jersey-deep) 7px 14px,
+          var(--cream) 14px 21px,
+          var(--ink) 21px 28px
+        );
+      }
+      .col1 {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      .ticket {
+        display: flex;
+        background: var(--cream);
+        color: var(--ink);
+        border: 2px solid var(--ink);
+        box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.5);
+        text-decoration: none;
+      }
+      .stub {
+        flex: 0 0 86px;
+        border-right: 2px dashed var(--ink);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 12px 6px;
+        color: var(--cream);
+      }
+      .stub .day {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 36px;
+        line-height: 0.85;
+      }
+      .stub .mon {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        font-size: 10px;
+        margin-top: 3px;
+      }
+      .s-jersey {
+        background: var(--jersey-deep);
+      }
+      .s-warm {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .s-bright {
+        background: var(--jersey-bright);
+        color: var(--ink);
+      }
+      .s-ink {
+        background: var(--ink);
+      }
+      .tbody {
+        padding: 11px 15px;
+      }
+      .tpill {
+        display: inline-flex;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        font-size: 9.5px;
+        font-weight: 600;
+        padding: 2px 7px;
+        border: 1.5px solid var(--ink);
+        background: var(--cream);
+        color: var(--ink);
+      }
+      .tbody h3 {
+        margin: 6px 0 4px;
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 19px;
+      }
+      .tmeta {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10px;
+        color: var(--ink-muted);
+      }
     </style>
   </head>
   <body>
     <div class="harness-head">
       <h1>Phase 6.E · /evenementen — Round 4: FILTER BAR</h1>
       <p>
-        Layout locked (single column, month-grouped, type-coloured clickable stubs). This round picks the
-        <b>eventType filter</b> treatment — and the key question: do the filters <b>carry the colour coding</b>
-        (so they double as the legend, removing a separate legend row), or stay neutral with a legend underneath?
-        "Alles" is the default (no filter). Each treatment is shown above a slice of the locked list.
+        Layout locked (single column, month-grouped, type-coloured clickable
+        stubs). This round picks the
+        <b>eventType filter</b> treatment — and the key question: do the filters
+        <b>carry the colour coding</b>
+        (so they double as the legend, removing a separate legend row), or stay
+        neutral with a legend underneath? "Alles" is the default (no filter).
+        Each treatment is shown above a slice of the locked list.
       </p>
     </div>
 
     <!-- A -->
-    <div class="direction-bar"><span class="tag">A</span> Neutrale pills + legenda <span class="says">— cream outline pills; a separate colour legend below. Cleanest pills, but the legend is a second element.</span></div>
-    <div class="stage"><div class="container">
-      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
-      <div class="row" style="margin-top:14px;">
-        <span class="pill on">Alles</span><span class="pill">Clubevent</span><span class="pill">Supporters</span><span class="pill">Jeugd</span><span class="pill">Andere</span>
+    <div class="direction-bar">
+      <span class="tag">A</span> Neutrale pills + legenda
+      <span class="says"
+        >— cream outline pills; a separate colour legend below. Cleanest pills,
+        but the legend is a second element.</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="kicker">KCVV ELEWIJT · AGENDA</div>
+        <h1 class="pagetitle">Evenementen.</h1>
+        <div class="row" style="margin-top: 14px">
+          <span class="pill on">Alles</span><span class="pill">Clubevent</span
+          ><span class="pill">Supporters</span><span class="pill">Jeugd</span
+          ><span class="pill">Andere</span>
+        </div>
+        <div class="legend">
+          <span><i class="dot d-jersey"></i>Clubevent</span
+          ><span><i class="dot d-warm"></i>Supporters</span
+          ><span><i class="dot d-bright"></i>Jeugd</span
+          ><span><i class="dot d-ink"></i>Andere</span>
+        </div>
+        <div class="month">
+          <h2>September</h2>
+          <div class="seam"></div>
+        </div>
+        <div class="col1">
+          <a class="ticket"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="tmeta">18:00 · Kantine KCVV</div>
+            </div></a
+          >
+          <a class="ticket"
+            ><div class="stub s-bright">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="tmeta">Sportpark Elewijt</div>
+            </div></a
+          >
+        </div>
       </div>
-      <div class="legend"><span><i class="dot d-jersey"></i>Clubevent</span><span><i class="dot d-warm"></i>Supporters</span><span><i class="dot d-bright"></i>Jeugd</span><span><i class="dot d-ink"></i>Andere</span></div>
-      <div class="month"><h2>September</h2><div class="seam"></div></div>
-      <div class="col1">
-        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
-      </div>
-    </div></div>
+    </div>
 
     <!-- B -->
-    <div class="direction-bar"><span class="tag">B</span> Kleur-pills = legenda <span class="says">— the filter chips ARE colour-coded, so they teach the colour system. No separate legend. Selected = filled, off = dimmed outline.</span></div>
-    <div class="stage"><div class="container">
-      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
-      <div class="row" style="margin-top:14px;">
-        <span class="cpill cp-all">Alles</span>
-        <span class="cpill cp-jersey"><i class="dot d-jersey"></i>Clubevent</span>
-        <span class="cpill cp-warm"><i class="dot d-warm"></i>Supporters</span>
-        <span class="cpill cp-bright"><i class="dot d-bright"></i>Jeugd</span>
-        <span class="cpill cp-ink"><i class="dot d-ink"></i>Andere</span>
+    <div class="direction-bar">
+      <span class="tag">B</span> Kleur-pills = legenda
+      <span class="says"
+        >— the filter chips ARE colour-coded, so they teach the colour system.
+        No separate legend. Selected = filled, off = dimmed outline.</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="kicker">KCVV ELEWIJT · AGENDA</div>
+        <h1 class="pagetitle">Evenementen.</h1>
+        <div class="row" style="margin-top: 14px">
+          <span class="cpill cp-all">Alles</span>
+          <span class="cpill cp-jersey"
+            ><i class="dot d-jersey"></i>Clubevent</span
+          >
+          <span class="cpill cp-warm"
+            ><i class="dot d-warm"></i>Supporters</span
+          >
+          <span class="cpill cp-bright"><i class="dot d-bright"></i>Jeugd</span>
+          <span class="cpill cp-ink"><i class="dot d-ink"></i>Andere</span>
+        </div>
+        <div class="month">
+          <h2>September</h2>
+          <div class="seam"></div>
+        </div>
+        <div class="col1">
+          <a class="ticket"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="tmeta">18:00 · Kantine KCVV</div>
+            </div></a
+          >
+          <a class="ticket"
+            ><div class="stub s-bright">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="tmeta">Sportpark Elewijt</div>
+            </div></a
+          >
+        </div>
       </div>
-      <div class="month"><h2>September</h2><div class="seam"></div></div>
-      <div class="col1">
-        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
-      </div>
-    </div></div>
+    </div>
 
     <!-- C -->
-    <div class="direction-bar"><span class="tag">C</span> Editoriale tabs <span class="says">— newspaper section nav: underline tabs, active = warm underline. Quietest; colour cue moves entirely onto the stubs (+ small legend).</span></div>
-    <div class="stage"><div class="container">
-      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
-      <div class="tabs" style="margin-top:16px;">
-        <span class="tab on">Alles</span><span class="tab">Clubevent</span><span class="tab">Supporters</span><span class="tab">Jeugd</span><span class="tab">Andere</span>
+    <div class="direction-bar">
+      <span class="tag">C</span> Editoriale tabs
+      <span class="says"
+        >— newspaper section nav: underline tabs, active = warm underline.
+        Quietest; colour cue moves entirely onto the stubs (+ small
+        legend).</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="kicker">KCVV ELEWIJT · AGENDA</div>
+        <h1 class="pagetitle">Evenementen.</h1>
+        <div class="tabs" style="margin-top: 16px">
+          <span class="tab on">Alles</span><span class="tab">Clubevent</span
+          ><span class="tab">Supporters</span><span class="tab">Jeugd</span
+          ><span class="tab">Andere</span>
+        </div>
+        <div class="legend">
+          <span><i class="dot d-jersey"></i>Clubevent</span
+          ><span><i class="dot d-warm"></i>Supporters</span
+          ><span><i class="dot d-bright"></i>Jeugd</span
+          ><span><i class="dot d-ink"></i>Andere</span>
+        </div>
+        <div class="month">
+          <h2>September</h2>
+          <div class="seam"></div>
+        </div>
+        <div class="col1">
+          <a class="ticket"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="tmeta">18:00 · Kantine KCVV</div>
+            </div></a
+          >
+          <a class="ticket"
+            ><div class="stub s-bright">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="tmeta">Sportpark Elewijt</div>
+            </div></a
+          >
+        </div>
       </div>
-      <div class="legend"><span><i class="dot d-jersey"></i>Clubevent</span><span><i class="dot d-warm"></i>Supporters</span><span><i class="dot d-bright"></i>Jeugd</span><span><i class="dot d-ink"></i>Andere</span></div>
-      <div class="month"><h2>September</h2><div class="seam"></div></div>
-      <div class="col1">
-        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
-      </div>
-    </div></div>
+    </div>
 
     <!-- D -->
-    <div class="direction-bar"><span class="tag">D</span> Compacte dropdown <span class="says">— a single "Type ▾" select. Minimal chrome, scales if categories ever grow, but hides the options behind a click.</span></div>
-    <div class="stage"><div class="container">
-      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
-      <div class="row" style="margin-top:16px; justify-content:space-between;">
-        <span class="select">Type: Alles ▾</span>
-        <span style="font-family:var(--font-mono); font-size:11px; color:#cfe9d8; text-transform:uppercase; letter-spacing:0.07em;">6 evenementen</span>
+    <div class="direction-bar">
+      <span class="tag">D</span> Compacte dropdown
+      <span class="says"
+        >— a single "Type ▾" select. Minimal chrome, scales if categories ever
+        grow, but hides the options behind a click.</span
+      >
+    </div>
+    <div class="stage">
+      <div class="container">
+        <div class="kicker">KCVV ELEWIJT · AGENDA</div>
+        <h1 class="pagetitle">Evenementen.</h1>
+        <div
+          class="row"
+          style="margin-top: 16px; justify-content: space-between"
+        >
+          <span class="select">Type: Alles ▾</span>
+          <span
+            style="
+              font-family: var(--font-mono);
+              font-size: 11px;
+              color: #cfe9d8;
+              text-transform: uppercase;
+              letter-spacing: 0.07em;
+            "
+            >6 evenementen</span
+          >
+        </div>
+        <div class="legend">
+          <span><i class="dot d-jersey"></i>Clubevent</span
+          ><span><i class="dot d-warm"></i>Supporters</span
+          ><span><i class="dot d-bright"></i>Jeugd</span
+          ><span><i class="dot d-ink"></i>Andere</span>
+        </div>
+        <div class="month">
+          <h2>September</h2>
+          <div class="seam"></div>
+        </div>
+        <div class="col1">
+          <a class="ticket"
+            ><div class="stub s-jersey">
+              <div class="day">14</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Clubevent</span>
+              <h3>Mosselfeest</h3>
+              <div class="tmeta">18:00 · Kantine KCVV</div>
+            </div></a
+          >
+          <a class="ticket"
+            ><div class="stub s-bright">
+              <div class="day">22</div>
+              <div class="mon">SEP</div>
+            </div>
+            <div class="tbody">
+              <span class="tpill">Jeugdwerking</span>
+              <h3>Jeugdtornooi U10–U13</h3>
+              <div class="tmeta">Sportpark Elewijt</div>
+            </div></a
+          >
+        </div>
       </div>
-      <div class="legend"><span><i class="dot d-jersey"></i>Clubevent</span><span><i class="dot d-warm"></i>Supporters</span><span><i class="dot d-bright"></i>Jeugd</span><span><i class="dot d-ink"></i>Andere</span></div>
-      <div class="month"><h2>September</h2><div class="seam"></div></div>
-      <div class="col1">
-        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
-      </div>
-    </div></div>
+    </div>
 
-    <div class="harness-head" style="background: var(--ink-soft);">
-      <p>After the filter locks, remaining: <b>states</b> (empty list / filtered-to-zero / multi-day / time-less) ·
-      then the <code>&lt;EventHero&gt;</code> <b>detail page</b> (hero + iCal "Zet in agenda" + "Andere events" grid).
-      Filter × month rule already locked: a month with zero matches after filtering hides its header.</p>
+    <div class="harness-head" style="background: var(--ink-soft)">
+      <p>
+        After the filter locks, remaining: <b>states</b> (empty list /
+        filtered-to-zero / multi-day / time-less) · then the
+        <code>&lt;EventHero&gt;</code> <b>detail page</b> (hero + iCal "Zet in
+        agenda" + "Andere events" grid). Filter × month rule already locked: a
+        month with zero matches after filtering hides its header.
+      </p>
     </div>
   </body>
 </html>

--- a/docs/design/mockups/phase-6-events/6e4-filterbar-compare.html
+++ b/docs/design/mockups/phase-6-events/6e4-filterbar-compare.html
@@ -1,0 +1,165 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.E — /evenementen · Round 4: filter bar</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,500&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-deep: #e1d7bf; --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--jersey-deep-dark); color: var(--cream); font-family: var(--font-body); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 78ch; line-height: 1.55; }
+      .harness-head code { color: var(--warm); }
+      .direction-bar { background: var(--warm); color: var(--ink);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
+      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
+      .stage { padding: 26px 28px 44px; }
+      .container { max-width: 880px; margin: 0 auto; }
+      .pagetitle { font-family: var(--font-display); font-weight: 900; font-size: 46px; color: var(--cream); margin: 0 0 4px; letter-spacing: -0.01em; }
+      .kicker { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.1em; font-size: 11px; color: var(--warm); margin-bottom: 8px; }
+
+      /* filter atoms */
+      .pill { display: inline-flex; align-items: center; gap:6px; font-family: var(--font-mono); text-transform: uppercase;
+        letter-spacing: 0.07em; font-size: 11px; font-weight: 600; padding: 7px 13px; border: 1.5px solid var(--cream);
+        background: transparent; color: var(--cream); white-space: nowrap; cursor: pointer; }
+      .pill.on { background: var(--cream); color: var(--ink); }
+      .row { display: flex; gap: 9px; flex-wrap: wrap; align-items: center; }
+      .dot { width: 11px; height: 11px; border: 1.5px solid var(--ink); display:inline-block; }
+      .d-jersey { background: var(--jersey-deep); } .d-warm { background: var(--warm); } .d-bright { background: var(--jersey-bright); } .d-ink { background: var(--ink); }
+      .legend { display:flex; gap:15px; flex-wrap:wrap; font-family: var(--font-mono); font-size: 10px; text-transform:uppercase; letter-spacing:0.07em; color:#cfe9d8; margin-top:14px; }
+      .legend span { display:inline-flex; align-items:center; gap:6px; }
+
+      /* colour-coded filter chips (B) */
+      .cpill { display:inline-flex; align-items:center; gap:7px; font-family: var(--font-mono); text-transform:uppercase;
+        letter-spacing:0.07em; font-size:11px; font-weight:600; padding:7px 13px; border:1.5px solid var(--ink); cursor:pointer; }
+      .cpill .dot { border-color: rgba(0,0,0,0.35); }
+      .cp-all { background: var(--cream); color: var(--ink); }
+      .cp-jersey { background: var(--jersey-deep); color: var(--cream); }
+      .cp-warm { background: var(--warm); color: var(--ink); }
+      .cp-bright { background: var(--jersey-bright); color: var(--ink); }
+      .cp-ink { background: var(--ink); color: var(--cream); }
+      .cpill.off { background: transparent; color: var(--cream); border-color: var(--cream); opacity: 0.6; }
+
+      /* tabs (C) */
+      .tabs { display:flex; gap: 24px; border-bottom: 2px solid rgba(245,241,230,0.25); padding-bottom: 0; flex-wrap: wrap; }
+      .tab { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.08em; font-size: 12px; font-weight: 600;
+        color: rgba(245,241,230,0.7); padding: 0 2px 10px; border-bottom: 3px solid transparent; cursor: pointer; }
+      .tab.on { color: var(--cream); border-bottom-color: var(--warm); }
+
+      /* dropdown (D) */
+      .select { display:inline-flex; align-items:center; gap:10px; font-family: var(--font-mono); text-transform:uppercase;
+        letter-spacing:0.06em; font-size:12px; font-weight:600; padding: 10px 16px; border:1.5px solid var(--cream); background: transparent; color: var(--cream); cursor:pointer; }
+
+      /* mini list context */
+      .month { display: flex; align-items: center; gap: 14px; margin: 22px 0 14px; }
+      .month h2 { margin: 0; font-family: var(--font-display); font-weight: 900; font-size: 24px; color: var(--cream); }
+      .seam { flex: 1; height: 11px; background: repeating-linear-gradient(-45deg, var(--cream) 0 7px, var(--jersey-deep) 7px 14px, var(--cream) 14px 21px, var(--ink) 21px 28px); }
+      .col1 { display:flex; flex-direction:column; gap: 16px; }
+      .ticket { display: flex; background: var(--cream); color: var(--ink); border: 2px solid var(--ink); box-shadow: 5px 5px 0 rgba(0,0,0,0.5); text-decoration: none; }
+      .stub { flex: 0 0 86px; border-right: 2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding: 12px 6px; color: var(--cream); }
+      .stub .day { font-family: var(--font-display); font-weight: 900; font-size: 36px; line-height: 0.85; }
+      .stub .mon { font-family: var(--font-mono); text-transform: uppercase; font-size: 10px; margin-top: 3px; }
+      .s-jersey { background: var(--jersey-deep); } .s-warm { background: var(--warm); color: var(--ink); } .s-bright { background: var(--jersey-bright); color: var(--ink); } .s-ink { background: var(--ink); }
+      .tbody { padding: 11px 15px; }
+      .tpill { display:inline-flex; font-family: var(--font-mono); text-transform:uppercase; letter-spacing:0.07em; font-size:9.5px; font-weight:600; padding:2px 7px; border:1.5px solid var(--ink); background: var(--cream); color: var(--ink); }
+      .tbody h3 { margin: 6px 0 4px; font-family: var(--font-display); font-weight: 900; font-size: 19px; }
+      .tmeta { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.06em; font-size: 10px; color: var(--ink-muted); }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.E · /evenementen — Round 4: FILTER BAR</h1>
+      <p>
+        Layout locked (single column, month-grouped, type-coloured clickable stubs). This round picks the
+        <b>eventType filter</b> treatment — and the key question: do the filters <b>carry the colour coding</b>
+        (so they double as the legend, removing a separate legend row), or stay neutral with a legend underneath?
+        "Alles" is the default (no filter). Each treatment is shown above a slice of the locked list.
+      </p>
+    </div>
+
+    <!-- A -->
+    <div class="direction-bar"><span class="tag">A</span> Neutrale pills + legenda <span class="says">— cream outline pills; a separate colour legend below. Cleanest pills, but the legend is a second element.</span></div>
+    <div class="stage"><div class="container">
+      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
+      <div class="row" style="margin-top:14px;">
+        <span class="pill on">Alles</span><span class="pill">Clubevent</span><span class="pill">Supporters</span><span class="pill">Jeugd</span><span class="pill">Andere</span>
+      </div>
+      <div class="legend"><span><i class="dot d-jersey"></i>Clubevent</span><span><i class="dot d-warm"></i>Supporters</span><span><i class="dot d-bright"></i>Jeugd</span><span><i class="dot d-ink"></i>Andere</span></div>
+      <div class="month"><h2>September</h2><div class="seam"></div></div>
+      <div class="col1">
+        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
+      </div>
+    </div></div>
+
+    <!-- B -->
+    <div class="direction-bar"><span class="tag">B</span> Kleur-pills = legenda <span class="says">— the filter chips ARE colour-coded, so they teach the colour system. No separate legend. Selected = filled, off = dimmed outline.</span></div>
+    <div class="stage"><div class="container">
+      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
+      <div class="row" style="margin-top:14px;">
+        <span class="cpill cp-all">Alles</span>
+        <span class="cpill cp-jersey"><i class="dot d-jersey"></i>Clubevent</span>
+        <span class="cpill cp-warm"><i class="dot d-warm"></i>Supporters</span>
+        <span class="cpill cp-bright"><i class="dot d-bright"></i>Jeugd</span>
+        <span class="cpill cp-ink"><i class="dot d-ink"></i>Andere</span>
+      </div>
+      <div class="month"><h2>September</h2><div class="seam"></div></div>
+      <div class="col1">
+        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
+      </div>
+    </div></div>
+
+    <!-- C -->
+    <div class="direction-bar"><span class="tag">C</span> Editoriale tabs <span class="says">— newspaper section nav: underline tabs, active = warm underline. Quietest; colour cue moves entirely onto the stubs (+ small legend).</span></div>
+    <div class="stage"><div class="container">
+      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
+      <div class="tabs" style="margin-top:16px;">
+        <span class="tab on">Alles</span><span class="tab">Clubevent</span><span class="tab">Supporters</span><span class="tab">Jeugd</span><span class="tab">Andere</span>
+      </div>
+      <div class="legend"><span><i class="dot d-jersey"></i>Clubevent</span><span><i class="dot d-warm"></i>Supporters</span><span><i class="dot d-bright"></i>Jeugd</span><span><i class="dot d-ink"></i>Andere</span></div>
+      <div class="month"><h2>September</h2><div class="seam"></div></div>
+      <div class="col1">
+        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
+      </div>
+    </div></div>
+
+    <!-- D -->
+    <div class="direction-bar"><span class="tag">D</span> Compacte dropdown <span class="says">— a single "Type ▾" select. Minimal chrome, scales if categories ever grow, but hides the options behind a click.</span></div>
+    <div class="stage"><div class="container">
+      <div class="kicker">KCVV ELEWIJT · AGENDA</div><h1 class="pagetitle">Evenementen.</h1>
+      <div class="row" style="margin-top:16px; justify-content:space-between;">
+        <span class="select">Type: Alles ▾</span>
+        <span style="font-family:var(--font-mono); font-size:11px; color:#cfe9d8; text-transform:uppercase; letter-spacing:0.07em;">6 evenementen</span>
+      </div>
+      <div class="legend"><span><i class="dot d-jersey"></i>Clubevent</span><span><i class="dot d-warm"></i>Supporters</span><span><i class="dot d-bright"></i>Jeugd</span><span><i class="dot d-ink"></i>Andere</span></div>
+      <div class="month"><h2>September</h2><div class="seam"></div></div>
+      <div class="col1">
+        <a class="ticket"><div class="stub s-jersey"><div class="day">14</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Clubevent</span><h3>Mosselfeest</h3><div class="tmeta">18:00 · Kantine KCVV</div></div></a>
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tbody"><span class="tpill">Jeugdwerking</span><h3>Jeugdtornooi U10–U13</h3><div class="tmeta">Sportpark Elewijt</div></div></a>
+      </div>
+    </div></div>
+
+    <div class="harness-head" style="background: var(--ink-soft);">
+      <p>After the filter locks, remaining: <b>states</b> (empty list / filtered-to-zero / multi-day / time-less) ·
+      then the <code>&lt;EventHero&gt;</code> <b>detail page</b> (hero + iCal "Zet in agenda" + "Andere events" grid).
+      Filter × month rule already locked: a month with zero matches after filtering hides its header.</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-events/6e4-filterbar-compare.html
+++ b/docs/design/mockups/phase-6-events/6e4-filterbar-compare.html
@@ -452,6 +452,32 @@
           <span class="cpill cp-bright"><i class="dot d-bright"></i>Jeugd</span>
           <span class="cpill cp-ink"><i class="dot d-ink"></i>Andere</span>
         </div>
+        <div
+          style="
+            font-family: var(--font-mono);
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.07em;
+            color: #cfe9d8;
+            margin-top: 10px;
+          "
+        >
+          ↑ default (all chips show their colour = the legend) · ↓ unselected
+          state (.off — dimmed outline, colour kept in the dot)
+        </div>
+        <div class="row" style="margin-top: 6px">
+          <span class="cpill cp-all">Alles</span>
+          <span class="cpill cp-jersey off"
+            ><i class="dot d-jersey"></i>Clubevent</span
+          >
+          <span class="cpill cp-warm off"
+            ><i class="dot d-warm"></i>Supporters</span
+          >
+          <span class="cpill cp-bright off"
+            ><i class="dot d-bright"></i>Jeugd</span
+          >
+          <span class="cpill cp-ink off"><i class="dot d-ink"></i>Andere</span>
+        </div>
         <div class="month">
           <h2>September</h2>
           <div class="seam"></div>

--- a/docs/design/mockups/phase-6-events/6e4-filterbar-locked.md
+++ b/docs/design/mockups/phase-6-events/6e4-filterbar-locked.md
@@ -1,0 +1,32 @@
+# Phase 6.E · /evenementen — Round 4 (IA · filter bar) — LOCKED
+
+**Date:** 2026-06-02
+**Mockup:** `6e4-filterbar-compare.html`
+
+## Decision — Variant B "Kleur-pills = legenda"
+
+- The eventType **filter chips are colour-coded** to match the stub date-block colours, so the
+  filter row **doubles as the legend** — there is **no separate legend row**.
+  - Clubevent = `jersey-deep` · Supportersactiviteit = `warm` · Jeugdwerking = `jersey-bright` ·
+    Andere = `ink`.
+- **"Alles"** is the neutral default chip (cream), no filter applied.
+- **Selected** chip = filled with its type colour; **unselected** = dimmed cream outline.
+- Single-select in v1 (one type at a time or "Alles"). Multi-select can come later if needed.
+
+### Accessibility note
+
+The chip still carries its **text label** (e.g. "Clubevent"), so type is never conveyed by
+colour alone (WCAG 1.4.1). The colour is reinforcement; the label is the truth.
+
+## Carried-forward rules
+
+- **Filter × month**: a month whose tickets are all filtered out **hides its header** (no empty
+  month sections).
+- This resolves the Round-2 open question: the legend is **not** a separate element — it lives in
+  the filter chips.
+
+## Remaining 6.E rounds
+
+- **States**: empty list, filtered-to-zero, multi-day events, time-less events.
+- **Detail page**: the new `<EventHero>` (hero + external-link CTA + "Zet in agenda" iCal +
+  "Andere events" grid). Body Portable Text, RSVP, and sponsor footer are dropped per §6.7.

--- a/docs/design/mockups/phase-6-events/6e5-eventhero-compare.html
+++ b/docs/design/mockups/phase-6-events/6e5-eventhero-compare.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.E — /evenementen/[slug] · Round 5: EventHero</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,500&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-deep: #e1d7bf; --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: #000; color: var(--ink); font-family: var(--font-body); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 80ch; line-height: 1.55; }
+      .harness-head code { color: var(--warm); }
+      .direction-bar { background: var(--warm); color: var(--ink); padding: 11px 28px; font-family: var(--font-mono);
+        font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase; display: flex; gap: 14px; align-items: baseline;
+        border-bottom: 2px solid var(--ink); border-top: 3px solid var(--ink); }
+      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
+      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
+      .stage { padding: 40px 28px 48px; }
+      .container { max-width: 920px; margin: 0 auto; }
+
+      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
+      .pill { display:inline-flex; align-items:center; gap:6px; font-family: var(--font-mono); text-transform:uppercase;
+        letter-spacing:0.08em; font-size:11px; font-weight:600; padding:4px 10px; border:1.5px solid var(--ink); background: var(--cream); color: var(--ink); }
+      .pill.jersey { background: var(--jersey-deep); color: var(--cream); }
+      .cta { display:inline-flex; align-items:center; gap:8px; font-family: var(--font-mono); text-transform:uppercase;
+        letter-spacing:0.06em; font-size:12px; font-weight:700; padding:12px 18px; border:2px solid var(--ink); text-decoration:none; cursor:pointer; }
+      .cta.go { background: var(--warm); color: var(--ink); }
+      .cta.ghost { background: transparent; color: var(--ink); }
+      .cta.ghost.oncream { border-color: var(--ink); color: var(--ink); }
+      .ctas { display:flex; gap:12px; flex-wrap:wrap; margin-top: 22px; }
+      .photo { background: var(--cream-deep) center/cover; filter: saturate(0.9) contrast(1.05); }
+      .ph-mossel { background-image: linear-gradient(135deg,#15543a,#2f7d56); }
+      .back { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:0.08em; font-size:11px; color:#cfe9d8; margin-bottom: 18px; display:inline-block; }
+
+      .display { font-family: var(--font-display); font-weight: 900; line-height: 0.95; letter-spacing: -0.01em; }
+      .em { font-style: italic; font-weight: 500; color: var(--warm); }
+
+      /* Andere events strip (reuses locked list ticket) */
+      .other { margin-top: 40px; }
+      .other h3 { font-family: var(--font-display); font-weight: 900; font-size: 24px; color: var(--cream); margin: 0 0 16px; display:flex; align-items:center; gap:14px; }
+      .other .seam { flex:1; height:11px; background: repeating-linear-gradient(-45deg, var(--cream) 0 7px, var(--jersey-deep) 7px 14px, var(--cream) 14px 21px, var(--ink) 21px 28px); }
+      .grid2 { display:grid; grid-template-columns: repeat(2,1fr); gap:18px; }
+      .ticket { display:flex; background: var(--cream); border:2px solid var(--ink); box-shadow:5px 5px 0 rgba(0,0,0,0.5); text-decoration:none; color: var(--ink); }
+      .stub { flex:0 0 80px; border-right:2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding:12px 6px; color: var(--cream); }
+      .stub .day { font-family: var(--font-display); font-weight:900; font-size:32px; line-height:0.85; }
+      .stub .mon { font-family: var(--font-mono); text-transform:uppercase; font-size:10px; margin-top:2px; }
+      .s-warm{background:var(--warm);color:var(--ink);} .s-bright{background:var(--jersey-bright);color:var(--ink);} .s-ink{background:var(--ink);}
+      .tb { padding:10px 14px; } .tb h4 { margin:5px 0 3px; font-family: var(--font-display); font-weight:900; font-size:18px; }
+      .tb .m { font-family: var(--font-mono); text-transform:uppercase; font-size:9.5px; letter-spacing:0.06em; color: var(--ink-muted); }
+      .tp { display:inline-flex; font-family: var(--font-mono); text-transform:uppercase; font-size:9px; letter-spacing:0.07em; font-weight:600; padding:2px 6px; border:1.5px solid var(--ink); }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.E · /evenementen/[slug] — Round 5: EVENTHERO (detail page)</h1>
+      <p>
+        The detail page is a new <code>&lt;EventHero&gt;</code> + two CTAs (<b>Reserveer</b> = externalLink, shown only
+        when set · <b>Zet in agenda</b> = iCal, always) + an <b>"Andere events"</b> grid (reuses the locked list ticket).
+        No body text. Example event: <i>Mosselfeest</i> (Clubevent · jersey-deep · 14 SEP 18:00 · Kantine · has cover &amp;
+        externalLink). Four hero voices — which harmonises best with the ticket-stub list?
+      </p>
+    </div>
+
+    <!-- A · Grote ticket -->
+    <div class="direction-bar"><span class="tag">A</span> Grote ticket <span class="says">— the event AS one big ticket: scaled-up tear-off date + body. Maximum coherence with the list.</span></div>
+    <div class="stage" style="background: var(--jersey-deep-dark);"><div class="container">
+      <a class="back">← Alle evenementen</a>
+      <div style="display:flex; background:var(--cream); border:2px solid var(--ink); box-shadow:9px 9px 0 rgba(0,0,0,0.5);">
+        <div style="flex:0 0 180px; background:var(--jersey-deep); color:var(--cream); border-right:2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding:28px 14px;">
+          <div class="mono" style="opacity:0.85;">ZA</div>
+          <div class="display" style="font-size:92px; line-height:0.8;">14</div>
+          <div class="mono" style="font-size:15px; margin-top:4px;">SEP</div>
+          <div class="mono" style="margin-top:14px; font-size:12px;">18:00</div>
+        </div>
+        <div style="padding:30px 32px;">
+          <span class="pill jersey">Clubevent</span>
+          <h1 class="display" style="font-size:clamp(38px,5.5vw,60px); margin:14px 0 10px;">Mossel<span class="em">feest.</span></h1>
+          <div class="mono" style="color:var(--ink-muted);">KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT</div>
+          <div class="ctas"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Zet in agenda</a></div>
+        </div>
+      </div>
+      <div class="other"><h3>Andere events <div class="seam"></div></h3><div class="grid2">
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
+        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
+      </div></div>
+    </div></div>
+
+    <!-- B · Poster -->
+    <div class="direction-bar"><span class="tag">B</span> Poster <span class="says">— full-bleed cover, overlaid title/date, CTAs on a cream bar below. Image-forward (needs a cover).</span></div>
+    <div class="stage" style="background:#000; padding-top:0; padding-left:0; padding-right:0;">
+      <div style="position:relative;">
+        <div class="photo ph-mossel" style="height:380px;"></div>
+        <div style="position:absolute; inset:0; background:linear-gradient(to top, rgba(10,10,10,0.92), rgba(10,10,10,0.15) 60%); display:flex; flex-direction:column; justify-content:flex-end; padding:34px 28px;">
+          <div class="container" style="color:var(--cream);">
+            <span class="pill jersey">Clubevent</span>
+            <h1 class="display" style="font-size:clamp(40px,6vw,68px); color:var(--cream); margin:14px 0 8px;">Mossel<span class="em">feest.</span></h1>
+            <div class="mono" style="color:#e6e0cf;">ZA 14 SEP · 18:00 · KANTINE KCVV</div>
+          </div>
+        </div>
+      </div>
+      <div style="background:var(--cream); border-top:2px solid var(--ink); border-bottom:2px solid var(--ink);">
+        <div class="container" style="padding:20px 28px;"><div class="ctas" style="margin-top:0;"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Zet in agenda</a></div></div>
+      </div>
+      <div class="stage" style="background:var(--jersey-deep-dark);"><div class="container"><div class="other" style="margin-top:0;"><h3>Andere events <div class="seam"></div></h3><div class="grid2">
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
+        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
+      </div></div></div></div>
+    </div>
+
+    <!-- C · Split -->
+    <div class="direction-bar"><span class="tag">C</span> Split <span class="says">— cover one half, cream info panel the other (FeaturedEventBand scaled up). Balanced; degrades to panel-only with no cover.</span></div>
+    <div class="stage" style="background: var(--jersey-deep-dark);"><div class="container">
+      <a class="back">← Alle evenementen</a>
+      <div style="display:grid; grid-template-columns:1fr 1fr; border:2px solid var(--ink); box-shadow:9px 9px 0 rgba(0,0,0,0.5); overflow:hidden; background:var(--cream);">
+        <div style="padding:34px 32px;">
+          <span class="pill jersey">Clubevent</span>
+          <h1 class="display" style="font-size:clamp(34px,4.5vw,52px); margin:14px 0 10px;">Mossel<span class="em">feest.</span></h1>
+          <div class="mono" style="color:var(--ink-muted); line-height:1.8;">ZA 14 SEP · 18:00<br/>KANTINE KCVV</div>
+          <div class="ctas"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Agenda</a></div>
+        </div>
+        <div class="photo ph-mossel" style="border-left:2px solid var(--ink); min-height:280px;"></div>
+      </div>
+      <div class="other"><h3>Andere events <div class="seam"></div></h3><div class="grid2">
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
+        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
+      </div></div>
+    </div></div>
+
+    <!-- D · Editoriaal -->
+    <div class="direction-bar"><span class="tag">D</span> Editoriaal <span class="says">— cream page, big serif title, cover as a taped/tilted figure. Quietest; least tied to the ticket motif.</span></div>
+    <div class="stage" style="background: var(--cream);"><div class="container">
+      <a class="back" style="color:var(--ink-muted);">← Alle evenementen</a>
+      <div style="text-align:center; max-width:680px; margin:0 auto;">
+        <span class="pill jersey" style="margin-bottom:16px;">Clubevent</span>
+        <div class="mono" style="color:var(--ink-muted); margin:14px 0 6px;">ZATERDAG 14 SEPTEMBER · 18:00</div>
+        <h1 class="display" style="font-size:clamp(44px,7vw,80px);">Mossel<span class="em" style="color:var(--jersey-deep);">feest.</span></h1>
+        <div class="mono" style="color:var(--ink-muted); margin-top:8px;">KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT</div>
+        <div class="ctas" style="justify-content:center;"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Zet in agenda</a></div>
+      </div>
+      <div class="photo ph-mossel" style="height:300px; margin:34px auto 0; max-width:760px; border:2px solid var(--ink); box-shadow:8px 8px 0 var(--ink); transform:rotate(-1deg);"></div>
+      <div class="other" style="margin-top:48px;"><h3 style="color:var(--ink);">Andere events <div class="seam"></div></h3><div class="grid2">
+        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
+        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
+      </div></div>
+    </div></div>
+
+    <div class="harness-head" style="background: var(--ink-soft);">
+      <p>CTA rules (all directions): <b>Reserveer ↗</b> renders only when <code>externalLink</code> is set (label =
+      <code>externalLink.label</code>, fallback "Reserveer"); <b>＋ Zet in agenda</b> (iCal download) is always present.
+      No-cover fallback + multi-day date display are details for the next pass.</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-events/6e5-eventhero-compare.html
+++ b/docs/design/mockups/phase-6-events/6e5-eventhero-compare.html
@@ -12,155 +12,638 @@
     />
     <style>
       :root {
-        --cream: #f5f1e6; --cream-deep: #e1d7bf; --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
-        --jersey: #4acf52; --jersey-deep: #008755; --jersey-bright: #22c55e; --jersey-deep-dark: #133d28;
-        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
-        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+        --cream: #f5f1e6;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-bright: #22c55e;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c;
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
       }
-      * { box-sizing: border-box; }
-      body { margin: 0; background: #000; color: var(--ink); font-family: var(--font-body); }
-      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
-      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
-      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 80ch; line-height: 1.55; }
-      .harness-head code { color: var(--warm); }
-      .direction-bar { background: var(--warm); color: var(--ink); padding: 11px 28px; font-family: var(--font-mono);
-        font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase; display: flex; gap: 14px; align-items: baseline;
-        border-bottom: 2px solid var(--ink); border-top: 3px solid var(--ink); }
-      .direction-bar .tag { background: var(--ink); color: var(--warm); padding: 2px 9px; font-weight: 700; }
-      .direction-bar .says { color: var(--ink-soft); text-transform: none; letter-spacing: 0; font-size: 12px; font-weight: 600; }
-      .stage { padding: 40px 28px 48px; }
-      .container { max-width: 920px; margin: 0 auto; }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: #000;
+        color: var(--ink);
+        font-family: var(--font-body);
+      }
+      .harness-head {
+        background: var(--ink);
+        color: var(--cream);
+        padding: 22px 28px;
+        font-family: var(--font-mono);
+      }
+      .harness-head h1 {
+        margin: 0 0 6px;
+        font-size: 15px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .harness-head p {
+        margin: 0;
+        font-size: 13px;
+        color: #b9b9b9;
+        max-width: 80ch;
+        line-height: 1.55;
+      }
+      .harness-head code {
+        color: var(--warm);
+      }
+      .direction-bar {
+        background: var(--warm);
+        color: var(--ink);
+        padding: 11px 28px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        display: flex;
+        gap: 14px;
+        align-items: baseline;
+        border-bottom: 2px solid var(--ink);
+        border-top: 3px solid var(--ink);
+      }
+      .direction-bar .tag {
+        background: var(--ink);
+        color: var(--warm);
+        padding: 2px 9px;
+        font-weight: 700;
+      }
+      .direction-bar .says {
+        color: var(--ink-soft);
+        text-transform: none;
+        letter-spacing: 0;
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .stage {
+        padding: 40px 28px 48px;
+      }
+      .container {
+        max-width: 920px;
+        margin: 0 auto;
+      }
 
-      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
-      .pill { display:inline-flex; align-items:center; gap:6px; font-family: var(--font-mono); text-transform:uppercase;
-        letter-spacing:0.08em; font-size:11px; font-weight:600; padding:4px 10px; border:1.5px solid var(--ink); background: var(--cream); color: var(--ink); }
-      .pill.jersey { background: var(--jersey-deep); color: var(--cream); }
-      .cta { display:inline-flex; align-items:center; gap:8px; font-family: var(--font-mono); text-transform:uppercase;
-        letter-spacing:0.06em; font-size:12px; font-weight:700; padding:12px 18px; border:2px solid var(--ink); text-decoration:none; cursor:pointer; }
-      .cta.go { background: var(--warm); color: var(--ink); }
-      .cta.ghost { background: transparent; color: var(--ink); }
-      .cta.ghost.oncream { border-color: var(--ink); color: var(--ink); }
-      .ctas { display:flex; gap:12px; flex-wrap:wrap; margin-top: 22px; }
-      .photo { background: var(--cream-deep) center/cover; filter: saturate(0.9) contrast(1.05); }
-      .ph-mossel { background-image: linear-gradient(135deg,#15543a,#2f7d56); }
-      .back { font-family: var(--font-mono); text-transform:uppercase; letter-spacing:0.08em; font-size:11px; color:#cfe9d8; margin-bottom: 18px; display:inline-block; }
+      .mono {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        font-size: 11px;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 11px;
+        font-weight: 600;
+        padding: 4px 10px;
+        border: 1.5px solid var(--ink);
+        background: var(--cream);
+        color: var(--ink);
+      }
+      .pill.jersey {
+        background: var(--jersey-deep);
+        color: var(--cream);
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 12px;
+        font-weight: 700;
+        padding: 12px 18px;
+        border: 2px solid var(--ink);
+        text-decoration: none;
+        cursor: pointer;
+      }
+      .cta.go {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .cta.ghost {
+        background: transparent;
+        color: var(--ink);
+      }
+      .cta.ghost.oncream {
+        border-color: var(--ink);
+        color: var(--ink);
+      }
+      .ctas {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        margin-top: 22px;
+      }
+      .photo {
+        background: var(--cream-deep) center/cover;
+        filter: saturate(0.9) contrast(1.05);
+      }
+      .ph-mossel {
+        background-image: linear-gradient(135deg, #15543a, #2f7d56);
+      }
+      .back {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 11px;
+        color: #cfe9d8;
+        margin-bottom: 18px;
+        display: inline-block;
+      }
 
-      .display { font-family: var(--font-display); font-weight: 900; line-height: 0.95; letter-spacing: -0.01em; }
-      .em { font-style: italic; font-weight: 500; color: var(--warm); }
+      .display {
+        font-family: var(--font-display);
+        font-weight: 900;
+        line-height: 0.95;
+        letter-spacing: -0.01em;
+      }
+      .em {
+        font-style: italic;
+        font-weight: 500;
+        color: var(--warm);
+      }
 
       /* Andere events strip (reuses locked list ticket) */
-      .other { margin-top: 40px; }
-      .other h3 { font-family: var(--font-display); font-weight: 900; font-size: 24px; color: var(--cream); margin: 0 0 16px; display:flex; align-items:center; gap:14px; }
-      .other .seam { flex:1; height:11px; background: repeating-linear-gradient(-45deg, var(--cream) 0 7px, var(--jersey-deep) 7px 14px, var(--cream) 14px 21px, var(--ink) 21px 28px); }
-      .grid2 { display:grid; grid-template-columns: repeat(2,1fr); gap:18px; }
-      .ticket { display:flex; background: var(--cream); border:2px solid var(--ink); box-shadow:5px 5px 0 rgba(0,0,0,0.5); text-decoration:none; color: var(--ink); }
-      .stub { flex:0 0 80px; border-right:2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding:12px 6px; color: var(--cream); }
-      .stub .day { font-family: var(--font-display); font-weight:900; font-size:32px; line-height:0.85; }
-      .stub .mon { font-family: var(--font-mono); text-transform:uppercase; font-size:10px; margin-top:2px; }
-      .s-warm{background:var(--warm);color:var(--ink);} .s-bright{background:var(--jersey-bright);color:var(--ink);} .s-ink{background:var(--ink);}
-      .tb { padding:10px 14px; } .tb h4 { margin:5px 0 3px; font-family: var(--font-display); font-weight:900; font-size:18px; }
-      .tb .m { font-family: var(--font-mono); text-transform:uppercase; font-size:9.5px; letter-spacing:0.06em; color: var(--ink-muted); }
-      .tp { display:inline-flex; font-family: var(--font-mono); text-transform:uppercase; font-size:9px; letter-spacing:0.07em; font-weight:600; padding:2px 6px; border:1.5px solid var(--ink); }
+      .other {
+        margin-top: 40px;
+      }
+      .other h3 {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 24px;
+        color: var(--cream);
+        margin: 0 0 16px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+      }
+      .other .seam {
+        flex: 1;
+        height: 11px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--cream) 0 7px,
+          var(--jersey-deep) 7px 14px,
+          var(--cream) 14px 21px,
+          var(--ink) 21px 28px
+        );
+      }
+      .grid2 {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 18px;
+      }
+      .ticket {
+        display: flex;
+        background: var(--cream);
+        border: 2px solid var(--ink);
+        box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.5);
+        text-decoration: none;
+        color: var(--ink);
+      }
+      .stub {
+        flex: 0 0 80px;
+        border-right: 2px dashed var(--ink);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 12px 6px;
+        color: var(--cream);
+      }
+      .stub .day {
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 32px;
+        line-height: 0.85;
+      }
+      .stub .mon {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        font-size: 10px;
+        margin-top: 2px;
+      }
+      .s-warm {
+        background: var(--warm);
+        color: var(--ink);
+      }
+      .s-bright {
+        background: var(--jersey-bright);
+        color: var(--ink);
+      }
+      .s-ink {
+        background: var(--ink);
+      }
+      .tb {
+        padding: 10px 14px;
+      }
+      .tb h4 {
+        margin: 5px 0 3px;
+        font-family: var(--font-display);
+        font-weight: 900;
+        font-size: 18px;
+      }
+      .tb .m {
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        font-size: 9.5px;
+        letter-spacing: 0.06em;
+        color: var(--ink-muted);
+      }
+      .tp {
+        display: inline-flex;
+        font-family: var(--font-mono);
+        text-transform: uppercase;
+        font-size: 9px;
+        letter-spacing: 0.07em;
+        font-weight: 600;
+        padding: 2px 6px;
+        border: 1.5px solid var(--ink);
+      }
     </style>
   </head>
   <body>
     <div class="harness-head">
-      <h1>Phase 6.E · /evenementen/[slug] — Round 5: EVENTHERO (detail page)</h1>
+      <h1>
+        Phase 6.E · /evenementen/[slug] — Round 5: EVENTHERO (detail page)
+      </h1>
       <p>
-        The detail page is a new <code>&lt;EventHero&gt;</code> + two CTAs (<b>Reserveer</b> = externalLink, shown only
-        when set · <b>Zet in agenda</b> = iCal, always) + an <b>"Andere events"</b> grid (reuses the locked list ticket).
-        No body text. Example event: <i>Mosselfeest</i> (Clubevent · jersey-deep · 14 SEP 18:00 · Kantine · has cover &amp;
-        externalLink). Four hero voices — which harmonises best with the ticket-stub list?
+        The detail page is a new <code>&lt;EventHero&gt;</code> + two CTAs (<b
+          >Reserveer</b
+        >
+        = externalLink, shown only when set · <b>Zet in agenda</b> = iCal,
+        always) + an <b>"Andere events"</b> grid (reuses the locked list
+        ticket). No body text. Example event: <i>Mosselfeest</i> (Clubevent ·
+        jersey-deep · 14 SEP 18:00 · Kantine · has cover &amp; externalLink).
+        Four hero voices — which harmonises best with the ticket-stub list?
       </p>
     </div>
 
     <!-- A · Grote ticket -->
-    <div class="direction-bar"><span class="tag">A</span> Grote ticket <span class="says">— the event AS one big ticket: scaled-up tear-off date + body. Maximum coherence with the list.</span></div>
-    <div class="stage" style="background: var(--jersey-deep-dark);"><div class="container">
-      <a class="back">← Alle evenementen</a>
-      <div style="display:flex; background:var(--cream); border:2px solid var(--ink); box-shadow:9px 9px 0 rgba(0,0,0,0.5);">
-        <div style="flex:0 0 180px; background:var(--jersey-deep); color:var(--cream); border-right:2px dashed var(--ink); display:flex; flex-direction:column; align-items:center; justify-content:center; padding:28px 14px;">
-          <div class="mono" style="opacity:0.85;">ZA</div>
-          <div class="display" style="font-size:92px; line-height:0.8;">14</div>
-          <div class="mono" style="font-size:15px; margin-top:4px;">SEP</div>
-          <div class="mono" style="margin-top:14px; font-size:12px;">18:00</div>
-        </div>
-        <div style="padding:30px 32px;">
-          <span class="pill jersey">Clubevent</span>
-          <h1 class="display" style="font-size:clamp(38px,5.5vw,60px); margin:14px 0 10px;">Mossel<span class="em">feest.</span></h1>
-          <div class="mono" style="color:var(--ink-muted);">KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT</div>
-          <div class="ctas"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Zet in agenda</a></div>
-        </div>
-      </div>
-      <div class="other"><h3>Andere events <div class="seam"></div></h3><div class="grid2">
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
-        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
-      </div></div>
-    </div></div>
-
-    <!-- B · Poster -->
-    <div class="direction-bar"><span class="tag">B</span> Poster <span class="says">— full-bleed cover, overlaid title/date, CTAs on a cream bar below. Image-forward (needs a cover).</span></div>
-    <div class="stage" style="background:#000; padding-top:0; padding-left:0; padding-right:0;">
-      <div style="position:relative;">
-        <div class="photo ph-mossel" style="height:380px;"></div>
-        <div style="position:absolute; inset:0; background:linear-gradient(to top, rgba(10,10,10,0.92), rgba(10,10,10,0.15) 60%); display:flex; flex-direction:column; justify-content:flex-end; padding:34px 28px;">
-          <div class="container" style="color:var(--cream);">
+    <div class="direction-bar">
+      <span class="tag">A</span> Grote ticket
+      <span class="says"
+        >— the event AS one big ticket: scaled-up tear-off date + body. Maximum
+        coherence with the list.</span
+      >
+    </div>
+    <div class="stage" style="background: var(--jersey-deep-dark)">
+      <div class="container">
+        <a class="back">← Alle evenementen</a>
+        <div
+          style="
+            display: flex;
+            background: var(--cream);
+            border: 2px solid var(--ink);
+            box-shadow: 9px 9px 0 rgba(0, 0, 0, 0.5);
+          "
+        >
+          <div
+            style="
+              flex: 0 0 180px;
+              background: var(--jersey-deep);
+              color: var(--cream);
+              border-right: 2px dashed var(--ink);
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              padding: 28px 14px;
+            "
+          >
+            <div class="mono" style="opacity: 0.85">ZA</div>
+            <div class="display" style="font-size: 92px; line-height: 0.8">
+              14
+            </div>
+            <div class="mono" style="font-size: 15px; margin-top: 4px">SEP</div>
+            <div class="mono" style="margin-top: 14px; font-size: 12px">
+              18:00
+            </div>
+          </div>
+          <div style="padding: 30px 32px">
             <span class="pill jersey">Clubevent</span>
-            <h1 class="display" style="font-size:clamp(40px,6vw,68px); color:var(--cream); margin:14px 0 8px;">Mossel<span class="em">feest.</span></h1>
-            <div class="mono" style="color:#e6e0cf;">ZA 14 SEP · 18:00 · KANTINE KCVV</div>
+            <h1
+              class="display"
+              style="font-size: clamp(38px, 5.5vw, 60px); margin: 14px 0 10px"
+            >
+              Mossel<span class="em">feest.</span>
+            </h1>
+            <div class="mono" style="color: var(--ink-muted)">
+              KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT
+            </div>
+            <div class="ctas">
+              <a class="cta go">Reserveer ↗</a
+              ><a class="cta ghost oncream">＋ Zet in agenda</a>
+            </div>
+          </div>
+        </div>
+        <div class="other">
+          <h3>
+            Andere events
+            <div class="seam"></div>
+          </h3>
+          <div class="grid2">
+            <a class="ticket"
+              ><div class="stub s-bright">
+                <div class="day">22</div>
+                <div class="mon">SEP</div>
+              </div>
+              <div class="tb">
+                <span class="tp">Jeugdwerking</span>
+                <h4>Jeugdtornooi</h4>
+                <div class="m">Sportpark Elewijt</div>
+              </div></a
+            >
+            <a class="ticket"
+              ><div class="stub s-warm">
+                <div class="day">05</div>
+                <div class="mon">OKT</div>
+              </div>
+              <div class="tb">
+                <span class="tp">Supporters</span>
+                <h4>Busreis uitwedstrijd</h4>
+                <div class="m">Vertrek Kantine</div>
+              </div></a
+            >
           </div>
         </div>
       </div>
-      <div style="background:var(--cream); border-top:2px solid var(--ink); border-bottom:2px solid var(--ink);">
-        <div class="container" style="padding:20px 28px;"><div class="ctas" style="margin-top:0;"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Zet in agenda</a></div></div>
+    </div>
+
+    <!-- B · Poster -->
+    <div class="direction-bar">
+      <span class="tag">B</span> Poster
+      <span class="says"
+        >— full-bleed cover, overlaid title/date, CTAs on a cream bar below.
+        Image-forward (needs a cover).</span
+      >
+    </div>
+    <div
+      class="stage"
+      style="
+        background: #000;
+        padding-top: 0;
+        padding-left: 0;
+        padding-right: 0;
+      "
+    >
+      <div style="position: relative">
+        <div class="photo ph-mossel" style="height: 380px"></div>
+        <div
+          style="
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(
+              to top,
+              rgba(10, 10, 10, 0.92),
+              rgba(10, 10, 10, 0.15) 60%
+            );
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            padding: 34px 28px;
+          "
+        >
+          <div class="container" style="color: var(--cream)">
+            <span class="pill jersey">Clubevent</span>
+            <h1
+              class="display"
+              style="
+                font-size: clamp(40px, 6vw, 68px);
+                color: var(--cream);
+                margin: 14px 0 8px;
+              "
+            >
+              Mossel<span class="em">feest.</span>
+            </h1>
+            <div class="mono" style="color: #e6e0cf">
+              ZA 14 SEP · 18:00 · KANTINE KCVV
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="stage" style="background:var(--jersey-deep-dark);"><div class="container"><div class="other" style="margin-top:0;"><h3>Andere events <div class="seam"></div></h3><div class="grid2">
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
-        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
-      </div></div></div></div>
+      <div
+        style="
+          background: var(--cream);
+          border-top: 2px solid var(--ink);
+          border-bottom: 2px solid var(--ink);
+        "
+      >
+        <div class="container" style="padding: 20px 28px">
+          <div class="ctas" style="margin-top: 0">
+            <a class="cta go">Reserveer ↗</a
+            ><a class="cta ghost oncream">＋ Zet in agenda</a>
+          </div>
+        </div>
+      </div>
+      <div class="stage" style="background: var(--jersey-deep-dark)">
+        <div class="container">
+          <div class="other" style="margin-top: 0">
+            <h3>
+              Andere events
+              <div class="seam"></div>
+            </h3>
+            <div class="grid2">
+              <a class="ticket"
+                ><div class="stub s-bright">
+                  <div class="day">22</div>
+                  <div class="mon">SEP</div>
+                </div>
+                <div class="tb">
+                  <span class="tp">Jeugdwerking</span>
+                  <h4>Jeugdtornooi</h4>
+                  <div class="m">Sportpark Elewijt</div>
+                </div></a
+              >
+              <a class="ticket"
+                ><div class="stub s-warm">
+                  <div class="day">05</div>
+                  <div class="mon">OKT</div>
+                </div>
+                <div class="tb">
+                  <span class="tp">Supporters</span>
+                  <h4>Busreis uitwedstrijd</h4>
+                  <div class="m">Vertrek Kantine</div>
+                </div></a
+              >
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- C · Split -->
-    <div class="direction-bar"><span class="tag">C</span> Split <span class="says">— cover one half, cream info panel the other (FeaturedEventBand scaled up). Balanced; degrades to panel-only with no cover.</span></div>
-    <div class="stage" style="background: var(--jersey-deep-dark);"><div class="container">
-      <a class="back">← Alle evenementen</a>
-      <div style="display:grid; grid-template-columns:1fr 1fr; border:2px solid var(--ink); box-shadow:9px 9px 0 rgba(0,0,0,0.5); overflow:hidden; background:var(--cream);">
-        <div style="padding:34px 32px;">
-          <span class="pill jersey">Clubevent</span>
-          <h1 class="display" style="font-size:clamp(34px,4.5vw,52px); margin:14px 0 10px;">Mossel<span class="em">feest.</span></h1>
-          <div class="mono" style="color:var(--ink-muted); line-height:1.8;">ZA 14 SEP · 18:00<br/>KANTINE KCVV</div>
-          <div class="ctas"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Agenda</a></div>
+    <div class="direction-bar">
+      <span class="tag">C</span> Split
+      <span class="says"
+        >— cover one half, cream info panel the other (FeaturedEventBand scaled
+        up). Balanced; degrades to panel-only with no cover.</span
+      >
+    </div>
+    <div class="stage" style="background: var(--jersey-deep-dark)">
+      <div class="container">
+        <a class="back">← Alle evenementen</a>
+        <div
+          style="
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            border: 2px solid var(--ink);
+            box-shadow: 9px 9px 0 rgba(0, 0, 0, 0.5);
+            overflow: hidden;
+            background: var(--cream);
+          "
+        >
+          <div style="padding: 34px 32px">
+            <span class="pill jersey">Clubevent</span>
+            <h1
+              class="display"
+              style="font-size: clamp(34px, 4.5vw, 52px); margin: 14px 0 10px"
+            >
+              Mossel<span class="em">feest.</span>
+            </h1>
+            <div class="mono" style="color: var(--ink-muted); line-height: 1.8">
+              ZA 14 SEP · 18:00<br />KANTINE KCVV
+            </div>
+            <div class="ctas">
+              <a class="cta go">Reserveer ↗</a
+              ><a class="cta ghost oncream">＋ Agenda</a>
+            </div>
+          </div>
+          <div
+            class="photo ph-mossel"
+            style="border-left: 2px solid var(--ink); min-height: 280px"
+          ></div>
         </div>
-        <div class="photo ph-mossel" style="border-left:2px solid var(--ink); min-height:280px;"></div>
+        <div class="other">
+          <h3>
+            Andere events
+            <div class="seam"></div>
+          </h3>
+          <div class="grid2">
+            <a class="ticket"
+              ><div class="stub s-bright">
+                <div class="day">22</div>
+                <div class="mon">SEP</div>
+              </div>
+              <div class="tb">
+                <span class="tp">Jeugdwerking</span>
+                <h4>Jeugdtornooi</h4>
+                <div class="m">Sportpark Elewijt</div>
+              </div></a
+            >
+            <a class="ticket"
+              ><div class="stub s-warm">
+                <div class="day">05</div>
+                <div class="mon">OKT</div>
+              </div>
+              <div class="tb">
+                <span class="tp">Supporters</span>
+                <h4>Busreis uitwedstrijd</h4>
+                <div class="m">Vertrek Kantine</div>
+              </div></a
+            >
+          </div>
+        </div>
       </div>
-      <div class="other"><h3>Andere events <div class="seam"></div></h3><div class="grid2">
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
-        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
-      </div></div>
-    </div></div>
+    </div>
 
     <!-- D · Editoriaal -->
-    <div class="direction-bar"><span class="tag">D</span> Editoriaal <span class="says">— cream page, big serif title, cover as a taped/tilted figure. Quietest; least tied to the ticket motif.</span></div>
-    <div class="stage" style="background: var(--cream);"><div class="container">
-      <a class="back" style="color:var(--ink-muted);">← Alle evenementen</a>
-      <div style="text-align:center; max-width:680px; margin:0 auto;">
-        <span class="pill jersey" style="margin-bottom:16px;">Clubevent</span>
-        <div class="mono" style="color:var(--ink-muted); margin:14px 0 6px;">ZATERDAG 14 SEPTEMBER · 18:00</div>
-        <h1 class="display" style="font-size:clamp(44px,7vw,80px);">Mossel<span class="em" style="color:var(--jersey-deep);">feest.</span></h1>
-        <div class="mono" style="color:var(--ink-muted); margin-top:8px;">KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT</div>
-        <div class="ctas" style="justify-content:center;"><a class="cta go">Reserveer ↗</a><a class="cta ghost oncream">＋ Zet in agenda</a></div>
+    <div class="direction-bar">
+      <span class="tag">D</span> Editoriaal
+      <span class="says"
+        >— cream page, big serif title, cover as a taped/tilted figure.
+        Quietest; least tied to the ticket motif.</span
+      >
+    </div>
+    <div class="stage" style="background: var(--cream)">
+      <div class="container">
+        <a class="back" style="color: var(--ink-muted)">← Alle evenementen</a>
+        <div style="text-align: center; max-width: 680px; margin: 0 auto">
+          <span class="pill jersey" style="margin-bottom: 16px">Clubevent</span>
+          <div class="mono" style="color: var(--ink-muted); margin: 14px 0 6px">
+            ZATERDAG 14 SEPTEMBER · 18:00
+          </div>
+          <h1 class="display" style="font-size: clamp(44px, 7vw, 80px)">
+            Mossel<span class="em" style="color: var(--jersey-deep)"
+              >feest.</span
+            >
+          </h1>
+          <div class="mono" style="color: var(--ink-muted); margin-top: 8px">
+            KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT
+          </div>
+          <div class="ctas" style="justify-content: center">
+            <a class="cta go">Reserveer ↗</a
+            ><a class="cta ghost oncream">＋ Zet in agenda</a>
+          </div>
+        </div>
+        <div
+          class="photo ph-mossel"
+          style="
+            height: 300px;
+            margin: 34px auto 0;
+            max-width: 760px;
+            border: 2px solid var(--ink);
+            box-shadow: 8px 8px 0 var(--ink);
+            transform: rotate(-1deg);
+          "
+        ></div>
+        <div class="other" style="margin-top: 48px">
+          <h3 style="color: var(--ink)">
+            Andere events
+            <div class="seam"></div>
+          </h3>
+          <div class="grid2">
+            <a class="ticket"
+              ><div class="stub s-bright">
+                <div class="day">22</div>
+                <div class="mon">SEP</div>
+              </div>
+              <div class="tb">
+                <span class="tp">Jeugdwerking</span>
+                <h4>Jeugdtornooi</h4>
+                <div class="m">Sportpark Elewijt</div>
+              </div></a
+            >
+            <a class="ticket"
+              ><div class="stub s-warm">
+                <div class="day">05</div>
+                <div class="mon">OKT</div>
+              </div>
+              <div class="tb">
+                <span class="tp">Supporters</span>
+                <h4>Busreis uitwedstrijd</h4>
+                <div class="m">Vertrek Kantine</div>
+              </div></a
+            >
+          </div>
+        </div>
       </div>
-      <div class="photo ph-mossel" style="height:300px; margin:34px auto 0; max-width:760px; border:2px solid var(--ink); box-shadow:8px 8px 0 var(--ink); transform:rotate(-1deg);"></div>
-      <div class="other" style="margin-top:48px;"><h3 style="color:var(--ink);">Andere events <div class="seam"></div></h3><div class="grid2">
-        <a class="ticket"><div class="stub s-bright"><div class="day">22</div><div class="mon">SEP</div></div><div class="tb"><span class="tp">Jeugdwerking</span><h4>Jeugdtornooi</h4><div class="m">Sportpark Elewijt</div></div></a>
-        <a class="ticket"><div class="stub s-warm"><div class="day">05</div><div class="mon">OKT</div></div><div class="tb"><span class="tp">Supporters</span><h4>Busreis uitwedstrijd</h4><div class="m">Vertrek Kantine</div></div></a>
-      </div></div>
-    </div></div>
+    </div>
 
-    <div class="harness-head" style="background: var(--ink-soft);">
-      <p>CTA rules (all directions): <b>Reserveer ↗</b> renders only when <code>externalLink</code> is set (label =
-      <code>externalLink.label</code>, fallback "Reserveer"); <b>＋ Zet in agenda</b> (iCal download) is always present.
-      No-cover fallback + multi-day date display are details for the next pass.</p>
+    <div class="harness-head" style="background: var(--ink-soft)">
+      <p>
+        CTA rules (all directions): <b>Reserveer ↗</b> renders only when
+        <code>externalLink</code> is set (label =
+        <code>externalLink.label</code>, fallback "Reserveer");
+        <b>＋ Zet in agenda</b> (iCal download) is always present. No-cover
+        fallback + multi-day date display are details for the next pass.
+      </p>
     </div>
   </body>
 </html>

--- a/docs/design/mockups/phase-6-events/6e5-eventhero-compare.html
+++ b/docs/design/mockups/phase-6-events/6e5-eventhero-compare.html
@@ -344,9 +344,7 @@
             >
               Mossel<span class="em">feest.</span>
             </h1>
-            <div class="mono" style="color: var(--ink-muted)">
-              KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT
-            </div>
+            <div class="mono" style="color: var(--ink-muted)">KANTINE KCVV</div>
             <div class="ctas">
               <a class="cta go">Reserveer ↗</a
               ><a class="cta ghost oncream">＋ Zet in agenda</a>
@@ -522,7 +520,7 @@
             </div>
             <div class="ctas">
               <a class="cta go">Reserveer ↗</a
-              ><a class="cta ghost oncream">＋ Agenda</a>
+              ><a class="cta ghost oncream">＋ Zet in agenda</a>
             </div>
           </div>
           <div
@@ -585,7 +583,7 @@
             >
           </h1>
           <div class="mono" style="color: var(--ink-muted); margin-top: 8px">
-            KANTINE KCVV · DRIESSTRAAT 14, ELEWIJT
+            KANTINE KCVV
           </div>
           <div class="ctas" style="justify-content: center">
             <a class="cta go">Reserveer ↗</a

--- a/docs/design/mockups/phase-6-events/6e5-eventhero-locked.md
+++ b/docs/design/mockups/phase-6-events/6e5-eventhero-locked.md
@@ -1,0 +1,49 @@
+# Phase 6.E · /evenementen/[slug] — Round 5 (EventHero detail) — LOCKED
+
+**Date:** 2026-06-02
+**Mockup:** `6e5-eventhero-compare.html`
+
+## Decision — Variant D "Editoriaal"
+
+The detail page is intentionally **calm and light**, contrasting the dark, energetic ticket-wall
+list (dark index → cream detail).
+
+### `<EventHero>` composition (cream page, centred)
+
+1. `eventType` **pill** (jersey-deep), top.
+2. **Date/location kicker** — mono, full date: `ZATERDAG 14 SEPTEMBER · 18:00`.
+3. **Title** — big display serif with italic emphasis on the accent word (jersey-deep).
+4. **Location line** — mono, under the title.
+5. **CTAs** (centred):
+   - **Reserveer ↗** — warm filled; renders **only when `externalLink` is set** (label =
+     `externalLink.label`, fallback "Reserveer").
+   - **＋ Zet in agenda** — outline; **always present** (iCal download).
+6. **Cover** — `TapedFigure` (tilted + taped) below the CTAs, **only when `coverImage` exists**.
+   No-cover events are just the centred text block + CTAs (graceful, the common case).
+
+### Below the hero
+
+- **"Andere events"** section — `StripedSeam` heading + the locked list **ticket** component
+  (type-coloured stubs) in a grid. No body Portable Text, no RSVP, no sponsor footer (per §6.7).
+
+## ⚠️ Data caveat for the PRD (audit)
+
+- The root **`event`** schema has **`location`** (new delta) but **no `address`** field. The
+  mockup's "DRIESSTRAAT 14, ELEWIJT" line is **address**, which only exists on the **`eventFact`**
+  block (articleType:event articles). So:
+  - For **`event` docs**: show **`location`** only.
+  - For **`articleType:event`** entries: `location` (+ `address` if we choose to surface it).
+  - Do **not** invent an address for root events. (Confirm in PRD whether to add `address` to the
+    `event` delta or accept location-only.)
+
+## Rejected
+
+- **A · Grote ticket** — most coherent with the list, but the owner chose the editorial contrast.
+- **B · Poster** — too cover-dependent (most events have none).
+- **C · Split** — fine, but the editorial centred treatment won on calm/restraint.
+
+## Remaining 6.E details (PRD or quick round)
+
+- **States**: empty list · filtered-to-zero · multi-day date range on stub + hero · time-less
+  events (no time component) · no-cover fallbacks.
+- Stub colour-contrast tuning on the dark field (from Round 2).

--- a/docs/prd/redesign-phase-6e-events.md
+++ b/docs/prd/redesign-phase-6e-events.md
@@ -1,0 +1,172 @@
+# PRD: Redesign Phase 6.E — Events (`/evenementen`)
+
+**Status**: Ready for implementation (design locked)
+**Date**: 2026-06-02
+**Design contract**: `docs/design/mockups/phase-6-events/6e-design-summary-locked.md` (rounds `6e1`–`6e5`)
+**Epic**: #1528 (Redesign Phase 6) · **Milestone**: `redesign-retro-terrace-fanzine`
+
+---
+
+## 1. Problem statement
+
+The events surface is the last un-redesigned route in Phase 6. Today `/events` renders a
+pre-redesign green hero + grey card grid (`<EventsList>` / `<EventCard>`), the detail route
+`(main)/events/[slug]` is a legacy CTA page, and the `event` schema has no way to categorise an
+event (no type) or state where it happens (no `location`). The redesign needs an events index that
+reads like a club's "wat is er te doen" poster wall and a calm detail page — both in the
+retro-terrace-fanzine language — plus the schema fields to drive type-based scanning.
+
+## 2. Scope
+
+**In scope (packages):** `packages/sanity-schemas`, `apps/web`, `apps/studio` + `apps/studio-staging`
+(schema consumed by both).
+
+**In scope (work):**
+
+- Schema deltas: `location` + `eventType` enum on `event`; `eventType` on `eventFact`.
+- New `<TicketStub>` and `<EventHero>` components (+ Storybook, tests, VR).
+- `/evenementen` list (single-column, month-grouped, colour-coded filter chips) + `/evenementen/[slug]`
+  editorial detail (CTAs + iCal + "Andere events").
+- Merge `articleType:event` articles into the list feed.
+- Route rename `/events` → `/evenementen` with **301** redirects; sitemap + SEO updates.
+- States (empty / filtered-to-zero / multi-day / time-less / no-cover) + analytics.
+- Retire legacy `<EventCard>` / `<EventsList>` / old `/events` route.
+
+**OUT of scope (name it):**
+
+- `/kalender` (the 3-source feed _including PSD matches_) — separate surface (§6.6), Phase 6.D.
+- Any `apps/api` / `packages/api-contract` change — events are **Sanity-native**, read via
+  `EventRepository` GROQ. The BFF is not touched.
+- RSVP, ticketing/payment, body Portable Text on the detail page, sponsor/credit footer (dropped per §6.7).
+- Adding `eventFact`'s richer fields (`capacity`, `sessions`, `ageGroup`, …) to the root `event` doc.
+
+## 3. Tracer bullet
+
+**One real upcoming event rendered as a bare `<TicketStub>` at the new `/evenementen` route, end to
+end.** Crosses every layer: `event` schema gains `location` + `eventType` → `sanity typegen`
+regenerates `sanity.types.ts` → `EVENTS_QUERY` extended (upcoming-only + new fields) →
+`EventRepository.findAll` → new `/evenementen` page renders a minimal type-coloured ticket list →
+`/events` 301s to `/evenementen`. No month grouping, no filters, no detail rebuild, no design polish.
+Proves the schema→typegen→GROQ→route→component chain and the redirect before any styling.
+
+## 4. Phases
+
+```text
+Phase 1: Tracer — event schema delta + /evenementen route + bare <TicketStub> list + 301   (always first)
+Phase 2: <TicketStub> finalised + month-grouped list shell
+Phase 3: Filter bar (colour chips = legend) + empty / filtered-to-zero states
+Phase 4: <EventHero> + /evenementen/[slug] editorial detail + iCal + "Andere events" + detail states
+Phase 5: Merged feed — eventType on eventFact + articleType:event articles in the list
+Phase 6: SEO / sitemap / analytics / JSON-LD + retire legacy + VR baselines
+```
+
+## 5. Acceptance criteria per phase
+
+### Phase 1 — Tracer bullet
+
+- [ ] `event` schema gains `location` (string, optional) and `eventType` (string enum:
+      `Clubevent` | `Supportersactiviteit` | `Jeugdwerking` | `Andere`, optional in v1) in
+      `packages/sanity-schemas/src/event.ts`; both studios pick it up.
+- [ ] `pnpm --filter @kcvv/studio typegen` (or the repo typegen script) re-run; `sanity.types.ts` updated.
+- [ ] `EVENTS_QUERY` extended to project `location`, `eventType` and filter **upcoming-only**
+      (`coalesce(dateEnd, dateStart) >= now()`), keeping `order(dateStart asc)`.
+- [ ] New route `apps/web/src/app/.../evenementen/page.tsx` renders `EventRepository.findAll()` as a
+      minimal list of `<TicketStub>` (type-coloured date block + pill + title + location). No grouping/filters.
+- [ ] `/events` and `/events/[slug]` issue **301** redirects to `/evenementen` (+ `/evenementen/[slug]`).
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 2 — `<TicketStub>` + month-grouped list shell
+
+- [ ] `<TicketStub>` finalised: whole-card link → `/evenementen/[slug]`; type-coloured tear-off date
+      block (Clubevent=jersey-deep · Supporters=warm · Jeugd=jersey-bright · Andere=ink), dashed
+      divider (no punch-holes); body = `eventType` pill + display-serif title + mono `time · location`.
+- [ ] Hover/focus-visible: `group-hover:scale-[1.02] group-hover:-rotate-1` + "Meer details →" reveal
+      (`opacity-0 → group-hover:opacity-100`), with `motion-reduce` resets — mirrors `<EditorialHero>`.
+- [ ] `eventType` is conveyed by both colour **and** the text pill (WCAG 1.4.1).
+- [ ] List renders single column, **grouped by month** (`<StripedSeam>` header + display-serif month
+      name); year shown only when crossing into the next calendar year.
+- [ ] Storybook stories: each `eventType` colour, hover state, multi-day, no-time. Unit test: link href,
+      reveal present, reduced-motion class.
+- [ ] VR baselines committed for `<TicketStub>` states (same PR).
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 3 — Filter bar + empty states
+
+- [ ] Colour-coded filter chips (Alles + 4 types) that **double as the legend** (no separate legend);
+      selected = filled, unselected = dimmed outline; **single-select**, "Alles" default.
+- [ ] Filtering hides any month whose tickets are all filtered out (no empty month headers).
+- [ ] Empty list state (no upcoming events): centred message, no filter row / month headers.
+- [ ] Filtered-to-zero state: per-type message + "Toon alles" reset.
+- [ ] `event_filter` analytics fires with `event_type`; GTM tag + GA4 report updated.
+- [ ] Storybook: filter row (each selected state), empty, filtered-zero. VR baselines committed.
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 4 — `<EventHero>` + detail page
+
+- [ ] New `<EventHero>` (editorial cream, centred): `eventType` pill · mono full-date/location kicker ·
+      display-serif title w/ italic jersey-deep emphasis · location line · centred CTAs · `<TapedFigure>`
+      cover (tilted+taped) **only when `coverImage` set**.
+- [ ] `/evenementen/[slug]` rebuilt with `<EventHero>` from `EVENT_BY_SLUG_QUERY` (extended with
+      `location`, `eventType`).
+- [ ] **Reserveer ↗** CTA renders only when `externalLink.url` set (label = `externalLink.label`,
+      fallback "Reserveer"); opens in new tab.
+- [ ] **＋ Zet in agenda** CTA always present; downloads a valid `.ics` (VEVENT with title, start, end,
+      location, description) — client-side blob.
+- [ ] "Andere events" section: `<StripedSeam>` heading + `<TicketStub>` grid of other upcoming events
+      (current excluded); hidden when none.
+- [ ] States: multi-day (start day on stub, range in kicker), time-less (`00:00` → omit time), no-cover
+      (omit figure).
+- [ ] `event_view` + `event_cta_click` (`cta: reserveer | agenda`) analytics fire; GTM + GA4 updated.
+- [ ] JSON-LD `SportsEvent`/`Event` emitted on the detail page (reuse existing builder if suitable).
+- [ ] Storybook (`<EventHero>` w/ + w/o cover, w/ + w/o externalLink, multi-day) + e2e smoke. VR baselines.
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 5 — Merged feed (articleType:event)
+
+- [ ] `eventType` enum added to the `eventFact` block schema (both studios) + typegen re-run.
+- [ ] List query merges `event` docs **and** `article` docs where `articleType == "event"` (date from the
+      `eventFact` block), upcoming-only, into one chronological, month-grouped, type-filterable feed.
+- [ ] Article-sourced tickets link to the **article** (`/nieuws/[slug]`); event-doc tickets link to
+      `/evenementen/[slug]`. Both render via `<TicketStub>`.
+- [ ] Filters apply across both sources; sort is by event date across the merged set.
+- [ ] Tests cover the merge + ordering + per-source link target. `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 6 — SEO / analytics / legacy retirement
+
+- [ ] Sitemap updated to `/evenementen` + `/evenementen/[slug]` (drop `/events`); OG image from
+      `coverImage`/`ogImage`.
+- [ ] Legacy `<EventCard>` / `<EventsList>` and the old `(landing)/events` + `(main)/events/[slug]`
+      routes retired once `/evenementen` fully replaces them (redirects kept).
+- [ ] VR Phase-4 page fixtures cover `/evenementen` (list, filtered, empty) + one `/evenementen/[slug]`.
+- [ ] Playwright e2e: list renders, filter narrows, ticket → detail, CTAs present.
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+## 6. Effect Schema / api-contract changes
+
+**None in `packages/api-contract` or `apps/api`.** Events are Sanity-native and read through
+`EventRepository` (`apps/web/src/lib/repositories/event.repository.ts`) via GROQ + `@sanity/cli`
+typegen. Changes are confined to:
+
+- **Sanity schema** (`packages/sanity-schemas/src/event.ts`, `eventFact.ts`) — new fields.
+- **GROQ + typegen** — `EVENTS_QUERY`, `EVENT_BY_SLUG_QUERY` extended; `sanity.types.ts` regenerated;
+  `EventVM` / `EventDetailVM` re-derived.
+
+## 7. Open questions
+
+- `[ ]` **`address` on the detail page** — root `event` has `location` only (no `address`; that lives on
+  `eventFact`). Recommendation: **`location`-only** for event docs; do not add `address` to the `event`
+  delta. — owner confirm; default to location-only if no objection.
+- `[ ]` **`eventType` required vs optional** — optional in v1 (existing events have none) with an "Andere"
+  fallback at render time, or a one-off migration to backfill? — decide before Phase 1 ships; default
+  optional + render-time fallback.
+- `[ ]` **iCal generation** — client-side `.ics` blob (recommended, no BFF) vs a BFF endpoint. — resolved
+  in Phase 4; default client-side.
+- `[ ]` **Multi-select filters** — single-select locked for v1; revisit only if owner wants combinations.
+- `[ ]` **Dutch empty-state copy** — proposed: _"Geen evenementen gepland — kom snel terug."_ /
+  _"Geen [type] gepland."_ — owner to confirm final strings.
+- `[ ]` **Article-sourced ticket link target** (Phase 5) — confirmed `/nieuws/[slug]` for `articleType:event`
+  articles vs a synthetic event page — assumed `/nieuws/[slug]`.
+
+## 8. Discovered unknowns
+
+_Filled during implementation._

--- a/docs/prd/redesign-phase-6e-events.md
+++ b/docs/prd/redesign-phase-6e-events.md
@@ -52,12 +52,12 @@ Proves the schema→typegen→GROQ→route→component chain and the redirect be
 ## 4. Phases
 
 ```text
-Phase 1: Tracer — event schema delta + /evenementen route + bare <TicketStub> list + 301   (always first)
-Phase 2: <TicketStub> finalised + month-grouped list shell
-Phase 3: Filter bar (colour chips = legend) + empty / filtered-to-zero states
-Phase 4: <EventHero> + /evenementen/[slug] editorial detail + iCal + "Andere events" + detail states
-Phase 5: Merged feed — eventType on eventFact + articleType:event articles in the list
-Phase 6: SEO / sitemap / analytics / JSON-LD + retire legacy + VR baselines
+Phase 1: Tracer — event schema delta + /evenementen route + bare <TicketStub> list + 301   → #1964 (tracer-bullet)
+Phase 2: <TicketStub> finalised + month-grouped list shell                                  → #1965 (blocked-by #1964)
+Phase 3: Filter bar (colour chips = legend) + empty / filtered-to-zero states               → #1966 (blocked-by #1965)
+Phase 4: <EventHero> + /evenementen/[slug] editorial detail + iCal + "Andere events"        → #1967 (blocked-by #1966)
+Phase 5: Merged feed — eventType on eventFact + articleType:event articles in the list       → #1968 (blocked-by #1967)
+Phase 6: SEO / sitemap / analytics / JSON-LD + retire legacy + VR baselines                 → #1969 (blocked-by #1968)
 ```
 
 ## 5. Acceptance criteria per phase

--- a/docs/prd/redesign-phase-6e-events.md
+++ b/docs/prd/redesign-phase-6e-events.md
@@ -70,15 +70,16 @@ Phase 6: SEO / sitemap / analytics / JSON-LD + retire legacy + VR baselines     
 - [ ] `pnpm --filter @kcvv/studio typegen` (or the repo typegen script) re-run; `sanity.types.ts` updated.
 - [ ] `EVENTS_QUERY` extended to project `location`, `eventType` and filter **upcoming-only**
       (`coalesce(dateEnd, dateStart) >= now()`), keeping `order(dateStart asc)`.
-- [ ] New route `apps/web/src/app/.../evenementen/page.tsx` renders `EventRepository.findAll()` as a
+- [ ] New route `apps/web/src/app/(main)/evenementen/page.tsx` renders `EventRepository.findAll()` as a
       minimal list of `<TicketStub>` (type-coloured date block + pill + title + location). No grouping/filters.
+      (Lives in the `(main)` group alongside `kalender` + the events detail; the legacy list moves out of `(landing)`.)
 - [ ] `/events` and `/events/[slug]` issue **301** redirects to `/evenementen` (+ `/evenementen/[slug]`).
 - [ ] `pnpm --filter @kcvv/web check-all` passes.
 
 ### Phase 2 — `<TicketStub>` + month-grouped list shell
 
 - [ ] `<TicketStub>` finalised: whole-card link → `/evenementen/[slug]`; type-coloured tear-off date
-      block (Clubevent=jersey-deep · Supporters=warm · Jeugd=jersey-bright · Andere=ink), dashed
+      block (Clubevent=jersey-deep · Supportersactiviteit=warm · Jeugdwerking=jersey-bright · Andere=ink), dashed
       divider (no punch-holes); body = `eventType` pill + display-serif title + mono `time · location`.
 - [ ] Hover/focus-visible: `group-hover:scale-[1.02] group-hover:-rotate-1` + "Meer details →" reveal
       (`opacity-0 → group-hover:opacity-100`), with `motion-reduce` resets — mirrors `<EditorialHero>`.


### PR DESCRIPTION
Design-only PR — **no application code**. Lands the Phase 6.E (Events) design checkpoint and implementation PRD on main so the phase issues (#1964–#1969) can be picked up.

Part of epic #1528 (Redesign Phase 6). Milestone: `redesign-retro-terrace-fanzine`.

## What's here

**Design checkpoint** — `docs/design/mockups/phase-6-events/` (5 drilled + locked rounds, one HTML compare + `*-locked.md` each, plus a consolidated `6e-design-summary-locked.md`):

- **Voice** — ticket stubs on a dark jersey-deep field
- **Anatomy** — type-coloured clickable stub; whole-card → detail; hover tilt + "Meer details →" (EditorialHero idiom); eventType pill kept for a11y
- **Layout** — single column, grouped by month (StripedSeam headers)
- **Filters** — colour-coded chips that double as the legend; "Alles" default
- **EventHero** — editorial cream detail page; Reserveer + "Zet in agenda" (iCal) CTAs; "Andere events" grid

**Implementation PRD** — `docs/prd/redesign-phase-6e-events.md`: problem, scope, tracer bullet, 6 phases with per-phase acceptance criteria, Sanity-only data-layer note (no `apps/api` / `api-contract` change), and open questions with defaults.

## Issues created from the PRD

| # | Phase | Blocked by |
|---|---|---|
| #1964 | 1 · tracer (schema delta + `/evenementen` + bare `<TicketStub>` + 301) | — |
| #1965 | 2 · `<TicketStub>` + month-grouped list | #1964 |
| #1966 | 3 · filter bar + empty states | #1965 |
| #1967 | 4 · `<EventHero>` + detail + iCal + Andere events | #1966 |
| #1968 | 5 · merged feed (`eventType` on `eventFact` + event articles) | #1967 |
| #1969 | 6 · SEO/sitemap/analytics + retire legacy + VR | #1968 |

## Confirmed build deltas (for reviewers)

- Schema: `location` + `eventType` enum on `event`; `eventType` on `eventFact`
- New components: `<TicketStub>`, `<EventHero>`
- Route `/events` → `/evenementen` (301)

## Open questions (defaults in the PRD, owner can override)

- Detail page: `location`-only vs add `address` to `event` (default: location-only)
- `eventType`: optional + "Andere" fallback vs required-with-backfill (default: optional)
- iCal: client-side `.ics` vs BFF (default: client-side)
- Final Dutch empty-state copy

## Testing

Docs-only — prettier-clean; mockups open standalone in a browser. No code paths touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive, locked design specs and interactive mockups for Phase 6.E — Events (/evenementen): month-grouped list layouts, ticket-stub list pattern, color-coded single-select filter chips, detail-page EventHero variants, and “Andere events” grid.
  * Specifies CTAs (conditional external “Reserveer” and always-present iCal “＋ Zet in agenda”), UI states (empty, multi-day, time-less), accessibility notes, PRD with implementation phases, and recorded schema/data decisions for implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->