### PR TITLE
docs(sponsors): Phase 7 /sponsors redesign — design checkpoint + PRD (#1529)

### DIFF
--- a/docs/design/mockups/phase-7-sponsors/7-design-summary-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/7-design-summary-locked.md
@@ -1,0 +1,119 @@
+# Phase 7 · /sponsors — DESIGN SUMMARY (LOCKED)
+
+**Date:** 2026-06-07
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7 master)
+**Supersedes (on landing):** `docs/prd/sponsors-redesign.md`
+**Drill record:** `7d0`…`7d5` lock docs + `*-compare.html` in this folder (authoritative for design).
+
+The `/sponsors` redesign in the retro-terrace-fanzine system. Register: **grateful, warm,
+gracious** — never a sales funnel. Every choice maps to an approved primitive.
+
+---
+
+## 1. Final page spine
+
+```text
+/sponsors  (cream paper field, newsprint grain)
+├─ <SponsorHero>  (split)
+│   ├─ left:  MonoLabel kicker "ER IS MAAR ÉÉN PLEZANTE COMPAGNIE"
+│   │         + EditorialHeading "Merci aan onze sponsors." (italic display, jersey-deep period)
+│   │         + italic-display lead
+│   └─ right: <FeaturedSponsorCard> — ONE marquee, "In de kijker" jersey tab
+│             → when 0 featured: left column goes full-width, no card
+├─ <StripedSeam>  (colorPair ink-cream, height md)
+├─ Hoofdsponsors  (the ONLY tier label — MonoLabel kicker + paper-edge rule)
+│   └─ <TapedCardGrid cols=3>  large taped tiles: logo + italic name caption
+├─ [unlabeled wall]  sponsor + sympathisant merged, NO header
+│   └─ dense grid (reuse homepage SponsorTile): logo only, name = missing-logo fallback
+└─ <StripedSeam> → <SponsorCtaBand>  (jersey-deep-dark footer band)
+        "Ook jouw zaak langs de lijn?" + sub-line + warm "Word sponsor +" paper-stamp
+```
+
+## 2. Locked decisions (index)
+
+| Round | Lock                                                                                                                                        |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 7.d0  | Data reality: 3 Dutch tiers, logo/tier optional, `description` featured-only, hero is a sibling (NOT EditorialHero generic), spotlight kept |
+| 7.d1  | Voice = A·Merci (grateful) + D's prominent featured card                                                                                    |
+| 7.d2  | Featured = single marquee in hero; pick = highest-tier-then-name; collapse on 0                                                             |
+| 7.d3  | Tier treatment = label only "Hoofdsponsors"; sponsor+sympathisant merge into one unlabeled wall                                             |
+| 7.d4  | CTA = jersey-deep-dark footer band; full page spine                                                                                         |
+| 7.d5  | Featured chrome = light body + jersey "In de kijker" tab (no dingbat)                                                                       |
+
+## 3. Derived detail specs (mapped to primitives — NOT re-drilled)
+
+- **Type scale:** headline via `<EditorialHeading>` (italic-display, period-terminated). Kickers
+  via `<MonoLabel>` (mono caps, 0.18em tracking). Lead = `font-display` italic. Name captions =
+  `font-display` italic. Wall/caption micro-text = mono.
+- **Hover (canonical press-down, `feedback_canonical_press_down_hover`):** every clickable tile +
+  the CTA button + the featured-card link: `hover:shadow-none hover:translate-x-1
+hover:translate-y-1 transition-all duration-300`.
+- **Greyscale→colour (master-plan decision 16, as in `<SponsorsBlock>`):** `grayscale
+group-hover:grayscale-0 group-focus-visible:grayscale-0 transition-all duration-300
+motion-reduce:transition-none` on every logo `<Image>`.
+- **Border / divider triples** `{weight, color-token, opacity}`:
+  - Hoofd tile frame: `2px · --color-ink · 1` + `--shadow-paper` offset.
+  - Wall tile frame: `1.5px · --color-ink · 1` (no shadow — flatter, denser).
+  - Featured card frame: `2px · --color-ink · 1`; tab bottom: `2px · --color-ink · 1`.
+  - Tier-kicker rule: `2px · --color-paper-edge · 1`.
+  - Footer band top+bottom: `2px · --color-ink · 1`.
+  - Section seams: `<StripedSeam colorPair="ink-cream" height="md">`.
+- **Focus ring:** `focus-visible:outline-2 focus-visible:outline-offset-2
+focus-visible:outline-jersey-deep` (as in `<SponsorsBlock>`).
+- **Contrast:** small text on jersey-deep / jersey-deep-dark uses `text-white` (cream is <AA there
+  — Phase 6.C rule). The "In de kijker" tab + footer band copy follow this.
+
+## 4. Empty states
+
+- **0 sponsors total:** hero headline-only (no marquee) → reskinned `<SponsorEmptyState>` →
+  footer band. No empty grids/labels.
+- **0 hoofdsponsors:** drop the "Hoofdsponsors" label + taped grid; render only the wall.
+- **0 in wall (only hoofd):** drop the wall; hoofd grid + footer band.
+- **0 featured:** hero left column full-width (locked 7.d2).
+
+## 5. Build deltas (PRD seed)
+
+**Components — new (all under `apps/web/src/components/sponsors/`):**
+
+- `<SponsorHero>` — sibling hero (kicker + EditorialHeading + lead + optional `<FeaturedSponsorCard>`).
+- `<FeaturedSponsorCard>` — F3 tab+body marquee card.
+- `<SponsorCtaBand>` — jersey-deep-dark footer band (or fold into a reskinned `<SponsorCallToAction>`).
+
+**Components — reskin / reuse:**
+
+- `<SponsorsPage>` — rebuilt composition; drop `SectionStack` + `diagonal` + `getSponsorsSections`
+  - dark `kcvv-black` header (legacy tokens). Use `<StripedSeam>`.
+- Hoofd grid → `<TapedCardGrid>` of a tile (logo + italic name).
+- Wall → reuse/extract the homepage `<SponsorsBlock>`'s `SponsorTile` (already redesign-ready) as a
+  shared `<SponsorTile>` so /sponsors + homepage share one tile.
+- `formatSponsorAlt` — reuse for alt text.
+
+**Components — retire (legacy, no redesign consumer after this):**
+
+- `<SponsorsSpotlight>` (carousel, `kcvv-green-dark`), `<SponsorGrid>`, `<SponsorCard>`,
+  `<SponsorLogo>` (size/showNames API) — verify consumers, then delete with stories/tests.
+- `getSponsorsSections` + its `SectionStack`/`diagonal` usage.
+
+**Data / repository:** `SPONSORS_QUERY` already projects `id, name, url, type, tier, featured,
+description, logoUrl` — sufficient. Consider a larger `logoUrl` (`w=600`) for the marquee + hoofd
+tiles (currently `w=400`). The legacy hidden `type` fallback bucketing may be dropped (untiered →
+sympathisant/wall).
+
+**Analytics (required — `feedback_analytics_prd_requirement`):** events `sponsor_view`
+(page view), `sponsor_click` (tile → params: tier, hashed id), `sponsor_featured_click`,
+`sponsor_cta_click`. **Add `sponsor_` to the live GTM Custom-Event trigger regex** (manual step,
+call out in PR). No PII — hash any internal id.
+
+**SEO:** keep breadcrumb JSON-LD; metadata exists. Optional `ItemList` JSON-LD of sponsors.
+
+**Testing:** component stories + `vr` tag + baselines for `<SponsorHero>`,
+`<FeaturedSponsorCard>`, `<SponsorTile>`, `<SponsorCtaBand>`, tier grid (state coverage:
+featured/no-featured, hoofd-empty, wall-empty, all-empty). Pages/\* story (not vr) + e2e smoke
+already covers `/sponsors`.
+
+## 6. Open for PRD time (not design)
+
+- Exact footer-band copy + sub-line wording.
+- Whether `<SponsorCtaBand>` is a new component or a reskinned `<SponsorCallToAction>`.
+- `logoUrl` width bump decision.

