### PR TITLE
fix(teams): backfill team squad photos from legacy Drupal (#2070)

### DIFF
--- a/scripts/team-image-backfill/.gitignore
+++ b/scripts/team-image-backfill/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/scripts/team-image-backfill/README.md
+++ b/scripts/team-image-backfill/README.md
@@ -1,0 +1,38 @@
+# team-image-backfill
+
+One-time recovery of team squad photos (`team.teamImage`) from the legacy Drupal
+site into Sanity. See issue #2070.
+
+`team.teamImage` is an editorial field — PSD sync never populates it, and the
+original Drupal → Sanity migration missed it, so every team shipped without a
+photo. The photos still exist in Drupal (`node/team` →
+`field_media_article_image`) and this script recovers them.
+
+## How matching works
+
+- **Seniors** (`A-Ploeg` / `B-Ploeg`) and any ambiguous youth band are matched
+  via the explicit `SLUG_OVERRIDES` map in `src/backfill-team-images.ts`.
+- **Youth** are matched dynamically by age token (`U17`, `U13`, …). A band that
+  resolves to more than one current team (today: `U7` = groen/wit, `U9` =
+  wit/groen/U9P) is reported as **unmatched** — never guessed. Add a
+  `SLUG_OVERRIDES` line once the target team is decided, then re-run.
+- Teams that already have a `teamImage` are skipped (idempotent). `--force`
+  overwrites.
+
+## Run
+
+```bash
+npm install
+
+# 1. Dry-run — prints the match plan, writes nothing.
+SANITY_DATASET=staging npm run backfill -- --dry-run
+
+# 2. Apply to staging.
+SANITY_DATASET=staging npm run backfill
+
+# 3. Apply to production (guarded — both vars required).
+SANITY_DATASET=production SANITY_ALLOW_PRODUCTION=1 npm run backfill
+```
+
+Auth: `SANITY_API_TOKEN` (write token) or a logged-in
+`~/.config/sanity/config.json`.

--- a/scripts/team-image-backfill/package-lock.json
+++ b/scripts/team-image-backfill/package-lock.json
@@ -1,0 +1,753 @@
+{
+  "name": "team-image-backfill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "team-image-backfill",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sanity/client": "7.22.1"
+      },
+      "devDependencies": {
+        "tsx": "4.22.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/client": {
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.1.tgz",
+      "integrity": "sha512-DrQqLAes7W9Ek2iKgTZ+ffY1v3DURJ6//iXJZMEQSUeRbxls2ifRTdV1gRS26v8nMkL0OCH+WCoUUseD4vhuQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/eventsource": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
+      "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/event-source-polyfill": "1.0.5",
+        "@types/eventsource": "1.1.15",
+        "event-source-polyfill": "1.0.31",
+        "eventsource": "2.0.2"
+      }
+    },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
+      "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-it": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.8.0.tgz",
+      "integrity": "sha512-vRyooMBzoIdEbARGT3JcvWqMD67YzC5SKlMqofyfck1ebLh2zzlpD4hVQ3xiuuiADk4jNs0rTezVlxCMqOlZfA==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^7.0.0",
+        "is-retry-allowed": "^2.2.0",
+        "through2": "^4.0.2",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/team-image-backfill/package.json
+++ b/scripts/team-image-backfill/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "team-image-backfill",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "backfill": "tsx src/backfill-team-images.ts"
+  },
+  "dependencies": {
+    "@sanity/client": "7.22.1"
+  },
+  "devDependencies": {
+    "tsx": "4.22.4"
+  }
+}

