### PR TITLE
feat(calendar): unified CalendarFeedItem VM + by-type filter on /kalender (#1992)

### DIFF
--- a/apps/web/src/app/(main)/kalender/__tests__/loading-toolbar.test.tsx
+++ b/apps/web/src/app/(main)/kalender/__tests__/loading-toolbar.test.tsx
@@ -6,7 +6,7 @@
  *
  * The real toolbar has:
  * 1. Top row: view toggle (segmented control) + subscribe button
- * 2. Second row: FilterTabs (scrollable pill-shaped team filter tabs)
+ * 2. Second row: KalenderFilterBar (pill-shaped by-type colour chips)
  * 3. Calendar grid
  *
  * @see https://github.com/kcvvelewijt/www.kcvvelewijt.be/issues/1261
@@ -49,7 +49,7 @@ describe("Calendar loading skeleton — toolbar chrome", () => {
     );
     expect(filterTabs).not.toBeNull();
 
-    // Should have at least 3 pill-shaped placeholders (Alle teams + 2 team tabs)
+    // Should have at least 3 pill placeholders (Alles + Wedstrijden + event types)
     const pills = filterTabs!.querySelectorAll("[data-testid='skeleton-pill']");
     expect(pills.length).toBeGreaterThanOrEqual(3);
   });

