### PR TITLE
docs(news): lock match preview/recap article body (5.d-mat) (#1791)

### DIFF
--- a/docs/design/mockups/phase-5-article-detail/5d-mat/round-1-card-shape-comparisons.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-mat/round-1-card-shape-comparisons.html
@@ -1,0 +1,239 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · 5.d-mat · Round 1 · Match article card (preview + recap)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a;
+        --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b;
+        --color-jersey-deep: #006e47;
+        --color-warm: #d8763a;
+        --color-alert: #c0392b;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink);
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink);
+        --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono: "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--color-cream-soft);
+        color: var(--color-ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        padding: 32px 24px 96px;
+      }
+      header.page { max-width: 1680px; margin: 0 auto 28px; }
+      header.page .meta {
+        font-family: var(--font-mono); font-size: 11px; text-transform: uppercase;
+        letter-spacing: 0.14em; opacity: 0.75;
+      }
+      header.page h1 {
+        font-family: var(--font-display); font-style: italic; font-size: 38px;
+        margin: 6px 0 10px; letter-spacing: -0.02em;
+      }
+      header.page p { margin: 0 0 6px; max-width: 96ch; font-size: 14px; line-height: 1.6; }
+      header.page code {
+        font-family: var(--font-mono); font-size: 12px; background: var(--color-cream-deep); padding: 1px 5px;
+      }
+
+      .grid {
+        max-width: 1680px; margin: 0 auto; display: grid;
+        grid-template-columns: repeat(3, 1fr); gap: 26px; align-items: start;
+      }
+      .variant { display: flex; flex-direction: column; gap: 14px; }
+      .variant > .vhead .label {
+        font-family: var(--font-mono); font-size: 10px; text-transform: uppercase;
+        letter-spacing: 0.18em; color: var(--color-jersey-deep); font-weight: 700;
+      }
+      .variant > .vhead h2 {
+        margin: 3px 0 5px; font-family: var(--font-display); font-style: italic;
+        font-size: 23px; letter-spacing: -0.015em;
+      }
+      .variant > .vhead p { margin: 0; font-size: 12.5px; line-height: 1.5; color: var(--color-ink-muted); }
+
+      .state-label {
+        font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase;
+        letter-spacing: 0.16em; color: var(--color-ink-muted); margin: 6px 0 -4px;
+      }
+      /* faux article body context */
+      .body { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 22px; }
+      .prose { font-family: var(--font-display); font-size: 15px; line-height: 1.7; color: #222; margin: 0 0 16px; }
+      .prose.after { margin: 16px 0 0; }
+
+      /* shared bits */
+      .crest {
+        width: 26px; height: 26px; border-radius: 999px; border: 1px solid var(--color-ink-muted);
+        display: inline-flex; align-items: center; justify-content: center;
+        font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-muted); flex: 0 0 auto; background: transparent;
+      }
+      .crest.kcvv { border-color: var(--color-jersey-deep); color: var(--color-jersey-deep); }
+      .ftbadge {
+        font-family: var(--font-mono); font-size: 10px; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.16em; border: 2px solid var(--color-ink); background: var(--color-cream);
+        padding: 3px 6px; box-shadow: var(--shadow-paper-sm);
+      }
+      .cta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--color-jersey-deep); font-weight: 700; }
+      .kick { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-ink-muted); }
+
+      /* ── Variant A: scoreboard band ───────────────────────────── */
+      .a-card { background: var(--color-cream-soft); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); padding: 16px 18px; text-align: center; }
+      .a-kick { text-align: center; }
+      .a-row { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px; margin: 12px 0; }
+      .a-team { display: flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: 600; font-size: 15px; }
+      .a-team.home { justify-content: flex-end; }
+      .a-team.away { justify-content: flex-start; }
+      .a-score { font-family: var(--font-display-big); font-weight: 900; font-size: 30px; letter-spacing: -0.02em; }
+      .a-foot { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--color-ink-muted); border-top: 1px dashed var(--color-ink-muted); padding-top: 10px; }
+
+      /* ── Variant B: inline editorial reference (left rule) ─────── */
+      .b-ref { border-left: 4px solid var(--color-jersey-deep); padding: 4px 0 4px 16px; }
+      .b-line { font-family: var(--font-display); font-size: 20px; font-style: italic; margin: 6px 0; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+      .b-score { font-family: var(--font-display-big); font-weight: 900; font-style: normal; }
+      .b-meta { font-size: 12.5px; color: var(--color-ink-muted); display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+
+      /* ── Variant C: taped result card ─────────────────────────── */
+      .c-wrap { position: relative; padding-top: 10px; }
+      .c-card { position: relative; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); padding: 16px 18px 14px; transform: rotate(-0.6deg); }
+      .c-tape { position: absolute; top: -10px; left: 22px; width: 96px; height: 26px; background: rgba(0,110,71,0.30); border: 1px solid rgba(0,0,0,0.18); transform: rotate(-4deg); }
+      .c-top { display: flex; justify-content: space-between; align-items: flex-start; }
+      .c-badge-slot { position: absolute; top: -10px; right: -8px; }
+      .c-row { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; margin: 12px 0 10px; }
+      .c-team { display: flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: 600; font-size: 14.5px; }
+      .c-team.away { flex-direction: row-reverse; }
+      .c-score { font-family: var(--font-display-big); font-weight: 900; font-size: 24px; }
+      .c-foot { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--color-ink-muted); }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 5 · 5.d-mat · Round 1 · Match article body card</div>
+      <h1>matchPreview / matchRecap — bespoke link-out card</h1>
+      <p>
+        Decision locked before this round: the article body does <strong>not</strong> re-render lineups/events/stats
+        (those stay canonical on <code>/wedstrijd/[matchId]</code>). The body is editorial prose + a compact card that
+        <strong>links</strong> to the match. This round picks the card's <strong>shape</strong>. Each variant shown in
+        <strong>recap</strong> (score + FT badge) and <strong>preview</strong> (kickoff time, no badge), sitting after a line of prose.
+      </p>
+    </header>
+
+    <div class="grid">
+      <!-- ════ A ════ -->
+      <section class="variant">
+        <div class="vhead">
+          <div class="label">Variant A</div>
+          <h2>Scoreboard band</h2>
+          <p>Full-width, centered, symmetric mirror. Big central score. Distinct from MatchTeaser's asymmetric date-stub.</p>
+        </div>
+
+        <div class="state-label">Recap</div>
+        <div class="body">
+          <p class="prose">…en zo sleepte KCVV in de slotfase toch de drie punten over de streep, na een owngoal en een koele strafschop.</p>
+          <div class="a-card">
+            <div class="kick a-kick">3e Provinciale · za 13 sep ’26</div>
+            <div class="a-row">
+              <span class="a-team home">KCVV Elewijt <span class="crest kcvv">K</span></span>
+              <span class="a-score">2&nbsp;–&nbsp;1</span>
+              <span class="a-team away"><span class="crest">R</span> Racing Mechelen</span>
+            </div>
+            <div class="a-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div>
+        </div>
+
+        <div class="state-label">Preview</div>
+        <div class="body">
+          <p class="prose">Zondag wacht de topper tegen Racing — een ploeg die thuis nog niet verloor dit seizoen.</p>
+          <div class="a-card">
+            <div class="kick a-kick">3e Provinciale · za 13 sep ’26</div>
+            <div class="a-row">
+              <span class="a-team home">KCVV Elewijt <span class="crest kcvv">K</span></span>
+              <span class="a-score" style="font-size:22px">15:00</span>
+              <span class="a-team away"><span class="crest">R</span> Racing Mechelen</span>
+            </div>
+            <div class="a-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════ B ════ -->
+      <section class="variant">
+        <div class="vhead">
+          <div class="label">Variant B</div>
+          <h2>Inline editorial reference</h2>
+          <p>Lightest touch — a left-ruled strip (blockquote-like), no box/tape. Reads as part of the prose flow.</p>
+        </div>
+
+        <div class="state-label">Recap</div>
+        <div class="body">
+          <p class="prose">…en zo sleepte KCVV in de slotfase toch de drie punten over de streep, na een owngoal en een koele strafschop.</p>
+          <div class="b-ref">
+            <div class="kick">De wedstrijd · 3e Provinciale</div>
+            <div class="b-line"><span class="crest kcvv">K</span> KCVV Elewijt <span class="b-score">2–1</span> Racing Mechelen <span class="crest">R</span></div>
+            <div class="b-meta"><span>za 13 sep · Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div>
+        </div>
+
+        <div class="state-label">Preview</div>
+        <div class="body">
+          <p class="prose">Zondag wacht de topper tegen Racing — een ploeg die thuis nog niet verloor dit seizoen.</p>
+          <div class="b-ref">
+            <div class="kick">De wedstrijd · 3e Provinciale</div>
+            <div class="b-line"><span class="crest kcvv">K</span> KCVV Elewijt <span class="b-score" style="font-style:italic;font-weight:600">vs</span> Racing Mechelen <span class="crest">R</span></div>
+            <div class="b-meta"><span>za 13 sep · 15:00 · Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════ C ════ -->
+      <section class="variant">
+        <div class="vhead">
+          <div class="label">Variant C</div>
+          <h2>Taped result card</h2>
+          <p>Echoes the hero language: washi-tape corner, FT corner stamp, slight rotation, press-down hover. More "object" than B.</p>
+        </div>
+
+        <div class="state-label">Recap</div>
+        <div class="body">
+          <p class="prose">…en zo sleepte KCVV in de slotfase toch de drie punten over de streep, na een owngoal en een koele strafschop.</p>
+          <div class="c-wrap">
+            <div class="c-card">
+              <div class="c-tape"></div>
+              <div class="c-badge-slot"><span class="ftbadge">FT</span></div>
+              <div class="c-top"><span class="kick">3e Provinciale · za 13 sep</span></div>
+              <div class="c-row">
+                <span class="c-team home"><span class="crest kcvv">K</span> KCVV</span>
+                <span class="c-score">2–1</span>
+                <span class="c-team away"><span class="crest">R</span> Racing</span>
+              </div>
+              <div class="c-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="state-label">Preview</div>
+        <div class="body">
+          <p class="prose">Zondag wacht de topper tegen Racing — een ploeg die thuis nog niet verloor dit seizoen.</p>
+          <div class="c-wrap">
+            <div class="c-card">
+              <div class="c-tape"></div>
+              <div class="c-top"><span class="kick">3e Provinciale · za 13 sep</span></div>
+              <div class="c-row">
+                <span class="c-team home"><span class="crest kcvv">K</span> KCVV</span>
+                <span class="c-score" style="font-size:18px">15:00</span>
+                <span class="c-team away"><span class="crest">R</span> Racing</span>
+              </div>
+              <div class="c-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-mat/round-2-goalscorer-rollcall.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-mat/round-2-goalscorer-rollcall.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · 5.d-mat · Round 2 · Goalscorer roll-call (recap)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a; --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b; --color-jersey-deep: #006e47; --color-warm: #d8763a; --color-alert: #c0392b;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink); --shadow-paper-md: 4px 4px 0 0 var(--color-ink); --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono: "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body { background: var(--color-cream-soft); color: var(--color-ink); font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; padding: 32px 24px 96px; }
+      header.page { max-width: 1680px; margin: 0 auto 28px; }
+      header.page .meta { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; opacity: 0.75; }
+      header.page h1 { font-family: var(--font-display); font-style: italic; font-size: 38px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 6px; max-width: 96ch; font-size: 14px; line-height: 1.6; }
+      header.page code { font-family: var(--font-mono); font-size: 12px; background: var(--color-cream-deep); padding: 1px 5px; }
+      .grid { max-width: 1680px; margin: 0 auto; display: grid; grid-template-columns: repeat(3, 1fr); gap: 26px; align-items: start; }
+      .variant { display: flex; flex-direction: column; gap: 12px; }
+      .vhead .label { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--color-jersey-deep); font-weight: 700; }
+      .vhead h2 { margin: 3px 0 5px; font-family: var(--font-display); font-style: italic; font-size: 22px; }
+      .vhead p { margin: 0; font-size: 12.5px; line-height: 1.5; color: var(--color-ink-muted); }
+      .body { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 22px; }
+      .prose { font-family: var(--font-display); font-size: 15px; line-height: 1.7; color: #222; margin: 0 0 18px; }
+
+      .crest { width: 24px; height: 24px; border-radius: 999px; border: 1px solid var(--color-ink-muted); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 10px; color: var(--color-ink-muted); flex: 0 0 auto; }
+      .crest.kcvv { border-color: var(--color-jersey-deep); color: var(--color-jersey-deep); }
+      .ftbadge { font-family: var(--font-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.16em; border: 2px solid var(--color-ink); background: var(--color-cream); padding: 3px 6px; box-shadow: var(--shadow-paper-sm); }
+      .cta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--color-jersey-deep); font-weight: 700; }
+      .kick { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-ink-muted); }
+
+      /* locked card C */
+      .c-wrap { position: relative; padding-top: 10px; }
+      .c-card { position: relative; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); padding: 16px 18px 14px; transform: rotate(-0.6deg); }
+      .c-tape { position: absolute; top: -10px; left: 22px; width: 96px; height: 26px; background: rgba(0,110,71,0.30); border: 1px solid rgba(0,0,0,0.18); transform: rotate(-4deg); }
+      .c-badge-slot { position: absolute; top: -10px; right: -8px; }
+      .c-row { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; margin: 12px 0 10px; }
+      .c-team { display: flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: 600; font-size: 14.5px; }
+      .c-team.away { flex-direction: row-reverse; }
+      .c-score { font-family: var(--font-display-big); font-weight: 900; font-size: 24px; }
+      .c-foot { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--color-ink-muted); }
+
+      /* goal item shared */
+      .goal { font-size: 12.5px; }
+      .goal .min { font-family: var(--font-mono); color: var(--color-ink-muted); font-size: 11px; }
+      .goal .tag { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-ink-muted); }
+
+      /* V1 — inline summary line inside card */
+      .v1-goals { border-top: 1px dashed var(--color-ink-muted); margin-top: 10px; padding-top: 10px; display: flex; flex-wrap: wrap; gap: 6px 14px; }
+      .v1-goals .side { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--color-jersey-deep); }
+
+      /* V2 — two columns inside card */
+      .v2-cols { border-top: 1px dashed var(--color-ink-muted); margin-top: 10px; padding-top: 10px; display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+      .v2-cols .col h4 { margin: 0 0 5px; font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--color-ink-muted); }
+      .v2-cols .col.away { text-align: right; }
+      .v2-cols .goal { margin: 3px 0; }
+
+      /* V3 — separate "Doelpunten" block below card */
+      .v3-block { margin-top: 14px; background: var(--color-cream-soft); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 12px 16px; }
+      .v3-block h4 { margin: 0 0 8px; font-family: var(--font-display); font-style: italic; font-size: 16px; }
+      .v3-list { display: flex; flex-direction: column; gap: 5px; }
+      .v3-list .goal { display: flex; align-items: baseline; gap: 8px; }
+      .v3-list .goal .ball { color: var(--color-jersey-deep); }
+      .v3-list .goal.kcvv .who { font-weight: 700; color: var(--color-jersey-deep); }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 5 · 5.d-mat · Round 2 · Goalscorer roll-call (recap only)</div>
+      <h1>Recap goalscorers — goals-only, attached to card C</h1>
+      <p>
+        Card shape locked = <strong>C (taped result card)</strong>. This round picks how the recap <strong>goalscorers</strong>
+        (from <code>events</code>, <strong>goals only</strong> — not the full card/sub timeline, which stays on <code>/wedstrijd</code>) attach.
+        Sample: 2–1 KCVV — 12' e.d. Mertens, 78' Janssens (pen) · 55' Devos. Preview has no goals, so it just renders card C with no roll-call.
+      </p>
+    </header>
+
+    <div class="grid">
+      <!-- V1 -->
+      <section class="variant">
+        <div class="vhead"><div class="label">Variant 1</div><h2>Inline summary line</h2><p>Goals as one wrapped line inside the card, under a dashed rule. Most compact; reads as a caption.</p></div>
+        <div class="body">
+          <p class="prose">…en zo sleepte KCVV in de slotfase toch de drie punten over de streep.</p>
+          <div class="c-wrap"><div class="c-card">
+            <div class="c-tape"></div><div class="c-badge-slot"><span class="ftbadge">FT</span></div>
+            <div class="kick">3e Provinciale · za 13 sep</div>
+            <div class="c-row"><span class="c-team home"><span class="crest kcvv">K</span> KCVV</span><span class="c-score">2–1</span><span class="c-team away"><span class="crest">R</span> Racing</span></div>
+            <div class="v1-goals">
+              <span><span class="side">KCVV</span> <span class="goal"><span class="min">12'</span> Mertens <span class="tag">e.d.</span> · <span class="min">78'</span> Janssens <span class="tag">pen</span></span></span>
+              <span><span class="side" style="color:var(--color-ink-muted)">Racing</span> <span class="goal"><span class="min">55'</span> Devos</span></span>
+            </div>
+            <div class="c-foot" style="margin-top:10px"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div></div>
+        </div>
+      </section>
+
+      <!-- V2 -->
+      <section class="variant">
+        <div class="vhead"><div class="label">Variant 2</div><h2>Two columns (home | away)</h2><p>Scorers split by team inside the card, mirroring the scoreboard. Clear attribution; a touch taller.</p></div>
+        <div class="body">
+          <p class="prose">…en zo sleepte KCVV in de slotfase toch de drie punten over de streep.</p>
+          <div class="c-wrap"><div class="c-card">
+            <div class="c-tape"></div><div class="c-badge-slot"><span class="ftbadge">FT</span></div>
+            <div class="kick">3e Provinciale · za 13 sep</div>
+            <div class="c-row"><span class="c-team home"><span class="crest kcvv">K</span> KCVV</span><span class="c-score">2–1</span><span class="c-team away"><span class="crest">R</span> Racing</span></div>
+            <div class="v2-cols">
+              <div class="col home"><h4>KCVV</h4>
+                <div class="goal"><span class="min">12'</span> Mertens <span class="tag">e.d.</span></div>
+                <div class="goal"><span class="min">78'</span> Janssens <span class="tag">pen</span></div>
+              </div>
+              <div class="col away"><h4>Racing</h4>
+                <div class="goal"><span class="min">55'</span> Devos</div>
+              </div>
+            </div>
+            <div class="c-foot" style="margin-top:10px"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div></div>
+        </div>
+      </section>
+
+      <!-- V3 -->
+      <section class="variant">
+        <div class="vhead"><div class="label">Variant 3</div><h2>Separate "Doelpunten" block</h2><p>Card C stays a clean result; goals live in their own paper block below it (display heading + ⚽ list). Most editorial.</p></div>
+        <div class="body">
+          <p class="prose">…en zo sleepte KCVV in de slotfase toch de drie punten over de streep.</p>
+          <div class="c-wrap"><div class="c-card">
+            <div class="c-tape"></div><div class="c-badge-slot"><span class="ftbadge">FT</span></div>
+            <div class="kick">3e Provinciale · za 13 sep</div>
+            <div class="c-row"><span class="c-team home"><span class="crest kcvv">K</span> KCVV</span><span class="c-score">2–1</span><span class="c-team away"><span class="crest">R</span> Racing</span></div>
+            <div class="c-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div></div>
+          <div class="v3-block">
+            <h4>Doelpunten.</h4>
+            <div class="v3-list">
+              <div class="goal kcvv"><span class="ball">⚽</span> <span class="min">12'</span> <span class="who">Mertens</span> <span class="tag">eigen doelpunt</span></div>
+              <div class="goal"><span class="ball">⚽</span> <span class="min">55'</span> <span class="who">Devos</span></div>
+              <div class="goal kcvv"><span class="ball">⚽</span> <span class="min">78'</span> <span class="who">Janssens</span> <span class="tag">strafschop</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-mat/round-3-final-locked.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-mat/round-3-final-locked.html
@@ -45,7 +45,7 @@
       .c-foot { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--color-ink-muted); }
 
       /* Doelpunten — reuse <MatchEvents filter="goals"> sided rows (Option F) */