--- a/docs/design/mockups/phase-7-sponsors/7-final-page.html
+++ b/docs/design/mockups/phase-7-sponsors/7-final-page.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /sponsors · FINAL locked page</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .tagstrip { background: var(--ink); color: var(--cream); font-family: var(--font-mono); font-size: 12px; padding: 9px 28px; letter-spacing: 0.04em; }
+      .tagstrip b { color: var(--warm); }
+      .wrap { max-width: 1080px; margin: 0 auto; padding: 0 28px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .swatch { width: 24px; height: 24px; border: 1px solid var(--ink); flex: none; filter: grayscale(1); transition: filter .3s; }
+      .tile:hover .swatch, .fc:hover .swatch { filter: grayscale(0); }
+
+      /* hero */
+      .hero { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 38px; align-items: end; padding: 56px 0 18px; }
+      .hero h1 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(40px,5.4vw,72px); line-height: 0.9; margin: 14px 0 0; letter-spacing: -0.01em; }
+      .hero h1 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 20px; line-height: 1.5; margin: 18px 0 0; color: var(--ink-soft); max-width: 46ch; }
+      /* F3 featured card */
+      .fc { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); }
+      .fc .tab { background: var(--jersey-deep); color: var(--cream); font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; padding: 9px 16px; border-bottom: 2px solid var(--ink); }
+      .fc .body { padding: 18px 22px 20px; }
+      .fc .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 20px; margin: 2px 0 12px; min-height: 60px; display:flex; align-items:center; justify-content:center; }
+      .fc .logo-box .swatch { width: 28px; height: 28px; }
+      .fc .fname { font-family: var(--font-display); font-style: italic; font-size: 22px; }
+      .fc .blurb { font-size: 13px; line-height: 1.5; color: var(--ink-soft); margin-top: 6px; }
+      .fc .visit { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--jersey-deep); margin-top: 12px; display: inline-block; }
+
+      /* seam */
+      .seam { height: 16px; margin: 30px 0 0; background:
+        repeating-linear-gradient(135deg, var(--ink) 0 10px, var(--cream) 10px 20px);
+        border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); opacity: 0.92; }
+
+      /* hoofd */
+      .tier-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); display: flex; align-items: center; gap: 12px; margin: 36px 0 16px; }
+      .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .gmain { display: grid; grid-template-columns: repeat(3,1fr); gap: 20px; }
+      .gmain .tile { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); padding: 22px 14px 12px; text-align: center; transition: all .3s; }
+      .gmain .tile:nth-child(1){transform:rotate(-0.4deg)} .gmain .tile:nth-child(2){transform:rotate(0.3deg)} .gmain .tile:nth-child(3){transform:rotate(0.5deg)} .gmain .tile:nth-child(4){transform:rotate(-0.25deg)}
+      .gmain .tile:hover { box-shadow: none; transform: translate(4px,4px); }
+      .gmain .lb { display:flex; align-items:center; justify-content:center; min-height: 50px; } .gmain .swatch { width: 30px; height: 30px; }
+      .gmain .cap { font-family: var(--font-display); font-style: italic; font-size: 15px; margin-top: 10px; }
+
+      /* wall */
+      .wall { display: grid; grid-template-columns: repeat(6,1fr); gap: 12px; margin-top: 26px; }
+      .wall .tile { background: var(--cream-soft); border: 1.5px solid var(--ink); padding: 16px 10px; text-align: center; transition: all .3s; }
+      .wall .tile:hover { transform: translate(2px,2px); }
+      .wall .lb { display:flex; align-items:center; justify-content:center; min-height: 34px; } .wall .swatch { width: 20px; height: 20px; }
+      .wall .nm { font-family: var(--font-display); font-style: italic; font-size: 12px; color: var(--ink-muted); }
+
+      /* footer band */
+      .cta { margin-top: 50px; background: var(--jersey-deep-dark); color: var(--cream); border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); padding: 46px 0; }
+      .cta .inner { max-width: 1080px; margin: 0 auto; padding: 0 28px; display: flex; justify-content: space-between; align-items: center; gap: 24px; flex-wrap: wrap; }
+      .cta h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 32px; margin: 0; }
+      .cta p { margin: 8px 0 0; color: rgba(245,241,230,0.8); font-size: 14px; max-width: 48ch; }
+      .cta .pill { display: inline-block; font-family: var(--font-mono); font-weight: 700; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; border: 2px solid var(--ink); padding: 14px 24px; background: var(--warm); color: var(--ink); box-shadow: 4px 4px 0 0 var(--ink); }
+    </style>
+  </head>
+  <body>
+    <div class="tagstrip">Phase 7 · /sponsors — <b>FINAL locked page</b> · A·Merci + F3 featured tab · placeholder logos (hover for colour) · all locks 7.d0–7.d5</div>
+
+    <div class="wrap">
+      <!-- HERO -->
+      <div class="hero">
+        <div>
+          <div class="kicker">Er is maar één plezante compagnie</div>
+          <h1>Merci aan onze sponsors<span class="dot">.</span></h1>
+          <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking. KCVV Elewijt draait op de steun van wie mee aan de zijlijn staat.</p>
+        </div>
+        <div class="fc">
+          <div class="tab">In de kijker</div>
+          <div class="body">
+            <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+            <div class="fname">Garage Peeters</div>
+            <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen voor het hele seizoen.</div>
+            <a class="visit" href="#">Bezoek website ↗</a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="seam"></div>
+
+    <div class="wrap">
+      <!-- HOOFD -->
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+
+      <!-- WALL (unlabeled) -->
+      <div class="wall">
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#7a4ea0"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#2f8f5b"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#b0562e"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#3a7abd"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#c93f1c"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#2e6fb0"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#888"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#999"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#777"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+        <div class="tile"><div class="lb"><span class="swatch" style="background:#929292"></span></div></div>
+        <div class="tile"><div class="lb"><span class="nm">Café De Zwaan</span></div></div>
+      </div>
+    </div>
+
+    <!-- FOOTER CTA BAND -->
+    <div class="cta">
+      <div class="inner">
+        <div>
+          <h2>Ook jouw zaak langs de lijn?</h2>
+          <p>Word sponsor en steun mee de club, de jeugd en de toekomst van KCVV Elewijt.</p>
+        </div>
+        <a class="pill" href="#">Word sponsor +</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-sponsors/7d1-voice-compare.html
+++ b/docs/design/mockups/phase-7-sponsors/7d1-voice-compare.html
@@ -1,0 +1,339 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /sponsors · Round 1: VOICE compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Freight is Typekit-only; Fraunces is the closest free editorial serif for mockup fidelity -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6;
+        --cream-soft: #ede8da;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #008755;
+        --jersey-deep-dark: #133d28;
+        --warm: #f0c264;
+        --brick: #c93f1c;
+        --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, "Times New Roman", serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+
+      /* ---------- compare-harness chrome (NOT part of the design) ---------- */
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0 0 4px; font-size: 13px; color: #b9b9b9; max-width: 80ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar {
+        position: sticky; top: 0; z-index: 50;
+        background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px;
+        letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink);
+      }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 0 0 8px; }
+
+      /* ---------- shared design tokens-as-classes ---------- */
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; }
+      .wrap { max-width: 1080px; margin: 0 auto; padding: 0 28px; }
+      .logo-box {
+        display: flex; align-items: center; justify-content: center; gap: 8px;
+        font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+        color: var(--ink-muted); text-align: center; line-height: 1.2;
+      }
+      .swatch { width: 18px; height: 18px; border: 1px solid var(--ink); flex: none; filter: grayscale(1); transition: filter .3s; }
+      .tile:hover .swatch, .board:hover .swatch { filter: grayscale(0); }
+      .cap { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--ink-muted); }
+      .cta-pill {
+        display: inline-block; font-family: var(--font-mono); font-weight: 700; font-size: 13px;
+        letter-spacing: 0.08em; text-transform: uppercase; border: 2px solid var(--ink);
+        padding: 11px 20px; background: var(--warm); color: var(--ink); box-shadow: 4px 4px 0 0 var(--ink);
+      }
+
+      /* ======================================================
+         A · MERCI — grateful terrace thank-you
+      ====================================================== */
+      .dir-a { background: var(--cream); padding: 56px 0 44px; }
+      .dir-a .kicker { color: var(--jersey-deep); }
+      .dir-a h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(40px, 6vw, 76px); line-height: 0.92; margin: 14px 0 0; letter-spacing: -0.01em; }
+      .dir-a h2 .dot { color: var(--jersey-deep); }
+      .dir-a .lead { font-family: var(--font-display); font-size: 20px; line-height: 1.5; max-width: 60ch; margin: 20px 0 0; color: var(--ink-soft); }
+      .dir-a .tier-kicker { margin-top: 44px; color: var(--ink-muted); display: flex; align-items: center; gap: 12px; }
+      .dir-a .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .dir-a .grid-main { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-top: 18px; }
+      .dir-a .grid-second { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-top: 14px; }
+      .dir-a .tile { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); padding: 22px 14px 12px; text-align: center; }
+      .dir-a .grid-main .tile { transform: rotate(-0.4deg); }
+      .dir-a .grid-main .tile:nth-child(2) { transform: rotate(0.3deg); }
+      .dir-a .grid-main .tile:nth-child(3) { transform: rotate(0.5deg); }
+      .dir-a .tile .logo-box { min-height: 56px; font-size: 13px; }
+      .dir-a .grid-second .tile .logo-box { min-height: 38px; font-size: 11px; }
+      .dir-a .tile .swatch { width: 22px; height: 22px; }
+      .dir-a .tile .name { font-family: var(--font-display); font-style: italic; font-size: 14px; margin-top: 8px; }
+      .dir-a .footer-cta { margin-top: 40px; }
+
+      /* ======================================================
+         B · EREBLAD — printed honour-board / programme back-page
+      ====================================================== */
+      .dir-b { background: var(--cream); padding: 52px 0 44px; }
+      .dir-b .masthead { border-top: 3px solid var(--ink); border-bottom: 1px solid var(--ink); padding: 8px 0; display: flex; justify-content: space-between; align-items: baseline; }
+      .dir-b .masthead .kicker { color: var(--ink); }
+      .dir-b h2 { font-family: var(--font-display); font-weight: 900; font-size: clamp(36px, 5vw, 60px); line-height: 1; margin: 22px 0 0; text-align: center; letter-spacing: -0.01em; }
+      .dir-b .rule2 { border-bottom: 3px double var(--ink); margin: 14px 0 6px; }
+      .dir-b .sub { text-align: center; font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-muted); }
+      .dir-b .ledger { margin-top: 34px; border: 2px solid var(--ink); }
+      .dir-b .ledger-band { background: var(--ink); color: var(--cream); font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; padding: 7px 12px; }
+      .dir-b .rowmain { display: grid; grid-template-columns: repeat(2, 1fr); }
+      .dir-b .rowsecond { display: grid; grid-template-columns: repeat(4, 1fr); }
+      .dir-b .rowreg { display: grid; grid-template-columns: repeat(6, 1fr); }
+      .dir-b .cell { border-right: 1px solid var(--ink); border-bottom: 1px solid var(--ink); padding: 20px 10px; text-align: center; }
+      .dir-b .rowmain .cell { padding: 34px 10px; }
+      .dir-b .rowreg .cell { padding: 13px 8px; }
+      .dir-b .cell .swatch { width: 20px; height: 20px; }
+      .dir-b .cell .name { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--ink-soft); margin-top: 7px; }
+      .dir-b .footer-cta { margin-top: 34px; text-align: center; }
+
+      /* ======================================================
+         C · RECLAMEBORDEN — pitchside advertising boards
+      ====================================================== */
+      .dir-c { background: var(--jersey-deep-dark); color: var(--cream); padding: 52px 0 46px; position: relative; overflow: hidden; }
+      .dir-c::before { content: ""; position: absolute; inset: 0; background: radial-gradient(120% 80% at 50% -10%, rgba(74,207,82,0.16), transparent 60%); pointer-events: none; }
+      .dir-c .kicker { color: var(--warm); }
+      .dir-c h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(38px, 5.5vw, 66px); line-height: 0.95; margin: 14px 0 0; color: var(--cream); }
+      .dir-c .lead { font-size: 16px; max-width: 56ch; margin: 16px 0 0; color: rgba(245,241,230,0.72); line-height: 1.55; }
+      .dir-c .boards { margin-top: 40px; display: flex; flex-direction: column; gap: 14px; }
+      .dir-c .board-band { display: flex; align-items: center; gap: 10px; }
+      .dir-c .band-label { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: rgba(245,241,230,0.55); width: 92px; flex: none; }
+      .dir-c .board-row { display: flex; gap: 12px; flex: 1; }
+      .dir-c .board { flex: 1; background: var(--cream); color: var(--ink); border: 2px solid var(--ink); box-shadow: 0 4px 0 0 rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.04em; }
+      .dir-c .board-main { height: 78px; font-size: 13px; }
+      .dir-c .board-second { height: 54px; }
+      .dir-c .board-reg { height: 34px; font-size: 10px; }
+      .dir-c .board .swatch { width: 20px; height: 20px; }
+      .dir-c .footer-cta { margin-top: 38px; }
+      .dir-c .cta-pill { background: var(--jersey); box-shadow: 4px 4px 0 0 #000; }
+
+      /* ======================================================
+         D · PARTNERS — partnership / recruitment-forward
+      ====================================================== */
+      .dir-d { background: var(--cream); padding: 52px 0 44px; }
+      .dir-d .split { display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 36px; align-items: center; }
+      .dir-d .kicker { color: var(--jersey-deep); }
+      .dir-d h2 { font-family: var(--font-display); font-weight: 900; font-size: clamp(38px, 5vw, 64px); line-height: 0.96; margin: 14px 0 0; }
+      .dir-d h2 em { font-style: italic; color: var(--jersey-deep); }
+      .dir-d .lead { font-size: 16px; line-height: 1.6; max-width: 48ch; margin: 18px 0 24px; color: var(--ink-soft); }
+      .dir-d .cta-row { display: flex; gap: 14px; align-items: center; }
+      .dir-d .cta-row .ghost { font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); }
+      .dir-d .feature-card { background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 24px; transform: rotate(-0.5deg); }
+      .dir-d .feature-card .kicker { color: var(--warm); }
+      .dir-d .feature-card .logo-box { background: var(--cream); color: var(--ink); border: 2px solid var(--ink); padding: 22px; margin: 14px 0; min-height: 70px; }
+      .dir-d .feature-card .swatch { width: 26px; height: 26px; }
+      .dir-d .feature-card .fname { font-family: var(--font-display); font-style: italic; font-size: 22px; }
+      .dir-d .feature-card .blurb { font-size: 13px; line-height: 1.5; color: rgba(245,241,230,0.78); margin-top: 6px; }
+      .dir-d .proof { margin-top: 44px; }
+      .dir-d .proof .tier-kicker { color: var(--ink-muted); display: flex; align-items: center; gap: 12px; }
+      .dir-d .proof .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .dir-d .proof-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; margin-top: 14px; }
+      .dir-d .proof-grid .tile { background: var(--cream-soft); border: 1.5px solid var(--ink); padding: 14px 8px; text-align: center; }
+      .dir-d .proof-grid .swatch { width: 16px; height: 16px; }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 22px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend b { font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /sponsors — Round 1: VOICE</h1>
+      <p>
+        Four registers for the sponsors page. Placeholder local-business names + greyscale
+        swatches stand in for real logos (voice round = chrome/tone, not final fields). Every
+        direction obeys the locked data reality: logos primary, greyscale→hover-colour,
+        name fallback, 3 tiers (hoofdsponsor / sponsor / sympathisant), "In de kijker" band kept
+        but deferred. See <a href="./data-reality-locked.md">data-reality-locked.md</a>.
+      </p>
+      <p>Hover any swatch to preview the greyscale→colour reveal.</p>
+    </div>
+
+    <!-- ============ A · MERCI ============ -->
+    <div class="direction-bar"><span class="tag">A</span> Merci — grateful terrace <span class="note">warmth-led; gratitude is the organizing emotion</span></div>
+    <section class="stage dir-a">
+      <div class="wrap">
+        <div class="kicker">Er is maar één plezante compagnie</div>
+        <h2>Merci aan onze sponsors<span class="dot">.</span></h2>
+        <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking. KCVV Elewijt
+          draait op de steun van lokale partners die mee aan de zijlijn staan — wedstrijd na
+          wedstrijd, seizoen na seizoen.</p>
+
+        <div class="kicker tier-kicker">Hoofdsponsors</div>
+        <div class="grid-main">
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="name">Garage Peeters</div></div>
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="name">Bouwwerken Van Assche</div></div>
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="name">Immo Zennevallei</div></div>
+        </div>
+
+        <div class="kicker tier-kicker">Sponsors</div>
+        <div class="grid-second">
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div></div>
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div></div>
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div></div>
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div></div>
+          <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c93f1c"></span></div></div>
+        </div>
+
+        <div class="footer-cta"><span class="cta-pill">Word sponsor +</span></div>
+      </div>
+    </section>
+
+    <!-- ============ B · EREBLAD ============ -->
+    <div class="direction-bar"><span class="tag">B</span> Ereblad — programme back-page <span class="note">institutional record; dense thin-ink ledger, logos as the archive</span></div>
+    <section class="stage dir-b">
+      <div class="wrap">
+        <div class="masthead">
+          <span class="kicker">KCVV Elewijt</span>
+          <span class="kicker">Seizoen 25/26</span>
+        </div>
+        <h2>Onze sponsors.</h2>
+        <div class="rule2"></div>
+        <div class="sub">Met dank aan wie de club mee draagt</div>
+
+        <div class="ledger">
+          <div class="ledger-band">Hoofdsponsors</div>
+          <div class="rowmain">
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="name">Garage Peeters</div></div>
+            <div class="cell" style="border-right:none"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="name">Bouwwerken Van Assche</div></div>
+          </div>
+          <div class="ledger-band">Sponsors</div>
+          <div class="rowsecond">
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div><div class="name">Immo Zennevallei</div></div>
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div><div class="name">Frituur 't Pleintje</div></div>
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div><div class="name">Apotheek Centrum</div></div>
+            <div class="cell" style="border-right:none"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div><div class="name">Slagerij Janssens</div></div>
+          </div>
+          <div class="ledger-band">Sympathisanten</div>
+          <div class="rowreg">
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#888"></span></div></div>
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#999"></span></div></div>
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#777"></span></div></div>
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+            <div class="cell"><div class="logo-box"><span class="swatch" style="background:#929292"></span></div></div>
+            <div class="cell" style="border-right:none"><div class="logo-box"><span class="name" style="margin:0">Café De Zwaan</span></div></div>
+          </div>
+        </div>
+        <div class="footer-cta"><span class="cta-pill" style="background:var(--cream-soft)">Word sponsor +</span></div>
+      </div>
+    </section>
+
+    <!-- ============ C · RECLAMEBORDEN ============ -->
+    <div class="direction-bar"><span class="tag">C</span> Reclameborden — pitchside boards <span class="note">terrace/matchday metaphor; logos as advertising boards, floodlight colour-reveal</span></div>
+    <section class="stage dir-c">
+      <div class="wrap">
+        <div class="kicker">Langs de lijn</div>
+        <h2>Zij staan langs de lijn.</h2>
+        <p class="lead">Elke wedstrijd staan ze rond het veld. De borden van wie KCVV Elewijt
+          mogelijk maakt — van hoofdsponsor tot sympathisant.</p>
+
+        <div class="boards">
+          <div class="board-band">
+            <span class="band-label">Hoofdsponsors</span>
+            <div class="board-row">
+              <div class="board board-main"><span class="swatch" style="background:#c0392b"></span> Garage Peeters</div>
+              <div class="board board-main"><span class="swatch" style="background:#2e6fb0"></span> Bouwwerken Van Assche</div>
+            </div>
+          </div>
+          <div class="board-band">
+            <span class="band-label">Sponsors</span>
+            <div class="board-row">
+              <div class="board board-second"><span class="swatch" style="background:#e0a020"></span> Immo</div>
+              <div class="board board-second"><span class="swatch" style="background:#2f8f5b"></span> Frituur</div>
+              <div class="board board-second"><span class="swatch" style="background:#b0562e"></span> Apotheek</div>
+              <div class="board board-second"><span class="swatch" style="background:#3a7abd"></span> Slagerij</div>
+            </div>
+          </div>
+          <div class="board-band">
+            <span class="band-label">Sympathisanten</span>
+            <div class="board-row">
+              <div class="board board-reg"><span class="swatch" style="background:#888"></span></div>
+              <div class="board board-reg"><span class="swatch" style="background:#999"></span></div>
+              <div class="board board-reg"><span class="swatch" style="background:#777"></span></div>
+              <div class="board board-reg"><span class="swatch" style="background:#8a8a8a"></span></div>
+              <div class="board board-reg">Café De Zwaan</div>
+            </div>
+          </div>
+        </div>
+        <div class="footer-cta"><span class="cta-pill">Zet jouw bord langs de lijn +</span></div>
+      </div>
+    </section>
+
+    <!-- ============ D · PARTNERS ============ -->
+    <div class="direction-bar"><span class="tag">D</span> Partners — recruitment-forward <span class="note">page sells sponsorship; CTA in hero, existing sponsors as social proof</span></div>
+    <section class="stage dir-d">
+      <div class="wrap">
+        <div class="split">
+          <div>
+            <div class="kicker">Partner worden</div>
+            <h2>Word <em>partner</em> van KCVV.</h2>
+            <p class="lead">Bereik elke week honderden supporters, ouders en buurtbewoners.
+              Steun de jeugd en zet jouw zaak in de kijker — van bord langs de lijn tot
+              hoofdsponsor.</p>
+            <div class="cta-row">
+              <span class="cta-pill">Word sponsor +</span>
+              <span class="ghost">of bekijk onze partners ↓</span>
+            </div>
+          </div>
+          <div class="feature-card">
+            <div class="kicker">In de kijker</div>
+            <div class="logo-box"><span class="swatch" style="background:#c0392b;width:26px;height:26px"></span></div>
+            <div class="fname">Garage Peeters</div>
+            <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen voor het
+              hele seizoen.</div>
+          </div>
+        </div>
+
+        <div class="proof">
+          <div class="kicker tier-kicker">Onze partners</div>
+          <div class="proof-grid">
+            <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div></div>
+            <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div></div>
+            <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div></div>
+            <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div></div>
+            <div class="tile"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div></div>
+            <div class="tile"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="legend">
+      <b>How to read these:</b> all four reuse approved primitives (EditorialHeading,
+      MonoLabel kickers, TapedCard/TapedCardGrid tiles, the SponsorsBlock dense grid,
+      paper-stamp CTA). Net-new vocabulary flagged as deltas:<br />
+      • <b>C</b> introduces a wide "advertising-board" tile + a jersey-deep-dark page field —
+      net-new shape, biggest departure from the cream-paper system.<br />
+      • <b>D</b> foregrounds recruitment + an editorial feature card (the kept "In de kijker"
+      band, pulled into the hero) — most commercial register.<br />
+      • <b>A</b> and <b>B</b> stay entirely inside the existing cream-paper vocabulary;
+      A is warm/rotated, B is dense/orthogonal-ledger.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-sponsors/7d1-voice-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/7d1-voice-locked.md
@@ -1,0 +1,46 @@
+# Phase 7 · /sponsors — Round 1 (VOICE) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7d1-voice-compare.html`
+**Owner:** @climacon
+
+## Decision
+
+**Voice = Direction A "Merci" (grateful terrace) + Direction D's prominent featured card.**
+
+The `/sponsors` page adopts a **warm gratitude register** inside the existing cream-paper
+vocabulary, with **one borrowed element from D**: the "In de kijker" featured partner gets a
+prominent **editorial feature card** (logo + name + blurb), not a quiet grid cell.
+
+- Cream-paper field (no dark page), club-motto kicker, big italic-display headline
+  **"Merci aan onze sponsors."**, warm gratitude lead.
+- Tiers as gratitude sections with `MonoLabel` kickers (Hoofdsponsors / Sponsors /
+  Sympathisanten) + taped logo tiles, hierarchy by cell size.
+- **"In de kijker" featured card carried from D** — a real highlight near the top, not a
+  carousel and not buried in a grid. Exact count/placement/visual = IA + detail rounds.
+- "Word sponsor +" CTA present but **not** the page's organizing purpose (rejected D's
+  recruitment-forward framing).
+
+## Rejected (and why)
+
+- **B · Ereblad (honour board)** — too quiet/archival; sits in tension with a prominent
+  featured card. (Borrow its tier-grouping discipline into the IA, not its register.)
+- **C · Reclameborden (pitchside boards)** — most distinctive and on-theme, but introduces
+  net-new vocabulary (wide board tile + jersey-deep-dark page) and reads colder than the
+  club's "plezante compagnie" warmth. Parked as a possible future flourish, not the base.
+- **D · Partners (recruitment-forward)** — its featured card is kept, but its sales register
+  ("bereik honderden supporters") reframes the page as a funnel. KCVV is a club, not a sales
+  page (`feedback_no_magazine_chrome` spirit). Gratitude wins; recruitment is a footer CTA.
+
+## Carry-forward into the IA round (7.d2)
+
+- **Featured count + placement:** multiple sponsors can be `featured=true` — does the page
+  show one marquee card, a row of cards, or hero-integrated vs. its own band below the hero?
+- **Tier hierarchy treatment:** size-graded grids (A as drawn) vs. hoofd-as-feature-cards vs.
+  flat wall — how differentiated are the three tiers?
+- **Tile field anatomy:** is the name caption always shown beneath the logo, or only as the
+  missing-logo fallback? (master plan leans "small mono caption beneath"; homepage
+  `<SponsorsBlock>` currently shows logo-only.)
+- **CTA placement:** footer band vs. inline after the grids.
+- The featured card's exact **visual treatment** (card chrome, blurb length, link) is a
+  later DETAIL round, per the 7.d0 deferral.