--- a/apps/web/src/app/(main)/kalender/loading.tsx
+++ b/apps/web/src/app/(main)/kalender/loading.tsx
@@ -43,16 +43,18 @@ export default function CalendarLoading() {
             />
           </div>
 
-          {/* Team filter tabs — pill-shaped placeholders matching FilterTabs (md) */}
+          {/* Type filter chips — pill placeholders matching KalenderFilterBar
+              (Alles · Wedstrijden · Clubevent · Supportersactiviteit ·
+              Jeugdwerking · Andere) */}
           <div
-            className="flex gap-2"
+            className="flex flex-wrap gap-2"
             data-testid="calendar-skeleton-filter-tabs"
           >
-            {["w-24", "w-20", "w-20", "w-24"].map((w, i) => (
+            {["w-16", "w-28", "w-24", "w-44", "w-28", "w-20"].map((w, i) => (
               <div
                 key={i}
-                className={`${w} h-[42px] animate-pulse rounded border-2 border-gray-300 bg-gray-100`}
-                /* h-[42px] ≈ py-3 × 2 + text-sm line-height, matching FilterTabs medium size */
+                className={`${w} h-[34px] animate-pulse rounded-full border-2 border-gray-300 bg-gray-100`}
+                /* h-[34px] ≈ py-1.5 × 2 + label line-height, matching KalenderFilterBar chips */
                 data-testid="skeleton-pill"
               />
             ))}

--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -16,11 +16,12 @@ import {
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import { InteriorPageHero } from "@/components/layout";
 import { CalendarWidget } from "@/components/calendar/CalendarWidget";
-import {
-  transformMatchToCalendar,
-  eventListItemToCalendarEvent,
+import { transformMatchToCalendar, buildCalendarFeed } from "./utils";
+import type {
+  CalendarMatch,
+  CalendarFeedItem,
+  CalendarTeamInfo,
 } from "./utils";
-import type { CalendarMatch, CalendarEvent, CalendarTeamInfo } from "./utils";
 
 export const metadata: Metadata = {
   title: "Wedstrijdkalender | KCVV Elewijt",
@@ -44,8 +45,7 @@ export const metadata: Metadata = {
 };
 
 interface CalendarData {
-  matches: CalendarMatch[];
-  events: CalendarEvent[];
+  feed: CalendarFeedItem[];
   teams: CalendarTeamInfo[];
 }
 
@@ -108,23 +108,25 @@ async function fetchCalendarData(): Promise<CalendarData> {
         label: t.name,
       }));
 
-      // The repo already resolves each item's detail `href`
-      // (`/evenementen/[slug]` for event docs, `/nieuws/[slug]` for articles).
-      const events: CalendarEvent[] = feedItems.map(
-        eventListItemToCalendarEvent,
+      // Compose matches + the event feed into one chronological, discriminated
+      // `CalendarFeedItem[]` (each tagged with its `kalenderType`). The widget
+      // filters this by type and projects it back to the renderers. The repo
+      // already resolved each event's detail href (`/evenementen/[slug]` for
+      // event docs, `/nieuws/[slug]` for articles).
+      const feed = buildCalendarFeed(
+        [...deduplicatedMatches.values()],
+        feedItems,
       );
 
       return {
-        matches: [...deduplicatedMatches.values()],
-        events,
+        feed,
         teams: teamInfos,
       };
     }).pipe(
       Effect.catchAll((error) => {
         console.error("[Calendar] Failed to fetch calendar data:", error);
         return Effect.succeed({
-          matches: [],
-          events: [],
+          feed: [],
           teams: [],
         } as CalendarData);
       }),
@@ -152,11 +154,7 @@ export default async function CalendarPage() {
       />
 
       <div className="mx-auto max-w-5xl px-4 py-10">
-        <CalendarWidget
-          matches={data.matches}
-          events={data.events}
-          teams={data.teams}
-        />
+        <CalendarWidget feed={data.feed} teams={data.teams} />
       </div>
     </div>
   );

--- a/apps/web/src/app/(main)/kalender/utils.test.ts
+++ b/apps/web/src/app/(main)/kalender/utils.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import {
   transformMatchToCalendar,
   eventListItemToCalendarEvent,
+  buildCalendarFeed,
   getMatchesForDay,
   getEventsForDay,
   getDaysInMonth,
@@ -329,5 +330,99 @@ describe("getMatchDotType", () => {
       awayTeam: { id: 2, name: "KCVV Elewijt A" },
     });
     expect(getMatchDotType(match)).toBe("away");
+  });
+});
+
+// ── buildCalendarFeed ─────────────────────────────────────────────────────
+
+describe("buildCalendarFeed", () => {
+  it("merges matches and events into one feed sorted chronologically by dateStart", () => {
+    const feed = buildCalendarFeed(
+      [
+        makeCalendarMatch({ id: 1, date: "2026-09-20T15:00:00Z" }),
+        makeCalendarMatch({ id: 2, date: "2026-09-12T18:00:00Z" }),
+      ],
+      [
+        makeEventListItem({ id: "e-late", dateStart: "2026-09-25T18:00:00Z" }),
+        makeEventListItem({
+          id: "a-early",
+          dateStart: "2026-09-14T10:00:00Z",
+          source: "article",
+          href: "/nieuws/a-early",
+        }),
+      ],
+    );
+
+    // 09-12 match · 09-14 article · 09-20 match · 09-25 event
+    expect(feed.map((item) => item.id)).toEqual([
+      "match-2",
+      "a-early",
+      "match-1",
+      "e-late",
+    ]);
+  });
+
+  it("tags matches as 'Wedstrijden' and events/articles with their eventType (null → 'Andere')", () => {
+    const feed = buildCalendarFeed(
+      [makeCalendarMatch({ id: 1, date: "2026-09-10T15:00:00Z" })],
+      [
+        makeEventListItem({
+          id: "clubevent",
+          dateStart: "2026-09-11T10:00:00Z",
+          eventType: "Clubevent",
+        }),
+        makeEventListItem({
+          id: "untyped",
+          dateStart: "2026-09-12T10:00:00Z",
+          eventType: null,
+        }),
+      ],
+    );
+
+    const typeById = Object.fromEntries(
+      feed.map((item) => [item.id, item.kalenderType]),
+    );
+    expect(typeById["match-1"]).toBe("Wedstrijden");
+    expect(typeById["clubevent"]).toBe("Clubevent");
+    expect(typeById["untyped"]).toBe("Andere");
+  });
+
+  it("discriminates by source — match items carry the CalendarMatch, event/article items the CalendarEvent with its resolved href", () => {
+    const [matchItem, eventItem, articleItem] = buildCalendarFeed(
+      [makeCalendarMatch({ id: 7, date: "2026-09-10T15:00:00Z" })],
+      [
+        makeEventListItem({
+          id: "evt",
+          dateStart: "2026-09-11T10:00:00Z",
+          source: "event",
+          href: "/evenementen/spaghetti-avond",
+        }),
+        makeEventListItem({
+          id: "art",
+          dateStart: "2026-09-12T10:00:00Z",
+          source: "article",
+          href: "/nieuws/jeugdtornooi",
+        }),
+      ],
+    );
+
+    // match item — id is source-prefixed so it can't collide with a Sanity _id.
+    expect(matchItem?.source).toBe("match");
+    if (matchItem?.source === "match") {
+      expect(matchItem.id).toBe("match-7");
+      expect(matchItem.match.id).toBe(7);
+    }
+
+    // event-doc item links to /evenementen/[slug].
+    expect(eventItem?.source).toBe("event");
+    if (eventItem && eventItem.source !== "match") {
+      expect(eventItem.event.href).toBe("/evenementen/spaghetti-avond");
+    }
+
+    // article item links to /nieuws/[slug].
+    expect(articleItem?.source).toBe("article");
+    if (articleItem && articleItem.source !== "match") {
+      expect(articleItem.event.href).toBe("/nieuws/jeugdtornooi");
+    }
   });
 });

--- a/apps/web/src/app/(main)/kalender/utils.ts
+++ b/apps/web/src/app/(main)/kalender/utils.ts
@@ -5,6 +5,10 @@
 import { DateTime } from "luxon";
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import type { EventListItemVM } from "@/lib/repositories/event.repository";
+import {
+  DEFAULT_EVENT_TYPE,
+  type EventType,
+} from "@/components/event/event-type-style";
 import type { MatchStatus } from "@/components/match/types";
 import { getScoreDisplay, type ScoreDisplay } from "@/lib/utils/match-display";
 export type { ScoreDisplay } from "@/lib/utils/match-display";
@@ -90,6 +94,82 @@ export function eventListItemToCalendarEvent(
     dateEnd: item.dateEnd ?? undefined,
     href: item.href,
   };
+}
+
+/**
+ * The kalender filter facet (#1992 — Phase 6.D Phase 2): the four event
+ * categories plus `"Wedstrijden"` for PSD matches. `Wedstrijden` is NOT a Sanity
+ * `eventType`, so this is a deliberate superset of `EventType` — it keeps the
+ * strict `EVENT_TYPE_FILL` (`satisfies Record<EventType, …>`) untouched while
+ * letting one predicate filter both matches and events.
+ */
+export type KalenderType = "Wedstrijden" | EventType;
+
+/**
+ * Unified calendar feed item — a discriminated union over `source` that merges
+ * the two sources the calendar renders: PSD matches and the 6.E event feed
+ * (`event` docs + `articleType:event` articles). Every item carries a single
+ * `kalenderType` facet so the by-type filter narrows matches and events through
+ * one predicate. The source payload is preserved so the existing month/week
+ * renderers (which consume `CalendarMatch[]` / `CalendarEvent[]`) can be
+ * projected back from a filtered feed without re-fetching.
+ */
+export type CalendarFeedItem =
+  | {
+      source: "match";
+      id: string;
+      dateStart: string;
+      kalenderType: "Wedstrijden";
+      match: CalendarMatch;
+    }
+  | {
+      source: "event" | "article";
+      id: string;
+      dateStart: string;
+      kalenderType: KalenderType;
+      event: CalendarEvent;
+    };
+
+/** ISO → epoch ms sort key; an unparseable date sorts to the end (not NaN). */
+function toFeedSortKey(iso: string): number {
+  const ms = DateTime.fromISO(iso).toMillis();
+  return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
+}
+
+/**
+ * Compose PSD matches + the 6.E event feed into one chronological
+ * `CalendarFeedItem[]`. Matches are tagged `"Wedstrijden"`; events/articles take
+ * their `eventType` (a missing type → `"Andere"` via `DEFAULT_EVENT_TYPE`, the
+ * same fallback `/evenementen` applies). Match ids are source-prefixed
+ * (`match-<id>`) so a numeric PSD id can never collide with a Sanity `_id`.
+ */
+export function buildCalendarFeed(
+  matches: CalendarMatch[],
+  events: EventListItemVM[],
+): CalendarFeedItem[] {
+  const matchItems = matches.map(
+    (match): CalendarFeedItem => ({
+      source: "match",
+      id: `match-${match.id}`,
+      dateStart: match.date,
+      kalenderType: "Wedstrijden",
+      match,
+    }),
+  );
+
+  const eventItems = events.map(
+    (event): CalendarFeedItem => ({
+      source: event.source,
+      id: event.id,
+      dateStart: event.dateStart,
+      kalenderType: event.eventType ?? DEFAULT_EVENT_TYPE,
+      event: eventListItemToCalendarEvent(event),
+    }),
+  );
+
+  return [...matchItems, ...eventItems].sort(
+    (a, b) => toFeedSortKey(a.dateStart) - toFeedSortKey(b.dateStart),
+  );
 }
 
 const TIMEZONE = "Europe/Brussels";

--- a/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.stories.tsx
+++ b/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.stories.tsx
@@ -3,9 +3,10 @@ import { within, userEvent } from "storybook/test";
 import { CalendarWidget } from "./CalendarWidget";
 import type {
   CalendarMatch,
-  CalendarEvent,
   CalendarTeamInfo,
 } from "@/app/(main)/kalender/utils";
+import { buildCalendarFeed } from "@/app/(main)/kalender/utils";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
 import CalendarLoading from "@/app/(main)/kalender/loading";
 import { fixtureImage } from "@test-fixtures/images";
 
@@ -56,12 +57,16 @@ const matches: CalendarMatch[] = [
   },
 ];
 
