### PR TITLE
feat(calendar): /kalender consumes 3-source event feed (#1991)

### DIFF
--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -11,12 +11,15 @@ import { BffService } from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import {
   EventRepository,
-  type EventVM,
+  type EventListItemVM,
 } from "@/lib/repositories/event.repository";
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import { InteriorPageHero } from "@/components/layout";
 import { CalendarWidget } from "@/components/calendar/CalendarWidget";
-import { transformMatchToCalendar } from "./utils";
+import {
+  transformMatchToCalendar,
+  eventListItemToCalendarEvent,
+} from "./utils";
 import type { CalendarMatch, CalendarEvent, CalendarTeamInfo } from "./utils";
 
 export const metadata: Metadata = {
@@ -90,10 +93,13 @@ async function fetchCalendarData(): Promise<CalendarData> {
           return map;
         }, new Map<number, CalendarMatch>());
 
-      // Fetch events (graceful degradation on failure)
-      const eventVMs = yield* eventRepo
-        .findAll()
-        .pipe(Effect.catchAll(() => Effect.succeed([] as EventVM[])));
+      // Fetch the merged event feed — `event` docs + `articleType:event`
+      // articles (Phase 6.E, #1968) — so event-articles surface on the
+      // calendar alongside matches. Graceful degradation on failure: a Sanity
+      // error yields an empty feed, not a crash.
+      const feedItems = yield* eventRepo
+        .findUpcomingForList()
+        .pipe(Effect.catchAll(() => Effect.succeed([] as EventListItemVM[])));
 
       const teamInfos: CalendarTeamInfo[] = teamsWithPsd.map((t) => ({
         id: t.id,
@@ -102,13 +108,11 @@ async function fetchCalendarData(): Promise<CalendarData> {
         label: t.name,
       }));
 
-      const events: CalendarEvent[] = eventVMs.map((e) => ({
-        id: e.id,
-        title: e.title,
-        dateStart: e.dateStart,
-        dateEnd: e.dateEnd ?? undefined,
-        href: e.href,
-      }));
+      // The repo already resolves each item's detail `href`
+      // (`/evenementen/[slug]` for event docs, `/nieuws/[slug]` for articles).
+      const events: CalendarEvent[] = feedItems.map(
+        eventListItemToCalendarEvent,
+      );
 
       return {
         matches: [...deduplicatedMatches.values()],

--- a/apps/web/src/app/(main)/kalender/utils.test.ts
+++ b/apps/web/src/app/(main)/kalender/utils.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import {
   transformMatchToCalendar,
+  eventListItemToCalendarEvent,
   getMatchesForDay,
   getEventsForDay,
   getDaysInMonth,
@@ -12,6 +13,7 @@ import {
   getMatchDotType,
 } from "./utils";
 import type { Match } from "@/lib/effect/schemas/match.schema";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
 import type { CalendarMatch, CalendarEvent } from "./utils";
 
 function createMatch(overrides: Partial<Match> = {}): Match {
@@ -84,6 +86,61 @@ describe("transformMatchToCalendar", () => {
     expect(result.homeScore).toBeUndefined();
     expect(result.awayScore).toBeUndefined();
     expect(result.scoreDisplay).toEqual({ type: "vs" });
+  });
+});
+
+// ── eventListItemToCalendarEvent ──────────────────────────────────────────
+
+function makeEventListItem(
+  overrides: Partial<EventListItemVM> = {},
+): EventListItemVM {
+  return {
+    id: "event-1",
+    title: "Spaghetti-avond",
+    href: "/evenementen/spaghetti-avond",
+    dateStart: "2026-04-15T18:00:00Z",
+    dateEnd: "2026-04-15T22:00:00Z",
+    eventType: "Clubevent",
+    location: "Sportpark Driesput, Elewijt",
+    source: "event",
+    ...overrides,
+  };
+}
+
+describe("eventListItemToCalendarEvent", () => {
+  it("maps an event-doc row to a calendar event keeping its /evenementen/[slug] href", () => {
+    const result = eventListItemToCalendarEvent(makeEventListItem());
+
+    expect(result).toEqual({
+      id: "event-1",
+      title: "Spaghetti-avond",
+      dateStart: "2026-04-15T18:00:00Z",
+      dateEnd: "2026-04-15T22:00:00Z",
+      href: "/evenementen/spaghetti-avond",
+    });
+  });
+
+  it("maps a source:article row through with its /nieuws/[slug] href intact", () => {
+    const result = eventListItemToCalendarEvent(
+      makeEventListItem({
+        id: "article-1",
+        title: "Jeugdtornooi groot succes",
+        href: "/nieuws/jeugdtornooi-verslag",
+        source: "article",
+        dateEnd: null,
+      }),
+    );
+
+    expect(result.href).toBe("/nieuws/jeugdtornooi-verslag");
+    expect(result.id).toBe("article-1");
+  });
+
+  it("normalises a null dateEnd to undefined (CalendarEvent has no nullable end)", () => {
+    const result = eventListItemToCalendarEvent(
+      makeEventListItem({ dateEnd: null }),
+    );
+
+    expect(result.dateEnd).toBeUndefined();
   });
 });
 

--- a/apps/web/src/app/(main)/kalender/utils.ts
+++ b/apps/web/src/app/(main)/kalender/utils.ts
@@ -4,6 +4,7 @@
 
 import { DateTime } from "luxon";
 import type { Match } from "@/lib/effect/schemas/match.schema";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
 import type { MatchStatus } from "@/components/match/types";
 import { getScoreDisplay, type ScoreDisplay } from "@/lib/utils/match-display";
 export type { ScoreDisplay } from "@/lib/utils/match-display";
@@ -66,6 +67,28 @@ export function transformMatchToCalendar(match: Match): CalendarMatch {
     competition: match.competition,
     team: match.kcvv_team_label,
     isHome: match.is_home,
+  };
+}
+
+/**
+ * Project a merged-feed item (`EventRepository.findUpcomingForList()`) onto the
+ * `CalendarEvent` shape the widget renders. The repo already resolves each
+ * item's `href` — `/evenementen/[slug]` for `event` docs, `/nieuws/[slug]` for
+ * `source: "article"` rows — so this only narrows the fields the calendar
+ * consumes: a `null` end date becomes `undefined` (`CalendarEvent.dateEnd` is
+ * optional, not nullable). Requiring the merged-feed `EventListItemVM` (which
+ * the event-docs-only `EventVM` is not assignable to — it lacks `source`) keeps
+ * the page on the 3-source feed; a revert to `findAll()` is a compile error.
+ */
+export function eventListItemToCalendarEvent(
+  item: EventListItemVM,
+): CalendarEvent {
+  return {
+    id: item.id,
+    title: item.title,
+    dateStart: item.dateStart,
+    dateEnd: item.dateEnd ?? undefined,
+    href: item.href,
   };
 }
 


### PR DESCRIPTION
Closes #1991

Phase 6.D tracer bullet — proves the Phase 6.E merged event feed is consumable by the calendar end-to-end, before any data-model or visual work.

## Changes

- **`/kalender` now consumes the 3-source-ready feed.** `fetchCalendarData` (`apps/web/src/app/(main)/kalender/page.tsx`) switches the event source from `eventRepo.findAll()` (standalone `event` docs only) to `eventRepo.findUpcomingForList()` — the Phase 6.E merge of `event` docs + `articleType:event` articles (#1968). Event-articles now surface on the calendar alongside matches.
- **New mapper `eventListItemToCalendarEvent()`** in `kalender/utils.ts`, mirroring the existing `transformMatchToCalendar` peer. It narrows the merged-feed `EventListItemVM` to the widget's `CalendarEvent` shape and normalises a `null` `dateEnd` to `undefined`. The repo already resolves each item's detail `href` (`/evenementen/[slug]` for event docs, `/nieuws/[slug]` for articles), so the mapper passes it through.
- **Compile-time guard:** the mapper requires `EventListItemVM` (which `EventVM` is not assignable to — it lacks `source`), so a revert to `findAll()` is a type error.
- **Graceful degradation preserved** — the `Effect.catchAll(() => …empty feed…)` on the event fetch is retained; a Sanity failure still yields an empty event list, not a crash.

Out of scope (Phase 2, #1992): the unified `CalendarFeedItem` VM and the by-type `<FilterTabs>` swap. No new types, no filter change, no redesign.

## Testing

- `pnpm --filter @kcvv/web check-all` ✅ (lint + type-check + 3213 tests + build).
- 3 new unit tests for `eventListItemToCalendarEvent` (event-doc → `/evenementen/[slug]`, `source:"article"` → `/nieuws/[slug]`, `null` dateEnd → `undefined`).
- `/kalender` e2e smoke (`apps/web/test/e2e/routes.spec.ts`) unchanged — runs in CI.
- The repo-level merge + href resolution is already covered by `event.repository.test.ts`.

## Staging verification

The existing #1968 staging seed (`seed-1968-merged-events-staging.mjs`, re-run idempotently on the `staging` dataset) provides upcoming event-articles:

- **`/nieuws/najaarstornooi-u13-2026`** — `eventFact.date 2026-09-19`, Jeugdwerking
- **`/nieuws/supportersquiz-2026`** — `eventFact.date 2026-10-17`, Supportersactiviteit

On this PR's Vercel preview, open `/kalender`, navigate to **September 2026** → the *Najaarstornooi U13* event dot renders on the 19th and links to `/nieuws/najaarstornooi-u13-2026` (and October → *Supportersquiz*). Standalone `event` docs continue to link to `/evenementen/[slug]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved calendar event data loading and conversion process.
* **Tests**
  * Added comprehensive test coverage for event-to-calendar format conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->