### PR TITLE
docs(club): Phase 7 board-pages redesign — reuse-confirm + PRD (#1529)

### DIFF
--- a/docs/design/mockups/phase-7-board/7b1-board-hero-and-reuse-compare.html
+++ b/docs/design/mockups/phase-7-board/7b1-board-hero-and-reuse-compare.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — board pages · reuse confirm + hero treatment</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 84ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar.lk { background: var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1000px; margin: 0 auto; padding: 0 28px; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+
+      /* HERO A — cream editorial */
+      .heroA { display:grid; grid-template-columns: 1.05fr 0.95fr; gap: 32px; align-items:center; padding: 46px 0 22px; }
+      .heroA h1 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: clamp(34px,4.6vw,58px); line-height:.92; margin: 12px 0 0; }
+      .heroA h1 .dot { color: var(--jersey-deep); }
+      .heroA .lead { font-family: var(--font-display); font-size: 17px; line-height:1.5; margin: 14px 0 0; color: var(--ink-soft); max-width: 42ch; }
+      .groupphoto { background: repeating-linear-gradient(45deg, var(--cream-deep) 0 14px, var(--cream-soft) 14px 28px); border:2px solid var(--ink); box-shadow: 6px 7px 0 0 var(--ink); aspect-ratio: 16/10; display:flex; align-items:flex-end; padding:12px; transform: rotate(-1deg); font-family: var(--font-mono); font-size:11px; text-transform:uppercase; color: var(--ink-muted); }
+
+      /* HERO B — dark group photo */
+      .heroB { background: var(--jersey-deep-dark); color: var(--cream); border-bottom: 2px solid var(--ink); padding: 44px 0; position:relative; overflow:hidden; }
+      .heroB::before { content:""; position:absolute; inset:0; background: radial-gradient(120% 80% at 70% 0%, rgba(74,207,82,0.14), transparent 60%); }
+      .heroB .inner { position:relative; display:grid; grid-template-columns: 1fr 1fr; gap:32px; align-items:center; }
+      .heroB .kicker { color: var(--warm); }
+      .heroB h1 { font-family: var(--font-display); font-style: italic; font-weight:900; font-size: clamp(34px,4.6vw,58px); line-height:.92; margin:12px 0 0; color: var(--cream); }
+      .heroB .lead { font-size: 15px; color: rgba(245,241,230,.78); margin-top:12px; max-width: 40ch; line-height:1.5; }
+      .heroB .gp { background: rgba(245,241,230,.08); border:2px solid var(--cream); aspect-ratio:16/10; display:flex; align-items:flex-end; padding:12px; font-family: var(--font-mono); font-size:11px; text-transform:uppercase; color: rgba(245,241,230,.6); }
+
+      .seam { height: 14px; margin: 24px 0; background: repeating-linear-gradient(135deg, var(--ink) 0 10px, var(--cream) 10px 20px); border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); opacity:.92; }
+      .seckick { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-muted); display:flex; align-items:center; gap:10px; margin: 0 0 14px; }
+      .seckick::after { content:""; height:2px; flex:1; background: var(--paper-edge); }
+      .prose { max-width: 60ch; font-size: 15px; line-height: 1.65; color: var(--ink-soft); border-left: 3px solid var(--jersey-deep); padding-left: 16px; }
+
+      /* TeamStaff (6.C) grid — faithful to component */
+      .staffgrid { display:grid; grid-template-columns: repeat(auto-fill, minmax(150px,1fr)); gap:16px; margin-top: 6px; }
+      .scard { border:2px solid var(--ink); background: var(--cream); box-shadow: 3px 3px 0 0 var(--ink); display:flex; flex-direction:column; align-items:center; padding:12px; text-align:center; }
+      .scard .av { width:64px; height:64px; border-radius:9999px; border:2px solid var(--ink); overflow:hidden; background: var(--cream-soft); display:flex; align-items:center; justify-content:center; }
+      .scard .av .mono { font-family: var(--font-display); font-weight:900; font-style:normal; color: var(--jersey-deep); font-size:22px; }
+      .scard .av .ph { width:100%; height:100%; background: repeating-linear-gradient(45deg,#d7d0bb 0 8px,#c8c1aa 8px 16px); filter: sepia(.3) saturate(.8); }
+      .scard .nm { font-family: var(--font-display); margin-top:8px; line-height:1.05; }
+      .scard .nm b { font-weight:600; } .scard .nm em { font-style:italic; font-weight:400; }
+      .scard .fn { font-family: var(--font-mono); font-size:9px; letter-spacing:.06em; text-transform:uppercase; color: var(--ink-muted); margin-top:4px; }
+
+      .cta { margin-top: 40px; background: var(--jersey-deep-dark); color: var(--cream); border-top:2px solid var(--ink); border-bottom:2px solid var(--ink); padding: 40px 0; }
+      .cta .inner { max-width:1000px; margin:0 auto; padding:0 28px; display:flex; justify-content:space-between; align-items:center; gap:20px; flex-wrap:wrap; }
+      .cta h2 { font-family: var(--font-display); font-style:italic; font-weight:900; font-size:28px; margin:0; }
+      .cta p { margin:6px 0 0; color: rgba(245,241,230,.8); font-size:13px; max-width:44ch; }
+      .pill { font-family: var(--font-mono); font-weight:700; font-size:12px; letter-spacing:.08em; text-transform:uppercase; border:2px solid var(--ink); padding:12px 20px; background: var(--warm); color: var(--ink); box-shadow:4px 4px 0 0 var(--ink); }
+      .note-strip { background: var(--cream-deep); border-top:1px dashed var(--ink); border-bottom:1px dashed var(--ink); padding:10px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .legend { background: var(--cream-deep); border-top:2px solid var(--ink); padding:20px 28px; font-family: var(--font-mono); font-size:12.5px; line-height:1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · board pages (bestuur / jeugdbestuur / angels) — reuse confirm</h1>
+      <p>Per the epic this is a <b>confirm-the-6.C-&lt;TeamStaff&gt;-reuse</b>, not a full drill. The body
+        (description → TeamStaff roster → organigram CTA) is shown once and is the confirmation. The
+        only genuine choice is the <b>hero treatment</b> (A cream-editorial vs B dark group-photo) —
+        boards have real group photos. NOT ultras (that's a separate custom page).</p>
+    </div>
+
+    <!-- HERO A -->
+    <div class="direction-bar"><span class="tag">Hero A</span> Cream-editorial <span class="note">consistent with sponsors/jeugd; group photo in a TapedFigure</span></div>
+    <div class="wrap"><div class="heroA">
+      <div>
+        <div class="kicker">De club</div>
+        <h1>Bestuur<span class="dot">.</span></h1>
+        <p class="lead">De mensen achter KCVV Elewijt — wie de club draaiende houdt, dag in dag uit.</p>
+      </div>
+      <div class="groupphoto">[ bestuur groepsfoto · TapedFigure ]</div>
+    </div></div>
+
+    <!-- HERO B -->
+    <div class="direction-bar"><span class="tag">Hero B</span> Dark group-photo <span class="note">jersey-deep-dark band; the group photo pops on dark (closer to today's treatment)</span></div>
+    <div class="heroB"><div class="wrap"><div class="inner">
+      <div>
+        <div class="kicker">De club</div>
+        <h1>Bestuur.</h1>
+        <p class="lead">De mensen achter KCVV Elewijt — wie de club draaiende houdt, dag in dag uit.</p>
+      </div>
+      <div class="gp">[ bestuur groepsfoto ]</div>
+    </div></div></div>
+
+    <!-- SHARED BODY -->
+    <div class="direction-bar lk"><span class="tag" style="background:#cfeede">SHARED</span> Body — identical for both heroes · confirms the 6.C &lt;TeamStaff&gt; reuse</div>
+    <div class="wrap"><div class="seam"></div></div>
+    <div class="wrap">
+      <div class="seckick">Over het bestuur</div>
+      <div class="prose">Het bestuur van KCVV Elewijt staat in voor het dagelijkse en strategische beleid van de club — van financiën en sponsoring tot infrastructuur en jeugdwerking. (CMS-beschrijving, sanitised HTML.)</div>
+
+      <div class="seckick" style="margin-top:34px">De leden</div>
+      <div class="staffgrid">
+        <div class="scard"><div class="av"><span class="mono">JD</span></div><div class="nm"><b>Jan</b> <em>De Smet</em></div><div class="fn">Voorzitter</div></div>
+        <div class="scard"><div class="av"><span class="ph"></span></div><div class="nm"><b>Marie</b> <em>Peeters</em></div><div class="fn">Secretaris</div></div>
+        <div class="scard"><div class="av"><span class="mono">LV</span></div><div class="nm"><b>Luc</b> <em>Van Assche</em></div><div class="fn">Penningmeester</div></div>
+        <div class="scard"><div class="av"><span class="ph"></span></div><div class="nm"><b>Sofie</b> <em>Janssens</em></div><div class="fn">Bestuurslid</div></div>
+        <div class="scard"><div class="av"><span class="mono">PD</span></div><div class="nm"><b>Peter</b> <em>Dubois</em></div><div class="fn">Bestuurslid</div></div>
+      </div>
+      <p style="font-family:var(--font-mono); font-size:11px; color:var(--ink-muted); margin-top:10px">↑ 6.C &lt;TeamStaff&gt; verbatim (round newsprint photo / jersey-deep monogram, name first-semibold + last-italic). <b>Role-label fix needed:</b> feed board <code>role</code> ("Voorzitter") into the label or these would all read "Staf".</p>
+    </div>
+
+    <div class="cta"><div class="inner">
+      <div><h2>Wie doet wat?</h2><p>Bekijk het volledige organigram en vind snel de juiste persoon voor jouw vraag.</p></div>
+      <a class="pill" href="#">Organigram bekijken →</a>
+    </div></div>
+
+    <div class="legend">
+      <b>Confirmation:</b> the 6.C &lt;TeamStaff&gt; roster + an editorial description + an organigram
+      CtaBand fully cover the board pages — no fresh component design needed. Retires
+      &lt;TeamRoster&gt;/&lt;StaffCard&gt; → unblocks the other half of #1960.<br />
+      <b>One choice:</b> Hero A (cream, consistent) vs Hero B (dark, group-photo-forward).<br />
+      <b>Build note:</b> board <code>role</code> → display label (extend resolveFunctionLabel to pass
+      through free-text role, or map role→functionTitle at the board build site).
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-board/7b1-board-reuse-locked.md
+++ b/docs/design/mockups/phase-7-board/7b1-board-reuse-locked.md
@@ -1,0 +1,65 @@
+# Phase 7 · Board pages (bestuur / jeugdbestuur / angels) — REUSE CONFIRM — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7b1-board-hero-and-reuse-compare.html`
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7 master)
+**Supersedes (on landing):** `docs/prd/club-landing-page-redesign.md` (board portion)
+
+Per the epic, this is a **confirm-the-6.C-`<TeamStaff>`-reuse**, not a full design drill. Confirmed.
+
+## Scope
+
+- **In:** `/club/bestuur`, `/club/jeugdbestuur`, `/club/angels` — all via `createBoardPage` →
+  `<BestuurPage>`. Each board is a Sanity `team` doc (header + staff [+ rare players]).
+- **OUT:** `/club/ultras` — it is **NOT** a board page. `UltrasPage` is a custom component
+  (`InteriorPageHero` + bespoke content), not `createBoardPage`/`BestuurPage`. Needs its own
+  treatment — flagged as a separate Phase 7 item (see §5).
+
+## Decision
+
+**Reuse the 6.C `<TeamStaff>` roster verbatim. Hero B = dark group-photo.**
+
+Reskinned board page spine:
+
+```text
+/club/{bestuur,jeugdbestuur,angels}
+├─ Hero (B) — jersey-deep-dark band: kicker "De club" + EditorialHeading {team name} with a
+│             **warm "." accent** (D1 — gold period; the cream hero's jersey-deep "." recoloured
+│             warm so it pops on dark green; on-brand CtaBand colour; bright-jersey green retired)
+│             + tagline lead + group photo (team.teamImage). The group photo pops on dark;
+│             jersey-deep-dark is the redesign dark (NOT retired kcvv-black) → in-system.
+├─ <StripedSeam>
+├─ Over het … — editorial description block (sanitised HTML from team.body/tagline),
+│               jersey-deep left-accent rule. Auto-hides when empty.
+├─ De leden — <TeamStaff> (6.C) verbatim: round newsprint photo / jersey-deep monogram,
+│             name first-semibold + last-italic, mono function label. Auto-hides when empty.
+└─ <CtaBand> — jersey-deep-dark "Wie doet wat?" → /club/organigram (Organigram bekijken).
+```
+
+## Reuse caveat — role-label fix (BUILD-TIME, required)
+
+Board titles ("Voorzitter", "Secretaris", "Penningmeester", "Bestuurslid") live in
+**`team.staff[].role`** (free text). `member.functionTitle` is PSD-synced and **empty** for board
+members. `<TeamStaff>`'s `resolveFunctionLabel` only treats `role` as a _bucket_
+(trainer/afgevaardigde) → an unrecognised board role falls through to **"Staf"**.
+
+**Fix (pick one at build):**
+
+1. Extend `resolveFunctionLabel`: after the bucket check, **pass through free-text `role`**
+   before the "Staf" fallback. (Safe — trainer pages pass recognised buckets first.) — preferred,
+   benefits any free-text role.
+2. Or map `role → functionTitle` when building `TeamStaffMemberData` at the board build site.
+
+## Consequences
+
+- **Retires `<TeamRoster>` + `<StaffCard>`** (the board pages were their last consumer) →
+  **unblocks the other half of #1960** (combined with /jeugd retiring TeamOverview/TeamCard).
+- Drops `<InteriorPageHero>`, `<SectionStack>`, `diagonal`, `<SectionCta>` from board pages.
+- `players` on a board team are rare; render via `<TeamStaff>` only (titles via role) or ignore —
+  boards are staff-by-role, no squad. Decide at build (default: staff-only).
+
+## §5 — ultras follow-up
+
+`/club/ultras` (custom supporters page) is un-redesigned and outside board scope. Flag a separate
+Phase 7 item to redesign it (or fold into the club-landings work). Not covered by this lock.

--- a/docs/design/mockups/phase-7-board/7b2-dark-hero-accent-compare.html
+++ b/docs/design/mockups/phase-7-board/7b2-dark-hero-accent-compare.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 — board dark hero · title accent</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --ink: #0a0a0a; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 80ch; line-height: 1.6; }
+      .bar { background: var(--jersey-deep); color: var(--cream); padding: 10px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; border-bottom: 2px solid var(--ink); display:flex; gap:12px; align-items:baseline; }
+      .bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight:700; border:1.5px solid var(--ink); }
+      .bar .note { color:#cfeede; text-transform:none; letter-spacing:0; font-size:12px; }
+      .hero { background: var(--jersey-deep-dark); color: var(--cream); padding: 48px 0; position:relative; overflow:hidden; border-bottom:2px solid var(--ink); }
+      .hero::before { content:""; position:absolute; inset:0; background: radial-gradient(120% 80% at 70% 0%, rgba(74,207,82,0.14), transparent 60%); }
+      .wrap { max-width: 1000px; margin:0 auto; padding: 0 28px; position:relative; }
+      .kicker { font-family: var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; color: var(--warm); }
+      h1 { font-family: var(--font-display); font-style: italic; font-weight:900; font-size: clamp(40px,6vw,76px); line-height:.9; margin: 12px 0 0; color: var(--cream); }
+      .lead { font-size:15px; color: rgba(245,241,230,.78); margin-top:14px; max-width:42ch; }
+
+      /* accent treatments */
+      .dot-warm { color: var(--warm); }
+      .dot-ink { color: var(--ink); }
+      .dot-cream { color: var(--cream); opacity:.55; }
+      /* highlighter underline (warm marker under the word) */
+      .mark { position: relative; display:inline-block; }
+      .mark::after { content:""; position:absolute; left:-2px; right:-2px; bottom:0.12em; height:0.32em; background: var(--warm); opacity:.9; z-index:-1; transform: rotate(-1deg); }
+      /* ink chip behind the dot so black is legible */
+      .dot-chip { background: var(--warm); color: var(--ink); padding: 0 0.12em; }
+
+      .note-strip { background: #e1d7bf; border-top:1px dashed var(--ink); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink); }
+      .legend { background:#e1d7bf; border-top:2px solid var(--ink); padding:18px 28px; font-family: var(--font-mono); font-size:12.5px; line-height:1.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · board dark hero — title accent</h1>
+      <p>The cream hero uses a jersey-deep "." accent. On the jersey-deep-dark board hero, here are
+        the in-system ways to highlight the title. (Bright-jersey green is retired, so it's not an
+        option.)</p>
+    </div>
+
+    <div class="bar"><span class="tag">D1</span> Warm "." <span class="note">gold period — same idiom as cream, clear pop on dark, on-brand (CtaBand colour)</span></div>
+    <div class="hero"><div class="wrap">
+      <div class="kicker">De club</div>
+      <h1>Bestuur<span class="dot-warm">.</span></h1>
+      <p class="lead">De mensen achter KCVV Elewijt.</p>
+    </div></div>
+
+    <div class="bar"><span class="tag">D2</span> Warm highlighter underline <span class="note">marker stroke under the word (HighlighterStroke), warm — bolder, more "fanzine"</span></div>
+    <div class="hero"><div class="wrap">
+      <div class="kicker">De club</div>
+      <h1><span class="mark">Bestuur</span><span class="dot-cream">.</span></h1>
+      <p class="lead">De mensen achter KCVV Elewijt.</p>
+    </div></div>
+
+    <div class="bar"><span class="tag">D3</span> Ink "." on a warm chip <span class="note">your "black accent" — black period stays legible by sitting on a small warm block</span></div>
+    <div class="hero"><div class="wrap">
+      <div class="kicker">De club</div>
+      <h1>Bestuur<span class="dot-chip">.</span></h1>
+      <p class="lead">De mensen achter KCVV Elewijt.</p>
+    </div></div>
+
+    <div class="note-strip">Plain ink "." (black on dark green) was tried and dropped: ~1.3:1 contrast, effectively invisible. D3 keeps the black but makes it legible on a warm chip.</div>
+
+    <div class="legend">
+      <b>D1</b> warm "." = closest parallel to the cream hero, cleanest · <b>D2</b> warm underline =
+      bolder marker emphasis on the whole word · <b>D3</b> ink-on-warm-chip = your black accent, kept
+      legible. All use the existing <code>--color-warm</code> token; no bright-jersey green.
+    </div>
+  </body>
+</html>

--- a/docs/prd/redesign-phase-7-board.md
+++ b/docs/prd/redesign-phase-7-board.md
@@ -1,0 +1,85 @@
+# PRD: Redesign Phase 7 — Board pages (`/club/bestuur`, `/jeugdbestuur`, `/angels`)
+
+**Status**: Ready for implementation (design locked — reuse-confirm)
+**Date**: 2026-06-07
+**Design contract**: `docs/design/mockups/phase-7-board/7b1-board-reuse-locked.md` (+ `7b2` accent)
+**Epic**: #1529 (Redesign Phase 7) · **Milestone**: `redesign-retro-terrace-fanzine`
+**Supersedes**: board portion of `docs/prd/club-landing-page-redesign.md`
+
+---
+
+## 1. Problem statement
+
+The three board pages (`/club/bestuur`, `/club/jeugdbestuur`, `/club/angels`) render via
+`createBoardPage` → `<BestuurPage>` in pre-redesign vocabulary: `<InteriorPageHero>` +
+`<SectionStack>` (`diagonal`, `kcvv-black`) + a `<TeamRoster>`/`<StaffCard>` member roster +
+`<SectionCta>`. They were the **last consumers of `<TeamRoster>`/`<StaffCard>`** — retiring them
+**unblocks the remaining half of #1960**.
+
+This is a **reuse-confirm**, not a redesign drill: the locked 6.C `<TeamStaff>` roster + a hero +
+an editorial description + the existing `<CtaBand>` cover the page with no new component design.
+
+## 2. Scope
+
+### In scope (`apps/web` only)
+
+- Rebuild `createBoardPage` / `<BestuurPage>` onto the locked spine (drop `SectionStack` +
+  `InteriorPageHero` + `diagonal` + `SectionCta`).
+- New `<BoardHero>` (jersey-deep-dark, group photo, warm "." accent) — or reuse a shared dark hero.
+- Reuse 6.C `<TeamStaff>` for the member roster (with the role-label fix, §5).
+- Editorial description block (sanitised HTML), jersey-deep left-accent, auto-hide on empty.
+- Organigram `<CtaBand>` (jersey-deep-dark) → `/club/organigram`.
+- Retire `<TeamRoster>` + `<StaffCard>`.
+
+### Out of scope
+
+- **`/club/ultras`** — NOT a board page (custom `UltrasPage`). Separate Phase 7 item (#TBD).
+- **No Sanity schema change.** Board = existing `team` doc (header + `staff[]` + rare `players`).
+- **No BFF change.**
+
+## 3. Phases
+
+1. **Reskin** — rebuild board pages on the locked spine (hero + description + `<TeamStaff>` +
+   `<CtaBand>`) incl. the role-label fix.
+2. **Retire + cleanup** — delete `<TeamRoster>`/`<StaffCard>`; comment/close-out #1960; analytics +
+   final checks.
+
+## 4. Acceptance criteria
+
+### Phase 1 — Reskin
+
+- [ ] `<BestuurPage>` recomposed: `<BoardHero>` (jersey-deep-dark, kicker "De club" +
+      `<EditorialHeading>` team name + **warm "." accent** + tagline lead + `team.teamImage` group
+      photo) → `<StripedSeam>` → description block (sanitised HTML, jersey-deep left rule,
+      auto-hide) → "De leden" `<TeamStaff>` → organigram `<CtaBand>`.
+- [ ] No `SectionStack` / `InteriorPageHero` / `diagonal` / `kcvv-black` / `<SectionCta>`.
+- [ ] **Role-label fix:** board `role` (free text e.g. "Voorzitter") renders as the staff function
+      label — extend `resolveFunctionLabel` to pass through unrecognised free-text `role` before the
+      "Staf" fallback (preferred), or map `role → functionTitle` at the board build site. Add a
+      regression test: a "Voorzitter" role renders "Voorzitter", not "Staf".
+- [ ] `players` (rare on boards) handled — staff-only roster by default.
+- [ ] All three routes (bestuur/jeugdbestuur/angels) render; e2e smokes green.
+- [ ] Stories (`vr`) for `<BoardHero>` + the board page composition states (photo/no-photo,
+      empty-description). `check-all` passes.
+
+### Phase 2 — Retire + cleanup
+
+- [ ] `git grep` confirms zero remaining consumers of `<TeamRoster>` + `<StaffCard>`; delete them
+      (files + stories + tests + barrels).
+- [ ] **#1960:** comment that both halves (TeamOverview/TeamCard via /jeugd; TeamRoster/StaffCard
+      via boards) are now retired → ready to close once both PRs land.
+- [ ] Analytics: `board_view` page view (param: `board` slug); add `board_` to the GTM trigger
+      regex (manual, note in PR). No PII.
+- [ ] Keep breadcrumb JSON-LD; metadata via `createBoardPage`. `check-all` + VR green.
+
+## 5. Reuse caveat — role-label fix (carried from 7b1)
+
+Board titles live in `team.staff[].role` (free text); `member.functionTitle` is PSD-empty for board
+members. `<TeamStaff>`'s `resolveFunctionLabel` treats `role` only as a bucket → unrecognised board
+roles fall to "Staf". Fix at build (pass-through free-text role, or map role→functionTitle).
+
+## 6. Open questions
+
+1. `<BoardHero>` as a new component vs. a shared dark hero primitive with `<TeamHero>`?
+2. Confirm whether any board team carries `players` in production (Sanity budget — defensive
+   staff-only default regardless).


### PR DESCRIPTION
## What

Design checkpoint **+ PRD** for the Phase 7 **board pages** (`/club/bestuur`, `/jeugdbestuur`, `/angels`). **Docs only.** Per the epic this is a **confirm-the-6.C-`<TeamStaff>`-reuse**, not a full drill.

Part of #1529. Supersedes the board portion of `docs/prd/club-landing-page-redesign.md`.

## Locked

- **Reuse 6.C `<TeamStaff>`** for the member roster — confirmed, no new component design.
- **Spine:** dark group-photo hero (jersey-deep-dark, **warm '.' title accent** — 7b2 D1) → editorial description → `<TeamStaff>` → organigram `<CtaBand>`.
- **Retires `<TeamRoster>`/`<StaffCard>`** → unblocks the other half of #1960.

## Key catches (verification)

- **Role-label fix (build-time):** board titles ('Voorzitter'…) live in `team.staff[].role` (free text); `member.functionTitle` is PSD-empty → `resolveFunctionLabel` would render 'Staf'. Fix: pass through free-text role (or map role→functionTitle). Regression test required.
- **`/club/ultras` is NOT a board page** (custom `UltrasPage`) → flagged as a separate Phase 7 item.

## Files

- `7b1-board-reuse-locked.md` (+ `7b2-dark-hero-accent-compare.html`) · `docs/prd/redesign-phase-7-board.md` (2 phases, no schema/BFF change).

## Testing

Docs only — implementation PRD owns build/tests/VR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specifications and mockups for Phase 7 board page redesign.
  * Defined new visual treatments for board pages (`/club/bestuur`, `/club/jeugdbestuur`, `/club/angels`), including hero variants and dark hero accent options.
  * Documented staff roster reuse and role-label display improvements for board pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->