--- a/scripts/team-image-backfill/src/backfill-team-images.ts
+++ b/scripts/team-image-backfill/src/backfill-team-images.ts
@@ -1,0 +1,274 @@
+/**
+ * Backfill team squad photos from the legacy Drupal site into Sanity.
+ *
+ * Context: `team.teamImage` is an editorial Sanity field. Teams are PSD-synced
+ * (PSD never sets editorial fields), so squad photos had to be migrated from
+ * Drupal `node/team` during the initial cutover — that step was missed, leaving
+ * every team without a photo. The photos still exist in Drupal under
+ * `field_media_article_image` and are recoverable. See issue #2070.
+ *
+ * What it does:
+ *   1. Fetch Drupal `node/team` (+ included media/files) → resolve photo URLs.
+ *   2. Fetch current Sanity teams (`_id, name, age, slug, teamImage`).
+ *   3. Match by age (+ name discriminator); ambiguous ages need an explicit
+ *      override (SLUG_OVERRIDES) — never guessed.
+ *   4. For each matched team WITHOUT an existing photo: download the JPEG,
+ *      upload it as a Sanity asset, patch `team.teamImage`.
+ *
+ * Idempotent: teams that already have a `teamImage` are skipped (re-running is
+ * a no-op). Pass `--force` to overwrite existing photos.
+ *
+ * Usage:
+ *   # Dry-run (default dataset = staging) — prints the match plan, no writes.
+ *   SANITY_DATASET=staging pnpm backfill --dry-run
+ *   # Apply to staging.
+ *   SANITY_DATASET=staging pnpm backfill
+ *   # Apply to production (guarded).
+ *   SANITY_DATASET=production SANITY_ALLOW_PRODUCTION=1 pnpm backfill
+ */
+import { client, dataset } from "./sanity-client";
+
+const DRUPAL_BASE_URL = "https://api.kcvvelewijt.be";
+const DRY_RUN = process.argv.includes("--dry-run");
+const FORCE = process.argv.includes("--force");
+
+/**
+ * Explicit Drupal-title → Sanity-slug overrides. Used when an age band maps to
+ * more than one current team (the dynamic age match can't disambiguate), or for
+ * the seniors whose Drupal title ("A-Ploeg"/"B-Ploeg") carries no age token.
+ *
+ * The ambiguous youth bands (U7 = groen/wit, U9 = wit/groen/U9P) are left out
+ * deliberately — their legacy photos are old cohorts and the target team is the
+ * owner's call. Add a line here once decided, then re-run.
+ */
+const SLUG_OVERRIDES: Record<string, string> = {
+  "A-Ploeg": "eerste-elftallen-a",
+  "B-Ploeg": "eerste-elftallen-b",
+  // "U7": "kcvve-u7-groen",   // owner decision (groen | wit)
+  // "U9 - A": "kcvve-u9-wit",  // owner decision (wit | groen | u9p)
+};
+
+interface SanityTeam {
+  _id: string;
+  name: string;
+  age: string | null;
+  slug: string | null;
+  hasImage: boolean;
+}
+
+interface DrupalTeam {
+  title: string;
+  imageUrl: string | null;
+}
+
+interface JsonApiResource {
+  type: string;
+  id: string;
+  attributes?: Record<string, unknown>;
+  relationships?: Record<string, { data?: { id: string } | null }>;
+}
+
+/** Pull all Drupal teams with their resolved image file URLs. */
+async function fetchDrupalTeams(): Promise<DrupalTeam[]> {
+  const url = `${DRUPAL_BASE_URL}/jsonapi/node/team?page%5Blimit%5D=60&include=field_media_article_image.field_media_image`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Drupal fetch failed: HTTP ${res.status}`);
+  const json = (await res.json()) as {
+    data: JsonApiResource[];
+    included?: JsonApiResource[];
+  };
+
+  const included = json.included ?? [];
+  const files = new Map(
+    included.filter((r) => r.type === "file--file").map((r) => [r.id, r]),
+  );
+  const media = new Map(
+    included.filter((r) => r.type.startsWith("media")).map((r) => [r.id, r]),
+  );
+
+  const resolveImageUrl = (mediaId: string): string | null => {
+    const m = media.get(mediaId);
+    const fileRef = m?.relationships?.field_media_image?.data;
+    if (!fileRef) return null;
+    const file = files.get(fileRef.id);
+    const uri = (file?.attributes?.uri as { url?: string } | undefined)?.url;
+    return uri ? `${DRUPAL_BASE_URL}${uri}` : null;
+  };
+
+  return json.data.map((node) => {
+    const mediaRef = node.relationships?.field_media_article_image?.data;
+    return {
+      title: String(node.attributes?.title ?? ""),
+      imageUrl: mediaRef ? resolveImageUrl(mediaRef.id) : null,
+    };
+  });
+}
+
+/** Pull current (non-archived) Sanity teams. */
+async function fetchSanityTeams(): Promise<SanityTeam[]> {
+  return client.fetch(
+    `*[_type == "team" && archived != true]{
+      _id, name, age, "slug": slug.current, "hasImage": defined(teamImage)
+    } | order(age asc, name asc)`,
+  );
+}
+
+/** Parse an age token ("U17") from a Drupal team title; null for non-youth. */
+function parseAgeToken(title: string): string | null {
+  const m = title.match(/U\d{1,2}/i);
+  return m ? m[0].toUpperCase() : null;
+}
+
+type MatchOutcome =
+  | { kind: "matched"; team: SanityTeam }
+  | { kind: "skip-no-image" }
+  | { kind: "skip-already-has"; team: SanityTeam }
+  | { kind: "unmatched"; reason: string };
+
+function matchTeam(drupal: DrupalTeam, sanity: SanityTeam[]): MatchOutcome {
+  if (!drupal.imageUrl) return { kind: "skip-no-image" };
+
+  // 1) Explicit override by slug (seniors + any owner-resolved ambiguity).
+  const overrideSlug = SLUG_OVERRIDES[drupal.title];
+  if (overrideSlug) {
+    const team = sanity.find((t) => t.slug === overrideSlug);
+    if (!team)
+      return {
+        kind: "unmatched",
+        reason: `override slug "${overrideSlug}" not found in ${dataset}`,
+      };
+    return team.hasImage && !FORCE
+      ? { kind: "skip-already-has", team }
+      : { kind: "matched", team };
+  }
+
+  // 2) Dynamic match by age band. Require the age token to also appear in the
+  //    Sanity name so a band like U17 (which also holds a U16-named team) lands
+  //    on the right doc.
+  const age = parseAgeToken(drupal.title);
+  if (!age)
+    return {
+      kind: "unmatched",
+      reason: `no age token and no override for "${drupal.title}"`,
+    };
+
+  const candidates = sanity.filter(
+    (t) => t.age === age && t.name.toUpperCase().includes(age),
+  );
+  if (candidates.length === 0)
+    return { kind: "unmatched", reason: `no ${age} team in ${dataset}` };
+  if (candidates.length > 1)
+    return {
+      kind: "unmatched",
+      reason: `ambiguous — ${candidates.length} ${age} teams (${candidates
+        .map((c) => c.slug)
+        .join(", ")}); add a SLUG_OVERRIDES entry`,
+    };
+
+  const team = candidates[0];
+  return team.hasImage && !FORCE
+    ? { kind: "skip-already-has", team }
+    : { kind: "matched", team };
+}
+
+/** Download a Drupal image and upload it as a Sanity image asset. */
+async function uploadImage(imageUrl: string): Promise<string> {
+  const res = await fetch(imageUrl);
+  if (!res.ok) throw new Error(`image fetch failed: HTTP ${res.status} ${imageUrl}`);
+  const contentType = res.headers.get("content-type") ?? "image/jpeg";
+  const buffer = Buffer.from(await res.arrayBuffer());
+  const filename = decodeURIComponent(imageUrl.split("/").pop() ?? "team.jpg");
+  const asset = await client.assets.upload("image", buffer, {
+    filename,
+    contentType,
+  });
+  return asset._id;
+}
+
+async function main(): Promise<void> {
+  if (dataset === "production" && process.env.SANITY_ALLOW_PRODUCTION !== "1") {
+    console.error(
+      "Refusing to write to production. Set SANITY_ALLOW_PRODUCTION=1 to proceed.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\nTeam-image backfill — dataset=${dataset} ${DRY_RUN ? "(DRY RUN)" : ""}${
+      FORCE ? " (FORCE)" : ""
+    }\n`,
+  );
+
+  const [drupalTeams, sanityTeams] = await Promise.all([
+    fetchDrupalTeams(),
+    fetchSanityTeams(),
+  ]);
+
+  const planned: { drupal: DrupalTeam; team: SanityTeam }[] = [];
+  const skippedHas: string[] = [];
+  const skippedNoImg: string[] = [];
+  const unmatched: string[] = [];
+
+  for (const drupal of drupalTeams) {
+    const outcome = matchTeam(drupal, sanityTeams);
+    switch (outcome.kind) {
+      case "matched":
+        planned.push({ drupal, team: outcome.team });
+        console.log(
+          `  MATCH   ${drupal.title.padEnd(12)} → ${outcome.team.name} (${outcome.team.slug})`,
+        );
+        break;
+      case "skip-already-has":
+        skippedHas.push(`${drupal.title} → ${outcome.team.slug}`);
+        break;
+      case "skip-no-image":
+        skippedNoImg.push(drupal.title);
+        break;
+      case "unmatched":
+        unmatched.push(`${drupal.title} — ${outcome.reason}`);
+        break;
+    }
+  }
+
+  console.log(
+    `\nPlan: ${planned.length} to upload · ${skippedHas.length} already have a photo · ` +
+      `${skippedNoImg.length} no legacy image · ${unmatched.length} unmatched\n`,
+  );
+  if (unmatched.length) {
+    console.log("Unmatched / needs decision:");
+    unmatched.forEach((u) => console.log(`  - ${u}`));
+    console.log("");
+  }
+
+  if (DRY_RUN) {
+    console.log("Dry run — no writes performed.");
+    return;
+  }
+
+  let uploaded = 0;
+  for (const { drupal, team } of planned) {
+    try {
+      const assetId = await uploadImage(drupal.imageUrl!);
+      await client
+        .patch(team._id)
+        .set({
+          teamImage: {
+            _type: "image",
+            asset: { _type: "reference", _ref: assetId },
+          },
+        })
+        .commit();
+      uploaded += 1;
+      console.log(`  ✓ ${team.name} ← ${drupal.title}`);
+    } catch (err) {
+      console.error(`  ✗ ${team.name} ← ${drupal.title}: ${(err as Error).message}`);
+    }
+  }
+
+  console.log(`\nDone — ${uploaded}/${planned.length} photos written to ${dataset}.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/team-image-backfill/src/sanity-client.ts
+++ b/scripts/team-image-backfill/src/sanity-client.ts
@@ -1,0 +1,33 @@
+import { createClient } from "@sanity/client";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export const dataset = process.env.SANITY_DATASET ?? "staging";
+
+function resolveToken(): string {
+  if (process.env.SANITY_API_TOKEN) return process.env.SANITY_API_TOKEN;
+
+  try {
+    const configPath = join(homedir(), ".config", "sanity", "config.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (config.authToken) return config.authToken;
+  } catch (err) {
+    console.debug("Failed to read Sanity config:", (err as Error).message);
+  }
+
+  console.error(
+    "No Sanity auth token found (checked SANITY_API_TOKEN env var and ~/.config/sanity/config.json)",
+  );
+  process.exit(1);
+}
+
+console.log(`Using dataset: ${dataset}`);
+
+export const client = createClient({
+  projectId: "vhb33jaz",
+  dataset,
+  apiVersion: "2024-01-01",
+  token: resolveToken(),
+  useCdn: false,
+});


### PR DESCRIPTION
Closes #2070

## Context

`team.teamImage` ("Team squad photo") is an **editorial** Sanity field. Teams are PSD-synced (PSD never sets editorial fields), so squad photos had to be migrated from the legacy Drupal site during the initial cutover — **that step was missed**, leaving all 25 teams without a photo. Surfaced while scoping the Phase 7 `/jeugd` redesign (#2038–#2042), where team photos were requested back into the listing.

The photos still exist in Drupal (`node/team` → `field_media_article_image`) and are recovered here.

## Changes

New standalone `scripts/team-image-backfill/` (mirrors `scripts/responsibility-seeding/` — outside the pnpm workspace, own `@sanity/client` + `tsx`):

- Fetches Drupal teams + media, resolves photo URLs.
- Matches to Sanity by **age token + name**; seniors (`A-Ploeg`/`B-Ploeg`) and any ambiguous band via an explicit `SLUG_OVERRIDES` map.
- **Never guesses** — a band that maps to >1 current team is reported as unmatched.
- **Idempotent** (skips teams that already have a photo), `--dry-run`, and a production guard (`SANITY_ALLOW_PRODUCTION=1`).

## This migration has already been run (staging + production)

| | Recovered | Skipped (no legacy photo) | Pending decision |
|---|---|---|---|
| **11 teams** | A, B, U10, U11, U12, U13, U14, U15, U17, U21, U6 | Angels, Jeugdbestuur, Bestuur, U5, U8, U16, U19, Reserven, Weitse Gans | **U7**, **U9** |

Verified post-run: production `count(*[_type=="team" && defined(teamImage)]) == 11`, assets resolve on `cdn.sanity.io`.

## Pending owner decision (follow-up, not blocking)

Two legacy photos map to more than one current team and were left unmatched rather than guessed:

- **U7** (1 legacy photo, `23-24` cohort) → `kcvve-u7-groen` **or** `kcvve-u7-wit`?
- **U9** (1 legacy photo, `2022-23` cohort) → `kcvve-u9-wit` / `kcvve-u9-groen` / `kcvve-u9p`?

To apply once decided: add a line to `SLUG_OVERRIDES`, re-run (idempotent — only the new team is written).

## Testing

- Dry-run reviewed on staging — match plan correct, ambiguous bands flagged.
- Applied to **staging** (10/10) then **production** (11/11); both verified via GROQ + CDN URL resolution.
- Re-running is a no-op (idempotency confirmed: A-Ploeg was skipped on staging where it already had a photo).
- Scope: `scripts/` is not a pnpm workspace member, so no `apps/web` code path is affected.

## Next

Unblocks the `/jeugd` + `/ploegen` photo-card redesign (#2038–#2042) — design drills and VR baselines can now use real photos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated team image backfill utility that restores missing team image data from a legacy system with intelligent matching logic and built-in safety features, including dry-run mode and production environment guards.

* **Chores**
  * Added script configuration, package dependencies, and comprehensive documentation for the new backfill utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->