### PR TITLE
docs(calendar): Phase 6.D design gate — lock both-views direction (#1993)

### DIFF
--- a/docs/design/mockups/phase-6-kalender/6d-kalender-locked.md
+++ b/docs/design/mockups/phase-6-kalender/6d-kalender-locked.md
@@ -1,0 +1,124 @@
+# Phase 6.D — `/kalender` design lock
+
+**Issue:** #1993 (design gate) · **PRD:** `docs/prd/redesign-phase-6d-kalender.md`
+**Status:** LOCKED 2026-06-05 (drilled with owner, rounds 6d1–6d4). Supersedes the parked
+A/B in master-plan §6.6. Build phases (#1994/#1995) take their final ACs from here.
+
+Drill artefacts (this dir): `6d0-data-reality-audit.md` · `6d1-reskin-vs-agenda-compare.html`
+· `6d2-agenda-density-compare.html` · `6d3-grid-cell-compare.html`.
+
+---
+
+## The headline decision (6d1)
+
+**Ship BOTH presentations behind a user-driven view toggle — grid is the default.** Not an
+auto-by-filter switch (rejected), not one-or-the-other. The widget's existing `Maand / Week`
+segmented control extends to a **3-way view toggle**:
+
+| View      | Form                         | Default | URL              |
+| --------- | ---------------------------- | ------- | ---------------- |
+| **Maand** | month **grid** (reskinned)   | ✅ yes  | `?view=month`    |
+| **Week**  | week **grid** (reskinned)    | —       | `?view=week`     |
+| **Agenda**| month **list** (newspaper)   | —       | `?view=agenda`   |
+
+**Owner quote:** _"I want both, with a tab or something to switch. Grid as default."_
+
+## Shared period window (6d4)
+
+**All three views render the SAME navigated window** — the `‹ September '26 ›` month nav
+(and the week nav in Week view) is shared state, not per-view. Switching Maand↔Agenda keeps
+the current month; `‹ ›` pages months.
+
+- **Agenda is month-windowed** — it shows exactly the current month's items as a list, then
+  pages by month. **Never the whole season** (~1000 matches at kickoff) and **never a flat
+  "all upcoming" feed.** Owner: _"only if it is also filtered like the grid (per month/week)…
+  Dont want to show the entire season (neither upcoming-only)."_
+- Past browsing is native to all views via the shared month nav (matches are full-season;
+  events are upcoming-only by data, so past months simply carry no events).
+
+## Grid cell — dense-day treatment (6d3 → v2)
+
+A month-cell renders, top to bottom:
+
+1. **Events first** — each as a **full-width italic display title** + a type-colour dot
+   (`•`). They stack when a day has 2+. Events are rare + high-value, so they never hide.
+2. **Match pips below** — option-(i) colour pips, one per match: **filled card-red = thuis,
+   ring card-red = uit**, bright-green = jeugd-only-tint is NOT used (matches are all
+   `Wedstrijden`/card-red; the jeugd colour belongs to event-type Jeugdwerking). **No count
+   badge** — the pip row is the volume signal (owner: _"pips only, no badge"_).
+
+Clicking a day opens the **selected-day detail** below the grid: full scoreboard rows reusing
+the **6.C `<TeamAgendaRow>`** vocabulary (time · crests · KCVV-team label · thuis/uit ·
+outcome colour) + event rows. (Unchanged interaction model from today's widget.)
+
+## Agenda view — dense-day treatment (6d2)
+
+**Labelled wall — show everything, no collapsing** (owner pick (i)):
+
+- Month header (`<EditorialHeading>` "September '26.") → **day groups** with a
+  `<DashedDivider>`; each day group carries a **count sub-header** ("Zaterdag 12 sep · 10
+  wedstrijden · 1 evenement") that sets expectation.
+- **Every row is shown** — no fold, no "+N more" by default (zero interaction).
+- **Events get a tinted row** (jersey-deep wash) so they stand out from the match stack and
+  are never buried — the one rescue the labelled-wall relies on.
+- Match row = compact scoreboard (crest · `Team — Opponent` · VS/score · competition caption ·
+  thuis/uit + outcome underline), reusing the 6.C row vocabulary at list density.
+
+## Filters (confirmed from #1992 — finalised here)
+
+- **By-type colour chips** (`<KalenderFilterBar>`), reusing `/evenementen`'s `EVENT_CHIP_BASE`
+  + `EVENT_TYPE_FILL` vocabulary, on the light field. Locked set + order:
+  **Alles · Wedstrijden · Clubevent · Supportersactiviteit · Jeugdwerking · Andere.**
+- **Wedstrijden = `card-red` (`#c93f1c`)** — owner-locked (6d1/#1992), repurposing the Phase
+  6.B alert token as the primary-category fill. The chip row **doubles as the colour legend**
+  — so the standalone bottom legend ("Thuiswedstrijd / Uitwedstrijd / Evenement") that the
+  legacy widget carried is **dropped** (the chips + cell vocabulary cover it).
+- The filter applies across all three views (`?type=`), dedup-guarded `kalender_filter`
+  (already shipped #1992). Filtered-to-zero state already shipped #1992.
+
+## Outcome colour (reuse — 6.C lock)
+
+**win = jersey-deep · draw = none · loss = brick (`--color-alert`)**, as a flat underline on
+the score — applies to played matches in both the grid detail and the agenda. No new vocabulary.
+
+## iCal subscribe (retain + reskin)
+
+The **"Abonneer" panel is kept** — a **matches-only "follow your team" feed**, orthogonal to
+the type filter (per PRD §2/§7). Reskin the `<CalendarSubscribePanel>` chrome to paper/ink +
+the chip vocabulary; `/api/calendar.ics` is unchanged. No events in the subscribe feed
+(per-event "Zet in agenda" already exists on `/evenementen/[slug]`).
+
+---
+
+## Build implications (re-spec for #1994 / #1995)
+
+**#1994 — Build the locked presentation:**
+
+- Add an **Agenda view** rendering of the current-month feed window (labelled-wall list):
+  new `<CalendarAgenda>` (Features/Calendar) composing month header + day groups (count
+  sub-header + `<DashedDivider>`) + match/event rows (reuse 6.C row + `<TicketStub>`/MonoLabel
+  type tags). VR-tagged + stories (empty / one-event-day / dense-Saturday / filtered).
+- Extend the view toggle to 3-way (`Maand/Week/Agenda`), `?view=agenda`; share the month nav.
+- **Reskin the grid** (`<CalendarMonth>`/`<CalendarWeek>` cells) to the 6d3 treatment
+  (events-on-top titles + match pips, no badge) + paper/ink chrome; reskin the selected-day
+  detail to the 6.C `<TeamAgendaRow>` scoreboard.
+- Reskin `<CalendarSubscribePanel>` chrome. Drop the legacy bottom dot-legend.
+- VR: the whole kalender surface (widget + agenda + chips) **adopts `vr`** at this phase —
+  this is where the provisional #1992 `<KalenderFilterBar>` (currently non-VR) gets baselined,
+  alongside the reskinned grid + new agenda. (Deferred from #1992 by design.)
+
+**#1995 — iCal + analytics + SEO + cleanup:**
+
+- `kalender_view_toggle` analytics on the Maand/Week/Agenda switch (taxonomy PRD §9, was
+  "A/B-dependent" — now confirmed needed). `kalender_view` page-view. The manual GTM RegEx
+  step (append `kalender_`) + the `kalender_type` GA4-dimension decision land here.
+- Optional `ItemList` JSON-LD of the current window's items.
+
+## Reuse mandate / no new vocabulary
+
+Every surface maps back to an approved primitive: `EVENT_CHIP_BASE`/`EVENT_TYPE_FILL`
+(filter), 6.C `<TeamAgendaRow>` + outcome colour (match rows), `<EditorialHeading>` (month
+headers), `<DashedDivider>` (day groups), `<TicketStub>`/`<MonoLabel>` (type tags),
+`<TapedCard>` shell (panels). **Net-new is only:** the 3-way toggle's Agenda option, the
+grid-cell events-on-top+pips composition, and the agenda day-group count sub-header. No new
+colour tokens (card-red already exists). No schema/BFF/api-contract change.

--- a/docs/design/mockups/phase-6-kalender/6d0-data-reality-audit.md
+++ b/docs/design/mockups/phase-6-kalender/6d0-data-reality-audit.md
@@ -1,0 +1,101 @@
+# 6.D Kalender — `6d0` Data-Reality Audit
+
+**Issue:** #1993 (Phase 6.D design gate) · **PRD:** `docs/prd/redesign-phase-6d-kalender.md`
+**Purpose:** Establish what the calendar actually renders — per-source row data + real
+volume/density — so the `6d1` reskin-vs-agenda A/B is decided against reality, not the
+master-plan §6.6 sketch (which was drafted picturing a sparse events agenda).
+
+Audit only — no design decisions here. Decisions land in `6d1`+ and the lock doc.
+
+---
+
+## 1. The feed (post-#1991/#1992)
+
+`/kalender` renders one `CalendarFeedItem[]` (`apps/web/src/app/(main)/kalender/utils.ts`,
+`buildCalendarFeed`) — a discriminated union over `source`, each row carrying a single
+`kalenderType` facet (`"Wedstrijden" | EventType`) and an ISO `dateStart`:
+
+| `source`  | Origin                         | Detail link            | `kalenderType`            |
+| --------- | ------------------------------ | ---------------------- | ------------------------- |
+| `match`   | PSD via BFF (`getMatches`)     | `/wedstrijd/[matchId]` | `"Wedstrijden"`           |
+| `event`   | Sanity `event` doc             | `/evenementen/[slug]`  | `eventType` (→ `Andere`)  |
+| `article` | Sanity `articleType:event`     | `/nieuws/[slug]`       | `eventType` (→ `Andere`)  |
+
+## 2. What each source provides for a calendar row
+
+### 2.1 Match (`CalendarMatch`) — the rich, structured row
+
+`id` · `date` (ISO) · `time` (`HH:mm`) · `homeTeam`/`awayTeam` `{ id, name, logo? }` ·
+`homeScore`/`awayScore` · `scoreDisplay` (`vs` | `score`) · `status`
+(`scheduled`/`finished`/…) · `competition` (e.g. "2e Provinciale") · `team`
+(`kcvv_team_label` — "A-ploeg", "U15 A") · `isHome`.
+
+- A match row wants **two crests + a score/VS + a time + the KCVV team label + home/away**.
+  This is a *two-sided scoreboard*, not a one-line title. The 6.B/6.C work already locked
+  this vocabulary (`<MatchHero>`, `<TeamAgendaRow>`: symmetric desktop / KCVV-centric mobile;
+  outcome colour win=jersey-deep / draw=none / loss=brick).
+- `status` distinguishes upcoming (VS + time) from played (score). A calendar spanning the
+  season holds **both** past results and future fixtures.
+
+### 2.2 Event / article (`CalendarEvent` + `kalenderType`) — the sparse, editorial row
+
+`id` · `title` (one display string) · `href` · `dateStart` · `dateEnd?` (multi-day) ·
+`kalenderType` (the colour facet) · `location` (on the source VM; not currently surfaced
+by the widget). No crests, no score — a **single-line title + type tag + optional location**.
+This is exactly the master-plan §6.6 agenda row shape.
+
+## 3. Volume & density — the decisive finding
+
+The calendar is **match-dominated by volume, event-sparse**, and matches **cluster onto
+two weekend days**:
+
+- **Teams:** the page queries every Sanity `team` with a `psdId` (A + B + the full youth
+  ladder U6→U21 across Bovenbouw/Middenbouw/Onderbouw) — on the order of **~15–20 teams**,
+  each with a full-season fixture list. (Exact count is season-dependent; the design must not
+  assume a small N.)
+- **Weekend clustering:** youth play **Saturday**, seniors **Sunday**. A single in-season
+  **Saturday can carry ~10–15 match rows**; a weekend ~15–20. Weekdays are mostly empty.
+- **Events:** a handful **per month** (spaghetti-avond, tornooi, quiz). Event-articles rarer
+  still. Across a whole month, events + articles together are typically **single digits**.
+
+> **Implication for `6d1`:** the master-plan §6.6 "tabular month agenda" was sketched for the
+> sparse *events* surface. Applied to the real feed, a flat chronological agenda renders a
+> **wall of ~10–15 near-identical match rows on every Saturday**, with the occasional event
+> lost among them. The existing month **grid** absorbs density natively (a day-cell shows N
+> dots / a count, detail-on-select). So the A/B is not merely cosmetic — it is **"can the
+> agenda form survive match density?"** vs **"can the grid form carry the fanzine voice?"**.
+> Any agenda direction (B) must answer dense-Saturday grouping (by team-order? collapsed
+> "N wedstrijden" header? time-buckets?); any grid direction (A) must answer how a fanzine
+> day-cell shows 10+ items without becoming dot-soup.
+
+## 4. Type mix vs the filter
+
+By-type filter facets (locked #1992): **Wedstrijden · Clubevent · Supportersactiviteit ·
+Jeugdwerking · Andere** (+ Alles). Realistic distribution: **Wedstrijden** is ~95%+ of rows;
+the four event types share the sparse remainder. So:
+
+- The **default ("Alles") view is dominated by matches**; selecting an event type collapses
+  the calendar to a near-empty set (→ the filtered-to-zero state ships in #1992 already).
+- A **"Wedstrijden"-off** view (events only) is the sparse case the §6.6 agenda fits best —
+  worth noting the agenda form shines precisely when matches are filtered out.
+
+## 5. Past / archive reality
+
+The feed today is **upcoming-leaning** for events (`findUpcomingForList` is upcoming-only),
+but **matches are full-season** (BFF `getMatches` returns played + scheduled). The current
+widget is month-navigable into the past (you can page back to a played month and see scores).
+The agenda form (B) is naturally "from now forward"; preserving past-month browsing is a
+direction-dependent open question (carried into `6d1`).
+
+## 6. Inputs the A/B must carry
+
+1. **Density is the gating constraint** (§3) — both directions must show a realistic dense
+   Saturday, not a tidy 3-row month.
+2. **Match row = two-sided scoreboard** (§2.1), reusing 6.B/6.C vocabulary — not a §6.6
+   one-line title row. Event row = §6.6 one-line title + type tag (§2.2).
+3. **Carry #1992 locks:** by-type **colour chips** (reusing `EventFilterBar` vocabulary) +
+   **Wedstrijden = card-red**; `?type=` filter; dedup-guarded `kalender_filter`.
+4. **iCal subscribe** panel is retained (matches-only team feed, orthogonal to the type
+   filter) — reskinned in the chosen direction.
+5. **Outcome colour** (win=jersey-deep / draw=none / loss=brick) is already locked for
+   matches+standings (6.C) — reuse, don't reinvent.

--- a/docs/design/mockups/phase-6-kalender/6d1-reskin-vs-agenda-compare.html
+++ b/docs/design/mockups/phase-6-kalender/6d1-reskin-vs-agenda-compare.html
@@ -1,0 +1,328 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.D — /kalender · Round 1: reskin-widget vs newspaper-agenda</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Freight is Typekit-only; Fraunces is the closest free editorial serif for mockup fidelity -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6;
+        --cream-soft: #ede8da;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-bright: #22c55e;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c; /* = --color-card-red · Wedstrijden tint (locked #1992) */
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, "Times New Roman", serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+
+      /* ---------- compare-harness chrome (NOT part of the design) ---------- */
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0 0 4px; font-size: 13px; color: #b9b9b9; max-width: 92ch; line-height: 1.55; }
+      .harness-head a { color: var(--warm); }
+      .opt-bar { position: sticky; top: 0; z-index: 50; padding: 11px 28px; font-family: var(--font-mono);
+        font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase; display: flex; gap: 14px;
+        align-items: baseline; border-bottom: 2px solid var(--ink); color: var(--cream); }
+      .opt-bar.a { background: var(--jersey-deep); }
+      .opt-bar.b { background: var(--brick); }
+      .opt-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 10px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .opt-bar .says { color: #f2e9d6; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .maps { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-muted); padding: 8px 28px;
+        background: var(--cream-soft); border-bottom: 1px dashed var(--paper-edge); }
+      .maps b { color: var(--ink-soft); }
+      .stage { padding: 30px 28px 60px; max-width: 1040px; margin: 0 auto; }
+
+      /* ---------- shared design-system approximations ---------- */
+      .mono { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.09em; font-size: 11px; }
+      .chiprow { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 22px; }
+      .chip { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: 0.07em; font-size: 11px;
+        font-weight: 600; padding: 6px 13px; border: 2px solid var(--ink); border-radius: 999px; background: transparent;
+        color: var(--ink); cursor: pointer; }
+      .chip.sel.all { background: var(--ink); color: var(--cream); }
+      .chip.wed { border-color: var(--brick); }
+      .chip.sel.wed { background: var(--brick); color: var(--cream); }
+      .chip.club { border-color: var(--jersey-deep); }
+      .chip.supp { border-color: var(--warm); }
+      .chip.jeugd { border-color: var(--jersey-bright); }
+      .chip.and { border-color: var(--ink); }
+      .display { font-family: var(--font-display); font-weight: 900; line-height: 0.95; letter-spacing: -0.01em; }
+      .tag { display: inline-flex; align-items: center; font-family: var(--font-mono); text-transform: uppercase;
+        letter-spacing: 0.07em; font-size: 9.5px; font-weight: 600; padding: 2px 7px; border: 1.5px solid var(--ink); white-space: nowrap; }
+      .tag.wed { background: var(--brick); color: var(--cream); }
+      .tag.club { background: var(--jersey-deep); color: #fff; }
+      .tag.supp { background: var(--warm); color: var(--ink); }
+      .tag.jeugd { background: var(--jersey-bright); color: var(--ink); }
+      .tag.and { background: var(--ink); color: var(--cream); }
+      .crest { width: 22px; height: 22px; border-radius: 50%; border: 1.5px solid var(--ink); background: var(--cream-deep);
+        display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 9px; font-weight: 700; flex: none; }
+      .crest.kcvv { background: var(--jersey-deep); color: var(--cream); }
+
+      /* ================= OPTION A — reskinned month grid ================= */
+      .a-wrap { background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 var(--ink); }
+      .a-toolbar { display: flex; justify-content: space-between; align-items: center; padding: 14px 16px; border-bottom: 2px solid var(--ink); }
+      .a-seg { display: inline-flex; border: 2px solid var(--ink); border-radius: 8px; overflow: hidden; }
+      .a-seg span { padding: 5px 14px; font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+      .a-seg .on { background: var(--ink); color: var(--cream); }
+      .a-monthnav { display: flex; align-items: center; gap: 12px; }
+      .a-monthnav .m { font-family: var(--font-display); font-weight: 900; font-size: 22px; }
+      .a-monthnav button { border: 2px solid var(--ink); background: var(--cream); width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
+      .a-grid { display: grid; grid-template-columns: repeat(7, 1fr); }
+      .a-dow { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; text-align: center;
+        padding: 8px 0; color: var(--ink-muted); border-bottom: 1px dashed var(--paper-edge); }
+      .a-cell { min-height: 92px; border-right: 1px dashed var(--paper-edge); border-bottom: 1px dashed var(--paper-edge); padding: 5px 6px; position: relative; }
+      .a-cell:nth-child(7n) { border-right: none; }
+      .a-cell .d { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); }
+      .a-cell.out .d { opacity: .35; }
+      .a-cell.sel { background: color-mix(in srgb, var(--jersey-deep) 12%, var(--cream)); outline: 2px solid var(--jersey-deep); outline-offset: -2px; }
+      .a-pips { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 6px; }
+      .a-pip { width: 8px; height: 8px; border-radius: 50%; }
+      .a-pip.wed { background: var(--brick); }
+      .a-pip.wedaway { background: transparent; border: 1.5px solid var(--brick); }
+      .a-pip.club { background: var(--jersey-deep); }
+      .a-pip.jeugd { background: var(--jersey-bright); }
+      .a-count { position: absolute; top: 5px; right: 6px; font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+        background: var(--brick); color: var(--cream); border-radius: 999px; padding: 0 6px; }
+      .a-detail { border-top: 2px solid var(--ink); padding: 16px; }
+      .a-detail h4 { font-family: var(--font-display); font-weight: 900; font-size: 18px; margin: 0 0 12px; }
+      .a-row { display: grid; grid-template-columns: 46px 1fr auto; gap: 10px; align-items: center; padding: 8px 0; border-bottom: 1px dashed var(--paper-edge); }
+      .a-row .time { font-family: var(--font-mono); font-size: 12px; color: var(--ink-muted); }
+      .a-row .teams { display: flex; align-items: center; gap: 7px; font-weight: 600; font-size: 13.5px; }
+      .a-row .teams .sub { color: var(--ink-muted); font-weight: 500; }
+      .a-mini-event { display: flex; align-items: center; gap: 8px; padding: 8px 0; border-bottom: 1px dashed var(--paper-edge); }
+      .a-mini-event .et { font-family: var(--font-display); font-weight: 700; font-size: 14px; font-style: italic; }
+
+      /* ================= OPTION B — newspaper agenda ================= */
+      .b-wrap { background: var(--cream); }
+      .b-month { font-family: var(--font-display); font-weight: 900; font-size: clamp(34px, 5vw, 52px); line-height: .95; margin: 28px 0 4px; }
+      .b-month .em { font-style: italic; color: var(--jersey-deep); }
+      .b-monthrule { border: none; border-top: 2px solid var(--ink); margin: 0 0 10px; }
+      .b-daygroup { margin-bottom: 6px; }
+      .b-dayhead { display: flex; align-items: baseline; justify-content: space-between; padding: 12px 0 6px; border-bottom: 1px dashed var(--paper-edge); }
+      .b-dayhead .dh { font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .08em; font-size: 12px; font-weight: 600; }
+      .b-dayhead .cnt { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); }
+      /* agenda row: date · content · tag */
+      .b-row { display: grid; grid-template-columns: 64px 1fr auto; gap: 14px; align-items: center; padding: 9px 0; border-bottom: 1px dashed var(--paper-edge); }
+      .b-row .when { font-family: var(--font-mono); font-size: 12px; color: var(--ink-muted); line-height: 1.3; }
+      .b-row .when b { display: block; color: var(--ink); font-size: 13px; }
+      .b-match { display: flex; align-items: center; gap: 9px; }
+      .b-match .ml { display: flex; align-items: center; gap: 6px; min-width: 0; }
+      .b-match .nm { font-weight: 600; font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .b-match .score { font-family: var(--font-display); font-weight: 900; font-size: 17px; padding: 0 8px; }
+      .b-match .vs { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); padding: 0 6px; }
+      .b-match .comp { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); text-transform: uppercase; letter-spacing: .05em; }
+      /* outcome underline (win jersey-deep / draw none / loss brick) — locked 6.C */
+      .b-match .score.win { box-shadow: inset 0 -4px 0 var(--jersey-deep); }
+      .b-match .score.loss { box-shadow: inset 0 -4px 0 var(--brick); }
+      .b-event .et { font-family: var(--font-display); font-weight: 700; font-size: 16px; font-style: italic; }
+      .b-event .loc { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); text-transform: uppercase; letter-spacing: .05em; }
+      .note { font-family: var(--font-mono); font-size: 11px; color: var(--brick); background: color-mix(in srgb, var(--brick) 8%, var(--cream));
+        border: 1px dashed var(--brick); padding: 8px 12px; margin: 8px 0 0; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.D · /kalender — Round 1: reskin-widget vs newspaper-agenda</h1>
+      <p>
+        Same data in both: a dense in-season window — <b>Saturday 12 Sep (10 youth matches + a Clubevent)</b>,
+        <b>Sunday 13 Sep (A-ploeg)</b>, plus a sprinkling either side. The only variable is the FORM. Both carry the
+        #1992 locks: by-type colour chips + <b>Wedstrijden = card-red</b>; outcome colour (win=jersey-deep /
+        loss=brick) per 6.C. Grounded by <a href="./6d0-data-reality-audit.md">6d0 data-reality audit</a> — the calendar
+        is ~95% matches, clustered on weekends, so the gating question is how each form survives a 10-match Saturday.
+      </p>
+      <p>Fonts are free stand-ins (Fraunces≈Freight, Archivo≈Quasimoda). Tokens match globals.css. Harness chrome (dark bars) is not part of the design.</p>
+    </div>
+
+    <div style="background:#fffaf0;border-bottom:3px solid var(--ink);border-top:3px dashed var(--jersey-deep);padding:16px 28px;font-family:var(--font-mono)">
+      <div style="font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--jersey-deep)">★ LOCKED — 2026-06-05 — BOTH, user-toggled, grid default</div>
+      <p style="margin:8px 0 0;font-size:12.5px;line-height:1.6;color:var(--ink-soft);max-width:94ch">
+        Owner: <i>"I want both, with a tab or something to switch. Grid as default."</i> → Resolution: ship <b>both</b>
+        presentations behind the widget's existing view segmented-control, extended to a 3-way
+        <b>Maand (grid · DEFAULT) · Week (grid) · Agenda (newspaper list)</b> — `?view=month|week|agenda`. NOT an
+        auto-by-filter switch (that was rejected Option C); a manual view tab the user drives. Both views carry the
+        #1992 by-type colour chips + Wedstrijden=card-red and the 6.C outcome colour. Next drills: <b>6d2</b> agenda
+        dense-day mitigation (the ⚠ wall) · 6d3 grid cell density treatment · 6d4 view-toggle affordance · 6d5 iCal
+        subscribe + past/archive paging. The A/B panels below stay for reference.
+      </p>
+    </div>
+
+    <!-- ============================ OPTION A ============================ -->
+    <div class="opt-bar a">
+      <span class="tag">OPTION A</span> RESKIN THE MONTH-GRID WIDGET
+      <span class="says">keep grid + day-detail; dress it in fanzine paper/ink — density stays compact in cells</span>
+    </div>
+    <div class="maps">
+      <b>Reuses:</b> existing CalendarMonth grid + selected-day detail · <b>TapedCard</b> shell · #1992 KalenderFilterBar chips ·
+      6.C TeamAgendaRow scoreboard in the detail · iCal subscribe button. <b>Net-new:</b> fanzine cell styling + count badge.
+    </div>
+    <div class="stage">
+      <div class="chiprow">
+        <button class="chip sel all">Alles</button>
+        <button class="chip wed">Wedstrijden</button>
+        <button class="chip club">Clubevent</button>
+        <button class="chip supp">Supportersactiviteit</button>
+        <button class="chip jeugd">Jeugdwerking</button>
+        <button class="chip and">Andere</button>
+      </div>
+      <div class="a-wrap">
+        <div class="a-toolbar">
+          <div class="a-seg"><span class="on">Maand</span><span>Week</span></div>
+          <div class="a-monthnav">
+            <button>‹</button><span class="m">September ’26</span><button>›</button>
+          </div>
+          <button class="chip" style="border-radius:8px">⤓ Abonneer</button>
+        </div>
+        <div class="a-grid">
+          <div class="a-dow">Ma</div><div class="a-dow">Di</div><div class="a-dow">Wo</div><div class="a-dow">Do</div><div class="a-dow">Vr</div><div class="a-dow">Za</div><div class="a-dow">Zo</div>
+          <!-- week 1 -->
+          <div class="a-cell out"><span class="d">31</span></div>
+          <div class="a-cell"><span class="d">1</span></div>
+          <div class="a-cell"><span class="d">2</span></div>
+          <div class="a-cell"><span class="d">3</span></div>
+          <div class="a-cell"><span class="d">4</span></div>
+          <div class="a-cell"><span class="d">5</span><div class="a-pips"><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip wed"></span></div></div>
+          <div class="a-cell"><span class="d">6</span><div class="a-pips"><span class="a-pip wed"></span></div></div>
+          <!-- week 2 (dense Saturday 12) -->
+          <div class="a-cell"><span class="d">7</span></div>
+          <div class="a-cell"><span class="d">8</span></div>
+          <div class="a-cell"><span class="d">9</span><div class="a-pips"><span class="a-pip club"></span></div></div>
+          <div class="a-cell"><span class="d">10</span></div>
+          <div class="a-cell"><span class="d">11</span></div>
+          <div class="a-cell sel"><span class="d">12</span><span class="a-count">10</span>
+            <div class="a-pips">
+              <span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span>
+              <span class="a-pip wed"></span><span class="a-pip wedaway"></span><span class="a-pip wed"></span><span class="a-pip wedaway"></span>
+              <span class="a-pip wed"></span><span class="a-pip club"></span>
+            </div>
+          </div>
+          <div class="a-cell"><span class="d">13</span><div class="a-pips"><span class="a-pip wed"></span></div></div>
+          <!-- week 3 -->
+          <div class="a-cell"><span class="d">14</span></div>
+          <div class="a-cell"><span class="d">15</span></div>
+          <div class="a-cell"><span class="d">16</span></div>
+          <div class="a-cell"><span class="d">17</span></div>
+          <div class="a-cell"><span class="d">18</span></div>
+          <div class="a-cell"><span class="d">19</span><span class="a-count">7</span><div class="a-pips"><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip wed"></span><span class="a-pip wedaway"></span><span class="a-pip wed"></span><span class="a-pip jeugd"></span></div></div>
+          <div class="a-cell"><span class="d">20</span><div class="a-pips"><span class="a-pip wed"></span></div></div>
+          <!-- week 4 -->
+          <div class="a-cell"><span class="d">21</span></div>
+          <div class="a-cell"><span class="d">22</span></div>
+          <div class="a-cell"><span class="d">23</span></div>
+          <div class="a-cell"><span class="d">24</span></div>
+          <div class="a-cell"><span class="d">25</span></div>
+          <div class="a-cell"><span class="d">26</span><span class="a-count">9</span><div class="a-pips"><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip jeugd"></span><span class="a-pip wed"></span><span class="a-pip wedaway"></span><span class="a-pip wed"></span><span class="a-pip wed"></span><span class="a-pip jeugd"></span></div></div>
+          <div class="a-cell"><span class="d">27</span><div class="a-pips"><span class="a-pip wed"></span></div></div>
+        </div>
+        <!-- selected-day detail (Zaterdag 12) -->
+        <div class="a-detail">
+          <h4>Zaterdag 12 september <span style="font-family:var(--font-mono);font-size:12px;color:var(--ink-muted);font-weight:400">· 10 wedstrijden · 1 evenement</span></h4>
+          <div class="a-row"><span class="time">10:00</span><span class="teams"><span class="crest kcvv">KCVV</span> U7 KCVV <span class="sub">— Zemst</span></span><span class="tag wed">Thuis</span></div>
+          <div class="a-row"><span class="time">10:00</span><span class="teams"><span class="crest kcvv">KCVV</span> U9 KCVV <span class="sub">— Eppegem</span></span><span class="tag wed">Thuis</span></div>
+          <div class="a-row"><span class="time">11:00</span><span class="teams"><span class="crest">EPP</span> U11 Eppegem <span class="sub">— KCVV</span></span><span class="tag" style="background:transparent">Uit</span></div>
+          <div class="a-row"><span class="time">11:30</span><span class="teams"><span class="crest kcvv">KCVV</span> U13 KCVV <span class="sub">— Diest</span></span><span class="tag wed">Thuis</span></div>
+          <div class="a-row"><span class="time">13:00</span><span class="teams"><span class="crest kcvv">KCVV</span> U15 A KCVV <span class="sub">— Mechelen</span></span><span class="tag wed">Thuis</span></div>
+          <div class="a-row" style="color:var(--ink-muted)"><span class="time"></span><span class="teams" style="font-style:italic;font-weight:500">+ 5 meer wedstrijden …</span><span></span></div>
+          <div class="a-mini-event"><span class="time" style="font-family:var(--font-mono);font-size:12px;color:var(--ink-muted)">18:00</span><span class="a-et" style="font-family:var(--font-display);font-weight:700;font-style:italic;font-size:14px">Spaghetti-avond</span><span class="tag club" style="margin-left:auto">Clubevent</span></div>
+        </div>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--ink-muted);max-width:90ch">
+        <b>A reads:</b> "a calendar." Density is absorbed — a 10-match Saturday is a count badge + pips; the scoreboard rows
+        only appear on the selected day. Familiar mental model, scannable across a whole month, past-month paging is native.
+        <b>Cost:</b> two-step (scan grid → click day); the fanzine voice lives mostly in chrome, not the data; pips/counts
+        are abstract (you don't see WHO plays until you click).
+      </p>
+    </div>
+
+    <!-- ============================ OPTION B ============================ -->
+    <div class="opt-bar b">
+      <span class="tag">OPTION B</span> NEWSPAPER MONTH-AGENDA (master-plan §6.6)
+      <span class="says">flat chronological list, month-grouped; every item on the page — editorial, voice-forward</span>
+    </div>
+    <div class="maps">
+      <b>Reuses:</b> EditorialHeading month headers · DashedDivider rows · #1992 KalenderFilterBar chips · 6.C scoreboard row +
+      outcome underline · MonoLabel type tags. <b>Net-new:</b> day-group sub-header with a "N wedstrijden" count to tame dense days.
+    </div>
+    <div class="stage">
+      <div class="chiprow">
+        <button class="chip sel all">Alles</button>
+        <button class="chip wed">Wedstrijden</button>
+        <button class="chip club">Clubevent</button>
+        <button class="chip supp">Supportersactiviteit</button>
+        <button class="chip jeugd">Jeugdwerking</button>
+        <button class="chip and">Andere</button>
+      </div>
+      <div class="b-wrap">
+        <h2 class="b-month">September <span class="em">’26.</span></h2>
+        <hr class="b-monthrule" />
+
+        <!-- sparse weekday-ish lead-in -->
+        <div class="b-daygroup">
+          <div class="b-dayhead"><span class="dh">Dinsdag 9 september</span></div>
+          <div class="b-row">
+            <span class="when"><b>20:00</b></span>
+            <span class="b-event"><span class="et">Algemene ledenvergadering</span> <span class="loc">· Kantine, Driesstraat</span></span>
+            <span class="tag club">Clubevent</span>
+          </div>
+        </div>
+
+        <!-- DENSE Saturday 12 — the stress case -->
+        <div class="b-daygroup">
+          <div class="b-dayhead"><span class="dh">Zaterdag 12 september</span><span class="cnt">10 wedstrijden · 1 evenement</span></div>
+          <div class="b-row"><span class="when"><b>10:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">U7 KCVV — Zemst</span></span><span class="vs">VS</span><span class="comp">Tornooi</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row"><span class="when"><b>10:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">U9 KCVV — Eppegem</span></span><span class="vs">VS</span><span class="comp">Comp.</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row"><span class="when"><b>11:00</b></span><span class="b-match"><span class="ml"><span class="crest">EPP</span><span class="nm">U11 Eppegem — KCVV</span></span><span class="vs">VS</span><span class="comp">Comp.</span></span><span class="tag" style="background:transparent">Uit</span></div>
+          <div class="b-row"><span class="when"><b>11:30</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">U13 KCVV — Diest</span></span><span class="vs">VS</span><span class="comp">Comp.</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row"><span class="when"><b>13:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">U15 A KCVV — Mechelen</span></span><span class="vs">VS</span><span class="comp">Comp.</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row"><span class="when"><b>14:30</b></span><span class="b-match"><span class="ml"><span class="crest">TER</span><span class="nm">U17 Tervuren — KCVV</span></span><span class="vs">VS</span><span class="comp">Comp.</span></span><span class="tag" style="background:transparent">Uit</span></div>
+          <div class="b-row"><span class="when"><b>15:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">U21 KCVV — Vilvoorde</span></span><span class="vs">VS</span><span class="comp">Comp.</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row"><span class="when"><b>15:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">B-ploeg KCVV — Weerde</span></span><span class="vs">VS</span><span class="comp">3e Prov.</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row" style="color:var(--ink-muted)"><span class="when"></span><span style="font-style:italic">+ 2 meer wedstrijden (U6, U10) …</span><span></span></div>
+          <div class="b-row"><span class="when"><b>18:00</b></span><span class="b-event"><span class="et">Spaghetti-avond</span> <span class="loc">· Kantine</span></span><span class="tag club">Clubevent</span></div>
+          <p class="note">⚠ Density stress: 10 near-identical match rows stack under one Saturday — the Spaghetti-avond is easy to miss in the wall. This is the §6.6 agenda's weak spot the 6d0 audit flagged; the "N wedstrijden" day-header + a possible collapse-by-default for Wedstrijden is the mitigation to drill in 6d2.</p>
+        </div>
+
+        <!-- Sunday A-team — where the agenda SHINES (sparse, hero-worthy) -->
+        <div class="b-daygroup">
+          <div class="b-dayhead"><span class="dh">Zondag 13 september</span></div>
+          <div class="b-row"><span class="when"><b>15:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">A-ploeg KCVV — Racing Mechelen</span></span><span class="vs">VS</span><span class="comp">2e Prov.</span></span><span class="tag wed">Thuis</span></div>
+        </div>
+
+        <div class="b-daygroup">
+          <div class="b-dayhead"><span class="dh">Zaterdag 19 september</span><span class="cnt">7 wedstrijden · 1 evenement</span></div>
+          <div class="b-row"><span class="when"><b>10:00</b></span><span class="b-event"><span class="et">Najaarstornooi U13</span> <span class="loc">· Sportpark Driesput</span></span><span class="tag jeugd">Jeugdwerking</span></div>
+          <div class="b-row"><span class="when"><b>14:00</b></span><span class="b-match"><span class="ml"><span class="crest kcvv">KCVV</span><span class="nm">A-ploeg KCVV — Kampenhout</span></span><span class="score loss">1–2</span><span class="comp">2e Prov.</span></span><span class="tag wed">Thuis</span></div>
+          <div class="b-row" style="color:var(--ink-muted)"><span class="when"></span><span style="font-style:italic">+ 6 meer wedstrijden …</span><span></span></div>
+        </div>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:12px;color:var(--ink-muted);max-width:90ch">
+        <b>B reads:</b> "a club magazine." Every item is on the page, voice-forward, beautiful for the sparse cases
+        (a lone Sunday A-match, an event). One-step (no click to see WHO plays). <b>Cost:</b> a 10-match Saturday is a wall
+        of near-identical rows that buries the occasional event (see ⚠); needs a density mitigation (day-count header,
+        collapse-Wedstrijden-by-default, or time-bucketing) to be drilled in 6d2; whole-season past browsing is a long scroll.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-kalender/6d2-agenda-density-compare.html
+++ b/docs/design/mockups/phase-6-kalender/6d2-agenda-density-compare.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.D — /kalender · 6d2: agenda dense-day mitigation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream:#f5f1e6;--cream-soft:#ede8da;--cream-deep:#e1d7bf;--ink:#0a0a0a;--ink-soft:#1f1f1f;--ink-muted:#6b6b6b;
+        --jersey-deep:#008755;--jersey-bright:#22c55e;--warm:#f0c264;--brick:#c93f1c;--paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif;--font-body:"Archivo",system-ui,sans-serif;--font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E")}
+      .harness-head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono)}
+      .harness-head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase}
+      .harness-head p{margin:0;font-size:13px;color:#b9b9b9;max-width:92ch;line-height:1.55}
+      .harness-head a{color:var(--warm)}
+      .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:0}
+      @media(max-width:1100px){.grid3{grid-template-columns:1fr}}
+      .col{padding:0 22px 40px;border-right:1px dashed var(--paper-edge)}
+      .col:last-child{border-right:none}
+      .opt-h{position:sticky;top:0;background:var(--jersey-deep);color:var(--cream);padding:10px 14px;margin:0 -22px 4px;
+        font-family:var(--font-mono);font-size:12px;letter-spacing:.05em;text-transform:uppercase;border-bottom:2px solid var(--ink);z-index:5}
+      .opt-h.ii{background:var(--brick)}.opt-h.iii{background:var(--ink)}
+      .gloss{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);padding:10px 0 14px;line-height:1.5;min-height:64px}
+      .gloss b{color:var(--ink-soft)}
+      .month{font-family:var(--font-display);font-weight:900;font-size:30px;margin:14px 0 2px}
+      .month .em{font-style:italic;color:var(--jersey-deep)}
+      .mrule{border:none;border-top:2px solid var(--ink);margin:0 0 8px}
+      .dayhead{display:flex;align-items:baseline;justify-content:space-between;padding:10px 0 5px;border-bottom:1px dashed var(--paper-edge)}
+      .dayhead .dh{font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.07em;font-size:11.5px;font-weight:600}
+      .dayhead .cnt{font-family:var(--font-mono);font-size:10.5px;color:var(--ink-muted)}
+      .row{display:grid;grid-template-columns:42px 1fr auto;gap:9px;align-items:center;padding:7px 0;border-bottom:1px dashed var(--paper-edge)}
+      .row .when{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted)}
+      .nm{font-weight:600;font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:flex;align-items:center;gap:6px}
+      .crest{width:18px;height:18px;border-radius:50%;border:1.5px solid var(--ink);background:var(--cream-deep);display:inline-flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:7.5px;font-weight:700;flex:none}
+      .crest.kcvv{background:var(--jersey-deep);color:var(--cream)}
+      .tag{font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.06em;font-size:9px;font-weight:600;padding:2px 6px;border:1.5px solid var(--ink);white-space:nowrap}
+      .tag.wed{background:var(--brick);color:var(--cream)}.tag.uit{background:transparent}
+      .tag.club{background:var(--jersey-deep);color:#fff}.tag.jeugd{background:var(--jersey-bright);color:var(--ink)}
+      .et{font-family:var(--font-display);font-weight:700;font-style:italic;font-size:14px}
+      /* collapse group (option ii) */
+      .grp{display:flex;align-items:center;gap:9px;padding:9px 0;border-bottom:1px dashed var(--paper-edge);cursor:pointer;background:color-mix(in srgb,var(--brick) 7%,var(--cream))}
+      .grp .disc{font-family:var(--font-mono);font-size:11px;font-weight:700;color:var(--brick)}
+      .grp .lbl{font-weight:700;font-size:13px}
+      .grp .chev{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--ink-muted)}
+      .event-strong{background:color-mix(in srgb,var(--jersey-deep) 6%,var(--cream))}
+      /* tier subgroup (option iii) */
+      .tier{font-family:var(--font-mono);text-transform:uppercase;letter-spacing:.07em;font-size:10px;font-weight:700;color:var(--jersey-deep);padding:8px 0 3px}
+      .verdict{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);padding:12px 0 0;line-height:1.5}
+      .verdict .pro{color:var(--jersey-deep)}.verdict .con{color:var(--brick)}
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.D · 6d2 — Agenda view: dense-day mitigation</h1>
+      <p>
+        The <a href="./6d1-reskin-vs-agenda-compare.html">6d1</a> lock ships BOTH views (grid default + agenda tab). The agenda's
+        one weakness is the dense Saturday — 10 near-identical match rows that bury the occasional event. Same
+        <b>Zaterdag 12 september (10 wedstrijden + Spaghetti-avond)</b> rendered three ways. Which keeps the agenda
+        readable AND never buries events? (Grid view already handles density; this is purely the agenda tab.)
+      </p>
+    </div>
+
+    <div class="grid3">
+      <!-- ============ (i) Labeled wall ============ -->
+      <div class="col">
+        <div class="opt-h">(i) Labelled wall — show everything</div>
+        <div class="gloss"><b>All rows, always.</b> Day-count header sets expectation; events get a tinted row so they stand out. Zero interaction — everything is on the page.</div>
+        <h2 class="month">September <span class="em">’26.</span></h2><hr class="mrule" />
+        <div class="dayhead"><span class="dh">Zaterdag 12 sep</span><span class="cnt">10 wed · 1 event</span></div>
+        <div class="row"><span class="when">10:00</span><span class="nm"><span class="crest kcvv">K</span>U7 KCVV — Zemst</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">10:00</span><span class="nm"><span class="crest kcvv">K</span>U9 KCVV — Eppegem</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">11:00</span><span class="nm"><span class="crest">E</span>U11 Eppegem — KCVV</span><span class="tag uit">Uit</span></div>
+        <div class="row"><span class="when">11:30</span><span class="nm"><span class="crest kcvv">K</span>U13 KCVV — Diest</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">13:00</span><span class="nm"><span class="crest kcvv">K</span>U15 A — Mechelen</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">14:30</span><span class="nm"><span class="crest">T</span>U17 Tervuren — KCVV</span><span class="tag uit">Uit</span></div>
+        <div class="row"><span class="when">15:00</span><span class="nm"><span class="crest kcvv">K</span>U21 KCVV — Vilvoorde</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">15:00</span><span class="nm"><span class="crest kcvv">K</span>B-ploeg — Weerde</span><span class="tag wed">Thuis</span></div>
+        <div class="row" style="color:var(--ink-muted)"><span class="when"></span><span style="font-style:italic">+ U6, U10 …</span><span></span></div>
+        <div class="row event-strong"><span class="when">18:00</span><span class="et">Spaghetti-avond</span><span class="tag club">Clubevent</span></div>
+        <div class="verdict"><span class="pro">+ everything visible, 0 clicks</span><br /><span class="con">– still long; event tint is the only rescue</span></div>
+      </div>
+
+      <!-- ============ (ii) Collapse Wedstrijden ============ -->
+      <div class="col">
+        <div class="opt-h ii">(ii) Collapse matches ▸ — events always open</div>
+        <div class="gloss"><b>Matches fold into one tappable group per day</b> ("10 wedstrijden ▸", collapsed by default); events render in full beneath, never buried. One tap expands the matches. Honours the by-type filter (selecting Wedstrijden auto-expands).</div>
+        <h2 class="month">September <span class="em">’26.</span></h2><hr class="mrule" />
+        <div class="dayhead"><span class="dh">Zaterdag 12 sep</span></div>
+        <div class="grp"><span class="disc">⚽</span><span class="lbl">10 wedstrijden</span><span class="chev">▸ toon</span></div>
+        <div class="row event-strong"><span class="when">18:00</span><span class="et">Spaghetti-avond</span><span class="tag club">Clubevent</span></div>
+        <div class="dayhead" style="margin-top:14px"><span class="dh">Zaterdag 19 sep</span></div>
+        <div class="row event-strong"><span class="when">10:00</span><span class="et">Najaarstornooi U13</span><span class="tag jeugd">Jeugd</span></div>
+        <div class="grp"><span class="disc">⚽</span><span class="lbl">7 wedstrijden</span><span class="chev">▸ toon</span></div>
+        <div class="verdict"><span class="pro">+ events never buried; day skim-able; great when you came for events</span><br /><span class="con">– matches (95% of data) hidden 1 tap deep by default</span></div>
+      </div>
+
+      <!-- ============ (iii) Group by tier ============ -->
+      <div class="col">
+        <div class="opt-h iii">(iii) Group by tier within the day</div>
+        <div class="gloss"><b>Within each day, matches split into Senioren / Jeugd sub-groups</b> (each foldable); events sit above as their own block. Structured — mirrors how people think ("did the A-ploeg play?").</div>
+        <h2 class="month">September <span class="em">’26.</span></h2><hr class="mrule" />
+        <div class="dayhead"><span class="dh">Zaterdag 12 sep</span><span class="cnt">10 wed · 1 event</span></div>
+        <div class="row event-strong"><span class="when">18:00</span><span class="et">Spaghetti-avond</span><span class="tag club">Clubevent</span></div>
+        <div class="tier">▾ Senioren (1)</div>
+        <div class="row"><span class="when">15:00</span><span class="nm"><span class="crest kcvv">K</span>B-ploeg — Weerde</span><span class="tag wed">Thuis</span></div>
+        <div class="tier">▾ Jeugd (9)</div>
+        <div class="row"><span class="when">10:00</span><span class="nm"><span class="crest kcvv">K</span>U7 KCVV — Zemst</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">10:00</span><span class="nm"><span class="crest kcvv">K</span>U9 KCVV — Eppegem</span><span class="tag wed">Thuis</span></div>
+        <div class="row"><span class="when">11:00</span><span class="nm"><span class="crest">E</span>U11 Eppegem — KCVV</span><span class="tag uit">Uit</span></div>
+        <div class="row" style="color:var(--ink-muted)"><span class="when"></span><span style="font-style:italic">+ 6 jeugd …</span><span></span></div>
+        <div class="verdict"><span class="pro">+ structured; "did A/B play?" answered fast; events on top</span><br /><span class="con">– most chrome; two sub-headers per day; folding state to manage</span></div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-6-kalender/6d3-grid-cell-compare.html
+++ b/docs/design/mockups/phase-6-kalender/6d3-grid-cell-compare.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 6.D — /kalender · 6d3: grid month-cell dense-day treatment</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,500&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{--cream:#f5f1e6;--cream-soft:#ede8da;--cream-deep:#e1d7bf;--ink:#0a0a0a;--ink-muted:#6b6b6b;
+        --jersey-deep:#008755;--jersey-bright:#22c55e;--warm:#f0c264;--brick:#c93f1c;--paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif;--font-body:"Archivo",system-ui,sans-serif;--font-mono:"IBM Plex Mono",monospace}
+      *{box-sizing:border-box}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E")}
+      .harness-head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono)}
+      .harness-head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase}
+      .harness-head p{margin:0;font-size:13px;color:#b9b9b9;max-width:92ch;line-height:1.55}
+      .harness-head a{color:var(--warm)}
+      .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:0}
+      @media(max-width:1100px){.grid3{grid-template-columns:1fr}}
+      .col{padding:0 22px 30px;border-right:1px dashed var(--paper-edge)}.col:last-child{border-right:none}
+      .opt-h{position:sticky;top:0;background:var(--jersey-deep);color:var(--cream);padding:10px 14px;margin:0 -22px 10px;
+        font-family:var(--font-mono);font-size:12px;letter-spacing:.05em;text-transform:uppercase;border-bottom:2px solid var(--ink);z-index:5}
+      .opt-h.ii{background:var(--brick)}.opt-h.iii{background:var(--ink)}
+      .gloss{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);padding:0 0 12px;line-height:1.5;min-height:58px}
+      .gloss b{color:var(--ink)}
+      /* a mini 3-cell row of the grid: Fri 11 / Sat 12 (dense) / Sun 13 */
+      .mini{display:grid;grid-template-columns:repeat(3,1fr);border:2px solid var(--ink);background:var(--cream)}
+      .cell{min-height:128px;border-right:1px dashed var(--paper-edge);padding:6px 7px;position:relative}
+      .cell:last-child{border-right:none}
+      .cell.sat{background:color-mix(in srgb,var(--jersey-deep) 7%,var(--cream))}
+      .d{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted)}
+      .d.today{color:var(--ink);font-weight:700}
+      /* (i) pips + count */
+      .pips{display:flex;flex-wrap:wrap;gap:3px;margin-top:7px}
+      .pip{width:8px;height:8px;border-radius:50%}
+      .pip.wed{background:var(--brick)}.pip.uit{background:transparent;border:1.5px solid var(--brick)}
+      .pip.club{background:var(--jersey-deep)}.pip.jeugd{background:var(--jersey-bright)}
+      .countbadge{position:absolute;top:6px;right:7px;font-family:var(--font-mono);font-size:10px;font-weight:700;background:var(--brick);color:var(--cream);border-radius:999px;padding:0 6px}
+      /* (ii) type-count chips */
+      .cchips{display:flex;flex-wrap:wrap;gap:4px;margin-top:8px}
+      .cc{font-family:var(--font-mono);font-size:10px;font-weight:700;padding:1px 6px;border:1.5px solid var(--ink);display:inline-flex;gap:3px;align-items:center}
+      .cc.wed{background:var(--brick);color:var(--cream)}.cc.club{background:var(--jersey-deep);color:#fff}.cc.jeugd{background:var(--jersey-bright);color:var(--ink)}
+      /* (iii) event-forward */
+      .evt{margin-top:7px;font-family:var(--font-display);font-style:italic;font-weight:700;font-size:12px;line-height:1.15;display:flex;gap:4px;align-items:flex-start}
+      .evt .dot{width:7px;height:7px;border-radius:50%;background:var(--jersey-deep);margin-top:4px;flex:none}
+      .wsum{margin-top:6px;font-family:var(--font-mono);font-size:10.5px;font-weight:700;color:var(--brick);display:flex;gap:4px;align-items:center}
+      .wsum .bar{height:6px;background:var(--brick);border-radius:3px}
+      .verdict{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);padding:12px 0 0;line-height:1.5}
+      .verdict .pro{color:var(--jersey-deep)}.verdict .con{color:var(--brick)}
+      .legend{font-family:var(--font-mono);font-size:10px;color:var(--ink-muted);margin-top:8px}
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 6.D · 6d3 — Grid month-cell: dense-day treatment (DEFAULT view)</h1>
+      <p>
+        The grid is the default view (<a href="./6d1-reskin-vs-agenda-compare.html">6d1</a> lock). A fanzine day-cell must
+        show a 10-match Saturday legibly in ~128px, and — per the 6d2 "don't bury events" principle — the lone event must
+        not vanish among match indicators. Three cells shown: <b>Vr 11 (quiet) · Za 12 (10 wed + 1 event) · Zo 13 (A-ploeg)</b>.
+        Clicking any day still opens the full scoreboard detail below the grid (unchanged).
+      </p>
+    </div>
+
+    <div style="background:#fffaf0;border-bottom:3px solid var(--ink);border-top:3px dashed var(--jersey-deep);padding:18px 28px">
+      <div style="font-family:var(--font-mono);font-size:13px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--jersey-deep)">★ v2 ITERATION — combine (iii) events-on-top + (i) match pips below</div>
+      <p style="font-family:var(--font-mono);margin:8px 0 16px;font-size:12.5px;line-height:1.6;color:var(--ink-soft);max-width:94ch">
+        Owner: <i>"events on top full width, then the pips as in (i)."</i> → Events render as full-width italic titles at the
+        top of the cell (impossible to miss, stack cleanly when there are 2+); matches render as the familiar option-(i)
+        colour pips below, with a count badge on busy days. Best of both: events surface, match density stays compact.
+      </p>
+      <div class="mini" style="max-width:560px">
+        <div class="cell"><span class="d">11</span></div>
+        <div class="cell sat"><span class="d today">12</span><span class="countbadge">⚽10</span>
+          <div class="evt" style="margin-top:6px"><span class="dot"></span>Spaghetti-avond</div>
+          <div class="pips" style="margin-top:8px"><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip wed"></span><span class="pip uit"></span><span class="pip wed"></span><span class="pip uit"></span><span class="pip wed"></span><span class="pip wed"></span></div>
+        </div>
+        <div class="cell"><span class="d">13</span><div class="pips" style="margin-top:7px"><span class="pip wed"></span></div></div>
+      </div>
+      <!-- a 2-event day to test full-width stacking -->
+      <div class="mini" style="max-width:560px;margin-top:10px">
+        <div class="cell"><span class="d">18</span></div>
+        <div class="cell sat"><span class="d today">19</span><span class="countbadge">⚽7</span>
+          <div class="evt" style="margin-top:6px"><span class="dot" style="background:var(--jersey-bright)"></span>Najaarstornooi U13</div>
+          <div class="evt" style="margin-top:4px"><span class="dot"></span>Kaas- &amp; wijnavond</div>
+          <div class="pips" style="margin-top:8px"><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip wed"></span><span class="pip uit"></span><span class="pip wed"></span><span class="pip jeugd"></span></div>
+        </div>
+        <div class="cell"><span class="d">20</span><div class="pips" style="margin-top:7px"><span class="pip wed"></span></div></div>
+      </div>
+      <div class="legend" style="padding:0 0 2px">events = italic display title + type-colour dot · matches = option-(i) pips (● brick thuis · ○ ring uit · ● bright jeugd) · ⚽N badge on busy days</div>
+    </div>
+
+    <div style="font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);padding:10px 28px;background:var(--cream-soft);border-bottom:1px dashed var(--paper-edge)">Original 6d3 options (i)/(ii)/(iii) kept below for reference.</div>
+
+    <div class="grid3">
+      <!-- (i) pips + count -->
+      <div class="col">
+        <div class="opt-h">(i) Colour pips + count badge</div>
+        <div class="gloss"><b>One pip per item</b>, coloured by type (filled=thuis, ring=uit for matches); a count badge when a day is busy. Abstract but ultra-compact; the existing widget's idiom, reskinned.</div>
+        <div class="mini">
+          <div class="cell"><span class="d">11</span></div>
+          <div class="cell sat"><span class="d today">12</span><span class="countbadge">11</span>
+            <div class="pips"><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip jeugd"></span><span class="pip wed"></span><span class="pip uit"></span><span class="pip wed"></span><span class="pip uit"></span><span class="pip wed"></span><span class="pip jeugd"></span><span class="pip club"></span></div>
+          </div>
+          <div class="cell"><span class="d">13</span><div class="pips"><span class="pip wed"></span></div></div>
+        </div>
+        <div class="legend">● brick=wed thuis · ○ ring=uit · ● green=clubevent · ● bright=jeugd</div>
+        <div class="verdict"><span class="pro">+ compact, whole month scannable, familiar</span><br /><span class="con">– event pip lost among 10 match pips (buries events) · counts abstract</span></div>
+      </div>
+
+      <!-- (ii) type-count chips -->
+      <div class="col">
+        <div class="opt-h ii">(ii) Type-count chips</div>
+        <div class="gloss"><b>One small chip per present type with a count</b> (⚽10 in card-red, the event as its own coloured chip). Reads the day's shape at a glance; the event always gets its own chip so it can't hide.</div>
+        <div class="mini">
+          <div class="cell"><span class="d">11</span></div>
+          <div class="cell sat"><span class="d today">12</span>
+            <div class="cchips"><span class="cc wed">⚽10</span><span class="cc club">1</span></div>
+          </div>
+          <div class="cell"><span class="d">13</span><div class="cchips"><span class="cc wed">⚽1</span></div></div>
+        </div>
+        <div class="legend">⚽N = N wedstrijden (card-red) · coloured chip per event type</div>
+        <div class="verdict"><span class="pro">+ day-shape legible · event never buried · very compact</span><br /><span class="con">– you still don't see WHO/WHEN until you click</span></div>
+      </div>
+
+      <!-- (iii) event-forward -->
+      <div class="col">
+        <div class="opt-h iii">(iii) Event-forward + match summary</div>
+        <div class="gloss"><b>Events shown as titles in-cell</b> (they're rare + high-value); matches collapse to a single "⚽ 10" summary bar. Mirrors the 6d2 agenda principle exactly: events surface, matches summarise.</div>
+        <div class="mini">
+          <div class="cell"><span class="d">11</span></div>
+          <div class="cell sat"><span class="d today">12</span>
+            <div class="evt"><span class="dot"></span>Spaghetti-avond</div>
+            <div class="wsum"><span>⚽ 10</span><span class="bar" style="width:34px"></span></div>
+          </div>
+          <div class="cell"><span class="d">13</span><div class="wsum"><span>⚽ 1</span><span class="bar" style="width:10px"></span></div></div>
+        </div>
+        <div class="legend">event title in italic display · ⚽N bar = match volume</div>
+        <div class="verdict"><span class="pro">+ events impossible to miss · consistent w/ agenda · still compact</span><br /><span class="con">– long event titles truncate · two visual languages in one cell</span></div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/plans/2026-04-27-redesign-master-design.md
+++ b/docs/plans/2026-04-27-redesign-master-design.md
@@ -494,7 +494,15 @@ Existing `docs/prd/teams-landing-page.md` is superseded — restate in Phase 6.
 
 Hero: `<EditorialHero variant="generic">` `Kalender.` Body: cream paper page with month-by-month sections. Each month: `<EditorialHeading size="display-md">April '26.</EditorialHeading>` followed by a `<DashedDivider>`-separated list of events — date column (mono), title column (display), location column (mono), tag column (`<MonoLabel>` for type). No card treatment — it's a tabular agenda. Filter row reskins `<FilterTabs>` (matches / events / training / supporter activities).
 
-> **STATUS (2026-05-28) — direction locked (6.D).** `/kalender` is **already built** as an interactive month/week/list widget + iCal subscribe; the tabular agenda above is one of two candidates. **Reskin-the-widget vs rebuild-to-this-agenda is parked for a 6.D.d1 visual A/B** (owner wants to see both side-by-side). Filters are **by type** — Wedstrijden + Clubevent + Supporters + Jeugdwerking + Andere — not matches/events/training/supporter (training has no standalone data source). Feed merges 3 sources: PSD matches + `event` docs + `articleType:event` articles. See #1528.
+> **STATUS (2026-06-05) — design LOCKED (6.D, #1993).** The reskin-vs-rebuild A/B resolved to
+> **ship BOTH**, behind a user-driven 3-way view toggle: **Maand (grid · default) / Week (grid) /
+> Agenda (this tabular list)** — all three render the same month-windowed feed, sharing the period
+> nav. The tabular agenda above is the Agenda tab, rendered as a **labelled wall** (show all, day-count
+> header, events tinted). Grid cell = events-on-top titles + match pips. Filters are **by type**
+> (Wedstrijden + Clubevent + Supportersactiviteit + Jeugdwerking + Andere) via colour chips reusing
+> `<EventFilterBar>`'s vocabulary — **Wedstrijden = card-red**; the chip row is the legend.
+> Feed merges 3 sources (PSD matches + `event` docs + `articleType:event` articles — shipped #1991/#1992).
+> Full lock: `docs/design/mockups/phase-6-kalender/6d-kalender-locked.md`. Build = #1994/#1995. See #1528.
 
 ### 6.7 Events list + detail (`/events`, `/events/[slug]`)
 

--- a/docs/prd/redesign-phase-6d-kalender.md
+++ b/docs/prd/redesign-phase-6d-kalender.md
@@ -108,33 +108,50 @@ will be rewritten against the locked design contract.
 - [ ] Empty + filtered-to-zero states render (no blank widget).
 - [ ] `pnpm --filter @kcvv/web check-all` passes.
 
-### Phase 3 — Design gate (no build)
+### Phase 3 — Design gate (no build) — ✅ LOCKED 2026-06-05 (#1993)
 
-- [ ] `6d0` data-reality audit committed (what each source actually provides for a calendar row;
-      youth-match volume; dense-day rendering needs).
-- [ ] `6d1` produces **side-by-side mockups**: (A) reskin the existing widget vs (B) rebuild to the
-      §6.6 newspaper agenda. Owner selects a direction (recorded in the lock doc).
-- [ ] Per-component drills (`6d2…`) lock the chosen direction's primitives (e.g. month-cell match
-      row, type-coloured filter legend, iCal subscribe affordance) per the repo design-drill cadence.
-- [ ] Lock doc(s) under `docs/design/mockups/phase-6-kalender/*-locked.md`; this PRD's §7 + Phases
-      4–5 rewritten against the lock; master-plan §6.6 status note updated to point here.
+Lock doc: `docs/design/mockups/phase-6-kalender/6d-kalender-locked.md`.
 
-### Phase 4 — Build presentation (provisional, rewritten at Phase 3 lock)
+- [x] `6d0` data-reality audit committed (`…/6d0-data-reality-audit.md`).
+- [x] `6d1` side-by-side mockups produced — **owner picked: ship BOTH presentations, user-toggled,
+      grid default** (not A-or-B, not auto-by-filter). Recorded in the lock doc.
+- [x] Per-component drills locked: `6d2` agenda dense-day = **labelled wall** (show all, day-count
+      header, events tinted) · `6d3` grid cell = **events-on-top titles + match pips, no badge** ·
+      `6d4` agenda is **month-windowed** (shares the grid's period nav; not whole-season, not flat
+      upcoming). Filter = #1992 colour chips + **Wedstrijden = card-red** (confirmed).
+- [x] Lock doc committed; §7 + Phases 4–5 rewritten below; master-plan §6.6 status note updated.
 
-- [ ] The locked direction is implemented in retro-terrace-fanzine language, composing approved
-      primitives; new sub-components ship Storybook stories (`Features/Calendar/*`) + unit tests.
-- [ ] Each `vr`-tagged new/changed story has committed baselines (captured in Docker).
-- [ ] States covered: empty feed, filtered-to-zero, loading skeleton, dense day, no-cover items.
+### Phase 4 — Build the locked presentation (#1994)
+
+- [ ] **3-way view toggle** — Maand (grid · **default**) / Week (grid) / Agenda (list),
+      `?view=month|week|agenda`; the month/week period nav is **shared across all three views**.
+- [ ] **Agenda view** — new `<CalendarAgenda>` (`Features/Calendar/*`): the current-month-windowed
+      labelled-wall list — `<EditorialHeading>` month header + day groups (count sub-header +
+      `<DashedDivider>`) + match/event rows reusing the 6.C `<TeamAgendaRow>` vocabulary +
+      `<TicketStub>`/`<MonoLabel>` type tags; **event rows tinted** so a dense day never buries them.
+- [ ] **Grid reskin** (`<CalendarMonth>`/`<CalendarWeek>`) — 6d3 cell: events-on-top full-width
+      titles + match pips (filled = thuis, ring = uit), **no count badge**; paper/ink chrome.
+      Selected-day detail reuses the 6.C `<TeamAgendaRow>` scoreboard + outcome colour
+      (win = jersey-deep / draw = none / loss = brick).
+- [ ] Drop the legacy bottom dot-legend — the colour chips are the legend.
+- [ ] New sub-components ship `Features/Calendar/*` Storybook stories + unit tests.
+- [ ] **VR adoption for the whole kalender surface** — `<KalenderFilterBar>` (deferred from #1992),
+      the reskinned grid, and `<CalendarAgenda>` get the `vr` tag + committed Docker baselines.
+- [ ] States covered: empty feed, filtered-to-zero, loading skeleton, dense day (10-match Saturday),
+      2-event day.
 - [ ] `pnpm --filter @kcvv/web check-all` passes.
 
-### Phase 5 — iCal + analytics + SEO + cleanup (provisional)
+### Phase 5 — iCal + analytics + SEO + cleanup (#1995)
 
-- [ ] iCal subscribe panel reskinned + retained as a team-match feed; `/api/calendar.ics` unchanged.
-- [ ] `kalender_*` analytics fire (taxonomy §9); `kalender_` appended to the live GTM trigger RegEx
-      (manual step, called out in the PR body) and any new DLVs/GA4 params mapped.
-- [ ] Metadata refreshed; optional `ItemList` JSON-LD of upcoming items validated.
-- [ ] Legacy `<CalendarWidget>` children retired or absorbed per the locked direction; orphaned
-      compact-match components reconciled (coordinate with #1960).
+- [ ] `<CalendarSubscribePanel>` reskinned (paper/ink + chip vocabulary), retained as a matches-only
+      "follow your team" feed; `/api/calendar.ics` unchanged.
+- [ ] `kalender_*` analytics fire (taxonomy §9) — incl. **`kalender_view_toggle`** (Maand/Week/Agenda
+      switch — the §9 "A/B-dependent" caveat now resolves to **yes**) + `kalender_view` page-view.
+      `kalender_` appended to the live GTM trigger RegEx (manual step, PR body); the `kalender_type`
+      GA4-dimension decision (reuse `event_type` vs register new) made + DLVs/params mapped.
+- [ ] Metadata refreshed; optional `ItemList` JSON-LD of the **current window's** items validated.
+- [ ] Legacy `<CalendarWidget>` children retired or absorbed per the lock; orphaned compact-match
+      components reconciled (coordinate with #1960).
 - [ ] CI `visual-regression` + e2e green; `pnpm --filter @kcvv/web check-all` passes.
 
 ## 6. Effect Schema / api-contract changes
@@ -147,24 +164,26 @@ will be rewritten against the locked design contract.
   `CalendarMatch` / `CalendarEvent` VMs in the kalender route's `utils.ts` (or a sibling module) — the
   same Sanity-native, apps/web-only posture 6.E took.
 
-## 7. Open questions
+## 7. Open questions — ✅ RESOLVED at the Phase 3 gate (#1993, 2026-06-05)
 
-- `[ ]` **Reskin the existing ~2k-line widget vs rebuild to the §6.6 newspaper agenda** — the central
-  decision, **parked by owner instruction pending side-by-side mockups**. Resolved at Phase 3
-  (`6d1`). Everything in Phases 4–5 is provisional until this locks.
-- `[ ]` **Dense month-cell match rendering** — the `<MatchTeaser>` `compact` variant was retired in
-  #1913 (6.B). If the reskin direction wins, month cells likely need a calendar-specific compact row.
-  Answered by the Phase 3 drills + the 6d0 audit (how many matches land on a single day for youth).
-- `[ ]` **Filter component: reuse `/evenementen`'s custom `<EventFilterBar>` (colour chips) extended
-  with a `Wedstrijden` chip, or the design-system `<FilterTabs>`?** Master plan §6.6 says FilterTabs;
-  `/evenementen` shipped a custom bar. Resolve at Phase 2/Phase 3 — and pin the `Wedstrijden` colour
-  (extend `EVENT_TYPE_FILL`, or borrow the 6.C win/draw/loss outcome language). Owner decision.
-- `[ ]` **Does the iCal _subscribe_ feed stay matches-only?** Recommendation: yes — it's a "follow a
-  team" feature, orthogonal to the type filter; per-event "Zet in agenda" already covers events.
-  Confirm at Phase 5.
-- `[ ]` **Past/archive scope** — `/evenementen` is upcoming-only, but a _calendar_ arguably wants to
-  page backwards. Today's widget is month-navigable (implicitly past-capable). Confirm whether 6.D
-  keeps month navigation into the past or goes upcoming-only. Answered by the Phase 3 direction.
+All headline questions are answered in `docs/design/mockups/phase-6-kalender/6d-kalender-locked.md`.
+
+- `[x]` **Reskin vs rebuild** → **ship BOTH**, behind a user-driven 3-way view toggle
+  (Maand grid · **default** / Week grid / Agenda list). Not A-or-B; not an auto-by-filter switch.
+- `[x]` **Dense month-cell match rendering** → 6d3 cell: events-on-top full-width titles + match
+  pips (filled = thuis, ring = uit), **no count badge**; full scoreboard on day-click reuses the
+  6.C `<TeamAgendaRow>`. Agenda dense-day (6d2) = **labelled wall** (show all, day-count header,
+  events tinted).
+- `[x]` **Filter component + `Wedstrijden` colour** → reuse `/evenementen`'s colour-chip vocabulary
+  (`<KalenderFilterBar>`, `EVENT_CHIP_BASE` + `EVENT_TYPE_FILL`), **not** `<FilterTabs>`;
+  **Wedstrijden = `card-red`**. Shipped #1992, confirmed here. The chip row is the legend (the
+  legacy bottom dot-legend is dropped).
+- `[x]` **iCal subscribe stays matches-only** → yes; retained + reskinned, orthogonal to the type
+  filter.
+- `[x]` **Past/archive scope** → the Agenda is **month-windowed** and shares the grid's period nav
+  (`‹ Month ›`); page back/forward by month in any view. **Not** whole-season (≈1000 matches at
+  kickoff) and **not** flat upcoming-only. Past months simply carry played results (matches are
+  full-season) and no events (events are upcoming-only by data).
 
 ## 8. Discovered unknowns (filled during implementation)
 


### PR DESCRIPTION
Closes #1993

Phase 6.D **design gate** (docs + HTML mockups only — no production code). Resolves the parked reskin-vs-rebuild A/B and re-specs the build phases. Mirrors the 6.C `docs(teams)` design-lock (#1937).

## The decision

Drilled with the owner (rounds 6d1–6d4). **Ship BOTH presentations behind a user-driven 3-way view toggle — grid is the default:**

| View | Form | Default |
|------|------|---------|
| **Maand** | month **grid** (reskinned) | ✅ |
| **Week** | week **grid** (reskinned) | — |
| **Agenda** | month **list** (newspaper) | — |

All three render the **same month-windowed feed**, sharing the `‹ Month ›` period nav — not whole-season (≈1000 matches at kickoff), not flat upcoming-only.

## Drill artefacts (`docs/design/mockups/phase-6-kalender/`)

- **`6d0-data-reality-audit.md`** — the calendar is ~95% matches, weekend-clustered (a Saturday carries ~10-15 match rows); density is the gating constraint the master-plan §6.6 sparse-events sketch missed.
- **`6d1-reskin-vs-agenda-compare.html`** — A (grid) vs B (agenda) on identical dense data → owner: **both, toggled, grid default**.
- **`6d2-agenda-density-compare.html`** — agenda dense-day → **labelled wall** (show all, day-count header, events tinted so they never bury).
- **`6d3-grid-cell-compare.html`** (+v2) — grid cell → **events-on-top full-width titles + match pips, no count badge**.
- **`6d-kalender-locked.md`** — canonical lock doc (composition, reuse mandate, build implications).

## Carried / confirmed

- Filter = #1992 colour chips + **Wedstrijden = card-red** (the chip row is the legend; legacy bottom dot-legend dropped).
- Match rows + outcome colour (win=jersey-deep / draw=none / loss=brick) **reuse 6.C `<TeamAgendaRow>`**.
- iCal subscribe **retained + reskinned** (matches-only "follow your team" feed).
- **No** schema / BFF / api-contract change; **no** new colour token.

## Re-spec

- PRD §7 open questions → **all resolved**; Phases 4 (#1994) + 5 (#1995) ACs rewritten against the lock (incl. VR adoption for the whole kalender surface — where #1992's deferred `<KalenderFilterBar>` baselines land — and `kalender_view_toggle` analytics now confirmed).
- Master-plan §6.6 status note updated to point here.

## Review note

This is a **design lock for owner sign-off** — open the four mockup HTMLs in a browser (the `★ LOCKED`/`★ v2` banners record each decision). No code, no tests; the next code lands in #1994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Phase 6.D calendar redesign specifications finalized, including a 3-way month/week/agenda view toggle with distinct layout treatments
  * Added design mockups comparing grid and agenda presentations with dense-day handling strategies
  * Updated product requirements with finalized acceptance criteria for grid reskin, agenda view, and subscription panel changes
  * Documented calendar feed composition and filtering behavior specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->