--- a/docs/design/mockups/phase-7-sponsors/7d2-featured-ia-compare.html
+++ b/docs/design/mockups/phase-7-sponsors/7d2-featured-ia-compare.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /sponsors · Round 2: IA — featured count + placement</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0 0 4px; font-size: 13px; color: #b9b9b9; max-width: 82ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+      .wrap { max-width: 1080px; margin: 0 auto; padding: 48px 28px 36px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      h2.hd { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(38px, 5.5vw, 66px); line-height: 0.92; margin: 12px 0 0; }
+      h2.hd .dot { color: var(--jersey-deep); }
+      .lead { font-family: var(--font-display); font-size: 19px; line-height: 1.5; max-width: 56ch; margin: 16px 0 0; color: var(--ink-soft); }
+      .swatch { width: 22px; height: 22px; border: 1px solid var(--ink); flex: none; filter: grayscale(1); transition: filter .3s; }
+      .tile:hover .swatch, .fcard:hover .swatch { filter: grayscale(0); }
+      .tier-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); display: flex; align-items: center; gap: 12px; margin-top: 38px; }
+      .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .grid-main { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-top: 16px; }
+      .tile { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); padding: 22px 14px 12px; text-align: center; }
+      .tile:nth-child(1){transform:rotate(-0.4deg)} .tile:nth-child(2){transform:rotate(0.3deg)} .tile:nth-child(3){transform:rotate(0.5deg)}
+      .tile .logo-box { min-height: 54px; display:flex; align-items:center; justify-content:center; }
+      .tile .name { font-family: var(--font-display); font-style: italic; font-size: 14px; margin-top: 8px; }
+
+      /* featured card */
+      .fcard { background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 22px; }
+      .fcard .kicker { color: var(--warm); }
+      .fcard .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 18px; margin: 12px 0; min-height: 60px; display:flex; align-items:center; justify-content:center; }
+      .fcard .logo-box .swatch { width: 26px; height: 26px; }
+      .fcard .fname { font-family: var(--font-display); font-style: italic; font-size: 20px; }
+      .fcard .blurb { font-size: 13px; line-height: 1.5; color: rgba(245,241,230,0.8); margin-top: 6px; }
+      .fcard .visit { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--warm); margin-top: 10px; display: inline-block; }
+
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+
+      /* V1 split hero */
+      .v1-split { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 34px; align-items: end; }
+      /* V2 band */
+      .fband { margin-top: 28px; background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 4px 4px 0 0 var(--ink); padding: 22px 22px 24px; }
+      .fband .band-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .fband-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 14px; }
+      .fband .fcard { box-shadow: 3px 3px 0 0 var(--ink); padding: 18px; }
+      .fband .fcard .fname { font-size: 17px; }
+      /* V3 inline strip */
+      .fstrip { margin-top: 30px; border: 2px solid var(--ink); background: var(--cream-soft); display: grid; grid-template-columns: 150px 1fr; }
+      .fstrip .label { background: var(--jersey-deep-dark); color: var(--warm); font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; padding: 16px; display: flex; align-items: center; }
+      .fstrip .row { display: flex; gap: 0; }
+      .fstrip .mini { flex: 1; padding: 14px; border-left: 1px solid var(--ink); display: flex; align-items: center; gap: 10px; }
+      .fstrip .mini .swatch { width: 20px; height: 20px; }
+      .fstrip .mini .mn { font-family: var(--font-display); font-style: italic; font-size: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /sponsors — Round 2: IA — featured "In de kijker" count + placement</h1>
+      <p>Voice locked to A·Merci + a prominent featured card (<a href="./7d1-voice-locked.md">7d1-voice-locked.md</a>).
+        This round only varies <b>how many featured cards show and where they sit</b>. Everything else
+        (Merci hero, taped tier grids, CTA) is held constant. Data reality: 0, 1, or many sponsors
+        can have <code>featured=true</code> — each variant notes how it scales + its empty (0-featured) behaviour.</p>
+    </div>
+
+    <!-- ===== V1 — single marquee in the hero (split) ===== -->
+    <div class="direction-bar"><span class="tag">V1</span> Marquee in hero (split) <span class="note">headline left, ONE featured card right — D's original placement</span></div>
+    <div class="wrap">
+      <div class="v1-split">
+        <div>
+          <div class="kicker">Er is maar één plezante compagnie</div>
+          <h2 class="hd">Merci aan onze sponsors<span class="dot">.</span></h2>
+          <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+        </div>
+        <div class="fcard">
+          <div class="kicker">In de kijker</div>
+          <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+          <div class="fname">Garage Peeters</div>
+          <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen voor het hele seizoen.</div>
+          <span class="visit">Bezoek website ↗</span>
+        </div>
+      </div>
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="grid-main">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="name">Garage Peeters</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="name">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="name">Immo Zennevallei</div></div>
+      </div>
+    </div>
+    <div class="note-strip">SCALES: shows ONE card only — if several sponsors are featured, picks the top one (e.g. highest tier). EMPTY: hero collapses to headline-only (full width). RISK: wastes the other featured flags.</div>
+
+    <!-- ===== V2 — featured band below hero (1–N cards) ===== -->
+    <div class="direction-bar"><span class="tag">V2</span> Featured band below hero <span class="note">hero = headline only; a full-width "In de kijker" band holds 1–3 cards</span></div>
+    <div class="wrap">
+      <div class="kicker">Er is maar één plezante compagnie</div>
+      <h2 class="hd">Merci aan onze sponsors<span class="dot">.</span></h2>
+      <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking. KCVV Elewijt draait op de steun van lokale partners.</p>
+
+      <div class="fband">
+        <div class="band-kicker">In de kijker</div>
+        <div class="fband-grid">
+          <div class="fcard"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="fname">Garage Peeters</div><div class="blurb">Leverde de wedstrijdballen voor het hele seizoen.</div><span class="visit">Bezoek ↗</span></div>
+          <div class="fcard"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="fname">Bouwwerken Van Assche</div><div class="blurb">Vernieuwde de kleedkamers in de zomerstop.</div><span class="visit">Bezoek ↗</span></div>
+          <div class="fcard"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div><div class="fname">Frituur 't Pleintje</div><div class="blurb">Elke thuiswedstrijd present aan de kantine.</div><span class="visit">Bezoek ↗</span></div>
+        </div>
+      </div>
+
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="grid-main">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="name">Garage Peeters</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="name">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="name">Immo Zennevallei</div></div>
+      </div>
+    </div>
+    <div class="note-strip">SCALES: 1 card → centred; 2–3 → row; 4+ → wrap/cap at 3 + "meer". EMPTY: whole band hides (no orphan header). RISK: featured sponsors appear twice (band + their tier grid) — accepted as deliberate emphasis.</div>
+
+    <!-- ===== V3 — inline labelled strip above the grids ===== -->
+    <div class="direction-bar"><span class="tag">V3</span> Inline "In de kijker" strip <span class="note">compact labelled row between hero and grids — logo + name, no blurb</span></div>
+    <div class="wrap">
+      <div class="kicker">Er is maar één plezante compagnie</div>
+      <h2 class="hd">Merci aan onze sponsors<span class="dot">.</span></h2>
+      <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+
+      <div class="fstrip">
+        <div class="label">In de kijker</div>
+        <div class="row">
+          <div class="mini tile"><span class="swatch" style="background:#c0392b"></span><span class="mn">Garage Peeters</span></div>
+          <div class="mini tile"><span class="swatch" style="background:#2e6fb0"></span><span class="mn">Bouwwerken Van Assche</span></div>
+        </div>
+      </div>
+
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="grid-main">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="name">Garage Peeters</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="name">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="name">Immo Zennevallei</div></div>
+      </div>
+    </div>
+    <div class="note-strip">SCALES: horizontal strip, N minis (wraps). EMPTY: strip hides. NOTE: drops the blurb (description goes unused) — lightest, but loses the editorial "feature" feel you liked in D.</div>
+
+    <div class="legend">
+      <b>Trade-off in one line:</b> V1 = boldest single hero, wastes extra featured flags ·
+      V2 = scales to many + keeps the blurb/editorial feel (closest to "featured like D") ·
+      V3 = lightest, but discards the <code>description</code> blurb.<br />
+      Featured-card <b>visual chrome</b> (jersey-deep-dark vs cream, blurb length, link style)
+      is a later DETAIL round — judge placement/count here, not the exact card styling.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-sponsors/7d2-featured-ia-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/7d2-featured-ia-locked.md
@@ -1,0 +1,39 @@
+# Phase 7 · /sponsors — Round 2 (IA: featured placement) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7d2-featured-ia-compare.html`
+**Owner:** @climacon
+
+## Decision
+
+**Featured = V1 · single marquee card in the hero (split layout).**
+
+The hero is a two-column split: **headline + lead on the left, one "In de kijker" featured
+partner card on the right.**
+
+## Data rules (required because `featured` can match 0 / 1 / many)
+
+- **Pick exactly ONE** featured sponsor for the marquee. Deterministic selection:
+  **highest tier first** (`hoofdsponsor` → `sponsor` → `sympathisant`, untiered last), then
+  **`name` `localeCompare("nl")`**. Mirrors the existing `<SponsorsBlock>` sort.
+- **0 featured →** hero collapses to **headline-only, full width** (no empty card, no orphan
+  "In de kijker" label).
+- The marquee sponsor **still appears in its tier grid below** — deliberate double-emphasis,
+  not a bug. No dedup.
+- A featured sponsor **without** a `logo` → marquee shows the italic-display name fallback in
+  the logo slot. **Without** a `description` → blurb line is omitted (card shrinks); the card
+  still renders on logo + name + link.
+
+## Accepted trade-off
+
+- Extra `featured=true` flags beyond the first are **not surfaced** in the marquee. Accepted:
+  the owner wants one bold hero highlight, not a row. If the club routinely flags many, revisit
+  toward V2 (band) — noted, not built.
+
+## Carry-forward into the next IA round (7.d3 — tier treatment)
+
+- **Master-plan/data conflict to honour:** §6.8 says main-tier tiles carry a "short blurb."
+  **There is no field for this** — `description` is featured-only (surfaced in the marquee).
+  Tier tiles may show **logo (or name fallback) + name caption + outbound link only.** No blurb.
+- Open: tier hierarchy treatment (size-graded grids vs. hoofd-as-feature-rows vs. flat wall) +
+  tile name-caption rule (always vs. only-on-missing-logo) + CTA placement.

--- a/docs/design/mockups/phase-7-sponsors/7d3-tier-treatment-compare.html
+++ b/docs/design/mockups/phase-7-sponsors/7d3-tier-treatment-compare.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /sponsors · Round 3: IA — tier hierarchy treatment</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0 0 4px; font-size: 13px; color: #b9b9b9; max-width: 82ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar.lk { background: var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+      .wrap { max-width: 1080px; margin: 0 auto; padding: 40px 28px 30px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .swatch { width: 22px; height: 22px; border: 1px solid var(--ink); flex: none; filter: grayscale(1); transition: filter .3s; }
+      .tile:hover .swatch, .fcard:hover .swatch, .prow:hover .swatch, .cell:hover .swatch { filter: grayscale(0); }
+      .tier-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); display: flex; align-items: center; gap: 12px; margin-top: 34px; }
+      .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .cap { font-family: var(--font-display); font-style: italic; font-size: 13px; margin-top: 7px; }
+      .capm { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--ink-muted); margin-top: 6px; }
+
+      /* locked hero (shown once) */
+      .hero { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 34px; align-items: end; max-width: 1080px; margin: 0 auto; padding: 40px 28px 8px; }
+      .hero h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(34px,4.6vw,58px); line-height: 0.92; margin: 12px 0 0; }
+      .hero h2 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 18px; line-height: 1.5; margin: 14px 0 0; color: var(--ink-soft); }
+      .fcard { background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 20px; }
+      .fcard .kicker { color: var(--warm); }
+      .fcard .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 16px; margin: 10px 0; min-height: 52px; display:flex; align-items:center; justify-content:center; }
+      .fcard .logo-box .swatch { width: 24px; height: 24px; }
+      .fcard .fname { font-family: var(--font-display); font-style: italic; font-size: 19px; }
+      .fcard .blurb { font-size: 12.5px; line-height: 1.5; color: rgba(245,241,230,0.8); margin-top: 5px; }
+      .seam { height: 0; border-top: 2px dashed var(--ink); max-width: 1080px; margin: 18px auto 0; opacity: 0.5; }
+
+      /* ===== T1 size-graded taped grids ===== */
+      .t1 .gmain { display: grid; grid-template-columns: repeat(3,1fr); gap: 18px; margin-top: 14px; }
+      .t1 .gsecond { display: grid; grid-template-columns: repeat(5,1fr); gap: 12px; margin-top: 14px; }
+      .t1 .greg { display: grid; grid-template-columns: repeat(7,1fr); gap: 9px; margin-top: 14px; }
+      .t1 .tile { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); padding: 18px 12px 10px; text-align: center; }
+      .t1 .gmain .tile:nth-child(1){transform:rotate(-0.4deg)} .t1 .gmain .tile:nth-child(2){transform:rotate(0.3deg)} .t1 .gmain .tile:nth-child(3){transform:rotate(0.5deg)}
+      .t1 .gsecond .tile { box-shadow: 2px 2px 0 0 var(--ink); padding: 14px 8px 8px; }
+      .t1 .greg .tile { box-shadow: none; border-width: 1.5px; padding: 11px 6px; }
+      .t1 .logo-box { display:flex; align-items:center; justify-content:center; min-height: 46px; }
+      .t1 .gsecond .logo-box { min-height: 34px; } .t1 .greg .logo-box { min-height: 26px; }
+      .t1 .gmain .swatch { width: 26px; height: 26px; } .t1 .greg .swatch { width: 16px; height: 16px; }
+
+      /* ===== T2 two-class: partner rows + one wall ===== */
+      .t2 .prow { display: grid; grid-template-columns: 120px 1fr auto; align-items: center; gap: 20px; background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 4px 4px 0 0 var(--ink); padding: 18px 22px; margin-top: 14px; }
+      .t2 .prow:nth-child(odd){transform:rotate(-0.25deg)}
+      .t2 .prow .logo-box { display:flex; align-items:center; justify-content:center; }
+      .t2 .prow .swatch { width: 30px; height: 30px; }
+      .t2 .prow .pname { font-family: var(--font-display); font-style: italic; font-size: 22px; }
+      .t2 .prow .visit { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--jersey-deep); }
+      .t2 .wall { display: grid; grid-template-columns: repeat(6,1fr); gap: 10px; margin-top: 14px; }
+      .t2 .wall .tile { background: var(--cream-soft); border: 1.5px solid var(--ink); padding: 13px 8px; text-align: center; }
+      .t2 .wall .logo-box { display:flex; align-items:center; justify-content:center; min-height: 30px; }
+      .t2 .wall .swatch { width: 18px; height: 18px; }
+
+      /* ===== T3 flat honour wall (ledger) ===== */
+      .t3 .ledger { border: 2px solid var(--ink); margin-top: 14px; }
+      .t3 .band { background: var(--ink); color: var(--cream); font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; padding: 7px 12px; }
+      .t3 .rmain { display: grid; grid-template-columns: repeat(3,1fr); }
+      .t3 .rsecond { display: grid; grid-template-columns: repeat(5,1fr); }
+      .t3 .rreg { display: grid; grid-template-columns: repeat(8,1fr); }
+      .t3 .cell { border-right: 1px solid var(--ink); border-bottom: 1px solid var(--ink); padding: 18px 8px; text-align: center; }
+      .t3 .rmain .cell { padding: 26px 8px; }
+      .t3 .rreg .cell { padding: 10px 6px; }
+      .t3 .cell .logo-box { display:flex; align-items:center; justify-content:center; min-height: 28px; }
+      .t3 .rmain .swatch { width: 26px; height: 26px; } .t3 .rreg .swatch { width: 15px; height: 15px; }
+      .t3 .cell .nm { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--ink-soft); margin-top: 5px; }
+
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /sponsors — Round 3: IA — tier hierarchy treatment</h1>
+      <p>Hero locked (A·Merci + V1 marquee, <a href="./7d2-featured-ia-locked.md">7d2 lock</a>) — shown once below, identical in all three.
+        This round varies only <b>how differentiated the three tiers are</b> in the page body.
+        Data-corrected: tier tiles show <b>logo (or italic-name fallback) + name + outbound link only — NO blurb</b>
+        (the §6.8 "main blurb" has no field; <code>description</code> is featured-only).</p>
+    </div>
+
+    <!-- locked hero -->
+    <div class="direction-bar lk"><span class="tag" style="background:#cfeede">LOCKED</span> Hero — identical across T1/T2/T3</div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Er is maar één plezante compagnie</div>
+        <h2>Merci aan onze sponsors<span class="dot">.</span></h2>
+        <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+      </div>
+      <div class="fcard">
+        <div class="kicker">In de kijker</div>
+        <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+        <div class="fname">Garage Peeters</div>
+        <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen.</div>
+      </div>
+    </div>
+    <div class="seam"></div>
+
+    <!-- ===== T1 ===== -->
+    <div class="direction-bar"><span class="tag">T1</span> Size-graded taped grids <span class="note">one taped-paper vocabulary, scaling down: big→medium→dense. Hierarchy by cell size + shadow.</span></div>
+    <section class="t1"><div class="wrap" style="padding-top:8px">
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+      <div class="tier-kicker">Sponsors</div>
+      <div class="gsecond">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div><div class="capm">Frituur 't Pleintje</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div><div class="capm">Apotheek Centrum</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div><div class="capm">Slagerij Janssens</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div><div class="capm">Tuincenter De Linde</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c93f1c"></span></div><div class="capm">Café De Zwaan</div></div>
+      </div>
+      <div class="tier-kicker">Sympathisanten</div>
+      <div class="greg">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#888"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#999"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#777"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#929292"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7d7d7d"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#959595"></span></div></div>
+      </div>
+    </div></section>
+    <div class="note-strip">Consistent, calm, scales for any count per tier. Hoofd feels valued via size; sympathisanten read as a tidy logo wall. Closest to master-plan §6.8 (minus the unbacked blurb).</div>
+
+    <!-- ===== T2 ===== -->
+    <div class="direction-bar"><span class="tag">T2</span> Partner rows + one wall <span class="note">2 classes only: hoofd = wide partner rows (logo+name+link); sponsor & sympathisant merge into one dense wall.</span></div>
+    <section class="t2"><div class="wrap" style="padding-top:8px">
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="prow"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="pname">Garage Peeters</div><div class="visit">Bezoek website ↗</div></div>
+      <div class="prow"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="pname">Bouwwerken Van Assche</div><div class="visit">Bezoek website ↗</div></div>
+      <div class="prow"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="pname">Immo Zennevallei</div><div class="visit">Bezoek website ↗</div></div>
+      <div class="tier-kicker">Sponsors &amp; sympathisanten</div>
+      <div class="wall">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c93f1c"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#888"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#999"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#777"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#929292"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7d7d7d"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#959595"></span></div></div>
+      </div>
+    </div></section>
+    <div class="note-strip">Strongest top hierarchy — hoofd read as named partners with links. BUT collapses the sponsor/sympathisant distinction into one wall (loses a real tier the schema models). Best if hoofd count is small (2–5).</div>
+
+    <!-- ===== T3 ===== -->
+    <div class="direction-bar"><span class="tag">T3</span> Flat honour wall (ledger) <span class="note">B's programme back-page discipline inside the warm frame: one thin-ink grid, tiers = ink bands, hoofd cells bigger.</span></div>
+    <section class="t3"><div class="wrap" style="padding-top:8px">
+      <div class="ledger">
+        <div class="band">Hoofdsponsors</div>
+        <div class="rmain">
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="nm">Garage Peeters</div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="nm">Bouwwerken Van Assche</div></div>
+          <div class="cell" style="border-right:none"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="nm">Immo Zennevallei</div></div>
+        </div>
+        <div class="band">Sponsors</div>
+        <div class="rsecond">
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div><div class="nm">Frituur</div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div><div class="nm">Apotheek</div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div><div class="nm">Slagerij</div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div><div class="nm">Tuincenter</div></div>
+          <div class="cell" style="border-right:none"><div class="logo-box"><span class="swatch" style="background:#c93f1c"></span></div><div class="nm">Café De Zwaan</div></div>
+        </div>
+        <div class="band">Sympathisanten</div>
+        <div class="rreg">
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#888"></span></div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#999"></span></div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#777"></span></div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#929292"></span></div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#7d7d7d"></span></div></div>
+          <div class="cell"><div class="logo-box"><span class="swatch" style="background:#959595"></span></div></div>
+          <div class="cell" style="border-right:none"><div class="logo-box"><span class="swatch" style="background:#828282"></span></div></div>
+        </div>
+      </div>
+    </div></section>
+    <div class="note-strip">Most compact + archival; all three tiers visible at once with no scroll. Reads cooler/more institutional — sits slightly against the warm Merci hero. Borrows the rejected B register back in for the body only.</div>
+
+    <div class="legend">
+      <b>One-line trade-off:</b> T1 = calm, scalable, on-spec (size differentiates) ·
+      T2 = boldest hoofd-as-partners, but merges two real tiers into one wall ·
+      T3 = densest honour-board, but tonally cooler than the hero.<br />
+      Tile <b>name-caption rule</b> (always-show vs only-on-missing-logo) + <b>CTA placement</b>
+      are the next IA micro-questions; exact borders/type sizes are later DETAIL rounds.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-sponsors/7d3-tier-treatment-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/7d3-tier-treatment-locked.md
@@ -1,0 +1,46 @@
+# Phase 7 · /sponsors — Round 3 (IA: tier treatment) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7d3-tier-treatment-compare.html` (+ label refinement)
+**Owner:** @climacon
+
+## Decision
+
+**Label only the top tier. One celebrated group + one gracious wall.**
+
+The page body has exactly **two visual classes**, not three:
+
+1. **Hoofdsponsors** — the only labeled group. A `MonoLabel` header **"Hoofdsponsors"** over
+   **large taped tiles** (≈3-col `<TapedCardGrid>`), each tile = logo (or italic-name fallback)
+   **+ italic-display name caption**. Slight rotation per the taped-card pool.
+
+2. **Everyone else** — `sponsor` + `sympathisant` **merged into one unlabeled dense logo wall**
+   below, **no header**. Tiles = logo only (name shown **only** as the missing-logo fallback).
+   Ordered `sponsor` before `sympathisant`, then `name` `localeCompare("nl")`, so larger
+   contributors lead — but **no size step and no label** distinguishes the two.
+
+Rationale (owner): headering a group **"Sympathisanten"** publicly brands the club's smallest
+supporters as the bottom rung. Dropping that header (and the `sponsor` one) removes the
+"degrading" rank callout while still celebrating the hoofdsponsors who fund the most.
+
+## Accepted consequence
+
+- **The `sponsor` vs `sympathisant` schema distinction is no longer visually expressed** on
+  `/sponsors` (both live in the merged wall). This is intentional. The tier field still drives
+  **ordering** (sponsors first) and the **homepage** `<SponsorsBlock>` (which shows hoofd+sponsor
+  only) is unaffected. If a visible second-tier step is ever wanted back, re-introduce a subtle
+  cell-size difference inside the wall — noted, not built.
+
+## Tile field anatomy (resolved here)
+
+- **Hoofd tile:** logo (or italic-name fallback) + italic-display name caption. Clickable when
+  `url` present (visible link affordance = detail round).
+- **Wall tile:** logo only; italic-name fallback when no logo; clickable when `url` present.
+- **No blurb anywhere in the tiers** (carried from 7.d2 — `description` is featured-only).
+
+## Carry-forward
+
+- **CTA placement** ("Word sponsor +") — last open IA micro-question → next round, shown in a
+  full-page assembly.
+- Then DETAIL rounds: hero type scale, featured-card chrome, tile borders/shadows/hover, the
+  visible "Bezoek website" affordance, empty states (0 sponsors / 0 hoofd / 0 featured).

