### PR TITLE
docs(ui): Phase 7 /hulp hub redesign (organigram + hulp) — design lock + PRD

### DIFF
--- a/docs/design/mockups/phase-7-organigram/7o0-data-and-ux-reality-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o0-data-and-ux-reality-locked.md
@@ -1,0 +1,139 @@
+# Phase 7 · `/club/organigram` — Round 0 (DATA + UX REALITY) — LOCKED
+
+**Date:** 2026-06-07
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7 master) · **Milestone:** `redesign-retro-terrace-fanzine`
+**Supersedes (on landing):** the organigram portion of any legacy club-landing PRD.
+
+> **🔀 RE-SCOPED 2026-06-08 → unified `/hulp` hub.** Mid-drill, `/club/organigram` and `/hulp` were found
+> to be one job and merged into a single hub (canonical `/hulp`, two nav doors, org-as-`#structuur`,
+> finder folded in). Phase 7 + Phase 8 fused. **The authoritative frame is now
+> [`7o2c-hulp-hub-rescope-locked.md`](./7o2c-hulp-hub-rescope-locked.md).** Read it alongside this doc —
+> the data/UX facts below still hold (they're the Structuur half), but the surface is the hub, not a
+> standalone organigram page.
+
+This is the grounding round: **verified facts only**, no design decision. Everything here was
+read out of the live code on `main` (not planning docs). It bounds what the drill can choose.
+
+---
+
+## 1. What `/club/organigram` actually is today
+
+A **tabbed interactive tool** wrapped in legacy chrome, server-rendered then hydrated.
+
+- **Shell:** `app/(main)/club/organigram/page.tsx` → `<SectionStack>` with three bands:
+  hero (`<InteriorPageHero>`, `bg-kcvv-black`), content (`<UnifiedOrganigramClient>`, `bg-gray-100`),
+  CTA (`<SectionCta>` "Wie zoek je?", `bg-kcvv-black`), joined by `diagonal` `<SectionTransition>`s.
+  ISR `revalidate = 3600`. Breadcrumb JSON-LD. Legacy hero strings: label `"De club"`,
+  headline `"Clubstructuur"`, body `"Ontdek de organisatie achter KCVV Elewijt."`.
+- **Client:** `<UnifiedOrganigramClient>` — three views switched by a tab bar:
+  | Tab value | Label | Component | What it is |
+  | --- | --- | --- | --- |
+  | `cards` | **Overzicht** | `<CardHierarchy>` | vertical expand/collapse card tree (mobile default) |
+  | `chart` | **Diagram** | `<EnhancedOrgChart>` | `d3-org-chart` pan/zoom canvas (desktop default) |
+  | `responsibilities` | **Hulp** | `<ResponsibilityFinder>` | "wie kan me helpen met…" finder |
+- Plus: a top **`<UnifiedSearchBar>`** (searches people + responsibilities), **`<MemberDetailsModal>`**
+  (click any node/card/result → modal), department filter (`all`/`hoofdbestuur`/`jeugdbestuur`),
+  PNG export, keyboard shortcuts, swipe gestures, deep-linkable via `?view=`/`?memberId=`.
+
+## 2. UX problems we are fixing (not just reskinning)
+
+Confirmed against code; the owner loves the **diagram concept** but the interaction is poor:
+
+1. **Diagram scroll-jacking (the #1 pain).** `<EnhancedOrgChart>` builds a `new OrgChart()`
+   (`EnhancedOrgChart.tsx:196`) whose `d3-zoom` behaviour binds `wheel` on the SVG → mouse-wheel
+   **zooms the chart instead of scrolling the page**. On a long editorial page the diagram becomes a
+   scroll trap.
+2. **Orientation / "getting lost."** Free pan + zoom + expand/collapse with no persistent "you are
+   here." Recovery is the lone `fit()` button. No breadcrumb, no anchored root.
+3. **Three-view discoverability.** `Overzicht` / `Diagram` / `Hulp` read as equal peers, but
+   **Hulp** (find the right contact for a real-life question) is the most useful end-user job and is
+   buried as the 3rd tab. The two browse views (`cards` + `chart`) render the **same hierarchy**
+   twice — redundancy with a desktop/mobile default split, not a deliberate IA.
+4. **Mobile diagram.** A pan/zoom canvas needs its own `<MobileNavigationDrawer>`; pinch-zoom inside
+   a vertically-scrolling page is awkward.
+
+> **Confirmed (Round-0 sign-off):** "the organigram in 3d" = this **`d3-org-chart` Diagram view**
+> (keep the node-tree idea, fix the interaction). A **literal 3-D spatial visualization** was
+> investigated as a serious contender in 7o3 and **rejected** (owner, 2026-06-08: "doesn't add value,
+> au contraire — remove this 3D completely"). The explorer ships **2-D spotlight drill-down only**.
+> All four pains below are in-scope priorities (owner picked every one).
+
+## 3. DATA REALITY — what a node / person / question actually carries
+
+Everything renderable is bounded by three Sanity schemas (`packages/sanity-schemas/src/`). **Design
+must not invent fields.**
+
+### `organigramNode` (a position/box in the chart)
+
+| Field | Type | Populated? | Use |
+| --- | --- | --- | --- |
+| `title` | string | **always** (required) | position name — "Voorzitter", "Hoofdtrainer" |
+| `description` | text | optional | role blurb (shown in modal) |
+| `roleCode` | string ≤6 | optional | short badge — "T1", "VP" |
+| `department` | enum | usually | `hoofdbestuur` \| `jeugdbestuur` \| `algemeen` (filter) |
+| `parentNode` | ref | root=null | hierarchy edge |
+| `members[]` | ref[] → staffMember | **0 / 1 / 2+** | drives **vacant / single / shared** states |
+| `active`, `sortOrder` | bool / num | — | query filter + ordering |
+
+A synthetic **`club` root** ("KCVV Elewijt", flat logo) is prepended in the repository.
+
+### `staffMember` (a person inside a node)
+
+Projected into the chart as: `id`, `name` (`firstName+lastName`, can be empty), `imageUrl`
+(`photo` → **often missing → `/images/logo-flat.png` fallback**), `email?`, `phone?`, `psdId`
+(→ links to the `/staf/{psdId}` profile page). **NOT surfaced here** (lives on the profile page):
+`bio`, `functionTitle`, `birthDate`, `joinDate`. So a node card can reliably show **photo-or-fallback,
+name, position title, optional role badge, optional email/phone** — nothing richer.
+
+### `responsibility` (a "Hulp" entry)
+
+`id` (slug), `audience[]` (`speler`/`ouder`/`trainer`/`supporter`/`niet-lid`/`andere`), `question`
+(lowercase, no period), `keywords[]`, `summary` (1–2 sentences), `category`
+(`medisch`/`sportief`/`administratief`/`gedrag`/`algemeen`/`commercieel`), `icon?`
+(**Lucide name today — redesign canonical is Phosphor Fill → build must map or re-key**),
+`primaryContact` (discriminated: `position` → resolves to current node holders / `team-role` →
+trainer·afgevaardigde / `manual` → role+email+phone), `steps[]` (`description` + optional `link` +
+optional per-step `contact`), `relatedPaths[]`.
+
+## 4. MUST PRESERVE (functionality contract)
+
+- **Three jobs:** browse the hierarchy, see a person's detail, find the right contact for a question.
+- **Deep-linking:** `?view=`, `?memberId=`, and Hulp→chart "Bekijk in organigram" centering.
+- **Analytics (5 events, names frozen — `organigram_` is in the live GTM regex):**
+  `organigram_view_changed {view, source}` · `organigram_member_clicked {member_id(hashed), view}` ·
+  `organigram_search_used {query_text(sanitised)}` · `organigram_department_filtered {department}` ·
+  `organigram_export_png`. Member IDs hashed via `hashMemberId`, queries via `sanitizeQuery`.
+- **A11y:** `<SkipLink>`, `<KeyboardShortcuts>` (`?` `1` `2` `3` `/` `Esc`), `<ScreenReaderAnnouncer>`
+  (aria-live view announcements), focus management in the modal, swipe gestures on mobile.
+
+## 5. RETIRE vs REUSE (seed for the PRD)
+
+**Retire (legacy chrome / tokens):** `<InteriorPageHero>`, `<SectionStack>`, `<SectionCta>`,
+`diagonal` `<SectionTransition>`, `bg-kcvv-black`, the `kcvv-green`/`kcvv-green-hover` node accents
+and modal-header gradient, the hard-coded hex palette in `NodeRenderer.tsx`
+(`#4acf52`/`#41b147`/…). **Keep the jobs, reskin the surfaces.**
+
+**Reuse (Phase 7 vocabulary — locked elsewhere, do not re-drill):** cream-paper field + paper-grain;
+`EditorialHeading` (italic serif display — **never** the Ultras heavy-sans, a one-page exception);
+`MonoLabel`/kicker; `<StripedSeam>` (replaces `diagonal`); `<CtaBand>` (jersey-deep-dark,
+warm paper-stamp button); the **6.C `<TeamStaff>` people-card** vocabulary (round newsprint photo /
+jersey-deep monogram, name first-semibold + last-italic, mono function label) as the node/person idiom;
+the dark "roster spotlight" hero with warm "." accent; tokens `--cream(-soft/-deep)`, `--ink(-soft/-muted)`,
+`--jersey-deep`, `--jersey-deep-dark`, `--warm`, `--paper-edge`. Phosphor Fill icons via
+`@/lib/icons.redesign`.
+
+## 6. Open decisions → the drill plan (each its own `*-compare.html` + `*-locked.md`)
+
+| Round | Decision | Why it's a decision |
+| --- | --- | --- |
+| **7o1** | **Voice / register** — hero treatment + overall chrome tone (editorial-story vs find-a-contact tool) | sets center of gravity |
+| **7o2** | **View model / IA** — how many views, which is primary, default, ordering; kill the cards↔diagram redundancy; surface Hulp | the discoverability fix |
+| **7o3** | **Diagram interaction model** — the scroll/orientation fix (contained pan-zoom vs in-page tree vs spotlight-drill-down vs lanes) | the #1 pain |
+| **7o4** | **Node / people-card chrome** — `<TeamStaff>` idiom applied to vacant/single/shared nodes | per-element detail |
+| **7o5** | **Member detail disclosure** — modal vs side-panel vs bottom-sheet vs inline expand | per-element detail |
+| **7o6** | **Responsibility Finder (Hulp)** — category-grid vs audience-first vs search-first; contact + steps treatment | per-element detail |
+| **7o7** | **Page assembly** — search placement, seams, `<CtaBand>` destination, empty states, SEO/analytics wiring | final assembly |
+
+Sequence honours **voice → IA → details**. 7o2 must lock before 7o3 (IA decides whether the diagram
+is a co-equal view or an opt-in deep-explore). Rounds may merge if a decision collapses.

--- a/docs/design/mockups/phase-7-organigram/7o0-data-and-ux-reality-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o0-data-and-ux-reality-locked.md
@@ -27,11 +27,13 @@ A **tabbed interactive tool** wrapped in legacy chrome, server-rendered then hyd
   ISR `revalidate = 3600`. Breadcrumb JSON-LD. Legacy hero strings: label `"De club"`,
   headline `"Clubstructuur"`, body `"Ontdek de organisatie achter KCVV Elewijt."`.
 - **Client:** `<UnifiedOrganigramClient>` — three views switched by a tab bar:
+
   | Tab value | Label | Component | What it is |
   | --- | --- | --- | --- |
   | `cards` | **Overzicht** | `<CardHierarchy>` | vertical expand/collapse card tree (mobile default) |
   | `chart` | **Diagram** | `<EnhancedOrgChart>` | `d3-org-chart` pan/zoom canvas (desktop default) |
   | `responsibilities` | **Hulp** | `<ResponsibilityFinder>` | "wie kan me helpen met…" finder |
+
 - Plus: a top **`<UnifiedSearchBar>`** (searches people + responsibilities), **`<MemberDetailsModal>`**
   (click any node/card/result → modal), department filter (`all`/`hoofdbestuur`/`jeugdbestuur`),
   PNG export, keyboard shortcuts, swipe gestures, deep-linkable via `?view=`/`?memberId=`.

--- a/docs/design/mockups/phase-7-organigram/7o0-data-and-ux-reality-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o0-data-and-ux-reality-locked.md
@@ -36,7 +36,7 @@ A **tabbed interactive tool** wrapped in legacy chrome, server-rendered then hyd
 
 - Plus: a top **`<UnifiedSearchBar>`** (searches people + responsibilities), **`<MemberDetailsModal>`**
   (click any node/card/result → modal), department filter (`all`/`hoofdbestuur`/`jeugdbestuur`),
-  PNG export, keyboard shortcuts, swipe gestures, deep-linkable via `?view=`/`?memberId=`.
+  PNG export, keyboard shortcuts, swipe gestures, deep-linkable via `?view=`/`?member=`.
 
 ## 2. UX problems we are fixing (not just reskinning)
 
@@ -101,7 +101,7 @@ optional per-step `contact`), `relatedPaths[]`.
 ## 4. MUST PRESERVE (functionality contract)
 
 - **Three jobs:** browse the hierarchy, see a person's detail, find the right contact for a question.
-- **Deep-linking:** `?view=`, `?memberId=`, and Hulp→chart "Bekijk in organigram" centering.
+- **Deep-linking:** `?view=`, `?member=`, and Hulp→chart "Bekijk in organigram" centering.
 - **Analytics (5 events, names frozen — `organigram_` is in the live GTM regex):**
   `organigram_view_changed {view, source}` · `organigram_member_clicked {member_id(hashed), view}` ·
   `organigram_search_used {query_text(sanitised)}` · `organigram_department_filtered {department}` ·

--- a/docs/design/mockups/phase-7-organigram/7o1-register-locked.html
+++ b/docs/design/mockups/phase-7-organigram/7o1-register-locked.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o1 LOCKED — dark band + search (A+C)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .head { background: var(--ink); color: var(--cream); padding: 16px 28px; font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.05em; text-transform: uppercase; }
+      .head b { color: var(--warm); }
+      .stage { padding: 40px 28px; }
+      .wrap { max-width: 1040px; margin: 0 auto; }
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--warm); }
+      .eh { font-family: var(--font-display); font-style: italic; font-weight: 900; line-height: 0.92; font-size: clamp(36px, 5vw, 58px); color: var(--cream); margin: 12px 0 0; }
+      .dot-warm { color: var(--warm); font-style: normal; }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; font-size: 17px; line-height: 1.45; color: rgba(245,241,230,0.82); margin-top: 12px; max-width: 42ch; }
+      .searchbar { margin-top: 20px; display: flex; align-items: center; gap: 10px; border: 2px solid var(--ink); background: var(--cream); box-shadow: 4px 4px 0 0 var(--ink); padding: 12px 15px; max-width: 480px; }
+      .searchbar .mag { font-family: var(--font-mono); color: var(--jersey-deep); font-weight: 600; font-size: 17px; }
+      .searchbar .ph { color: var(--ink-muted); font-size: 14px; }
+      .chips { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+      .chip { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; border: 1.5px solid rgba(245,241,230,0.5); color: var(--cream); padding: 6px 11px; }
+      .pgrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+      .pcard { border: 2px solid var(--ink); background: var(--cream); box-shadow: 3px 3px 0 0 var(--ink); display: flex; flex-direction: column; align-items: center; padding: 11px 8px; text-align: center; }
+      .pcard .av { width: 52px; height: 52px; border-radius: 9999px; border: 2px solid var(--ink); overflow: hidden; background: var(--cream-soft); display: flex; align-items: center; justify-content: center; }
+      .pcard .av .mono { font-family: var(--font-display); font-weight: 900; color: var(--jersey-deep); font-size: 19px; }
+      .pcard .av .ph { width: 100%; height: 100%; background: repeating-linear-gradient(45deg, #d7d0bb 0 7px, #c8c1aa 7px 14px); filter: sepia(0.3) saturate(0.8); }
+      .pcard .nm { font-family: var(--font-display); margin-top: 7px; line-height: 1.04; font-size: 13px; }
+      .pcard .nm b { font-weight: 600; } .pcard .nm em { font-style: italic; font-weight: 400; }
+      .pcard .fn { font-family: var(--font-mono); font-size: 8px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); margin-top: 4px; }
+      .artefact { border: 2px solid var(--ink); background: var(--cream-soft); box-shadow: 5px 6px 0 0 var(--ink); transform: rotate(-1deg); padding: 16px 16px 14px; position: relative; }
+      .artefact .tape { position: absolute; top: -11px; left: 50%; transform: translateX(-50%) rotate(-1.5deg); width: 108px; height: 22px; background: rgb(232 224 200 / 0.85); border: 1px solid rgba(10,10,10,0.25); }
+      .artefact .cap2 { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); text-align: center; }
+      .tree { display: block; margin: 8px auto 2px; }
+      .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; border-top: 2px solid var(--paper-edge); margin-top: 10px; padding-top: 10px; }
+      .stat { text-align: center; }
+      .stat .num { font-family: var(--font-display); font-style: normal; font-weight: 900; font-size: 26px; line-height: 1; color: var(--jersey-deep); display: block; }
+      .stat .lab { font-family: var(--font-mono); font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); display: block; margin-top: 3px; }
+      .cap { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: rgba(245,241,230,0.7); text-align: center; margin-bottom: 9px; }
+      .note { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-muted); line-height: 1.7; max-width: 92ch; margin-top: 4px; }
+      .note b { color: var(--jersey-deep); }
+    </style>
+  </head>
+  <body>
+    <div class="head">7o1 LOCKED · <b>Dark band + search (A+C)</b> · the /club/organigram hero</div>
+    <div class="stage">
+      <div class="wrap">
+        <div style="background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 6px 0 0 var(--ink); padding: 38px 34px; position: relative; overflow: hidden;">
+          <div style="position:absolute; inset:0; background: radial-gradient(120% 80% at 72% 0%, rgba(74,207,82,0.14), transparent 60%);"></div>
+          <div style="position: relative; display: grid; grid-template-columns: 1.2fr 0.8fr; gap: 34px; align-items: center;">
+            <div>
+              <span class="kicker">De club</span>
+              <h1 class="eh">Wie doet wat<span class="dot-warm">.</span></h1>
+              <p class="lead">Het bestuur, de jeugdwerking en de mensen erachter — typ een naam, functie of vraag, of blader hieronder door de structuur.</p>
+              <div class="searchbar"><span class="mag">⌕</span><span class="ph">Zoek een naam, functie of vraag…</span></div>
+              <div class="chips">
+                <span class="chip">Ik ben ouder</span><span class="chip">Speler</span><span class="chip">Trainer</span><span class="chip">Supporter</span>
+              </div>
+            </div>
+            <div>
+              <div class="artefact">
+                <div class="tape" aria-hidden="true"></div>
+                <div class="cap2">De structuur</div>
+                <svg class="tree" width="210" height="118" viewBox="0 0 210 118" aria-hidden="true">
+                  <g fill="none" stroke="#0a0a0a" stroke-width="2">
+                    <line x1="105" y1="26" x2="105" y2="40" />
+                    <line x1="48" y1="40" x2="162" y2="40" />
+                    <line x1="48" y1="40" x2="48" y2="52" />
+                    <line x1="105" y1="40" x2="105" y2="52" />
+                    <line x1="162" y1="40" x2="162" y2="52" />
+                    <line x1="162" y1="78" x2="162" y2="90" />
+                    <line x1="134" y1="90" x2="190" y2="90" />
+                    <line x1="134" y1="90" x2="134" y2="100" />
+                    <line x1="190" y1="90" x2="190" y2="100" />
+                  </g>
+                  <rect x="84" y="8" width="42" height="18" fill="#008755" stroke="#0a0a0a" stroke-width="2" />
+                  <rect x="30" y="52" width="36" height="16" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2" />
+                  <rect x="87" y="52" width="36" height="16" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2" />
+                  <rect x="144" y="52" width="36" height="16" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2" />
+                  <rect x="118" y="100" width="32" height="14" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2" />
+                  <rect x="174" y="100" width="32" height="14" fill="#f0c264" stroke="#0a0a0a" stroke-width="2" />
+                </svg>
+                <div class="stats">
+                  <div class="stat"><span class="num">23</span><span class="lab">posities</span></div>
+                  <div class="stat"><span class="num">30</span><span class="lab">mensen</span></div>
+                  <div class="stat"><span class="num">2</span><span class="lab">afdelingen</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="note">
+          <b>Locked spine:</b> jersey-deep-dark band · 2px ink border · 6px paper-shadow · radial jersey wash. Left:
+          warm kicker “De club” · &lt;EditorialHeading&gt; “Wie doet wat<b>.</b>” with warm period · italic lead · embedded
+          search (cream, ink-bordered) · audience chips. Right: a cream taped <b>structure artefact</b> — abstract paper
+          org-tree motif (no names) + an index strip built from <b>real derivable counts only</b> (positions = active
+          nodes · mensen = distinct staff · afdelingen). <b>No individual faces are selected.</b> Numbers shown are
+          placeholders; final labels are a copy detail (avoid foregrounding vacancies). The audience chips' Hulp-jump
+          behaviour is confirmed in 7o6; the below-hero arrangement is decided in 7o2.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o1-register-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o1-register-locked.md
@@ -1,0 +1,70 @@
+# Phase 7 · `/club/organigram` — Round 1 (VOICE / REGISTER) — LOCKED
+
+**Date:** 2026-06-07
+**Mockup:** `7o1-voice-register-compare.html` (A/B/C) → `7o1-register-locked.html` (grafted result)
+**Owner:** @climacon
+**Tracker:** #1529 · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision
+
+**A + C graft — dark "roster spotlight" band with an embedded search.**
+
+The hero is the board-page **jersey-deep-dark roster-spotlight band** (authoritative, ties
+`/club/organigram` to `/club/bestuur` et al.) but wears the **find-a-contact tool's search affordance**
+inside it. This resolves the register tension directly: the page keeps the editorial club voice **and**
+puts the page's single most useful job — "find the right person/answer" — above the fold, attacking the
+"Hulp is buried / 3-view discoverability" pain at the very top of the page rather than hoping users find
+the 3rd tab.
+
+Rejected the pure editorial heroes because a tool people arrive at *with a task* should not make them
+hunt: **B** (cream sibling-editorial) was the quietest but lowest-energy for a task; **A alone** kept
+search in the chrome strip (one scroll-step too far down); **C alone** (search-led, browse demoted below
+a seam) fixed discoverability but abandoned the editorial sibling language and pre-committed too much IA.
+The graft keeps A's voice and borrows only C's search placement.
+
+## Locked hero spine (see `7o1-register-locked.html`)
+
+```text
+<OrganigramHero>  — jersey-deep-dark · 2px ink border · 6px paper-shadow · radial jersey wash
+├─ LEFT (1.2fr)
+│  ├─ Kicker (warm)            "De club"           — mono 12px / 0.18em / uppercase
+│  ├─ EditorialHeading (cream) "Wie doet wat."     — italic serif 900, warm "." period accent
+│  ├─ Lead (cream / .82 op.)   one editorial line, ≤42ch
+│  ├─ Search (cream, ink-bordered, 4px shadow)     — the <UnifiedSearchBar> entry point
+│  └─ Audience chips           ouder · speler · trainer · supporter   (jump into Hulp — confirm in 7o6)
+└─ RIGHT (0.8fr)
+   └─ Structure artefact (cream taped card on the dark band): abstract paper org-tree motif (no names) +
+      an index strip of real derivable counts. NO individual faces.
+```
+
+### Hero right-column artefact — RESOLVED (no people)
+
+There is **no `featured`/`heroSpotlight` field** on `organigramNode` (verified), so a face-roster would
+have to be either a deterministic rule, a non-person artefact, or a new editorial field. **Chosen: a
+non-person structure artefact** — abstract paper org-tree motif + an index built from **only derivable
+counts**: `posities` = active node count, `mensen` = distinct non-archived staff, `afdelingen` =
+populated departments (hoofdbestuur/jeugdbestuur). Rationale: avoids per-node editorial upkeep, can't go
+stale, and previews the diagram concept at the top of the page. **Do not foreground vacancies** in the
+index (lead with positions/people/departments); exact labels are a copy detail for 7o7. Rejected:
+*top-of-structure roster* (deterministic but could surface a vacant/odd top node + needs a shared-node
+rule) and *editor-curated `heroSpotlight`* (ongoing editorial burden the owner consistently drops).
+
+Contrast: small text on jersey-deep / jersey-deep-dark uses **`text-white`/cream per the 6.C AA rule**;
+the warm period + warm kicker carry the accent. **No Ultras heavy-sans** — `EditorialHeading` italic serif.
+
+## What this locks vs defers
+
+- **Locks:** the dark roster-spotlight register; the warm-accent editorial heading; search lives **in the
+  hero**; people rendered with the 6.C `<TeamStaff>` idiom.
+- **Defers to 7o2 (IA):** everything *below* the hero — whether browse is one mode or two, whether the
+  diagram is an inline section / a 2nd mode / an opt-in focused experience, and how Hulp is arranged. The
+  audience chips are a **hero placeholder** for the find-a-contact entry, not an IA commitment.
+- **Defers to 7o3:** the diagram interaction (and the literal 3-D investigation).
+- **Defers to 7o6:** the audience chips' exact behaviour (filtering the Hulp finder by `audience`).
+
+## Carry-forward
+
+- Name the hero component `<OrganigramHero>` (new, `apps/web/src/components/organigram/`).
+- The embedded search is the existing `<UnifiedSearchBar>` reskinned — same people+responsibility ranking,
+  same `organigram_search_used` event; only the chrome changes.
+- Keep the kicker "De club" (matches the board-page hero kicker) for cross-/club cohesion.