-      .goals { margin-top: 16px; }
+      .goals { margin-top: 30px; }
       .goals h4 { margin: 0 0 6px; font-family: var(--font-display); font-style: italic; font-size: 17px; }
       .goals .rule { border-top: 2px solid var(--color-ink); margin-bottom: 8px; }
       .grow { display: grid; grid-template-columns: 40px 1fr 22px 1fr; align-items: center; gap: 6px; padding: 5px 0; border-bottom: 1px dashed var(--color-ink-muted); }

--- a/docs/design/mockups/phase-5-article-detail/5d-mat/round-3-final-locked.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-mat/round-3-final-locked.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phase 5 · 5.d-mat · LOCKED · Card C + sided Doelpunten</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a; --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b; --color-jersey-deep: #006e47; --color-warm: #d8763a; --color-alert: #c0392b;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink); --shadow-paper-md: 4px 4px 0 0 var(--color-ink); --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono: "Quasimoda", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body { background: var(--color-cream-soft); color: var(--color-ink); font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px 24px 96px; }
+      header.page { max-width: 1320px; margin: 0 auto 28px; }
+      header.page .meta { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-jersey-deep); font-weight: 700; }
+      header.page h1 { font-family: var(--font-display); font-style: italic; font-size: 36px; margin: 6px 0 10px; }
+      header.page p { margin: 0 0 6px; max-width: 92ch; font-size: 14px; line-height: 1.6; }
+      header.page code { font-family: var(--font-mono); font-size: 12px; background: var(--color-cream-deep); padding: 1px 5px; }
+      .grid { max-width: 1320px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 30px; align-items: start; }
+      .state-label { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.16em; color: var(--color-ink-muted); margin: 0 0 8px; }
+      .body { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 24px; }
+      .prose { font-family: var(--font-display); font-size: 15.5px; line-height: 1.75; color: #222; margin: 0 0 18px; }
+
+      .crest { width: 24px; height: 24px; border-radius: 999px; border: 1px solid var(--color-ink-muted); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 10px; color: var(--color-ink-muted); flex: 0 0 auto; }
+      .crest.kcvv { border-color: var(--color-jersey-deep); color: var(--color-jersey-deep); }
+      .ftbadge { font-family: var(--font-mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.16em; border: 2px solid var(--color-ink); background: var(--color-cream); padding: 3px 6px; box-shadow: var(--shadow-paper-sm); }
+      .cta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--color-jersey-deep); font-weight: 700; }
+      .kick { font-family: var(--font-mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-ink-muted); }
+
+      /* card C (locked) */
+      .c-wrap { position: relative; padding-top: 10px; }
+      .c-card { position: relative; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-lift); padding: 16px 18px 14px; transform: rotate(-0.6deg); }
+      .c-tape { position: absolute; top: -10px; left: 22px; width: 96px; height: 26px; background: rgba(0,110,71,0.30); border: 1px solid rgba(0,0,0,0.18); transform: rotate(-4deg); }
+      .c-badge-slot { position: absolute; top: -10px; right: -8px; }
+      .c-row { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; margin: 12px 0 10px; }
+      .c-team { display: flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: 600; font-size: 15px; }
+      .c-team.away { flex-direction: row-reverse; }
+      .c-score { font-family: var(--font-display-big); font-weight: 900; font-size: 26px; }
+      .c-foot { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--color-ink-muted); }
+
+      /* Doelpunten — reuse <MatchEvents filter="goals"> sided rows (Option F) */
+      .goals { margin-top: 16px; }
+      .goals h4 { margin: 0 0 6px; font-family: var(--font-display); font-style: italic; font-size: 17px; }
+      .goals .rule { border-top: 2px solid var(--color-ink); margin-bottom: 8px; }
+      .grow { display: grid; grid-template-columns: 40px 1fr 22px 1fr; align-items: center; gap: 6px; padding: 5px 0; border-bottom: 1px dashed var(--color-ink-muted); }
+      .grow:last-child { border-bottom: 0; }
+      .grow .min { font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-muted); }
+      .grow .home { text-align: right; font-family: var(--font-display); font-size: 14px; }
+      .grow .away { text-align: left; font-family: var(--font-display); font-size: 14px; }
+      .grow .ball { width: 18px; height: 18px; margin: 0 auto; }
+      .grow .tag { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-ink-muted); }
+      .kcvvname { color: var(--color-jersey-deep); font-weight: 600; }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 5 · 5.d-mat · LOCKED (round 1 = card C, round 2 = V3 sided)</div>
+      <h1>matchPreview / matchRecap — locked body</h1>
+      <p>
+        Editorial hero (announcement-shape, kicker VOORBESCHOUWING / MATCHVERSLAG) → prose → <strong>card C</strong> (taped result card,
+        links to <code>/wedstrijd/[matchId]</code>). On <strong>recap</strong>, a <strong>Doelpunten</strong> section follows, reusing
+        <code>&lt;MatchEvents filter="goals"&gt;</code> (sided rows: home left / away right, central football glyph). No lineups, no cards/subs,
+        no stats — those stay on the match page. <strong>Preview</strong> = card C only (no goals exist yet).
+      </p>
+    </header>
+
+    <div class="grid">
+      <!-- RECAP -->
+      <section>
+        <div class="state-label">matchRecap</div>
+        <div class="body">
+          <p class="prose">Een vroege treffer zette de toon, en in de slotfase besliste een koele strafschop de partij. KCVV pakt zo de drie punten tegen een taaie tegenstander.</p>
+          <div class="c-wrap"><div class="c-card">
+            <div class="c-tape"></div><div class="c-badge-slot"><span class="ftbadge">FT</span></div>
+            <div class="kick">3e Provinciale · za 13 sep</div>
+            <div class="c-row"><span class="c-team home"><span class="crest kcvv">K</span> KCVV Elewijt</span><span class="c-score">2–1</span><span class="c-team away"><span class="crest">R</span> Racing Mechelen</span></div>
+            <div class="c-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div></div>
+          <div class="goals">
+            <h4>Doelpunten.</h4>
+            <div class="rule"></div>
+            <div class="grow"><span class="min">23'</span><span class="home"><span class="kcvvname">Janssens</span></span><span class="ball"><svg viewBox="0 0 24 24" width="18" height="18"><circle cx="12" cy="12" r="9" fill="var(--color-cream)" stroke="var(--color-ink)" stroke-width="1.5"/><polygon points="12,7 15,9.2 14,12.8 10,12.8 9,9.2" fill="var(--color-ink)"/></svg></span><span class="away"></span></div>
+            <div class="grow"><span class="min">55'</span><span class="home"></span><span class="ball"><svg viewBox="0 0 24 24" width="18" height="18"><circle cx="12" cy="12" r="9" fill="var(--color-cream)" stroke="var(--color-ink)" stroke-width="1.5"/><polygon points="12,7 15,9.2 14,12.8 10,12.8 9,9.2" fill="var(--color-ink)"/></svg></span><span class="away">Devos</span></div>
+            <div class="grow"><span class="min">78'</span><span class="home"><span class="kcvvname">Peeters</span> <span class="tag">pen</span></span><span class="ball"><svg viewBox="0 0 24 24" width="18" height="18"><circle cx="12" cy="12" r="9" fill="var(--color-cream)" stroke="var(--color-ink)" stroke-width="1.5"/><polygon points="12,7 15,9.2 14,12.8 10,12.8 9,9.2" fill="var(--color-ink)"/></svg></span><span class="away"></span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- PREVIEW -->
+      <section>
+        <div class="state-label">matchPreview</div>
+        <div class="body">
+          <p class="prose">Zondag wacht de topper tegen Racing — een ploeg die thuis nog niet verloor dit seizoen. Een driepunter zou KCVV naar de subtop tillen.</p>
+          <div class="c-wrap"><div class="c-card">
+            <div class="c-tape"></div>
+            <div class="kick">3e Provinciale · za 13 sep</div>
+            <div class="c-row"><span class="c-team home"><span class="crest kcvv">K</span> KCVV Elewijt</span><span class="c-score" style="font-size:19px">15:00</span><span class="c-team away"><span class="crest">R</span> Racing Mechelen</span></div>
+            <div class="c-foot"><span>Driesstraat</span><span class="cta">naar wedstrijd →</span></div>
+          </div></div>
+          <p class="prose" style="margin-top:16px; font-size:13px; color:var(--color-ink-muted); font-style:italic;">(no Doelpunten section — preview has no goals yet)</p>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-mat/round-4-hero-composition.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-mat/round-4-hero-composition.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Phase 5 · 5.d-mat · Round 4 · Hero composition (H1/H2/H3)</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a; --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b; --color-jersey-deep: #006e47; --color-warm: #d8763a; --color-alert: #c0392b;
+        --shadow-paper-lift: 6px 6px 0 0 var(--color-ink); --shadow-paper-md: 4px 4px 0 0 var(--color-ink); --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono: "Quasimoda", ui-monospace, "SF Mono", "Menlo", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--color-cream-soft); color: var(--color-ink); font-family: ui-sans-serif, system-ui, sans-serif; padding: 30px 22px 90px; }
+      header.page { max-width: 1860px; margin: 0 auto 24px; }
+      header.page .meta { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-jersey-deep); font-weight: 700; }
+      header.page h1 { font-family: var(--font-display); font-style: italic; font-size: 34px; margin: 6px 0 8px; }
+      header.page p { margin: 0; max-width: 100ch; font-size: 13.5px; line-height: 1.6; }
+      .rowlabel { max-width: 1860px; margin: 22px auto 8px; font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; color: var(--color-ink-muted); border-top: 1px solid var(--color-ink-muted); padding-top: 8px; }
+      .grid { max-width: 1860px; margin: 0 auto; display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; align-items: start; }
+      .opt .cap { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.16em; color: var(--color-jersey-deep); font-weight: 700; margin-bottom: 4px; }
+      .opt .name { font-family: var(--font-display); font-style: italic; font-size: 19px; margin-bottom: 2px; }
+      .opt .desc { font-size: 11.5px; color: var(--color-ink-muted); line-height: 1.45; margin-bottom: 10px; min-height: 46px; }
+      .opt .bodynote { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--color-ink-muted); margin-top: 8px; padding: 6px 8px; background: var(--color-cream-deep); }
+
+      /* hero shell */
+      .hero { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 16px; display: grid; grid-template-columns: 1.5fr 1fr; gap: 14px; align-items: center; }
+      .ed .kick { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.13em; color: var(--color-ink-muted); }
+      .ed h2 { font-family: var(--font-display-big); font-weight: 900; font-size: 23px; line-height: 1.05; margin: 6px 0 7px; letter-spacing: -0.02em; }
+      .ed .lead { font-family: var(--font-display); font-size: 12.5px; line-height: 1.45; color: #333; margin: 0; }
+      .cover { background: repeating-linear-gradient(45deg, var(--color-cream-deep), var(--color-cream-deep) 8px, var(--color-cream-soft) 8px, var(--color-cream-soft) 16px); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); aspect-ratio: 4/3; position: relative; }
+      .cover .tape { position: absolute; top: -8px; left: 30%; width: 60px; height: 18px; background: rgba(0,110,71,0.3); border: 1px solid rgba(0,0,0,0.15); transform: rotate(-4deg); }
+      .cover .ph { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 9px; color: var(--color-ink-muted); }
+      .crest { width: 22px; height: 22px; border-radius: 999px; border: 1px solid var(--color-ink-muted); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 9px; color: var(--color-ink-muted); }
+      .crest.kcvv { border-color: var(--color-jersey-deep); color: var(--color-jersey-deep); }
+
+      /* H1 — integrated match strip under the kicker */
+      .matchstrip { display: flex; align-items: center; gap: 8px; margin: 7px 0; padding: 7px 9px; background: var(--color-cream-soft); border: 1.5px solid var(--color-ink); font-family: var(--font-display); font-weight: 600; font-size: 13px; }
+      .matchstrip .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 16px; margin: 0 2px; }
+
+      /* H2 — matchup folded into kicker only */
+      /* H3 — score-forward overlay on the cover */
+      .cover .scoreover { position: absolute; left: 50%; bottom: 8px; transform: translateX(-50%); background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 5px 12px; display: flex; align-items: center; gap: 8px; }
+      .cover .scoreover .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 20px; }
+      .h3 .ed h2 { font-size: 21px; }
+    </style>
+  </head>
+  <body>
+    <header class="page">
+      <div class="meta">Phase 5 · 5.d-mat · Round 4 · hero composition</div>
+      <h1>Where does the matchup live — hero or body?</h1>
+      <p>#1791 locked the body (card C + Doelpunten) in isolation. This round decides the <strong>hero</strong> treatment for matchPreview/matchRecap and reconciles it with the body. Cover = placeholder. Recap row on top, preview row below; each option notes its <strong>body</strong>.</p>
+    </header>
+
+    <div class="rowlabel">Recap (finished match)</div>
+    <div class="grid">
+      <!-- H1 recap -->
+      <div class="opt">
+        <div class="cap">H1</div><div class="name">Hero absorbs the match</div>
+        <div class="desc">Integrated match strip (crests + score) under the kicker. Hero owns the matchup.</div>
+        <div class="hero"><div class="ed">
+          <div class="kick">Matchverslag · 3e Provinciale · za 13 sep</div>
+          <h2>KCVV pakt de drie punten in slotfase.</h2>
+          <div class="matchstrip"><span class="crest kcvv">K</span> KCVV <span class="sc">2–1</span> Racing <span class="crest">R</span></div>
+          <p class="lead">Een koele strafschop besliste een taaie partij.</p>
+        </div><div class="cover"><div class="tape"></div><div class="ph">cover</div></div></div>
+        <div class="bodynote">body: prose + Doelpunten + "naar wedstrijd →" link · CARD C DROPPED</div>
+      </div>
+      <!-- H2 recap -->
+      <div class="opt">
+        <div class="cap">H2</div><div class="name">Editorial hero + card C in body</div>
+        <div class="desc">Hero stays editorial; matchup only hinted in the kicker. Card C carries the result in the body.</div>
+        <div class="hero"><div class="ed">
+          <div class="kick">Matchverslag · KCVV–Racing 2–1 · za 13 sep</div>
+          <h2>KCVV pakt de drie punten in slotfase.</h2>
+          <p class="lead">Een koele strafschop besliste een taaie partij.</p>
+        </div><div class="cover"><div class="tape"></div><div class="ph">cover</div></div></div>
+        <div class="bodynote">body: prose + CARD C (result) + Doelpunten</div>
+      </div>
+      <!-- H3 recap -->
+      <div class="opt h3">
+        <div class="cap">H3</div><div class="name">Score-forward match hero</div>
+        <div class="desc">The result is the showcase — big score stamped on the cover. Most "match" of the three.</div>
+        <div class="hero"><div class="ed">
+          <div class="kick">Matchverslag · 3e Provinciale</div>
+          <h2>KCVV pakt de drie punten.</h2>
+          <p class="lead">Een koele strafschop besliste een taaie partij tegen Racing.</p>
+        </div><div class="cover"><div class="tape"></div><div class="ph">cover</div>
+          <div class="scoreover"><span class="crest kcvv">K</span><span class="sc">2–1</span><span class="crest">R</span></div>
+        </div></div>
+        <div class="bodynote">body: prose + Doelpunten + "naar wedstrijd →" link · CARD C DROPPED</div>
+      </div>
+    </div>
+
+    <div class="rowlabel">Preview (upcoming match)</div>
+    <div class="grid">
+      <!-- H1 preview -->
+      <div class="opt">
+        <div class="cap">H1</div><div class="name">Hero absorbs the match</div>
+        <div class="desc">Same strip, fixture state (crests + kickoff).</div>
+        <div class="hero"><div class="ed">
+          <div class="kick">Voorbeschouwing · 3e Provinciale · za 13 sep</div>
+          <h2>Topper tegen Racing wacht.</h2>
+          <div class="matchstrip"><span class="crest kcvv">K</span> KCVV <span class="sc" style="font-size:13px">15:00</span> Racing <span class="crest">R</span></div>
+          <p class="lead">Een driepunter tilt KCVV naar de subtop.</p>
+        </div><div class="cover"><div class="tape"></div><div class="ph">cover</div></div></div>
+        <div class="bodynote">body: prose + "naar wedstrijd →" link · CARD C DROPPED</div>
+      </div>
+      <!-- H2 preview -->
+      <div class="opt">
+        <div class="cap">H2</div><div class="name">Editorial hero + card C in body</div>
+        <div class="desc">Matchup hinted in kicker; card C (fixture) in body.</div>
+        <div class="hero"><div class="ed">
+          <div class="kick">Voorbeschouwing · vs Racing · za 13 sep 15:00</div>
+          <h2>Topper tegen Racing wacht.</h2>
+          <p class="lead">Een driepunter tilt KCVV naar de subtop.</p>
+        </div><div class="cover"><div class="tape"></div><div class="ph">cover</div></div></div>
+        <div class="bodynote">body: prose + CARD C (fixture)</div>
+      </div>
+      <!-- H3 preview -->
+      <div class="opt h3">
+        <div class="cap">H3</div><div class="name">Score-forward match hero</div>
+        <div class="desc">No score yet → fixture stamp (vs + kickoff) on the cover.</div>
+        <div class="hero"><div class="ed">
+          <div class="kick">Voorbeschouwing · 3e Provinciale</div>
+          <h2>Topper tegen Racing.</h2>
+          <p class="lead">Een driepunter tilt KCVV naar de subtop.</p>
+        </div><div class="cover"><div class="tape"></div><div class="ph">cover</div>
+          <div class="scoreover"><span class="crest kcvv">K</span><span class="sc" style="font-size:13px">za 15:00</span><span class="crest">R</span></div>
+        </div></div>
+        <div class="bodynote">body: prose + "naar wedstrijd →" link · CARD C DROPPED</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/5d-mat/round-5-hero-h3-final.html
+++ b/docs/design/mockups/phase-5-article-detail/5d-mat/round-5-hero-h3-final.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Phase 5 · 5.d-mat · H3 hero LOCKED — desktop + mobile</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6; --color-cream-soft: #ede8da; --color-cream-deep: #e1d7bf;
+        --color-ink: #0a0a0a; --color-ink-muted: #6b6b6b;
+        --color-jersey: #00a86b; --color-jersey-deep: #006e47; --color-warm: #d8763a; --color-alert: #c0392b;
+        --shadow-paper-md: 4px 4px 0 0 var(--color-ink); --shadow-paper-sm: 2px 2px 0 0 var(--color-ink);
+        --font-display: "Freight Display Pro", "Playfair Display", ui-serif, Georgia, serif;
+        --font-display-big: "Freight Display Pro Black", "Playfair Display", ui-serif, Georgia, serif;
+        --font-mono: "Quasimoda", ui-monospace, "SF Mono", "Menlo", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--color-cream-soft); color: var(--color-ink); font-family: ui-sans-serif, system-ui, sans-serif; padding: 30px 22px 90px; }
+      .page { max-width: 1500px; margin: 0 auto; }
+      .page > .meta { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--color-jersey-deep); font-weight: 700; }
+      .page > h1 { font-family: var(--font-display); font-style: italic; font-size: 32px; margin: 6px 0 6px; }
+      .page > p { margin: 0 0 18px; max-width: 96ch; font-size: 13.5px; line-height: 1.6; }
+      .rowlabel { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.16em; color: var(--color-ink-muted); border-top: 1px solid var(--color-ink-muted); padding-top: 8px; margin: 24px 0 10px; }
+
+      /* shared score overlay — balanced: crest · score · crest, centred */
+      .scorebar { display: inline-flex; align-items: center; gap: 14px; background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); padding: 6px 16px; }
+      .scorebar .crest { width: 26px; height: 26px; border-radius: 999px; border: 1.5px solid var(--color-ink-muted); display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 11px; color: var(--color-ink-muted); flex: 0 0 auto; }
+      .scorebar .crest.kcvv { border-color: var(--color-jersey-deep); color: var(--color-jersey-deep); }
+      .scorebar .sc { font-family: var(--font-display-big); font-weight: 900; font-size: 22px; line-height: 1; letter-spacing: -0.01em; min-width: 58px; text-align: center; font-variant-numeric: tabular-nums; }
+      .scorebar .badge { font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: 0.14em; border: 1.5px solid var(--color-ink); padding: 2px 5px; margin-left: 2px; }
+
+      .ed .kick { font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.13em; color: var(--color-ink-muted); }
+      .ed h2 { font-family: var(--font-display-big); font-weight: 900; line-height: 1.04; letter-spacing: -0.02em; margin: 7px 0 8px; }
+      .ed .lead { font-family: var(--font-display); line-height: 1.45; color: #333; margin: 0; }
+      .cover { background: repeating-linear-gradient(45deg, var(--color-cream-deep), var(--color-cream-deep) 9px, var(--color-cream-soft) 9px, var(--color-cream-soft) 18px); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-sm); position: relative; }
+      .cover .tape { position: absolute; top: -8px; left: 34%; width: 64px; height: 18px; background: rgba(0,110,71,0.3); border: 1px solid rgba(0,0,0,0.15); transform: rotate(-4deg); }
+      .cover .ph { position: absolute; top: 8px; left: 10px; font-family: var(--font-mono); font-size: 9px; color: var(--color-ink-muted); }
+      /* overlay anchored bottom-centre, straddling the cover's lower edge */
+      .cover .scorewrap { position: absolute; left: 50%; bottom: -18px; transform: translateX(-50%); }
+
+      /* ── desktop ── */
+      .desk { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; }
+      .desk .hero { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); padding: 18px; display: grid; grid-template-columns: 1.5fr 1fr; gap: 18px; align-items: center; }
+      .desk .cover { aspect-ratio: 4/3; }
+      .desk .ed h2 { font-size: 26px; }
+      .desk .ed .lead { font-size: 13px; }
+      .colcap { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-ink-muted); margin-bottom: 6px; }
+
+      /* ── mobile (375px) ── */
+      .mob { display: flex; gap: 30px; flex-wrap: wrap; }
+      .phone { width: 360px; }
+      .phone .hero { background: var(--color-cream); border: 2px solid var(--color-ink); box-shadow: var(--shadow-paper-md); padding: 0 0 16px; }
+      .phone .cover { aspect-ratio: 16/10; border-left: 0; border-right: 0; border-top: 0; }
+      .phone .ed { padding: 26px 16px 0; }
+      .phone .ed h2 { font-size: 22px; }
+      .phone .ed .lead { font-size: 13px; }
+      .bodynote { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--color-ink-muted); margin-top: 10px; padding: 6px 8px; background: var(--color-cream-deep); }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="meta">Phase 5 · 5.d-mat · H3 hero — LOCKED</div>
+      <h1>Score-forward match hero — aligned score + mobile</h1>
+      <p>Score (recap) / fixture (preview) on a balanced <code>crest · score · crest</code> bar straddling the cover's lower edge, centred. Body drops card C → prose + (recap) Doelpunten + "naar wedstrijd →". Desktop: editorial + cover side-by-side. Mobile: cover on top with the score bar, editorial below.</p>
+
+      <div class="rowlabel">Desktop</div>
+      <div class="desk">
+        <div>
+          <div class="colcap">matchRecap</div>
+          <div class="hero">
+            <div class="ed">
+              <div class="kick">Matchverslag · 3e Provinciale · za 13 sep</div>
+              <h2>KCVV pakt de drie punten in de slotfase.</h2>
+              <p class="lead">Een koele strafschop besliste een taaie partij tegen Racing.</p>
+            </div>
+            <div class="cover"><div class="tape"></div><div class="ph">cover</div>
+              <div class="scorewrap"><div class="scorebar"><span class="crest kcvv">K</span><span class="sc">2 – 1</span><span class="crest">R</span><span class="badge">FT</span></div></div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div class="colcap">matchPreview</div>
+          <div class="hero">
+            <div class="ed">
+              <div class="kick">Voorbeschouwing · 3e Provinciale · za 13 sep</div>
+              <h2>Topper tegen Racing wacht.</h2>
+              <p class="lead">Een driepunter tilt KCVV naar de subtop.</p>
+            </div>
+            <div class="cover"><div class="tape"></div><div class="ph">cover</div>
+              <div class="scorewrap"><div class="scorebar"><span class="crest kcvv">K</span><span class="sc" style="font-size:14px">15:00</span><span class="crest">R</span></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="rowlabel">Mobile (360px)</div>
+      <div class="mob">
+        <div class="phone">
+          <div class="colcap">matchRecap</div>
+          <div class="hero">
+            <div class="cover"><div class="tape"></div><div class="ph">cover</div>
+              <div class="scorewrap"><div class="scorebar"><span class="crest kcvv">K</span><span class="sc">2 – 1</span><span class="crest">R</span><span class="badge">FT</span></div></div>
+            </div>
+            <div class="ed">
+              <div class="kick">Matchverslag · 3e Provinciale · za 13 sep</div>
+              <h2>KCVV pakt de drie punten in de slotfase.</h2>
+              <p class="lead">Een koele strafschop besliste een taaie partij tegen Racing.</p>
+            </div>
+          </div>
+        </div>
+        <div class="phone">
+          <div class="colcap">matchPreview</div>
+          <div class="hero">
+            <div class="cover"><div class="tape"></div><div class="ph">cover</div>
+              <div class="scorewrap"><div class="scorebar"><span class="crest kcvv">K</span><span class="sc" style="font-size:14px">15:00</span><span class="crest">R</span></div></div>
+            </div>
+            <div class="ed">
+              <div class="kick">Voorbeschouwing · 3e Provinciale · za 13 sep</div>
+              <h2>Topper tegen Racing wacht.</h2>
+              <p class="lead">Een driepunter tilt KCVV naar de subtop.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bodynote">BODY (both states): editorial prose → (recap only) Doelpunten section → "naar wedstrijd →" link. CARD C dropped — the hero now carries the matchup.</div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-5-article-detail/match-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/match-locked.md
@@ -40,6 +40,8 @@ A `<TapedCard>`-based card, whole-card link to `/wedstrijd/[matchId]`:
 
 Below card C on **recap only** (preview has no goals → card C alone):
 
