### PR TITLE
docs(jeugd): Phase 7 /jeugd redesign — design checkpoint + PRD (#1529)

### DIFF
--- a/docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md
@@ -1,0 +1,117 @@
+# Phase 7 · /jeugd — DESIGN SUMMARY (LOCKED)
+
+**Date:** 2026-06-07
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7 master)
+**Supersedes (on landing):** `docs/prd/jeugd-landing-page.md`
+**Drill record:** `7j0`–`7j3` lock docs + `7j0b` verification + `*-compare.html` + `7j-final-page.html`.
+
+The `/jeugd` redesign in the retro-terrace-fanzine system. Audience: **parents**. Register:
+**development through plezier** — serious opleiding, fun as the engine. Non-commercial.
+
+---
+
+## 1. Final page spine
+
+```text
+/jeugd  (cream paper, parent-facing, NO sponsors, NO trainers grid)
+├─ <JeugdHero> (split)
+│   ├─ left:  MonoLabel "DE JEUGDOPLEIDING · U6 TOT U21"
+│   │         + EditorialHeading "Beter worden begint met plezier."
+│   │         + lead "Een doordachte opleiding … met gediplomeerde trainers en plezier als motor…"
+│   └─ right: youth team/training photo in <TapedFigure> (newsprint)
+├─ <StripedSeam>
+├─ Filosofie / visie  (#visie anchor) — PullQuote/TapedCard, the jeugdvisie copy
+├─ Nav hub  (reskinned <JeugdEditorialGrid>) — uniform 16:9, fixed-position bubbling
+│     · NEWS cards (photographic, jersey-deep tag) ← bubble latest Jeugd articles
+│     · NAV cards (jersey-deep glyph panel, cream tag, NO photo) ← pinned: word lid ·
+│       jeugdvisie→#visie · trainingen/PSD · organigram · hulp · medisch
+├─ Divisions — <YouthDirectory> Bovenbouw / Middenbouw / Onderbouw (reuse 6.C)
+└─ <JeugdCtaBand> — jersey-deep-dark "Interesse in onze jeugd?" + "Schrijf je in" → /hulp
+```
+
+## 2. Locked decisions (index)
+
+| Round | Lock                                                                                                                                                                     |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 7j0   | Data reality: 3 sources (jeugdLandingPage cards · youth teams · Jeugd articles); reuse YouthDirectory (retires TeamOverview/TeamCard); sibling hero; voice = for parents |
+| 7j0b  | Verification: editorial grid IS the nav hub (6 nav + 3 articles); 3 dead routes repointed; hero = photo; filosofie/visie STAYS (absorbs jeugdvisie)                      |
+| 7j1   | Voice = "Beter worden begint met plezier." (BD3 title + BD2 lead); artefact = youth photo; keep "gediplomeerde trainers"                                                 |
+| 7j2   | Order = Hero → Visie → Nav hub → Divisions → CTA                                                                                                                         |
+| 7j3   | Nav hub = uniform 16:9 image-top cards, fixed-position bubbling (articles auto-fill slots, nav pinned)                                                                   |
+| —     | Nav cards visually distinct from news cards (per /nieuws variant precedent): NEWS = photographic + jersey-deep tag; NAV = jersey-deep graphic panel + glyph + cream tag  |
+
+## 3. Derived detail specs (mapped to primitives — NOT re-drilled)
+
+- **Hero:** `<EditorialHeading>` (italic display, jersey-deep period) + `<MonoLabel>` kicker +
+  `<TapedFigure>` youth photo (newsprint filter, `landscape-4-3` or `16-9`). Split mirrors the
+  sponsors `<SponsorHero>` structure.
+- **Nav-hub cards (uniform 16:9 image-top):**
+  - **News variant** — `<TapedFigure>`-style 16:9 cover photo, greyscale→hover-colour,
+    jersey-deep tag pill, italic-display title, mono "Lees meer →".
+  - **Nav variant** — 16:9 `bg-jersey-deep` panel (no photo) with a Phosphor-fill glyph
+    (`@/lib/icons.redesign`) + cream tag pill + italic-display title + mono arrow. `text-white`
+    on jersey-deep (contrast rule). One distinct, coherent variant — not a new vocabulary.
+  - Both: `border-2 border-ink`, `shadow-paper`, canonical press-down hover.
+  - **Tag pill (both variants): editorially managed** — `editorialCards.tag` when set, else
+    fallback `Jeugd` (news) / `Praktisch` (nav). Never blank; real CMS data, not invented (7j3
+    refinement). News pill = jersey-deep on photo; nav pill = cream on the jersey-deep panel.
+  - Fixed-position template preserved; `cardType` selects variant + bubbling; `position` =
+    placement order only (no longer drives size).
+- **Filosofie/visie:** `<PullQuote>` or a `<TapedCard>` block, jersey-deep quote mark, italic
+  display body, `#visie` id. Copy distinct from the hero lead. Replaces `<MissionBanner>`.
+- **Divisions:** reuse `<YouthDirectory>` verbatim (6.C locked) — Bovenbouw/Middenbouw/Onderbouw
+  age chips → `/ploegen/[slug]`.
+- **CTA band:** mirror the locked sponsors `<SponsorCtaBand>` chrome (jersey-deep-dark,
+  `border-y-2 border-ink`, warm paper-stamp button, canonical press-down). Target → `/hulp`
+  (see §6 open).
+- **Hover / focus / border triples:** identical conventions to the sponsors summary §3.
+
+## 4. Empty states
+
+- **0 youth teams:** `<YouthDirectory>` already hides empty division groups; if all empty, drop the
+  divisions section.
+- **0 Jeugd articles:** the nav hub's article slots fall back to nav-only (current
+  `buildItemsFromHardcoded` behaviour) — no empty article cards.
+- **0 editorialCards (singleton unset):** fall back to the hardcoded nav set (repointed targets).
+
+## 5. Build deltas (PRD seed)
+
+**New (under `apps/web/src/components/jeugd/`):**
+
+- `<JeugdHero>` — sibling hero (kicker + EditorialHeading + lead + `<TapedFigure>` photo).
+- `<JeugdCtaBand>` — or reuse a shared CTA band extracted with `<SponsorCtaBand>`.
+
+**Reskin / reuse:**
+
+- `<JeugdEditorialGrid>` → nav hub: uniform 16:9, two card variants (news/nav), fixed-position
+  bubbling preserved. `<EditorialCard>` reskinned (or a new `<JeugdHubCard>`) to 16:9 image-top
+  TapedCard chrome with `variant: "news" | "nav"`.
+- `<MissionBanner>` → reskinned into the filosofie/visie block (or replaced by `<PullQuote>`).
+- `<YouthDirectory>` (6.C) — reuse verbatim → **retires `<TeamOverview>` + `<TeamCard>`** (unblocks
+  half of #1960).
+- `/jeugd/page.tsx` — drop `SectionStack` + `getJeugdSections` + `InteriorPageHero` + `SectionCta`
+  (legacy `kcvv-black`/`diagonal`); recompose on the locked spine with `<StripedSeam>`.
+
+**Repoint dead targets (no new routes):** jeugdvisie → `#visie`; medisch → a Jeugd article or
+`/hulp`; word lid + CTA → `/hulp` (or mailto). Editor can override via the singleton.
+
+**Data / repositories:** `TeamRepository` (youth) + `ArticleRepository` (Jeugd, limit 3) +
+`JeugdLandingPageRepository` (editorialCards) — all exist, **no change**. `groupTeamsForLanding`
+for divisions.
+
+**Analytics (required):** `jeugd_view` (page view), `jeugd_card_click` (params: `card_type`
+news/nav, `tag`, hashed article id for news). **Add `jeugd_` to the live GTM trigger regex**
+(manual step). No PII.
+
+**Testing:** stories + `vr` for `<JeugdHero>`, the nav-hub card (news + nav variants), the
+filosofie/visie block, `<JeugdCtaBand>` (+ empty states). Pages/\* story (not vr) + e2e `/jeugd`
+smoke already exists.
+
+## 6. Open for PRD time (not design)
+
+- **CTA + "word lid" target:** defaulting to `/hulp`; revisit if/when the membership intake form
+  (#1473) ships.
+- **medisch** card target: a specific Jeugd article slug vs `/hulp`.
+- Whether `<JeugdCtaBand>` and `<SponsorCtaBand>` share one extracted `<CtaBand>` primitive.
+- Hero photo aspect (`16-9` vs `4-3`) + which youth photo asset.

--- a/docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md
@@ -53,9 +53,11 @@ The `/jeugd` redesign in the retro-terrace-fanzine system. Audience: **parents**
     (`@/lib/icons.redesign`) + cream tag pill + italic-display title + mono arrow. `text-white`
     on jersey-deep (contrast rule). One distinct, coherent variant — not a new vocabulary.
   - Both: `border-2 border-ink`, `shadow-paper`, canonical press-down hover.
-  - **Tag pill (both variants): editorially managed** — `editorialCards.tag` when set, else
-    fallback `Jeugd` (news) / `Praktisch` (nav). Never blank; real CMS data, not invented (7j3
-    refinement). News pill = jersey-deep on photo; nav pill = cream on the jersey-deep panel.
+  - **Tag pill — editorially managed (per variant; see 7j3 data audit for the full rule):** news
+    cards use `article.tags[0]` → `Jeugd`; nav cards use `editorialCards.tag` → the card's hardcoded
+    `NAV_CARDS` label (e.g. `Praktisch`). `editorialCards.tag` is **not** read for news/article cards.
+    Real CMS data, not invented (7j3 refinement). News pill = jersey-deep on photo; nav pill = cream
+    on the jersey-deep panel.
   - Fixed-position template preserved; `cardType` selects variant + bubbling; `position` =
     placement order only (no longer drives size).
 - **Filosofie/visie:** `<PullQuote>` or a `<TapedCard>` block, jersey-deep quote mark, italic

--- a/docs/design/mockups/phase-7-jeugd/7j-final-page.html
+++ b/docs/design/mockups/phase-7-jeugd/7j-final-page.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /jeugd · FINAL locked page</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .tagstrip { background: var(--ink); color: var(--cream); font-family: var(--font-mono); font-size: 12px; padding: 9px 28px; letter-spacing: 0.04em; }
+      .tagstrip b { color: var(--warm); }
+      .wrap { max-width: 1040px; margin: 0 auto; padding: 0 28px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .seckick { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-muted); display:flex; align-items:center; gap:10px; margin: 0 0 16px; }
+      .seckick::after { content:""; height:2px; flex:1; background: var(--paper-edge); }
+
+      /* hero */
+      .hero { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 34px; align-items: center; padding: 54px 0 24px; }
+      .hero h1 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(36px,5vw,62px); line-height: 0.9; margin: 14px 0 0; letter-spacing: -0.01em; }
+      .hero h1 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 19px; line-height: 1.5; max-width: 46ch; margin: 18px 0 0; color: var(--ink-soft); }
+      .hero .meta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); margin-top: 16px; }
+      .photo { background: repeating-linear-gradient(45deg, var(--cream-deep) 0 14px, var(--cream-soft) 14px 28px); border: 2px solid var(--ink); box-shadow: 6px 7px 0 0 var(--ink); aspect-ratio: 4/3; display:flex; align-items:flex-end; padding: 12px; transform: rotate(-1.2deg); font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing:0.08em; color: var(--ink-muted); }
+
+      .seam { height: 16px; margin: 34px 0; background: repeating-linear-gradient(135deg, var(--ink) 0 10px, var(--cream) 10px 20px); border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); opacity:.92; }
+
+      /* filosofie / visie */
+      .visie { background: var(--cream-soft); border: 2px solid var(--ink); box-shadow: 4px 4px 0 0 var(--ink); padding: 28px; display:grid; grid-template-columns: auto 1fr; gap: 22px; align-items:center; }
+      .visie .qm { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 70px; color: var(--jersey-deep); line-height: .6; }
+      .visie .q { font-family: var(--font-display); font-style: italic; font-size: 24px; line-height: 1.35; }
+      .visie .sub { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-muted); margin-top: 10px; }
+
+      /* nav hub — uniform 16:9, two variants */
+      .hub { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+      .card { border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); overflow:hidden; display:flex; flex-direction:column; text-decoration:none; color:var(--ink); transition: all .3s; background: var(--cream-soft); }
+      .card:hover { box-shadow:none; transform: translate(3px,3px); }
+      .card .top { aspect-ratio: 16/9; border-bottom: 2px solid var(--ink); display:flex; align-items:flex-start; padding: 9px; }
+      .tagm { font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; padding: 3px 7px; border: 1.5px solid var(--ink); }
+      .card .bd { padding: 11px 13px 13px; }
+      .card .ttl { font-family: var(--font-display); font-style: italic; font-weight: 800; font-size: 17px; line-height: 1.1; }
+      .card .arr { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--jersey-deep); margin-top: 8px; display:inline-block; }
+      /* news variant — photographic */
+      .card.news .top { background: repeating-linear-gradient(45deg, #cfe3d2 0 11px, #bcd6c0 11px 22px); filter: grayscale(1); transition: filter .3s; }
+      .card.news:hover .top { filter: grayscale(0); }
+      .card.news .tagm { background: var(--jersey-deep); color: var(--cream); border-color: var(--jersey-deep); }
+      /* nav variant — graphic jersey-deep panel + glyph, NO photo */
+      .card.nav .top { background: var(--jersey-deep); color: var(--cream); align-items:center; justify-content:center; position: relative; }
+      .card.nav .tagm { position:absolute; top:9px; left:9px; background: var(--cream); color: var(--ink); border-color: var(--ink); }
+      .card.nav .glyph { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 40px; color: var(--cream); }
+      .card.nav { background: var(--cream); }
+
+      /* divisions */
+      .divs { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; }
+      .divcol h4 { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); border-bottom: 1px solid var(--paper-edge); padding-bottom: 5px; margin: 0 0 10px; }
+      .divcol .chips { display:flex; flex-wrap: wrap; gap: 7px; }
+      .divcol .chip { border: 2px solid var(--ink); background: var(--cream-soft); box-shadow: 2px 2px 0 0 var(--ink); padding: 8px 11px; display:flex; flex-direction:column; align-items:center; gap:2px; text-decoration:none; transition: all .3s; }
+      .divcol .chip:hover { box-shadow:none; transform: translate(2px,2px); }
+      .divcol .chip .n { font-family: var(--font-display); font-weight: 900; font-style: italic; color: var(--jersey-deep); font-size: 20px; }
+      .divcol .chip .lab { font-family: var(--font-mono); font-size: 8px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); }
+
+      /* CTA band */
+      .cta { margin-top: 46px; background: var(--jersey-deep-dark); color: var(--cream); border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); padding: 44px 0; }
+      .cta .inner { max-width: 1040px; margin: 0 auto; padding: 0 28px; display:flex; justify-content: space-between; align-items:center; gap: 22px; flex-wrap: wrap; }
+      .cta h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 30px; margin: 0; }
+      .cta p { margin: 7px 0 0; color: rgba(245,241,230,0.8); font-size: 14px; max-width: 46ch; }
+      .pill { font-family: var(--font-mono); font-weight: 700; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; border: 2px solid var(--ink); padding: 13px 22px; background: var(--warm); color: var(--ink); box-shadow: 4px 4px 0 0 var(--ink); }
+    </style>
+  </head>
+  <body>
+    <div class="tagstrip">Phase 7 · /jeugd — <b>FINAL locked page</b> · hero photo + visie + nav hub (news vs nav variants) + divisions + CTA · placeholder data</div>
+
+    <div class="wrap">
+      <!-- HERO -->
+      <div class="hero">
+        <div>
+          <div class="kicker">De jeugdopleiding · U6 tot U21</div>
+          <h1>Beter worden begint met plezier<span class="dot">.</span></h1>
+          <p class="lead">Een doordachte opleiding van Onderbouw tot Bovenbouw, met gediplomeerde trainers en plezier als motor. Want wie graag speelt, groeit vanzelf — op en naast het veld.</p>
+          <div class="meta">Onderbouw → Middenbouw → Bovenbouw</div>
+        </div>
+        <div class="photo">[ jeugd team / training foto · TapedFigure ]</div>
+      </div>
+    </div>
+
+    <div class="wrap"><div class="seam"></div></div>
+
+    <!-- FILOSOFIE / VISIE (#visie) -->
+    <div class="wrap" id="visie">
+      <div class="seckick">Onze jeugdvisie</div>
+      <div class="visie">
+        <div class="qm">"</div>
+        <div>
+          <div class="q">Bij KCVV Elewijt staat plezier op één. Wie graag speelt, leert vanzelf — techniek, teamspirit en respect groeien mee.</div>
+          <div class="sub">de jeugdvisie · plezier · techniek · teamspirit</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- NAV HUB -->
+    <div class="wrap" style="margin-top:40px">
+      <div class="seckick">Ontdek onze jeugd</div>
+      <div class="hub">
+        <!-- fixed template; ARTICLE slots bubble latest Jeugd-nieuws, NAV cards pinned -->
+        <a class="card news"><div class="top"><span class="tagm">Jeugd</span></div><div class="bd"><div class="ttl">Onze U13 pakt de titel</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav"><div class="top"><span class="tagm">Aansluiten</span><span class="glyph">+</span></div><div class="bd"><div class="ttl">Word lid van KCVV</div><span class="arr">Schrijf je in →</span></div></a>
+        <a class="card news"><div class="top"><span class="tagm">Jeugd</span></div><div class="bd"><div class="ttl">Terugblik jeugdtornooi</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav"><div class="top"><span class="tagm">Visie</span><span class="glyph">★</span></div><div class="bd"><div class="ttl">Onze jeugdvisie</div><span class="arr">Ontdek →</span></div></a>
+        <a class="card news"><div class="top"><span class="tagm">Jeugd</span></div><div class="bd"><div class="ttl">Nieuwe trainers stellen zich voor</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav"><div class="top"><span class="tagm">Praktisch</span><span class="glyph">⚽</span></div><div class="bd"><div class="ttl">Trainingen & ProSoccerData</div><span class="arr">Meer info →</span></div></a>
+        <a class="card nav"><div class="top"><span class="tagm">Structuur</span><span class="glyph">▤</span></div><div class="bd"><div class="ttl">Organigram</div><span class="arr">Bekijk →</span></div></a>
+        <a class="card nav"><div class="top"><span class="tagm">Hulp</span><span class="glyph">?</span></div><div class="bd"><div class="ttl">Wie contacteer ik?</div><span class="arr">Zoek het op →</span></div></a>
+        <a class="card nav"><div class="top"><span class="tagm">Medisch</span><span class="glyph">+</span></div><div class="bd"><div class="ttl">Blessure of afmelding?</div><span class="arr">Lees meer →</span></div></a>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);margin-top:10px">News cards = photographic (green tag) · Nav cards = jersey-deep glyph panel (cream tag) — distinct but uniform 16:9. Article slots bubble latest nieuws; nav cards pinned.</p>
+    </div>
+
+    <!-- DIVISIONS -->
+    <div class="wrap" style="margin-top:42px">
+      <div class="seckick">Van U6 tot U21</div>
+      <div class="divs">
+        <div class="divcol"><h4>Bovenbouw</h4><div class="chips"><a class="chip"><span class="n">U21</span><span class="lab">ploeg</span></a><a class="chip"><span class="n">U17</span><span class="lab">ploeg</span></a></div></div>
+        <div class="divcol"><h4>Middenbouw</h4><div class="chips"><a class="chip"><span class="n">U15</span><span class="lab">ploeg</span></a><a class="chip"><span class="n">U13</span><span class="lab">ploeg</span></a><a class="chip"><span class="n">U12</span><span class="lab">ploeg</span></a></div></div>
+        <div class="divcol"><h4>Onderbouw</h4><div class="chips"><a class="chip"><span class="n">U10</span><span class="lab">ploeg</span></a><a class="chip"><span class="n">U9</span><span class="lab">ploeg</span></a><a class="chip"><span class="n">U8</span><span class="lab">ploeg</span></a><a class="chip"><span class="n">U6</span><span class="lab">ploeg</span></a></div></div>
+      </div>
+      <p style="font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);margin-top:10px">Reuses the locked 6.C &lt;YouthDirectory&gt; — each chip links to /ploegen/[slug].</p>
+    </div>
+
+    <!-- CTA -->
+    <div class="cta">
+      <div class="inner">
+        <div>
+          <h2>Interesse in onze jeugd?</h2>
+          <p>Nieuwe spelers zijn altijd welkom — van U6 tot U21. Kom gerust eens langs op training.</p>
+        </div>
+        <a class="pill" href="#">Schrijf je in +</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-jeugd/7j0-data-reality-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j0-data-reality-locked.md
@@ -1,0 +1,75 @@
+# Phase 7 · /jeugd — Round 0 (DATA REALITY) — LOCKED
+
+**Date:** 2026-06-07
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7 master)
+**Supersedes (on landing):** `docs/prd/jeugd-landing-page.md`
+
+Locks what data the /jeugd redesign may render, before voice/IA/detail drilling.
+
+---
+
+## 1. Live data sources (the only renderable data)
+
+1. **`jeugdLandingPage` Sanity singleton → `editorialCards[]`** (editor-curated grid):
+   `tag`, `title`, `description?`, `arrowText`, `href`, `image` (→ `imageUrl w=900`),
+   `position` (`featured` / `medium` / `third`), `cardType` (`nav` | `article`). The `article`
+   type auto-fills from Jeugd-category articles. Source: `jeugd-landing-page.repository.ts`.
+2. **Youth `team` docs** (via `TeamRepository`): `name`, `slug`, `age` (U6–U21), `tagline`,
+   `divisionFull`/`division`, `teamImage`. `groupTeamsForLanding` buckets by **division**:
+   Bovenbouw (U17–U21) / Middenbouw (U12–U16) / Onderbouw (U6–U11).
+3. **Jeugd-category articles** (`category: "Jeugd"`, limit 3) — feed the `article` editorial cards.
+
+**No jeugd-wide trainer field. No jeugd-specific sponsor field.** (See §3 decisions.)
+
+## 2. Reuse map
+
+| Asset                                                | State                                                                                        | Disposition                                                                                              |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `<YouthDirectory>` (6.C)                             | **Redesign-ready** (division groups, mono/jersey-deep, `font-display-big`)                   | **Reuse** for the divisions section → **retires `<TeamOverview>`/`<TeamCard>`** (unblocks half of #1960) |
+| `groupTeamsForLanding` / `YouthDivisionGroup`        | Reusable                                                                                     | Reuse the division buckets                                                                               |
+| `<JeugdEditorialGrid>`                               | **Legacy** (`bg-kcvv-green`, `font-title`, `text-kcvv-gray-blue`)                            | Rebuild on cream-paper vocabulary (TapedCard editorial cards)                                            |
+| `<MissionBanner>` (quote)                            | Legacy + **wrong founding year** (says 1948; canonical 1909, `reference_club_founding_year`) | Reskin as the filosofie/quote block; fix year in passing                                                 |
+| `<SectionCta>` / `SectionStack` + `getJeugdSections` | Legacy (`kcvv-black`, dark)                                                                  | Rebuild; drop SectionStack/dark header                                                                   |
+| `<JerseyShirt>` (Phase 4.5)                          | Redesign primitive                                                                           | Hero jersey-illustration artefact                                                                        |
+
+## 3. Decisions taken at this checkpoint
+
+1. **NO sponsors on /jeugd.** Resolves the §6.9-vs-must-avoid conflict in favour of the
+   must-avoid ("no commercial sponsor placement on jeugd page"). The youth page stays
+   non-commercial / parent-facing; sponsors live on `/sponsors` + homepage only. The §6.9
+   "supporting sponsors" line is overruled.
+2. **DROP the trainers grid.** §6.9 wanted one, but there is no jeugd-wide trainer data source
+   (staff is per-team only). Aggregating it is noisy + an editorial/eng burden with no curation
+   control. Trainers stay on each team-detail page. (`feedback_editorial_cost_discipline`.)
+3. **Hero is a sibling component, NOT `<EditorialHero variant="announcement">`** (§5.4
+   sibling-per-surface lock; same as sponsors). Headline "De toekomst van Elewijt." carries over;
+   jersey-illustration artefact via `<JerseyShirt>`.
+4. **Youth grouped by division** (Bovenbouw/Middenbouw/Onderbouw), not by age — reuse
+   `<YouthDirectory>`. (`project_youth_divisions`.)
+5. **Voice constraint locked: "for parents, not players."**
+
+## 4. Known issue to resolve at CTA round
+
+- 🐞 The current "Word ook lid" CTA targets **`/club/inschrijven`, which does not exist (404)**.
+  The redesign CTA must point somewhere real — contact/email, or the membership intake form
+  (#1473, nice-to-have, unbuilt). Decide at the CTA detail round.
+
+## 5. Page scope after decisions (lean)
+
+```text
+/jeugd  (parent-facing, non-commercial)
+├─ Hero (sibling)        — "De toekomst van Elewijt." + jersey-illustration artefact
+├─ Editorial cards grid  — jeugdLandingPage editorialCards (nav + article), reskinned
+├─ Filosofie / quote     — spelplezier mission (MissionBanner reskin, fix founding year)
+├─ Youth divisions       — <YouthDirectory> Bovenbouw / Middenbouw / Onderbouw
+└─ "Schrijf je in" CTA   — target TBD (current /club/inschrijven is 404)
+   (NO sponsors · NO trainers grid)
+```
+
+## 6. Carry-forward into VOICE round (7j1)
+
+- Register for a **parent-facing** youth page: proud/aspirational, fun-first/reassuring,
+  invitational/onboarding, or developmental/academy?
+- Headline candidate "De toekomst van Elewijt." (master plan) vs. alternatives — voice picks
+  the register, headline follows.

--- a/docs/design/mockups/phase-7-jeugd/7j0b-implementation-verification-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j0b-implementation-verification-locked.md
@@ -1,0 +1,53 @@
+# Phase 7 · /jeugd — Round 0b (IMPLEMENTATION VERIFICATION) — LOCKED
+
+**Date:** 2026-06-07
+**Owner:** @climacon
+**Why:** owner asked to verify the current implementation so the redesign drops nothing.
+Audit of `getJeugdSections.tsx`, `JeugdEditorialGrid.tsx`, `EditorialCard`, `TeamOverview`,
+`MissionBanner`, and route existence.
+
+## Findings
+
+1. **The editorial grid is the page's primary NAVIGATION HUB, not a minor section.**
+   `<JeugdEditorialGrid>` is a 9-item magazine grid = **3 auto-filled Jeugd-article slots + 6 nav
+   cards** to the practical parent tasks: _Word lid · Onze jeugdvisie · Trainingen &
+   ProSoccerData · Organigram · Wie contacteer ik? · Blessure/afmelding_. Driven by the
+   `jeugdLandingPage` singleton's `editorialCards` when present; falls back to hardcoded
+   `NAV_CARDS`. **The redesign must preserve all six affordances + the 3 article slots.**
+
+2. **Three nav/CTA destinations are dead routes (hardcoded fallback):**
+   `/club/inschrijven` (404), `/jeugd/visie` (404), `/jeugd/medisch` (404).
+   `/club/organigram` + `/hulp` exist. `/nieuws/prosoccerdata` depends on an article slug.
+   The Sanity singleton _may_ override these in prod (not verified — Sanity budget).
+
+3. **Hero is photo-based today** (`/images/youth-trainers.jpg`) with copy
+   _"Meer dan 200 jonge voetballers. Gediplomeerde trainers. Eén missie: plezier, techniek en
+   teamspirit."_ — concrete parent reassurance.
+
+4. **No loss from `TeamOverview` → `<YouthDirectory>`:** TeamOverview already buckets youth by
+   division internally + links each team to `/ploegen/[slug]`; YouthDirectory preserves both.
+   Filter buttons are not enabled on /jeugd. (Correction to 7j0: MissionBanner's _default_
+   attribution already reads "sinds 1909"; /jeugd passes a custom attribution anyway, so the
+   founding-year note does not apply here.)
+
+## Decisions
+
+1. **Repoint dead links to existing surfaces (no new routes built in this redesign):**
+   - **"Onze jeugdvisie"** → folds into the **filosofie section on /jeugd itself** (anchor
+     `#visie`); no separate `/jeugd/visie` page. ⇒ the filosofie/visie section **STAYS** (it now
+     absorbs the visie content — resolves the 7j2 keep/drop question in favour of KEEP).
+   - **"Blessure of afmelding?"** → a Jeugd article or `/hulp`.
+   - **"Word lid" + the page CTA** → `/hulp` or a `mailto:` until a real membership form exists
+     (#1473). Exact target finalised at the CTA detail round.
+   - Editor can still override any card href via the `jeugdLandingPage` singleton.
+2. **Hero artefact = youth team/training photo** in a `<TapedFigure>` newsprint frame (NOT
+   `<JerseyShirt>`). Warmer/more human for parents. Keep the **"gediplomeerde trainers"**
+   reassurance in the hero lead/meta.
+3. **Nav hub preserved** — reskin `<JeugdEditorialGrid>` to cream-paper TapedCard editorial cards
+   (featured/medium/third positions retained), all 6 nav affordances + 3 article slots intact.
+
+## Impact on the IA round (7j2 rebuilt)
+
+- Filosofie/visie section is now KEPT in every variant (absorbs jeugdvisie).
+- The "editorial cards" block is relabelled **"Nav hub"** and treated as primary functional content.
+- Hero shows a photo artefact, not an illustration.

--- a/docs/design/mockups/phase-7-jeugd/7j1-voice-compare.html
+++ b/docs/design/mockups/phase-7-jeugd/7j1-voice-compare.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /jeugd · Round 1: VOICE compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 82ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+      .hero { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 36px; align-items: center; padding: 52px 28px 30px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .hero h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(38px,5.4vw,72px); line-height: 0.9; margin: 14px 0 0; letter-spacing: -0.01em; }
+      .hero h2 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 19px; line-height: 1.5; max-width: 48ch; margin: 18px 0 0; color: var(--ink-soft); }
+      .hero .meta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); margin-top: 18px; }
+
+      /* jersey-illustration artefact (two-pass print placeholder) */
+      .artefact { display: flex; justify-content: center; }
+      .jersey { width: 230px; height: auto; transform: rotate(-2deg); filter: drop-shadow(5px 6px 0 rgba(10,10,10,0.85)); }
+
+      /* section hint below hero */
+      .hint { max-width: 1080px; margin: 0 auto; padding: 4px 28px 18px; }
+      .hint-row { display: flex; gap: 10px; flex-wrap: wrap; }
+      .chip { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-muted); border: 1.5px solid var(--paper-edge); padding: 6px 10px; }
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /jeugd — Round 1: VOICE</h1>
+      <p>Four parent-facing registers for the youth landing. Hero = sibling component (kicker +
+        EditorialHeading + lead + jersey-illustration artefact via &lt;JerseyShirt&gt;). Page below
+        is the locked lean scope: editorial cards → filosofie → divisions (Bovenbouw/Middenbouw/
+        Onderbouw, reusing &lt;YouthDirectory&gt;) → schrijf-je-in CTA. NO sponsors, NO trainers grid.
+        See <a href="./7j0-data-reality-locked.md">7j0 lock</a>. Voice = "for parents, not players".</p>
+    </div>
+
+    <!-- A -->
+    <div class="direction-bar"><span class="tag">A</span> Toekomst — proud / aspirational <span class="note">the kids ARE the club's future; confident, forward-looking</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Jeugdopleiding · U6 tot U21</div>
+        <h2>De toekomst van Elewijt<span class="dot">.</span></h2>
+        <p class="lead">Vandaag op het oefenveld, morgen in de eerste ploeg. Bij KCVV Elewijt groeien meer dan 300 kinderen op met de bal aan de voet.</p>
+        <div class="meta">Onderbouw · Middenbouw · Bovenbouw</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="hint"><div class="hint-row"><span class="chip">Editorial cards</span><span class="chip">Filosofie</span><span class="chip">Bovenbouw / Middenbouw / Onderbouw</span><span class="chip">Schrijf je in</span></div></div>
+    <div class="note-strip">Proud + outward. Appeals to club identity + parents who want their kid to "be part of something". "De toekomst van Elewijt." is the master-plan headline.</div>
+
+    <!-- B -->
+    <div class="direction-bar"><span class="tag">B</span> Plezier — fun-first / reassuring <span class="note">plezier &gt; prestatie; reassures parents it's not a pressure cooker</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Spelplezier op één</div>
+        <h2>Eerst plezier. <br>Dan de rest<span class="dot">.</span></h2>
+        <p class="lead">Bij KCVV Elewijt leren kinderen voetballen zonder de druk. Want wie graag speelt, groeit vanzelf — op en naast het veld.</p>
+        <div class="meta">U6 tot U21 · iedereen speelt</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="hint"><div class="hint-row"><span class="chip">Editorial cards</span><span class="chip">Filosofie</span><span class="chip">Bovenbouw / Middenbouw / Onderbouw</span><span class="chip">Schrijf je in</span></div></div>
+    <div class="note-strip">Most reassuring to parents (the real audience). Leads with the club's actual philosophy (the current MissionBanner quote). Warm, low-pressure.</div>
+
+    <!-- C -->
+    <div class="direction-bar"><span class="tag">C</span> Welkom — invitational / onboarding <span class="note">belonging + "kom erbij"; foregrounds joining</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Welkom op De Kapblok</div>
+        <h2>Iedereen hoort erbij<span class="dot">.</span></h2>
+        <p class="lead">Van de allerkleinsten tot de U21: bij KCVV Elewijt is er een plek voor elk kind. Kom eens langs op training — de eerste keer is altijd vrijblijvend.</p>
+        <div class="meta">U6 tot U21 · kom proberen</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="hint"><div class="hint-row"><span class="chip">Editorial cards</span><span class="chip">Filosofie</span><span class="chip">Bovenbouw / Middenbouw / Onderbouw</span><span class="chip">Schrijf je in</span></div></div>
+    <div class="note-strip">Most action-oriented for recruiting families. Pairs naturally with the schrijf-je-in CTA. RISK: leans on "kom proberen" copy that needs the CTA destination fixed (the 404).</div>
+
+    <!-- D -->
+    <div class="direction-bar"><span class="tag">D</span> Opleiding — developmental / academy <span class="note">structured pathway Onderbouw→Bovenbouw; quality coaching</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">De jeugdopleiding</div>
+        <h2>Stap voor stap, <br>seizoen na seizoen<span class="dot">.</span></h2>
+        <p class="lead">Van Onderbouw over Middenbouw naar Bovenbouw: een doordachte opleiding waar elk kind op zijn tempo beter wordt — met plezier als basis.</p>
+        <div class="meta">Onderbouw → Middenbouw → Bovenbouw</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="hint"><div class="hint-row"><span class="chip">Editorial cards</span><span class="chip">Filosofie</span><span class="chip">Bovenbouw / Middenbouw / Onderbouw</span><span class="chip">Schrijf je in</span></div></div>
+    <div class="note-strip">Most "serious football education" — appeals to parents weighing clubs on quality. RISK: can read as performance-focused, brushing against "plezier op één" + "for parents not players". The division pathway maps 1:1 to the YouthDirectory below.</div>
+
+    <div class="legend">
+      <b>One-line trade-off:</b> A = proud club-future (master-plan headline) ·
+      B = fun-first, most reassuring to parents ·
+      C = invitational, best for recruiting (needs the CTA fixed) ·
+      D = academy/pathway, risks reading performance-y.<br />
+      All four reuse the same primitives (EditorialHeading, MonoLabel kicker, JerseyShirt artefact)
+      and the same locked page scope beneath the hero. Voice picks the register; headline follows.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-jeugd/7j1-voice-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j1-voice-locked.md
@@ -1,0 +1,41 @@
+# Phase 7 · /jeugd — Round 1 (VOICE) — LOCKED
+
+**Date:** 2026-06-07
+**Mockups:** `7j1-voice-compare.html` → `7j1b-voice-blend-compare.html`
+**Owner:** @climacon
+
+## Decision
+
+**Voice = B↔D blend "development through plezier" — BD3 headline + BD2 lead.**
+
+A youth landing that is **serious about the opleiding but rooted in plezier**, addressed to
+**parents**. Final hero copy:
+
+- **Kicker:** `DE JEUGDOPLEIDING · U6 TOT U21`
+- **Headline (from BD3):** **"Beter worden begint met plezier."** (`<EditorialHeading>`, italic
+  display, jersey-deep period)
+- **Lead (from BD2):** _"Een doordachte opleiding van Onderbouw tot Bovenbouw, met plezier als
+  motor. Want wie graag speelt, groeit vanzelf — op en naast het veld."_
+- **Meta row:** `Onderbouw → Middenbouw → Bovenbouw` (maps to `<YouthDirectory>` below)
+- **Artefact:** **youth team/training photo** in a `<TapedFigure>` newsprint frame (right column),
+  NOT `<JerseyShirt>` — warmer for parents (decided 7j0b).
+- **Reassurance to retain:** weave the current hero's **"gediplomeerde trainers"** credential
+  into the lead/meta (concrete parent reassurance surfaced in 7j0b verification).
+
+Rationale: BD3's title makes the development claim confidently while disarming the pressure worry
+("…begint met plezier"); BD2's lead names the structured pathway _and_ the plezier motor in prose.
+Avoids B's risk of reading unambitious and pure-D's risk of reading performance-y.
+
+## Rejected
+
+- **A · Toekomst** — proud/outward, but speaks to club identity more than to a parent choosing a
+  club. (Sentiment can survive as a sub-line elsewhere.)
+- **C · Welkom** — invitational; good energy but leans on "kom proberen" copy that depends on the
+  broken CTA target. Its onboarding warmth can inform the CTA-round copy.
+- **Pure B / pure D** — the blend supersedes both.
+
+## Carry-forward into IA round (7j2)
+
+- **Section order** of the scope (Hero → {nav hub, filosofie/visie, divisions} → CTA) — the
+  filosofie/visie section now STAYS (absorbs jeugdvisie per 7j0b), so this is order-only, not
+  keep/drop. Editorial grid is the **nav hub** (primary functional content).