--- a/docs/design/mockups/phase-7-sponsors/7d4-cta-assembly-compare.html
+++ b/docs/design/mockups/phase-7-sponsors/7d4-cta-assembly-compare.html
@@ -1,0 +1,197 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /sponsors · Round 4: IA — CTA placement (full assembly)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0 0 4px; font-size: 13px; color: #b9b9b9; max-width: 82ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar.lk { background: var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+      .wrap { max-width: 1080px; margin: 0 auto; padding: 0 28px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .swatch { width: 22px; height: 22px; border: 1px solid var(--ink); flex: none; filter: grayscale(1); transition: filter .3s; }
+      .tile:hover .swatch, .fcard:hover .swatch { filter: grayscale(0); }
+
+      /* hero */
+      .hero { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 34px; align-items: end; padding: 44px 0 8px; }
+      .hero h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(34px,4.6vw,58px); line-height: 0.92; margin: 12px 0 0; }
+      .hero h2 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 18px; line-height: 1.5; margin: 14px 0 0; color: var(--ink-soft); }
+      .fcard { background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 20px; }
+      .fcard .kicker { color: var(--warm); }
+      .fcard .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 16px; margin: 10px 0; min-height: 52px; display:flex; align-items:center; justify-content:center; }
+      .fcard .logo-box .swatch { width: 24px; height: 24px; }
+      .fcard .fname { font-family: var(--font-display); font-style: italic; font-size: 19px; }
+      .fcard .blurb { font-size: 12.5px; line-height: 1.5; color: rgba(245,241,230,0.8); margin-top: 5px; }
+
+      .tier-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); display: flex; align-items: center; gap: 12px; margin-top: 38px; }
+      .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .gmain { display: grid; grid-template-columns: repeat(3,1fr); gap: 18px; margin-top: 16px; }
+      .gmain .tile { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); padding: 18px 12px 10px; text-align: center; }
+      .gmain .tile:nth-child(1){transform:rotate(-0.4deg)} .gmain .tile:nth-child(2){transform:rotate(0.3deg)} .gmain .tile:nth-child(3){transform:rotate(0.5deg)}
+      .gmain .logo-box { display:flex; align-items:center; justify-content:center; min-height: 46px; } .gmain .swatch { width: 26px; height: 26px; }
+      .gmain .cap { font-family: var(--font-display); font-style: italic; font-size: 14px; margin-top: 8px; }
+      .wallgap { margin-top: 22px; }
+      .wall { display: grid; grid-template-columns: repeat(6,1fr); gap: 10px; }
+      .wall .tile { background: var(--cream-soft); border: 1.5px solid var(--ink); padding: 14px 8px; text-align: center; }
+      .wall .logo-box { display:flex; align-items:center; justify-content:center; min-height: 30px; } .wall .swatch { width: 18px; height: 18px; }
+
+      /* CTA C1 footer band */
+      .c1 { margin-top: 46px; background: var(--jersey-deep-dark); color: var(--cream); border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); padding: 40px 0; }
+      .c1 .inner { max-width: 1080px; margin: 0 auto; padding: 0 28px; display: flex; justify-content: space-between; align-items: center; gap: 24px; flex-wrap: wrap; }
+      .c1 h3 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 30px; margin: 0; }
+      .c1 p { margin: 6px 0 0; color: rgba(245,241,230,0.78); font-size: 14px; max-width: 46ch; }
+      .cta-pill { display: inline-block; font-family: var(--font-mono); font-weight: 700; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; border: 2px solid var(--ink); padding: 13px 22px; background: var(--warm); color: var(--ink); box-shadow: 4px 4px 0 0 var(--ink); }
+
+      /* CTA C2 inline quiet */
+      .c2 { margin: 44px 0 10px; text-align: center; }
+      .c2 p { font-family: var(--font-display); font-style: italic; font-size: 18px; color: var(--ink-soft); margin: 0 0 16px; }
+
+      /* CTA C3 join-the-wall tile */
+      .c3wall { display: grid; grid-template-columns: repeat(6,1fr); gap: 10px; }
+      .c3wall .tile { background: var(--cream-soft); border: 1.5px solid var(--ink); padding: 14px 8px; text-align: center; }
+      .c3wall .logo-box { display:flex; align-items:center; justify-content:center; min-height: 30px; } .c3wall .swatch { width: 18px; height: 18px; }
+      .c3wall .join { background: var(--warm); border: 2px dashed var(--ink); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; text-decoration: none; color: var(--ink); }
+      .c3wall .join .big { font-family: var(--font-display); font-style: italic; font-size: 15px; }
+      .c3wall .join .sm { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; }
+
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .secthead { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-muted); padding: 26px 28px 0; max-width: 1080px; margin: 0 auto; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /sponsors — Round 4: CTA placement (full assembly)</h1>
+      <p>Everything above the CTA is now LOCKED (hero split + marquee · "Hoofdsponsors" label + big taped tiles ·
+        one unlabeled wall for the rest). See <a href="./7d3-tier-treatment-locked.md">7d3 lock</a>.
+        This round only varies <b>where the "Word sponsor" CTA lives</b>. The recruitment CTA is deliberately
+        secondary (gratitude is the page's purpose).</p>
+    </div>
+
+    <!-- LOCKED assembled page -->
+    <div class="direction-bar lk"><span class="tag" style="background:#cfeede">LOCKED</span> Assembled page — hero + hoofd + wall (CTA is the variable below)</div>
+    <div class="wrap">
+      <div class="hero">
+        <div>
+          <div class="kicker">Er is maar één plezante compagnie</div>
+          <h2>Merci aan onze sponsors<span class="dot">.</span></h2>
+          <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+        </div>
+        <div class="fcard">
+          <div class="kicker">In de kijker</div>
+          <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+          <div class="fname">Garage Peeters</div>
+          <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen.</div>
+        </div>
+      </div>
+
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+
+      <div class="wallgap"></div>
+      <div class="wall">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c93f1c"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#888"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#999"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#777"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#929292"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7d7d7d"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#959595"></span></div></div>
+      </div>
+    </div>
+
+    <!-- ===== C1 footer band ===== -->
+    <div class="secthead">↓ CTA option C1</div>
+    <div class="direction-bar"><span class="tag">C1</span> Footer band <span class="note">full-width jersey-deep-dark close band: thank-you turns into invitation</span></div>
+    <div class="c1">
+      <div class="inner">
+        <div>
+          <h3>Ook jouw zaak langs de lijn?</h3>
+          <p>Word sponsor en steun mee de club, de jeugd en de toekomst van KCVV Elewijt.</p>
+        </div>
+        <span class="cta-pill">Word sponsor +</span>
+      </div>
+    </div>
+    <div class="note-strip">Strongest close, clear next step, mirrors the homepage ClubshopBanner dark-band idiom. Most "page has an ending".</div>
+
+    <!-- ===== C2 inline quiet ===== -->
+    <div class="secthead">↓ CTA option C2</div>
+    <div class="direction-bar"><span class="tag">C2</span> Inline quiet <span class="note">a single centred line + button on cream, no band</span></div>
+    <div class="wrap"><div class="c2">
+      <p>Wil je KCVV Elewijt steunen?</p>
+      <span class="cta-pill">Word sponsor +</span>
+    </div></div>
+    <div class="note-strip">Quietest, most modest — keeps the page all-cream/all-paper, no dark band. Risks reading as an afterthought.</div>
+
+    <!-- ===== C3 join-the-wall ===== -->
+    <div class="secthead">↓ CTA option C3</div>
+    <div class="direction-bar"><span class="tag">C3</span> "Jouw logo hier" tile <span class="note">CTA is the last cell of the wall — an open invitation to join</span></div>
+    <div class="wrap">
+      <div class="tier-kicker" style="margin-top:18px">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+      <div class="wallgap"></div>
+      <div class="c3wall">
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7a4ea0"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#2f8f5b"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#b0562e"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#3a7abd"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#c93f1c"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#888"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#999"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#777"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#8a8a8a"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#929292"></span></div></div>
+        <div class="tile"><div class="logo-box"><span class="swatch" style="background:#7d7d7d"></span></div></div>
+        <a class="tile join" href="#"><span class="big">Jouw logo hier?</span><span class="sm">Word sponsor +</span></a>
+      </div>
+    </div>
+    <div class="note-strip">Most charming + on-brand (the wall literally has a spot for you), low-pressure. But less prominent than a band and could be missed if the wall is long. Could PAIR with a slim C2 line too.</div>
+
+    <div class="legend">
+      <b>One-line trade-off:</b> C1 = strongest, clearest close (dark band) ·
+      C2 = quietest, all-paper, modest ·
+      C3 = most charming, woven into the wall, lower prominence.<br />
+      Picking one closes the IA. Then DETAIL rounds: hero type scale, featured-card chrome,
+      tile borders/shadows/hover + "Bezoek website" affordance, empty states.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-sponsors/7d4-cta-assembly-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/7d4-cta-assembly-locked.md
@@ -1,0 +1,37 @@
+# Phase 7 · /sponsors — Round 4 (IA: CTA + page spine) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7d4-cta-assembly-compare.html`
+**Owner:** @climacon
+
+## Decision
+
+**CTA = C1 · Footer band.** A full-width **jersey-deep-dark** close band after the wall: the
+gratitude turns into an invitation. Copy direction: heading **"Ook jouw zaak langs de lijn?"** +
+sub-line + a `warm` paper-stamp **"Word sponsor +"** button. Mirrors the homepage
+`<ClubshopBanner>` dark-band idiom for site consistency.
+
+## Page spine — LOCKED (full IA)
+
+```text
+/sponsors
+├─ Hero (split)
+│   ├─ left:  kicker "Er is maar één plezante compagnie" + EditorialHeading
+│   │         "Merci aan onze sponsors." + italic lead
+│   └─ right: "In de kijker" marquee featured card (1 sponsor; highest-tier-then-name)
+│             → collapses to full-width headline when 0 featured
+├─ Hoofdsponsors (the ONLY tier label) — big taped tiles + italic name caption
+├─ [unlabeled wall] sponsor + sympathisant merged — logo tiles, name = missing-logo fallback
+└─ Footer band CTA (jersey-deep-dark) — "Ook jouw zaak langs de lijn?" + Word sponsor +
+```
+
+## Carry-forward into DETAIL rounds
+
+1. **Featured "In de kijker" card chrome** (the deferred treatment from 7.d0): dark
+   jersey-deep-dark card vs. light cream card; blurb length; link affordance.
+2. **Tiles + wall:** border/shadow spec, canonical press-down hover, greyscale→colour spec,
+   name-caption type, visible "Bezoek website ↗" affordance on clickable tiles.
+3. **Empty states:** 0 sponsors total, 0 hoofdsponsors (wall only), 0 featured (hero collapse).
+4. **Border/divider spec triples** `{weight, color-token, opacity}` for every rule + the
+   footer-band edges (`feedback_border_spec_triple`).
+5. **Type scale** derived from `<EditorialHeading>` + `<MonoLabel>` — map, don't re-drill.

--- a/docs/design/mockups/phase-7-sponsors/7d5-featured-card-detail-compare.html
+++ b/docs/design/mockups/phase-7-sponsors/7d5-featured-card-detail-compare.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /sponsors · Round 5 (DETAIL): featured-card chrome</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd; --tape-cream: rgb(232 224 200 / 0.85);
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 82ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+      .hero { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 34px; align-items: end; padding: 40px 28px 14px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .hero h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(34px,4.4vw,54px); line-height: 0.92; margin: 12px 0 0; }
+      .hero h2 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 18px; line-height: 1.5; margin: 14px 0 0; color: var(--ink-soft); }
+      .swatch { width: 24px; height: 24px; border: 1px solid var(--ink); flex: none; filter: grayscale(1); transition: filter .3s; }
+      .fc:hover .swatch, .htile:hover .swatch { filter: grayscale(0); }
+      .visit { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; margin-top: 12px; display: inline-block; }
+
+      /* hoofd tiles shown beneath for differentiation check */
+      .hoofd { max-width: 1080px; margin: 0 auto; padding: 0 28px 30px; }
+      .tier-kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); display: flex; align-items: center; gap: 12px; margin: 26px 0 14px; }
+      .tier-kicker::after { content: ""; height: 2px; flex: 1; background: var(--paper-edge); }
+      .gmain { display: grid; grid-template-columns: repeat(3,1fr); gap: 18px; }
+      .htile { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); padding: 18px 12px 10px; text-align: center; }
+      .htile:nth-child(1){transform:rotate(-0.4deg)} .htile:nth-child(2){transform:rotate(0.3deg)} .htile:nth-child(3){transform:rotate(0.5deg)}
+      .htile .lb { display:flex; align-items:center; justify-content:center; min-height: 46px; } .htile .swatch { width: 26px; height: 26px; }
+      .htile .cap { font-family: var(--font-display); font-style: italic; font-size: 14px; margin-top: 8px; }
+
+      /* ===== F1 dark card ===== */
+      .f1 { background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 22px; }
+      .f1 .kicker { color: var(--warm); }
+      .f1 .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 18px; margin: 12px 0; min-height: 56px; display:flex; align-items:center; justify-content:center; }
+      .f1 .fname { font-family: var(--font-display); font-style: italic; font-size: 21px; }
+      .f1 .blurb { font-size: 13px; line-height: 1.5; color: rgba(245,241,230,0.82); margin-top: 6px; }
+      .f1 .visit { color: var(--warm); }
+
+      /* ===== F2 light taped card ===== */
+      .f2 { position: relative; background: var(--cream-soft); color: var(--ink); border: 2px solid var(--ink); box-shadow: 4px 4px 0 0 var(--ink); padding: 24px 22px 22px; transform: rotate(-0.5deg); }
+      .f2 .tape { position: absolute; top: -11px; left: 50%; transform: translateX(-50%) rotate(-1.5deg); width: 120px; height: 24px; background: var(--tape-cream); border: 1px solid rgba(10,10,10,0.25); }
+      .f2 .kicker { color: var(--jersey-deep); }
+      .f2 .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 18px; margin: 12px 0; min-height: 56px; display:flex; align-items:center; justify-content:center; }
+      .f2 .fname { font-family: var(--font-display); font-style: italic; font-size: 21px; }
+      .f2 .blurb { font-size: 13px; line-height: 1.5; color: var(--ink-soft); margin-top: 6px; }
+      .f2 .visit { color: var(--jersey-deep); }
+
+      /* ===== F3 light body + jersey banner tab ===== */
+      .f3 { background: var(--cream-soft); color: var(--ink); border: 2px solid var(--ink); box-shadow: 4px 4px 0 0 var(--ink); }
+      .f3 .tab { background: var(--jersey-deep); color: var(--cream); font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; padding: 8px 16px; border-bottom: 2px solid var(--ink); }
+      .f3 .body { padding: 18px 22px 22px; }
+      .f3 .logo-box { background: var(--cream); border: 2px solid var(--ink); padding: 18px; margin: 4px 0 12px; min-height: 56px; display:flex; align-items:center; justify-content:center; }
+      .f3 .fname { font-family: var(--font-display); font-style: italic; font-size: 21px; }
+      .f3 .blurb { font-size: 13px; line-height: 1.5; color: var(--ink-soft); margin-top: 6px; }
+      .f3 .visit { color: var(--jersey-deep); }
+
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /sponsors — Round 5 (DETAIL): "In de kijker" featured-card chrome</h1>
+      <p>Page spine locked (<a href="./7d4-cta-assembly-locked.md">7d4</a>). Each variant shows the
+        marquee card in its real hero context, with the hoofd taped tiles beneath — judge how clearly
+        the featured card reads as <b>more special</b> than an ordinary hoofd tile. Hover swatches for the
+        greyscale→colour reveal.</p>
+    </div>
+
+    <!-- F1 -->
+    <div class="direction-bar"><span class="tag">F1</span> Dark card <span class="note">jersey-deep-dark, cream text — boldest, unmistakably "featured"</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Er is maar één plezante compagnie</div>
+        <h2>Merci aan onze sponsors<span class="dot">.</span></h2>
+        <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+      </div>
+      <div class="fc f1">
+        <div class="kicker">In de kijker</div>
+        <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+        <div class="fname">Garage Peeters</div>
+        <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen voor het hele seizoen.</div>
+        <a class="visit" href="#">Bezoek website ↗</a>
+      </div>
+    </div>
+    <div class="hoofd">
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+    </div>
+    <div class="note-strip">Clearest signal — dark vs cream page = instantly "this one's special". Reuses the fcard idiom from the homepage feature surfaces. Strong contrast with the cream hoofd tiles below.</div>
+
+    <!-- F2 -->
+    <div class="direction-bar"><span class="tag">F2</span> Light taped card <span class="note">cream-soft + tape strip — fully consistent paper vocabulary</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Er is maar één plezante compagnie</div>
+        <h2>Merci aan onze sponsors<span class="dot">.</span></h2>
+        <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+      </div>
+      <div class="fc f2">
+        <span class="tape"></span>
+        <div class="kicker">In de kijker</div>
+        <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+        <div class="fname">Garage Peeters</div>
+        <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen voor het hele seizoen.</div>
+        <a class="visit" href="#">Bezoek website ↗</a>
+      </div>
+    </div>
+    <div class="hoofd">
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+    </div>
+    <div class="note-strip">Most consistent with the page's paper vocabulary. RISK: it's the same cream-soft + ink + shadow as the hoofd tiles below — only the tape strip + blurb + size set it apart, so it reads less "special".</div>
+
+    <!-- F3 -->
+    <div class="direction-bar"><span class="tag">F3</span> Light body + jersey tab <span class="note">cream card with a jersey-deep "In de kijker" banner tab — compromise</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Er is maar één plezante compagnie</div>
+        <h2>Merci aan onze sponsors<span class="dot">.</span></h2>
+        <p class="lead">Zonder hen geen ballen, geen tenues, geen jeugdwerking.</p>
+      </div>
+      <div class="fc f3">
+        <div class="tab">★ In de kijker</div>
+        <div class="body">
+          <div class="logo-box"><span class="swatch" style="background:#c0392b"></span></div>
+          <div class="fname">Garage Peeters</div>
+          <div class="blurb">Hoofdsponsor sinds dag één — leverde de wedstrijdballen voor het hele seizoen.</div>
+          <a class="visit" href="#">Bezoek website ↗</a>
+        </div>
+      </div>
+    </div>
+    <div class="hoofd">
+      <div class="tier-kicker">Hoofdsponsors</div>
+      <div class="gmain">
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#c0392b"></span></div><div class="cap">Garage Peeters</div></div>
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#2e6fb0"></span></div><div class="cap">Bouwwerken Van Assche</div></div>
+        <div class="htile"><div class="lb"><span class="swatch" style="background:#e0a020"></span></div><div class="cap">Immo Zennevallei</div></div>
+      </div>
+    </div>
+    <div class="note-strip">Keeps the page light but the coloured tab calls it out. The ★ glyph is a flag-candidate (memory: no decorative dingbats) — would ship text-only "In de kijker". Middle ground between F1's contrast and F2's quiet.</div>
+
+    <div class="legend">
+      <b>One-line trade-off:</b> F1 = boldest, clearest "featured" (dark) ·
+      F2 = most consistent but risks blending with hoofd tiles ·
+      F3 = light + coloured tab compromise (drop the ★).<br />
+      After this: tile/hover spec (canonical press-down), greyscale spec, empty states, border triples — mostly DERIVED from existing primitives, confirmed in one batch.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-sponsors/7d5-featured-card-detail-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/7d5-featured-card-detail-locked.md
@@ -1,0 +1,20 @@
+# Phase 7 · /sponsors — Round 5 (DETAIL: featured-card chrome) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7d5-featured-card-detail-compare.html`
+**Owner:** @climacon
+
+## Decision
+
+**Featured card = F3 · light cream-soft body + jersey-deep "In de kijker" banner tab.**
+
+- **Tab:** full-width header bar, `bg-jersey-deep` + `text-cream`, mono caps **"In de kijker"**,
+  `border-bottom: 2px solid ink`. **Text-only — no ★/dingbat** (`feedback_no_decorative_nav_ornaments`).
+- **Body:** `bg-cream-soft`, `border-2 border-ink`, `shadow-paper` offset. Contents: logo inset
+  (cream box, `border-2 border-ink`) → italic-display name → blurb (`description`) → mono
+  **"Bezoek website ↗"** link (`text-jersey-deep`) when `url` present.
+- **Blurb:** `description`, clamped to ~3 lines; omitted entirely when absent (card shrinks).
+- **Logo absent:** italic-display name fills the logo inset.
+
+Keeps the page light/paper while the coloured tab unambiguously flags the marquee — without the
+dark-card weight of F1 or the blends-with-hoofd risk of F2.