-const events: CalendarEvent[] = [
+const events: EventListItemVM[] = [
   {
     id: "e1",
     title: "Paastoernooi",
-    dateStart: "2026-03-20T10:00:00",
     href: "/evenementen/paastoernooi",
+    dateStart: "2026-03-20T10:00:00",
+    dateEnd: null,
+    eventType: "Clubevent",
+    location: "Sportpark Driesput, Elewijt",
+    source: "event",
   },
 ];
 
@@ -69,6 +74,8 @@ const teams: CalendarTeamInfo[] = [
   { id: "t1", name: "A-ploeg", psdId: 101, label: "A-ploeg" },
   { id: "t2", name: "U15 A", psdId: 103, label: "U15 A" },
 ];
+
+const feed = buildCalendarFeed(matches, events);
 
 const meta = {
   title: "Features/Calendar/CalendarWidget",
@@ -81,8 +88,7 @@ const meta = {
   },
   tags: ["autodocs"],
   args: {
-    matches,
-    events,
+    feed,
     teams,
   },
 } satisfies Meta<typeof CalendarWidget>;
@@ -104,6 +110,30 @@ export const WeekView: Story = {
   parameters: {
     nextjs: {
       navigation: { pathname: "/kalender", query: { view: "week" } },
+    },
+  },
+};
+
+/** By-type filter applied — only `Wedstrijden` (matches) survive the filter. */
+export const FilteredToWedstrijden: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/kalender",
+        query: { view: "month", type: "Wedstrijden" },
+      },
+    },
+  },
+};
+
+/** Filtered-to-zero — a category with no upcoming items shows the reset state. */
+export const FilteredToZero: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/kalender",
+        query: { view: "month", type: "Supportersactiviteit" },
+      },
     },
   },
 };

--- a/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.test.tsx
+++ b/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.test.tsx
@@ -7,9 +7,11 @@ import userEvent from "@testing-library/user-event";
 import { CalendarWidget } from "./CalendarWidget";
 import type {
   CalendarMatch,
-  CalendarEvent,
   CalendarTeamInfo,
 } from "@/app/(main)/kalender/utils";
+import { buildCalendarFeed } from "@/app/(main)/kalender/utils";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
+import { trackEvent } from "@/lib/analytics/track-event";
 import { getScoreDisplay } from "@/lib/utils/match-display";
 import { DateTime } from "luxon";
 
@@ -45,6 +47,8 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
+vi.mock("@/lib/analytics/track-event", () => ({ trackEvent: vi.fn() }));
+
 // ── Fixtures ───────────────────────────────────────────────────────────────
 
 function makeMatch(
@@ -70,14 +74,29 @@ function makeMatch(
   };
 }
 
+function makeEventVM(
+  overrides: Partial<EventListItemVM> & { id: string },
+): EventListItemVM {
+  return {
+    title: "Paastoernooi",
+    href: "/evenementen/paastoernooi",
+    dateStart: "2026-03-20T10:00:00",
+    dateEnd: null,
+    eventType: "Clubevent",
+    location: null,
+    source: "event",
+    ...overrides,
+  };
+}
+
 const teams: CalendarTeamInfo[] = [
   { id: "t1", name: "A-ploeg", psdId: 101, label: "A-ploeg" },
   { id: "t2", name: "B-ploeg", psdId: 102, label: "B-ploeg" },
 ];
 