--- a/docs/design/mockups/phase-7-organigram/7o1-voice-register-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o1-voice-register-compare.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o1: VOICE / REGISTER compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; background: var(--cream); color: var(--ink);
+        font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 90ch; }
+      .harness-head b { color: var(--warm); }
+      .direction-bar {
+        position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em;
+        text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink);
+      }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 30px 28px 44px; border-bottom: 1px dashed var(--paper-edge); }
+      .wrap { max-width: 1040px; margin: 0 auto; }
+
+      /* ---- shared component vocabulary ---- */
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); }
+      .eh { font-family: var(--font-display); font-style: italic; font-weight: 900; line-height: 0.92; margin: 10px 0 0; }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; line-height: 1.45; }
+      .dot-warm { color: var(--warm); font-style: normal; }
+      .dot-deep { color: var(--jersey-deep); font-style: normal; }
+
+      /* people-card (6.C TeamStaff idiom) */
+      .pgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
+      .pcard { border: 2px solid var(--ink); background: var(--cream); box-shadow: 3px 3px 0 0 var(--ink); display: flex; flex-direction: column; align-items: center; padding: 10px 8px; text-align: center; }
+      .pcard .av { width: 50px; height: 50px; border-radius: 9999px; border: 2px solid var(--ink); overflow: hidden; background: var(--cream-soft); display: flex; align-items: center; justify-content: center; }
+      .pcard .av .mono { font-family: var(--font-display); font-weight: 900; color: var(--jersey-deep); font-size: 18px; }
+      .pcard .av .ph { width: 100%; height: 100%; background: repeating-linear-gradient(45deg, #d7d0bb 0 7px, #c8c1aa 7px 14px); filter: sepia(0.3) saturate(0.8); }
+      .pcard .nm { font-family: var(--font-display); margin-top: 7px; line-height: 1.04; font-size: 13px; }
+      .pcard .nm b { font-weight: 600; } .pcard .nm em { font-style: italic; font-weight: 400; }
+      .pcard .fn { font-family: var(--font-mono); font-size: 8px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-muted); margin-top: 4px; }
+
+      /* tabs / chrome below hero */
+      .chrome { margin-top: 18px; }
+      .tabs { display: flex; gap: 0; border: 2px solid var(--ink); width: max-content; box-shadow: 3px 3px 0 0 var(--ink); background: var(--cream); }
+      .tab { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 9px 16px; border-right: 2px solid var(--ink); color: var(--ink-muted); }
+      .tab:last-child { border-right: none; }
+      .tab.active { background: var(--jersey-deep); color: var(--cream); }
+      .searchbar { margin-top: 12px; display: flex; align-items: center; gap: 10px; border: 2px solid var(--ink); background: var(--cream); box-shadow: 3px 3px 0 0 var(--ink); padding: 11px 14px; max-width: 560px; }
+      .searchbar .mag { font-family: var(--font-mono); color: var(--jersey-deep); font-weight: 600; }
+      .searchbar .ph { color: var(--ink-muted); font-size: 14px; }
+      .chip { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; border: 1.5px solid var(--ink); background: var(--cream); padding: 6px 11px; box-shadow: 2px 2px 0 0 var(--ink); }
+
+      /* seam */
+      .seam { height: 12px; margin: 20px 0; background: repeating-linear-gradient(135deg, var(--ink) 0 9px, var(--cream) 9px 18px); border-top: 2px solid var(--ink); border-bottom: 2px solid var(--ink); }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 22px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 0; padding-left: 18px; }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /club/organigram · 7o1 — VOICE / REGISTER</h1>
+      <p>
+        First decision: <b>the page's center of gravity + chrome tone.</b> Same data, same Phase-7 vocabulary,
+        three registers — from "editorial story about the club" to "practical tool to find who to contact."
+        This sets how the three jobs (browse · person detail · find-a-contact) are weighted. The
+        <b>view-model (how many views / what's primary)</b> is the NEXT round (7o2); the
+        <b>diagram interaction + 3-D investigation</b> is 7o3. Placeholder names/positions are illustrative.
+      </p>
+    </div>
+
+    <!-- ===================== OPTION A ===================== -->
+    <div class="direction-bar"><span class="tag">A</span> Dark “roster spotlight” band <span class="note">authoritative · matches the board pages · org = the club's spine</span></div>
+    <div class="stage">
+      <div class="wrap">
+        <div style="background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 34px 30px; position: relative; overflow: hidden;">
+          <div style="position:absolute; inset:0; background: radial-gradient(120% 80% at 72% 0%, rgba(74,207,82,0.14), transparent 60%);"></div>
+          <div style="position: relative; display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 30px; align-items: center;">
+            <div>
+              <span class="kicker" style="color: var(--warm);">De club</span>
+              <h1 class="eh" style="font-size: clamp(34px, 4.8vw, 56px); color: var(--cream);">Wie doet wat<span class="dot-warm">.</span></h1>
+              <p class="lead" style="font-size: 17px; color: rgba(245,241,230,0.82); margin-top: 12px; max-width: 40ch;">
+                Het bestuur, de jeugdwerking en de mensen erachter — in één overzicht. Klik door tot je de juiste persoon vindt.
+              </p>
+            </div>
+            <div>
+              <div class="pgrid" style="grid-template-columns: repeat(2, 1fr); gap: 9px;">
+                <div class="pcard"><div class="av"><span class="mono">LB</span></div><div class="nm"><b>Luc</b> <em>Boons</em></div><div class="fn">Voorzitter</div></div>
+                <div class="pcard"><div class="av"><span class="ph"></span></div><div class="nm"><b>Inge</b> <em>Maes</em></div><div class="fn">Secretaris</div></div>
+                <div class="pcard"><div class="av"><span class="mono">DV</span></div><div class="nm"><b>Dirk</b> <em>Van Loo</em></div><div class="fn">Penningm.</div></div>
+                <div class="pcard"><div class="av"><span class="ph"></span></div><div class="nm"><b>Sam</b> <em>Peeters</em></div><div class="fn">Jeugdvz.</div></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chrome">
+          <div class="tabs"><span class="tab active">Overzicht</span><span class="tab">Diagram</span><span class="tab">Hulp</span></div>
+          <div class="searchbar"><span class="mag">⌕</span><span class="ph">Zoek een naam, functie of vraag…</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===================== OPTION B ===================== -->
+    <div class="direction-bar"><span class="tag">B</span> Cream sibling-editorial hero <span class="note">warm · quiet · consistent with sponsors / jeugd / geschiedenis</span></div>
+    <div class="stage">
+      <div class="wrap">
+        <div style="display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 34px; align-items: center;">
+          <div>
+            <span class="kicker">De club</span>
+            <h1 class="eh" style="font-size: clamp(34px, 4.8vw, 56px); color: var(--ink);">De clubstructuur<span class="dot-deep">.</span></h1>
+            <p class="lead" style="font-size: 18px; color: var(--ink-soft); margin-top: 12px; max-width: 44ch;">
+              Een kleine club draait op veel vrijwilligers. Hier zie je hoe alles in elkaar past — en wie je aanspreekt.
+            </p>
+          </div>
+          <div>
+            <div style="border: 2px solid var(--ink); background: var(--cream-soft); box-shadow: 5px 6px 0 0 var(--ink); transform: rotate(-1deg); padding: 16px 14px; position: relative;">
+              <div style="position:absolute; top:-11px; left:50%; transform: translateX(-50%) rotate(-1.5deg); width: 110px; height: 22px; background: rgb(232 224 200 / 0.85); border: 1px solid rgba(10,10,10,0.25);"></div>
+              <div class="micro" style="text-align:center; margin-bottom: 10px;">Hoofdbestuur · 2025–26</div>
+              <div class="pgrid" style="grid-template-columns: repeat(3, 1fr); gap: 8px;">
+                <div class="pcard" style="box-shadow:2px 2px 0 0 var(--ink);"><div class="av" style="width:42px;height:42px;"><span class="mono" style="font-size:15px;">LB</span></div><div class="nm" style="font-size:11px;"><b>Luc</b> <em>B.</em></div></div>
+                <div class="pcard" style="box-shadow:2px 2px 0 0 var(--ink);"><div class="av" style="width:42px;height:42px;"><span class="ph"></span></div><div class="nm" style="font-size:11px;"><b>Inge</b> <em>M.</em></div></div>
+                <div class="pcard" style="box-shadow:2px 2px 0 0 var(--ink);"><div class="av" style="width:42px;height:42px;"><span class="mono" style="font-size:15px;">DV</span></div><div class="nm" style="font-size:11px;"><b>Dirk</b> <em>V.</em></div></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="chrome">
+          <div class="tabs"><span class="tab active">Overzicht</span><span class="tab">Diagram</span><span class="tab">Hulp</span></div>
+          <div class="searchbar"><span class="mag">⌕</span><span class="ph">Zoek een naam, functie of vraag…</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===================== OPTION C ===================== -->
+    <div class="direction-bar"><span class="tag">C</span> Tool / “wegwijzer” register <span class="note">find-a-contact first · search-led · directly answers the “Hulp is buried” pain</span></div>
+    <div class="stage">
+      <div class="wrap">
+        <div style="background: var(--jersey-deep-dark); color: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 5px 0 0 var(--ink); padding: 34px 30px; position: relative; overflow: hidden;">
+          <div style="position:absolute; inset:0; background: radial-gradient(120% 80% at 50% 0%, rgba(74,207,82,0.13), transparent 60%);"></div>
+          <div style="position: relative; text-align: center; max-width: 680px; margin: 0 auto;">
+            <span class="kicker" style="color: var(--warm);">Organigram &amp; hulp</span>
+            <h1 class="eh" style="font-size: clamp(34px, 5vw, 58px); color: var(--cream);">Wie zoek je<span class="dot-warm">?</span></h1>
+            <p class="lead" style="font-size: 16px; color: rgba(245,241,230,0.82); margin: 12px auto 0; max-width: 46ch;">
+              Een naam, een functie, of gewoon een vraag — typ het, wij wijzen je de juiste persoon.
+            </p>
+            <div class="searchbar" style="margin: 20px auto 0; max-width: 520px; background: var(--cream); box-shadow: 4px 4px 0 0 var(--ink);">
+              <span class="mag">⌕</span><span class="ph">bv. “lidgeld”, “Hoofdtrainer”, of een naam…</span>
+            </div>
+            <div style="display:flex; gap: 8px; justify-content: center; flex-wrap: wrap; margin-top: 14px;">
+              <span class="chip">Ik ben ouder</span><span class="chip">Speler</span><span class="chip">Trainer</span><span class="chip">Supporter</span>
+            </div>
+          </div>
+        </div>
+        <div class="seam"></div>
+        <div class="wrap" style="text-align:center;">
+          <span class="kicker">Of blader door de structuur</span>
+          <div class="tabs" style="margin: 10px auto 0;"><span class="tab active">Overzicht</span><span class="tab">Diagram</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===================== LEGEND ===================== -->
+    <div class="legend">
+      <h3>Decision 7o1 — pick the register</h3>
+      <p>
+        <b>A · Dark roster spotlight</b> — leads with the people, authoritative, reuses the board-page hero verbatim →
+        strongest visual tie to the rest of /club. Treats browse (Overzicht/Diagram) as the main act, Hulp as a peer tab.<br />
+        <b>B · Cream sibling-editorial</b> — quietest, most "magazine," matches sponsors/jeugd/geschiedenis exactly →
+        best whole-of-Phase-7 consistency, but the lowest-energy entry for a tool people come to with a task.<br />
+        <b>C · Tool / wegwijzer</b> — puts the search + audience chips ABOVE the fold and demotes browse below a seam →
+        directly fixes “Hulp is the useful job but buried” + “3-view discoverability”; biggest departure from the editorial sibling heroes.
+      </p>
+      <p class="micro">
+        Note: C pre-states part of the IA (search-first) that 7o2 would otherwise drill. A/B keep the IA open. Hybrids are
+        available — e.g. A's dark band WITH C's embedded search — say the word and I'll graft. Person-cards above use the
+        locked 6.C &lt;TeamStaff&gt; idiom (round newsprint photo / jersey-deep monogram · first-semibold + last-italic · mono function label).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o2-view-model-ia-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o2-view-model-ia-compare.html
@@ -1,0 +1,195 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o2: VIEW MODEL / IA compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 94ch; }
+      .harness-head b { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar.rec .tag { background: var(--jersey); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 26px 28px 34px; border-bottom: 1px dashed var(--paper-edge); }
+      .grid { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: 320px 1fr; gap: 30px; align-items: start; }
+
+      /* device schematic */
+      .device { border: 2px solid var(--ink); background: var(--cream); box-shadow: 5px 5px 0 0 var(--ink); padding: 10px; }
+      .scrollnote { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-muted); text-align: center; margin: 4px 0 8px; }
+      .band { border: 1.5px solid var(--ink); margin-bottom: 7px; padding: 9px 10px; font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .band small { display: block; font-size: 9px; text-transform: none; letter-spacing: 0; color: var(--ink-muted); margin-top: 3px; font-family: var(--font-body); }
+      .band.hero { background: var(--jersey-deep-dark); color: var(--cream); border-color: var(--ink); }
+      .band.hero small { color: rgba(245,241,230,0.7); }
+      .band.nav { background: var(--cream-deep); }
+      .band.sticky { background: var(--cream-deep); position: relative; }
+      .band.sticky::after { content: "📌 sticky"; position: absolute; right: 8px; top: 8px; font-size: 8px; color: var(--ink-muted); }
+      .band.section { background: var(--cream-soft); }
+      .band.diagram { background: repeating-linear-gradient(45deg, var(--cream-soft) 0 9px, var(--cream-deep) 9px 18px); }
+      .band.hulp { background: color-mix(in srgb, var(--jersey-deep) 12%, var(--cream)); border-color: var(--jersey-deep); }
+      .band.cta { background: var(--jersey-deep-dark); color: var(--cream); }
+      .tabs { display: flex; gap: 0; border: 1.5px solid var(--ink); }
+      .tabs span { flex: 1; text-align: center; font-family: var(--font-mono); font-size: 9.5px; padding: 7px 4px; text-transform: uppercase; letter-spacing: 0.04em; border-right: 1.5px solid var(--ink); }
+      .tabs span:last-child { border-right: none; }
+      .tabs span.on { background: var(--jersey-deep); color: var(--cream); }
+      .popbtn { border: 1.5px dashed var(--jersey-deep); color: var(--jersey-deep); background: var(--cream); text-align: center; font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.05em; padding: 8px; margin-bottom: 7px; }
+      .overlay { border: 2px solid var(--ink); background: var(--jersey-deep-dark); color: var(--cream); padding: 9px 10px; font-family: var(--font-mono); font-size: 10px; text-transform: uppercase; box-shadow: 4px 4px 0 0 var(--warm); }
+      .overlay small { display:block; text-transform: none; font-family: var(--font-body); font-size: 9px; color: rgba(245,241,230,0.8); margin-top: 3px; }
+
+      /* notes + pain matrix */
+      .notes h3 { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 22px; margin: 2px 0 8px; }
+      .notes p { font-size: 14px; line-height: 1.55; color: var(--ink-soft); margin: 0 0 12px; max-width: 60ch; }
+      .matrix { border-collapse: collapse; font-family: var(--font-mono); font-size: 11px; width: 100%; max-width: 520px; }
+      .matrix td, .matrix th { border: 1.5px solid var(--ink); padding: 6px 9px; text-align: left; }
+      .matrix th { background: var(--ink); color: var(--cream); text-transform: uppercase; letter-spacing: 0.05em; font-size: 10px; }
+      .y { color: var(--jersey-deep); font-weight: 600; } .m { color: #b07d00; font-weight: 600; } .n { color: var(--brick); font-weight: 600; }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 22px 28px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.75; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .legend b { color: var(--jersey-deep); }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 7 · /club/organigram · 7o2 — VIEW MODEL / IA</h1>
+      <p>
+        The 7o1 hero is fixed. This decides <b>everything below it</b>: how many views, what's primary, and how the
+        three jobs (browse the structure · a person's detail · find-a-contact/Hulp) are arranged. The four pains in play:
+        <b>scroll-jacking</b>, <b>orientation</b>, <b>3-view discoverability</b>, <b>mobile</b>. NB: this round only decides
+        the <b>container</b> for the diagram — what the diagram interaction actually is (pan-zoom vs in-page tree vs literal
+        3-D) is the next round, 7o3.
+      </p>
+    </div>
+
+    <!-- ===== C baseline ===== -->
+    <div class="direction-bar"><span class="tag">C</span> Keep 3 tabs (reskin only) <span class="note">baseline · least change · least improvement</span></div>
+    <div class="stage"><div class="grid">
+      <div class="device">
+        <div class="scrollnote">— one pane visible at a time —</div>
+        <div class="band hero">HERO + zoek</div>
+        <div class="tabs"><span class="on">Overzicht</span><span>Diagram</span><span>Hulp</span></div>
+        <div class="band section" style="margin-top:7px; height:120px;">ACTIEVE VIEW<small>cards / diagram / hulp — exactly today's three, restyled</small></div>
+        <div class="band cta">CTA-band</div>
+      </div>
+      <div class="notes">
+        <h3>Same machine, new paint.</h3>
+        <p>Three co-equal tabs, just reskinned in Phase-7 vocabulary. Cheapest, lowest-risk — but it keeps the two
+          redundant browse views (cards ≈ diagram) and leaves Hulp as the 3rd tab. None of the four pains is structurally
+          solved; the diagram still owns a pane and can still scroll-jack.</p>
+        <table class="matrix"><tr><th>Scroll-jack</th><th>Orientation</th><th>Discoverability</th><th>Mobile</th></tr>
+          <tr><td class="n">✗</td><td class="n">✗</td><td class="n">✗</td><td class="m">△</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- ===== B two-mode ===== -->
+    <div class="direction-bar"><span class="tag">B</span> Two modes: Structuur ⟷ Hulp <span class="note">collapse 3→2 · diagram = a render of Structuur</span></div>
+    <div class="stage"><div class="grid">
+      <div class="device">
+        <div class="scrollnote">— one mode visible at a time —</div>
+        <div class="band hero">HERO + zoek</div>
+        <div class="tabs"><span class="on">Structuur</span><span>Hulp</span></div>
+        <div class="tabs" style="margin-top:7px; border-style:dashed;"><span class="on">Lijst</span><span>Diagram</span></div>
+        <div class="band section" style="margin-top:7px; height:104px;">STRUCTUUR<small>one browse surface; list↔diagram is a sub-toggle, not a peer tab</small></div>
+        <div class="band cta">CTA-band</div>
+      </div>
+      <div class="notes">
+        <h3>Browse, or get help.</h3>
+        <p>Two co-equal modes. The cards/diagram redundancy is demoted to a <em>sub-toggle inside one “Structuur”
+          mode</em> (list vs diagram = two renderings of the same data, by choice). Hulp is lifted to half the page.
+          Solves redundancy + discoverability cleanly; still a mode-switch (not the house single-scroll), and the diagram
+          sub-view can still scroll-jack when active.</p>
+        <table class="matrix"><tr><th>Scroll-jack</th><th>Orientation</th><th>Discoverability</th><th>Mobile</th></tr>
+          <tr><td class="m">△</td><td class="m">△</td><td class="y">✓</td><td class="y">✓</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- ===== A single-scroll ===== -->
+    <div class="direction-bar"><span class="tag">A</span> Single-scroll + sticky section-nav <span class="note">matches 6.C / jeugd house style · all sections inline</span></div>
+    <div class="stage"><div class="grid">
+      <div class="device">
+        <div class="scrollnote">↓ one continuous scroll ↓</div>
+        <div class="band hero">HERO + zoek</div>
+        <div class="band sticky">Structuur · Diagram · Hulp</div>
+        <div class="band section">① STRUCTUUR<small>directory of people by department</small></div>
+        <div class="band diagram">② DIAGRAM<small>the node-tree, inline</small></div>
+        <div class="band hulp">③ HULP<small>responsibility finder</small></div>
+        <div class="band cta">CTA-band</div>
+      </div>
+      <div class="notes">
+        <h3>One page, scroll it all.</h3>
+        <p>Everything stacked on one scroll with a sticky in-page nav — identical to the locked 6.C team + /jeugd pattern.
+          Best whole-of-Phase-7 consistency and discoverability (nothing hidden behind a tab). Catch: an interactive
+          diagram <em>inline</em> is exactly where scroll-jacking bites — so this <b>forces 7o3 to a tame, scroll-safe
+          inline diagram</b> (expand/collapse tree, no free pan-zoom) and leaves <b>no natural home for an immersive 3-D
+          explorer</b>.</p>
+        <table class="matrix"><tr><th>Scroll-jack</th><th>Orientation</th><th>Discoverability</th><th>Mobile</th></tr>
+          <tr><td class="m">△*</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr></table>
+        <p style="font-size:11px; font-family:var(--font-mono); color:var(--ink-muted);">*only if 7o3 drops pan/zoom for an inline tree.</p>
+      </div>
+    </div></div>
+
+    <!-- ===== D single-scroll + opt-in immersive ===== -->
+    <div class="direction-bar rec"><span class="tag">D ★</span> Single-scroll · diagram = opt-in fullscreen “Verken” <span class="note">recommended · scroll-safe by construction · the home for 3-D</span></div>
+    <div class="stage"><div class="grid">
+      <div class="device">
+        <div class="scrollnote">↓ calm scroll ↓ &nbsp; + &nbsp; ⤢ pops out</div>
+        <div class="band hero">HERO + zoek</div>
+        <div class="band sticky">Structuur · Hulp</div>
+        <div class="band section">① STRUCTUUR<small>directory: people by department (quick scan)</small></div>
+        <div class="popbtn">⤢ &nbsp;Open de organigram-verkenner</div>
+        <div class="overlay">▣ IMMERSIVE DIAGRAM / 3-D<small>fullscreen focused mode — owns the screen, pan/zoom/rotate expected, no page-scroll conflict, Esc to return</small></div>
+        <div class="band hulp">② HULP<small>responsibility finder</small></div>
+        <div class="band cta">CTA-band</div>
+      </div>
+      <div class="notes">
+        <h3>Calm page. Immersive on demand.</h3>
+        <p>The page itself is a quiet single-scroll: a <b>directory</b> (people grouped by department — the quick “who’s
+          who” scan) + <b>Hulp</b> + CTA. The relational <b>diagram/3-D explorer is a deliberate opt-in</b> launched from a
+          button into a <b>fullscreen focused mode</b>. That one move resolves scroll-jacking <em>by construction</em>
+          (the canvas only exists when it owns the whole screen) and gives the <b>literal 3-D investigation its natural
+          home</b> — rotate/zoom is expected in a verkenner, not in a page section. Directory vs diagram stop being
+          redundant: one is “scan who’s who”, the other is “explore how it connects”.</p>
+        <table class="matrix"><tr><th>Scroll-jack</th><th>Orientation</th><th>Discoverability</th><th>Mobile</th></tr>
+          <tr><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr></table>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o2 — pick the view model</h3>
+      <p>
+        <b>C</b> reskins today's 3 tabs (solves nothing structurally). <b>B</b> collapses to Structuur⟷Hulp (kills
+        redundancy, still mode-switch). <b>A</b> goes full single-scroll like the rest of Phase 7 (best consistency, but
+        an inline interactive diagram fights scroll → forces a tame 7o3 + no 3-D home). <b>D ★</b> keeps the calm
+        single-scroll for browse+Hulp but makes the diagram an <b>opt-in fullscreen verkenner</b> — the only option that
+        fixes all four pains <em>and</em> gives the literal 3-D idea a place to live.
+      </p>
+      <p style="color:var(--ink-muted);">
+        Whatever wins sets the <b>container</b> for 7o3. A → inline tame tree. B → diagram as a sub-render. D → immersive
+        focused mode (pan-zoom / drill / 3-D all viable there). A “D but with a small inline structure preview that
+        expands to fullscreen” hybrid is available on request.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o2-view-model-locked.html
+++ b/docs/design/mockups/phase-7-organigram/7o2-view-model-locked.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o2 LOCKED — D + finding-model I + order A</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:16px 28px;font-family:var(--font-mono);font-size:12px;letter-spacing:.05em;text-transform:uppercase;}
+      .head b{color:var(--warm);}
+      .wrap{max-width:1020px;margin:0 auto;padding:0 24px;}
+      .kicker{font-family:var(--font-mono);font-size:12px;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:var(--jersey-deep);}
+      .dot{color:var(--jersey-deep);font-style:normal;}
+      .seam{height:12px;background:repeating-linear-gradient(135deg,var(--ink) 0 9px,var(--cream) 9px 18px);border-top:2px solid var(--ink);border-bottom:2px solid var(--ink);}
+
+      .hero{background:var(--jersey-deep-dark);color:var(--cream);border-bottom:2px solid var(--ink);padding:30px 0 28px;position:relative;overflow:hidden;}
+      .hero::before{content:"";position:absolute;inset:0;background:radial-gradient(120% 80% at 72% 0%,rgba(74,207,82,.14),transparent 60%);}
+      .hero .row{position:relative;display:grid;grid-template-columns:1.2fr 0.8fr;gap:28px;align-items:center;}
+      .hero .kicker{color:var(--warm);}
+      .hero h1{font-family:var(--font-display);font-style:italic;font-weight:900;line-height:.94;color:var(--cream);font-size:clamp(30px,4.4vw,48px);margin:10px 0 0;}
+      .hero .lead{font-family:var(--font-display);font-style:italic;font-size:15px;color:rgba(245,241,230,.82);margin-top:10px;max-width:42ch;}
+      .hsearch{margin-top:16px;display:flex;align-items:center;gap:9px;border:2px solid var(--ink);background:var(--cream);box-shadow:4px 4px 0 0 var(--ink);padding:10px 13px;max-width:460px;}
+      .hsearch .mag{color:var(--jersey-deep);font-weight:600;}.hsearch .ph{color:var(--ink-muted);font-size:13px;}
+      .hsearch .ai{margin-left:auto;font-family:var(--font-mono);font-size:8px;letter-spacing:.06em;text-transform:uppercase;color:var(--jersey-deep);border:1.5px solid var(--jersey-deep);padding:2px 5px;}
+      .hlabel{font-family:var(--font-mono);font-size:10px;letter-spacing:.05em;text-transform:uppercase;color:rgba(245,241,230,.7);margin:13px 0 6px;}
+      .hchips{display:flex;gap:7px;flex-wrap:wrap;}
+      .hchip{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;border:1.5px solid rgba(245,241,230,.5);color:var(--cream);padding:5px 9px;}
+      .hchip::before{content:"↓ ";color:var(--warm);}
+      .miniart{border:2px solid var(--ink);background:var(--cream-soft);box-shadow:4px 5px 0 0 var(--ink);transform:rotate(-1deg);padding:12px;}
+      .miniart .cap{font-family:var(--font-mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-muted);text-align:center;}
+      .miniart .st{display:grid;grid-template-columns:repeat(3,1fr);gap:3px;border-top:2px solid var(--paper-edge);margin-top:8px;padding-top:8px;text-align:center;}
+      .miniart .st .n{font-family:var(--font-display);font-weight:900;font-size:21px;color:var(--jersey-deep);display:block;line-height:1;}
+      .miniart .st .l{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;color:var(--ink-muted);}
+
+      .snav{position:sticky;top:0;z-index:30;background:var(--cream-deep);border-bottom:2px solid var(--ink);}
+      .snav .in{max-width:1020px;margin:0 auto;padding:9px 24px;display:flex;gap:8px;align-items:center;}
+      .snav a{font-family:var(--font-mono);font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;border:1.5px solid var(--ink);padding:6px 12px;background:var(--cream);color:var(--ink);text-decoration:none;box-shadow:2px 2px 0 0 var(--ink);}
+      .snav a.on{background:var(--jersey-deep);color:var(--cream);}
+      .snav .sp{flex:1;}.snav .mini{font-family:var(--font-mono);font-size:10px;color:var(--ink-muted);}
+
+      .sec{padding:28px 0 6px;}
+      .sec .kicker{display:block;}
+      .sec h2{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:clamp(26px,3.4vw,36px);margin:8px 0 0;}
+      .sec .intro{font-size:14px;color:var(--ink-soft);max-width:64ch;margin:8px 0 0;}
+
+      .deptlabel{display:flex;align-items:baseline;gap:10px;margin:20px 0 12px;}
+      .deptlabel .ml{font-family:var(--font-mono);font-size:12px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;color:var(--ink);border-bottom:2px solid var(--jersey-deep);padding-bottom:3px;}
+      .deptlabel .ct{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);}
+      .pgrid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:14px;}
+      .pcard{border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 var(--ink);display:flex;flex-direction:column;align-items:center;padding:13px 10px;text-align:center;transition:all .2s;}
+      .pcard:hover{box-shadow:none;transform:translate(3px,3px);}
+      .pcard .av{width:58px;height:58px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;}
+      .pcard .av .mono{font-family:var(--font-display);font-weight:900;color:var(--jersey-deep);font-size:21px;}
+      .pcard .av .ph{width:100%;height:100%;background:repeating-linear-gradient(45deg,#d7d0bb 0 8px,#c8c1aa 8px 16px);filter:sepia(.3) saturate(.8);}
+      .pcard .nm{font-family:var(--font-display);margin-top:8px;line-height:1.05;font-size:14px;}
+      .pcard .nm b{font-weight:600;}.pcard .nm em{font-style:italic;font-weight:400;}
+      .pcard .fn{font-family:var(--font-mono);font-size:9px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-muted);margin-top:4px;}
+      .pcard.vacant{border-style:dashed;background:var(--cream-soft);box-shadow:none;}
+      .pcard.vacant .av{border-style:dashed;background:transparent;}
+      .pcard.vacant .av .q{font-family:var(--font-display);font-style:italic;font-size:23px;color:var(--ink-muted);}
+      .pcard.vacant .fn{color:var(--brick);}
+      .av-rel{position:relative;}
+      .badge2{position:absolute;bottom:-3px;right:-3px;background:var(--jersey-deep);color:var(--cream);border:2px solid var(--ink);border-radius:9999px;width:21px;height:21px;font-family:var(--font-mono);font-size:10px;display:flex;align-items:center;justify-content:center;font-weight:600;}
+      .showall{margin-top:12px;font-family:var(--font-mono);font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--jersey-deep);border:1.5px solid var(--jersey-deep);padding:7px 13px;display:inline-block;}
+
+      .hulp .catbar{display:flex;gap:7px;flex-wrap:wrap;margin:14px 0 16px;}
+      .hulp .catbar .c{font-family:var(--font-mono);font-size:11px;letter-spacing:.04em;text-transform:uppercase;border:1.5px solid var(--ink);padding:6px 11px;background:var(--cream);box-shadow:2px 2px 0 0 var(--ink);}
+      .hulp .catbar .c.on{background:var(--jersey-deep);color:var(--cream);}
+      .hulp .qcard{border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 var(--ink);padding:15px 18px;margin-bottom:12px;}
+      .hulp .qcard .cat{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--jersey-deep);}
+      .hulp .qcard .q{font-family:var(--font-display);font-style:italic;font-weight:600;font-size:18px;margin:4px 0 6px;}
+      .hulp .qcard .sm{font-size:13px;color:var(--ink-soft);line-height:1.5;max-width:62ch;}
+      .hulp .qcard .ct{display:inline-flex;gap:8px;align-items:center;margin-top:10px;font-family:var(--font-mono);font-size:11px;border:1.5px solid var(--ink);padding:5px 10px;box-shadow:2px 2px 0 0 var(--ink);background:var(--cream-soft);}
+
+      .verk{margin:8px 0 4px;border:2px solid var(--ink);background:var(--jersey-deep-dark);box-shadow:5px 5px 0 0 var(--ink);overflow:hidden;}
+      .verk .preview{height:180px;background:radial-gradient(110% 90% at 50% -10%,rgba(74,207,82,.18),transparent 60%),var(--jersey-deep-dark);position:relative;}
+      .verk svg{position:absolute;inset:0;margin:auto;}
+      .verk .ov{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;padding:18px;gap:9px;background:linear-gradient(to top,rgba(19,61,40,.85),transparent 55%);}
+      .verk .ov .t{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:22px;color:var(--cream);}
+      .verk .ov .s{font-family:var(--font-mono);font-size:10px;letter-spacing:.05em;text-transform:uppercase;color:rgba(245,241,230,.78);}
+      .verk .ov .btn{font-family:var(--font-mono);font-size:12px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;border:2px solid var(--ink);background:var(--warm);color:var(--ink);padding:11px 18px;box-shadow:4px 4px 0 0 var(--ink);}
+      .opensinto{font-family:var(--font-mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-muted);text-align:center;margin:16px 0 8px;}
+      .fs{border:2px solid var(--ink);background:#0e2b1d;box-shadow:6px 6px 0 0 var(--warm);}
+      .fs .bar{display:flex;align-items:center;gap:9px;padding:9px 12px;border-bottom:1.5px solid rgba(245,241,230,.2);background:#0a2016;flex-wrap:wrap;}
+      .fs .bar .ttl{font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--cream);}
+      .fs .bar .sp{flex:1;}
+      .fs .ctl{font-family:var(--font-mono);font-size:10px;color:var(--cream);border:1.5px solid rgba(245,241,230,.4);padding:4px 8px;}
+      .fs .ctl.warm{border-color:var(--warm);color:var(--warm);}
+      .fs .crumb{font-family:var(--font-mono);font-size:10px;color:rgba(245,241,230,.8);padding:7px 12px;border-bottom:1.5px solid rgba(245,241,230,.12);}
+      .fs .crumb b{color:var(--warm);}
+      .fs .canvas{height:240px;position:relative;background:linear-gradient(rgba(245,241,230,.05) 1px,transparent 1px) 0 0/26px 26px,linear-gradient(90deg,rgba(245,241,230,.05) 1px,transparent 1px) 0 0/26px 26px,radial-gradient(120% 90% at 50% 0%,rgba(74,207,82,.14),transparent 55%);}
+      .fs .hint{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:9.5px;letter-spacing:.05em;text-transform:uppercase;color:rgba(245,241,230,.6);text-align:center;}
+      .fnode{position:absolute;border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 rgba(0,0,0,.5);padding:6px 9px;text-align:center;}
+      .fnode .nn{font-family:var(--font-display);font-weight:600;font-size:12px;}.fnode .nf{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;color:var(--ink-muted);}
+      .fnode.root{background:var(--jersey-deep);color:var(--cream);}.fnode.root .nf{color:rgba(245,241,230,.8);}
+      .fnode.cur{box-shadow:0 0 0 3px var(--warm),3px 3px 0 0 rgba(0,0,0,.5);}
+
+      .cta{margin-top:30px;background:var(--jersey-deep-dark);color:var(--cream);border-top:2px solid var(--ink);border-bottom:2px solid var(--ink);padding:34px 0;}
+      .cta .in{max-width:1020px;margin:0 auto;padding:0 24px;display:flex;justify-content:space-between;align-items:center;gap:18px;flex-wrap:wrap;}
+      .cta h2{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:26px;margin:0;}
+      .cta p{margin:5px 0 0;color:rgba(245,241,230,.8);font-size:13px;}
+      .cta .pill{font-family:var(--font-mono);font-weight:700;font-size:12px;letter-spacing:.06em;text-transform:uppercase;border:2px solid var(--ink);padding:12px 18px;background:var(--warm);color:var(--ink);box-shadow:4px 4px 0 0 var(--ink);}
+      .ann{font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);line-height:1.7;background:var(--cream-deep);border:1.5px dashed var(--ink);padding:10px 14px;margin:18px 0;}
+      .ann b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">7o2 LOCKED · <b>D + finding-model I + order A</b> · single-scroll · one search front door · Structuur → Hulp → Verkenner</div>
+
+    <!-- HERO -->
+    <div class="hero"><div class="wrap"><div class="row">
+      <div>
+        <span class="kicker">De club</span>
+        <h1>Wie doet wat<span class="dot" style="color:var(--warm)">.</span></h1>
+        <p class="lead">Het bestuur, de jeugdwerking en de mensen erachter. Typ een naam, functie of vraag — of blader hieronder.</p>
+        <div class="hsearch"><span class="mag">⌕</span><span class="ph">bv. “Boons”, “Hoofdtrainer”, of “mijn kind is geblesseerd”…</span><span class="ai">semantisch</span></div>
+        <div class="hlabel">Of meteen naar je vraag:</div>
+        <div class="hchips"><span class="hchip">Ik ben ouder</span><span class="hchip">Speler</span><span class="hchip">Trainer</span><span class="hchip">Supporter</span></div>
+      </div>
+      <div class="miniart">
+        <div class="cap">De structuur</div>
+        <svg width="100%" height="78" viewBox="0 0 210 78" aria-hidden="true">
+          <g fill="none" stroke="#0a0a0a" stroke-width="2"><line x1="105" y1="20" x2="105" y2="32"/><line x1="55" y1="32" x2="155" y2="32"/><line x1="55" y1="32" x2="55" y2="44"/><line x1="105" y1="32" x2="105" y2="44"/><line x1="155" y1="32" x2="155" y2="44"/></g>
+          <rect x="86" y="6" width="38" height="14" fill="#008755" stroke="#0a0a0a" stroke-width="2"/>
+          <rect x="38" y="44" width="34" height="13" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2"/>
+          <rect x="88" y="44" width="34" height="13" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2"/>
+          <rect x="138" y="44" width="34" height="13" fill="#f0c264" stroke="#0a0a0a" stroke-width="2"/>
+        </svg>
+        <div class="st"><div><span class="n">23</span><span class="l">posities</span></div><div><span class="n">30</span><span class="l">mensen</span></div><div><span class="n">2</span><span class="l">afdelingen</span></div></div>
+      </div>
+    </div></div></div>
+
+    <!-- STICKY NAV (order A) -->
+    <div class="snav"><div class="in">
+      <a href="#structuur" class="on">Structuur</a>
+      <a href="#hulp">Hulp</a>
+      <a href="#verkenner">Verkenner</a>
+      <span class="sp"></span>
+      <span class="mini">⌕ zoek bovenaan</span>
+    </div></div>
+
+    <!-- ① STRUCTUUR (compact) -->
+    <div class="wrap" id="structuur">
+      <div class="sec"><span class="kicker">Sectie 1 · wie</span><h2>De structuur<span class="dot">.</span></h2>
+        <p class="intro">Wie zit waar, per afdeling. Klik iemand aan voor contact en functie — of open de verkenner onderaan om te zien hoe alles samenhangt.</p>
+      </div>
+      <div class="deptlabel"><span class="ml">Hoofdbestuur</span><span class="ct">7 functies · 1 vacant</span></div>
+      <div class="pgrid">
+        <div class="pcard"><div class="av"><span class="mono">LB</span></div><div class="nm"><b>Luc</b> <em>Boons</em></div><div class="fn">Voorzitter</div></div>
+        <div class="pcard"><div class="av"><span class="ph"></span></div><div class="nm"><b>Inge</b> <em>Maes</em></div><div class="fn">Secretaris</div></div>
+        <div class="pcard"><div class="av"><span class="mono">DV</span></div><div class="nm"><b>Dirk</b> <em>Van Loo</em></div><div class="fn">Penningmeester</div></div>
+        <div class="pcard"><div class="av av-rel"><span class="ph"></span><span class="badge2">2</span></div><div class="nm"><b>Wedstrijd-</b> <em>secretariaat</em></div><div class="fn">2 personen</div></div>
+        <div class="pcard vacant"><div class="av"><span class="q">?</span></div><div class="nm"><em>Open functie</em></div><div class="fn">Vacant</div></div>
+      </div>
+      <a class="showall" href="#">Toon alle 23 functies →</a>
+    </div>
+
+    <div class="seam" style="margin-top:30px;"></div>
+
+    <!-- ② HULP (browse catalogue of the same answers the search returns) -->
+    <div class="wrap hulp" id="hulp">
+      <div class="sec"><span class="kicker">Sectie 2 · vind hulp</span><h2>Wie kan me helpen<span class="dot">?</span></h2>
+        <p class="intro">Geen idee wie je moet hebben? Typ je vraag bovenaan, of blader hier per thema. (Dezelfde antwoorden die de zoekbalk vindt — hier om te bladeren i.p.v. te typen.)</p>
+      </div>
+      <div class="catbar"><span class="c on">Alles</span><span class="c">Medisch</span><span class="c">Sportief</span><span class="c">Administratief</span><span class="c">Gedrag</span><span class="c">Commercieel</span></div>
+      <div class="qcard"><div class="cat">Administratief</div><div class="q">Hoe schrijf ik mijn kind in?</div><div class="sm">Inschrijven kan het hele seizoen door. De jeugdsecretaris helpt met formulieren, lidgeld en de juiste ploeg.</div><span class="ct">✉ Karen Wouters · Jeugdsecretaris</span></div>
+      <div class="qcard"><div class="cat">Medisch</div><div class="q">Mijn zoon is geblesseerd — wat nu?</div><div class="sm">Verwittig de trainer en vul het ongevalsformulier in binnen de week. De gerechtelijk correspondent dient het in bij Voetbal Vlaanderen.</div><span class="ct">✉ Peter Geerts · Gerechtelijk correspondent</span></div>
+      <div class="ann"><b>7o6 detail:</b> finder layout (category-grid vs audience-first) + contact/steps treatment is the Hulp round. Shown representative so the scroll reads end-to-end. The audience chips in the hero deep-link here, pre-filtered.</div>
+    </div>
+
+    <div class="seam"></div>
+
+    <!-- ③ VERKENNER (opt-in fullscreen finale) -->
+    <div class="wrap" id="verkenner">
+      <div class="sec"><span class="kicker">Sectie 3 · verken</span><h2>Hoe alles samenhangt<span class="dot">.</span></h2>
+        <p class="intro">De directory toont wie; de verkenner toont <em>hoe</em>. Open ’m op volledig scherm en klik je een weg door de structuur — zonder de pagina te kapen.</p>
+      </div>
+      <div class="verk">
+        <div class="preview">
+          <svg width="380" height="146" viewBox="0 0 380 146" aria-hidden="true">
+            <g fill="none" stroke="rgba(245,241,230,.5)" stroke-width="2"><line x1="190" y1="36" x2="190" y2="56"/><line x1="90" y1="56" x2="290" y2="56"/><line x1="90" y1="56" x2="90" y2="72"/><line x1="190" y1="56" x2="190" y2="72"/><line x1="290" y1="56" x2="290" y2="72"/></g>
+            <rect x="160" y="16" width="60" height="20" rx="2" fill="#008755" stroke="#0a0a0a" stroke-width="2"/>
+            <rect x="60" y="72" width="60" height="20" rx="2" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2"/>
+            <rect x="160" y="72" width="60" height="20" rx="2" fill="#f5f1e6" stroke="#0a0a0a" stroke-width="2"/>
+            <rect x="260" y="72" width="60" height="20" rx="2" fill="#f0c264" stroke="#0a0a0a" stroke-width="2"/>
+          </svg>
+          <div class="ov"><div class="t">De organigram-verkenner</div><div class="s">klik je een weg · verken de hele club</div><div class="btn">⤢ Open op volledig scherm</div></div>
+        </div>
+      </div>
+      <div class="opensinto">↓ klik en het opent in een eigen, gefocust scherm ↓</div>
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Organigram-verkenner</span><span class="sp"></span><span class="ctl">–</span><span class="ctl">100%</span><span class="ctl">+</span><span class="ctl">⤢ passend</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; Hoofdbestuur &nbsp;▸&nbsp; <b>Voorzitter</b></div>
+        <div class="canvas">
+          <div class="fnode root" style="left:44%;top:14px;"><div class="nn">KCVV Elewijt</div><div class="nf">de club</div></div>
+          <div class="fnode cur" style="left:20%;top:112px;"><div class="nn">Luc Boons</div><div class="nf">Voorzitter</div></div>
+          <div class="fnode" style="left:45%;top:112px;"><div class="nn">Inge Maes</div><div class="nf">Secretaris</div></div>
+          <div class="fnode" style="left:69%;top:112px;"><div class="nn">Sam Peeters</div><div class="nf">Jeugdvoorzitter</div></div>
+          <div class="hint">klik een kind → nieuw midden · klik ouder/buur → omhoog/opzij · Esc sluit — pagina blijft waar ze was</div>
+        </div>
+      </div>
+      <div class="ann"><b>7o3 LOCKED:</b> the verkenner is a <b>spotlight drill-down</b> (click a node → it becomes the new centre; parent above, siblings flanking, children below). <b>2-D only — 3-D was investigated and removed.</b> Container = fullscreen focused mode with persistent breadcrumb + zoom/fit + Esc, so it can never scroll-jack.</div>
+    </div>
+
+    <div class="cta"><div class="in">
+      <div><h2>Niemand gevonden voor jouw vraag?</h2><p>Stuur ons een berichtje — we verbinden je met de juiste persoon.</p></div>
+      <span class="pill">Contacteer de club →</span>
+    </div></div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o2-view-model-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o2-view-model-locked.md
@@ -1,0 +1,90 @@
+# Phase 7 · `/club/organigram` — Round 2 (VIEW MODEL / IA + FINDING MODEL) — LOCKED
+
+**Date:** 2026-06-07
+**Mockups:** `7o2-view-model-ia-compare.html` (view models A–D) · `7o2b-finding-model-compare.html`
+(finding models I–III) → `7o2-view-model-locked.html` (the resolved page)
+**Owner:** @climacon
+**Tracker:** #1529 · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision (four locks, one coherent page)
+
+1. **View model = D — single-scroll + opt-in fullscreen "verkenner".**
+   The page body is a calm single-scroll (house style, matches 6.C team + /jeugd) with a sticky in-page
+   section nav. The relational diagram is **not** an inline section that fights the page; it is an
+   **opt-in fullscreen focused mode** launched from a button. This fixes **scroll-jacking by
+   construction** (a canvas that owns the whole screen cannot hijack page scroll) and gives the literal
+   **3-D investigation its natural home** (rotate/zoom is expected in a verkenner, not in a page band).
+
+2. **Finding model = I — one search front door; the sections are the browse backup.**
+   The hero search is the single fast path and spans **both** intents: typing returns **Personen**
+   (name·function → contact) **and** **Antwoorden/hulpvragen** (question → answer+contact), typed and
+   labelled. The three sections below are the **same dataset reached by browsing instead of typing** —
+   Structuur = browse people, Hulp = browse the answers by theme, Verkenner = browse relationships.
+   **Nothing is duplicated:** Hulp is the *catalogue you land in if you click instead of type*, never a
+   second search box. Resolves the "is this duplicated?" confusion: **search is the verb, sections are
+   the nouns.**
+
+3. **Search intelligence = semantic/AI (investigate, scoped issue).**
+   Today's `UnifiedSearchBar` is keyword/substring ranking. Upgrade it to **semantic search over the
+   `responsibility` docs** using the **existing bge-m3 + Vectorize stack** that already powers `/zoeken`,
+   so natural language ("mijn kind heeft zich bezeerd") resolves to the right Hulp answer without keyword
+   overlap. This is **extra BFF/embeddings build → its own PRD phase/issue**, not free; people-search can
+   stay keyword. (Reinforces the order decision below: typed questions resolve at the very top.)
+
+4. **Section order = A — hero → (compact) Structuur → Hulp → Verkenner → CTA.**
+   Hulp sits **above** the heavy Verkenner so a scroller reaches it; the immersive explorer is the opt-in
+   finale. Structuur is **compact** (department headers + a few cards + "Toon alle N functies →") so it
+   doesn't wall off Hulp.
+
+### Why Hulp is reachable despite being section 2 (the burial worry)
+
+A question-asker is routed to help **from the hero**, three ways, before scrolling past anything:
+
+- the **search returns answers directly** (semantic makes this strong) — often no scroll needed;
+- the **hero audience chips** ("Ik ben ouder / Speler / Trainer / Supporter") **deep-link into Hulp**,
+  pre-filtered by `responsibility.audience`;
+- the **sticky nav** keeps **Hulp** one tap away at every scroll position.
+
+## Locked page spine (see `7o2-view-model-locked.html`)
+
+```text
+<OrganigramHero>            7o1 dark band + embedded UNIFIED search (semantic) + audience chips → Hulp
+<OrganigramSectionNav>      sticky: Structuur · Hulp · Verkenner
+① #structuur  — <StructureDirectory>   people by department (compact, "Toon alle N →"); states: single/shared/vacant
+   <StripedSeam>
+② #hulp       — <ResponsibilityFinder>  browse answers by theme (the catalogue; same data the search returns)
+   <StripedSeam>
+③ #verkenner  — <OrganigramExplorer>    inline teaser → OPT-IN FULLSCREEN spotlight drill-down (2-D)
+                                          (persistent breadcrumb + zoom/fit + Esc → never scroll-jacks)
+<CtaBand>                   jersey-deep-dark "Niemand gevonden?" → contact
+```
+
+## What this locks vs defers
+
+- **Locks:** single-scroll + sticky nav; the fullscreen-verkenner container; one unified search as the
+  front door; sections = browse-the-same-data; semantic-search as a scoped build; order Structuur→Hulp→Verkenner.
+- **Resolved in 7o3:** the verkenner's internal interaction is a **spotlight drill-down, 2-D only**
+  (3-D investigated and removed) inside that fullscreen container.
+- **Defers to 7o4:** Structuur people-card states (single / shared / **vacant**) chrome.
+- **Defers to 7o5:** what opens when you click a person (modal vs panel vs sheet).
+- **Defers to 7o6:** Hulp finder layout (category-grid vs audience-first) + contact/steps treatment +
+  the audience-chip deep-link behaviour.
+- **Defers to 7o7:** final copy, exact stat labels, empty states, analytics/SEO wiring.
+
+## Component seeds (new, `apps/web/src/components/organigram/`)
+
+`<OrganigramHero>` · `<OrganigramSectionNav>` · `<StructureDirectory>` (replaces `<CardHierarchy>` as the
+calm browse) · `<ResponsibilityFinder>` (reskin) · `<OrganigramExplorer>` (the fullscreen verkenner —
+absorbs/replaces `<EnhancedOrgChart>` + `<MobileNavigationDrawer>` + `<ContactOverlay>`) ·
+reuse-reskin `<UnifiedSearchBar>` (now semantic-capable) + `<MemberDetailsModal>` (7o5).
+
+## Rejected
+
+- **View model C** (3 tabs reskin) — solves none of the four pains; keeps cards≈diagram redundancy.
+- **View model A** (everything inline incl. diagram) — an inline interactive explorer competes with the
+  page for scroll/focus; the fullscreen verkenner keeps it a deliberate, focused mode.
+- **View model B** (2 modes) — better, but a mode-switch rather than the house single-scroll.
+- **Finding II** (two scoped search boxes) — zero overlap but forces the user to self-diagnose intent.
+- **Finding III** (Hulp-led) — demotes the structure explorer the owner explicitly wanted central.
+- **Order B/C** — B (Hulp-first) over-prioritises help and pushes structure down toward III; C
+  (two-door split) adds a router the hero chips already provide.