--- a/docs/design/mockups/phase-7-jeugd/7j1b-voice-blend-compare.html
+++ b/docs/design/mockups/phase-7-jeugd/7j1b-voice-blend-compare.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /jeugd · Round 1b: VOICE blend (B↔D)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 84ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .scale { font-family: var(--font-mono); font-size: 11px; color: #cfeede; margin-top: 6px; }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+      .hero { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 36px; align-items: center; padding: 52px 28px 26px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .hero h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(38px,5.2vw,66px); line-height: 0.92; margin: 14px 0 0; letter-spacing: -0.01em; }
+      .hero h2 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 19px; line-height: 1.5; max-width: 50ch; margin: 18px 0 0; color: var(--ink-soft); }
+      .hero .meta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); margin-top: 18px; }
+      .artefact { display: flex; justify-content: center; }
+      .jersey { width: 220px; height: auto; transform: rotate(-2deg); filter: drop-shadow(5px 6px 0 rgba(10,10,10,0.85)); }
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /jeugd — Round 1b: VOICE blend (B ↔ D)</h1>
+      <p>You picked "between B (plezier-first) and D (developmental pathway)." The shared idea:
+        <b>development through plezier</b> — KCVV is serious about kids getting better, but fun is
+        the engine. These three slide along that axis so you can pin the exact balance. Same hero
+        primitive + locked lean scope below.</p>
+      <div class="scale">B (plezier) ◄─────── BD1 ─── BD2 ─── BD3 ───────► D (opleiding)</div>
+    </div>
+
+    <!-- BD1 -->
+    <div class="direction-bar"><span class="tag">BD1</span> Lean-B <span class="note">plezier leads, growth implied — three-verb rhythm</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">Spelplezier op één · U6 tot U21</div>
+        <h2>Spelen, leren, groeien<span class="dot">.</span></h2>
+        <p class="lead">Bij KCVV Elewijt leren kinderen voetballen zonder de druk — en worden ze stap voor stap beter, elk op zijn eigen tempo.</p>
+        <div class="meta">Onderbouw → Middenbouw → Bovenbouw</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="note-strip">Warmest of the three. "Groeien" carries the development note lightly; plezier is the headline emotion. Closest to the current MissionBanner philosophy.</div>
+
+    <!-- BD2 -->
+    <div class="direction-bar"><span class="tag">BD2</span> Balanced <span class="note">explicit learning AND explicit plezier — the true midpoint</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">De jeugdopleiding · U6 tot U21</div>
+        <h2>Leren voetballen. <br>Met plezier<span class="dot">.</span></h2>
+        <p class="lead">Een doordachte opleiding van Onderbouw tot Bovenbouw, met plezier als motor. Want wie graag speelt, groeit vanzelf — op en naast het veld.</p>
+        <div class="meta">Onderbouw → Middenbouw → Bovenbouw</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="note-strip">The true midpoint: names both "leren voetballen" (opleiding) and "met plezier" in the headline. "Doordachte opleiding … met plezier als motor" states the philosophy outright. Most explicit about being a real opleiding without losing the warmth.</div>
+
+    <!-- BD3 -->
+    <div class="direction-bar"><span class="tag">BD3</span> Lean-D <span class="note">development-forward, plezier framed as the method</span></div>
+    <div class="hero">
+      <div>
+        <div class="kicker">De jeugdopleiding</div>
+        <h2>Beter worden begint <br>met plezier<span class="dot">.</span></h2>
+        <p class="lead">Van Onderbouw over Middenbouw naar Bovenbouw: bij KCVV Elewijt groeit elk kind op zijn tempo — met spelplezier als de basis van alles.</p>
+        <div class="meta">Onderbouw → Middenbouw → Bovenbouw</div>
+      </div>
+      <div class="artefact">
+        <svg class="jersey" viewBox="0 0 200 220" aria-hidden="true"><g fill="none" stroke="#0a0a0a" stroke-width="3"><path d="M60 28 L30 50 L46 78 L62 66 L62 196 Q62 200 66 200 L134 200 Q138 200 138 196 L138 66 L154 78 L170 50 L140 28 Q120 44 100 44 Q80 44 60 28 Z" fill="#008755"/><path d="M88 30 Q100 42 112 30" /><g stroke="#0a0a0a" stroke-width="6" opacity="0.85"><line x1="84" y1="60" x2="84" y2="198"/><line x1="100" y1="48" x2="100" y2="200"/><line x1="116" y1="60" x2="116" y2="198"/></g></g></svg>
+      </div>
+    </div>
+    <div class="note-strip">Development-forward but explicitly rooted in plezier ("begint met plezier"). Strongest "we take the opleiding seriously" signal while still disarming the pressure worry.</div>
+
+    <div class="legend">
+      <b>All three</b> keep the Onderbouw→Bovenbouw pathway in the meta (maps to the
+      &lt;YouthDirectory&gt; below) and the jersey artefact. Difference is only headline + kicker +
+      lead emphasis:<br />
+      BD1 "Spelen, leren, groeien." (plezier-led) · BD2 "Leren voetballen. Met plezier."
+      (balanced) · BD3 "Beter worden begint met plezier." (development-led).
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-jeugd/7j2-ia-compare.html
+++ b/docs/design/mockups/phase-7-jeugd/7j2-ia-compare.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /jeugd · Round 2: IA — section order (rebuilt)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 86ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar.lk { background: var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1000px; margin: 0 auto; padding: 0 28px; }
+
+      /* locked hero — photo artefact */
+      .hero { display: grid; grid-template-columns: 1.05fr 0.95fr; gap: 30px; align-items: center; padding: 40px 0 22px; }
+      .kicker { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .hero h2 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(28px,3.6vw,46px); line-height: 0.92; margin: 10px 0 0; }
+      .hero h2 .dot { color: var(--jersey-deep); }
+      .hero .lead { font-family: var(--font-display); font-size: 15px; line-height: 1.5; margin: 12px 0 0; color: var(--ink-soft); }
+      .photo { background: repeating-linear-gradient(45deg, var(--cream-deep) 0 12px, var(--cream-soft) 12px 24px); border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); aspect-ratio: 4/3; display: flex; align-items: center; justify-content: center; transform: rotate(-1deg); font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); }
+
+      /* generic section blocks */
+      .sec { border: 2px solid var(--ink); margin: 14px 0; background: var(--cream-soft); }
+      .sec.hub { box-shadow: 4px 4px 0 0 var(--ink); }
+      .sec .lbl { background: var(--ink); color: var(--cream); font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.13em; text-transform: uppercase; padding: 7px 12px; display:flex; justify-content:space-between; }
+      .sec.hub .lbl { background: var(--jersey-deep); }
+      .sec .bd { padding: 16px; }
+      /* nav hub mini: 3 articles + 6 nav cards */
+      .hubgrid { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 8px; }
+      .hubgrid .feat { grid-row: 1 / 3; background: var(--cream-deep); border: 1.5px solid var(--ink); min-height: 110px; display:flex; align-items:flex-end; padding: 8px; font-family: var(--font-display); font-style: italic; font-size: 13px; }
+      .hubgrid .c { background: var(--cream-deep); border: 1.5px solid var(--ink); min-height: 50px; padding: 6px; font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; color: var(--ink-muted); display:flex; align-items:flex-end; }
+      .hubgrid .art { background: #d7e7d9; }
+      .hubnote { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); margin-top: 8px; }
+      /* divisions mini */
+      .divs { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+      .divcol h4 { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); border-bottom: 1px solid var(--paper-edge); padding-bottom: 4px; margin: 0 0 8px; }
+      .divcol .chips { display:flex; flex-wrap: wrap; gap: 5px; }
+      .divcol .chip { border: 1.5px solid var(--ink); background: var(--cream); padding: 5px 7px; font-family: var(--font-display); font-style: italic; font-weight: 800; color: var(--jersey-deep); font-size: 13px; }
+      /* filosofie/visie */
+      .visie { display: grid; grid-template-columns: 1fr; gap: 6px; }
+      .visie .q { font-family: var(--font-display); font-style: italic; font-size: 19px; line-height: 1.4; color: var(--ink-soft); border-left: 4px solid var(--jersey-deep); padding-left: 14px; }
+      .visie .sub { font-family: var(--font-mono); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--ink-muted); }
+      /* cta */
+      .ctaband { background: var(--jersey-deep-dark); color: var(--cream); }
+      .ctaband .bd { display:flex; justify-content: space-between; align-items: center; gap: 16px; }
+      .ctaband h3 { font-family: var(--font-display); font-style: italic; font-size: 20px; margin: 0; }
+      .pill { font-family: var(--font-mono); font-weight: 700; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; border: 2px solid var(--ink); padding: 10px 16px; background: var(--warm); color: var(--ink); box-shadow: 3px 3px 0 0 var(--ink); }
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /jeugd — Round 2: IA — section order (rebuilt after verification)</h1>
+      <p>Updated per the 7j0b implementation audit: hero uses a <b>youth photo</b>; the editorial
+        grid is the <b>NAV HUB</b> (3 Jeugd-article slots + 6 nav cards: word lid · jeugdvisie ·
+        trainingen/PSD · organigram · hulp · medisch); the <b>filosofie/visie</b> section now STAYS
+        (it absorbs the jeugdvisie target as anchor <code>#visie</code>). This round is ORDER-ONLY of
+        {nav hub, filosofie/visie, divisions}. See <a href="./7j0b-implementation-verification-locked.md">7j0b</a>.</p>
+    </div>
+
+    <!-- LOCKED hero -->
+    <div class="direction-bar lk"><span class="tag" style="background:#cfeede">LOCKED</span> Hero — photo artefact, identical in all variants</div>
+    <div class="wrap"><div class="hero">
+      <div>
+        <div class="kicker">De jeugdopleiding · U6 tot U21</div>
+        <h2>Beter worden begint met plezier<span class="dot">.</span></h2>
+        <p class="lead">Een doordachte opleiding van Onderbouw tot Bovenbouw, met gediplomeerde trainers en plezier als motor. Want wie graag speelt, groeit vanzelf.</p>
+      </div>
+      <div class="photo">[ youth team / training photo · TapedFigure ]</div>
+    </div></div>
+
+    <!-- IA-A approach-first -->
+    <div class="direction-bar"><span class="tag">IA-A</span> Approach → Teams → Hub <span class="note">narrative first; practical links + news before the CTA</span></div>
+    <div class="wrap">
+      <div class="sec"><div class="lbl"><span>Filosofie / visie</span><span>#visie anchor</span></div><div class="bd"><div class="visie"><div class="q">"Wie graag speelt, groeit vanzelf — op en naast het veld."</div><div class="sub">de jeugdvisie · plezier · techniek · teamspirit</div></div></div></div>
+      <div class="sec"><div class="lbl"><span>Divisions</span><span>YouthDirectory</span></div><div class="bd"><div class="divs"><div class="divcol"><h4>Bovenbouw</h4><div class="chips"><span class="chip">U21</span><span class="chip">U17</span></div></div><div class="divcol"><h4>Middenbouw</h4><div class="chips"><span class="chip">U15</span><span class="chip">U13</span></div></div><div class="divcol"><h4>Onderbouw</h4><div class="chips"><span class="chip">U10</span><span class="chip">U8</span><span class="chip">U6</span></div></div></div></div></div>
+      <div class="sec hub"><div class="lbl"><span>Nav hub</span><span>3 articles + 6 nav cards</span></div><div class="bd"><div class="hubgrid"><div class="feat art">Featured Jeugd-artikel</div><div class="c">Word lid</div><div class="c art">Artikel</div><div class="c">Jeugdvisie</div><div class="c">Trainingen/PSD</div><div class="c">Organigram</div><div class="c">Hulp</div></div><div class="hubnote">+ Medisch · article slots auto-fill from Jeugd-nieuws</div></div></div>
+      <div class="sec ctaband"><div class="lbl"><span>CTA</span><span>schrijf je in → /hulp</span></div><div class="bd"><h3>Interesse in onze jeugd?</h3><span class="pill">Schrijf je in +</span></div></div>
+    </div>
+    <div class="note-strip">Reads like a story: pitch (hero) → why (visie) → which teams → where to go next (hub) → join. Hub's news sits lower (less immediate). The visie card in the hub anchors up to the visie section.</div>
+
+    <!-- IA-B teams-first -->
+    <div class="direction-bar"><span class="tag">IA-B</span> Teams → Hub → Visie <span class="note">parent sees their kid's age group first</span></div>
+    <div class="wrap">
+      <div class="sec"><div class="lbl"><span>Divisions</span><span>YouthDirectory</span></div><div class="bd"><div class="divs"><div class="divcol"><h4>Bovenbouw</h4><div class="chips"><span class="chip">U21</span><span class="chip">U17</span></div></div><div class="divcol"><h4>Middenbouw</h4><div class="chips"><span class="chip">U15</span><span class="chip">U13</span></div></div><div class="divcol"><h4>Onderbouw</h4><div class="chips"><span class="chip">U10</span><span class="chip">U8</span><span class="chip">U6</span></div></div></div></div></div>
+      <div class="sec hub"><div class="lbl"><span>Nav hub</span><span>3 articles + 6 nav cards</span></div><div class="bd"><div class="hubgrid"><div class="feat art">Featured Jeugd-artikel</div><div class="c">Word lid</div><div class="c art">Artikel</div><div class="c">Jeugdvisie</div><div class="c">Trainingen/PSD</div><div class="c">Organigram</div><div class="c">Hulp</div></div><div class="hubnote">+ Medisch · article slots auto-fill from Jeugd-nieuws</div></div></div>
+      <div class="sec"><div class="lbl"><span>Filosofie / visie</span><span>#visie anchor</span></div><div class="bd"><div class="visie"><div class="q">"Wie graag speelt, groeit vanzelf — op en naast het veld."</div><div class="sub">de jeugdvisie · plezier · techniek · teamspirit</div></div></div></div>
+      <div class="sec ctaband"><div class="lbl"><span>CTA</span><span>schrijf je in → /hulp</span></div><div class="bd"><h3>Interesse in onze jeugd?</h3><span class="pill">Schrijf je in +</span></div></div>
+    </div>
+    <div class="note-strip">Most task-efficient: a parent finds their kid's age group + the practical hub up top. RISK: the visie lands late (but its hub card anchors down to it), and news is mid-page.</div>
+
+    <!-- IA-C hub-first (current order) -->
+    <div class="direction-bar"><span class="tag">IA-C</span> Hub → Teams → Visie <span class="note">closest to today's order (editorial → teams → quote)</span></div>
+    <div class="wrap">
+      <div class="sec hub"><div class="lbl"><span>Nav hub</span><span>3 articles + 6 nav cards</span></div><div class="bd"><div class="hubgrid"><div class="feat art">Featured Jeugd-artikel</div><div class="c">Word lid</div><div class="c art">Artikel</div><div class="c">Jeugdvisie</div><div class="c">Trainingen/PSD</div><div class="c">Organigram</div><div class="c">Hulp</div></div><div class="hubnote">+ Medisch · article slots auto-fill from Jeugd-nieuws</div></div></div>
+      <div class="sec"><div class="lbl"><span>Divisions</span><span>YouthDirectory</span></div><div class="bd"><div class="divs"><div class="divcol"><h4>Bovenbouw</h4><div class="chips"><span class="chip">U21</span><span class="chip">U17</span></div></div><div class="divcol"><h4>Middenbouw</h4><div class="chips"><span class="chip">U15</span><span class="chip">U13</span></div></div><div class="divcol"><h4>Onderbouw</h4><div class="chips"><span class="chip">U10</span><span class="chip">U8</span><span class="chip">U6</span></div></div></div></div></div>
+      <div class="sec"><div class="lbl"><span>Filosofie / visie</span><span>#visie anchor</span></div><div class="bd"><div class="visie"><div class="q">"Wie graag speelt, groeit vanzelf — op en naast het veld."</div><div class="sub">de jeugdvisie · plezier · techniek · teamspirit</div></div></div></div>
+      <div class="sec ctaband"><div class="lbl"><span>CTA</span><span>schrijf je in → /hulp</span></div><div class="bd"><h3>Interesse in onze jeugd?</h3><span class="pill">Schrijf je in +</span></div></div>
+    </div>
+    <div class="note-strip">News + nav hub lead (most engagement up top), matching today's order. RISK: the big 9-item hub right under the hero is visually heavy before any narrative; teams pushed down.</div>
+
+    <div class="legend">
+      <b>One-line trade-off:</b> IA-A = story arc (visie → teams → hub), warmest ·
+      IA-B = task-first (teams + hub up top), most parent-efficient ·
+      IA-C = news/hub-first (status-quo order), most engagement but heaviest opener.<br />
+      Nav-hub internals (featured/medium/third magazine layout), division card styling, the photo
+      treatment, and CTA target are later DETAIL rounds.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-jeugd/7j2-ia-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j2-ia-locked.md
@@ -1,0 +1,39 @@
+# Phase 7 · /jeugd — Round 2 (IA: section order) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7j2-ia-compare.html` (rebuilt post-verification)
+**Owner:** @climacon
+
+## Decision
+
+**Order = Visie → Hub → Teams → CTA** (a variant the owner specified, not one of the three drawn).
+
+```text
+/jeugd  (parent-facing, non-commercial)
+├─ Hero (sibling)        — "Beter worden begint met plezier." + youth PHOTO (TapedFigure)
+├─ Filosofie / visie     — the jeugdvisie content; anchor target #visie
+├─ Nav hub               — reskinned <JeugdEditorialGrid>: 3 Jeugd-article slots + 6 nav cards
+│                          (word lid · jeugdvisie→#visie · trainingen/PSD · organigram · hulp · medisch)
+├─ Divisions             — <YouthDirectory> Bovenbouw / Middenbouw / Onderbouw (reuse 6.C)
+└─ CTA                    — "Schrijf je in" → /hulp or mailto (final target at CTA round)
+   (NO sponsors · NO trainers grid)
+```
+
+Rationale: pitch (hero) → why/approach (visie) → practical links + news (hub) → the actual teams
+(divisions) → join (CTA). Visie leads the body so the "Onze jeugdvisie" hub card can anchor up to
+`#visie` on the same page (no separate `/jeugd/visie` route).
+
+## Reminder (scope, not re-decided here)
+
+- This locks ORDER + section inventory + data only. **Each section's visual design is a separate
+  DETAIL round** (low-fidelity blocks in the mockup are not the design).
+
+## Carry-forward into DETAIL rounds
+
+1. **Nav hub** — the magazine layout (featured/medium/third), TapedCard card chrome, how `article`
+   vs `nav` cards differ, greyscale/photo treatment. (Biggest remaining drill.)
+2. **Hero** — youth-photo `<TapedFigure>` treatment (frame, overlap, sizing); fold "gediplomeerde
+   trainers" into the lead.
+3. **Filosofie / visie** — quote vs richer block; the `#visie` anchor; distinct copy from the hero lead.
+4. **Divisions** — reuse 6.C `<YouthDirectory>` (already locked) — confirm, minimal drilling.
+5. **CTA** — band chrome + final target (the `/club/inschrijven` 404 fix).

--- a/docs/design/mockups/phase-7-jeugd/7j3-navhub-compare.html
+++ b/docs/design/mockups/phase-7-jeugd/7j3-navhub-compare.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — /jeugd · Round 3 (DETAIL): nav hub layout</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 86ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1040px; margin: 0 auto; padding: 30px 28px 8px; }
+      .seckick { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-muted); display:flex; align-items:center; gap:10px; margin-bottom: 14px; }
+      .seckick::after { content:""; height:2px; flex:1; background: var(--paper-edge); }
+
+      /* ---- card chrome (shared) ---- */
+      .card { border: 2px solid var(--ink); box-shadow: 3px 3px 0 0 var(--ink); background: var(--cream-soft); display:flex; flex-direction:column; overflow:hidden; transition: all .3s; text-decoration:none; color:var(--ink); }
+      .card:hover { box-shadow: none; transform: translate(3px,3px); }
+      .card .img { background: repeating-linear-gradient(45deg, var(--cream-deep) 0 10px, #dcd2b6 10px 20px); border-bottom: 2px solid var(--ink); filter: grayscale(1); transition: filter .3s; flex:1; min-height: 64px; display:flex; align-items:flex-start; justify-content:flex-start; padding:8px; }
+      .card:hover .img { filter: grayscale(0); }
+      .card.art .img { background: repeating-linear-gradient(45deg, #cfe3d2 0 10px, #bcd6c0 10px 20px); }
+      .card .tagm { font-family: var(--font-mono); font-size: 9px; font-weight:600; letter-spacing: 0.1em; text-transform: uppercase; background: var(--cream); border:1.5px solid var(--ink); padding: 3px 6px; }
+      .card.art .tagm { background: var(--jersey-deep); color: var(--cream); border-color: var(--jersey-deep); }
+      .card .body { padding: 10px 12px 12px; }
+      .card .ttl { font-family: var(--font-display); font-style: italic; font-weight: 800; font-size: 16px; line-height: 1.1; }
+      .card .desc { font-size: 11px; color: var(--ink-muted); margin-top: 4px; }
+      .card .arr { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--jersey-deep); margin-top: 8px; display:inline-block; }
+
+      /* N1 magazine */
+      .mag { display: grid; grid-template-columns: repeat(12, 1fr); grid-auto-rows: 120px; gap: 12px; }
+      .mag .feat { grid-column: span 7; grid-row: span 2; }
+      .mag .m1 { grid-column: 8 / 13; grid-row: 1; }
+      .mag .m2 { grid-column: 8 / 13; grid-row: 2; }
+      .mag .t { grid-column: span 4; }
+      .mag .feat .ttl { font-size: 24px; } .mag .feat .img { min-height: 120px; }
+
+      /* N2 uniform */
+      .uni { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; grid-auto-rows: 168px; }
+
+      /* N3 two-zone */
+      .zone-news { display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; grid-auto-rows: 176px; margin-bottom: 28px; }
+      .zone-nav { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+      .navchip { border: 2px solid var(--ink); background: var(--cream-soft); box-shadow: 2px 2px 0 0 var(--ink); padding: 14px; display:flex; flex-direction:column; gap:4px; text-decoration:none; color:var(--ink); transition: all .3s; }
+      .navchip:hover { box-shadow:none; transform: translate(2px,2px); }
+      .navchip .tagm { align-self:flex-start; }
+      .navchip .ttl { font-family: var(--font-display); font-style:italic; font-weight:800; font-size:16px; }
+      .navchip .arr { font-family: var(--font-mono); font-size: 10px; letter-spacing:0.06em; text-transform:uppercase; color: var(--jersey-deep); }
+
+      .note-strip { background: var(--cream-deep); border-top: 1px dashed var(--ink); border-bottom: 1px dashed var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 20px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /jeugd — Round 3 (DETAIL): nav hub layout</h1>
+      <p>The nav hub = 3 Jeugd-article slots (green tag) + 6 nav cards (cream tag): word lid ·
+        jeugdvisie · trainingen/PSD · organigram · hulp · medisch. All three treatments use the same
+        TapedCard chrome + greyscale→hover image; they differ in <b>layout</b>. Card chrome itself
+        (image-top shown here) can still be tuned later. See <a href="./7j2-ia-locked.md">7j2</a>.</p>
+    </div>
+
+    <!-- N1 -->
+    <div class="direction-bar"><span class="tag">N1</span> Magazine (keep positions) <span class="note">featured + medium + thirds; editor controls position via Sanity</span></div>
+    <div class="wrap">
+      <div class="seckick">Ontdek onze jeugd</div>
+      <div class="mag">
+        <a class="card art feat"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Featured Jeugd-artikel</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav m1"><div class="img"><span class="tagm">Aansluiten</span></div><div class="body"><div class="ttl">Word lid van KCVV</div><span class="arr">Schrijf je in →</span></div></a>
+        <a class="card art m2"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Jeugd-artikel 2</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav t"><div class="img"><span class="tagm">Visie</span></div><div class="body"><div class="ttl">Onze jeugdvisie</div><span class="arr">Ontdek →</span></div></a>
+        <a class="card art t"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Jeugd-artikel 3</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav t"><div class="img"><span class="tagm">Praktisch</span></div><div class="body"><div class="ttl">Trainingen & PSD</div><span class="arr">Meer info →</span></div></a>
+        <a class="card nav t"><div class="img"><span class="tagm">Structuur</span></div><div class="body"><div class="ttl">Organigram</div><span class="arr">Bekijk →</span></div></a>
+        <a class="card nav t"><div class="img"><span class="tagm">Hulp</span></div><div class="body"><div class="ttl">Wie contacteer ik?</div><span class="arr">Zoek het op →</span></div></a>
+        <a class="card nav t"><div class="img"><span class="tagm">Medisch</span></div><div class="body"><div class="ttl">Blessure of afmelding?</div><span class="arr">Lees meer →</span></div></a>
+      </div>
+    </div>
+    <div class="note-strip">Faithful to today: rich magazine rhythm, editor keeps featured/medium/third control via the jeugdLandingPage singleton. RISK: busiest layout; article + nav cards interleave so "news" and "practical links" are visually mixed.</div>
+
+    <!-- N2 -->
+    <div class="direction-bar"><span class="tag">N2</span> Uniform grid <span class="note">all cards equal in a clean 3-col grid; drops the position hierarchy</span></div>
+    <div class="wrap">
+      <div class="seckick">Ontdek onze jeugd</div>
+      <div class="uni">
+        <a class="card art"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Featured Jeugd-artikel</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card art"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Jeugd-artikel 2</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card art"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Jeugd-artikel 3</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card nav"><div class="img"><span class="tagm">Aansluiten</span></div><div class="body"><div class="ttl">Word lid van KCVV</div><span class="arr">Schrijf je in →</span></div></a>
+        <a class="card nav"><div class="img"><span class="tagm">Visie</span></div><div class="body"><div class="ttl">Onze jeugdvisie</div><span class="arr">Ontdek →</span></div></a>
+        <a class="card nav"><div class="img"><span class="tagm">Praktisch</span></div><div class="body"><div class="ttl">Trainingen & PSD</div><span class="arr">Meer info →</span></div></a>
+        <a class="card nav"><div class="img"><span class="tagm">Structuur</span></div><div class="body"><div class="ttl">Organigram</div><span class="arr">Bekijk →</span></div></a>
+        <a class="card nav"><div class="img"><span class="tagm">Hulp</span></div><div class="body"><div class="ttl">Wie contacteer ik?</div><span class="arr">Zoek het op →</span></div></a>
+        <a class="card nav"><div class="img"><span class="tagm">Medisch</span></div><div class="body"><div class="ttl">Blessure of afmelding?</div><span class="arr">Lees meer →</span></div></a>
+      </div>
+    </div>
+    <div class="note-strip">Calmest + most scannable; every card equal weight. RISK: loses the editorial "featured" emphasis + the magazine character; the Sanity `position` field becomes unused (simplifies the schema usage).</div>
+
+    <!-- N3 -->
+    <div class="direction-bar"><span class="tag">N3</span> Two zones <span class="note">separate "Jeugdnieuws" (articles) from "Praktisch" (nav cards)</span></div>
+    <div class="wrap">
+      <div class="seckick">Jeugdnieuws</div>
+      <div class="zone-news">
+        <a class="card art"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Featured Jeugd-artikel</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card art"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Jeugd-artikel 2</div><span class="arr">Lees meer →</span></div></a>
+        <a class="card art"><div class="img"><span class="tagm">Jeugd</span></div><div class="body"><div class="ttl">Jeugd-artikel 3</div><span class="arr">Lees meer →</span></div></a>
+      </div>
+      <div class="seckick">Praktisch</div>
+      <div class="zone-nav">
+        <a class="navchip"><span class="tagm">Aansluiten</span><span class="ttl">Word lid van KCVV</span><span class="arr">Schrijf je in →</span></a>
+        <a class="navchip"><span class="tagm">Visie</span><span class="ttl">Onze jeugdvisie</span><span class="arr">Ontdek →</span></a>
+        <a class="navchip"><span class="tagm">Praktisch</span><span class="ttl">Trainingen & PSD</span><span class="arr">Meer info →</span></a>
+        <a class="navchip"><span class="tagm">Structuur</span><span class="ttl">Organigram</span><span class="arr">Bekijk →</span></a>
+        <a class="navchip"><span class="tagm">Hulp</span><span class="ttl">Wie contacteer ik?</span><span class="arr">Zoek het op →</span></a>
+        <a class="navchip"><span class="tagm">Medisch</span><span class="ttl">Blessure of afmelding?</span><span class="arr">Lees meer →</span></a>
+      </div>
+    </div>
+    <div class="note-strip">Clearest information model: news (image cards) vs practical links (compact text chips) are visually distinct tasks. RISK: biggest change from today; drops the interleaved magazine layout + the Sanity `position`/mixed-type model (articles + nav would be split, not co-positioned).</div>
+
+    <div class="legend">
+      <b>One-line trade-off:</b> N1 = faithful magazine, editor keeps position control, busiest ·
+      N2 = calm uniform grid, drops the position hierarchy ·
+      N3 = two clean zones (nieuws vs praktisch), clearest but biggest model change.<br />
+      Note: N2/N3 stop using the Sanity <code>position</code> field — a small schema-usage
+      simplification (not a schema change). Exact card chrome (image-top vs text-only, tag style)
+      is a further micro-detail, tunable after the layout is picked.
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-jeugd/7j3-navhub-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j3-navhub-locked.md
@@ -1,0 +1,57 @@
+# Phase 7 · /jeugd — Round 3 (DETAIL: nav hub) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7j3-navhub-compare.html` (+ uniform-16:9 + bubbling refinements)
+**Owner:** @climacon
+
+## Decision
+
+**Uniform 16:9 card grid with the current fixed-position "bubbling" logic preserved.**
+
+The nav hub keeps today's model — it is **not** split into zones (N3 rejected) and **not** reflowed
+into articles-first (N2-as-drawn rejected). Instead:
+
+- **Card chrome (uniform):** every card is identical — a **16:9 image-top** region + text below
+  (MonoLabel tag · italic-display title · optional description · mono arrow link). Replaces today's
+  full-bleed-background + overlay model. TapedCard vocabulary, greyscale→hover-colour image,
+  canonical press-down hover.
+- **Fixed-position template:** the 9 slots sit at **predetermined positions**. Some slots are
+  **article slots**, the rest are **fixed nav slots**.
+  - **Article slots bubble:** the latest Jeugd-category articles auto-fill the article slots in
+    order (newest first) — "bubbling up into fixed places."
+  - **Nav links are pinned:** the 6 practical nav cards (word lid · jeugdvisie→`#visie` ·
+    trainingen/PSD · organigram · hulp · medisch) stay on their fixed spots regardless.
+- **Uniform sizing:** the Sanity `editorialCards.position` (`featured`/`medium`/`third`) no longer
+  drives **size** (all cards are equal 16:9) — it now only controls **placement/order** within the
+  fixed template. `cardType` (`nav` | `article`) still selects pinned-nav vs bubbling-article.
+
+## Nav-card label refinement (data audit)
+
+The tag pill is **editorially managed** — sourced from `editorialCards[].tag` (the editor sets it
+on the `jeugdLandingPage` singleton) — with a **type-based fallback** when empty. The pill stays on
+**both** variants. This is data-honest (it's real CMS data, not invented) and never blank.
+
+- **Tag source (per card):** `editorialCards.tag` when set →
+  fallback **`Jeugd`** for news/article cards, **`Praktisch`** for nav cards.
+  (Article-card fallback may prefer the article's own `article.tags[0]` before "Jeugd" — richer;
+  decide at build.)
+- `editorialCards.tag` **stays in use** (no schema change). The earlier "drop the pill" /
+  "single constant Praktisch" framings are both superseded by this editor-sourced + fallback rule.
+- Visual: news pill = jersey-deep on the photo; nav pill = cream on the jersey-deep glyph panel.
+
+## Implications
+
+- **No schema change.** `jeugdLandingPage.editorialCards` (`tag`, `title`, `description`,
+  `arrowText`, `href`, `image`, `position`, `cardType`) is reused as-is; only the render changes
+  (uniform 16:9, position = placement not size).
+- `<EditorialCard>` is reskinned (or replaced) to the 16:9 image-top TapedCard chrome; the
+  `JeugdEditorialGrid` build logic (article bubbling into slots + nav fallback) is preserved.
+- Nav-card targets repointed per 7j0b (jeugdvisie → `#visie`, etc.).
+
+## Carry-forward (remaining DETAIL rounds)
+
+- **Hero** — youth-photo `<TapedFigure>` treatment + fold in "gediplomeerde trainers".
+- **Filosofie / visie** — block treatment + `#visie` anchor + copy distinct from hero lead.
+- **Divisions** — confirm 6.C `<YouthDirectory>` reuse (likely no drill).
+- **CTA** — band chrome + final target (the `/club/inschrijven` 404 fix).
+- **Card chrome micro-detail** — tag style, title size, hover — tune alongside the hero treatment.

--- a/docs/design/mockups/phase-7-jeugd/7j3-navhub-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j3-navhub-locked.md
@@ -27,16 +27,20 @@ into articles-first (N2-as-drawn rejected). Instead:
 
 ## Nav-card label refinement (data audit)
 
-The tag pill is **editorially managed** — sourced from `editorialCards[].tag` (the editor sets it
-on the `jeugdLandingPage` singleton) — with a **type-based fallback** when empty. The pill stays on
-**both** variants. This is data-honest (it's real CMS data, not invented) and never blank.
+The tag pill is **editorially managed** — sourced from CMS data (`editorialCards[].tag` for nav
+cards, `article.tags[0]` for news cards) with a **constant fallback** when empty. The pill stays on
+**both** variants. This is data-honest (it's real CMS data, not invented).
 
-- **Tag source (per card):** `editorialCards.tag` when set →
-  fallback **`Jeugd`** for news/article cards, **`Praktisch`** for nav cards.
-  (Article-card fallback may prefer the article's own `article.tags[0]` before "Jeugd" — richer;
-  decide at build.)
-- `editorialCards.tag` **stays in use** (no schema change). The earlier "drop the pill" /
-  "single constant Praktisch" framings are both superseded by this editor-sourced + fallback rule.
+- **Tag source — news/article cards:** `article.tags[0]` when present, else the constant **`Jeugd`**
+  (precedence: `article.tags[0]` → `Jeugd`). `editorialCards.tag` is **not** read for article slots —
+  articles bubble in and carry their own tags. See `JeugdEditorialGrid.tsx`:
+  `tag={article.tags[0] ?? "Jeugd"}`.
+- **Tag source — nav cards:** `editorialCards.tag` when set (CMS override), else the pinned card's own
+  hardcoded label in `NAV_CARDS` (e.g. **`Praktisch`**, `Aansluiten`, …). `Praktisch` is one of those
+  six literals, **not** a generic nav fallback — a Sanity nav card with no `tag` renders an empty pill
+  (`tag={entry.tag ?? ""}` for `variant="nav"`).
+- `editorialCards.tag` **stays in use** (no schema change) for nav cards. The earlier "drop the pill" /
+  "single constant Praktisch" framings are both superseded by this rule.
 - Visual: news pill = jersey-deep on the photo; nav pill = cream on the jersey-deep glyph panel.
 
 ## Implications

--- a/docs/prd/redesign-phase-7-jeugd.md
+++ b/docs/prd/redesign-phase-7-jeugd.md
@@ -81,8 +81,10 @@ cream grid. Proves route + data + e2e before new components land.
       preserved (article slots auto-fill latest Jeugd articles; nav cards pinned).
 - [ ] Two card variants: **news** (photographic, jersey-deep tag, greyscale→hover) vs **nav**
       (jersey-deep glyph panel via `@/lib/icons.redesign`, cream tag, `text-white`, no photo).
-- [ ] Tag pill (both variants) is **editorially managed**: `editorialCards.tag` when set, else
-      fallback `Jeugd` (news) / `Praktisch` (nav). Never blank. `editorialCards.tag` stays in use.
+- [ ] Tag pill (both variants) is **editorially managed**: news/article cards use `article.tags[0]`
+      → `Jeugd` (`editorialCards.tag` is **not** read for article slots); nav cards use
+      `editorialCards.tag` → the card's hardcoded `NAV_CARDS` label (e.g. `Praktisch`).
+      `editorialCards.tag` stays in use for nav cards.
 - [ ] `position` drives placement/order only (not size); `cardType` selects variant + bubbling.
 - [ ] Repointed targets: jeugdvisie → `#visie`; medisch → Jeugd article / `/hulp`; word lid →
       `/hulp` (or mailto). Editor overrides via the singleton still honoured.

--- a/docs/prd/redesign-phase-7-jeugd.md
+++ b/docs/prd/redesign-phase-7-jeugd.md
@@ -1,0 +1,132 @@
+# PRD: Redesign Phase 7 — Jeugd (`/jeugd`)
+
+**Status**: Ready for implementation (design locked)
+**Date**: 2026-06-07
+**Design contract**: `docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md` (rounds `7j0`–`7j3` + `7j0b`)
+**Epic**: #1529 (Redesign Phase 7) · **Milestone**: `redesign-retro-terrace-fanzine`
+**Supersedes**: `docs/prd/jeugd-landing-page.md` (delete on landing)
+
+---
+
+## 1. Problem statement
+
+`/jeugd` is a pre-redesign route: a dark `kcvv-black` `InteriorPageHero` + `SectionStack` with
+`diagonal` transitions + a dark `<TeamOverview>` youth grid + a green `<MissionBanner>` + a legacy
+`<SectionCta>`. Retired tokens, retiring diagonal seam.
+
+Phase 7 rebuilds it for **parents** in the retro-terrace-fanzine language with a **development-through-
+plezier** register, reusing the 6.C `<YouthDirectory>` (which **retires `<TeamOverview>`/`<TeamCard>`
+→ unblocks half of #1960**). Non-commercial: **no sponsors, no trainers grid** (locked 7j0).
+
+## 2. Scope
+
+### In scope (`apps/web` only)
+
+- Rebuild `src/app/(landing)/jeugd/page.tsx` onto the locked spine (drop `SectionStack` +
+  `getJeugdSections` + `InteriorPageHero` + `SectionCta`); use `<StripedSeam>`.
+- New `<JeugdHero>` (photo) + `<JeugdCtaBand>`.
+- Reskin `<JeugdEditorialGrid>` → **nav hub**: uniform 16:9 image-top cards, two variants
+  (news photographic / nav graphic), fixed-position bubbling preserved.
+- Filosofie/visie block (`#visie`) replacing `<MissionBanner>`.
+- Reuse `<YouthDirectory>` (6.C); retire `<TeamOverview>`/`<TeamCard>`.
+- Repoint dead nav/CTA targets (7j0b).
+- `jeugd_*` analytics + GTM regex.
+
+### Out of scope
+
+- **No Sanity schema change.** `jeugdLandingPage.editorialCards` reused as-is (render changes only:
+  uniform 16:9, `position` = placement not size).
+- **No new routes.** `/jeugd/visie` → `#visie` anchor; `/jeugd/medisch`, `/club/inschrijven` →
+  existing surfaces (`/hulp` / a Jeugd article). Building a real membership form is #1473, separate.
+- **No BFF change.** Youth teams + articles read from Sanity via existing repositories.
+- Board pages / organigram / geschiedenis (other Phase 7 landings) — separate.
+
+## 3. Tracer bullet
+
+**Phase 1**: rebuild the route + page skeleton on the new vocabulary (no SectionStack/diagonal/dark
+hero), swap `<TeamOverview>` for `<YouthDirectory>`, render the existing nav cards in a plain
+cream grid. Proves route + data + e2e before new components land.
+
+## 4. Phases
+
+1. **Tracer** — route rebuild + `<YouthDirectory>` swap (retires TeamOverview/TeamCard).
+2. **`<JeugdHero>` (photo) + filosofie/visie block** (`#visie`).
+3. **Nav hub** — reskin to uniform 16:9 + news/nav card variants + bubbling + repointed targets.
+4. **`<JeugdCtaBand>`** + empty states + repoint "word lid".
+5. **Analytics + SEO + legacy retirement** + final VR / check-all.
+
+## 5. Acceptance criteria per phase
+
+### Phase 1 — Tracer
+
+- [ ] `/jeugd/page.tsx` no longer uses `SectionStack` / `getJeugdSections` / `InteriorPageHero` /
+      `kcvv-black`; renders on cream with a temporary plain composition.
+- [ ] `<YouthDirectory>` renders the division grid (Bovenbouw/Middenbouw/Onderbouw via
+      `groupTeamsForLanding`); `<TeamOverview>`/`<TeamCard>` removed from `/jeugd`.
+- [ ] `getJeugdSections.tsx` (+ test) deleted.
+- [ ] e2e `/jeugd` smoke green; `pnpm --filter @kcvv/web check-all` passes.
+
+### Phase 2 — Hero + filosofie/visie
+
+- [ ] `<JeugdHero>` — MonoLabel kicker `DE JEUGDOPLEIDING · U6 TOT U21` + `<EditorialHeading>`
+      "Beter worden begint met plezier." + lead (incl. "gediplomeerde trainers") + right-column
+      `<TapedFigure>` youth photo.
+- [ ] Filosofie/visie block with `id="visie"` (PullQuote/TapedCard), copy distinct from the hero
+      lead; replaces `<MissionBanner>`.
+- [ ] `<StripedSeam>` between hero and visie. Stories (`vr`) + tests; VR baselines committed.
+
+### Phase 3 — Nav hub
+
+- [ ] `<JeugdEditorialGrid>` reskinned: uniform **16:9 image-top** cards; **fixed-position bubbling**
+      preserved (article slots auto-fill latest Jeugd articles; nav cards pinned).
+- [ ] Two card variants: **news** (photographic, jersey-deep tag, greyscale→hover) vs **nav**
+      (jersey-deep glyph panel via `@/lib/icons.redesign`, cream tag, `text-white`, no photo).
+- [ ] Tag pill (both variants) is **editorially managed**: `editorialCards.tag` when set, else
+      fallback `Jeugd` (news) / `Praktisch` (nav). Never blank. `editorialCards.tag` stays in use.
+- [ ] `position` drives placement/order only (not size); `cardType` selects variant + bubbling.
+- [ ] Repointed targets: jeugdvisie → `#visie`; medisch → Jeugd article / `/hulp`; word lid →
+      `/hulp` (or mailto). Editor overrides via the singleton still honoured.
+- [ ] Stories (`vr`) cover news + nav variants + the no-articles fallback. Tests for the build logic.
+
+### Phase 4 — CTA band + empty states
+
+- [ ] `<JeugdCtaBand>` — jersey-deep-dark (`border-y-2 border-ink`), "Interesse in onze jeugd?" +
+      "Schrijf je in +" paper-stamp, canonical press-down; target `/hulp` (see open §7). Shares
+      chrome with `<SponsorCtaBand>` (extract a `<CtaBand>` if clean).
+- [ ] Empty states: 0 divisions → drop section; 0 articles → nav-only hub.
+- [ ] `<StripedSeam>` before the band. Stories (`vr`) + tests.
+
+### Phase 5 — Analytics, SEO, legacy retirement, final pass
+
+- [ ] `jeugd_view` + `jeugd_card_click` (`card_type`, `tag`, hashed article id) wired;
+      **`jeugd_` added to the live GTM Custom-Event trigger regex** (manual, called out in PR).
+- [ ] Retire `<TeamOverview>` + `<TeamCard>` (files + stories + tests + barrels); `git grep`
+      confirms zero consumers → **comment on #1960** (its youth-grid half is now unblocked).
+- [ ] Retire/relocate `<MissionBanner>`, `<SectionCta>`, `<InteriorPageHero>` if `/jeugd` was the
+      last consumer (`git grep` first; some may still back other pages — keep if so).
+- [ ] Keep breadcrumb JSON-LD; metadata exists. `Pages/Jeugd` story refreshed (not `vr`).
+- [ ] Final `pnpm --filter @kcvv/web check-all` + VR green.
+
+## 6. Analytics
+
+| Event              | Trigger            | Params                                                          |
+| ------------------ | ------------------ | --------------------------------------------------------------- |
+| `jeugd_view`       | `/jeugd` page view | —                                                               |
+| `jeugd_card_click` | nav-hub card click | `card_type` (news/nav), `tag`, `article_id` (hashed, news only) |
+
+GTM: append `jeugd_` to the single live trigger RegEx. DLVs + GA4 mapping for `card_type`/`tag`.
+No PII — hash internal ids.
+
+## 7. Open questions
+
+1. CTA + "word lid" target: defaulting to `/hulp`; revisit when membership form (#1473) ships.
+2. "medisch" card target: specific Jeugd article slug vs `/hulp`.
+3. Extract a shared `<CtaBand>` from `<SponsorCtaBand>` + `<JeugdCtaBand>`?
+4. Hero photo aspect (`16-9` vs `4-3`) + which youth asset.
+
+## 8. Discovered unknowns
+
+- Production `jeugdLandingPage` singleton hrefs not verified (Sanity budget) — the hardcoded
+  fallback ships repointed targets regardless.
+- Whether `<MissionBanner>`/`<InteriorPageHero>`/`<SectionCta>` have other consumers — `git grep`
+  at retirement time; keep any still in use.


### PR DESCRIPTION
## What

Design checkpoint **+ implementation PRD** for the **Phase 7 `/jeugd`** youth landing (retro-terrace-fanzine). **Docs only — no code changes.** Parent-facing, non-commercial.

Part of #1529 (Phase 7 master). Supersedes `docs/prd/jeugd-landing-page.md` once implementation lands.

## Locked design

- **Voice** — *"Beter worden begint met plezier."* (development *through* plezier; serious opleiding, fun as the engine; addressed to parents).
- **Spine** — Hero (youth photo) → Filosofie/visie (`#visie`) → Nav hub → Divisions → CTA. **No sponsors, no trainers grid.**
- **Nav hub** — reskinned `<JeugdEditorialGrid>`: uniform **16:9** image-top cards, **fixed-position bubbling** (article slots auto-fill latest Jeugd articles; nav cards pinned). Two variants: **news** (photographic) vs **nav** (jersey-deep glyph panel). Tag pill **editorially managed** (`editorialCards.tag` → fallback `Jeugd`/`Praktisch`).
- **Divisions** — reuse the locked 6.C `<YouthDirectory>` → **retires `<TeamOverview>`/`<TeamCard>`, unblocking half of #1960.**

## Verification (per owner request)

Audited the current implementation so nothing's dropped. Key catches folded into the design:
- The editorial grid is the page's **primary nav hub** (6 nav cards + 3 article slots), not a minor section.
- **3 dead routes** (`/club/inschrijven`, `/jeugd/visie`, `/jeugd/medisch`) — repointed to existing surfaces (`#visie` anchor / `/hulp` / a Jeugd article); no new routes built here.
- Hero is photo-based today → kept a youth photo (warmer for parents) + retained the "gediplomeerde trainers" reassurance.

## Files

- `7j0`–`7j3` lock docs + `7j0b` verification + `*-compare.html` per round
- `7j-design-summary-locked.md` — consolidated spec + build deltas
- `7j-final-page.html` — canonical render
- `docs/prd/redesign-phase-7-jeugd.md` — 5 phases, `/prd-to-issues`-ready, no Sanity/BFF change

## Testing

Docs only — no code, no stories, no VR. The implementation PRD owns component build, tests, VR, and analytics wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added locked design specifications for the redesigned youth landing page, featuring a new hero section, vision/philosophy block, navigation hub with uniform card layout, age-group divisions, and call-to-action band. Ready for implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->