+// One match + one Clubevent event → the feed the widget filters by type.
 const defaultProps = {
-  matches: [makeMatch({ id: 1 })],
-  events: [] as CalendarEvent[],
+  feed: buildCalendarFeed([makeMatch({ id: 1 })], [makeEventVM({ id: "e1" })]),
   teams,
 };
 
@@ -150,16 +169,74 @@ describe("CalendarWidget", () => {
       await user.click(screen.getByText("Abonneer"));
       expect(screen.getByTestId("subscribe-panel")).toBeInTheDocument();
     });
+  });
 
-    it("passes team filter as preselectedTeamLabel", async () => {
+  describe("by-type filter", () => {
+    it("renders the by-type chips (Alles + Wedstrijden + event types)", () => {
+      render(<CalendarWidget {...defaultProps} />);
+      expect(screen.getByRole("button", { name: "Alles" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Wedstrijden" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Clubevent" }),
+      ).toBeInTheDocument();
+    });
+
+    it("marks the active ?type= chip as pressed", () => {
+      mockSearchParams = new URLSearchParams("type=Wedstrijden");
+      render(<CalendarWidget {...defaultProps} />);
+      expect(
+        screen.getByRole("button", { name: "Wedstrijden" }),
+      ).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("pushes ?type= and fires kalender_filter when selecting a new type", async () => {
       const user = userEvent.setup();
-      mockSearchParams = new URLSearchParams("team=A-ploeg");
       render(<CalendarWidget {...defaultProps} />);
 
-      await user.click(screen.getByText("Abonneer"));
-      // When preselected, only A-ploeg should have a remove button
-      const chips = screen.getAllByRole("button", { name: /×/ });
-      expect(chips).toHaveLength(1);
+      await user.click(screen.getByRole("button", { name: "Wedstrijden" }));
+
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("type=Wedstrijden"),
+        expect.anything(),
+      );
+      expect(trackEvent).toHaveBeenCalledWith("kalender_filter", {
+        kalender_type: "Wedstrijden",
+      });
+    });
+
+    it("dedup guard: re-pressing the active chip pushes nothing and fires no analytics", async () => {
+      const user = userEvent.setup();
+      mockSearchParams = new URLSearchParams("type=Wedstrijden");
+      render(<CalendarWidget {...defaultProps} />);
+
+      await user.click(screen.getByRole("button", { name: "Wedstrijden" }));
+
+      expect(mockPush).not.toHaveBeenCalled();
+      expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it("renders the filtered-to-zero state + reset when a type has no items", () => {
+      mockSearchParams = new URLSearchParams("type=Supportersactiviteit");
+      render(<CalendarWidget {...defaultProps} />);
+
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /Geen evenementen in de categorie Supportersactiviteit/i,
+      );
+      expect(
+        screen.getByRole("button", { name: "Toon alles" }),
+      ).toBeInTheDocument();
+    });
+
+    it("clicking 'Toon alles' from a filtered-to-zero state resets the URL to /kalender", async () => {
+      const user = userEvent.setup();
+      mockSearchParams = new URLSearchParams("type=Supportersactiviteit");
+      render(<CalendarWidget {...defaultProps} />);
+
+      await user.click(screen.getByRole("button", { name: "Toon alles" }));
+
+      expect(mockPush).toHaveBeenCalledWith("/kalender", expect.anything());
     });
   });
 });

--- a/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.tsx
+++ b/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.tsx
@@ -4,19 +4,30 @@ import { useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { DateTime } from "luxon";
 import { cn } from "@/lib/utils/cn";
-import { FilterTabs, type FilterTab } from "@/components/design-system";
+import { trackEvent } from "@/lib/analytics/track-event";
 import { CalendarMonth } from "../CalendarMonth";
 import { CalendarWeek } from "../CalendarWeek";
 import { CalendarSubscribePanel } from "../CalendarSubscribePanel";
+import {
+  KalenderFilterBar,
+  isKalenderFilterValue,
+  type KalenderFilterValue,
+} from "../KalenderFilterBar";
 import type {
+  CalendarFeedItem,
   CalendarMatch,
   CalendarEvent,
   CalendarTeamInfo,
 } from "@/app/(main)/kalender/utils";
 
 export interface CalendarWidgetProps {
-  matches: CalendarMatch[];
-  events: CalendarEvent[];
+  /**
+   * Unified, chronologically-sorted calendar feed — PSD matches + the 6.E event
+   * feed (`event` docs + `articleType:event` articles), composed by
+   * `buildCalendarFeed`. The widget filters this by `kalenderType` and projects
+   * it back to the match/event arrays the month/week renderers consume.
+   */
+  feed: CalendarFeedItem[];
   teams: CalendarTeamInfo[];
 }
 
@@ -28,16 +39,18 @@ const VIEW_TABS: { value: ViewMode; label: string; mobileHidden?: boolean }[] =
     { value: "week", label: "Week", mobileHidden: true },
   ];
 
-export function CalendarWidget({
-  matches,
-  events,
-  teams,
-}: CalendarWidgetProps) {
+export function CalendarWidget({ feed, teams }: CalendarWidgetProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const rawView = searchParams.get("view");
   const view: ViewMode = rawView === "week" ? "week" : "month";
-  const activeTeamFilter = searchParams.get("team") ?? "all";
+
+  // By-type filter (Phase 6.D Phase 2, #1992) — replaces the legacy by-team
+  // filter. An unknown `?type=` value falls back to "all".
+  const rawType = searchParams.get("type");
+  const activeTypeFilter: KalenderFilterValue = isKalenderFilterValue(rawType)
+    ? rawType
+    : "all";
 
   const today = DateTime.now();
   const [selectedDate, setSelectedDate] = useState(today.toISODate()!);
@@ -80,55 +93,45 @@ export function CalendarWidget({
     setWeekStart((ws) => DateTime.fromISO(ws).plus({ weeks: 1 }).toISODate()!);
   }
 
-  // Derive team tabs from match data
-  const teamLabels: string[] = [];
-  const seen = new Set<string>();
-  for (const m of matches) {
-    if (m.team && !seen.has(m.team)) {
-      seen.add(m.team);
-      teamLabels.push(m.team);
-    }
-  }
-  // Sort: seniors first (A, B), then youth by age descending (U21, U17, U15, ...)
-  // When same age group, sort by label (which includes team ID like "U15 A", "U15 B")
-  teamLabels.sort((a, b) => {
-    const ageOf = (label: string): number => {
-      const m = label.match(/U(\d+)/i);
-      return m ? parseInt(m[1], 10) : Infinity; // seniors = Infinity → sort first
-    };
-    const seniorOrder = ["A-ploeg", "B-ploeg"];
-    const sa = seniorOrder.indexOf(a);
-    const sb = seniorOrder.indexOf(b);
-    // Both senior → preserve A before B
-    if (sa !== -1 && sb !== -1) return sa - sb;
-    // One senior → senior first
-    if (sa !== -1) return -1;
-    if (sb !== -1) return 1;
-    // Both youth → higher age first (U21 > U17 > U15 > ...)
-    const ageDiff = ageOf(b) - ageOf(a);
-    return ageDiff !== 0 ? ageDiff : a.localeCompare(b);
-  });
-
-  function setTeam(team: string) {
+  function setType(value: KalenderFilterValue) {
+    // Dedup guard: re-pressing the active chip is a no-op, so neither the URL
+    // push nor the `kalender_filter` analytics event fires twice for the same
+    // selection (repo analytics policy).
+    if (value === activeTypeFilter) return;
     const params = new URLSearchParams(searchParams.toString());
-    if (team === "all") {
-      params.delete("team");
+    if (value === "all") {
+      params.delete("type");
     } else {
-      params.set("team", team);
+      params.set("type", value);
     }
     router.push(`/kalender${params.size ? `?${params.toString()}` : ""}`, {
       scroll: false,
     });
+    trackEvent("kalender_filter", { kalender_type: value });
   }
 
-  // Filter matches by active team filter
-  const filteredMatches =
-    activeTeamFilter === "all"
-      ? matches
-      : matches.filter((m) => m.team === activeTeamFilter);
+  // Narrow the unified feed to the active type, then project the survivors back
+  // to the match/event arrays the month/week renderers already consume.
+  const filteredFeed =
+    activeTypeFilter === "all"
+      ? feed
+      : feed.filter((item) => item.kalenderType === activeTypeFilter);
+  const matches: CalendarMatch[] = filteredFeed.flatMap((item) =>
+    item.source === "match" ? [item.match] : [],
+  );
+  const events: CalendarEvent[] = filteredFeed.flatMap((item) =>
+    item.source !== "match" ? [item.event] : [],
+  );
 
-  const preselectedTeamLabel =
-    activeTeamFilter !== "all" ? activeTeamFilter : undefined;
+  // Empty + filtered-to-zero copy — both render a message instead of a blank
+  // grid. "all" + nothing = genuinely empty; a specific facet + nothing = the
+  // selection emptied the calendar.
+  const zeroMessage =
+    activeTypeFilter === "all"
+      ? "Geen wedstrijden of evenementen gepland."
+      : activeTypeFilter === "Wedstrijden"
+        ? "Geen wedstrijden gepland."
+        : `Geen evenementen in de categorie ${activeTypeFilter} gepland.`;
 
   return (
     <div className="space-y-4">
@@ -185,68 +188,73 @@ export function CalendarWidget({
         </button>
       </div>
 
-      {/* Subscribe panel */}
-      <CalendarSubscribePanel
-        teams={teams}
-        preselectedTeamLabel={preselectedTeamLabel}
-        isOpen={subscribePanelOpen}
-      />
+      {/* Subscribe panel — a team-match feed, orthogonal to the type filter */}
+      <CalendarSubscribePanel teams={teams} isOpen={subscribePanelOpen} />
 
-      {/* Team filter */}
-      {teamLabels.length > 0 && (
-        <FilterTabs
-          tabs={[
-            { value: "all", label: "Alle teams" } as FilterTab,
-            ...teamLabels.map(
-              (team): FilterTab => ({ value: team, label: team }),
-            ),
-          ]}
-          activeTab={activeTeamFilter}
-          onChange={setTeam}
-          ariaLabel="Filter op team"
-          showCounts={false}
-        />
-      )}
+      {/* By-type filter chips (the row doubles as the colour legend) */}
+      <KalenderFilterBar selected={activeTypeFilter} onSelect={setType} />
 
-      {/* View content */}
-      {view === "month" && (
-        <CalendarMonth
-          matches={filteredMatches}
-          events={events}
-          selectedDate={selectedDate}
-          onSelectDate={setSelectedDate}
-          currentMonth={currentMonth}
-          currentYear={currentYear}
-          onPrevMonth={handlePrevMonth}
-          onNextMonth={handleNextMonth}
-        />
-      )}
-
-      {view === "week" && (
-        <CalendarWeek
-          matches={filteredMatches}
-          events={events}
-          weekStart={weekStart}
-          onPrevWeek={handlePrevWeek}
-          onNextWeek={handleNextWeek}
-        />
-      )}
-
-      {/* Legend */}
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 border-t border-gray-200 pt-4 text-xs text-gray-500">
-        <div className="flex items-center gap-1.5">
-          <span className="bg-kcvv-green-bright h-2 w-2 rounded-full" />
-          <span>Thuiswedstrijd</span>
+      {filteredFeed.length === 0 ? (
+        // role="status" (implicit aria-live="polite") so the message is
+        // announced when a filter selection empties the calendar — it appears
+        // on a client-side state change, not a page load.
+        <div
+          role="status"
+          className="flex flex-col items-center gap-3 py-12 text-center text-gray-600"
+        >
+          <p className="font-medium">{zeroMessage}</p>
+          {activeTypeFilter !== "all" && (
+            <button
+              type="button"
+              onClick={() => setType("all")}
+              className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              Toon alles
+            </button>
+          )}
         </div>
-        <div className="flex items-center gap-1.5">
-          <span className="border-kcvv-green-bright h-2 w-2 rounded-full border" />
-          <span>Uitwedstrijd</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-full bg-blue-500" />
-          <span>Evenement</span>
-        </div>
-      </div>
+      ) : (
+        <>
+          {view === "month" && (
+            <CalendarMonth
+              matches={matches}
+              events={events}
+              selectedDate={selectedDate}
+              onSelectDate={setSelectedDate}
+              currentMonth={currentMonth}
+              currentYear={currentYear}
+              onPrevMonth={handlePrevMonth}
+              onNextMonth={handleNextMonth}
+            />
+          )}
+
+          {view === "week" && (
+            <CalendarWeek
+              matches={matches}
+              events={events}
+              weekStart={weekStart}
+              onPrevWeek={handlePrevWeek}
+              onNextWeek={handleNextWeek}
+            />
+          )}
+
+          {/* Legend */}
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-1 border-t border-gray-200 pt-4 text-xs text-gray-500">
+            <div className="flex items-center gap-1.5">
+              <span className="bg-kcvv-green-bright h-2 w-2 rounded-full" />
+              <span>Thuiswedstrijd</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="border-kcvv-green-bright h-2 w-2 rounded-full border" />
+              <span>Uitwedstrijd</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-blue-500" />
+              <span>Evenement</span>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/calendar/KalenderFilterBar/KalenderFilterBar.stories.tsx
+++ b/apps/web/src/components/calendar/KalenderFilterBar/KalenderFilterBar.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "storybook/test";
+import { KalenderFilterBar } from "./KalenderFilterBar";
+
+const meta = {
+  title: "Features/Calendar/KalenderFilterBar",
+  component: KalenderFilterBar,
+  parameters: { layout: "fullscreen" },
+  // No `vr` tag yet: the kalender surface visual (field + chip treatment) is
+  // locked at the Phase 3 design gate (#1993), so baselining now would capture a
+  // provisional render that Phase 3/4 rebases. VR adoption for the kalender
+  // surface (this bar + <CalendarWidget>, both currently non-VR) lands with the
+  // Phase 3/4 lock — see PR #1992 notes.
+  tags: ["autodocs"],
+  // The filter bar lives on the light `/kalender` page; render it on that field
+  // so the ink chip text/outlines are evaluated in context (vs `<EventFilterBar>`,
+  // which renders on the dark `/evenementen` field).
+  decorators: [
+    (Story) => (
+      <div className="bg-gray-100 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: { onSelect: fn() },
+} satisfies Meta<typeof KalenderFilterBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default — "Alles" selected, no type filter applied. */
+export const Alles: Story = {
+  args: { selected: "all" },
+};
+
+/** Matches — the primary calendar category, card-red fill (#1992). */
+export const Wedstrijden: Story = {
+  args: { selected: "Wedstrijden" },
+};
+
+export const Clubevent: Story = {
+  args: { selected: "Clubevent" },
+};
+
+export const Supportersactiviteit: Story = {
+  args: { selected: "Supportersactiviteit" },
+};
+
+export const Jeugdwerking: Story = {
+  args: { selected: "Jeugdwerking" },
+};
+
+export const Andere: Story = {
+  args: { selected: "Andere" },
+};

--- a/apps/web/src/components/calendar/KalenderFilterBar/KalenderFilterBar.test.tsx
+++ b/apps/web/src/components/calendar/KalenderFilterBar/KalenderFilterBar.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { KalenderFilterBar } from "./KalenderFilterBar";
+
+describe("<KalenderFilterBar>", () => {
+  it("renders the reset + Wedstrijden chips plus a chip per event type", () => {
+    render(<KalenderFilterBar selected="all" onSelect={vi.fn()} />);
+
+    for (const label of [
+      "Alles",
+      "Wedstrijden",
+      "Clubevent",
+      "Supportersactiviteit",
+      "Jeugdwerking",
+      "Andere",
+    ]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("exposes a labelled group for the filter row", () => {
+    render(<KalenderFilterBar selected="all" onSelect={vi.fn()} />);
+
+    expect(
+      screen.getByRole("group", { name: /filter kalender op type/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks only the selected chip as pressed", () => {
+    render(<KalenderFilterBar selected="Wedstrijden" onSelect={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Wedstrijden" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Alles" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Clubevent" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("calls onSelect with 'Wedstrijden' when the matches chip is pressed", async () => {
+    const onSelect = vi.fn();
+    render(<KalenderFilterBar selected="all" onSelect={onSelect} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Wedstrijden" }));
+
+    expect(onSelect).toHaveBeenCalledWith("Wedstrijden");
+  });
+
+  it("calls onSelect with the event-type value when a type chip is pressed", async () => {
+    const onSelect = vi.fn();
+    render(<KalenderFilterBar selected="all" onSelect={onSelect} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Jeugdwerking" }));
+
+    expect(onSelect).toHaveBeenCalledWith("Jeugdwerking");
+  });
+
+  it('calls onSelect with "all" when the reset chip is pressed', async () => {
+    const onSelect = vi.fn();
+    render(<KalenderFilterBar selected="Wedstrijden" onSelect={onSelect} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Alles" }));
+
+    expect(onSelect).toHaveBeenCalledWith("all");
+  });
+});

--- a/apps/web/src/components/calendar/KalenderFilterBar/KalenderFilterBar.tsx
+++ b/apps/web/src/components/calendar/KalenderFilterBar/KalenderFilterBar.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { cn } from "@/lib/utils/cn";
+import { EVENT_CHIP_BASE } from "@/components/event/EventFilterBar";
+import {
+  EVENT_TYPE_FILL,
+  type EventType,
+} from "@/components/event/event-type-style";
+import type { KalenderType } from "@/app/(main)/kalender/utils";
+
+/** Filter selection: a specific kalender type, or `"all"` (the default — no filter). */
+export type KalenderFilterValue = KalenderType | "all";
+
+interface ChipStyle {
+  /** Filled state — the selected chip carries its category colour. */
+  selected: string;
+  /** Resting state — a colour outline + ink text that reads on the light field. */
+  unselected: string;
+}
+
+/**
+ * `Wedstrijden` (matches) — the primary calendar category. Owner-locked to the
+ * `card-red` token (#1992), repurposing the Phase 6.B alert tint as the match
+ * facet fill so it reads as the boldest chip in the row.
+ */
+const WEDSTRIJDEN_CHIP_STYLE: ChipStyle = {
+  selected: "bg-card-red text-cream border-card-red",
+  unselected: "border-card-red text-ink hover:bg-card-red/10",
+};
+
+/**
+ * The four event categories. The selected fill is pulled from the shared
+ * `EVENT_TYPE_FILL` map — the same colours `<TicketStub>` + `<EventFilterBar>`
+ * use — so a calendar chip can never drift from the ticket it labels. Resting
+ * styles are ink-toned for the light `/kalender` field (vs `<EventFilterBar>`'s
+ * cream tones for the dark `/evenementen` field); the dark/light reconcile is
+ * provisional pending the Phase 3 design gate (#1993).
+ */
+const EVENT_TYPE_CHIP_STYLE = {
+  Clubevent: {
+    selected: `${EVENT_TYPE_FILL.Clubevent} border-jersey-deep`,
+    unselected: "border-jersey-deep text-ink hover:bg-jersey-deep/10",
+  },
+  Supportersactiviteit: {
+    selected: `${EVENT_TYPE_FILL.Supportersactiviteit} border-warm`,
+    unselected: "border-warm text-ink hover:bg-warm/10",
+  },
+  Jeugdwerking: {
+    selected: `${EVENT_TYPE_FILL.Jeugdwerking} border-jersey-bright`,
+    unselected: "border-jersey-bright text-ink hover:bg-jersey-bright/10",
+  },
+  Andere: {
+    selected: `${EVENT_TYPE_FILL.Andere} border-ink`,
+    unselected: "border-ink/60 text-ink hover:bg-ink/5",
+  },
+} satisfies Record<EventType, ChipStyle>;
+
+/** "Alles" — the neutral no-filter reset; ink-filled when active on the light field. */
+const ALL_CHIP_STYLE: ChipStyle = {
+  selected: "bg-ink text-cream border-ink",
+  unselected: "border-ink/40 text-ink hover:bg-ink/5",
+};
+
+// Render order after the reset + matches chips: the four event types in
+// `<TicketStub>` order. Derived from the style map so it can't drift out of sync.
+const EVENT_TYPE_ORDER = Object.keys(EVENT_TYPE_CHIP_STYLE) as EventType[];
+
+/** Every valid filter value, in render order — the single source of truth for
+ *  validating a `?type=` URL param (an unknown value falls back to `"all"`). */
+const KALENDER_FILTER_VALUES: readonly KalenderFilterValue[] = [
+  "all",
+  "Wedstrijden",
+  ...EVENT_TYPE_ORDER,
+];
+
+/** Type guard: is `value` a renderable filter facet? Narrows a raw URL param. */
+export function isKalenderFilterValue(
+  value: string | null,
+): value is KalenderFilterValue {
+  return (
+    value !== null &&
+    (KALENDER_FILTER_VALUES as readonly string[]).includes(value)
+  );
+}
+
+export interface KalenderFilterBarProps {
+  /** Currently-selected filter (`"all"` = no filter). */
+  selected: KalenderFilterValue;
+  /**
+   * Fired when a chip is pressed — including re-pressing the active chip. The
+   * consumer owns the dedup guard so a no-op reselection never double-fires
+   * state, navigation, or analytics.
+   */
+  onSelect: (value: KalenderFilterValue) => void;
+}
+
+/**
+ * Colour-coded by-type filter chips for `/kalender` (Phase 6.D Phase 2, #1992).
+ * Reuses `/evenementen`'s chip vocabulary — the `EVENT_CHIP_BASE` pill shape +
+ * `EVENT_TYPE_FILL` colours — extended with a `Wedstrijden` chip for matches, so
+ * the filter row doubles as a colour legend. Single-select, "Alles" default. The
+ * locked set: `Alles · Wedstrijden · Clubevent · Supportersactiviteit ·
+ * Jeugdwerking · Andere`. Final field/visual is locked at the Phase 3 gate (#1993).
+ */
+export function KalenderFilterBar({
+  selected,
+  onSelect,
+}: KalenderFilterBarProps) {
+  const renderChip = (
+    value: KalenderFilterValue,
+    label: string,
+    style: ChipStyle,
+  ) => {
+    const isSelected = selected === value;
+    return (
+      <button
+        key={value}
+        type="button"
+        aria-pressed={isSelected}
+        onClick={() => onSelect(value)}
+        className={cn(
+          EVENT_CHIP_BASE,
+          // Light-field focus ring — EVENT_CHIP_BASE's cream ring is tuned for
+          // the dark /evenementen field; twMerge lets this ink ring win.
+          "focus-visible:outline-ink",
+          isSelected ? style.selected : style.unselected,
+        )}
+      >
+        {label}
+      </button>
+    );
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label="Filter kalender op type"
+      className="flex flex-wrap gap-2"
+    >
+      {renderChip("all", "Alles", ALL_CHIP_STYLE)}
+      {renderChip("Wedstrijden", "Wedstrijden", WEDSTRIJDEN_CHIP_STYLE)}
+      {EVENT_TYPE_ORDER.map((type) =>
+        renderChip(type, type, EVENT_TYPE_CHIP_STYLE[type]),
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/KalenderFilterBar/index.ts
+++ b/apps/web/src/components/calendar/KalenderFilterBar/index.ts
@@ -1,0 +1,6 @@
+export {
+  KalenderFilterBar,
+  isKalenderFilterValue,
+  type KalenderFilterBarProps,
+  type KalenderFilterValue,
+} from "./KalenderFilterBar";


### PR DESCRIPTION
Closes #1992

Phase 6.D **Phase 2** — unify the 3-source calendar data behind a discriminated view-model and swap the `/kalender` filter axis from team to type (matching `/evenementen` + master-plan §6.6). Direction-agnostic: both Phase 3 reskin/rebuild outcomes consume this exact VM + filter.

## Changes

- **`CalendarFeedItem` unified VM + `buildCalendarFeed`** (`kalender/utils.ts`): a discriminated union (`source: "match" | "event" | "article"`) composing PSD matches + the 6.E feed (`findUpcomingForList`) into one chronological list. Each item carries a single `kalenderType` facet — matches → `"Wedstrijden"`; events/articles → their `eventType` (`null` → `"Andere"` via `DEFAULT_EVENT_TYPE`). `KalenderType = "Wedstrijden" | EventType` is a deliberate superset, so the strict `EVENT_TYPE_FILL` (`satisfies Record<EventType>`) stays untouched. Match ids are source-prefixed (`match-<id>`) to avoid colliding with Sanity `_id`s.
- **`KalenderFilterBar`** (`components/calendar/KalenderFilterBar/`): colour-coded by-type chips reusing `/evenementen`'s vocabulary — the `EVENT_CHIP_BASE` pill shape + `EVENT_TYPE_FILL` colours (single source of truth, so chips can't drift from the tickets they label) — extended with a **`Wedstrijden`** chip. Replaces the by-team `<FilterTabs>`. Single-select, `Alles` default.
- **`CalendarWidget`**: consumes `CalendarFeedItem[]`, filters by `kalenderType`, projects back to the existing month/week renderers. URL param `?team=` → `?type=` (validated → `"all"` on unknown). Dedup-guarded `setType` fires `kalender_filter` only on a real change. Empty + filtered-to-zero states render a message + reset (no blank widget).
- **Skeleton** (`loading.tsx`) updated from 4 team-tab pills to 6 type-chip pills.

## Owner decisions (issue Open Question)

- **Filter control:** reuse `EventFilterBar`'s colour-chip vocabulary (not the literal design-system `<FilterTabs>`) — so the AC's "`<FilterTabs>`" wording is intentionally superseded by the issue's own Open Question.
- **`Wedstrijden` tint:** `card-red` (`--color-card-red`), repurposing the Phase 6.B alert token as the primary-category fill.
- The kalender **visual is provisional pending the Phase 3 design gate (#1993)** — incl. the dark/light field reconcile. **VR is deferred to the Phase 3/4 lock** (consistent with the still-non-VR `CalendarWidget`); `KalenderFilterBar` ships a story + unit tests but no baselines this PR.

## Analytics — ⚠️ manual GTM/GA4 step required

`kalender_filter` fires `{ kalender_type }` (PRD §9). Before it reaches GA4:

- **Append `kalender_` to the live GTM Custom Event trigger RegEx** (currently ends `…|player_|match_|team_`). Same trigger — keep it byte-identical to the deployed one.
- `kalender_type` values include the 5 facets **plus `"all"`** (fired on reset-to-all, mirroring `event_filter`).
- The `kalender_type` GA4 custom-dimension registration (new dimension vs reuse `event_type`) is **deferred to Phase 5** per PRD §9 — not done here.

## Testing

- `pnpm --filter @kcvv/web check-all` ✅ (lint + type-check + 3227 tests + build).
- New unit tests: `buildCalendarFeed` (ordering, per-source href, `kalenderType` incl. `null`→Andere), `KalenderFilterBar` (chips, aria-pressed, onSelect), `CalendarWidget` (by-type render, `?type=` pressed, push + `kalender_filter` on change, **dedup guard** no-fire, filtered-to-zero + reset).
- `/kalender` e2e smoke (`routes.spec.ts`) unchanged — runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