--- a/docs/design/mockups/phase-7-organigram/7o2-view-model-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o2-view-model-locked.md
@@ -12,8 +12,9 @@
    The page body is a calm single-scroll (house style, matches 6.C team + /jeugd) with a sticky in-page
    section nav. The relational diagram is **not** an inline section that fights the page; it is an
    **opt-in fullscreen focused mode** launched from a button. This fixes **scroll-jacking by
-   construction** (a canvas that owns the whole screen cannot hijack page scroll) and gives the literal
-   **3-D investigation its natural home** (rotate/zoom is expected in a verkenner, not in a page band).
+   construction** (a canvas that owns the whole screen cannot hijack page scroll) and gives the
+   relational diagram a focused **2-D** home where pan/zoom can't fight the page. _(A literal 3-D viewer
+   was later investigated at scale and **removed** — `7o3`; the verkenner is **2-D only**.)_
 
 2. **Finding model = I — one search front door; the sections are the browse backup.**
    The hero search is the single fast path and spans **both** intents: typing returns **Personen**

--- a/docs/design/mockups/phase-7-organigram/7o2b-finding-model-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o2b-finding-model-compare.html
@@ -1,0 +1,196 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o2b: THE FINDING MODEL (search ⟷ Hulp ⟷ browse)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .wrap{max-width:1060px;margin:0 auto;padding:0 24px;}
+
+      /* the shared "what the search returns" panel */
+      .explain{padding:26px 0;}
+      .explain h2{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:26px;margin:0 0 4px;}
+      .explain .sub{font-size:14px;color:var(--ink-soft);margin:0 0 18px;max-width:70ch;}
+      .demo{display:grid;grid-template-columns:1fr 1fr;gap:20px;}
+      .sbox{border:2px solid var(--ink);background:var(--cream);box-shadow:4px 4px 0 0 var(--ink);}
+      .sbox .inp{display:flex;align-items:center;gap:9px;padding:11px 14px;border-bottom:2px solid var(--ink);}
+      .sbox .inp .mag{color:var(--jersey-deep);font-weight:600;font-family:var(--font-mono);}
+      .sbox .inp .qy{font-family:var(--font-mono);font-size:14px;color:var(--ink);}
+      .sbox .inp .cur{width:1px;height:16px;background:var(--ink);display:inline-block;margin-left:1px;}
+      .grp{padding:8px 0;}
+      .grp .gh{font-family:var(--font-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-muted);padding:4px 14px;}
+      .res{display:flex;align-items:center;gap:10px;padding:8px 14px;}
+      .res:hover{background:var(--cream-soft);}
+      .res .ic{width:30px;height:30px;border:2px solid var(--ink);border-radius:9999px;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-weight:900;font-size:12px;color:var(--jersey-deep);background:var(--cream-soft);flex:none;}
+      .res .ic.q{border-radius:3px;color:var(--warm);background:var(--jersey-deep-dark);}
+      .res .tx{line-height:1.2;}
+      .res .tx .a{font-family:var(--font-display);font-weight:600;font-size:14px;}
+      .res .tx .b{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;color:var(--ink-muted);}
+      .res .go{margin-left:auto;font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--jersey-deep);border:1.5px solid var(--jersey-deep);padding:3px 7px;}
+      .tag{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-muted);margin:6px 0 0;text-align:center;}
+
+      .direction-bar{position:sticky;top:0;z-index:50;background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;display:flex;gap:14px;align-items:baseline;border-bottom:2px solid var(--ink);}
+      .direction-bar .t{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);}
+      .direction-bar.rec .t{background:var(--jersey);}
+      .direction-bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:24px 28px 32px;border-bottom:1px dashed var(--paper-edge);}
+      .mgrid{max-width:1060px;margin:0 auto;display:grid;grid-template-columns:300px 1fr;gap:28px;align-items:start;}
+
+      .map{border:2px solid var(--ink);background:var(--cream);box-shadow:5px 5px 0 0 var(--ink);padding:12px;}
+      .box{border:1.5px solid var(--ink);padding:8px 10px;margin-bottom:7px;font-family:var(--font-mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.04em;}
+      .box small{display:block;font-family:var(--font-body);text-transform:none;letter-spacing:0;font-size:9px;color:var(--ink-muted);margin-top:2px;}
+      .box.search{background:var(--jersey-deep-dark);color:var(--cream);} .box.search small{color:rgba(245,241,230,.72);}
+      .box.search2{background:var(--cream-deep);}
+      .box.ppl{background:var(--cream-soft);}
+      .box.ans{background:color-mix(in srgb,var(--jersey-deep) 12%,var(--cream));border-color:var(--jersey-deep);}
+      .box.verk{background:repeating-linear-gradient(45deg,var(--cream-soft) 0 8px,var(--cream-deep) 8px 16px);}
+      .arrow{font-family:var(--font-mono);font-size:9px;color:var(--ink-muted);text-align:center;margin:-2px 0 5px;}
+      .split{display:grid;grid-template-columns:1fr 1fr;gap:7px;}
+
+      .notes h3{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:22px;margin:0 0 8px;}
+      .notes p{font-size:14px;line-height:1.55;color:var(--ink-soft);margin:0 0 10px;max-width:64ch;}
+      .notes .bestfor{font-family:var(--font-mono);font-size:11px;color:var(--jersey-deep);text-transform:uppercase;letter-spacing:.05em;}
+      .notes .tradeoff{font-family:var(--font-mono);font-size:11px;color:var(--brick);text-transform:uppercase;letter-spacing:.05em;}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o2b — THE FINDING MODEL</h1>
+      <p>
+        Resolving the real question: <b>how do the search box, the Hulp finder, and the browse sections work together</b>
+        for someone looking for something specific? First — what the search actually <b>returns</b> (it spans people AND
+        answers). Then three coherent ways to organise the page around it. This decides the <b>finding model</b> before we
+        lock 7o2.
+      </p>
+    </div>
+
+    <!-- WHAT THE SEARCH RETURNS -->
+    <div class="wrap explain">
+      <h2>First: what one search box returns.</h2>
+      <p class="sub">The existing search ranks across <b>people</b> (name · function) and <b>hulpvragen</b> (question · keywords · summary). Two query kinds, two result types — typed and clearly labelled, so a click goes to the right place.</p>
+      <div class="demo">
+        <div>
+          <div class="sbox">
+            <div class="inp"><span class="mag">⌕</span><span class="qy">Boons</span><span class="cur"></span></div>
+            <div class="grp"><div class="gh">Personen</div>
+              <div class="res"><span class="ic">LB</span><span class="tx"><span class="a">Luc Boons</span><span class="b">Voorzitter · Hoofdbestuur</span></span><span class="go">contact →</span></div>
+            </div>
+          </div>
+          <div class="tag">“I know who” → a person → contact + “toon in verkenner”</div>
+        </div>
+        <div>
+          <div class="sbox">
+            <div class="inp"><span class="mag">⌕</span><span class="qy">lidgeld</span><span class="cur"></span></div>
+            <div class="grp"><div class="gh">Antwoorden · hulpvragen</div>
+              <div class="res"><span class="ic q">?</span><span class="tx"><span class="a">Hoe schrijf ik mijn kind in?</span><span class="b">Administratief · Karen Wouters</span></span><span class="go">antwoord →</span></div>
+              <div class="res"><span class="ic q">?</span><span class="tx"><span class="a">Wat kost een lidmaatschap?</span><span class="b">Administratief</span></span><span class="go">antwoord →</span></div>
+            </div>
+          </div>
+          <div class="tag">“I have a problem” → an answer → steps + the right contact</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- MODEL I -->
+    <div class="direction-bar rec"><span class="t">I ★</span> One front door · browse is the backup <span class="note">recommended · search = type · sections = browse · same data, two doors</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="map">
+        <div class="box search">⌕ ÉÉN ZOEKBALK (hero)<small>returns Personen + Antwoorden</small></div>
+        <div class="arrow">▼ &nbsp; liever bladeren? &nbsp; ▼</div>
+        <div class="box ppl">① Structuur — mensen<small>directory per afdeling</small></div>
+        <div class="box verk">② Verkenner — relaties<small>fullscreen explorer / 3-D</small></div>
+        <div class="box ans">③ Hulp — vragen per thema<small>browse the SAME answers the search finds</small></div>
+      </div>
+      <div class="notes">
+        <h3>Search is the verb. The sections are the nouns.</h3>
+        <p>One box up top answers both intents (a person <em>or</em> an answer). The three sections below are the
+          <em>same dataset</em> reached by browsing instead of typing — Structuur = browse people, Verkenner = browse
+          relationships, Hulp = browse the answers by topic. <b>Nothing is duplicated</b>: Hulp isn’t a second search, it’s
+          the catalogue you land in if you’d rather click categories than type. The fast user types; the browser scrolls.</p>
+        <p class="bestfor">Best for: clearest “how it fits”, keeps the loved structure-explorer, one mental model.</p>
+        <p class="tradeoff">Cost: the Hulp section must read as “browse the answers”, never as another search box.</p>
+      </div>
+    </div></div>
+
+    <!-- MODEL II -->
+    <div class="direction-bar"><span class="t">II</span> Two scoped doors: mensen ⟷ hulplijn <span class="note">each search stays in its lane · no blended results</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="map">
+        <div class="split">
+          <div class="box search">⌕ ZOEK PERSOON<small>people only</small></div>
+          <div class="box search" style="background:var(--jersey-deep);">⌕ STEL JE VRAAG<small>answers only</small></div>
+        </div>
+        <div class="arrow">▼ two separate halves ▼</div>
+        <div class="box ppl">DE MENSEN<small>directory + verkenner</small></div>
+        <div class="box ans">DE HULPLIJN<small>responsibility finder</small></div>
+      </div>
+      <div class="notes">
+        <h3>Pick your door first.</h3>
+        <p>Two explicitly separate lanes. A people-search feeds the structure half; a question-finder is its own half.
+          Each search is scoped to one domain, so results never mix. The page literally splits into “De mensen” and
+          “De hulplijn”.</p>
+        <p class="bestfor">Best for: zero overlap, each box does exactly one thing.</p>
+        <p class="tradeoff">Cost: two search boxes; the user must self-diagnose which intent they have before typing.</p>
+      </div>
+    </div></div>
+
+    <!-- MODEL III -->
+    <div class="direction-bar"><span class="t">III</span> Hulp-led · structure is reference <span class="note">lead with the question-finder · most users arrive with a problem</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="map">
+        <div class="box search">⌕ STEL JE VRAAG (hero)<small>answers first, + matching person</small></div>
+        <div class="arrow">▼ then, as reference ▼</div>
+        <div class="box ans">① Hulp — vragen per thema</div>
+        <div class="box ppl">② Structuur — mensen</div>
+        <div class="box verk">③ Verkenner — relaties</div>
+      </div>
+      <div class="notes">
+        <h3>Answer first, org chart second.</h3>
+        <p>Inverts the emphasis: the page leads with the problem-solver (because most end-users come with a question,
+          not a name). The org structure + verkenner become reference material lower down. The hero box is a
+          question-finder that also surfaces the matching contact.</p>
+        <p class="bestfor">Best for: a help-desk-first club site; demotes the org chart.</p>
+        <p class="tradeoff">Cost: buries the structure explorer you specifically loved; weaker as an “organigram” page.</p>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o2b — the finding model</h3>
+      <p>
+        <b>I ★</b> one search (people + answers) as the fast path, the three sections as the browse-the-same-data backup
+        — clearest “how it all fits”, keeps the structure explorer central. <b>II</b> two scoped boxes / two halves —
+        zero overlap but two doors. <b>III</b> Hulp-led — answer-first, structure demoted.
+      </p>
+      <p style="color:var(--ink-muted);">
+        Orthogonal call (any model): <b>search intelligence</b>. Today = keyword/substring ranking (free, exists). Upgrade =
+        semantic/AI over the responsibility docs (the bge-m3 + Vectorize stack already powering <b>/zoeken</b>) so natural
+        language like <em>“mijn kind heeft zich bezeerd”</em> finds the medical contact without a keyword match. Real value
+        for the Hulp job, but it’s extra BFF/embeddings build — a scoped issue, not free.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o2c-hulp-hub-rescope-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o2c-hulp-hub-rescope-locked.md
@@ -1,0 +1,70 @@
+# Phase 7 · `/club/organigram` → unified **`/hulp` HUB** — RE-SCOPE — LOCKED
+
+**Date:** 2026-06-08
+**Owner:** @climacon
+**Tracker:** #1529 (Phase 7) **fuses** #1530's `/hulp` (Phase 8) · **Milestone:** `redesign-retro-terrace-fanzine`
+**Amends:** `7o0`, `7o2`/`7o2b` · **Supersedes:** `7o6` bridge decision (`7o6-hulp-bridge-compare.html` — kept as history)
+
+## Decision
+
+`/club/organigram` and `/hulp` are **one job** — _"find the right person or answer at KCVV"_ — so they
+become **one hub**, not two pages. Discovery confusion today comes from **duplication** (the organigram's
+old "Hulp" tab re-renders the same finder as `/hulp`); the fix is to **merge into a single surface**, not
+to bridge between two.
+
+### The hub
+
+- **One search front door** (people **and** answers): a name/role → a **person**; a problem
+  ("mijn kind is geblesseerd") → an **answer + contact + steps**.
+- **Two browse modes** of the same contact graph:
+  - **Structuur** — org **directory** (people by afdeling) + fullscreen **`<OrganigramExplorer>`** spotlight
+    drill-down (2-D, **no 3-D**) + **`<MemberDetailPanel>`** (right side-panel, person-first).
+  - **Hulp** — the **responsibility finder** (reskinned `<HulpPage>`: search · category browse · answer ·
+    contact), with `team-role` / `manual` / `position` contact resolution intact.
+- Because a responsibility's contact **is** an organigram position, the two modes cross-reference
+  (answer's contact → "toon in structuur"; a person → "helpt met …").
+
+### URL + navigation
+
+- **Canonical URL = `/hulp`** (the human-friendly, already-linked, FAQ-SEO'd help front door).
+- **Two nav doors → one hub:** **"Hulp"** lands at the top (search + finder); **"Organigram"** (under
+  Club) lands at **`#structuur`**. Both audiences get the door they expect; both arrive at the same page.
+- **`/club/organigram` is retired as a route.** Site is **pre-launch → no redirects** (owner, 2026-06-08).
+- FAQ JSON-LD + "Hulp & Contact" metadata live on the hub.
+
+### Scope fusion
+
+- **#1529 (Phase 7) now delivers the `/hulp` hub, including the finder** that was #1530's `/hulp` scope.
+- **#1530 (Phase 8)** drops `/hulp`; retains `/zoeken`, `/privacy`, error pages. Both issues updated
+  2026-06-08.
+- Master-design **open question 7** (paper aesthetic on chrome — panels/forms) resolves **here**.
+
+## What carries over (the Structuur half — already locked)
+
+All prior locks become the **Structuur** half of the hub, unchanged:
+`7o1` hero (dark band + one search + audience chips) · `7o2` single-scroll + sticky nav + fullscreen
+verkenner · `7o3` spotlight explorer (2-D, **3-D removed**) · `7o4` card states (single / shared dual-avatar /
+**vacant recruit**) · `7o5` person-first `<MemberDetailPanel>` (right side-panel).
+
+## What is newly in scope (the Hulp half + glue)
+
+- **Reskin `<HulpPage>`** (finder: `HulpSearchInput`, `BrowseContent`, `CategorySection`, `QuestionCard`,
+  `AnswerCard`, `ContactCard`, `resolveContact`) to the fanzine vocabulary → **Round 7o6 (re-drilled)**.
+- **One unified search** spanning people + responsibilities as the hub's front door (replaces both the
+  organigram `UnifiedSearchBar` and the finder's `HulpSearchInput`); **semantic/AI** (bge-m3 + Vectorize)
+  folded in here.
+- **Cross-links** Structuur ⇄ Hulp (contact → "toon in structuur"; person → "helpt met").
+- **General contact form + address/hours** (master §6.11) — decide inclusion at **7o7**.
+- **Section order** within the hub (finder-first vs structure-first under the hero) — **7o7**.
+- **Two-nav-door wiring** + retiring `/club/organigram` route — **7o7** / PRD.
+
+## Superseded
+
+- **`7o6` bridge decision** ("B richer teaser → /hulp"): obsolete — Hulp is no longer a teaser to a
+  separate page; it's a **first-class section/half of this hub**. `7o6` is re-drilled as the **finder
+  reskin**.
+
+## Net
+
+One hub. One search. Two browse modes. Two nav doors. Homed on `/hulp`. Phase 7 + 8 fused. This **reduces**
+confusion (one job, one surface) instead of relocating it.

--- a/docs/design/mockups/phase-7-organigram/7o2c-hulp-hub-rescope-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o2c-hulp-hub-rescope-locked.md
@@ -54,8 +54,8 @@ verkenner · `7o3` spotlight explorer (2-D, **3-D removed**) · `7o4` card state
   organigram `UnifiedSearchBar` and the finder's `HulpSearchInput`); **semantic/AI** (bge-m3 + Vectorize)
   folded in here.
 - **Cross-links** Structuur ⇄ Hulp (contact → "toon in structuur"; person → "helpt met").
-- **General contact form + address/hours** (master §6.11) — decide inclusion at **7o7**.
-- **Section order** within the hub (finder-first vs structure-first under the hero) — **7o7**.
+- **General contact form + address/hours** (master §6.11) — **LOCKED `7o7`: dropped** (CtaBand only).
+- **Section order** — **LOCKED `7o7`: Hulp-first** (finder under the hero, Structuur second).
 - **Two-nav-door wiring** + retiring `/club/organigram` route — **7o7** / PRD.
 
 ## Superseded

--- a/docs/design/mockups/phase-7-organigram/7o3-explorer-at-scale-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o3-explorer-at-scale-compare.html
@@ -1,0 +1,308 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o3 — ALL FOUR at real scale (~25 nodes)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:96ch;}
+      .head b{color:var(--warm);}
+      .head .data{margin-top:10px;font-size:11.5px;color:#cfeede;}
+      .direction-bar{position:sticky;top:0;z-index:50;background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;display:flex;gap:14px;align-items:baseline;border-bottom:2px solid var(--ink);}
+      .direction-bar .t{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);}
+      .direction-bar.rec .t{background:var(--jersey);}
+      .direction-bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:20px 28px 28px;border-bottom:1px dashed var(--paper-edge);}
+      .mgrid{max-width:1180px;margin:0 auto;display:grid;grid-template-columns:1fr 320px;gap:24px;align-items:start;}
+
+      .fs{border:2px solid var(--ink);background:#0e2b1d;box-shadow:6px 6px 0 0 var(--ink);overflow:hidden;}
+      .fs .bar{display:flex;align-items:center;gap:7px;padding:8px 11px;border-bottom:1.5px solid rgba(245,241,230,.2);background:#0a2016;flex-wrap:wrap;}
+      .fs .bar .ttl{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--cream);}
+      .fs .bar .sp{flex:1;}
+      .fs .ctl{font-family:var(--font-mono);font-size:9px;color:var(--cream);border:1.5px solid rgba(245,241,230,.4);padding:3px 6px;}
+      .fs .ctl.warm{border-color:var(--warm);color:var(--warm);}
+      .fs .crumb{font-family:var(--font-mono);font-size:10px;color:rgba(245,241,230,.8);padding:6px 11px;border-bottom:1.5px solid rgba(245,241,230,.12);}
+      .fs .crumb b{color:var(--warm);}
+      .fs .stagebox{height:360px;position:relative;overflow:hidden;}
+      .grid-bg{position:absolute;inset:0;background:linear-gradient(rgba(245,241,230,.05) 1px,transparent 1px) 0 0/28px 28px,linear-gradient(90deg,rgba(245,241,230,.05) 1px,transparent 1px) 0 0/28px 28px,radial-gradient(120% 90% at 50% 0%,rgba(74,207,82,.12),transparent 55%);}
+      .hint{position:absolute;bottom:7px;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:9px;letter-spacing:.03em;text-transform:uppercase;color:rgba(245,241,230,.55);text-align:center;width:92%;}
+
+      /* generic node */
+      .nd{border:2px solid var(--ink);background:var(--cream);padding:3px 6px;text-align:center;box-shadow:2px 2px 0 0 rgba(0,0,0,.4);}
+      .nd .a{font-family:var(--font-display);font-weight:600;font-size:10px;line-height:1.05;}
+      .nd .b{font-family:var(--font-mono);font-size:6.5px;text-transform:uppercase;color:var(--ink-muted);}
+      .nd.root{background:var(--jersey-deep);color:var(--cream);}.nd.root .b{color:rgba(245,241,230,.85);}
+      .nd.dept{background:var(--jersey-deep-dark);color:var(--cream);}.nd.dept .b{color:rgba(245,241,230,.8);}
+      .nd.vac{background:var(--warm);}
+      .nd.cur{box-shadow:0 0 0 3px var(--warm),2px 2px 0 0 rgba(0,0,0,.4);}
+
+      /* A — collapsible tree (cols) */
+      .tree{position:absolute;inset:0;padding:14px;display:flex;flex-direction:column;align-items:center;gap:10px;overflow:auto;}
+      .tcols{display:flex;gap:14px;align-items:flex-start;justify-content:center;width:100%;}
+      .tcol{flex:1;min-width:150px;border:1.5px solid rgba(245,241,230,.25);padding:8px;}
+      .tcol .dh{display:flex;align-items:center;justify-content:space-between;gap:6px;margin-bottom:7px;}
+      .tcol .dh .nd{flex:1;}
+      .tcol .toggle{font-family:var(--font-mono);font-size:9px;color:var(--warm);border:1.5px solid var(--warm);padding:2px 6px;}
+      .tcol .kids{display:grid;grid-template-columns:1fr 1fr;gap:5px;}
+      .tcol.collapsed .kids{display:none;}
+      .tcol.collapsed{opacity:.85;}
+      .collapsed-note{font-family:var(--font-mono);font-size:9px;color:rgba(245,241,230,.65);text-align:center;padding:14px 4px;}
+
+      /* B — spotlight */
+      .b-parent{position:absolute;left:50%;top:14px;transform:translateX(-50%);}
+      .b-sib{position:absolute;top:46%;transform:translateY(-50%);font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:rgba(245,241,230,.6);border:1.5px solid rgba(245,241,230,.35);padding:6px 8px;}
+      .b-center{position:absolute;left:50%;top:34%;transform:translate(-50%,-50%);background:var(--cream);border:2px solid var(--ink);box-shadow:4px 4px 0 0 var(--warm);padding:9px 16px;text-align:center;}
+      .b-center .a{font-family:var(--font-display);font-weight:600;font-size:15px;}
+      .b-center .b{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;color:var(--ink-muted);}
+      .b-kids{position:absolute;left:3%;right:3%;bottom:30px;display:flex;flex-wrap:wrap;gap:7px;justify-content:center;}
+      .b-kids .nd{width:104px;}
+
+      /* C — radial */
+      .radial{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;}
+      .ring{position:relative;width:2px;height:2px;}
+      .rn{position:absolute;left:0;top:0;transform:rotate(calc(var(--i)*var(--step))) translateX(var(--r)) rotate(calc(var(--i)*var(--step)*-1));}
+      .rn .nd{width:78px;transform:translate(-50%,-50%);}
+      .spoke{position:absolute;left:0;top:0;height:1.5px;background:rgba(245,241,230,.22);transform-origin:left center;transform:rotate(calc(var(--i)*var(--step)));}
+
+      /* D — 3D clusters */
+      .scene{position:absolute;inset:0;perspective:820px;display:flex;align-items:center;justify-content:center;}
+      .world{position:relative;width:1px;height:1px;transform-style:preserve-3d;animation:orbit 22s linear infinite;}
+      .stagebox:hover .world{animation-play-state:paused;}
+      @keyframes orbit{from{transform:rotateX(-14deg) rotateY(0)}to{transform:rotateX(-14deg) rotateY(360deg)}}
+      .cluster{position:absolute;left:0;top:0;transform-style:preserve-3d;transform:rotateY(var(--ry)) translateZ(150px);}
+      .cluster .cn{position:absolute;left:0;top:0;transform:translate(-50%,-50%) translateY(var(--ty)) rotateY(calc(var(--ry)*-1));}
+      .cluster .cn .nd{width:88px;}
+      .floor{position:absolute;left:50%;top:50%;width:340px;height:340px;margin:-170px 0 0 -170px;border:1px solid rgba(245,241,230,.1);border-radius:50%;transform:rotateX(90deg);}
+      .root3{position:absolute;left:0;top:0;transform:translate(-50%,-50%) translateY(-150px);}
+
+      .notes h3{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:20px;margin:0 0 8px;}
+      .notes p{font-size:13px;line-height:1.5;color:var(--ink-soft);margin:0 0 9px;}
+      .sc{border-collapse:collapse;font-family:var(--font-mono);font-size:10px;width:100%;}
+      .sc td,.sc th{border:1.5px solid var(--ink);padding:5px 6px;text-align:left;}
+      .sc th{background:var(--ink);color:var(--cream);text-transform:uppercase;font-size:8.5px;}
+      .y{color:var(--jersey-deep);font-weight:600;}.m{color:#b07d00;font-weight:600;}.n{color:var(--brick);font-weight:600;}
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o3 — ALL FOUR, RE-MOCKED AT REAL SCALE</h1>
+      <p>Same realistic bestuur in every panel — <b>~25 nodes, 4 levels</b> — each shown with the scale-coping mechanism it would actually use. The honest question: which still reads when it's the <b>whole</b> club, not 5 tidy boxes? (Trainers are out of scope here — they're team-bound + dynamic, on <b>/ploegen</b> + Hulp.)</p>
+      <p class="data">DATASET · KCVV Elewijt → Hoofdbestuur (10) · Jeugdbestuur (10) · Algemeen (4) · incl. 2 vacant + 2 shared</p>
+    </div>
+
+    <!-- ============ A ============ -->
+    <div class="direction-bar"><span class="t">A</span> Collapsible 2-D tree <span class="note">scales by expand/collapse · the “official chart” idiom</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner — boom</span><span class="sp"></span><span class="ctl">– 70%</span><span class="ctl">+</span><span class="ctl">⤢ passend</span><span class="ctl">⊟ klap alles in</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>alle afdelingen</b></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="tree">
+            <div class="nd root" style="width:120px;"><div class="a">KCVV Elewijt</div><div class="b">de club</div></div>
+            <div class="tcols">
+              <div class="tcol">
+                <div class="dh"><div class="nd dept"><div class="a">Hoofdbestuur</div><div class="b">10 functies</div></div><span class="toggle">−</span></div>
+                <div class="kids">
+                  <div class="nd"><div class="a">Voorzitter</div><div class="b">L. Boons</div></div>
+                  <div class="nd"><div class="a">Ondervoorz.</div><div class="b">M. Smets</div></div>
+                  <div class="nd"><div class="a">Secretaris</div><div class="b">I. Maes</div></div>
+                  <div class="nd"><div class="a">Penningm.</div><div class="b">D. Van Loo</div></div>
+                  <div class="nd"><div class="a">Gerecht.</div><div class="b">P. Geerts</div></div>
+                  <div class="nd"><div class="a">Wedstr.secr.</div><div class="b">2 pers.</div></div>
+                  <div class="nd"><div class="a">Sponsor &amp; PR</div><div class="b">T. Verbeeck</div></div>
+                  <div class="nd"><div class="a">Materiaal</div><div class="b">J. Aerts</div></div>
+                  <div class="nd vac"><div class="a">Kantine</div><div class="b">vacant</div></div>
+                  <div class="nd"><div class="a">Infrastr.</div><div class="b">R. Pauwels</div></div>
+                </div>
+              </div>
+              <div class="tcol collapsed">
+                <div class="dh"><div class="nd dept"><div class="a">Jeugdbestuur</div><div class="b">10 functies</div></div><span class="toggle">+</span></div>
+                <div class="collapsed-note">ingeklapt — klik + om 10 functies te tonen</div>
+              </div>
+              <div class="tcol collapsed">
+                <div class="dh"><div class="nd dept"><div class="a">Algemeen</div><div class="b">4 functies</div></div><span class="toggle">+</span></div>
+                <div class="collapsed-note">ingeklapt — 4 functies</div>
+              </div>
+            </div>
+          </div>
+          <div class="hint">één afdeling open = leesbaar · alle drie open + dieper = breed → pannen/zoomen nodig</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>The official chart.</h3>
+        <p>Everyone recognises it, and collapse keeps it sane: open one branch at a time. Fully expanded it gets wide
+          and you pan — but it’s the only view that doubles as a printable “volledig organigram”. Cheapest (reuse
+          d3-org-chart’s collapse).</p>
+        <table class="sc"><tr><th>@25</th><th>Orient</th><th>Mobile</th><th>A11y</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="m">ok*</td><td class="y">✓</td><td class="m">△</td><td class="y">✓</td><td class="y">low</td><td class="n">low</td></tr></table>
+        <p style="font-size:10px;font-family:var(--font-mono);color:var(--ink-muted);">*only with collapse; fully-expanded = pan-heavy.</p>
+      </div>
+    </div></div>
+
+    <!-- ============ B ============ -->
+    <div class="direction-bar rec"><span class="t">B ★</span> Spotlight drill-down <span class="note">renders only the local neighbourhood · scale-proof at 25 or 250</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner</span><span class="sp"></span><span class="ctl">↤ terug</span><span class="ctl">⤢ overzicht</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>Jeugdbestuur</b> &nbsp;<span style="color:rgba(245,241,230,.4)">(10 functies)</span></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="b-parent nd root" style="width:130px;"><div class="a">KCVV Elewijt</div><div class="b">▲ ouder</div></div>
+          <div class="b-sib" style="left:12px;">◂ Hoofdbestuur</div>
+          <div class="b-sib" style="right:12px;">Algemeen ▸</div>
+          <div class="b-center"><div class="a">Jeugdbestuur</div><div class="b">afdeling · 10 functies</div></div>
+          <div class="b-kids">
+            <div class="nd"><div class="a">Jeugdvoorz.</div><div class="b">S. Peeters</div></div>
+            <div class="nd"><div class="a">Jeugdsecr.</div><div class="b">K. Wouters</div></div>
+            <div class="nd"><div class="a">TVJO</div><div class="b">T. Michiels</div></div>
+            <div class="nd"><div class="a">Coörd. Boven</div><div class="b">B. Janssens</div></div>
+            <div class="nd"><div class="a">Coörd. Midden</div><div class="b">E. Claes</div></div>
+            <div class="nd"><div class="a">Coörd. Onder</div><div class="b">N. De Cock</div></div>
+            <div class="nd"><div class="a">Gastheer</div><div class="b">A. Mertens</div></div>
+            <div class="nd vac"><div class="a">Tornooien</div><div class="b">vacant</div></div>
+            <div class="nd"><div class="a">Uitrusting</div><div class="b">K. Wille</div></div>
+            <div class="nd"><div class="a">Keeperstr.</div><div class="b">D. Cools</div></div>
+          </div>
+          <div class="hint">klik een kind → het wordt het nieuwe midden · klik “ouder” of een buur-afdeling om omhoog/opzij · nooit meer dan ±1 niveau in beeld</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>Only ever one neighbourhood.</h3>
+        <p>You always see parent + current + siblings + children — and nothing else. 25 nodes or 250, the screen looks
+          identical: calm, centred, readable. The breadcrumb is your map. Best orientation + the only one that’s genuinely
+          good on a phone (tap, no drag). Loses the “whole shape at once” that A/C give.</p>
+        <table class="sc"><tr><th>@25</th><th>Orient</th><th>Mobile</th><th>A11y</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="y">✓✓</td><td class="y">✓✓</td><td class="y">✓✓</td><td class="y">✓</td><td class="m">med</td><td class="m">med</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- ============ C ============ -->
+    <div class="direction-bar"><span class="t">C</span> Radial constellation <span class="note">whole org as one figure · at 25 the outer ring crowds — shown honestly</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner — radiaal</span><span class="sp"></span><span class="ctl">–</span><span class="ctl">+</span><span class="ctl warm">◎ 3-D</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>alle 24 functies</b></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="radial"><div class="ring" style="--step:18deg;">
+            <!-- spokes -->
+            <div class="spoke" style="--i:0;width:150px;"></div><div class="spoke" style="--i:2;width:150px;"></div><div class="spoke" style="--i:4;width:150px;"></div><div class="spoke" style="--i:6;width:150px;"></div><div class="spoke" style="--i:8;width:150px;"></div><div class="spoke" style="--i:10;width:150px;"></div><div class="spoke" style="--i:12;width:150px;"></div><div class="spoke" style="--i:14;width:150px;"></div><div class="spoke" style="--i:16;width:150px;"></div><div class="spoke" style="--i:18;width:150px;"></div>
+            <!-- root -->
+            <div style="position:absolute;left:0;top:0;"><div class="nd root" style="width:64px;transform:translate(-50%,-50%);"><div class="a">KCVV</div><div class="b">club</div></div></div>
+            <!-- outer ring: 20 positions -->
+            <div class="rn" style="--i:0;--r:150px;"><div class="nd"><div class="a">Voorzitter</div><div class="b">L.B.</div></div></div>
+            <div class="rn" style="--i:1;--r:150px;"><div class="nd"><div class="a">Ondervz.</div><div class="b">M.S.</div></div></div>
+            <div class="rn" style="--i:2;--r:150px;"><div class="nd"><div class="a">Secret.</div><div class="b">I.M.</div></div></div>
+            <div class="rn" style="--i:3;--r:150px;"><div class="nd"><div class="a">Penning.</div><div class="b">D.V.</div></div></div>
+            <div class="rn" style="--i:4;--r:150px;"><div class="nd"><div class="a">Gerecht.</div><div class="b">P.G.</div></div></div>
+            <div class="rn" style="--i:5;--r:150px;"><div class="nd"><div class="a">Wedstr.</div><div class="b">2p</div></div></div>
+            <div class="rn" style="--i:6;--r:150px;"><div class="nd"><div class="a">Sponsor</div><div class="b">T.V.</div></div></div>
+            <div class="rn" style="--i:7;--r:150px;"><div class="nd vac"><div class="a">Kantine</div><div class="b">vac</div></div></div>
+            <div class="rn" style="--i:8;--r:150px;"><div class="nd"><div class="a">Jeugdvz.</div><div class="b">S.P.</div></div></div>
+            <div class="rn" style="--i:9;--r:150px;"><div class="nd"><div class="a">Jeugdsecr.</div><div class="b">K.W.</div></div></div>
+            <div class="rn" style="--i:10;--r:150px;"><div class="nd"><div class="a">TVJO</div><div class="b">T.M.</div></div></div>
+            <div class="rn" style="--i:11;--r:150px;"><div class="nd"><div class="a">Boven</div><div class="b">B.J.</div></div></div>
+            <div class="rn" style="--i:12;--r:150px;"><div class="nd"><div class="a">Midden</div><div class="b">E.C.</div></div></div>
+            <div class="rn" style="--i:13;--r:150px;"><div class="nd"><div class="a">Onder</div><div class="b">N.D.</div></div></div>
+            <div class="rn" style="--i:14;--r:150px;"><div class="nd"><div class="a">Gastheer</div><div class="b">A.M.</div></div></div>
+            <div class="rn" style="--i:15;--r:150px;"><div class="nd vac"><div class="a">Tornooi</div><div class="b">vac</div></div></div>
+            <div class="rn" style="--i:16;--r:150px;"><div class="nd"><div class="a">Uitrust.</div><div class="b">K.W.</div></div></div>
+            <div class="rn" style="--i:17;--r:150px;"><div class="nd"><div class="a">Keepers</div><div class="b">D.C.</div></div></div>
+            <div class="rn" style="--i:18;--r:150px;"><div class="nd"><div class="a">Webm.</div><div class="b">W.G.</div></div></div>
+            <div class="rn" style="--i:19;--r:150px;"><div class="nd"><div class="a">Feest</div><div class="b">3p</div></div></div>
+          </div></div>
+          <div class="hint">mooi als geheel — maar 20 buitenste labels dringen samen · departementskleur vervaagt · diepe sub-bomen passen niet in één ring</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>Pretty whole, crowded parts.</h3>
+        <p>The “see the entire club in one figure” promise is real and lovely. But at 20+ outer nodes the ring jams,
+          labels collide, and the 4-level depth (cells under positions) has nowhere to go without a click-to-zoom that’s
+          really just B underneath. The 3-D toggle makes it prettier, not less crowded.</p>
+        <table class="sc"><tr><th>@25</th><th>Orient</th><th>Mobile</th><th>A11y</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="n">crowds</td><td class="n">✗</td><td class="m">△</td><td class="m">med-hi</td><td class="y">high</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- ============ D ============ -->
+    <div class="direction-bar"><span class="t">D ◎</span> Full 3-D, clustered by afdeling <span class="note">depth groups the departments · real CSS-3D below (hover to pause)</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner — 3-D</span><span class="sp"></span><span class="ctl">–</span><span class="ctl">+</span><span class="ctl warm">◎ 3-D</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>ruimtelijk</b> · sleep om te draaien</div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="scene"><div class="world">
+            <div class="floor"></div>
+            <div class="root3"><div class="nd root" style="width:96px;transform:translate(-50%,-50%);"><div class="a">KCVV Elewijt</div><div class="b">de club</div></div></div>
+            <!-- cluster: Hoofdbestuur -->
+            <div class="cluster" style="--ry:0deg;">
+              <div class="cn" style="--ty:-44px;"><div class="nd dept"><div class="a">Hoofdbestuur</div><div class="b">10</div></div></div>
+              <div class="cn" style="--ty:-4px;"><div class="nd"><div class="a">Voorzitter</div><div class="b">L. Boons</div></div></div>
+              <div class="cn" style="--ty:36px;"><div class="nd"><div class="a">Secretaris</div><div class="b">I. Maes</div></div></div>
+              <div class="cn" style="--ty:76px;"><div class="nd vac"><div class="a">Kantine</div><div class="b">vacant</div></div></div>
+            </div>
+            <!-- cluster: Jeugdbestuur -->
+            <div class="cluster" style="--ry:120deg;">
+              <div class="cn" style="--ty:-44px;"><div class="nd dept"><div class="a">Jeugdbestuur</div><div class="b">10</div></div></div>
+              <div class="cn" style="--ty:-4px;"><div class="nd"><div class="a">Jeugdvoorz.</div><div class="b">S. Peeters</div></div></div>
+              <div class="cn" style="--ty:36px;"><div class="nd"><div class="a">TVJO</div><div class="b">T. Michiels</div></div></div>
+              <div class="cn" style="--ty:76px;"><div class="nd"><div class="a">Coörd.</div><div class="b">×3</div></div></div>
+            </div>
+            <!-- cluster: Algemeen -->
+            <div class="cluster" style="--ry:240deg;">
+              <div class="cn" style="--ty:-44px;"><div class="nd dept"><div class="a">Algemeen</div><div class="b">4</div></div></div>
+              <div class="cn" style="--ty:-4px;"><div class="nd"><div class="a">Webmaster</div><div class="b">W. Goris</div></div></div>
+              <div class="cn" style="--ty:36px;"><div class="nd"><div class="a">Feest</div><div class="b">3 pers.</div></div></div>
+            </div>
+          </div></div>
+          <div class="hint">diepte groepeert de 3 afdelingen mooi — maar labels draaien weg/overlappen, en alle 25 tonen = wolk · three.js + 2-D fallback nodig</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>Departments float apart.</h3>
+        <p>Clustering by afdeling in 3-D actually helps — the three groups separate in depth. It’s the memorable one.
+          But showing all ~25 turns into a cloud, labels rotate away/overlap, and it leans hardest on build (three.js),
+          perf, and a mandatory 2-D fallback. Strongest as the ◎ <em>enhancement</em> over a 2-D base, not the base.</p>
+        <table class="sc"><tr><th>@25</th><th>Orient</th><th>Mobile</th><th>A11y</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="m">△</td><td class="n">✗→△</td><td class="n">✗→△</td><td class="n">high</td><td class="y">✓✓✓</td></tr></table>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o3 — reconsidered at ~25 nodes / 4 levels</h3>
+      <p>
+        <b>A</b> the official collapsible chart — reads when one branch is open, pans when fully expanded; doubles as a
+        print view. <b>B ★</b> spotlight — the only one that looks identical at 25 or 250 and the only genuinely good
+        phone experience; trades away “whole shape at once”. <b>C</b> radial — gorgeous as a whole, but 20 outer labels
+        collide and 4-level depth needs a B-style zoom underneath. <b>D ◎</b> 3-D clustered — memorable, helped by
+        depth-grouping, but heaviest and label-fragile; best as an enhancement, not the base.
+      </p>
+      <p style="color:var(--ink-muted);">
+        At real scale the field narrows to <b>a navigable base (B) ± a whole-shape view (A or C) ± a 3-D toggle (D)</b>.
+        Recommended: <b>B as the base</b> (scale-proof, mobile, oriented), with <b>A available as the “volledig
+        organigram” / print</b> view, and <b>D’s 3-D as the opt-in ◎ enhancement</b>. But you may value C’s whole-club
+        figure enough to make it the headline — your call. Tell me the base + which extras, and I’ll lock the combo
+        (3-D stays its own build phase).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o3-explorer-interaction-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o3-explorer-interaction-compare.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o3: EXPLORER INTERACTION (+ 3-D investigation)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:96ch;}
+      .head b{color:var(--warm);}
+      .direction-bar{position:sticky;top:0;z-index:50;background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;display:flex;gap:14px;align-items:baseline;border-bottom:2px solid var(--ink);}
+      .direction-bar .t{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);}
+      .direction-bar.rec .t{background:var(--jersey);}
+      .direction-bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:22px 28px 30px;border-bottom:1px dashed var(--paper-edge);}
+      .mgrid{max-width:1120px;margin:0 auto;display:grid;grid-template-columns:1fr 360px;gap:26px;align-items:start;}
+
+      /* fullscreen verkenner chrome (locked container) */
+      .fs{border:2px solid var(--ink);background:#0e2b1d;box-shadow:6px 6px 0 0 var(--ink);overflow:hidden;}
+      .fs .bar{display:flex;align-items:center;gap:8px;padding:8px 11px;border-bottom:1.5px solid rgba(245,241,230,.2);background:#0a2016;flex-wrap:wrap;}
+      .fs .bar .ttl{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--cream);}
+      .fs .bar .sp{flex:1;}
+      .fs .ctl{font-family:var(--font-mono);font-size:9.5px;color:var(--cream);border:1.5px solid rgba(245,241,230,.4);padding:3px 7px;}
+      .fs .ctl.warm{border-color:var(--warm);color:var(--warm);}
+      .fs .crumb{font-family:var(--font-mono);font-size:10px;color:rgba(245,241,230,.8);padding:6px 11px;border-bottom:1.5px solid rgba(245,241,230,.12);}
+      .fs .crumb b{color:var(--warm);}
+      .fs .stagebox{height:320px;position:relative;overflow:hidden;}
+      .grid-bg{position:absolute;inset:0;background:linear-gradient(rgba(245,241,230,.05) 1px,transparent 1px) 0 0/28px 28px,linear-gradient(90deg,rgba(245,241,230,.05) 1px,transparent 1px) 0 0/28px 28px,radial-gradient(120% 90% at 50% 0%,rgba(74,207,82,.13),transparent 55%);}
+      .hint{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:9px;letter-spacing:.04em;text-transform:uppercase;color:rgba(245,241,230,.55);text-align:center;width:90%;}
+
+      .node{position:absolute;border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 rgba(0,0,0,.45);padding:5px 8px;text-align:center;}
+      .node .nn{font-family:var(--font-display);font-weight:600;font-size:11px;}
+      .node .nf{font-family:var(--font-mono);font-size:7px;text-transform:uppercase;color:var(--ink-muted);}
+      .node.root{background:var(--jersey-deep);color:var(--cream);}.node.root .nf{color:rgba(245,241,230,.85);}
+      .node.warm{background:var(--warm);}
+      .node.cur{box-shadow:0 0 0 3px var(--warm),3px 3px 0 0 rgba(0,0,0,.45);}
+      svg.links{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;}
+      svg.links line{stroke:rgba(245,241,230,.45);stroke-width:2;}
+
+      /* B spotlight focus+context */
+      .center-node{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);border:2px solid var(--ink);background:var(--cream);box-shadow:4px 4px 0 0 var(--warm);padding:12px 18px;text-align:center;}
+      .center-node .nn{font-family:var(--font-display);font-weight:600;font-size:18px;}
+      .center-node .nf{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--ink-muted);}
+      .pill-up{position:absolute;left:50%;top:16px;transform:translateX(-50%);font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--cream);border:1.5px solid rgba(245,241,230,.5);padding:5px 10px;background:rgba(10,32,22,.6);}
+      .child-row{position:absolute;left:0;right:0;bottom:26px;display:flex;justify-content:center;gap:12px;}
+      .child{border:2px solid var(--ink);background:var(--cream-soft);box-shadow:2px 2px 0 0 rgba(0,0,0,.4);padding:6px 10px;text-align:center;}
+      .child .nn{font-family:var(--font-display);font-weight:600;font-size:11px;}.child .nf{font-family:var(--font-mono);font-size:7px;text-transform:uppercase;color:var(--ink-muted);}
+      .sib{position:absolute;top:50%;transform:translateY(-50%);font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:rgba(245,241,230,.6);}
+
+      /* C radial (tilted to hint 3-D) */
+      .radial{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;}
+      .ring{position:relative;width:300px;height:300px;transform:rotateX(34deg);transform-style:preserve-3d;}
+      .ring .spoke{position:absolute;left:50%;top:50%;height:2px;width:120px;background:rgba(245,241,230,.35);transform-origin:left center;}
+      . rcenter{}
+      .rnode{position:absolute;left:50%;top:50%;}
+
+      /* D true 3-D scene */
+      .scene{position:absolute;inset:0;perspective:760px;display:flex;align-items:center;justify-content:center;}
+      .world{position:relative;width:1px;height:1px;transform-style:preserve-3d;animation:orbit 18s linear infinite;}
+      .stagebox:hover .world{animation-play-state:paused;}
+      @keyframes orbit{from{transform:rotateX(-16deg) rotateY(0deg);}to{transform:rotateX(-16deg) rotateY(360deg);}}
+      .n3{position:absolute;transform-style:preserve-3d;border:2px solid var(--ink);padding:5px 9px;text-align:center;background:var(--cream);box-shadow:0 6px 14px rgba(0,0,0,.4);}
+      .n3 .nn{font-family:var(--font-display);font-weight:600;font-size:11px;}.n3 .nf{font-family:var(--font-mono);font-size:7px;text-transform:uppercase;color:var(--ink-muted);}
+      .n3.root{background:var(--jersey-deep);color:var(--cream);}.n3.root .nf{color:rgba(245,241,230,.85);}
+      .n3.warm{background:var(--warm);}
+      .strut{position:absolute;left:0;top:0;width:2px;background:rgba(74,207,82,.5);transform-origin:top center;}
+      .floor{position:absolute;left:50%;top:50%;width:260px;height:260px;margin:-130px 0 0 -130px;border:1px solid rgba(245,241,230,.12);border-radius:50%;transform:rotateX(90deg);}
+
+      .notes h3{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:21px;margin:0 0 8px;}
+      .notes p{font-size:13.5px;line-height:1.55;color:var(--ink-soft);margin:0 0 10px;}
+      .sc{border-collapse:collapse;font-family:var(--font-mono);font-size:10.5px;width:100%;}
+      .sc td,.sc th{border:1.5px solid var(--ink);padding:5px 7px;text-align:left;}
+      .sc th{background:var(--ink);color:var(--cream);text-transform:uppercase;font-size:9px;letter-spacing:.04em;}
+      .y{color:var(--jersey-deep);font-weight:600;}.m{color:#b07d00;font-weight:600;}.n{color:var(--brick);font-weight:600;}
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o3 — EXPLORER INTERACTION (+ 3-D)</h1>
+      <p>
+        The fullscreen container is locked (breadcrumb · zoom/fit · Esc — can’t scroll-jack). This decides
+        <b>what lives inside it</b> — from a fixed 2-D tree to a literal orbitable 3-D scene. <b>D and C animate for real</b>
+        (hover to pause). Weigh: orientation, mobile/touch, accessibility + performance, build cost, and wow. Note: any
+        option ships with a guaranteed <b>2-D fallback</b> for reduced-motion / no-WebGL / screen-readers.
+      </p>
+    </div>
+
+    <!-- A -->
+    <div class="direction-bar"><span class="t">A</span> Contained 2-D node-tree (pan/zoom, fixed) <span class="note">today's diagram, done right inside the container · cheapest · familiar</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner</span><span class="sp"></span><span class="ctl">–</span><span class="ctl">100%</span><span class="ctl">+</span><span class="ctl">⤢ passend</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>Hoofdbestuur</b></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <svg class="links"><line x1="50%" y1="58" x2="22%" y2="150"/><line x1="50%" y1="58" x2="50%" y2="150"/><line x1="50%" y1="58" x2="78%" y2="150"/><line x1="22%" y1="186" x2="22%" y2="244"/><line x1="78%" y1="186" x2="78%" y2="244"/></svg>
+          <div class="node root" style="left:43%;top:36px;"><div class="nn">KCVV Elewijt</div><div class="nf">de club</div></div>
+          <div class="node" style="left:14%;top:150px;"><div class="nn">Luc Boons</div><div class="nf">Voorzitter</div></div>
+          <div class="node" style="left:43%;top:150px;"><div class="nn">Inge Maes</div><div class="nf">Secretaris</div></div>
+          <div class="node" style="left:71%;top:150px;"><div class="nn">Sam Peeters</div><div class="nf">Jeugdvz.</div></div>
+          <div class="node" style="left:14%;top:244px;"><div class="nn">Tom Michiels</div><div class="nf">TVJO</div></div>
+          <div class="node warm" style="left:71%;top:244px;"><div class="nn">Open functie</div><div class="nf">Vacant</div></div>
+          <div class="hint">sleep om te pannen · scroll/pinch om te zoomen · klik = focus + uitklappen</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>The known quantity.</h3>
+        <p>The classic top-down org tree, but inside the fullscreen container so pan/zoom is fine. Reuses
+          d3-org-chart → cheapest + most familiar + fully accessible. But it’s the least “wow”, and big trees still
+          mean lots of panning to see it all.</p>
+        <table class="sc"><tr><th>Orient</th><th>Mobile</th><th>A11y/perf</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="y">✓</td><td class="m">△</td><td class="y">✓</td><td class="y">low</td><td class="n">low</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- B -->
+    <div class="direction-bar"><span class="t">B</span> Spotlight drill-down (focus + context) <span class="note">click to re-centre · never drag · always oriented · tap-native</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner</span><span class="sp"></span><span class="ctl">↤ terug</span><span class="ctl">⤢ overzicht</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; Hoofdbestuur &nbsp;▸&nbsp; <b>Voorzitter</b></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="pill-up">▲ Hoofdbestuur</div>
+          <div class="sib" style="left:14px;">◂ Secretaris</div>
+          <div class="sib" style="right:14px;">Penningmeester ▸</div>
+          <div class="center-node"><div class="nn">Luc Boons</div><div class="nf">Voorzitter · Hoofdbestuur</div></div>
+          <div class="child-row">
+            <div class="child"><div class="nn">Sportieve cel</div><div class="nf">3 leden</div></div>
+            <div class="child"><div class="nn">Gerechtelijk</div><div class="nf">P. Geerts</div></div>
+            <div class="child"><div class="nn">Wedstrijdsecr.</div><div class="nf">2 personen</div></div>
+          </div>
+          <div class="hint">klik een buur/kind → het schuift naar het midden · adem-ruimte, geen verdwalen · pijltjestoetsen werken</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>Always centred on someone.</h3>
+        <p>No free panning. The selected node sits dead centre; its parent floats above (breadcrumb), siblings flank
+          it, children fan below. You navigate by <em>clicking</em>, so you’re never lost and it’s perfect on touch.
+          Best pure-UX answer to “orientation” + “mobile”. 2-D, but a subtle depth-tilt can be added.</p>
+        <table class="sc"><tr><th>Orient</th><th>Mobile</th><th>A11y/perf</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="y">✓✓</td><td class="y">✓✓</td><td class="y">✓</td><td class="m">med</td><td class="m">med</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- C -->
+    <div class="direction-bar"><span class="t">C</span> Radial “constellation” + 3-D orbit toggle <span class="note">whole club as one shape · ◎ tilts it into orbit · animated below</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner</span><span class="sp"></span><span class="ctl">–</span><span class="ctl">+</span><span class="ctl warm">◎ 3-D aan</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>alle afdelingen</b></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="radial"><div class="ring">
+            <div class="rnode" style="transform:translate(-50%,-50%) translateZ(20px);"><div class="node root" style="position:static;"><div class="nn">KCVV</div><div class="nf">club</div></div></div>
+            <div class="rnode" style="transform:translate(-50%,-50%) rotateZ(0deg) translateX(120px) rotateZ(0deg);"><div class="node" style="position:static;"><div class="nn">Voorzitter</div><div class="nf">L. Boons</div></div></div>
+            <div class="rnode" style="transform:translate(-50%,-50%) rotateZ(72deg) translateX(120px) rotateZ(-72deg);"><div class="node" style="position:static;"><div class="nn">Secretaris</div><div class="nf">I. Maes</div></div></div>
+            <div class="rnode" style="transform:translate(-50%,-50%) rotateZ(144deg) translateX(120px) rotateZ(-144deg);"><div class="node warm" style="position:static;"><div class="nn">Vacant</div><div class="nf">penning.</div></div></div>
+            <div class="rnode" style="transform:translate(-50%,-50%) rotateZ(216deg) translateX(120px) rotateZ(-216deg);"><div class="node" style="position:static;"><div class="nn">Jeugd</div><div class="nf">S. Peeters</div></div></div>
+            <div class="rnode" style="transform:translate(-50%,-50%) rotateZ(288deg) translateX(120px) rotateZ(-288deg);"><div class="node" style="position:static;"><div class="nn">TVJO</div><div class="nf">T. Michiels</div></div></div>
+            <div class="spoke" style="transform:rotate(0deg);"></div><div class="spoke" style="transform:rotate(72deg);"></div><div class="spoke" style="transform:rotate(144deg);"></div><div class="spoke" style="transform:rotate(216deg);"></div><div class="spoke" style="transform:rotate(288deg);"></div>
+          </div></div>
+          <div class="hint">de hele club in één beeld · ◎ kantelt het vlak naar een 3-D constellatie die je kan ronddraaien</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>The whole shape, at a glance.</h3>
+        <p>A radial tree: the club at the centre, departments + positions radiating outward — you see the entire
+          organisation as one figure. The ◎ toggle tilts the plane into an orbitable 3-D constellation. Striking and
+          legible-as-a-whole; deep sub-trees need a click-to-recentre like B. Medium build (2-D SVG/CSS + an optional
+          CSS/r3f tilt).</p>
+        <table class="sc"><tr><th>Orient</th><th>Mobile</th><th>A11y/perf</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="m">△</td><td class="m">△</td><td class="m">△</td><td class="m">med-high</td><td class="y">high</td></tr></table>
+      </div>
+    </div></div>
+
+    <!-- D -->
+    <div class="direction-bar rec"><span class="t">D ◎</span> Full 3-D spatial explorer <span class="note">orbit the whole org in space · real CSS-3D below (hover to pause) · the investigation</span></div>
+    <div class="stage"><div class="mgrid">
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner — 3-D</span><span class="sp"></span><span class="ctl">–</span><span class="ctl">+</span><span class="ctl warm">◎ 3-D</span><span class="ctl">⤢ passend</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb">KCVV Elewijt &nbsp;▸&nbsp; <b>ruimtelijk</b> &nbsp;·&nbsp; sleep om te draaien</div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="scene"><div class="world">
+            <div class="floor"></div>
+            <!-- struts -->
+            <div class="strut" style="height:120px;transform:rotateX(90deg) rotateY(0deg);"></div>
+            <div class="strut" style="height:120px;transform:rotateX(90deg) rotateY(120deg);"></div>
+            <div class="strut" style="height:120px;transform:rotateX(90deg) rotateY(240deg);"></div>
+            <!-- nodes -->
+            <div class="n3 root" style="transform:translate(-50%,-50%) translateY(-70px);"><div class="nn">KCVV Elewijt</div><div class="nf">de club</div></div>
+            <div class="n3" style="transform:translate(-50%,-50%) translateY(40px) translateZ(110px);"><div class="nn">Luc Boons</div><div class="nf">Voorzitter</div></div>
+            <div class="n3" style="transform:translate(-50%,-50%) translateY(40px) rotateY(120deg) translateZ(110px) rotateY(-120deg);"><div class="nn">Inge Maes</div><div class="nf">Secretaris</div></div>
+            <div class="n3 warm" style="transform:translate(-50%,-50%) translateY(40px) rotateY(240deg) translateZ(110px) rotateY(-240deg);"><div class="nn">Open</div><div class="nf">Vacant</div></div>
+          </div></div>
+          <div class="hint">sleep om te orbiten · scroll = zoom · klik een node = focus · auto-draait tot je ‘m aanraakt</div>
+        </div>
+      </div>
+      <div class="notes">
+        <h3>Orbit the club.</h3>
+        <p>The org as a real spatial structure you rotate, zoom and fly through — depth carries hierarchy, the whole
+          thing turns. Maximum memorability; genuinely unique for a village club. Cost is real: <b>three.js / react-three-fiber</b>,
+          a WebGL + perf budget, label legibility in 3-D, and a mandatory <b>2-D fallback</b> for reduced-motion /
+          low-power / screen-readers. Best treated as the <b>◎ enhancement on top of a solid 2-D base</b>, not the only
+          way in.</p>
+        <table class="sc"><tr><th>Orient</th><th>Mobile</th><th>A11y/perf</th><th>Build</th><th>Wow</th></tr>
+          <tr><td class="m">△</td><td class="n">✗→△</td><td class="n">✗→△*</td><td class="n">high</td><td class="y">✓✓✓</td></tr></table>
+        <p style="font-size:10.5px;font-family:var(--font-mono);color:var(--ink-muted);">*only with the fallback + perf budget done properly.</p>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o3 — the explorer interaction</h3>
+      <p>
+        <b>A</b> safe 2-D tree (cheap, low wow). <b>B</b> spotlight drill-down — the strongest pure fix for orientation
+        + mobile (you’re never lost, never dragging). <b>C</b> radial constellation — the whole club as one figure, with
+        a 3-D orbit toggle. <b>D ◎</b> full 3-D spatial — maximum wow, heaviest build, needs a real 2-D fallback.
+      </p>
+      <p style="color:var(--ink-muted);">
+        These compose. The responsible shape for your “3-D is awesome” + “don’t let me get lost / fix mobile” is a
+        <b>solid 2-D base (B’s spotlight nav) that the ◎ toggle lifts into 3-D (D’s scene)</b> — progressive enhancement,
+        with C’s radial as a candidate base if you want the whole-shape view. Pick the <b>base</b> + how far the <b>3-D
+        toggle</b> goes, and I’ll lock the combination (and flag 3-D as its own build phase in the PRD, since it’s the
+        heavy part).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o3-explorer-locked.html
+++ b/docs/design/mockups/phase-7-organigram/7o3-explorer-locked.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o3 LOCKED — spotlight drill-down (2-D, no 3-D)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:16px 28px;font-family:var(--font-mono);font-size:12px;letter-spacing:.05em;text-transform:uppercase;}
+      .head b{color:var(--warm);}
+      .wrap{max-width:1040px;margin:0 auto;padding:24px;}
+      .lbl{font-family:var(--font-mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--jersey-deep);margin:6px 0 10px;}
+      .lbl b{color:var(--ink);}
+
+      .fs{border:2px solid var(--ink);background:#0e2b1d;box-shadow:6px 6px 0 0 var(--ink);overflow:hidden;margin-bottom:8px;}
+      .fs .bar{display:flex;align-items:center;gap:7px;padding:8px 11px;border-bottom:1.5px solid rgba(245,241,230,.2);background:#0a2016;flex-wrap:wrap;}
+      .fs .bar .ttl{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--cream);}
+      .fs .bar .sp{flex:1;}
+      .fs .ctl{font-family:var(--font-mono);font-size:9px;color:var(--cream);border:1.5px solid rgba(245,241,230,.4);padding:3px 6px;}
+      .fs .crumb{font-family:var(--font-mono);font-size:10px;color:rgba(245,241,230,.8);padding:6px 11px;border-bottom:1.5px solid rgba(245,241,230,.12);}
+      .fs .crumb b{color:var(--warm);}
+      .fs .crumb a{color:rgba(245,241,230,.8);text-decoration:underline;text-underline-offset:2px;}
+      .stagebox{height:340px;position:relative;overflow:hidden;}
+      .grid-bg{position:absolute;inset:0;background:linear-gradient(rgba(245,241,230,.05) 1px,transparent 1px) 0 0/28px 28px,linear-gradient(90deg,rgba(245,241,230,.05) 1px,transparent 1px) 0 0/28px 28px,radial-gradient(120% 90% at 50% 0%,rgba(74,207,82,.12),transparent 55%);}
+      .hint{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:rgba(245,241,230,.55);text-align:center;width:92%;}
+
+      .nd{border:2px solid var(--ink);background:var(--cream);padding:4px 7px;text-align:center;box-shadow:2px 2px 0 0 rgba(0,0,0,.4);}
+      .nd .a{font-family:var(--font-display);font-weight:600;font-size:11px;line-height:1.05;}
+      .nd .b{font-family:var(--font-mono);font-size:7px;text-transform:uppercase;color:var(--ink-muted);}
+      .nd.dept{background:var(--jersey-deep-dark);color:var(--cream);}.nd.dept .b{color:rgba(245,241,230,.8);}
+      .nd.vac{background:var(--warm);}
+
+      .b-parent{position:absolute;left:50%;top:14px;transform:translateX(-50%);}
+      .b-sib{position:absolute;top:44%;transform:translateY(-50%);font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:rgba(245,241,230,.62);border:1.5px solid rgba(245,241,230,.35);padding:7px 9px;}
+      .b-center{position:absolute;left:50%;top:33%;transform:translate(-50%,-50%);background:var(--cream);border:2px solid var(--ink);box-shadow:4px 4px 0 0 var(--warm);padding:9px 18px;text-align:center;}
+      .b-center .a{font-family:var(--font-display);font-weight:600;font-size:16px;}
+      .b-center .b{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;color:var(--ink-muted);}
+      .b-kids{position:absolute;left:3%;right:3%;bottom:30px;display:flex;flex-wrap:wrap;gap:7px;justify-content:center;}
+      .b-kids .nd{width:104px;cursor:pointer;}
+      .b-conn{position:absolute;left:50%;top:calc(33% + 22px);width:2px;height:34px;background:rgba(245,241,230,.3);transform:translateX(-50%);}
+
+      .spec{background:var(--cream-deep);border:1.5px solid var(--ink);padding:14px 16px;font-family:var(--font-mono);font-size:11.5px;line-height:1.7;color:var(--ink-soft);margin-top:6px;}
+      .spec b{color:var(--jersey-deep);} .spec .k{color:var(--ink);font-weight:600;}
+      .killed{background:#f3e0da;border:1.5px dashed var(--brick);padding:10px 14px;font-family:var(--font-mono);font-size:11px;color:var(--brick);margin-top:8px;}
+      .killed b{color:var(--brick);}
+    </style>
+  </head>
+  <body>
+    <div class="head">7o3 LOCKED · <b>Spotlight drill-down — 2-D only</b> · inside the fullscreen verkenner (7o2) · 3-D removed</div>
+
+    <div class="wrap">
+      <div class="lbl"><b>THE EXPLORER</b> — Spotlight drill-down (focus + context)</div>
+      <div class="fs">
+        <div class="bar"><span class="ttl">▣ Verkenner</span><span class="sp"></span><span class="ctl">↤ terug</span><span class="ctl">⤢ overzicht</span><span class="ctl">✕ Esc</span></div>
+        <div class="crumb"><a href="#">KCVV Elewijt</a> &nbsp;▸&nbsp; <b>Jeugdbestuur</b> &nbsp;<span style="color:rgba(245,241,230,.4)">(10 functies)</span></div>
+        <div class="stagebox"><div class="grid-bg"></div>
+          <div class="b-parent nd dept" style="width:138px;"><div class="a">KCVV Elewijt ▲</div><div class="b">ouder · klik om omhoog</div></div>
+          <div class="b-conn"></div>
+          <div class="b-sib" style="left:12px;">◂ Hoofdbestuur</div>
+          <div class="b-sib" style="right:12px;">Algemeen ▸</div>
+          <div class="b-center"><div class="a">Jeugdbestuur</div><div class="b">afdeling · 10 functies</div></div>
+          <div class="b-kids">
+            <div class="nd"><div class="a">Jeugdvoorz.</div><div class="b">S. Peeters</div></div>
+            <div class="nd"><div class="a">Jeugdsecr.</div><div class="b">K. Wouters</div></div>
+            <div class="nd"><div class="a">TVJO</div><div class="b">T. Michiels</div></div>
+            <div class="nd"><div class="a">Coörd. Boven</div><div class="b">B. Janssens</div></div>
+            <div class="nd"><div class="a">Coörd. Midden</div><div class="b">E. Claes</div></div>
+            <div class="nd"><div class="a">Coörd. Onder</div><div class="b">N. De Cock</div></div>
+            <div class="nd"><div class="a">Gastheer</div><div class="b">A. Mertens</div></div>
+            <div class="nd vac"><div class="a">Tornooien</div><div class="b">vacant</div></div>
+            <div class="nd"><div class="a">Uitrusting</div><div class="b">K. Wille</div></div>
+            <div class="nd"><div class="a">Keeperstr.</div><div class="b">D. Cools</div></div>
+          </div>
+          <div class="hint">klik kind → nieuw midden · klik ouder/buur → omhoog/opzij · klik persoon → detail (7o5) · ↑↓←→ + Enter · nooit verdwalen, nooit slepen</div>
+        </div>
+      </div>
+
+      <div class="spec">
+        <span class="k">LOCKED — spotlight (2-D, the whole explorer):</span> selected node centred · parent above + in breadcrumb · siblings flank (lateral move) · children fan below (descend). Navigate by <b>click</b> + <b>↑↓←→/Enter</b>; never free-pan, never drag. Persistent breadcrumb = the map → no “getting lost”. Click a <b>person/leaf → 7o5 detail</b> (contact). Node states (single / shared +N / vacant) → <b>7o4</b>. Mobile = tap-only. Container = fullscreen focused mode (7o2) → breadcrumb + zoom/fit + Esc; cannot scroll-jack. <b>Pan/zoom is only for the contained canvas; the spotlight needs neither.</b>
+      </div>
+      <div class="killed">
+        <b>REMOVED — 3-D (owner call, 2026-06-08):</b> the orbital 3-D enhancement is dropped entirely — “doesn’t add value, au contraire.” No three.js / react-three-fiber, no ◎ toggle, no spatial mode. The 2-D spotlight stands alone. (Investigated in <code>7o3-explorer-at-scale-compare.html</code> option D, retained as drill history.) No 3-D build phase in the PRD.
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o3-explorer-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o3-explorer-locked.md
@@ -1,0 +1,69 @@
+# Phase 7 · `/club/organigram` — Round 3 (EXPLORER INTERACTION) — LOCKED
+
+**Date:** 2026-06-07 (3-D removed 2026-06-08)
+**Mockups:** `7o3-explorer-interaction-compare.html` (A–D) · `7o3-explorer-at-scale-compare.html`
+(A–D re-mocked at ~25 nodes / 4 levels) → `7o3-explorer-locked.html`
+**Owner:** @climacon
+**Tracker:** #1529 · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision
+
+**The explorer is B (spotlight drill-down), 2-D only. 3-D is removed entirely.**
+
+Inside the locked fullscreen verkenner (7o2), the everyday — and only — interaction is **focus +
+context**: the selected node sits centred, its parent floats above (and in the breadcrumb), siblings
+flank it, children fan below — you navigate by **clicking**, never by free-panning. Re-mocked at the
+**real ~25-node / 4-level** bestuur, this was the only base that looks **identical at 25 or 250 nodes**
+and the only one genuinely usable on a phone.
+
+The orbital 3-D idea was **investigated and rejected** (owner, 2026-06-08: *"doesn't add value, au
+contraire — remove this 3D completely"*). The at-scale mock (option D) showed 3-D as a label-fragile
+cloud with real cost (three.js, perf, mobile/a11y) and no navigational payoff over the spotlight.
+**No 3-D ships — no toggle, no spatial mode, no WebGL dependency, no 3-D build phase.**
+
+## Why spotlight (the scale test)
+
+At ~25 nodes / 4 levels: **A** (collapsible tree) reads with one branch open but pans when fully
+expanded; **C** (radial) crowds at 20+ outer labels and can't hold the 4th level without a B-style zoom
+underneath; **D** (3-D) becomes a label-fragile cloud and is risky for mobile/a11y. Only **B** stays calm
+at any size — so B *is* the explorer.
+
+## Locked spec (see `7o3-explorer-locked.html`)
+
+```text
+layout    parent (above + breadcrumb) · selected (centre, warm-shadow) · siblings (flank) · children (fan below)
+navigate  click child → new centre · click parent/crumb → ascend · click sibling → lateral · "↤ terug" · "⤢ overzicht" (root)
+keyboard  ↑ parent · ↓ first child · ← / → siblings · Enter focus · Esc closes the verkenner
+orient    persistent breadcrumb "KCVV ▸ afdeling ▸ node" · never free-pan, never drag · always centred on someone
+leaf      click a person/leaf → opens the 7o5 member detail (contact)
+states    single / shared (+N badge) / vacant (warm, dashed) — chrome decided in 7o4
+mobile    tap-only; no pinch/drag required; children grid wraps/scrolls
+container fullscreen focused mode (7o2) — breadcrumb + zoom/fit + Esc; cannot scroll-jack
+```
+
+## What this locks vs defers
+
+- **Locks:** spotlight focus+context as the **entire** explorer interaction + accessibility model;
+  click/keyboard navigation + breadcrumb orientation; **2-D only, no 3-D**.
+- **Defers to 7o4:** node chrome for single / shared / vacant states (`<TeamStaff>` idiom on explorer
+  nodes + directory cards).
+- **Defers to 7o5:** the leaf-click detail surface (modal vs panel vs sheet).
+- **Defers to 7o7:** whether to also ship an **A-style collapsible "volledig organigram / print"**
+  secondary mode (candidate, not locked); explorer analytics (`organigram_member_clicked` view value;
+  a possible `organigram_explorer_opened`).
+
+## Component seed
+
+`<OrganigramExplorer>` (new) — owns the fullscreen container + the spotlight interaction; **absorbs/replaces**
+`<EnhancedOrgChart>`, `<MobileNavigationDrawer>`, and `<ContactOverlay>`. **No `three.js` / r3f dependency.**
+The d3-org-chart dependency is **retired** unless A-as-print (7o7) revives a contained tree.
+
+## Rejected
+
+- **A as base** — fine as a print/overview, pans when fully expanded; weaker on mobile; kept only as a
+  7o7 candidate secondary mode.
+- **C** — beautiful whole-club figure but crowds at real scale and can't express 4-level depth without
+  becoming B underneath.
+- **D / 3-D (any form)** — investigated at scale, **removed by owner**: cost + label-fragility +
+  mobile/a11y risk, no navigational value over the spotlight. The compare files are retained only as
+  drill history.

--- a/docs/design/mockups/phase-7-organigram/7o4-card-states-locked.html
+++ b/docs/design/mockups/phase-7-organigram/7o4-card-states-locked.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o4 LOCKED — card states (shared hover · vacant recruit)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:16px 28px;font-family:var(--font-mono);font-size:12px;letter-spacing:.05em;text-transform:uppercase;}
+      .head b{color:var(--warm);}
+      .wrap{max-width:1000px;margin:0 auto;padding:26px 24px;}
+      .grid{display:flex;gap:26px;flex-wrap:wrap;align-items:flex-start;}
+      .cell{display:flex;flex-direction:column;align-items:center;gap:10px;}
+      .cap{font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:var(--jersey-deep);}
+      .cap b{color:var(--ink);}
+
+      .pcard{border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 var(--ink);display:flex;flex-direction:column;align-items:center;padding:14px 12px;text-align:center;width:172px;position:relative;}
+      .pcard .av{width:64px;height:64px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;}
+      .pcard .av .mono{font-family:var(--font-display);font-weight:900;color:var(--jersey-deep);font-size:23px;}
+      .pcard .av .ph{width:100%;height:100%;background:repeating-linear-gradient(45deg,#d7d0bb 0 8px,#c8c1aa 8px 16px);filter:sepia(.3) saturate(.8);}
+      .pcard .nm{font-family:var(--font-display);margin-top:9px;line-height:1.05;font-size:16px;}
+      .pcard .nm b{font-weight:600;} .pcard .nm em{font-style:italic;font-weight:400;}
+      .pcard .fn{font-family:var(--font-mono);font-size:9px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-muted);margin-top:5px;}
+      .rolepill{position:absolute;top:9px;right:9px;font-family:var(--font-mono);font-size:8px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;background:var(--jersey-deep);color:var(--cream);border:1.5px solid var(--ink);padding:1px 5px;}
+
+      /* shared dual avatar — interactive hover */
+      .av.dual{position:relative;background:transparent;border:none;width:78px;height:64px;overflow:visible;}
+      .av.dual .c{position:absolute;width:52px;height:52px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .18s, box-shadow .18s;top:6px;}
+      .av.dual .c1{left:0;z-index:2;} .av.dual .c2{right:0;z-index:1;}
+      .av.dual .c .mono{font-family:var(--font-display);font-weight:900;color:var(--jersey-deep);font-size:18px;}
+      .av.dual .c:hover{z-index:5;transform:scale(1.12) translateY(-2px);box-shadow:0 4px 10px rgba(0,0,0,.3);}
+      .av.dual .c .tip{position:absolute;top:56px;left:50%;transform:translateX(-50%);white-space:nowrap;font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.04em;background:var(--ink);color:var(--cream);padding:3px 7px;opacity:0;pointer-events:none;transition:opacity .15s;z-index:6;}
+      .av.dual .c:hover .tip{opacity:1;}
+      .plusN{position:absolute;right:-6px;top:6px;width:30px;height:30px;border-radius:9999px;background:var(--jersey-deep);color:var(--cream);border:2px solid var(--ink);display:flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:11px;font-weight:600;z-index:3;}
+
+      /* vacant recruit */
+      .pcard.vac{background:var(--warm);box-shadow:4px 4px 0 0 var(--ink);}
+      .pcard.vac .av{background:rgba(255,255,255,.45);border-style:dashed;}
+      .pcard.vac .av .q{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:24px;color:var(--jersey-deep);}
+      .pcard.vac .cta{margin-top:9px;font-family:var(--font-mono);font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;border:1.5px solid var(--ink);padding:6px 10px;background:var(--cream);box-shadow:2px 2px 0 0 var(--ink);}
+
+      .spec{background:var(--cream-deep);border:1.5px solid var(--ink);padding:14px 16px;font-family:var(--font-mono);font-size:11.5px;line-height:1.75;color:var(--ink-soft);margin-top:26px;}
+      .spec b{color:var(--jersey-deep);} .spec .k{color:var(--ink);font-weight:600;}
+      .try{font-family:var(--font-mono);font-size:11px;color:var(--brick);text-align:center;margin-top:4px;}
+    </style>
+  </head>
+  <body>
+    <div class="head">7o4 LOCKED · <b>single (6.C) · shared = dual-avatar (hover-to-front) · vacant = recruit</b></div>
+    <div class="wrap">
+      <div class="grid">
+        <div class="cell">
+          <span class="cap"><b>SINGLE</b> · 6.C</span>
+          <div class="pcard"><span class="rolepill">VZ</span><div class="av"><span class="mono">LB</span></div><div class="nm"><b>Luc</b> <em>Boons</em></div><div class="fn">Voorzitter</div></div>
+          <span class="cap">photo or monogram</span>
+        </div>
+
+        <div class="cell">
+          <span class="cap"><b>SHARED</b> · 2 personen</span>
+          <div class="pcard">
+            <div class="av dual">
+              <span class="c c1"><span class="mono">JD</span><span class="tip">Jan De Smet</span></span>
+              <span class="c c2"><span class="ph"></span><span class="tip">Paula Vos</span></span>
+            </div>
+            <div class="nm"><b>Wedstrijd-</b> <em>secretariaat</em></div><div class="fn">2 personen</div>
+          </div>
+          <span class="try">← hover een avatar (komt naar voor + naam)</span>
+        </div>
+
+        <div class="cell">
+          <span class="cap"><b>SHARED 3+</b> · 2 + “+N”</span>
+          <div class="pcard">
+            <div class="av dual">
+              <span class="c c1"><span class="mono">EC</span><span class="tip">Els Claes</span></span>
+              <span class="c c2"><span class="mono">NB</span><span class="tip">Nina Bral</span></span>
+              <span class="plusN">+1</span>
+            </div>
+            <div class="nm"><b>Feest-</b> <em>comité</em></div><div class="fn">3 personen</div>
+          </div>
+          <span class="cap">“+1” → opent detail</span>
+        </div>
+
+        <div class="cell">
+          <span class="cap"><b>VACANT</b> · recruit</span>
+          <div class="pcard vac"><div class="av"><span class="q">+</span></div><div class="nm"><em>Penningmeester</em></div><div class="fn">deze plek is vrij</div><span class="cta">Iets voor jou? →</span></div>
+          <span class="cap">warm · CTA → contact/Hulp</span>
+        </div>
+      </div>
+
+      <div class="spec">
+        <span class="k">DISCOVERY (locked):</span> the card/node is a <b>summary of the position</b>. <b>Clicking it opens the 7o5 member detail, which lists every holder with name · photo · contact</b> — the one reliable, <b>touch-safe</b> path; works for 2 or 20.<br>
+        <span class="k">SHARED (S-A):</span> two overlapping avatars + “N personen”. <b>Desktop hover enhancement:</b> hovering an avatar brings it to the front (z-index + slight scale) and reveals its name in a tooltip — pointer-only, purely additive, never required. 3+ → two avatars + a <b>“+N”</b> chip; the whole card (and the chip) opens the detail. Same chrome at directory scale (64px) and smaller explorer-node scale.<br>
+        <span class="k">VACANT (V-C):</span> warm card · dashed avatar with “+” · position name · “deze plek is vrij” · soft <b>“Iets voor jou? →”</b> CTA to contact/Hulp. Vacant cards appear in the directory + explorer only — <b>never in the hero index</b>. (Honest volunteer call for a vrijwilligers-run club.)<br>
+        <span class="k">SHARED + roleCode:</span> optional <b>roleCode pill</b> top-right when present (e.g. “VZ”, “T1”); auto-hides otherwise.
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o4-card-states-locked.html
+++ b/docs/design/mockups/phase-7-organigram/7o4-card-states-locked.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Phase 7 · organigram · 7o4 LOCKED — card states (shared hover · vacant recruit)</title>
+    <title>Phase 7 · organigram · 7o4 LOCKED — card states (shared dual-avatar · vacant recruit)</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -38,14 +38,12 @@
       .pcard .fn{font-family:var(--font-mono);font-size:9px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-muted);margin-top:5px;}
       .rolepill{position:absolute;top:9px;right:9px;font-family:var(--font-mono);font-size:8px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;background:var(--jersey-deep);color:var(--cream);border:1.5px solid var(--ink);padding:1px 5px;}
 
-      /* shared dual avatar — interactive hover */
+      /* shared dual avatar — static cue (no hover) */
       .av.dual{position:relative;background:transparent;border:none;width:78px;height:64px;overflow:visible;}
-      .av.dual .c{position:absolute;width:52px;height:52px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .18s, box-shadow .18s;top:6px;}
+      .av.dual .c{position:absolute;width:52px;height:52px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;cursor:default;top:6px;}
       .av.dual .c1{left:0;z-index:2;} .av.dual .c2{right:0;z-index:1;}
       .av.dual .c .mono{font-family:var(--font-display);font-weight:900;color:var(--jersey-deep);font-size:18px;}
-      .av.dual .c:hover{z-index:5;transform:scale(1.12) translateY(-2px);box-shadow:0 4px 10px rgba(0,0,0,.3);}
-      .av.dual .c .tip{position:absolute;top:56px;left:50%;transform:translateX(-50%);white-space:nowrap;font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.04em;background:var(--ink);color:var(--cream);padding:3px 7px;opacity:0;pointer-events:none;transition:opacity .15s;z-index:6;}
-      .av.dual .c:hover .tip{opacity:1;}
+      .av.dual .c .tip{display:none;}
       .plusN{position:absolute;right:-6px;top:6px;width:30px;height:30px;border-radius:9999px;background:var(--jersey-deep);color:var(--cream);border:2px solid var(--ink);display:flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:11px;font-weight:600;z-index:3;}
 
       /* vacant recruit */
@@ -60,7 +58,7 @@
     </style>
   </head>
   <body>
-    <div class="head">7o4 LOCKED · <b>single (6.C) · shared = dual-avatar (hover-to-front) · vacant = recruit</b></div>
+    <div class="head">7o4 LOCKED · <b>single (6.C) · shared = dual-avatar (static cue) · vacant = recruit</b></div>
     <div class="wrap">
       <div class="grid">
         <div class="cell">
@@ -78,7 +76,7 @@
             </div>
             <div class="nm"><b>Wedstrijd-</b> <em>secretariaat</em></div><div class="fn">2 personen</div>
           </div>
-          <span class="try">← hover een avatar (komt naar voor + naam)</span>
+          <span class="try">klik de functie → opent de persoon (7o5)</span>
         </div>
 
         <div class="cell">
@@ -102,8 +100,8 @@
       </div>
 
       <div class="spec">
-        <span class="k">DISCOVERY (locked):</span> the card/node is a <b>summary of the position</b>. <b>Clicking it opens the 7o5 member detail, which lists every holder with name · photo · contact</b> — the one reliable, <b>touch-safe</b> path; works for 2 or 20.<br>
-        <span class="k">SHARED (S-A):</span> two overlapping avatars + “N personen”. <b>Desktop hover enhancement:</b> hovering an avatar brings it to the front (z-index + slight scale) and reveals its name in a tooltip — pointer-only, purely additive, never required. 3+ → two avatars + a <b>“+N”</b> chip; the whole card (and the chip) opens the detail. Same chrome at directory scale (64px) and smaller explorer-node scale.<br>
+        <span class="k">DISCOVERY (locked, person-first — 7o5):</span> the whole card/node is a <b>single click target</b> that opens the <b>person detail</b> directly — single holder → that person; shared → the first holder + a name-tab switcher. <b>No per-avatar interaction.</b><br>
+        <span class="k">SHARED (S-A):</span> two overlapping avatars + “N personen” are a <b>purely static visual cue</b> (no hover, no tooltip). 3+ → two avatars + a <b>“+N”</b> chip; the whole card (and the chip) opens the detail. Same chrome at directory scale (64px) and smaller explorer-node scale.<br>
         <span class="k">VACANT (V-C):</span> warm card · dashed avatar with “+” · position name · “deze plek is vrij” · soft <b>“Iets voor jou? →”</b> CTA to contact/Hulp. Vacant cards appear in the directory + explorer only — <b>never in the hero index</b>. (Honest volunteer call for a vrijwilligers-run club.)<br>
         <span class="k">SHARED + roleCode:</span> optional <b>roleCode pill</b> top-right when present (e.g. “VZ”, “T1”); auto-hides otherwise.
       </div>

--- a/docs/design/mockups/phase-7-organigram/7o4-card-states-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o4-card-states-locked.md
@@ -1,0 +1,59 @@
+# Phase 7 · `/club/organigram` — Round 4 (NODE / PEOPLE-CARD STATES) — LOCKED
+
+**Date:** 2026-06-08
+**Mockups:** `7o4-node-card-states-compare.html` → `7o4-card-states-locked.html` (interactive hover)
+**Owner:** @climacon
+**Tracker:** #1529 · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision
+
+The people-card uses the locked **6.C `<TeamStaff>` idiom** in all three occupancy states. Two state
+treatments were the open calls:
+
+- **Shared (2+ holders) = S-A dual-avatar** with an "N personen" label.
+- **Vacant (0 holders) = V-C recruit** — a warm volunteer call, not a dead placeholder.
+
+## Locked spec (see `7o4-card-states-locked.html`)
+
+```text
+SINGLE   6.C card: round newsprint photo OR jersey-deep monogram (~90% have no photo) ·
+         name first-semibold + last-italic · mono function label · optional roleCode pill top-right.
+SHARED   two overlapping avatars + "N personen". 3+ → two avatars + a "+N" chip.
+VACANT   warm card · dashed avatar with "+" · position name (italic) · "deze plek is vrij" ·
+         soft CTA "Iets voor jou? →" → contact/Hulp.
+SCALE    identical chrome at directory scale (64px avatar) and smaller explorer-node scale.
+```
+
+## Discovery model (REVISED 2026-06-08 — person-first, hover dropped)
+
+Clicking a node opens a **person's contact directly**, not a function summary:
+
+- **Single holder (~the common case):** click the card/node → that **person's contact** (7o5) opens
+  immediately.
+- **Shared (2+):** click → opens the **first holder's** contact with a **holder-switcher** (avatar+name
+  tabs for all holders) so you flip to co-holders — that's how you reach #3/#4. Always lands on a
+  contactable person.
+- **Hover-to-front: REMOVED** (owner, 2026-06-08: *"the hover effect is not needed — I expected click to
+  open the contact person immediately"*). The dual-avatar stays **only as a visual "2+ people" cue**; the
+  "+N" chip just signals count. No per-avatar hover/tooltip.
+
+## Constraints / edge cases
+
+- **Vacant cards never appear in the hero index** (7o1) — only in the directory + explorer.
+- **roleCode pill** (`organigramNode.roleCode`, ≤6 chars) renders top-right when present; auto-hides.
+- Monogram = initials of `firstName`/`lastName`; if a holder has no usable name, fall back to the
+  position monogram or the club flat-logo (existing fallback rule).
+- The vacant CTA target is the club contact / Hulp entry (final destination confirmed in 7o7).
+
+## What this defers
+
+- **7o5:** the member-detail surface that the shared/single card opens (and how it lists multiple
+  holders + their contacts).
+- **7o7:** the vacant-CTA destination wording/route; whether the recruit CTA also surfaces in an empty
+  department.
+
+## Component note
+
+The card is one component (`<OrgPersonCard>` or reuse/extend the 6.C `<TeamStaff>` card) parameterised by
+occupancy state (`single | shared | vacant`) + scale (`directory | node`). **No hover behaviour** — the
+dual-avatar is a static cue; the whole card is one click target that opens the 7o5 person detail.

--- a/docs/design/mockups/phase-7-organigram/7o4-node-card-states-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o4-node-card-states-compare.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o4: NODE / PEOPLE-CARD STATES</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .row-bar{position:sticky;top:0;z-index:50;background:var(--jersey-deep);color:var(--cream);padding:10px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;border-bottom:2px solid var(--ink);}
+      .row-bar.lock{background:var(--ink);} .row-bar.lock b{color:var(--jersey);}
+      .stage{padding:26px 28px 30px;border-bottom:1px dashed var(--paper-edge);}
+      .opts{max-width:1060px;margin:0 auto;display:flex;gap:22px;flex-wrap:wrap;align-items:flex-start;}
+      .opt{flex:1;min-width:240px;}
+      .opt .tag{font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;background:var(--warm);border:1.5px solid var(--ink);padding:2px 8px;display:inline-block;margin-bottom:10px;}
+      .opt .tag.rec{background:var(--jersey);}
+      .opt p{font-size:13px;color:var(--ink-soft);line-height:1.5;margin:10px 0 0;}
+      .cardwrap{display:flex;justify-content:center;padding:16px;background:var(--cream-soft);border:1.5px dashed var(--paper-edge);}
+
+      /* people card (6.C TeamStaff) */
+      .pcard{border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 var(--ink);display:flex;flex-direction:column;align-items:center;padding:14px 12px;text-align:center;width:170px;position:relative;}
+      .pcard .av{width:64px;height:64px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;}
+      .pcard .av .mono{font-family:var(--font-display);font-weight:900;color:var(--jersey-deep);font-size:23px;}
+      .pcard .av .ph{width:100%;height:100%;background:repeating-linear-gradient(45deg,#d7d0bb 0 8px,#c8c1aa 8px 16px);filter:sepia(.3) saturate(.8);}
+      .pcard .nm{font-family:var(--font-display);margin-top:9px;line-height:1.05;font-size:16px;}
+      .pcard .nm b{font-weight:600;} .pcard .nm em{font-style:italic;font-weight:400;}
+      .pcard .fn{font-family:var(--font-mono);font-size:9px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-muted);margin-top:5px;}
+      .rolepill{position:absolute;top:9px;right:9px;font-family:var(--font-mono);font-size:8px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;background:var(--jersey-deep);color:var(--cream);border:1.5px solid var(--ink);padding:1px 5px;}
+
+      /* shared variants */
+      .av.dual{position:relative;background:transparent;border:none;width:74px;}
+      .av.dual .c{position:absolute;width:50px;height:50px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;}
+      .av.dual .c1{left:0;top:7px;z-index:1;} .av.dual .c2{right:0;top:7px;}
+      .av.dual .c .mono{font-family:var(--font-display);font-weight:900;color:var(--jersey-deep);font-size:17px;}
+      .badgeN{position:absolute;bottom:-3px;right:-3px;background:var(--jersey-deep);color:var(--cream);border:2px solid var(--ink);border-radius:9999px;width:24px;height:24px;font-family:var(--font-mono);font-size:11px;display:flex;align-items:center;justify-content:center;font-weight:600;}
+      .av-rel{position:relative;}
+      .mini-list{margin-top:9px;display:flex;flex-direction:column;gap:5px;width:100%;}
+      .mini-list .mrow{display:flex;align-items:center;gap:7px;border:1.5px solid var(--ink);padding:4px 7px;background:var(--cream-soft);}
+      .mini-list .mrow .ma{width:24px;height:24px;border-radius:9999px;border:1.5px solid var(--ink);background:var(--cream);display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-weight:900;font-size:11px;color:var(--jersey-deep);flex:none;}
+      .mini-list .mrow .mn{font-family:var(--font-display);font-size:12px;}
+
+      /* vacant variants */
+      .pcard.vac-warm{background:var(--warm);}
+      .pcard.vac-warm .av{background:rgba(255,255,255,.4);border-style:solid;}
+      .pcard.vac-warm .av .q{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:26px;color:var(--ink);}
+      .pcard.vac-ghost{border-style:dashed;background:var(--cream-soft);box-shadow:none;}
+      .pcard.vac-ghost .av{border-style:dashed;background:transparent;}
+      .pcard.vac-ghost .av .q{font-family:var(--font-display);font-style:italic;font-size:26px;color:var(--ink-muted);}
+      .pcard.vac-ghost .fn{color:var(--brick);}
+      .pcard.vac-recruit{background:var(--warm);box-shadow:4px 4px 0 0 var(--ink);}
+      .pcard.vac-recruit .av{background:rgba(255,255,255,.45);border-style:dashed;}
+      .pcard.vac-recruit .av .q{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:24px;color:var(--jersey-deep);}
+      .pcard.vac-recruit .cta{margin-top:9px;font-family:var(--font-mono);font-size:9px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;border:1.5px solid var(--ink);padding:5px 9px;background:var(--cream);box-shadow:2px 2px 0 0 var(--ink);}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o4 — NODE / PEOPLE-CARD STATES</h1>
+      <p>The single-person card is the <b>locked 6.C &lt;TeamStaff&gt; idiom</b> (round newsprint photo / jersey-deep monogram · name first-semibold + last-italic · mono function label). Same chrome is used in the directory and (smaller) as explorer nodes. Two states still need a call: <b>shared</b> (a position held by 2+ people) and <b>vacant</b> (an open position, 0 people). The optional <b>roleCode pill</b> (“T1”, “VP”) is shown top-right where present.</p>
+    </div>
+
+    <!-- LOCKED single -->
+    <div class="row-bar lock">LOCKED · <b>single</b> — the 6.C &lt;TeamStaff&gt; card (reference)</div>
+    <div class="stage"><div class="opts">
+      <div class="opt" style="max-width:200px;">
+        <div class="cardwrap"><div class="pcard"><span class="rolepill">VZ</span><div class="av"><span class="mono">LB</span></div><div class="nm"><b>Luc</b> <em>Boons</em></div><div class="fn">Voorzitter</div></div></div>
+        <p>Monogram when no photo (~90% of staff). With a photo it’s the newsprint round portrait. roleCode pill optional.</p>
+      </div>
+      <div class="opt" style="max-width:200px;">
+        <div class="cardwrap"><div class="pcard"><div class="av"><span class="ph"></span></div><div class="nm"><b>Inge</b> <em>Maes</em></div><div class="fn">Secretaris</div></div></div>
+        <p>Photo variant (newsprint-treated). No roleCode here → no pill (auto-hides).</p>
+      </div>
+    </div></div>
+
+    <!-- SHARED -->
+    <div class="row-bar">DECISION 1 · <b>shared</b> — a position held by 2+ people (e.g. “Wedstrijdsecretariaat · 2 personen”)</div>
+    <div class="stage"><div class="opts">
+      <div class="opt">
+        <span class="tag rec">S-A ★ Dual avatar</span>
+        <div class="cardwrap"><div class="pcard"><div class="av dual"><span class="c c1"><span class="mono">JD</span></span><span class="c c2"><span class="ph"></span></span></div><div class="nm"><b>Wedstrijd-</b> <em>secretariaat</em></div><div class="fn">2 personen</div></div></div>
+        <p>Two overlapping avatars read “shared” instantly; “2 personen” label. Clean at card + node scale. (3+ → show 2 + a “+1”.)</p>
+      </div>
+      <div class="opt">
+        <span class="tag">S-B Badge + expand</span>
+        <div class="cardwrap"><div class="pcard"><div class="av av-rel"><span class="ph"></span><span class="badgeN">2</span></div><div class="nm"><b>Wedstrijd-</b> <em>secretariaat</em></div><div class="fn">klik voor beide</div></div></div>
+        <p>One avatar + a count badge; click opens both in the 7o5 detail. Most compact; the “shared” cue is subtler.</p>
+      </div>
+      <div class="opt">
+        <span class="tag">S-C Mini-list</span>
+        <div class="cardwrap"><div class="pcard" style="width:190px;"><div class="fn" style="margin-top:0;">Wedstrijdsecretariaat</div><div class="mini-list"><div class="mrow"><span class="ma">JD</span><span class="mn">Jan De Smet</span></div><div class="mrow"><span class="ma">PV</span><span class="mn">Paula Vos</span></div></div></div></div>
+        <p>Both names listed inside the card. Most explicit, but taller — awkward as a small explorer node and in a tight grid.</p>
+      </div>
+    </div></div>
+
+    <!-- VACANT -->
+    <div class="row-bar">DECISION 2 · <b>vacant</b> — an open position with 0 people</div>
+    <div class="stage"><div class="opts">
+      <div class="opt">
+        <span class="tag rec">V-C ★ Recruit</span>
+        <div class="cardwrap"><div class="pcard vac-recruit"><div class="av"><span class="q">+</span></div><div class="nm"><em>Penningmeester</em></div><div class="fn">deze plek is vrij</div><span class="cta">Iets voor jou? →</span></div></div>
+        <p>Turns a gap into a volunteer call — on-brand for a club run by vrijwilligers. Warm card, “+”, soft CTA → contact/Hulp. Honest (the seat IS open) and useful.</p>
+      </div>
+      <div class="opt">
+        <span class="tag">V-A Warm neutral</span>
+        <div class="cardwrap"><div class="pcard vac-warm"><div class="av"><span class="q">?</span></div><div class="nm"><em>Penningmeester</em></div><div class="fn">vacant</div></div></div>
+        <p>Warm card, “?”, “vacant” — flags the opening without a CTA. Calmer; no recruiting nudge.</p>
+      </div>
+      <div class="opt">
+        <span class="tag">V-B Ghost</span>
+        <div class="cardwrap"><div class="pcard vac-ghost"><div class="av"><span class="q">?</span></div><div class="nm"><em>Open functie</em></div><div class="fn">vacant</div></div></div>
+        <p>Dashed “ghost” card, brick label. Reads clearly as empty/placeholder; the most muted, least celebratory.</p>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o4 — shared + vacant card states</h3>
+      <p>
+        <b>Shared:</b> S-A dual-avatar (instant cue, scales) · S-B badge+expand (compact, subtle) · S-C mini-list
+        (explicit, tall). <b>Vacant:</b> V-C recruit (on-brand volunteer call) · V-A warm-neutral (flag only) ·
+        V-B ghost (muted placeholder).
+      </p>
+      <p style="color:var(--ink-muted);">
+        Locked regardless: single = 6.C &lt;TeamStaff&gt;; monogram fallback (no photo); optional roleCode pill top-right;
+        same chrome at directory scale (64px avatar) and explorer-node scale (smaller). Vacant cards never appear in the
+        hero index, only in the directory/explorer. Pick one shared + one vacant treatment.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o5-member-detail-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o5-member-detail-compare.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o5: MEMBER DETAIL disclosure</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .direction-bar{position:sticky;top:0;z-index:50;background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;display:flex;gap:14px;align-items:baseline;border-bottom:2px solid var(--ink);}
+      .direction-bar.rec{background:var(--jersey-deep);}.direction-bar.rec .t{background:var(--jersey);}
+      .direction-bar .t{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);}
+      .direction-bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:26px 28px 32px;border-bottom:1px dashed var(--paper-edge);}
+      .frame{max-width:1040px;margin:0 auto;position:relative;border:2px solid var(--ink);background:var(--cream-soft);height:430px;overflow:hidden;box-shadow:5px 5px 0 0 var(--ink);}
+      .pagebehind{position:absolute;inset:0;padding:16px;opacity:.55;}
+      .pagebehind .ph-h{height:40px;background:var(--jersey-deep-dark);border:2px solid var(--ink);margin-bottom:10px;}
+      .pagebehind .ph-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;}
+      .pagebehind .ph-c{height:90px;border:2px solid var(--ink);background:var(--cream);}
+      .backdrop{position:absolute;inset:0;background:rgba(10,10,10,.5);}
+
+      /* the detail content (shared, 3 holders) */
+      .detail{background:var(--cream);border:2px solid var(--ink);box-shadow:6px 6px 0 0 var(--ink);overflow:auto;}
+      .detail .dh{background:var(--jersey-deep-dark);color:var(--cream);padding:16px 18px;position:relative;}
+      .detail .dh .kick{font-family:var(--font-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--warm);}
+      .detail .dh .ttl{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:24px;margin:4px 0 0;}
+      .detail .dh .meta{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;color:rgba(245,241,230,.8);margin-top:6px;display:flex;gap:8px;flex-wrap:wrap;}
+      .detail .dh .meta .chip{border:1.5px solid rgba(245,241,230,.45);padding:2px 7px;}
+      .detail .x{position:absolute;top:12px;right:12px;font-family:var(--font-mono);font-size:11px;color:var(--cream);border:1.5px solid rgba(245,241,230,.5);padding:3px 8px;cursor:pointer;}
+      .detail .body{padding:16px 18px;}
+      .detail .desc{font-size:13px;color:var(--ink-soft);line-height:1.55;border-left:3px solid var(--jersey-deep);padding-left:12px;margin:0 0 16px;}
+      .detail .sub{font-family:var(--font-mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-muted);margin:0 0 9px;}
+      .mrow{display:flex;align-items:center;gap:11px;border:2px solid var(--ink);background:var(--cream-soft);box-shadow:2px 2px 0 0 var(--ink);padding:9px 11px;margin-bottom:9px;}
+      .mrow .av{width:42px;height:42px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream);display:flex;align-items:center;justify-content:center;flex:none;}
+      .mrow .av .mono{font-family:var(--font-display);font-weight:900;font-size:15px;color:var(--jersey-deep);}
+      .mrow .av .ph{width:100%;height:100%;background:repeating-linear-gradient(45deg,#d7d0bb 0 7px,#c8c1aa 7px 14px);filter:sepia(.3) saturate(.8);}
+      .mrow .who{flex:1;line-height:1.15;}
+      .mrow .who .nm{font-family:var(--font-display);font-weight:600;font-size:15px;}
+      .mrow .who .pf{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--jersey-deep);text-decoration:underline;text-underline-offset:2px;}
+      .mrow .acts{display:flex;gap:6px;}
+      .mrow .acts a{font-family:var(--font-mono);font-size:11px;border:1.5px solid var(--ink);width:30px;height:30px;display:flex;align-items:center;justify-content:center;background:var(--cream);box-shadow:1px 1px 0 0 var(--ink);}
+      .helps{margin-top:14px;}
+      .helps .chips{display:flex;gap:7px;flex-wrap:wrap;}
+      .helps .chips .h{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;border:1.5px solid var(--jersey-deep);color:var(--jersey-deep);padding:5px 9px;}
+
+      /* A modal */
+      .modal{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:440px;max-height:88%;}
+      /* B side panel */
+      .panel{position:absolute;top:0;right:0;bottom:0;width:380px;border-left:2px solid var(--ink);box-shadow:-6px 0 0 0 rgba(10,10,10,.12);}
+      .panel.detail{box-shadow:-6px 0 18px rgba(10,10,10,.25);}
+      /* C phone */
+      .phone{width:300px;margin:0 auto;height:100%;border:3px solid var(--ink);border-radius:22px;overflow:hidden;position:relative;background:var(--cream-soft);box-shadow:5px 5px 0 0 var(--ink);}
+      .phone .pb{position:absolute;inset:0;padding:10px;opacity:.5;}
+      .phone .pb .h{height:30px;background:var(--jersey-deep-dark);border:1.5px solid var(--ink);margin-bottom:7px;}
+      .phone .pb .g{display:grid;grid-template-columns:1fr 1fr;gap:6px;}
+      .phone .pb .c{height:60px;border:1.5px solid var(--ink);background:var(--cream);}
+      .phone .sheet{position:absolute;left:0;right:0;bottom:0;max-height:84%;border-top:2px solid var(--ink);border-radius:14px 14px 0 0;}
+      .phone .sheet .grab{width:40px;height:4px;background:var(--ink-muted);border-radius:2px;margin:8px auto 2px;}
+
+      .twocol{max-width:1040px;margin:0 auto;display:grid;grid-template-columns:1fr 320px;gap:24px;align-items:start;}
+      .notes h3{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:21px;margin:0 0 8px;}
+      .notes p{font-size:13.5px;line-height:1.55;color:var(--ink-soft);margin:0 0 9px;}
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o5 — MEMBER DETAIL (where the 3rd/4th holder lives)</h1>
+      <p>Click a person/position → this opens. Same content in every option: header (position · afdeling · roleCode), optional description, <b>“De mensen” — every holder listed</b> with per-person contact (✉ ☎) + “volledig profiel →”, then “helpt met” responsibility links. The example below is a <b>3-holder shared position</b>, so you can see exactly how #3 is reached + contacted. Decision = the <b>container</b>.</p>
+    </div>
+
+    <!-- A modal -->
+    <div class="direction-bar"><span class="t">A</span> Paper modal (centre) <span class="note">reskin of today’s MemberDetailsModal · focused, dims the page</span></div>
+    <div class="stage"><div class="twocol">
+      <div class="frame">
+        <div class="pagebehind"><div class="ph-h"></div><div class="ph-grid"><div class="ph-c"></div><div class="ph-c"></div><div class="ph-c"></div><div class="ph-c"></div></div></div>
+        <div class="backdrop"></div>
+        <div class="detail modal">
+          <div class="dh"><span class="x">✕ Esc</span><div class="kick">Jeugdbestuur</div><div class="ttl">Feestcomité</div><div class="meta"><span class="chip">3 personen</span><span class="chip">afdeling</span></div></div>
+          <div class="body">
+            <p class="desc">Organiseert de eetdagen, het kampioenenfeest en de receptie bij thuiswedstrijden.</p>
+            <p class="sub">De mensen — 3</p>
+            <div class="mrow"><span class="av"><span class="mono">EC</span></span><span class="who"><span class="nm">Els Claes</span><br><span class="pf">volledig profiel →</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            <div class="mrow"><span class="av"><span class="ph"></span></span><span class="who"><span class="nm">Nina Bral</span><br><span class="pf">volledig profiel →</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            <div class="mrow" style="box-shadow:2px 2px 0 0 var(--jersey-deep);border-color:var(--jersey-deep);"><span class="av"><span class="mono">WV</span></span><span class="who"><span class="nm">Wout Verlinden</span> <span style="font-family:var(--font-mono);font-size:8px;color:var(--brick);text-transform:uppercase;">← #3</span><br><span class="pf">volledig profiel →</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            <div class="helps"><p class="sub">Helpt met</p><div class="chips"><span class="h">Een evenement aanvragen</span><span class="h">Sponsoring eetdag</span></div></div>
+          </div>
+        </div>
+      </div>
+      <div class="notes"><h3>Focused, familiar.</h3><p>Centre modal over a dimmed page — the cheapest (reskin the existing modal). Commands full attention; fine on mobile too. But it covers the directory/explorer behind, so browsing person→person means open/close/open.</p></div>
+    </div></div>
+
+    <!-- B side panel -->
+    <div class="direction-bar rec"><span class="t">B ★</span> Side panel (slides from right) <span class="note">keeps the directory/explorer visible · best for browsing person→person · sits over the verkenner</span></div>
+    <div class="stage"><div class="twocol">
+      <div class="frame">
+        <div class="pagebehind" style="opacity:.8;"><div class="ph-h"></div><div class="ph-grid" style="grid-template-columns:repeat(3,1fr);"><div class="ph-c"></div><div class="ph-c"></div><div class="ph-c"></div><div class="ph-c"></div><div class="ph-c"></div><div class="ph-c"></div></div></div>
+        <div class="detail panel">
+          <div class="dh"><span class="x">✕</span><div class="kick">Jeugdbestuur</div><div class="ttl">Feestcomité</div><div class="meta"><span class="chip">3 personen</span></div></div>
+          <div class="body">
+            <p class="desc">Organiseert de eetdagen, het kampioenenfeest en de receptie bij thuiswedstrijden.</p>
+            <p class="sub">De mensen — 3</p>
+            <div class="mrow"><span class="av"><span class="mono">EC</span></span><span class="who"><span class="nm">Els Claes</span><br><span class="pf">profiel →</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            <div class="mrow"><span class="av"><span class="ph"></span></span><span class="who"><span class="nm">Nina Bral</span><br><span class="pf">profiel →</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            <div class="mrow" style="border-color:var(--jersey-deep);"><span class="av"><span class="mono">WV</span></span><span class="who"><span class="nm">Wout Verlinden</span> <span style="font-family:var(--font-mono);font-size:8px;color:var(--brick);">← #3</span><br><span class="pf">profiel →</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            <div class="helps"><p class="sub">Helpt met</p><div class="chips"><span class="h">Evenement aanvragen</span></div></div>
+          </div>
+        </div>
+      </div>
+      <div class="notes"><h3>Context stays put.</h3><p>Slides in from the right; the directory/explorer remains visible, so you can click another node and the panel just updates — ideal for the verkenner and for comparing people. On mobile it becomes a full-width sheet (see C). Slightly more build than the modal.</p></div>
+    </div></div>
+
+    <!-- C responsive sheet -->
+    <div class="direction-bar"><span class="t">C</span> Responsive: bottom-sheet (mobile) ↔ side-panel (desktop) <span class="note">mobile-native · same as B on desktop</span></div>
+    <div class="stage"><div class="twocol">
+      <div class="frame" style="background:var(--cream-deep);display:flex;align-items:center;">
+        <div class="phone">
+          <div class="pb"><div class="h"></div><div class="g"><div class="c"></div><div class="c"></div><div class="c"></div><div class="c"></div></div></div>
+          <div class="detail sheet">
+            <div class="grab"></div>
+            <div class="dh" style="padding-top:10px;"><div class="kick">Jeugdbestuur</div><div class="ttl" style="font-size:20px;">Feestcomité</div><div class="meta"><span class="chip">3 personen</span></div></div>
+            <div class="body">
+              <p class="sub">De mensen — 3</p>
+              <div class="mrow" style="padding:7px 9px;"><span class="av" style="width:34px;height:34px;"><span class="mono" style="font-size:12px;">EC</span></span><span class="who"><span class="nm" style="font-size:13px;">Els Claes</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+              <div class="mrow" style="padding:7px 9px;"><span class="av" style="width:34px;height:34px;"><span class="ph"></span></span><span class="who"><span class="nm" style="font-size:13px;">Nina Bral</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+              <div class="mrow" style="padding:7px 9px;border-color:var(--jersey-deep);"><span class="av" style="width:34px;height:34px;"><span class="mono" style="font-size:12px;">WV</span></span><span class="who"><span class="nm" style="font-size:13px;">Wout V. <span style="font-family:var(--font-mono);font-size:7px;color:var(--brick);">#3</span></span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="notes"><h3>Best on a phone.</h3><p>A bottom-sheet you swipe up — the most natural mobile contact card — that becomes B’s right side-panel on desktop. Best-of-both, but the most build (two presentations). Functionally identical content.</p></div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o5 — the member-detail container</h3>
+      <p>
+        Every option lists <b>all holders</b> (that’s how you reach #3/#4 — and contact them). <b>A</b> centre modal
+        (cheap, focused, covers context). <b>B ★</b> right side-panel (keeps the directory/explorer visible, updates as
+        you click around — great over the verkenner; full-width sheet on mobile). <b>C</b> responsive bottom-sheet ↔
+        side-panel (most mobile-native, most build).
+      </p>
+      <p style="color:var(--ink-muted);">
+        Content is data-bound: position · afdeling · optional roleCode · optional description · per-holder
+        photo/monogram + email/phone (only if present) + “volledig profiel →” (only if psdId) · “helpt met” →
+        links into Hulp. Single-holder = same panel without the list framing. B and C share the desktop presentation,
+        so the real fork is “modal vs panel”, then “do we also build the mobile bottom-sheet”.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o5-member-detail-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o5-member-detail-locked.md
@@ -19,6 +19,10 @@ verkenner and for browsing person→person). On mobile it becomes a **full-width
 - **Single holder (common):** click → that person's panel directly.
 - **Shared (2+):** click → lands on the **first holder**, with a **name-tab switcher** at the top listing
   all holders → flip to #2/#3/#4. Always lands on a real, contactable person.
+- **Vacant (0 holders) — carve-out:** a vacant node has **no person**, so the panel opens in a **vacant
+  state**: position title (afdeling/functie) + "deze plek is vrij" + the 7o4 **recruit CTA**
+  ("Iets voor jou? →"); **no** contact actions, **no** holder-switcher, **no** "Volledig profiel". This is
+  the explicit exception to "always lands on a contactable person" (`members.length === 0`).
 
 ## Content spec (data-bound — see `7o5-member-detail-v2-compare.html`)
 
@@ -39,11 +43,18 @@ not in the panel.
 
 - Opens from a **directory card** OR an **explorer leaf**; same panel, same content.
 - Right side-panel on desktop; **full-width bottom sheet** under the mobile breakpoint.
-- Close via ✕ / backdrop / **Esc**; focus trap while open; returns focus to the trigger.
-- Labelled dialog: `aria-label="Contactgegevens — {name}"` (distinct from the verkenner dialog).
-- Deep-link preserved: `?memberId=` opens the panel on load (existing behaviour).
-- **Analytics:** `organigram_member_clicked { member_id (hashed via hashMemberId), view }` — unchanged
-  event; fires on open. Switching holders in a shared panel re-fires with the new (hashed) id.
+- Close via ✕ / backdrop / **Esc**; focus trap while open; returns focus to the trigger. _(For an
+  **explorer**-launched panel, focus-return to the explorer node follows the `7o3` explorer keyboard spec.)_
+- Labelled dialog: `aria-label="Contactgegevens — {name}"` (distinct from the verkenner dialog). For a
+  **shared** position the `{name}` **updates to the current holder** on switch, so the announced context
+  stays correct.
+- **Holder-switcher a11y:** render as real controls — a button-based `role="tablist"`/`tab` (or a radio
+  group), not static spans — with `aria-selected` on the active holder.
+- Deep-link: `?memberId=` opens the panel on load; for a **shared** position it reflects the **currently
+  selected holder** and is **updated silently** (`updateUrlSilently` — no history push) when switching.
+- **Analytics:** `organigram_member_clicked { member_id (hashed via hashMemberId), view }` — **existing
+  event family, extended behaviour**: fires on panel open **and again on each holder-switch** (vs the prior
+  single-fire in `handleMemberClick`).
 
 ## Consolidation
 
@@ -54,7 +65,7 @@ person-first surface for every entry point (directory + explorer). The old cente
 
 - **7o6:** the Hulp finder that the "Helpt met" chips link into; exact `primaryContact`→position
   matching for "Helpt met".
-- **7o7:** the mobile breakpoint value; whether the panel also exposes the vacant-recruit CTA.
+- **7o7:** the mobile breakpoint value. _(The vacant-node carve-out + recruit CTA is resolved above.)_
 
 ## Rejected
 

--- a/docs/design/mockups/phase-7-organigram/7o5-member-detail-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o5-member-detail-locked.md
@@ -50,7 +50,7 @@ not in the panel.
   stays correct.
 - **Holder-switcher a11y:** render as real controls — a button-based `role="tablist"`/`tab` (or a radio
   group), not static spans — with `aria-selected` on the active holder.
-- Deep-link: `?memberId=` opens the panel on load; for a **shared** position it reflects the **currently
+- Deep-link: `?member=` opens the panel on load; for a **shared** position it reflects the **currently
   selected holder** and is **updated silently** (`updateUrlSilently` — no history push) when switching.
 - **Analytics:** `organigram_member_clicked { member_id (hashed via hashMemberId), view }` — **existing
   event family, extended behaviour**: fires on panel open **and again on each holder-switch** (vs the prior

--- a/docs/design/mockups/phase-7-organigram/7o5-member-detail-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o5-member-detail-locked.md
@@ -1,0 +1,65 @@
+# Phase 7 · `/club/organigram` — Round 5 (MEMBER DETAIL) — LOCKED
+
+**Date:** 2026-06-08
+**Mockups:** `7o5-member-detail-v2-compare.html` (person-first content + container options).
+The first pass `7o5-member-detail-compare.html` (position-summary model) is **superseded** — kept only as
+history.
+**Owner:** @climacon
+**Tracker:** #1529 · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision
+
+**Person-first contact detail, in a right side-panel (B).**
+
+Clicking a node opens a **person's contact** — not a function summary (owner correction, 2026-06-08:
+*"I expected click to open the contact person immediately"*). It slides in from the right so the
+directory/explorer stays visible and the panel just **updates as you click around** (ideal over the
+verkenner and for browsing person→person). On mobile it becomes a **full-width bottom sheet**.
+
+- **Single holder (common):** click → that person's panel directly.
+- **Shared (2+):** click → lands on the **first holder**, with a **name-tab switcher** at the top listing
+  all holders → flip to #2/#3/#4. Always lands on a real, contactable person.
+
+## Content spec (data-bound — see `7o5-member-detail-v2-compare.html`)
+
+```text
+header     afdeling · functie (kicker) · person photo/monogram · name (italic display) · roleCode pill (if present)
+actions    ✉ Mail · ☎ Bel   — render only when email/phone exist on that staffMember
+helpt met  responsibility chips → deep-link into the Hulp section/finder (the responsibilities whose
+           primaryContact resolves to THIS position); auto-hides when none
+profiel    "Volledig profiel →" → /staf/{psdId}   — only when psdId exists
+shared     holder-switcher (avatar + first-name tabs) above the header; lands on holder #1
+single     no switcher
+```
+
+Nothing richer than this — `staffMember.bio`/`birthDate`/`joinDate` stay on the `/staf/{psdId}` profile,
+not in the panel.
+
+## Behaviour / a11y
+
+- Opens from a **directory card** OR an **explorer leaf**; same panel, same content.
+- Right side-panel on desktop; **full-width bottom sheet** under the mobile breakpoint.
+- Close via ✕ / backdrop / **Esc**; focus trap while open; returns focus to the trigger.
+- Labelled dialog: `aria-label="Contactgegevens — {name}"` (distinct from the verkenner dialog).
+- Deep-link preserved: `?memberId=` opens the panel on load (existing behaviour).
+- **Analytics:** `organigram_member_clicked { member_id (hashed via hashMemberId), view }` — unchanged
+  event; fires on open. Switching holders in a shared panel re-fires with the new (hashed) id.
+
+## Consolidation
+
+`<MemberDetailPanel>` (new) **replaces both `<MemberDetailsModal>` and `<ContactOverlay>`** — one
+person-first surface for every entry point (directory + explorer). The old center-modal is retired.
+
+## Defers
+
+- **7o6:** the Hulp finder that the "Helpt met" chips link into; exact `primaryContact`→position
+  matching for "Helpt met".
+- **7o7:** the mobile breakpoint value; whether the panel also exposes the vacant-recruit CTA.
+
+## Rejected
+
+- **A center modal** — covers the directory/explorer; person→person browsing is open/close/open.
+- **C dedicated responsive bottom-sheet** — best mobile, but two presentations to build; B already
+  degrades to a full-width sheet on mobile for far less cost.
+- **Position-summary detail** (first pass) — owner wants person-first; the summary-then-list step was
+  wrong for the common single-holder case.

--- a/docs/design/mockups/phase-7-organigram/7o5-member-detail-v2-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o5-member-detail-v2-compare.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o5 v2 — person-first detail</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .sec-bar{background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;border-top:2px solid var(--ink);border-bottom:2px solid var(--ink);}
+      .stage{padding:26px 28px 30px;}
+      .row{max-width:1040px;margin:0 auto;display:flex;gap:26px;flex-wrap:wrap;align-items:flex-start;}
+
+      /* ---- the person-first detail card ---- */
+      .detail{width:360px;border:2px solid var(--ink);background:var(--cream);box-shadow:5px 5px 0 0 var(--ink);}
+      .dh{background:var(--jersey-deep-dark);color:var(--cream);padding:15px 16px;position:relative;}
+      .dh .x{position:absolute;top:11px;right:12px;font-family:var(--font-mono);font-size:11px;color:var(--cream);border:1.5px solid rgba(245,241,230,.5);padding:3px 7px;}
+      .dh .kick{font-family:var(--font-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--warm);}
+      .dh .person{display:flex;align-items:center;gap:12px;margin-top:9px;}
+      .dh .av{width:54px;height:54px;border-radius:9999px;border:2px solid var(--ink);overflow:hidden;background:var(--cream-soft);display:flex;align-items:center;justify-content:center;flex:none;}
+      .dh .av .mono{font-family:var(--font-display);font-weight:900;font-size:20px;color:var(--jersey-deep);}
+      .dh .av .ph{width:100%;height:100%;background:repeating-linear-gradient(45deg,#d7d0bb 0 7px,#c8c1aa 7px 14px);filter:sepia(.3) saturate(.8);}
+      .dh .nm{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:23px;line-height:1;}
+      .dh .role{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:rgba(245,241,230,.85);margin-top:4px;}
+      .dh .rolepill{display:inline-block;background:var(--warm);color:var(--ink);border:1.5px solid var(--ink);font-family:var(--font-mono);font-size:8px;font-weight:600;text-transform:uppercase;padding:1px 5px;margin-left:4px;}
+      .db{padding:15px 16px;}
+      .acts{display:flex;gap:9px;margin-bottom:14px;}
+      .acts a{flex:1;display:flex;align-items:center;justify-content:center;gap:7px;font-family:var(--font-mono);font-size:12px;border:2px solid var(--ink);padding:10px;background:var(--cream-soft);box-shadow:2px 2px 0 0 var(--ink);}
+      .sub{font-family:var(--font-mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-muted);margin:0 0 8px;}
+      .helps{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:14px;}
+      .helps .h{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;border:1.5px solid var(--jersey-deep);color:var(--jersey-deep);padding:5px 8px;}
+      .profile{font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--ink);border:2px solid var(--ink);padding:9px 12px;display:inline-block;box-shadow:2px 2px 0 0 var(--ink);background:var(--cream);}
+
+      /* shared: holder switcher */
+      .switch{background:var(--cream-deep);border-bottom:2px solid var(--ink);padding:9px 12px;}
+      .switch .lab{font-family:var(--font-mono);font-size:9px;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-muted);margin-bottom:7px;}
+      .switch .tabs{display:flex;gap:6px;flex-wrap:wrap;}
+      .switch .tab{display:flex;align-items:center;gap:6px;border:1.5px solid var(--ink);background:var(--cream);padding:4px 8px 4px 4px;font-family:var(--font-body);font-size:12px;cursor:pointer;}
+      .switch .tab .ta{width:22px;height:22px;border-radius:9999px;border:1.5px solid var(--ink);display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-weight:900;font-size:10px;color:var(--jersey-deep);background:var(--cream-soft);}
+      .switch .tab.on{background:var(--jersey-deep);color:var(--cream);box-shadow:2px 2px 0 0 var(--ink);}
+      .switch .tab.on .ta{background:var(--cream);}
+      .tagn{font-family:var(--font-mono);font-size:7px;color:var(--brick);text-transform:uppercase;margin-left:2px;}
+
+      .cap{font-family:var(--font-mono);font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--jersey-deep);margin-top:10px;}
+      .cap b{color:var(--ink);}
+
+      /* placement diagrams */
+      .opt{flex:1;min-width:260px;}
+      .opt .t{font-family:var(--font-mono);font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;background:var(--warm);border:1.5px solid var(--ink);padding:2px 8px;display:inline-block;margin-bottom:10px;}
+      .opt .t.rec{background:var(--jersey);}
+      .diag{width:200px;height:128px;border:2px solid var(--ink);background:var(--cream-soft);position:relative;overflow:hidden;box-shadow:3px 3px 0 0 var(--ink);}
+      .diag .pg{position:absolute;inset:6px;background:repeating-linear-gradient(0deg,var(--cream) 0 10px,var(--cream-deep) 10px 12px);opacity:.5;}
+      .diag .slot{position:absolute;background:var(--jersey-deep-dark);border:1.5px solid var(--ink);}
+      .diag.modal .slot{top:18px;bottom:18px;left:50%;width:96px;margin-left:-48px;}
+      .diag.modal::after{content:"";position:absolute;inset:0;background:rgba(10,10,10,.28);}
+      .diag.panel .slot{top:0;bottom:0;right:0;width:78px;}
+      .diag.sheet{width:118px;height:160px;border-radius:14px;}
+      .diag.sheet .slot{left:0;right:0;bottom:0;height:96px;border-radius:10px 10px 0 0;}
+      .opt p{font-size:13px;line-height:1.5;color:var(--ink-soft);margin:12px 0 0;max-width:42ch;}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o5 v2 — PERSON-FIRST DETAIL</h1>
+      <p>Corrected model: clicking a node opens a <b>person’s contact</b>, not a function summary. <b>Single holder → that person directly.</b> <b>Shared → the first holder + a name-tab switcher</b> to flip to co-holders (that’s how you reach #3). No hover anywhere. First pick the content (single vs shared), then the container.</p>
+    </div>
+
+    <!-- CONTENT -->
+    <div class="sec-bar">THE CONTENT · person-first (data-bound)</div>
+    <div class="stage"><div class="row">
+      <div>
+        <div class="detail">
+          <div class="dh"><span class="x">✕</span><div class="kick">Hoofdbestuur</div>
+            <div class="person"><span class="av"><span class="mono">LB</span></span>
+              <div><div class="nm">Luc Boons</div><div class="role">Voorzitter <span class="rolepill">VZ</span></div></div>
+            </div>
+          </div>
+          <div class="db">
+            <div class="acts"><a>✉ Mail</a><a>☎ Bel</a></div>
+            <p class="sub">Helpt met</p>
+            <div class="helps"><span class="h">Lid worden</span><span class="h">Algemene vragen</span></div>
+            <a class="profile">Volledig profiel →</a>
+          </div>
+        </div>
+        <div class="cap"><b>SINGLE</b> · opens immediately on click</div>
+      </div>
+
+      <div>
+        <div class="detail">
+          <div class="switch">
+            <div class="lab">Gedeelde functie · 3 personen — kies wie:</div>
+            <div class="tabs">
+              <span class="tab"><span class="ta">EC</span>Els</span>
+              <span class="tab"><span class="ta">NB</span>Nina</span>
+              <span class="tab on"><span class="ta">WV</span>Wout <span class="tagn">#3</span></span>
+            </div>
+          </div>
+          <div class="dh" style="padding-top:13px;"><span class="x">✕</span><div class="kick">Jeugdbestuur · Feestcomité</div>
+            <div class="person"><span class="av"><span class="mono">WV</span></span>
+              <div><div class="nm">Wout Verlinden</div><div class="role">Feestcomité</div></div>
+            </div>
+          </div>
+          <div class="db">
+            <div class="acts"><a>✉ Mail</a><a>☎ Bel</a></div>
+            <p class="sub">Helpt met</p>
+            <div class="helps"><span class="h">Evenement aanvragen</span></div>
+            <a class="profile">Volledig profiel →</a>
+          </div>
+        </div>
+        <div class="cap"><b>SHARED</b> · lands on first holder · tabs flip to #2/#3</div>
+      </div>
+    </div></div>
+
+    <!-- CONTAINER -->
+    <div class="sec-bar">THE CONTAINER · where it appears (decision)</div>
+    <div class="stage"><div class="row">
+      <div class="opt">
+        <span class="t">A · Modal</span>
+        <div class="diag modal"><div class="pg"></div><div class="slot"></div></div>
+        <p>Centre, dims the page (reskin of today’s MemberDetailsModal). Cheapest, focused — but covers the directory/explorer, so browsing person→person is open/close/open.</p>
+      </div>
+      <div class="opt">
+        <span class="t rec">B ★ · Side panel</span>
+        <div class="diag panel"><div class="pg"></div><div class="slot"></div></div>
+        <p>Slides from the right; the directory/explorer stays visible and the panel just updates as you click around — great over the verkenner. Becomes a full-width sheet on mobile. A bit more build than the modal.</p>
+      </div>
+      <div class="opt">
+        <span class="t">C · Responsive sheet</span>
+        <div class="diag sheet"><div class="pg"></div><div class="slot"></div></div>
+        <p>Dedicated bottom-sheet on mobile (swipe up) ↔ B’s side-panel on desktop. Most mobile-native; most build (two presentations).</p>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o5 — the member-detail container (content is now person-first + fixed)</h3>
+      <p>
+        Content: header (afdeling/functie · name · roleCode) · <b>✉ Mail / ☎ Bel</b> quick actions (only if present) ·
+        “Helpt met” → Hulp · “Volledig profiel →” (only if psdId). Shared adds the name-tab switcher. <b>A</b> modal
+        (cheap, covers context) · <b>B ★</b> side-panel (context-preserving, updates as you click, full-width sheet on
+        mobile) · <b>C</b> dedicated responsive bottom-sheet (most mobile-native, most build).
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o6-finder-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o6-finder-locked.md
@@ -1,0 +1,65 @@
+# Phase 7 · `/hulp` hub — Round 6 (HULP FINDER) — LOCKED
+
+**Date:** 2026-06-08
+**Mockups:** `7o6-finder-reskin-compare.html` (answer disclosure) · `7o6b-finder-initial-state-compare.html`
+(“Alles” at scale). Supersedes the `7o6` *bridge* decision (`7o6-hulp-bridge-compare.html`) — the hub
+makes Hulp a first-class half, not a teaser. Reskins the existing `<HulpPage>`.
+**Owner:** @climacon
+**Tracker:** #1529 (fused Phase 7+8) · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision
+
+The **Hulp half** of the hub is the existing `<HulpPage>` finder, **reskinned** to the fanzine vocabulary:
+
+- **One unified search above the browse.** The hub's single hero search **repeats in the sticky nav**, so
+  it sits right above the Hulp browse when scrolled. It returns **people + answers** (the same unified
+  search). The finder's old `HulpSearchInput` is **folded into it** — no separate finder search, no second
+  behaviour. (Confirms the 7o2c "one search" thesis.)
+- **Browse = category-led**, with the hero **audience chips** (`ouder`/`speler`/`trainer`/`supporter`) as a
+  filter and **category chips** (`Medisch`/`Sportief`/`Administratief`/`Gedrag`/`Algemeen`/`Commercieel`,
+  **Phosphor Fill** icons) for switching.
+- **"Alles" landing = capped category preview (A).** Each category shows its **top 3** questions + an
+  **"Alle N →"** affordance; selecting a category chip filters to that category's full list. Caps the
+  initial render no matter how the corpus grows; reuses the Structuur "Toon alle 23 →" pattern. "Top 3"
+  ordering uses existing declaration/`sortOrder`/alphabetical — **no fabricated "most asked"** (no
+  popularity data).
+- **Answer disclosure = inline accordion (A).** Click a question → it expands in place to **summary +
+  numbered steps + contact**. Matches master §6.11 ("FAQ accordions in TapedCard"), keeps the browse
+  context, and keeps all answers in the DOM for the FAQ rich-results JSON-LD.
+- **Contact reuses the locked person vocabulary** — monogram/photo · name · function · ✉/☎ (only if
+  present) — and a **"toon in structuur →"** cross-link that opens that node in the explorer + the person
+  panel (Structuur ⇄ Hulp). `team-role` / `manual` / `position` contact resolution
+  (`team-role-resolution.ts`, `resolveContact.ts`) is preserved unchanged.
+
+## Locked Hulp-half spine
+
+```text
+#hulp  — <HulpFinder> (reskinned <HulpPage>)
+├─ (unified search lives in hero + sticky bar, above this section)
+├─ audience filter chips  (from the hero) + category chips
+├─ "Alles" → capped category preview: per category → top 3 <QuestionCard> + "Alle N →"
+│            category chip → that category's full accordion list
+├─ <QuestionCard> → inline accordion → summary · numbered <steps> · <ContactCard>
+└─ <ContactCard> → person vocab + ✉/☎ + "toon in structuur →" (deep-link into <OrganigramExplorer>)
+```
+
+## Reskinned components (from `apps/web/src/components/hulp/HulpPage/`)
+
+`HulpPage` → hub `<HulpFinder>` · `BrowseContent`/`CategorySection` → capped category preview · `QuestionCard`
+→ accordion card · `AnswerCard` → accordion body (summary + steps) · `ContactCard` → person vocab + structuur
+cross-link · `HulpSearchInput` → **retired** (unified search) · `resolveContact`/`categoryMeta` → kept.
+
+## Defers to 7o7
+
+- Whether the hub also carries the master §6.11 **general contact form + address/hours** (`Driesstraat 32`
+  + openingsuren) below the finder.
+- Section order in the hub (finder-first vs structure-first) + the unified-search sticky behaviour.
+- FAQ JSON-LD ownership on the hub; analytics (`responsibility_*` events preserved/renamed).
+
+## Superseded / rejected
+
+- **7o6 bridge ("teaser → /hulp")** — obsolete after the hub merge.
+- **7o6 answer = side-panel (B)** — list + answer compete for width; answers not in initial DOM (weaker FAQ
+  SEO). The person panel stays the idiom for *people*, the accordion for *answers*.
+- **7o6b category-accordion (B) / search-led (C)** — B buries every question two clicks deep; C shows
+  nothing to scan on load. Capped preview is browsable **and** scales.

--- a/docs/design/mockups/phase-7-organigram/7o6-finder-reskin-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o6-finder-reskin-compare.html
@@ -145,7 +145,7 @@
       <p style="color:var(--ink-muted);">
         Either way: <b>contact reuses the locked person vocabulary</b> (monogram/photo · name · ✉/☎ · “toon in
         structuur →” cross-links into the explorer, opening that node + the person panel). Browse stays category-led with
-        the hero audience chips as a filter. Deep-link `/hulp#<slug>` per answer regardless.
+        the hero audience chips as a filter. Deep-link `/hulp#&lt;slug&gt;` per answer regardless.
       </p>
     </div>
   </body>

--- a/docs/design/mockups/phase-7-organigram/7o6-finder-reskin-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o6-finder-reskin-compare.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · /hulp hub · 7o6: Hulp finder reskin (answer disclosure)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .bar{background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;border-bottom:2px solid var(--ink);}
+      .bar.rec .tg{background:var(--jersey);} .bar .tg{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);margin-right:10px;}
+      .bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:24px 28px 30px;border-bottom:1px dashed var(--paper-edge);}
+      .wrap{max-width:920px;margin:0 auto;}
+      .kicker{font-family:var(--font-mono);font-size:12px;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:var(--jersey-deep);}
+      .h2{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:30px;margin:8px 0 0;}
+      .dot{color:var(--jersey-deep);}
+      .catbar{display:flex;gap:7px;flex-wrap:wrap;margin:16px 0;}
+      .catbar .c{font-family:var(--font-mono);font-size:11px;letter-spacing:.04em;text-transform:uppercase;border:1.5px solid var(--ink);padding:6px 11px;background:var(--cream);box-shadow:2px 2px 0 0 var(--ink);}
+      .catbar .c.on{background:var(--jersey-deep);color:var(--cream);}
+      .catlabel{font-family:var(--font-mono);font-size:12px;font-weight:600;letter-spacing:.14em;text-transform:uppercase;border-bottom:2px solid var(--jersey-deep);padding-bottom:3px;display:inline-block;margin:16px 0 12px;}
+
+      /* question card */
+      .q{border:2px solid var(--ink);background:var(--cream);box-shadow:3px 3px 0 0 var(--ink);margin-bottom:10px;}
+      .q .qhead{display:flex;align-items:center;gap:12px;padding:14px 16px;cursor:pointer;}
+      .q .qhead .ic{font-family:var(--font-mono);color:var(--jersey-deep);font-size:18px;width:24px;text-align:center;}
+      .q .qhead .qt{flex:1;font-family:var(--font-display);font-style:italic;font-weight:600;font-size:17px;}
+      .q .qhead .cat{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--ink-muted);}
+      .q .qhead .chev{font-family:var(--font-mono);color:var(--ink-muted);}
+      .q.open .qhead .chev{color:var(--jersey-deep);}
+      .q .ans{border-top:2px dashed var(--paper-edge);padding:14px 16px;display:none;}
+      .q.open .ans{display:block;}
+      .q .ans .sum{font-size:14px;color:var(--ink-soft);line-height:1.55;margin:0 0 12px;}
+      .steps{counter-reset:s;margin:0 0 14px;padding:0;list-style:none;}
+      .steps li{counter-increment:s;position:relative;padding:6px 0 6px 30px;font-size:13px;line-height:1.5;border-bottom:1px dotted var(--paper-edge);}
+      .steps li::before{content:counter(s);position:absolute;left:0;top:6px;width:20px;height:20px;background:var(--jersey-deep);color:var(--cream);font-family:var(--font-mono);font-size:10px;display:flex;align-items:center;justify-content:center;border:1.5px solid var(--ink);}
+      .contact{display:flex;align-items:center;gap:11px;border:2px solid var(--ink);background:var(--cream-soft);box-shadow:2px 2px 0 0 var(--ink);padding:9px 12px;}
+      .contact .av{width:38px;height:38px;border-radius:9999px;border:2px solid var(--ink);background:var(--cream);display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-weight:900;font-size:13px;color:var(--jersey-deep);flex:none;}
+      .contact .who{flex:1;line-height:1.2;}
+      .contact .who .nm{font-family:var(--font-display);font-weight:600;font-size:14px;}
+      .contact .who .fn{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--jersey-deep);}
+      .contact .acts{display:flex;gap:6px;}
+      .contact .acts a{font-family:var(--font-mono);font-size:11px;border:1.5px solid var(--ink);width:30px;height:30px;display:flex;align-items:center;justify-content:center;background:var(--cream);box-shadow:1px 1px 0 0 var(--ink);}
+      .struct-link{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--jersey-deep);border:1.5px solid var(--jersey-deep);padding:4px 7px;}
+
+      /* B panel variant mini */
+      .splitB{display:grid;grid-template-columns:1fr 320px;gap:16px;align-items:start;}
+      .qlistB .q{cursor:pointer;} .qlistB .q.sel{box-shadow:0 0 0 3px var(--warm),3px 3px 0 0 var(--ink);}
+      .panelB{border:2px solid var(--ink);background:var(--cream);box-shadow:-5px 5px 0 0 rgba(10,10,10,.15);}
+      .panelB .ph{background:var(--jersey-deep-dark);color:var(--cream);padding:13px 15px;}
+      .panelB .ph .k{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;color:var(--warm);}
+      .panelB .ph .t{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:19px;margin-top:4px;}
+      .panelB .pb{padding:14px 15px;}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /hulp hub · 7o6 — HULP FINDER RESKIN (the Hulp half)</h1>
+      <p>Reskin the existing <code>&lt;HulpPage&gt;</code> finder (search · category browse · answer · contact) into the hub’s fanzine vocabulary. IA is already good — the real fork is <b>how an answer reveals</b>. Browse stays <b>category-led</b> (icons = Phosphor Fill) with the hero’s audience chips as a filter. Contact reuses the locked person vocabulary; “toon in structuur” cross-links into the explorer.</p>
+    </div>
+
+    <!-- A accordion -->
+    <div class="bar rec"><span class="tg">A ★</span>Inline accordion <span class="note">· master §6.11 “FAQ accordions in TapedCard” · stay in the list · best for SEO/FAQ</span></div>
+    <div class="stage"><div class="wrap">
+      <span class="kicker">Hulp · vind het juiste antwoord</span>
+      <div class="h2">Wie kan me helpen<span class="dot">?</span></div>
+      <div class="catbar"><span class="c on">Alles</span><span class="c">Medisch</span><span class="c">Sportief</span><span class="c">Administratief</span><span class="c">Gedrag</span><span class="c">Commercieel</span></div>
+
+      <span class="catlabel">Administratief</span>
+      <div class="q open">
+        <div class="qhead"><span class="ic">▤</span><span class="qt">Hoe schrijf ik mijn kind in?</span><span class="chev">−</span></div>
+        <div class="ans">
+          <p class="sum">Inschrijven kan het hele seizoen door. De jeugdsecretaris helpt je met formulieren, lidgeld en de juiste ploeg.</p>
+          <ol class="steps">
+            <li>Mail of bel de jeugdsecretaris voor een afspraak.</li>
+            <li>Vul het inschrijvingsformulier in (online of op de club).</li>
+            <li>Betaal het lidgeld — je kind is verzekerd zodra dit in orde is.</li>
+          </ol>
+          <div class="contact"><span class="av">KW</span><span class="who"><span class="nm">Karen Wouters</span><span class="fn">Jeugdsecretaris</span></span><span class="struct-link">toon in structuur →</span><span class="acts"><a>✉</a><a>☎</a></span></div>
+        </div>
+      </div>
+      <div class="q">
+        <div class="qhead"><span class="ic">▤</span><span class="qt">Wat kost een lidmaatschap?</span><span class="chev">+</span></div>
+      </div>
+
+      <span class="catlabel">Medisch</span>
+      <div class="q">
+        <div class="qhead"><span class="ic">✚</span><span class="qt">Mijn zoon is geblesseerd — wat nu?</span><span class="chev">+</span></div>
+      </div>
+    </div></div>
+
+    <!-- B panel -->
+    <div class="bar"><span class="tg">B</span>Answer in a side-panel <span class="note">· same panel idiom as the person detail (7o5) · hub consistency</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="splitB">
+        <div class="qlistB">
+          <span class="catlabel">Administratief</span>
+          <div class="q sel"><div class="qhead"><span class="ic">▤</span><span class="qt">Hoe schrijf ik mijn kind in?</span><span class="chev">→</span></div></div>
+          <div class="q"><div class="qhead"><span class="ic">▤</span><span class="qt">Wat kost een lidmaatschap?</span><span class="chev">→</span></div></div>
+          <span class="catlabel">Medisch</span>
+          <div class="q"><div class="qhead"><span class="ic">✚</span><span class="qt">Mijn zoon is geblesseerd?</span><span class="chev">→</span></div></div>
+        </div>
+        <div class="panelB">
+          <div class="ph"><div class="k">Administratief</div><div class="t">Hoe schrijf ik mijn kind in?</div></div>
+          <div class="pb">
+            <p style="font-size:13px;color:var(--ink-soft);line-height:1.5;margin:0 0 12px;">Inschrijven kan het hele seizoen door…</p>
+            <ol class="steps"><li>Mail of bel de jeugdsecretaris.</li><li>Vul het formulier in.</li><li>Betaal het lidgeld.</li></ol>
+            <div class="contact"><span class="av">KW</span><span class="who"><span class="nm">Karen Wouters</span><span class="fn">Jeugdsecretaris</span></span><span class="acts"><a>✉</a><a>☎</a></span></div>
+          </div>
+        </div>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o6 — answer disclosure (finder reskin)</h3>
+      <p>
+        <b>A ★ accordion</b> — click a question, it expands in place to summary + numbered steps + contact. Matches
+        master §6.11 (“FAQ accordions in TapedCard”), keeps you in the browsing list, and all answers sit in the DOM
+        (good for the FAQ rich-results JSON-LD). <b>B panel</b> — the answer opens in a right side-panel, identical idiom
+        to the 7o5 person panel (hub consistency) — but the question list and the answer compete for width, and answers
+        aren’t in the initial DOM.
+      </p>
+      <p style="color:var(--ink-muted);">
+        Either way: <b>contact reuses the locked person vocabulary</b> (monogram/photo · name · ✉/☎ · “toon in
+        structuur →” cross-links into the explorer, opening that node + the person panel). Browse stays category-led with
+        the hero audience chips as a filter. Deep-link `/hulp#<slug>` per answer regardless.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o6-hulp-bridge-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o6-hulp-bridge-compare.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · organigram · 7o6: HULP section = bridge to /hulp</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .bar{background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;border-bottom:2px solid var(--ink);}
+      .bar.rec .tg{background:var(--jersey);} .bar .tg{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);margin-right:10px;}
+      .bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:24px 28px 30px;border-bottom:1px dashed var(--paper-edge);}
+      .wrap{max-width:1000px;margin:0 auto;}
+      .kicker{font-family:var(--font-mono);font-size:12px;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:var(--jersey-deep);}
+      .h2{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:30px;margin:8px 0 0;}
+      .dot{color:var(--jersey-deep);}
+
+      /* B richer teaser */
+      .chips{display:flex;gap:8px;flex-wrap:wrap;margin:14px 0;}
+      .chip{font-family:var(--font-mono);font-size:11px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;border:1.5px solid var(--ink);background:var(--cream);padding:7px 11px;box-shadow:2px 2px 0 0 var(--ink);}
+      .cats{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin:14px 0;}
+      .cat{border:2px solid var(--ink);background:var(--cream-soft);box-shadow:3px 3px 0 0 var(--ink);padding:13px;}
+      .cat .ic{font-family:var(--font-mono);color:var(--jersey-deep);font-size:18px;}
+      .cat .t{font-family:var(--font-display);font-weight:600;font-size:15px;margin-top:5px;}
+      .cat .s{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;color:var(--ink-muted);margin-top:3px;}
+      .toall{display:inline-flex;align-items:center;gap:8px;font-family:var(--font-mono);font-size:12px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;border:2px solid var(--ink);background:var(--warm);color:var(--ink);padding:11px 16px;box-shadow:4px 4px 0 0 var(--ink);margin-top:6px;}
+
+      /* A minimal band */
+      .band{background:var(--jersey-deep-dark);color:var(--cream);border:2px solid var(--ink);box-shadow:5px 5px 0 0 var(--ink);padding:24px 26px;display:flex;justify-content:space-between;align-items:center;gap:18px;flex-wrap:wrap;}
+      .band h3{font-family:var(--font-display);font-style:italic;font-weight:900;font-size:24px;margin:0;}
+      .band p{margin:5px 0 0;color:rgba(245,241,230,.8);font-size:13px;}
+      .band .go{font-family:var(--font-mono);font-weight:700;font-size:12px;letter-spacing:.05em;text-transform:uppercase;border:2px solid var(--ink);background:var(--warm);color:var(--ink);padding:12px 18px;box-shadow:4px 4px 0 0 var(--ink);}
+
+      /* C none */
+      .none{border:2px dashed var(--paper-edge);padding:20px;text-align:center;color:var(--ink-muted);font-family:var(--font-mono);font-size:12px;line-height:1.7;}
+      .none b{color:var(--jersey-deep);}
+      .heroref{background:var(--jersey-deep-dark);color:var(--cream);border:2px solid var(--ink);padding:14px 16px;margin-top:12px;border-radius:0;}
+      .heroref .hs{display:flex;align-items:center;gap:8px;border:2px solid var(--ink);background:var(--cream);padding:8px 11px;max-width:360px;}
+      .heroref .hs .ph{color:var(--ink-muted);font-size:12px;}
+      .heroref .hc{display:flex;gap:7px;margin-top:9px;flex-wrap:wrap;}
+      .heroref .hc span{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;border:1.5px solid rgba(245,241,230,.5);color:var(--cream);padding:4px 8px;}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /club/organigram · 7o6 — HULP = BRIDGE TO /hulp</h1>
+      <p><b>/hulp is Phase 8</b> (#1530) and already owns the canonical finder (search · browse · answer · contact). So the organigram does <b>not</b> rebuild a finder — its “Hulp” section <b>bridges</b> to /hulp, and the old inline <code>ResponsibilityFinder</code> tab is retired. Question: how much bridge? (Section order 7o2 stays: Structuur → Hulp → Verkenner.)</p>
+    </div>
+
+    <!-- B richer -->
+    <div class="bar rec"><span class="tg">B ★</span>Richer teaser <span class="note">· keeps the “find help” job visible on the page, delegates depth to /hulp</span></div>
+    <div class="stage"><div class="wrap">
+      <span class="kicker">Sectie · vind hulp</span>
+      <div class="h2">Wie kan me helpen<span class="dot">?</span></div>
+      <p style="font-size:14px;color:var(--ink-soft);max-width:60ch;margin:8px 0 0;">Kies waar je vraag over gaat, of wie je bent — je springt naar de juiste vraag &amp; contactpersoon.</p>
+      <div class="chips"><span class="chip">Ik ben ouder</span><span class="chip">Speler</span><span class="chip">Trainer</span><span class="chip">Supporter</span></div>
+      <div class="cats">
+        <div class="cat"><div class="ic">✚</div><div class="t">Medisch</div><div class="s">blessure · verzekering</div></div>
+        <div class="cat"><div class="ic">⚑</div><div class="t">Sportief</div><div class="s">ploeg · training</div></div>
+        <div class="cat"><div class="ic">▤</div><div class="t">Administratief</div><div class="s">lidgeld · inschrijven</div></div>
+      </div>
+      <a class="toall">Alle vragen &amp; contacten → /hulp</a>
+    </div></div>
+
+    <!-- A minimal -->
+    <div class="bar"><span class="tg">A</span>Minimal band <span class="note">· one clean bridge, lowest footprint</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="band">
+        <div><h3>Een vraag, maar niet wie je moet hebben?</h3><p>Onze hulplijn wijst je naar de juiste persoon — per thema of per situatie.</p></div>
+        <a class="go">Naar Hulp →</a>
+      </div>
+    </div></div>
+
+    <!-- C none -->
+    <div class="bar"><span class="tg">C</span>No section <span class="note">· hero handles it; page is pure structure</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="none">
+        Geen aparte Hulp-sectie. De <b>hero</b> doet het werk: de zoekbalk geeft ook antwoorden (→ /hulp) en de doelgroep-chips linken rechtstreeks naar /hulp. De pagina = enkel structuur.
+        <div class="heroref">
+          <div class="hs"><span style="color:var(--jersey-deep)">⌕</span><span class="ph">“lidgeld” of “mijn kind is geblesseerd”…</span></div>
+          <div class="hc"><span>↓ Ik ben ouder → /hulp</span><span>Speler → /hulp</span><span>Trainer → /hulp</span></div>
+        </div>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o6 — the Hulp bridge (all route to /hulp; none rebuild the finder)</h3>
+      <p>
+        <b>B ★</b> richer teaser (audience chips + 3 category tiles + “Alle vragen → /hulp”) — keeps the find-help job
+        visible on the page (the thing you worried was buried), delegates depth to /hulp. <b>A</b> minimal band — one
+        clean CTA to /hulp. <b>C</b> no section — the hero’s search + chips already bridge to /hulp; page stays pure
+        structure.
+      </p>
+      <p style="color:var(--ink-muted);">
+        Knock-on (confirm): the <b>semantic/AI search</b> investigated in 7o2b is really the <b>finder’s</b> job →
+        it belongs with <b>/hulp in Phase 8</b>, not this PR. The organigram <b>hero search</b> stays: people (name /
+        function → person panel) + question-hits that <b>link out to /hulp</b>. The old <code>ResponsibilityFinder</code>
+        is retired from the organigram either way.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o6b-finder-initial-state-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o6b-finder-initial-state-compare.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · /hulp hub · 7o6b: finder “Alles” initial state at scale</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:94ch;}
+      .head b{color:var(--warm);}
+      .bar{background:var(--jersey-deep);color:var(--cream);padding:11px 28px;font-family:var(--font-mono);font-size:13px;letter-spacing:.05em;text-transform:uppercase;border-bottom:2px solid var(--ink);}
+      .bar.rec .tg{background:var(--jersey);} .bar .tg{background:var(--warm);color:var(--ink);padding:2px 9px;font-weight:700;border:1.5px solid var(--ink);margin-right:10px;}
+      .bar .note{color:#cfeede;text-transform:none;letter-spacing:0;font-size:12px;}
+      .stage{padding:22px 28px 28px;border-bottom:1px dashed var(--paper-edge);}
+      .wrap{max-width:760px;margin:0 auto;}
+      .catbar{display:flex;gap:6px;flex-wrap:wrap;margin:0 0 16px;}
+      .catbar .c{font-family:var(--font-mono);font-size:10px;letter-spacing:.04em;text-transform:uppercase;border:1.5px solid var(--ink);padding:5px 9px;background:var(--cream);box-shadow:2px 2px 0 0 var(--ink);}
+      .catbar .c.on{background:var(--jersey-deep);color:var(--cream);}
+      .catlabel{display:flex;align-items:center;gap:9px;font-family:var(--font-mono);font-size:11px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;margin:14px 0 9px;}
+      .catlabel .ml{border-bottom:2px solid var(--jersey-deep);padding-bottom:2px;}
+      .catlabel .ic{color:var(--jersey-deep);font-size:15px;}
+      .q{display:flex;align-items:center;gap:10px;border:2px solid var(--ink);background:var(--cream);box-shadow:2px 2px 0 0 var(--ink);padding:10px 13px;margin-bottom:7px;}
+      .q .qt{flex:1;font-family:var(--font-display);font-style:italic;font-weight:600;font-size:15px;}
+      .q .chev{font-family:var(--font-mono);color:var(--ink-muted);font-size:12px;}
+      .more{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--jersey-deep);border:1.5px solid var(--jersey-deep);padding:6px 10px;display:inline-block;margin:2px 0 6px;}
+
+      /* B accordion rows */
+      .crow{display:flex;align-items:center;gap:11px;border:2px solid var(--ink);background:var(--cream-soft);box-shadow:3px 3px 0 0 var(--ink);padding:13px 15px;margin-bottom:8px;cursor:pointer;}
+      .crow .ic{color:var(--jersey-deep);font-size:18px;width:24px;text-align:center;}
+      .crow .t{flex:1;font-family:var(--font-display);font-weight:600;font-size:17px;}
+      .crow .ct{font-family:var(--font-mono);font-size:10px;color:var(--ink-muted);}
+      .crow .chev{font-family:var(--font-mono);color:var(--ink-muted);}
+      .crow.open{background:var(--jersey-deep);color:var(--cream);} .crow.open .ct{color:rgba(245,241,230,.8);} .crow.open .ic,.crow.open .chev{color:var(--cream);}
+      .nested{margin:0 0 10px 14px;}
+
+      /* C search-led */
+      .bigsearch{display:flex;align-items:center;gap:11px;border:2px solid var(--ink);background:var(--cream);box-shadow:4px 4px 0 0 var(--ink);padding:14px 16px;}
+      .bigsearch .mag{color:var(--jersey-deep);font-size:18px;}.bigsearch .ph{color:var(--ink-muted);font-size:15px;}
+      .csub{font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--ink-muted);margin:14px 0 9px;}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /hulp hub · 7o6b — FINDER “ALLES” INITIAL STATE (at scale)</h1>
+      <p>Answer reveal = inline accordion (7o6 locked). This decides what the browse shows on load when <b>“Alles”</b> is selected and there are <b>many</b> questions (and growing). The hero search is still the fast path; this is the browse-fallback. Goal: never dump the full flat list.</p>
+    </div>
+
+    <!-- A capped preview -->
+    <div class="bar rec"><span class="tg">A ★</span>Category sections, capped preview <span class="note">· top 3 per categorie + “Alle N →” · mirrors the Structuur “Toon alle 23 →”</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="catbar"><span class="c on">Alles</span><span class="c">Medisch</span><span class="c">Sportief</span><span class="c">Administratief</span><span class="c">Gedrag</span><span class="c">Commercieel</span></div>
+      <div class="catlabel"><span class="ic">✚</span><span class="ml">Medisch</span> <span style="color:var(--ink-muted);font-weight:400;letter-spacing:0;">· 8 vragen</span></div>
+      <div class="q"><span class="qt">Mijn kind is geblesseerd — wat nu?</span><span class="chev">+</span></div>
+      <div class="q"><span class="qt">Hoe werkt de sportverzekering?</span><span class="chev">+</span></div>
+      <div class="q"><span class="qt">Waar vind ik een keuringsattest?</span><span class="chev">+</span></div>
+      <a class="more">Alle 8 medische vragen →</a>
+      <div class="catlabel"><span class="ic">▤</span><span class="ml">Administratief</span> <span style="color:var(--ink-muted);font-weight:400;letter-spacing:0;">· 9 vragen</span></div>
+      <div class="q"><span class="qt">Hoe schrijf ik mijn kind in?</span><span class="chev">+</span></div>
+      <div class="q"><span class="qt">Wat kost een lidmaatschap?</span><span class="chev">+</span></div>
+      <div class="q"><span class="qt">Hoe zeg ik mijn lidmaatschap op?</span><span class="chev">+</span></div>
+      <a class="more">Alle 9 administratieve vragen →</a>
+    </div></div>
+
+    <!-- B category accordion -->
+    <div class="bar"><span class="tg">B</span>Category accordion <span class="note">· Alles = ~6 collapsed category rows · click to expand questions</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="catbar"><span class="c on">Alles</span><span class="c">per thema ↓</span></div>
+      <div class="crow"><span class="ic">✚</span><span class="t">Medisch</span><span class="ct">8 vragen</span><span class="chev">+</span></div>
+      <div class="crow open"><span class="ic">▤</span><span class="t">Administratief</span><span class="ct">9 vragen</span><span class="chev">−</span></div>
+      <div class="nested">
+        <div class="q"><span class="qt">Hoe schrijf ik mijn kind in?</span><span class="chev">+</span></div>
+        <div class="q"><span class="qt">Wat kost een lidmaatschap?</span><span class="chev">+</span></div>
+      </div>
+      <div class="crow"><span class="ic">⚑</span><span class="t">Sportief</span><span class="ct">6 vragen</span><span class="chev">+</span></div>
+      <div class="crow"><span class="ic">◎</span><span class="t">Gedrag</span><span class="ct">3 vragen</span><span class="chev">+</span></div>
+      <div class="crow"><span class="ic">€</span><span class="t">Commercieel</span><span class="ct">4 vragen</span><span class="chev">+</span></div>
+    </div></div>
+
+    <!-- C search-led -->
+    <div class="bar"><span class="tg">C</span>Search-led <span class="note">· Alles = prompt + category chips · questions appear after typing / picking</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="bigsearch"><span class="mag">⌕</span><span class="ph">Typ je vraag… bv. “lidgeld”, “blessure”, “boete”</span></div>
+      <div class="csub">— of kies een thema —</div>
+      <div class="catbar"><span class="c">Medisch · 8</span><span class="c">Sportief · 6</span><span class="c">Administratief · 9</span><span class="c">Gedrag · 3</span><span class="c">Commercieel · 4</span></div>
+      <p style="font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);margin-top:14px;">(geen vragenlijst tot je typt of een thema kiest)</p>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decision 7o6b — the “Alles” landing at scale</h3>
+      <p>
+        <b>A ★ capped preview</b> — each category shows its top 3 + “Alle N →”; the category chip filters to that
+        category’s full list. Browsable on load, caps the render no matter how big the corpus grows, and reuses the
+        Structuur “Toon alle 23 →” pattern. <b>B category accordion</b> — Alles shows ~6 collapsed category rows; one
+        click expands a category. Most compact load, but every question is two clicks deep. <b>C search-led</b> — no list
+        until you type or pick a theme; leans hardest on search (which the hero already provides).
+      </p>
+      <p style="color:var(--ink-muted);">
+        “Top 3” needs an order with no popularity data — use existing declaration/`sortOrder` or alphabetical (no
+        fabricated “most asked”). Selecting a category chip → that category’s full accordion list. Search (hero or a
+        finder-local field) always shortcuts straight to matching questions.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o7-hub-assembly-compare.html
+++ b/docs/design/mockups/phase-7-organigram/7o7-hub-assembly-compare.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 7 · /hulp hub · 7o7 — full assembly</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,900;1,9..144,400&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root{
+        --cream:#f5f1e6; --cream-soft:#ede8da; --cream-deep:#e1d7bf;
+        --ink:#0a0a0a; --ink-soft:#1f1f1f; --ink-muted:#6b6b6b;
+        --jersey:#4acf52; --jersey-deep:#008755; --jersey-deep-dark:#133d28;
+        --warm:#f0c264; --brick:#c93f1c; --paper-edge:#d9d2bd;
+        --font-display:"Fraunces",georgia,serif; --font-body:"Archivo",system-ui,sans-serif; --font-mono:"IBM Plex Mono",monospace;
+      }
+      *{box-sizing:border-box;}
+      body{margin:0;background:var(--cream);color:var(--ink);font-family:var(--font-body);
+        background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");}
+      .head{background:var(--ink);color:var(--cream);padding:22px 28px;font-family:var(--font-mono);}
+      .head h1{margin:0 0 6px;font-size:15px;letter-spacing:.04em;text-transform:uppercase;}
+      .head p{margin:0;font-size:13px;color:#b9b9b9;line-height:1.6;max-width:96ch;}
+      .head b{color:var(--warm);}
+      .stage{padding:26px 28px;}
+      .cols{max-width:1080px;margin:0 auto;display:grid;grid-template-columns:1fr 1fr;gap:30px;align-items:start;}
+      .coltitle{font-family:var(--font-mono);font-size:12px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;margin-bottom:10px;}
+      .coltitle .tg{background:var(--warm);border:1.5px solid var(--ink);padding:2px 8px;margin-right:8px;}
+      .coltitle.rec .tg{background:var(--jersey);}
+
+      .spine{border:2px solid var(--ink);background:var(--cream-soft);box-shadow:5px 5px 0 0 var(--ink);overflow:hidden;}
+      .nav{background:var(--cream-deep);border-bottom:2px solid var(--ink);padding:8px 10px;display:flex;gap:6px;align-items:center;font-family:var(--font-mono);font-size:9px;text-transform:uppercase;}
+      .nav .d{border:1.5px solid var(--ink);padding:4px 8px;background:var(--cream);box-shadow:1px 1px 0 0 var(--ink);}
+      .nav .d.on{background:var(--jersey-deep);color:var(--cream);}
+      .nav .sp{flex:1;}
+      .nav .s{border:1.5px solid var(--ink);padding:4px 8px;color:var(--jersey-deep);background:var(--cream);}
+      .b{padding:11px 12px;border-bottom:1.5px dashed var(--paper-edge);font-family:var(--font-mono);font-size:10px;text-transform:uppercase;letter-spacing:.03em;}
+      .b small{display:block;font-family:var(--font-body);text-transform:none;letter-spacing:0;font-size:10px;color:var(--ink-muted);margin-top:3px;}
+      .b.hero{background:var(--jersey-deep-dark);color:var(--cream);} .b.hero small{color:rgba(245,241,230,.72);}
+      .b.struct{background:var(--cream);}
+      .b.hulp{background:color-mix(in srgb,var(--jersey-deep) 12%,var(--cream));}
+      .b.form{background:var(--cream-deep);}
+      .b.cta{background:var(--jersey-deep-dark);color:var(--cream);}
+      .b.opt{border:1.5px dashed var(--brick);} .b.opt .fl{color:var(--brick);font-family:var(--font-mono);font-size:8px;}
+      .b .n{display:inline-block;background:var(--warm);color:var(--ink);border:1px solid var(--ink);font-size:8px;padding:0 4px;margin-right:5px;}
+
+      .legend{background:var(--cream-deep);border-top:2px solid var(--ink);padding:22px 28px;font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+      .legend h3{margin:0 0 8px;font-size:13px;letter-spacing:.08em;text-transform:uppercase;}
+      .legend b{color:var(--jersey-deep);}
+      .locked{max-width:1080px;margin:18px auto 0;font-family:var(--font-mono);font-size:11px;color:var(--ink-muted);line-height:1.7;border:1.5px solid var(--paper-edge);padding:12px 14px;background:var(--cream);}
+      .locked b{color:var(--jersey-deep);}
+    </style>
+  </head>
+  <body>
+    <div class="head">
+      <h1>Phase 7 · /hulp hub · 7o7 — FULL ASSEMBLY</h1>
+      <p>Everything locked, assembled into one single-scroll hub at <b>/hulp</b> with <b>two nav doors</b> ("Hulp" → top, "Organigram" → <code>#structuur</code>). Two open decisions: <b>(1) scroll order</b> — Hulp-first vs Structuur-first — and <b>(2) the general contact form + address/hours</b> (master §6.11): include, or just a CtaBand?</p>
+    </div>
+
+    <div class="stage"><div class="cols">
+      <!-- order 1 hulp first -->
+      <div>
+        <div class="coltitle rec"><span class="tg">ORDER 1 ★</span>Hulp-first (help-primary)</div>
+        <div class="spine">
+          <div class="nav"><span class="d on">Hulp</span><span class="d">Organigram →#structuur</span><span class="sp"></span><span class="s">⌕ zoek</span></div>
+          <div class="b hero">HERO — “Wie doet wat.”<small>one unified search (people + answers) · audience chips · structure index artefact</small></div>
+          <div class="b hulp"><span class="n">①</span>HULP — de vraagvinder<small>search-above · category preview (top 3 + “Alle N →”) · accordion antwoorden · contact (+ toon in structuur)</small></div>
+          <div class="b struct" id="structuur"><span class="n">②</span>STRUCTUUR<small>directory per afdeling (Toon alle 23 →) · “Open verkenner ⤢” → fullscreen spotlight · person side-panel</small></div>
+          <div class="b form opt"><span class="fl">optie (decision 2)</span> CONTACT-FORMULIER + Driesstraat 32 + uren</div>
+          <div class="b cta">CTA-band — “Niemand gevonden? → Contacteer de club”</div>
+        </div>
+        <p style="font-size:12.5px;color:var(--ink-soft);line-height:1.5;max-width:46ch;margin-top:12px;">The “Hulp” door lands you immediately on the finder — matches the help-primary identity + the dominant “I have a problem” intent. Structure browse follows; the “Organigram” door jumps straight to it.</p>
+      </div>
+
+      <!-- order 2 structuur first -->
+      <div>
+        <div class="coltitle"><span class="tg">ORDER 2</span>Structuur-first (the old 7o2 order)</div>
+        <div class="spine">
+          <div class="nav"><span class="d on">Hulp</span><span class="d">Organigram →#structuur</span><span class="sp"></span><span class="s">⌕ zoek</span></div>
+          <div class="b hero">HERO — “Wie doet wat.”<small>one unified search · audience chips · structure index artefact</small></div>
+          <div class="b struct"><span class="n">①</span>STRUCTUUR<small>directory per afdeling · “Open verkenner ⤢” · person side-panel</small></div>
+          <div class="b hulp"><span class="n">②</span>HULP — de vraagvinder<small>search-above · category preview · accordion antwoorden · contact</small></div>
+          <div class="b form opt"><span class="fl">optie (decision 2)</span> CONTACT-FORMULIER + Driesstraat 32 + uren</div>
+          <div class="b cta">CTA-band — “Niemand gevonden? → Contacteer de club”</div>
+        </div>
+        <p style="font-size:12.5px;color:var(--ink-soft);line-height:1.5;max-width:46ch;margin-top:12px;">Leads with “who’s who” (the org), then the problem finder. Browse-first feel; but the help-primary front door (“Hulp”) then sits below the structure on scroll.</p>
+      </div>
+    </div></div>
+
+    <div class="locked">
+      <b>Locked into this assembly (no re-drill):</b> hero 7o1 (dark band + one search + chips + structure index) · single-scroll + sticky nav 7o2 · Structuur = directory + fullscreen <b>spotlight explorer (2-D, no 3-D)</b> 7o3 · card states (single / shared dual-avatar / <b>vacant recruit</b>) 7o4 · person-first right side-panel 7o5 · Hulp finder (unified search + capped category preview + accordion answers + contact w/ “toon in structuur”) 7o6 · canonical <b>/hulp</b>, two nav doors, <code>/club/organigram</code> retired 7o2c.
+    </div>
+
+    <div class="legend">
+      <h3>Decision 7o7 — (1) scroll order · (2) contact form</h3>
+      <p>
+        <b>Order 1 ★ Hulp-first</b> — the help finder right after the hero (matches the /hulp identity + the dominant
+        “I have a problem” intent); Structuur follows, reached directly via its nav door. <b>Order 2 Structuur-first</b>
+        — “who’s who” first, then the finder (browse-first feel, but help sits lower).
+      </p>
+      <p>
+        <b>Contact form?</b> Master §6.11 specced a general contact form + <code>Driesstraat 32</code> + opening hours.
+        <b>Include</b> it (a catch-all “couldn’t find it? message us” + the club’s physical contact) — or keep it lean
+        with just the <b>CtaBand → contact</b> (the finder already routes to specific people)?
+      </p>
+      <p style="color:var(--ink-muted);">
+        Defaults I'll bake into the PRD unless you say otherwise: FAQ + Breadcrumb + Organization JSON-LD on the hub ·
+        analytics keep `organigram_*` + `responsibility_*` (one `organigram_view`→`hub_view`, explorer-open + 3-D events
+        dropped) · legacy retired (UnifiedOrganigramClient, d3-org-chart, ContactOverlay, MemberDetailsModal, old
+        ResponsibilityFinder, HulpSearchInput, InteriorPageHero/SectionStack) · the A-style “volledig organigram / print”
+        view = <b>deferred follow-up</b>, not v1.
+      </p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-7-organigram/7o7-hub-assembly-locked.md
+++ b/docs/design/mockups/phase-7-organigram/7o7-hub-assembly-locked.md
@@ -1,0 +1,57 @@
+# Phase 7 · `/hulp` hub — Round 7 (FULL ASSEMBLY) — LOCKED
+
+**Date:** 2026-06-08
+**Mockup:** `7o7-hub-assembly-compare.html`
+**Owner:** @climacon
+**Tracker:** #1529 (fused Phase 7+8) · **Milestone:** `redesign-retro-terrace-fanzine`
+
+## Decision
+
+The unified **`/hulp` hub** assembles as a single-scroll page, **Hulp-first**, with a **CtaBand-only**
+contact close (no form).
+
+### Final spine
+
+```text
+/hulp   (canonical) — cream paper · two nav doors: "Hulp" → top · "Organigram" → #structuur
+<OrganigramSectionNav>  sticky: Hulp · Structuur  +  the unified ⌕ search (repeated here)
+<OrganigramHero>        jersey-deep-dark band · kicker "De club" · EditorialHeading "Wie doet wat." (warm ".")
+                        · ONE unified search (people + answers) · audience chips → Hulp · structure index artefact
+① #hulp  <HulpFinder>   unified search above · audience + category chips · "Alles" = capped category preview
+                        (top 3 + "Alle N →") · <QuestionCard> inline accordion → summary · numbered steps ·
+                        <ContactCard> (person vocab + ✉/☎ + "toon in structuur →")
+   <StripedSeam>
+② #structuur            <StructureDirectory> people by afdeling (compact, "Toon alle 23 →"; states:
+                        single / shared dual-avatar / vacant-recruit) · "Open verkenner ⤢" →
+                        <OrganigramExplorer> fullscreen spotlight drill-down (2-D, NO 3-D) · breadcrumb +
+                        zoom/fit + Esc · click person → <MemberDetailPanel> (right side-panel, person-first,
+                        holder-switcher for shared)
+<CtaBand>               jersey-deep-dark "Niemand gevonden? → Contacteer de club" (mailto/contact)
+```
+
+Hero heading copy ("Wie doet wat." vs a help-forward variant) is finalised at PRD/copy time — structure
+is locked.
+
+## Baked-in defaults (locked unless flagged)
+
+- **No general contact form, no address/hours block** (owner: CtaBand only — the finder routes to specific
+  people). Master §6.11's form is dropped for this hub.
+- **SEO:** FAQ JSON-LD (from `responsibility` Q&As — answers in-DOM via the accordion) + BreadcrumbList +
+  Organization, all on the hub. "Hulp & Contact" metadata + canonical `/hulp`.
+- **Analytics:** keep `organigram_*` + `responsibility_*` families (both already in the live GTM regex).
+  `organigram_view_changed` → a single `hub_view`/section-in-view set; **drop** the 3-D + explorer-mode
+  events (no 3-D); preserve `organigram_member_clicked` (hashed), `organigram_search_used` (sanitised),
+  `responsibility_*`. New: `organigram_explorer_opened`. GTM regex already covers `organigram_|responsibility_`.
+- **Legacy retired** (these surfaces): `UnifiedOrganigramClient`, `EnhancedOrgChart` + **d3-org-chart dep**,
+  `MobileNavigationDrawer`, `ContactOverlay`, `MemberDetailsModal`, the old `ResponsibilityFinder`,
+  `HulpSearchInput`, `InteriorPageHero` / `SectionStack` / `SectionCta` / `diagonal` on `/hulp` + the old
+  `/club/organigram`.
+- **`/club/organigram` route retired** (pre-launch, no redirect); a nav entry "Organigram" points at
+  `/hulp#structuur`.
+- **"Volledig organigram / print" view** (the A-style collapsible tree from 7o3) = **deferred follow-up**,
+  not v1.
+
+## Drill complete
+
+Rounds `7o0`–`7o7` (+ `7o2c` re-scope) are locked. Next: the PRD
+(`docs/prd/redesign-phase-7-hulp-hub.md`) → `/prd-to-issues`.

--- a/docs/prd/redesign-phase-7-hulp-hub.md
+++ b/docs/prd/redesign-phase-7-hulp-hub.md
@@ -1,0 +1,208 @@
+# PRD: Redesign Phase 7 — `/hulp` hub (formerly `/club/organigram` + `/hulp`)
+
+**Status**: Ready for implementation (design locked)
+**Date**: 2026-06-08
+**Design contract**: `docs/design/mockups/phase-7-organigram/` — rounds `7o0`–`7o7` + the `7o2c` re-scope
+(authoritative architectural lock).
+**Epic**: #1529 (Redesign Phase 7) · **Milestone**: `redesign-retro-terrace-fanzine`
+**Fuses**: #1530's `/hulp` (Phase 8 `/hulp` removed — see both issues' 2026-06-08 re-scope banners).
+**Supersedes**: the organigram portion of any legacy club-landing PRD; master-design §6.10 (organigram)
+and §6.11 (`/hulp`) for these surfaces.
+
+---
+
+## 1. Problem statement
+
+Two un-redesigned, overlapping surfaces both answer the same question — _"find the right person or answer
+at KCVV"_:
+
+- **`/club/organigram`** — a heavy tabbed `UnifiedOrganigramClient` (Overzicht cards / Diagram / Hulp) on
+  legacy chrome (`InteriorPageHero`, `SectionStack`, `bg-kcvv-black`, `diagonal`). The **Diagram** is a
+  `d3-org-chart` canvas whose `d3-zoom` wheel handler **scroll-jacks the page**; free pan/zoom means users
+  **lose orientation**; the three views are poorly discoverable and the cards↔diagram pair is redundant.
+- **`/hulp`** — a separate, newer `<HulpPage>` responsibility-finder (search · browse · answer · contact).
+  The organigram's "Hulp" tab **duplicates** it → "which page do I go to?"
+
+The redesign **merges them into one `/hulp` hub** (decision `7o2c`): one unified search front door, two
+browse modes (**Structuur** + **Hulp**) of the same contact graph, two nav doors, homed on `/hulp`.
+`/club/organigram` is retired as a route (site is pre-launch — no redirects). This is a **Phase 7 + Phase 8
+fusion**.
+
+## 2. Scope
+
+### In scope
+
+- **New `/hulp` hub** (cream paper, fanzine vocabulary) replacing both `/club/organigram` and the old
+  `/hulp`.
+- **Structuur half:** `<OrganigramHero>`, `<OrganigramSectionNav>`, `<StructureDirectory>`,
+  `<OrgPersonCard>` (single/shared/vacant states), `<OrganigramExplorer>` (fullscreen 2-D spotlight),
+  `<MemberDetailPanel>` (person-first side-panel).
+- **Hulp half:** `<HulpFinder>` (reskinned `<HulpPage>`: capped category preview + accordion answers +
+  contact w/ "toon in structuur").
+- **One unified `<HubSearch>`** (people + answers) — merges `UnifiedSearchBar` + `HulpSearchInput`.
+- **Semantic/AI question search** (bge-m3 + Vectorize) over `responsibility` docs.
+- **Two nav doors** ("Hulp" → top, "Organigram" → `/hulp#structuur`); retire the `/club/organigram` route.
+- **Legacy retirement** (see §4 Phase 7).
+- SEO (FAQ + Breadcrumb + Organization JSON-LD), analytics, a11y, e2e + VR.
+
+### Out of scope
+
+- `/zoeken`, `/privacy`, error pages (remain **Phase 8** / #1530).
+- The board pages `/club/{bestuur,jeugdbestuur,angels}` (separate #1529 item, 6.C `<TeamStaff>` reuse).
+- A general contact form + address/hours block (owner: **CtaBand only**; master §6.11 form dropped).
+- A "volledig organigram / print" view (deferred follow-up).
+
+### No data-model change
+
+**Zero Sanity schema changes.** Everything renders from existing fields: `organigramNode`
+(title/description/roleCode/department/parentNode/members/active/sortOrder), `staffMember`
+(firstName/lastName/email/phone/photo/psdId), `responsibility` (question/summary/steps/audience/category/
+icon/primaryContact/relatedPaths). Vacant = the existing 0-members state; "toon in structuur" = the
+existing `nodeId` on a position contact; the structure index = derived counts. Semantic search adds
+**Vectorize/AI infra** (a Cloudflare index + BFF endpoint), not Sanity schema.
+
+### Packages touched
+
+`apps/web` (routes, components, repos already exist) · `apps/api` (BFF — semantic-search endpoint +
+Vectorize index, Phase 6 only) · no `packages/sanity-schemas` change.
+
+## 3. Final shape (locked — `7o7`)
+
+```text
+/hulp   cream paper · nav doors "Hulp" (top) / "Organigram" (#structuur)
+<OrganigramSectionNav>   sticky: Hulp · Structuur  +  unified ⌕ search
+<OrganigramHero>         jersey-deep-dark · "Wie doet wat." (warm ".") · unified search · audience chips · structure index
+① #hulp  <HulpFinder>    search-above · audience+category chips · "Alles" = capped category preview (top 3 + "Alle N →")
+                         · <QuestionCard> accordion → summary · numbered steps · <ContactCard> (✉/☎ · "toon in structuur →")
+<StripedSeam>
+② #structuur             <StructureDirectory> per afdeling (compact, "Toon alle 23 →") · "Open verkenner ⤢"
+                         → <OrganigramExplorer> fullscreen spotlight (2-D) · click person → <MemberDetailPanel>
+<CtaBand>                jersey-deep-dark "Niemand gevonden? → Contacteer de club"
+```
+
+Order = **Hulp-first**. Explorer = **2-D spotlight, no 3-D** (investigated + removed, `7o3`). Detail =
+**person-first right side-panel** (`7o5`). Card states = single / shared dual-avatar / **vacant recruit**
+(`7o4`).
+
+## 4. Phases
+
+> Phases are sequential; each ends green (`check-all`, stories, VR, e2e where relevant). Component-level
+> work ships its Storybook story (+ `vr` tag + baselines) and unit tests per the apps/web contract.
+
+### Phase 1 — Tracer: hub shell + route + unified search + nav
+Stand up `/hulp` as the hub: `<OrganigramSectionNav>` (two doors + sticky search), `<OrganigramHero>`
+(dark band + `<HubSearch>` + audience chips + structure-index artefact from real counts), skeleton
+`#hulp` / `#structuur` sections, `<CtaBand>`. Wire both repos server-side (ISR 3600). **Retire the
+`/club/organigram` route**; add the "Organigram" → `/hulp#structuur` nav entry. `<HubSearch>` ships
+keyword-ranked (people + answers), replacing `UnifiedSearchBar` + `HulpSearchInput`.
+
+### Phase 2 — Structuur directory + person card
+`<StructureDirectory>` (people grouped by afdeling, compact + "Toon alle N →"). `<OrgPersonCard>`
+(extends 6.C `<TeamStaff>`): **single** (photo/monogram) · **shared** (dual-avatar + "N personen", click →
+panel) · **vacant** (recruit: warm card, "deze plek is vrij", "Iets voor jou? →"). Optional roleCode pill.
+
+### Phase 3 — `<OrganigramExplorer>` (fullscreen 2-D spotlight)
+Opt-in fullscreen focused mode launched from "Open verkenner ⤢". Spotlight drill-down: selected node
+centred · parent above + breadcrumb · siblings flank · children fan below · click/keyboard nav
+(↑↓←→/Enter) · zoom/fit · Esc. **Retire `EnhancedOrgChart` + the `d3-org-chart` dependency,
+`MobileNavigationDrawer`, `ContactOverlay`.** No 3-D, no WebGL.
+
+### Phase 4 — `<MemberDetailPanel>` (person-first)
+Right side-panel (desktop) / full-width bottom sheet (mobile). **Single** → opens directly; **shared** →
+lands on first holder + **name-tab holder-switcher**. Contact (✉/☎ if present) · "Helpt met" → Hulp ·
+"Volledig profiel →" (`/staf/{psdId}` if present). Opens from a directory card **and** an explorer leaf.
+Labelled dialog, focus trap, `?memberId=` deep-link. **Retire `MemberDetailsModal`** (panel replaces it +
+`ContactOverlay`).
+
+### Phase 5 — `<HulpFinder>` (reskin `<HulpPage>`)
+Reskin to fanzine vocab: category + audience chips · **"Alles" = capped category preview** (top 3 per
+category by declaration/`sortOrder`/alpha — **no fabricated "most asked"** + "Alle N →") · `<QuestionCard>`
+**inline accordion** → summary · numbered steps · `<ContactCard>`. Contact reuses person vocab + a
+**"toon in structuur →"** cross-link (opens that node in the explorer + the panel). Preserve
+`resolveContact` / `team-role-resolution` (position / team-role / manual). **Retire the old
+`ResponsibilityFinder` + `HulpSearchInput`.**
+
+### Phase 6 — Semantic/AI question search
+Embed `responsibility` docs into a Cloudflare **Vectorize** index (`@cf/baai/bge-m3`, 1024-dim cosine,
+`MIN_SCORE ≈ 0.35`) via a BFF endpoint; route the hub search's **question intent** through it so natural
+language ("mijn kind heeft zich bezeerd") matches without keyword overlap. People-search stays
+keyword/structured. Graceful fallback to keyword if the index/endpoint is unavailable. _(Heaviest phase;
+may split into "index+endpoint" / "wire-up". If descoped, Phase 5's keyword search stands and this becomes
+a fast-follow.)_
+
+### Phase 7 — Assembly · cross-links · SEO · analytics · retirement · tests
+Final Hulp-first assembly + `<StripedSeam>` + cross-links (Structuur ⇄ Hulp). FAQ + BreadcrumbList +
+Organization JSON-LD. Analytics (§6) + GTM note. Delete all retired legacy + confirm `git grep` clean.
+Update `/hulp` e2e smoke (route is now the hub), add the `/club/organigram` removal. VR baselines for every
+new component story. `check-all` green.
+
+## 5. Acceptance criteria (per phase)
+
+**Phase 1** — [ ] `/hulp` renders the hub shell + sticky two-door nav + hero + unified search; [ ]
+`/club/organigram` route removed, "Organigram" nav → `/hulp#structuur`; [ ] structure-index counts derive
+from repo data; [ ] `<HubSearch>` returns people + answers (keyword); [ ] e2e smoke for `/hulp`; [ ]
+`check-all` green.
+**Phase 2** — [ ] directory groups by afdeling, "Toon alle N →" caps render; [ ] `<OrgPersonCard>` single
+/ shared / vacant-recruit stories + VR; [ ] no fabricated data (vacant = real 0-members).
+**Phase 3** — [ ] explorer fullscreen spotlight: breadcrumb + click/keyboard nav + zoom/fit + Esc; [ ] **no
+scroll-jacking** (no page wheel capture); [ ] `d3-org-chart` removed from `package.json`; [ ]
+`EnhancedOrgChart`/`MobileNavigationDrawer`/`ContactOverlay` deleted (`git grep` clean); [ ] mobile tap-only.
+**Phase 4** — [ ] panel opens from directory + explorer; single direct / shared switcher; contact actions
+only when data present; [ ] labelled dialog + focus trap + `?memberId=`; [ ] `MemberDetailsModal` deleted.
+**Phase 5** — [ ] "Alles" never renders the full flat list (capped preview); [ ] accordion answer = summary
++ steps + contact; [ ] "toon in structuur" deep-links the explorer; [ ] `ResponsibilityFinder` +
+`HulpSearchInput` deleted; [ ] `resolveContact` paths (position/team-role/manual) covered by tests.
+**Phase 6** — [ ] Vectorize index built (1024-dim cosine, bge-m3) + BFF endpoint; [ ] NL query matches the
+right answer above `MIN_SCORE`; [ ] keyword fallback on failure; [ ] no PII in embeddings beyond public Q&A.
+**Phase 7** — [ ] cross-links both ways; [ ] FAQ/Breadcrumb/Organization JSON-LD validate; [ ] analytics
+events fire (GTM note in PR); [ ] all legacy retired (`UnifiedOrganigramClient`, `SectionStack`,
+`InteriorPageHero`, `SectionCta`, `diagonal` on these surfaces); [ ] VR baselines committed; [ ]
+`check-all` + e2e green.
+
+## 6. Analytics
+
+`organigram_` and `responsibility_` are **already in the live GTM Custom-Event trigger regex** — no regex
+change required; new params still need DLVs + GA4 mappings.
+
+| Event | Trigger | Params |
+| --- | --- | --- |
+| `hub_view` | `/hulp` page view | — |
+| `organigram_section_in_view` | Structuur/Hulp section scrolled into view | `section` |
+| `organigram_search_used` | unified search query | `query_text` (sanitised via `sanitizeQuery`) |
+| `organigram_member_clicked` | open `<MemberDetailPanel>` (incl. holder-switch) | `member_id` (hashed via `hashMemberId`), `source` (directory/explorer/search) |
+| `organigram_explorer_opened` | "Open verkenner ⤢" | — |
+| `responsibility_view` | open a question accordion | `path_id` (slug) |
+| `responsibility_contact_click` | ✉/☎ on a Hulp contact | `path_id`, `contact_type` |
+| `responsibility_show_in_structure` | "toon in structuur →" | `node_id` (hashed) |
+
+Drop the legacy 3-D / diagram-mode events (no 3-D). No PII: hash internal ids, sanitise queries, never
+send emails/phones/raw names.
+
+## 7. SEO / structured data
+
+- `generateMetadata`: title "Hulp & wie-is-wie | KCVV Elewijt", description, OG, canonical `/hulp`.
+- **FAQPage** JSON-LD from `responsibility` Q&As (answers are in the DOM via the accordion — `7o6`).
+- **BreadcrumbList** (Home → Hulp). **Organization** (KCVV Elewijt) on the hub.
+- Per-answer fragment deep-links `/hulp#<slug>`.
+
+## 8. Accessibility
+
+- Spotlight explorer: full keyboard nav; the fullscreen mode is a labelled dialog ("Organigram-verkenner");
+  breadcrumb is the orientation anchor; **no pointer-only interaction** (tap-driven; the dropped hover was
+  never a discovery path).
+- `<MemberDetailPanel>`: labelled dialog "Contactgegevens — {name}", focus trap, Esc, focus restored.
+- Landmark/name uniqueness across hub dialog + nav (per repo convention).
+- Contrast: small text on jersey-deep(-dark) uses `text-white`/cream (6.C AA rule).
+- `aria-hidden` on decorative seams/artefacts; accordion uses `aria-expanded`/`aria-controls`.
+
+## 9. Open questions / discovered unknowns
+
+- **Hero heading copy** — "Wie doet wat." vs a help-forward variant for the help-primary hub (copy-time).
+- **Semantic phase sizing** — Phase 6 may split (index+endpoint / wire-up) or become a fast-follow if the
+  Cloudflare AI/Vectorize work outweighs the launch window; Phase 5 keyword search is the safe floor.
+- **Real corpus sizes** unknown (positions/people/responsibilities counts) — the capped-preview + "Toon
+  alle" patterns are built to scale regardless; verify against production seed.
+- **Nav wiring** — confirm the global nav exposes both "Hulp" (top-level) and "Organigram" (under Club)
+  pointing at the one hub.
+- **"Volledig organigram / print"** collapsible-tree view — deferred; revisit if a printable chart is
+  requested.

--- a/docs/prd/redesign-phase-7-hulp-hub.md
+++ b/docs/prd/redesign-phase-7-hulp-hub.md
@@ -89,32 +89,32 @@ Order = **Hulp-first**. Explorer = **2-D spotlight, no 3-D** (investigated + rem
 > Phases are sequential; each ends green (`check-all`, stories, VR, e2e where relevant). Component-level
 > work ships its Storybook story (+ `vr` tag + baselines) and unit tests per the apps/web contract.
 
-### Phase 1 — Tracer: hub shell + route + unified search + nav
+### Phase 1 — Tracer: hub shell + route + unified search + nav — #2052
 Stand up `/hulp` as the hub: `<OrganigramSectionNav>` (two doors + sticky search), `<OrganigramHero>`
 (dark band + `<HubSearch>` + audience chips + structure-index artefact from real counts), skeleton
 `#hulp` / `#structuur` sections, `<CtaBand>`. Wire both repos server-side (ISR 3600). **Retire the
 `/club/organigram` route**; add the "Organigram" → `/hulp#structuur` nav entry. `<HubSearch>` ships
 keyword-ranked (people + answers), replacing `UnifiedSearchBar` + `HulpSearchInput`.
 
-### Phase 2 — Structuur directory + person card
+### Phase 2 — Structuur directory + person card — #2053
 `<StructureDirectory>` (people grouped by afdeling, compact + "Toon alle N →"). `<OrgPersonCard>`
 (extends 6.C `<TeamStaff>`): **single** (photo/monogram) · **shared** (dual-avatar + "N personen", click →
 panel) · **vacant** (recruit: warm card, "deze plek is vrij", "Iets voor jou? →"). Optional roleCode pill.
 
-### Phase 3 — `<OrganigramExplorer>` (fullscreen 2-D spotlight)
+### Phase 3 — `<OrganigramExplorer>` (fullscreen 2-D spotlight) — #2054
 Opt-in fullscreen focused mode launched from "Open verkenner ⤢". Spotlight drill-down: selected node
 centred · parent above + breadcrumb · siblings flank · children fan below · click/keyboard nav
 (↑↓←→/Enter) · zoom/fit · Esc. **Retire `EnhancedOrgChart` + the `d3-org-chart` dependency,
 `MobileNavigationDrawer`, `ContactOverlay`.** No 3-D, no WebGL.
 
-### Phase 4 — `<MemberDetailPanel>` (person-first)
+### Phase 4 — `<MemberDetailPanel>` (person-first) — #2055
 Right side-panel (desktop) / full-width bottom sheet (mobile). **Single** → opens directly; **shared** →
 lands on first holder + **name-tab holder-switcher**. Contact (✉/☎ if present) · "Helpt met" → Hulp ·
 "Volledig profiel →" (`/staf/{psdId}` if present). Opens from a directory card **and** an explorer leaf.
 Labelled dialog, focus trap, `?memberId=` deep-link. **Retire `MemberDetailsModal`** (panel replaces it +
 `ContactOverlay`).
 
-### Phase 5 — `<HulpFinder>` (reskin `<HulpPage>`)
+### Phase 5 — `<HulpFinder>` (reskin `<HulpPage>`) — #2056
 Reskin to fanzine vocab: category + audience chips · **"Alles" = capped category preview** (top 3 per
 category by declaration/`sortOrder`/alpha — **no fabricated "most asked"** + "Alle N →") · `<QuestionCard>`
 **inline accordion** → summary · numbered steps · `<ContactCard>`. Contact reuses person vocab + a
@@ -122,7 +122,7 @@ category by declaration/`sortOrder`/alpha — **no fabricated "most asked"** + "
 `resolveContact` / `team-role-resolution` (position / team-role / manual). **Retire the old
 `ResponsibilityFinder` + `HulpSearchInput`.**
 
-### Phase 6 — Semantic/AI question search
+### Phase 6 — Semantic/AI question search — #2057
 Embed `responsibility` docs into a Cloudflare **Vectorize** index (`@cf/baai/bge-m3`, 1024-dim cosine,
 `MIN_SCORE ≈ 0.35`) via a BFF endpoint; route the hub search's **question intent** through it so natural
 language ("mijn kind heeft zich bezeerd") matches without keyword overlap. People-search stays
@@ -130,7 +130,7 @@ keyword/structured. Graceful fallback to keyword if the index/endpoint is unavai
 may split into "index+endpoint" / "wire-up". If descoped, Phase 5's keyword search stands and this becomes
 a fast-follow.)_
 
-### Phase 7 — Assembly · cross-links · SEO · analytics · retirement · tests
+### Phase 7 — Assembly · cross-links · SEO · analytics · retirement · tests — #2058
 Final Hulp-first assembly + `<StripedSeam>` + cross-links (Structuur ⇄ Hulp). FAQ + BreadcrumbList +
 Organization JSON-LD. Analytics (§6) + GTM note. Delete all retired legacy + confirm `git grep` clean.
 Update `/hulp` e2e smoke (route is now the hub), add the `/club/organigram` removal. VR baselines for every

--- a/docs/prd/redesign-phase-7-hulp-hub.md
+++ b/docs/prd/redesign-phase-7-hulp-hub.md
@@ -168,12 +168,12 @@ change required; new params still need DLVs + GA4 mappings.
 | --- | --- | --- |
 | `hub_view` | `/hulp` page view | — |
 | `organigram_section_in_view` | Structuur/Hulp section scrolled into view | `section` |
-| `organigram_search_used` | unified search query | `query_text` (sanitised via `sanitizeQuery`) |
+| `organigram_search_used` | unified search query | `query_length` (length only — no query content; matches the existing `responsibility_search` convention, replaces the legacy `query_text`) |
 | `organigram_member_clicked` | open `<MemberDetailPanel>` (incl. holder-switch) | `member_id` (hashed via `hashMemberId`), `source` (directory/explorer/search) |
 | `organigram_explorer_opened` | "Open verkenner ⤢" | — |
-| `responsibility_view` | open a question accordion | `path_id` (slug) |
-| `responsibility_contact_click` | ✉/☎ on a Hulp contact | `path_id`, `contact_type` |
-| `responsibility_show_in_structure` | "toon in structuur →" | `node_id` (hashed) |
+| `responsibility_view` | open a question accordion | `path_id` (public slug — not PII) |
+| `responsibility_contact_clicked` | ✉/☎ on a Hulp contact | `path_id`, `contact_type` |
+| `responsibility_organigram_link` | "toon in structuur →" | `node_id` (hashed via `hashMemberId` — the generic id-hasher; no separate node helper exists) |
 
 Drop the legacy 3-D / diagram-mode events (no 3-D). No PII: hash internal ids, sanitise queries, never
 send emails/phones/raw names.

--- a/docs/prd/redesign-phase-7-hulp-hub.md
+++ b/docs/prd/redesign-phase-7-hulp-hub.md
@@ -111,7 +111,7 @@ centred · parent above + breadcrumb · siblings flank · children fan below · 
 Right side-panel (desktop) / full-width bottom sheet (mobile). **Single** → opens directly; **shared** →
 lands on first holder + **name-tab holder-switcher**. Contact (✉/☎ if present) · "Helpt met" → Hulp ·
 "Volledig profiel →" (`/staf/{psdId}` if present). Opens from a directory card **and** an explorer leaf.
-Labelled dialog, focus trap, `?memberId=` deep-link. **Retire `MemberDetailsModal`** (panel replaces it +
+Labelled dialog, focus trap, `?member=` deep-link. **Retire `MemberDetailsModal`** (panel replaces it +
 `ContactOverlay`).
 
 ### Phase 5 — `<HulpFinder>` (reskin `<HulpPage>`) — #2056
@@ -148,7 +148,7 @@ from repo data; [ ] `<HubSearch>` returns people + answers (keyword); [ ] e2e sm
 scroll-jacking** (no page wheel capture); [ ] `d3-org-chart` removed from `package.json`; [ ]
 `EnhancedOrgChart`/`MobileNavigationDrawer`/`ContactOverlay` deleted (`git grep` clean); [ ] mobile tap-only.
 **Phase 4** — [ ] panel opens from directory + explorer; single direct / shared switcher; contact actions
-only when data present; [ ] labelled dialog + focus trap + `?memberId=`; [ ] `MemberDetailsModal` deleted.
+only when data present; [ ] labelled dialog + focus trap + `?member=`; [ ] `MemberDetailsModal` deleted.
 **Phase 5** — [ ] "Alles" never renders the full flat list (capped preview); [ ] accordion answer = summary
 + steps + contact; [ ] "toon in structuur" deep-links the explorer; [ ] `ResponsibilityFinder` +
 `HulpSearchInput` deleted; [ ] `resolveContact` paths (position/team-role/manual) covered by tests.


### PR DESCRIPTION
## Phase 7 — `/club/organigram` redesign → unified **`/hulp` hub** (design lock + PRD)

Docs-only. The design drill for `/club/organigram` (the last Phase 7 surface) concluded that
`/club/organigram` and `/hulp` are **one job** — _"find the right person or answer at KCVV"_ — and merges
them into a single hub. **Phase 7 + Phase 8 are fused** (issues #1529 / #1530 updated with re-scope banners).

### The locked hub (`docs/design/mockups/phase-7-organigram/`, rounds `7o0`–`7o7` + `7o2c`)

- **Canonical `/hulp`**, two nav doors ("Hulp" → top, "Organigram" → `#structuur`); `/club/organigram`
  route retired (pre-launch, no redirects).
- **One unified search** front door (people **+** answers); semantic/AI (bge-m3 + Vectorize) folded in.
- **Structuur half** — `<OrganigramHero>` (dark band) · `<StructureDirectory>` (people by afdeling, card
  states single / shared dual-avatar / **vacant-recruit**) · `<OrganigramExplorer>` **fullscreen 2-D
  spotlight drill-down** (breadcrumb + keyboard nav — fixes scroll-jacking + orientation) · person-first
  right `<MemberDetailPanel>`.
- **Hulp half** — reskinned `<HulpFinder>`: capped category preview ("Alles" never dumps the full list) +
  inline accordion answers + contact w/ "toon in structuur →".
- **Hulp-first** scroll order; CtaBand close (no contact form).

### Notable drill outcomes

- **3-D explorer investigated at real ~25-node scale and removed** ("doesn't add value, au contraire") —
  the 2-D spotlight is the whole explorer + its a11y fallback.
- **Person-first detail** (click opens a contact person, not a function summary).
- **No Sanity schema changes** — everything renders from existing fields.

### Contents

- 13 locked-decision docs + 13 HTML comparison mockups (one per drill round).
- PRD: `docs/prd/redesign-phase-7-hulp-hub.md` (7 build phases, AC, analytics, SEO, a11y).

Implementation issues to follow via `/prd-to-issues` under epic #1529 ·
milestone `redesign-retro-terrace-fanzine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 7 locked design suite and PRD for the unified /hulp hub, merging organigram + hulp into one hub.
  * Locked UX: Hulp‑first single‑scroll hub with unified search hero, Hulp finder (Q&A + category browse), Structuur directory, and CTA band.
  * Interaction patterns locked: 2‑D spotlight organigram explorer (no 3‑D), person‑first side panel (responsive), people‑card states (single/shared/vacant), inline answer disclosure.
  * Recorded data/field realities, SEO, analytics, accessibility requirements, and retirement of the legacy organigram route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->