+- **Gap from card C → Doelpunten: `30px`** (`mt-[30px]`) — the scorer list reads as
+  a distinct section, not attached to the card.
 - A `Doelpunten.` `<EditorialHeading>`-style italic display heading + 2px ink rule.
 - The list **reuses `<MatchEvents filter="goals">`** — its Option-F sided rows
   (home left / away right, central football glyph, minute on the far left).

--- a/docs/design/mockups/phase-5-article-detail/match-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/match-locked.md
@@ -1,47 +1,57 @@
 # Locked — matchPreview / matchRecap article body (5.d-mat)
 
-**Status:** Locked 2026-06-05 · **Issue:** #1791 · **Drill:** `5d-mat/` (rounds 1–3)
+**Status:** Locked 2026-06-05 · **Issue:** #1791 · **Drill:** `5d-mat/` (rounds 1–5)
 **Builds in:** #1470 (article variants) · **Sibling:** #1914 (match-page `<MatchArticleLinkCard>`)
 
 ## Decision summary
 
 The `matchPreview` / `matchRecap` article **does not re-render** lineups, the
 full event timeline, or stats — those stay canonical on `/wedstrijd/[matchId]`
-(Phase 6.B). The article body is **editorial prose + a compact card that links
-to the match**, plus (recap only) a **goals-only** scorer list.
+(Phase 6.B). The **hero carries the matchup** (score-forward, H3); the body is
+**editorial prose**, plus (recap only) a **goals-only** scorer list, then a link
+to the match.
+
+> **Round 4–5 reconciliation (supersedes the round-1 body card):** the matchup
+> moved into the hero (H3). The standalone body "card C" is **dropped** — keeping
+> both would duplicate teams + score. The match link is now a plain text CTA.
 
 Composition (top → bottom):
 
 ```text
-<EditorialHero variant="matchPreview|matchRecap">   ← announcement-shape hero,
+<EditorialHero variant="matchPreview|matchRecap">   ← H3 score-forward hero:
                                                        kicker VOORBESCHOUWING /
-                                                       MATCHVERSLAG (per #1470)
+                                                       MATCHVERSLAG + score bar
+                                                       on the cover (see below)
 <ArticleBody>                                        ← editorial prose
-<MatchCard>                                          ← Round 1 = Variant C
-[recap only] <Doelpunten>                            ← Round 2 = V3, sided
+[recap only] <Doelpunten>                            ← Round 2 = V3, sided goals
+"naar wedstrijd →"                                   ← plain text link to /wedstrijd
 ```
 