--- a/docs/design/mockups/phase-7-sponsors/data-reality-locked.md
+++ b/docs/design/mockups/phase-7-sponsors/data-reality-locked.md
@@ -1,0 +1,85 @@
+# Phase 7 · /sponsors — Round 0 (DATA REALITY) — LOCKED
+
+**Date:** 2026-06-06
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7 master)
+**Supersedes (on landing):** `docs/prd/sponsors-redesign.md`
+
+The first checkpoint locks **what data the design is allowed to render**, before any
+voice/IA/detail drilling. Mockups may only show fields the `sponsor` schema actually
+provides. Source of truth: `packages/sanity-schemas/src/sponsor.ts`.
+
+---
+
+## 1. Schema fields (the only renderable data)
+
+| Field                       | Type                   | Reality for design                                                                       |
+| --------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| `name`                      | string, **required**   | Always present. Primary content + the missing-logo fallback.                             |
+| `logo`                      | image, **optional**    | **May be absent** → italic-display name fallback. Repo projects `logoUrl` at `w=400`.    |
+| `url`                       | url, optional          | Outbound link. Not guaranteed — tile is non-interactive when absent.                     |
+| `tier`                      | enum, **warning-only** | `hoofdsponsor` / `sponsor` / `sympathisant`. **May be absent** — untiered records exist. |
+| `featured`                  | boolean                | Drives the "In de kijker" band (see §4). Orthogonal to `tier`.                           |
+| `description`               | text, optional         | Spotlight blurb only — surfaces **nowhere except** the featured band.                    |
+| `type`                      | legacy, hidden         | crossing/green/white/panel/other. Only a **tier fallback** for untiered legacy records.  |
+| `active`                    | boolean                | Only `active == true` is queried (`SPONSORS_QUERY`).                                     |
+| `metaDescription`/`ogImage` | SEO                    | Not page content.                                                                        |
+
+**No other fields exist.** No address, no "sponsor since", no category copy, no
+contact. Do not fabricate any of these in a mockup (`feedback_design_data_audit`).
+
+## 2. Tier model (locked)
+
+The saved-memory "main / second / regular" labels are **conceptual aliases** — the real
+enum is Dutch:
+
+| Schema value   | Alias   | Intended weight on /sponsors        |
+| -------------- | ------- | ----------------------------------- |
+| `hoofdsponsor` | main    | Largest cells / strongest hierarchy |
+| `sponsor`      | second  | Medium cells                        |
+| `sympathisant` | regular | Densest grid (smallest cells)       |
+
+- **Untiered records default to the lowest tier** (`sympathisant`), preserving the
+  current page's fallback behaviour. `type`-based legacy bucketing may be dropped at IA time.
+- Tier ordering for sorting: `hoofdsponsor (0) → sponsor (1) → sympathisant (2)`, then
+  `name` `localeCompare(nl)` — matches `<SponsorsBlock>`.
+
+## 3. Reuse map (existing primitives — `feedback_reuse_approved_primitives`)
+
+| Asset                                               | State                                                   | Disposition                                                                                                                                                                                 |
+| --------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<SponsorsBlock>` (homepage)                        | **Redesign-ready**                                      | `bg-cream-deep`, `<SectionHeader>`, `bg-cream-soft` tiles, greyscale→hover-colour, italic-name fallback, jersey-deep focus ring. The **dense-grid primitive** the sympathisant tier reuses. |
+| `formatSponsorAlt`                                  | Reusable                                                | Alt-text helper — keep.                                                                                                                                                                     |
+| `<SponsorsSpotlight>`                               | **Legacy** (`kcvv-green-dark`, carousel, rounded, blur) | Rebuild for the "In de kijker" band.                                                                                                                                                        |
+| `<SponsorGrid>` / `<SponsorCard>` / `<SponsorLogo>` | **Legacy** (size props, showNames)                      | Rebuild as `<TapedCardGrid>`-based tiers.                                                                                                                                                   |
+| `SponsorsPage` + `getSponsorsSections`              | **Legacy** (`SectionStack` + `diagonal`, `kcvv-black`)  | Rebuild; `diagonal` is retiring → `<StripedSeam>`.                                                                                                                                          |
+| `<SponsorCallToAction>` / `<SponsorEmptyState>`     | Legacy chrome                                           | Reskin in place.                                                                                                                                                                            |
+
+## 4. Decisions taken at this checkpoint
+
+1. **Hero is a sponsor-specific sibling, NOT `<EditorialHero variant="generic">`.**
+   Master plan §6.8 specifies a `generic` EditorialHero, but `EditorialHero` is locked to
+   articleTypes only — there is no `generic` variant, and §5.4 mandates a sibling hero per
+   non-article surface (precedents: `<TeamHero>`, `<EventHero>`). The sponsors hero will be a
+   lightweight composition (kicker + `<EditorialHeading>` + lead), drilled in the voice round.
+   The master plan predates this lock.
+
+2. **The "In de kijker" featured band STAYS in scope; visual treatment deferred.**
+   It is a `/sponsors`-only band (homepage never reads `featured`), driven by `featured` +
+   `description`, orthogonal to tier. Its exact form gets its own drill round after the
+   hero + tier voice is settled. The legacy auto-rotating carousel is **not** carried over.
+
+3. **Greyscale-by-default → full colour on hover/focus is locked** for every logo site-wide
+   (master-plan decision 16, `filter: grayscale(100%)` + `--motion-base`). Already implemented
+   in `<SponsorsBlock>`.
+
+4. **Logos are the primary asset.** Italic display (Freight → Fraunces in mockups) name
+   treatment is reserved for headlines, tier kickers, captions, and the missing-logo fallback.
+
+## 5. Carry-forward into the VOICE round (7.d1)
+
+- What register frames the page: gratitude, institutional honour-board, pitchside
+  advertising-boards, or partnership/recruitment?
+- Headline candidate: master plan offers both `Merci aan onze sponsors.` (decision 12) and
+  `Onze sponsors.` (§6.8) — voice round picks the register, headline follows.
+- Where the "Word sponsor" CTA sits (foregrounded vs. footer) is voice-dependent — defer.

--- a/docs/prd/redesign-phase-7-sponsors.md
+++ b/docs/prd/redesign-phase-7-sponsors.md
@@ -1,0 +1,145 @@
+# PRD: Redesign Phase 7 — Sponsors (`/sponsors`)
+
+**Status**: Ready for implementation (design locked)
+**Date**: 2026-06-07
+**Design contract**: `docs/design/mockups/phase-7-sponsors/7-design-summary-locked.md` (rounds `7d0`–`7d5`)
+**Epic**: #1529 (Redesign Phase 7) · **Milestone**: `redesign-retro-terrace-fanzine`
+**Supersedes**: `docs/prd/sponsors-redesign.md` (delete on landing)
+
+---
+
+## 1. Problem statement
+
+`/sponsors` is a pre-redesign route. Today it renders a dark `kcvv-black` hero + a green
+auto-rotating `<SponsorsSpotlight>` carousel + size-graded `<SponsorGrid>`s, all composed through
+`<SectionStack>` with `diagonal` transitions — i.e. retired tokens (`kcvv-black`,
+`kcvv-green-dark`) and the legacy diagonal seam that the StripedSeam migration is retiring (#1701).
+
+Phase 7 rebuilds it in the retro-terrace-fanzine language with a **grateful** register (the club
+thanks its partners; it is not a sales funnel). The homepage `<SponsorsBlock>` already proves the
+target tile vocabulary — this PRD brings the full page up to it and folds the two surfaces onto a
+shared tile.
+
+## 2. Scope
+
+### In scope (packages touched)
+
+- **`apps/web`** only.
+  - Rebuild `src/app/(landing)/sponsors/page.tsx` + `src/components/sponsors/SponsorsPage/` onto
+    the locked spine (hero → hoofd grid → unlabeled wall → footer band), dropping `SectionStack` +
+    `diagonal` + `getSponsorsSections` + the dark header.
+  - New `<SponsorHero>`, `<FeaturedSponsorCard>`, `<SponsorCtaBand>`.
+  - Extract the homepage `<SponsorsBlock>`'s inner `SponsorTile` into a shared
+    `src/components/sponsors/SponsorTile/` consumed by both the wall and the homepage block.
+  - Retire legacy `<SponsorsSpotlight>`, `<SponsorGrid>`, `<SponsorCard>`, `<SponsorLogo>`.
+  - `sponsor_*` analytics + GTM regex update.
+
+### Out of scope
+
+- **No Sanity schema change.** Every field the design renders already exists on `sponsor`
+  (`name`, `logo`, `url`, `tier`, `featured`, `description`). The hidden legacy `type` field is
+  untouched (its tier-fallback bucketing may simply stop being read).
+- **No BFF / api-contract change.** Sponsors are read natively from Sanity via
+  `SponsorRepository`, not the PSD BFF.
+- Homepage `SponsorsSection` behaviour (hoofd+sponsor only) is unchanged beyond consuming the
+  extracted shared `<SponsorTile>`.
+
+## 3. Tracer bullet
+
+**Phase 1** below is the tracer: the page renders end-to-end on the new vocabulary (no
+`SectionStack`/`diagonal`/dark header) with a headline-only hero + a single reused tile grid,
+proving the data path + route + e2e smoke before any new components land.
+
+## 4. Phases
+
+1. **Tracer** — rebuild route + `<SponsorsPage>` skeleton on new vocabulary; extract shared `<SponsorTile>`.
+2. **`<SponsorHero>` + `<FeaturedSponsorCard>`** — split hero + marquee.
+3. **Tier bodies** — hoofd `<TapedCardGrid>` + unlabeled merged wall + tier/empty logic.
+4. **`<SponsorCtaBand>`** + page-level empty states.
+5. **Analytics + SEO + legacy retirement** + final VR / check-all.
+
+## 5. Acceptance criteria per phase
+
+### Phase 1 — Tracer (route + skeleton + shared tile)
+
+- [ ] `src/components/sponsors/SponsorTile/` extracted from `<SponsorsBlock>`'s inner tile
+      (logo `<Image>` greyscale→hover-colour, italic-name fallback, jersey-deep focus ring,
+      optional `url` link) with `SponsorTile.stories.tsx` (`tags: ["vr"]`) + test + barrel.
+- [ ] `<SponsorsBlock>` refactored to consume the shared `<SponsorTile>` (no visual change → VR
+      baselines for `features-home-sponsorsblock--*` unchanged; if they move, justify).
+- [ ] `src/app/(landing)/sponsors/page.tsx` no longer uses `SectionStack` / `getSponsorsSections`
+      / `kcvv-black`; renders headline + a `<SponsorTile>` grid of all sponsors on cream.
+- [ ] `getSponsorsSections.tsx` + its test deleted; `SponsorsPage` simplified.
+- [ ] e2e `/sponsors` smoke stays green; `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 2 — `<SponsorHero>` + `<FeaturedSponsorCard>`
+
+- [ ] `<SponsorHero>` — split: MonoLabel kicker `ER IS MAAR ÉÉN PLEZANTE COMPAGNIE` +
+      `<EditorialHeading>` "Merci aan onze sponsors." (italic display, jersey-deep period) +
+      italic-display lead + right-column `<FeaturedSponsorCard>`.
+- [ ] **0 featured →** left column spans full width, no card (collapse).
+- [ ] `<FeaturedSponsorCard>` — F3: `bg-jersey-deep` mono-caps tab "In de kijker"
+      (`border-b-2 border-ink`, `text-cream`/`text-white` per contrast rule) + cream-soft body
+      (`border-2 border-ink`, `shadow-paper`) with logo inset → italic name → blurb
+      (`description`, ~3-line clamp, omitted when absent) → mono `Bezoek website ↗` when `url`.
+- [ ] Marquee selection: **one** sponsor, `tier` order (hoofd→sponsor→sympathisant, untiered last)
+      then `name` `localeCompare("nl")`.
+- [ ] Logo-absent featured → italic-name fills the inset.
+- [ ] Stories (`vr`) cover: featured present, 0-featured collapse, no-logo, no-blurb. Unit tests
+      cover selection + collapse branches. VR baselines committed.
+
+### Phase 3 — Tier bodies (hoofd grid + unlabeled wall)
+
+- [ ] Hoofdsponsors: `<MonoLabel>` kicker + paper-edge rule + `<TapedCardGrid>` of large tiles
+      (logo or italic-name fallback + italic-display name caption), canonical press-down hover.
+- [ ] Merged wall: `sponsor` + `sympathisant` in one **unlabeled** dense `<SponsorTile>` grid,
+      ordered `sponsor` before `sympathisant` then `name`; **no header, no blurb, no tier label**.
+- [ ] Untiered sponsors fall into the wall.
+- [ ] `<StripedSeam colorPair="ink-cream" height="md">` between hero and hoofd.
+- [ ] Empty branches: 0 hoofd → wall only; 0 wall → hoofd only. Stories (`vr`) per state + tests.
+
+### Phase 4 — `<SponsorCtaBand>` + empty states
+
+- [ ] `<SponsorCtaBand>` — jersey-deep-dark band (`border-y-2 border-ink`), italic-display heading
+      "Ook jouw zaak langs de lijn?" + sub-line + `warm` paper-stamp "Word sponsor +" with
+      canonical press-down. Copy finalised (see §7).
+- [ ] Legacy `<SponsorCallToAction>` either reskinned into this or retired.
+- [ ] 0-sponsors-total state: headline-only hero → reskinned `<SponsorEmptyState>` → CTA band.
+- [ ] Stories (`vr`) + tests; `<StripedSeam>` before the band.
+
+### Phase 5 — Analytics, SEO, legacy retirement, final pass
+
+- [ ] Analytics per §6 wired; **`sponsor_` added to the live GTM Custom-Event trigger regex**
+      (manual step, called out in PR body).
+- [ ] Retire `<SponsorsSpotlight>`, `<SponsorGrid>`, `<SponsorCard>`, `<SponsorLogo>` — files +
+      stories + tests + barrel exports; `git grep` confirms zero consumers.
+- [ ] Optional `ItemList` JSON-LD of sponsors (keep existing breadcrumb).
+- [ ] `Pages/Sponsors` story refreshed (not `vr`); e2e `/sponsors` smoke green.
+- [ ] Final `pnpm --filter @kcvv/web check-all` + VR green.
+
+## 6. Analytics
+
+| Event                    | Trigger                            | Params                        |
+| ------------------------ | ---------------------------------- | ----------------------------- |
+| `sponsor_view`           | `/sponsors` page view              | —                             |
+| `sponsor_featured_click` | featured marquee card / link click | `sponsor_id` (hashed), `tier` |
+| `sponsor_click`          | any tier/wall tile click           | `sponsor_id` (hashed), `tier` |
+| `sponsor_cta_click`      | "Word sponsor +" band button       | —                             |
+
+- GTM: append `sponsor_` to the single live Custom-Event trigger RegEx (do **not** add a new
+  trigger). New params (`sponsor_id`, `tier`) need DLVs + GA4 Event-tag param mapping.
+- No PII: hash internal Sanity ids via `hashMemberId`; never send raw ids or sponsor `url`.
+
+## 7. Open questions
+
+1. Exact footer-band copy + sub-line wording ("Ook jouw zaak langs de lijn?" is the design draft).
+2. `<SponsorCtaBand>` as a new component vs. a reskinned `<SponsorCallToAction>` (lean: fold the
+   reskin into the band, retire the old name).
+3. Bump `logoUrl` projection from `w=400` → `w=600` for the marquee + hoofd tiles? (wall stays 400).
+
+## 8. Discovered unknowns
+
+- Real per-tier counts are unknown (no speculative Sanity query per API-budget policy) — grids
+  must scale gracefully from 0 to many; state-coverage stories enforce this.
+- Whether any sponsor currently has `featured=true` with no `description` in production — the
+  no-blurb branch is built defensively regardless.