-## Round 1 — match card = **Variant C (taped result card)**
+## Hero (rounds 4–5) — **H3, score-forward**
 
-A `<TapedCard>`-based card, whole-card link to `/wedstrijd/[matchId]`:
+`<EditorialHero variant="matchPreview|matchRecap">` keeps the editorial shell
+(kicker + display H1 + lead + cover) and adds a **score bar** straddling the
+cover's lower edge — the same overlay idiom as the `event` variant's day-block.
 
-- Washi **tape** strip on the top-left corner; slight paper rotation (`-0.6°`);
-  `shadow-paper-lift`; canonical **press-down hover**
-  (`hover:shadow-none hover:translate-x-1 hover:translate-y-1`, `duration-300`).
-- **Top:** mono kicker `competition · short-date`. `<MatchStatusBadge>` as a
-  **corner stamp** top-right (it self-hides for `scheduled`, so preview shows none).
-- **Middle:** symmetric 3-col row — `[home crest + name] [score|time] [name + away crest]`.
-  Recap → `font-display-big` score (e.g. `2–1`); preview → kickoff `15:00` (or `vs`).
-- **Foot:** `venue` (left) · `naar wedstrijd →` mono CTA (right).
-- **Reuse:** `<TapedCard>`, `<MatchStatusBadge>`, `<Crest>`, `<MonoLabel>` — no new primitive.
-- Distinct from `<MatchTeaser>` (date-stub-led, asymmetric) by being **symmetric + tape-led**.
+- **Score bar:** a centred, balanced `crest · score · crest` pill (cream, `border-2 border-ink`,
+  `shadow-paper-sm`). Score is `font-display-big`, tabular, with a fixed min-width so
+  `2 – 1` and `15:00` stay centred. Recap appends an `<MatchStatusBadge>` (`FT`);
+  preview shows the **kickoff time** (or `vs`) and no badge.
+- **Kicker:** `VOORBESCHOUWING` (preview) / `MATCHVERSLAG` (recap) `· competition · date`.
+- **Desktop:** editorial column + cover side-by-side (the existing hero grid). The
+  bar sits bottom-centre of the cover.
+- **Mobile:** cover on top (full-bleed) with the score bar straddling its lower edge,
+  editorial (kicker + H1 + lead) below.
+- **Reuse:** the `event`-variant cover-overlay mechanism, `<Crest>`, `<MatchStatusBadge>`.
+- Because the hero carries the matchup, there is **no standalone body match card**
+  (the round-1 "card C" is dropped — see the reconciliation note above).
 
 ## Round 2 — recap goalscorers = **V3, sided "Doelpunten" block**
 
-Below card C on **recap only** (preview has no goals → card C alone):
+After the prose on **recap only** (preview has no goals → no Doelpunten):
 
-- **Gap from card C → Doelpunten: `30px`** (`mt-[30px]`) — the scorer list reads as
-  a distinct section, not attached to the card.
+- **Gap above Doelpunten: `30px`** (`mt-[30px]`) — the scorer list reads as a
+  distinct section.
 - A `Doelpunten.` `<EditorialHeading>`-style italic display heading + 2px ink rule.
 - The list **reuses `<MatchEvents filter="goals">`** — its Option-F rows
   (minute on the far left, then a **sided** glyph: home events render their glyph
@@ -69,25 +79,30 @@ exist in the schema. Previews have **no** score/events/lineup (not played yet).
 
 ## Implementation notes (for #1470)
 
-- The card + Doelpunten are **presentational** (props-only) so they're Storybook/
-  VR-able; the page server-fetches via `BffService.getMatchDetail(linkedMatch)`
-  and feeds them. Article renders without the card if the match 404s.
+- The hero score bar + Doelpunten are **presentational** (props-only) so they're
+  Storybook/VR-able; the page server-fetches via `BffService.getMatchDetail(linkedMatch)`
+  and feeds them. Article renders the editorial hero **without** the score bar if the
+  match 404s (graceful).
 - `matchPreview`/`matchRecap` excluded from `generateStaticParams` (on-demand ISR)
   so match data renders server-side without per-article PSD hits at build.
-- Goals for the roll-call = `events.filter(type === "goal")`.
+- Goals for the roll-call = `events.filter(type === "goal")` → `<MatchEvents filter="goals">`.
+- KCVV-in-`jersey-deep` highlight needs a small `highlightTeam` prop added to
+  `<MatchEvents>` (it currently renders all names in ink) — see Round 2.
+- **No standalone match card** to build (card C dropped). The match link is a plain
+  text CTA after the body.
 
 ## Reuse map
 
 | Element | Reuses |
 | --- | --- |
-| Card shell | `<TapedCard>` (tape, rotation, press-down) |
-| Status stamp | `<MatchStatusBadge>` |
-| Team crests | `<Crest>` |
-| Kicker / labels | `<MonoLabel>` |
-| Doelpunten rows | `<MatchEvents filter="goals">` |
+| Hero shell | `<EditorialHero>` (new `matchPreview`/`matchRecap` variants) |
+| Cover score bar | `event`-variant cover-overlay idiom + `<Crest>` + `<MatchStatusBadge>` |
+| Doelpunten rows | `<MatchEvents filter="goals">` (+ a `highlightTeam` prop) |
 
 ## Mockups
 
-- `5d-mat/round-1-card-shape-comparisons.html` — A/B/C card directions.
-- `5d-mat/round-2-goalscorer-rollcall.html` — V1/V2/V3 roll-call attachments.
-- `5d-mat/round-3-final-locked.html` — locked composition (card C + sided Doelpunten), recap + preview.
+- `5d-mat/round-1-card-shape-comparisons.html` — body card directions A/B/C (C chosen, later superseded).
+- `5d-mat/round-2-goalscorer-rollcall.html` — V1/V2/V3 roll-call attachments (V3, sided).
+- `5d-mat/round-3-final-locked.html` — body composition with card C (superseded by rounds 4–5).
+- `5d-mat/round-4-hero-composition.html` — hero options H1/H2/H3.
+- `5d-mat/round-5-hero-h3-final.html` — **locked** H3 hero (aligned score + mobile).

--- a/docs/design/mockups/phase-5-article-detail/match-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/match-locked.md
@@ -1,0 +1,85 @@
+# Locked — matchPreview / matchRecap article body (5.d-mat)
+
+**Status:** Locked 2026-06-05 · **Issue:** #1791 · **Drill:** `5d-mat/` (rounds 1–3)
+**Builds in:** #1470 (article variants) · **Sibling:** #1914 (match-page `<MatchArticleLinkCard>`)
+
+## Decision summary
+
+The `matchPreview` / `matchRecap` article **does not re-render** lineups, the
+full event timeline, or stats — those stay canonical on `/wedstrijd/[matchId]`
+(Phase 6.B). The article body is **editorial prose + a compact card that links
+to the match**, plus (recap only) a **goals-only** scorer list.
+
+Composition (top → bottom):
+
+```text
+<EditorialHero variant="matchPreview|matchRecap">   ← announcement-shape hero,
+                                                       kicker VOORBESCHOUWING /
+                                                       MATCHVERSLAG (per #1470)
+<ArticleBody>                                        ← editorial prose
+<MatchCard>                                          ← Round 1 = Variant C
+[recap only] <Doelpunten>                            ← Round 2 = V3, sided
+```
+
+## Round 1 — match card = **Variant C (taped result card)**
+
+A `<TapedCard>`-based card, whole-card link to `/wedstrijd/[matchId]`:
+
+- Washi **tape** strip on the top-left corner; slight paper rotation (`-0.6°`);
+  `shadow-paper-lift`; canonical **press-down hover**
+  (`hover:shadow-none hover:translate-x-1 hover:translate-y-1`, `duration-300`).
+- **Top:** mono kicker `competition · short-date`. `<MatchStatusBadge>` as a
+  **corner stamp** top-right (it self-hides for `scheduled`, so preview shows none).
+- **Middle:** symmetric 3-col row — `[home crest + name] [score|time] [name + away crest]`.
+  Recap → `font-display-big` score (e.g. `2–1`); preview → kickoff `15:00` (or `vs`).
+- **Foot:** `venue` (left) · `naar wedstrijd →` mono CTA (right).
+- **Reuse:** `<TapedCard>`, `<MatchStatusBadge>`, `<Crest>`, `<MonoLabel>` — no new primitive.
+- Distinct from `<MatchTeaser>` (date-stub-led, asymmetric) by being **symmetric + tape-led**.
+
+## Round 2 — recap goalscorers = **V3, sided "Doelpunten" block**
+
+Below card C on **recap only** (preview has no goals → card C alone):
+
+- A `Doelpunten.` `<EditorialHeading>`-style italic display heading + 2px ink rule.
+- The list **reuses `<MatchEvents filter="goals">`** — its Option-F sided rows
+  (home left / away right, central football glyph, minute on the far left).
+  Goals-only (no cards/subs) keeps it lighter than and distinct from the match
+  page's full timeline.
+- KCVV scorers rendered in `jersey-deep`; opponent in ink. Penalty / own-goal
+  carry a small mono `pen` / `e.d.` tag (from `event.isPenalty` / `isOwnGoal`).
+- **Football glyph = the existing `<MatchEvents>` goal SVG (cream ball + ink
+  pentagons), NOT an emoji** (icons-over-emojis rule).
+
+## Data reality (audited — drives the "no inline duplication" decision)
+
+`MatchDetail` (BFF, `getMatchDetail`) provides: teams (+logo, +score), date,
+venue, competition, status, optional `lineup`, optional `events` (goals/cards/
+subs w/ minute + player), `hasReport`. **No statistics** (possession/shots/xG)
+exist in the schema. Previews have **no** score/events/lineup (not played yet).
+→ A preview can only show fixture basics; a recap can show score + goals. Mocking
+"preview lineups" or a "stats grid" would fabricate data (forbidden).
+
+## Implementation notes (for #1470)
+
+- The card + Doelpunten are **presentational** (props-only) so they're Storybook/
+  VR-able; the page server-fetches via `BffService.getMatchDetail(linkedMatch)`
+  and feeds them. Article renders without the card if the match 404s.
+- `matchPreview`/`matchRecap` excluded from `generateStaticParams` (on-demand ISR)
+  so match data renders server-side without per-article PSD hits at build.
+- Goals for the roll-call = `events.filter(type === "goal")`.
+
+## Reuse map
+
+| Element | Reuses |
+| --- | --- |
+| Card shell | `<TapedCard>` (tape, rotation, press-down) |
+| Status stamp | `<MatchStatusBadge>` |
+| Team crests | `<Crest>` |
+| Kicker / labels | `<MonoLabel>` |
+| Doelpunten rows | `<MatchEvents filter="goals">` |
+
+## Mockups
+
+- `5d-mat/round-1-card-shape-comparisons.html` — A/B/C card directions.
+- `5d-mat/round-2-goalscorer-rollcall.html` — V1/V2/V3 roll-call attachments.
+- `5d-mat/round-3-final-locked.html` — locked composition (card C + sided Doelpunten), recap + preview.

--- a/docs/design/mockups/phase-5-article-detail/match-locked.md
+++ b/docs/design/mockups/phase-5-article-detail/match-locked.md
@@ -43,13 +43,19 @@ Below card C on **recap only** (preview has no goals → card C alone):
 - **Gap from card C → Doelpunten: `30px`** (`mt-[30px]`) — the scorer list reads as
   a distinct section, not attached to the card.
 - A `Doelpunten.` `<EditorialHeading>`-style italic display heading + 2px ink rule.
-- The list **reuses `<MatchEvents filter="goals">`** — its Option-F sided rows
-  (home left / away right, central football glyph, minute on the far left).
+- The list **reuses `<MatchEvents filter="goals">`** — its Option-F rows
+  (minute on the far left, then a **sided** glyph: home events render their glyph
+  on the **left**, away events on the **right**; the opposite side stays empty).
   Goals-only (no cards/subs) keeps it lighter than and distinct from the match
   page's full timeline.
-- KCVV scorers rendered in `jersey-deep`; opponent in ink. Penalty / own-goal
-  carry a small mono `pen` / `e.d.` tag (from `event.isPenalty` / `isOwnGoal`).
-- **Football glyph = the existing `<MatchEvents>` goal SVG (cream ball + ink
+- **Scorer names render in `text-ink` italic display** (MatchEvents' default — it
+  does **not** tint per team). Highlighting KCVV scorers in `jersey-deep` is a
+  desired delta that requires a small `highlightTeam` prop addition to
+  `<MatchEvents>` in #1470; it is **not** free from the current component.
+- **Penalty → `(strafschop)`** and **own-goal → `(e.d.)`** render as
+  parenthesized text after the name (from `event.isPenalty` / `event.isOwnGoal`);
+  own-goal uses `text-alert` (red), penalty uses `text-ink-muted` — **not** a mono tag.
+- **Goal glyph = the existing `<MatchEvents>` goal SVG (cream ball + ink
   pentagons), NOT an emoji** (icons-over-emojis rule).
 
 ## Data reality (audited — drives the "no inline duplication" decision)


### PR DESCRIPTION
Closes #1791

## What

Design lock for the `matchPreview` / `matchRecap` article body (drill 5.d-mat). Docs-only.

The article body = editorial hero → prose → a **taped result card** (Variant C) that links to `/wedstrijd/[matchId]`; **recap** adds a goals-only **"Doelpunten"** section reusing `<MatchEvents filter="goals">` (sided home/away). **No inline lineups/stats** — those stay canonical on the match page (avoids duplicating `/wedstrijd`).

This was driven by a data-reality audit: `MatchDetail` has no statistics, and previews have no score/events/lineup — so a rich symmetric body block (the original 4 options) would have fabricated data.

## Deliverables

- `5d-mat/round-1-card-shape-comparisons.html` — card directions A/B/C → **C locked**
- `5d-mat/round-2-goalscorer-rollcall.html` — roll-call V1/V2/V3 → **V3 (sided) locked**
- `5d-mat/round-3-final-locked.html` — locked composition (recap + preview)
- `match-locked.md` — the lock + reuse map + implementation notes for #1470

## Unblocks

#1470 (build the schema + EditorialHero variants + card C + Doelpunten to this lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 5 design specs and static mockups illustrating three match-card shape variants (A–C) for preview and recap modes.
  * Added a goalscorer roll-call mockup (recap) with three layout options and an alternate “Doelpunten” goals list presentation.
  * Added a locked-card mockup and a matching design specification detailing taped-card behavior, recap goals layout, and hero composition options (H1/H2/H3) for preview vs recap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->