### PR DESCRIPTION
## What

Design checkpoint for the **Phase 7 `/sponsors` redesign** (retro-terrace-fanzine). **Docs only — no code changes.** Captures six drill rounds, each an HTML comparison + a lock doc, in `docs/design/mockups/phase-7-sponsors/`.

Part of #1529 (Phase 7 master). Supersedes `docs/prd/sponsors-redesign.md` once the implementation PRD lands.

## Locked design

- **Voice** — grateful terrace: *"Merci aan onze sponsors."* Warm, never a sales funnel.
- **Hero** — split: kicker + headline + lead left; one **"In de kijker"** marquee featured card right (light body + jersey-deep tab). Collapses to full-width headline when nothing is featured.
- **Tiers** — only **Hoofdsponsors** is labeled (large taped tiles + names). `sponsor` + `sympathisant` merge into one **unlabeled wall** so no supporter is publicly branded "lowest".
- **Close** — jersey-deep-dark footer band *"Ook jouw zaak langs de lijn?"* + a secondary **Word sponsor** CTA.
- **Derived specs** (canonical press-down hover, greyscale→colour, border triples, type scale) all map to existing primitives — zero new vocabulary.

## Key data-reality catches

- Tier enum is Dutch (`hoofdsponsor`/`sponsor`/`sympathisant`), not the saved-memory "main/second/regular" aliases; `tier` + `logo` are both optional.
- `description` exists **only** for the featured card — the master plan's "main-tier blurb" has no field and was dropped.
- Hero is a **sibling component**, not `EditorialHero variant="generic"` (no such variant exists; §5.4 sibling-per-surface lock).

## Files

- `7d0`…`7d5` lock docs + `*-compare.html` per round
- `7-design-summary-locked.md` — consolidated spec + build deltas (new `<SponsorHero>` / `<FeaturedSponsorCard>` / `<SponsorCtaBand>`, reuse `SponsorTile` + `<TapedCardGrid>`, retire legacy carousel/grid, `sponsor_` analytics)
- `7-final-page.html` — canonical full-page render

## Testing

Docs only — no code, no stories, no VR baselines. The implementation PRD (next step) will own component build, tests, VR, and analytics wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
