### PR TITLE
feat(ui): /jeugd hero (photo) + filosofie/visie block (#2039)

### DIFF
--- a/apps/web/src/app/(landing)/jeugd/loading.tsx
+++ b/apps/web/src/app/(landing)/jeugd/loading.tsx
@@ -1,24 +1,36 @@
 /**
- * `/jeugd` loading skeleton — mirrors the Phase 7 tracer composition on cream
- * (header → editorial nav grid → youth-directory division grid). Replaces the
- * legacy dark `SectionStack`/`getJeugdSections` envelope.
+ * `/jeugd` loading skeleton — mirrors the Phase 7 composition on cream
+ * (split hero → seam → filosofie/visie block → editorial nav grid →
+ * youth-directory division grid). Replaces the legacy dark
+ * `SectionStack`/`getJeugdSections` envelope.
  */
-
-import { FooterSafeArea } from "@/components/design-system";
 
 export default function JeugdLoading() {
   return (
     <>
       <div className="mx-auto w-full max-w-[70rem] px-4 py-10 sm:py-14">
-        {/* Header */}
-        <div className="mb-12 flex animate-pulse flex-col gap-3">
-          <div className="bg-ink/10 h-3 w-48 rounded" />
-          <div className="bg-ink/10 h-12 w-72 max-w-full rounded" />
-          <div className="bg-ink/10 h-5 w-96 max-w-full rounded" />
+        {/* Split hero — text column + photo */}
+        <div className="grid animate-pulse items-center gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12">
+          <div className="flex flex-col gap-4">
+            <div className="bg-ink/10 h-3 w-48 rounded" />
+            <div className="bg-ink/10 h-14 w-80 max-w-full rounded" />
+            <div className="bg-ink/10 h-16 w-full max-w-[28rem] rounded" />
+            <div className="bg-ink/10 h-3 w-64 rounded" />
+          </div>
+          <div className="bg-ink/10 aspect-[3/2] w-full rounded-sm" />
+        </div>
+
+        {/* Seam */}
+        <div className="bg-ink/10 my-10 h-[18px] w-full animate-pulse rounded sm:my-12" />
+
+        {/* Filosofie / visie block */}
+        <div className="animate-pulse">
+          <div className="bg-ink/10 mb-4 h-3 w-40 rounded" />
+          <div className="bg-ink/10 h-32 w-full rounded-sm" />
         </div>
 
         {/* Editorial nav grid */}
-        <div className="grid animate-pulse grid-cols-1 gap-5 md:grid-cols-3">
+        <div className="mt-16 grid animate-pulse grid-cols-1 gap-5 md:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
             <div key={i} className="bg-ink/10 aspect-[16/9] rounded-sm" />
           ))}
@@ -39,8 +51,6 @@ export default function JeugdLoading() {
           ))}
         </div>
       </div>
-
-      <FooterSafeArea />
     </>
   );
 }

--- a/apps/web/src/app/(landing)/jeugd/page.test.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.test.tsx
@@ -37,17 +37,28 @@ describe("/jeugd page — cream tracer composition", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the page heading on cream (no SectionStack transitions)", async () => {
+  it("renders the JeugdHero heading on cream (no SectionStack transitions)", async () => {
     const JeugdPage = (await import("./page")).default;
     const { container } = render(await JeugdPage());
 
     expect(
-      screen.getByRole("heading", { level: 1, name: /jeugdopleiding/i }),
+      screen.getByRole("heading", {
+        level: 1,
+        name: /beter worden begint met plezier/i,
+      }),
     ).toBeInTheDocument();
     // The legacy dark SectionStack + diagonal transitions are gone.
     expect(
       container.querySelectorAll('[data-testid="section-transition"]'),
     ).toHaveLength(0);
+  });
+
+  it("renders the filosofie/visie block with the #visie anchor", async () => {
+    const JeugdPage = (await import("./page")).default;
+    const { container } = render(await JeugdPage());
+
+    expect(container.querySelector("section#visie")).toBeInTheDocument();
+    expect(screen.getByText("Onze jeugdvisie")).toBeInTheDocument();
   });
 
   it("no longer renders the legacy 'Word ook lid' CTA", async () => {

--- a/apps/web/src/app/(landing)/jeugd/page.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.tsx
@@ -18,9 +18,9 @@ import {
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
-import { MonoLabel } from "@/components/design-system/MonoLabel";
-import { EditorialHeading } from "@/components/design-system/EditorialHeading";
-import { FooterSafeArea } from "@/components/design-system";
+import { StripedSeam } from "@/components/design-system";
+import { JeugdHero } from "@/components/jeugd/JeugdHero/JeugdHero";
+import { JeugdVisie } from "@/components/jeugd/JeugdVisie/JeugdVisie";
 import { JeugdEditorialGrid } from "@/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid";
 import { YouthDirectory } from "@/components/team/YouthDirectory";
 
@@ -79,12 +79,11 @@ async function fetchEditorialConfig(): Promise<EditorialCardConfig[] | null> {
 }
 
 /**
- * `/jeugd` — Phase 7 tracer (PRD redesign-phase-7-jeugd §3). The route is
- * rebuilt on the cream vocabulary: a temporary editorial header + the existing
- * nav cards (`<JeugdEditorialGrid>`) + the 6.C `<YouthDirectory>` division grid
- * (replacing the legacy dark `<TeamOverview>`). The `<JeugdHero>`, filosofie
- * block, nav-hub reskin, and CTA band land in Phases 2-5 (#2039-#2042); this
- * proves the route + data + e2e on the new spine first.
+ * `/jeugd` — Phase 7 redesign (PRD redesign-phase-7-jeugd). The route renders
+ * on the cream vocabulary: `<JeugdHero>` (photo) → `<StripedSeam>` →
+ * `<JeugdVisie>` (the `#visie` filosofie block) → the existing nav cards
+ * (`<JeugdEditorialGrid>`) → the 6.C `<YouthDirectory>` division grid. The
+ * nav-hub reskin and CTA band land in the remaining phases (#2040-#2042).
  */
 export default async function JeugdPage() {
   const [teams, articles, editorialConfig] = await Promise.all([
@@ -105,35 +104,23 @@ export default async function JeugdPage() {
       />
 
       <div className="mx-auto w-full max-w-[70rem] px-4 py-10 sm:py-14">
-        {/* Temporary tracer header — replaced by <JeugdHero> in Phase 2. */}
-        <header className="mb-12 flex flex-col gap-3">
-          <span>
-            <MonoLabel variant="plain">
-              De jeugdopleiding · U6 tot U21
-            </MonoLabel>
-          </span>
-          <EditorialHeading
-            level={1}
-            size="display-2xl"
-            emphasis={{ text: "." }}
-          >
-            Jeugdopleiding
-          </EditorialHeading>
-          <p className="font-display text-ink-muted text-[length:var(--text-display-sm)] leading-[var(--text-display-sm--lh)] italic">
-            Van U6 tot U21 — ploegen, nieuws en praktische info voor onze
-            jongste compagnie.
-          </p>
-        </header>
+        <JeugdHero />
 
-        <JeugdEditorialGrid
-          articles={articles}
-          editorialConfig={editorialConfig}
-        />
+        <div className="my-10 sm:my-12">
+          <StripedSeam colorPair="ink-cream" height="md" />
+        </div>
+
+        <JeugdVisie />
+
+        <div className="mt-16">
+          <JeugdEditorialGrid
+            articles={articles}
+            editorialConfig={editorialConfig}
+          />
+        </div>
 
         <YouthDirectory divisions={youthByDivision} className="mt-16" />
       </div>
-
-      <FooterSafeArea />
     </>
   );
 }

--- a/apps/web/src/components/jeugd/JeugdHero/JeugdHero.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdHero/JeugdHero.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { JeugdHero } from "./JeugdHero";
+
+const meta = {
+  title: "Features/Jeugd/JeugdHero",
+  component: JeugdHero,
+  tags: ["autodocs", "vr"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          'The `/jeugd` split hero (Phase 7 / 7j1). Left column: MonoLabel kicker "De jeugdopleiding · U6 tot U21" + EditorialHeading "Beter worden begint met plezier." (jersey-deep period) + italic-display lead for parents + a mono division-path line. Right column: a youth photo in a newsprint `<TapedFigure>`. Mirrors `<SponsorHero>` / `<BoardHero>` on cream.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-cream mx-auto w-full max-w-[70rem] px-4 py-10 sm:py-14">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof JeugdHero>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default split hero with the committed youth photo (served by Storybook staticDirs). */
+export const Default: Story = {};
+
+/** Mobile viewport — the split stacks to a single column. */
+export const MobileViewport: Story = {
+  globals: { viewport: { value: "kcvvMobile" } },
+};

--- a/apps/web/src/components/jeugd/JeugdHero/JeugdHero.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdHero/JeugdHero.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ImageProps } from "next/image";
+import { JeugdHero } from "./JeugdHero";
+
+vi.mock("next/image", () => ({
+  default: ({ alt, src, ...rest }: ImageProps) => {
+    const props = { alt, src: typeof src === "string" ? src : "", ...rest };
+    return <img {...props} />;
+  },
+}));
+
+describe("JeugdHero", () => {
+  it("renders the kicker, level-1 heading (with jersey-deep period) and parent lead", () => {
+    render(<JeugdHero />);
+
+    expect(
+      screen.getByText("De jeugdopleiding · U6 tot U21"),
+    ).toBeInTheDocument();
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Beter worden begint met plezier.");
+
+    // The lead keeps the "gediplomeerde trainers" hook from the voice lock.
+    expect(
+      screen.getByText(/gediplomeerde trainers en plezier als motor/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the division-path mono line", () => {
+    render(<JeugdHero />);
+    expect(
+      screen.getByText("Onderbouw → Middenbouw → Bovenbouw"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the youth photo, defaulting to the committed youth asset", () => {
+    render(<JeugdHero />);
+    const img = screen.getByRole("img", {
+      name: /jeugdspelers van kcvv elewijt tijdens een training/i,
+    });
+    expect(img).toHaveAttribute("src", "/images/youth-trainers.jpg");
+  });
+
+  it("honours a custom imageUrl", () => {
+    render(<JeugdHero imageUrl="/images/custom-youth.jpg" />);
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "/images/custom-youth.jpg",
+    );
+  });
+});

--- a/apps/web/src/components/jeugd/JeugdHero/JeugdHero.tsx
+++ b/apps/web/src/components/jeugd/JeugdHero/JeugdHero.tsx
@@ -1,0 +1,77 @@
+import Image from "next/image";
+import {
+  EditorialHeading,
+  MonoLabel,
+  TapedFigure,
+} from "@/components/design-system";
+
+export interface JeugdHeroProps {
+  /**
+   * Youth team / training photo. Defaults to the committed youth asset
+   * (also the homepage `<YouthSection>` backdrop), so the page can render
+   * `<JeugdHero />` with no props.
+   */
+  imageUrl?: string;
+}
+
+/** Local committed youth asset — also the homepage YouthSection backdrop. */
+const DEFAULT_PHOTO = "/images/youth-trainers.jpg";
+
+/**
+ * <JeugdHero> — the `/jeugd` split hero (Phase 7 / Phase 2, design contract
+ * 7j1). Mirrors the `<SponsorHero>` / `<BoardHero>` sibling-hero structure on
+ * cream: a MonoLabel kicker + `<EditorialHeading>` "Beter worden begint met
+ * plezier." (jersey-deep period) + an italic-display lead for parents (keeps
+ * "gediplomeerde trainers"), beside a youth photo in a newsprint
+ * `<TapedFigure>`. Register: development through plezier.
+ *
+ * The text column uses `flex flex-col gap-4` with `mb-0` on the heading so the
+ * global `h1 { margin-bottom: 1em }` base rule (≈96px at display-2xl) collapses
+ * to the column gap — the same pattern as `<BoardHero>`.
+ */
+export function JeugdHero({ imageUrl = DEFAULT_PHOTO }: JeugdHeroProps) {
+  return (
+    <header className="grid items-center gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12">
+      <div className="flex flex-col gap-4">
+        <span>
+          <MonoLabel variant="plain">De jeugdopleiding · U6 tot U21</MonoLabel>
+        </span>
+        <EditorialHeading
+          level={1}
+          size="display-2xl"
+          emphasis={{ text: "." }}
+          className="mb-0"
+        >
+          Beter worden begint met plezier
+        </EditorialHeading>
+        <p className="text-ink-soft font-display text-[length:var(--text-display-sm)] leading-[var(--text-display-sm--lh)] italic">
+          Een doordachte opleiding van Onderbouw tot Bovenbouw, met
+          gediplomeerde trainers en plezier als motor. Want wie graag speelt,
+          groeit vanzelf — op en naast het veld.
+        </p>
+        <span>
+          <MonoLabel variant="plain">
+            Onderbouw → Middenbouw → Bovenbouw
+          </MonoLabel>
+        </span>
+      </div>
+
+      <TapedFigure
+        aspect="landscape-3-2"
+        bg="cream-soft"
+        tint="newsprint"
+        rotation="b"
+        tape={{ color: "warm", length: "md", position: "left", rotation: "a" }}
+        className="w-full"
+      >
+        <Image
+          src={imageUrl}
+          alt="Jeugdspelers van KCVV Elewijt tijdens een training"
+          fill
+          sizes="(min-width: 1024px) 32rem, 100vw"
+          className="object-cover"
+        />
+      </TapedFigure>
+    </header>
+  );
+}

--- a/apps/web/src/components/jeugd/JeugdVisie/JeugdVisie.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdVisie/JeugdVisie.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { JeugdVisie } from "./JeugdVisie";
+
+const meta = {
+  title: "Features/Jeugd/JeugdVisie",
+  component: JeugdVisie,
+  tags: ["autodocs", "vr"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          'The `/jeugd` filosofie/visie block (Phase 7 / 7j0b). Carries the `#visie` anchor. A mono section kicker "Onze jeugdvisie" above a cream-soft `<TapedCard>` pairing a jersey-deep `<QuoteMark>` with the visie statement (italic display) and a mono tag row. Replaces the retired green `<MissionBanner>`.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-cream mx-auto w-full max-w-[70rem] px-4 py-10 sm:py-14">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof JeugdVisie>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The filosofie/visie block as it renders below the hero seam. */
+export const Default: Story = {};
+
+/** Mobile viewport — the quote-mark + body grid holds on narrow screens. */
+export const MobileViewport: Story = {
+  globals: { viewport: { value: "kcvvMobile" } },
+};

--- a/apps/web/src/components/jeugd/JeugdVisie/JeugdVisie.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdVisie/JeugdVisie.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { JeugdVisie } from "./JeugdVisie";
+
+describe("JeugdVisie", () => {
+  it("renders a section carrying the #visie anchor", () => {
+    const { container } = render(<JeugdVisie />);
+    const section = container.querySelector("section#visie");
+    expect(section).toBeInTheDocument();
+  });
+
+  it("renders the section kicker and the visie statement", () => {
+    render(<JeugdVisie />);
+    expect(screen.getByText("Onze jeugdvisie")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Bij KCVV Elewijt staat plezier op één/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the mono tag row", () => {
+    render(<JeugdVisie />);
+    for (const tag of ["de jeugdvisie", "plezier", "techniek", "teamspirit"]) {
+      expect(screen.getByText(tag)).toBeInTheDocument();
+    }
+  });
+});

--- a/apps/web/src/components/jeugd/JeugdVisie/JeugdVisie.tsx
+++ b/apps/web/src/components/jeugd/JeugdVisie/JeugdVisie.tsx
@@ -1,0 +1,53 @@
+import {
+  MonoLabel,
+  MonoLabelRow,
+  QuoteMark,
+  TapedCard,
+} from "@/components/design-system";
+
+const VISIE_TAGS = [
+  { label: "de jeugdvisie" },
+  { label: "plezier" },
+  { label: "techniek" },
+  { label: "teamspirit" },
+];
+
+/**
+ * <JeugdVisie> — the `/jeugd` filosofie/visie block (Phase 7 / Phase 2, design
+ * contract 7j0b + 7j-final-page). Carries the `#visie` anchor — the repointed
+ * "jeugdvisie" nav card (Phase 3) lands here. Replaces the retired green
+ * `<MissionBanner>` with the cream vocabulary: a mono section kicker + a
+ * cream-soft `<TapedCard>` pairing a jersey-deep `<QuoteMark>` with the visie
+ * statement (italic display) and a mono tag row. Copy is deliberately distinct
+ * from the hero lead per the lock.
+ *
+ * Composed from primitives rather than `<PullQuote>` (the lock sanctions
+ * "PullQuote OR a TapedCard block"): the mockup lays the quote mark to the
+ * LEFT of the body in a grid, and the trailing row is a mono tag list — not a
+ * person attribution — so `<PullQuote>`'s top-quote-mark + name/role/source
+ * shape would be the wrong primitive here. Shared chrome (TapedCard, QuoteMark)
+ * still propagates.
+ */
+export function JeugdVisie() {
+  return (
+    <section id="visie" className="scroll-mt-24">
+      <div className="mb-4 flex items-center gap-2.5">
+        <MonoLabel variant="plain">Onze jeugdvisie</MonoLabel>
+        <span aria-hidden="true" className="bg-paper-edge h-0.5 flex-1" />
+      </div>
+
+      <TapedCard bg="cream-soft" padding="lg" shadow="md">
+        <div className="grid grid-cols-[auto_1fr] items-center gap-5 sm:gap-6">
+          <QuoteMark color="jersey" />
+          <div className="flex flex-col gap-3">
+            <p className="text-ink font-display text-[length:var(--text-display-sm)] leading-[var(--text-display-sm--lh)] italic">
+              Bij KCVV Elewijt staat plezier op één. Wie graag speelt, leert
+              vanzelf — techniek, teamspirit en respect groeien mee.
+            </p>
+            <MonoLabelRow items={VISIE_TAGS} />
+          </div>
+        </div>
+      </TapedCard>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #2039

Phase 2 of the `/jeugd` redesign (retro-terrace-fanzine). Replaces the temporary tracer header with the locked hero + filosofie/visie block on the cream spine.

## Changes

- **`<JeugdHero>`** (`components/jeugd/JeugdHero/`) — split photo hero mirroring `<SponsorHero>` / `<BoardHero>`: MonoLabel kicker `De jeugdopleiding · U6 tot U21` + `<EditorialHeading>` "Beter worden begint met plezier." (jersey-deep period) + parent lead (keeps "gediplomeerde trainers") + a division-path mono line, beside a newsprint `<TapedFigure>` youth photo.
- **`<JeugdVisie>`** (`components/jeugd/JeugdVisie/`) — the `section#visie` filosofie block: a mono section kicker + a cream-soft `<TapedCard>` pairing a jersey-deep `<QuoteMark>` with the visie statement (italic display) + a mono tag row. Copy is distinct from the hero lead. Carries the `#visie` anchor that the Phase 3 nav card repoints to.
- **`<StripedSeam>`** between hero and visie. Page recomposed: Hero → seam → Visie → nav grid → divisions (locked 7j2 IA).
- **Removed `<FooterSafeArea>`** (page + loading skeleton) — see note below.
- **Loading skeleton** updated to mirror the new composition.

## Design fidelity

- Copy + token values taken from the locked design contract `docs/design/mockups/phase-7-jeugd/` (`7j-design-summary-locked.md` + `7j-final-page.html`). The hero lead uses `text-ink-soft` (= `--ink-soft #1f1f1f`), exactly as the mockup's `.lead` specifies.
- `<JeugdVisie>` is composed from primitives rather than `<PullQuote>` (the lock sanctions "PullQuote OR a TapedCard block"): the mockup puts the quote mark to the **left** in a grid and the trailing row is a **mono tag list**, not a person attribution — so `<PullQuote>`'s top-quote-mark + name/role/source shape would be the wrong primitive. Shared chrome (TapedCard, QuoteMark) still propagates.
- Open Q#4 (hero photo aspect): `<TapedFigure>` has no `landscape-4-3`, so `landscape-3-2` is used (closest landscape, matches the `<BoardHero>` precedent). Asset: the committed `youth-trainers.jpg` (also the homepage YouthSection backdrop).

## Why `<FooterSafeArea>` was removed

`<FooterSafeArea>` reserves `h-[var(--footer-diagonal)]` clearance for the old `PageFooter`'s `overlap="full"` diagonal — but the redesign **deleted that footer**. The global footer is now the flat `<SiteFooter>` (no overlap/diagonal/clip-path; rendered directly under `<main>` in the root layout). The only remaining "PageFooter" references are stale JSDoc. The redesign-complete `/sponsors` page already omits `FooterSafeArea`, so this brings `/jeugd` in line. (A repo-wide retirement of `FooterSafeArea` from the remaining ~14 legacy pages is out of scope here.)

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, unit, `next build`).
- New unit tests: `JeugdHero` (kicker / h1 w/ appended period / lead / photo default + override), `JeugdVisie` (`#visie` anchor / kicker / statement / tag row), plus updated `/jeugd` page test (new h1 + `#visie`). 24 tests green across the jeugd surface.
- e2e `/jeugd` smoke still satisfied — `<JeugdHero>` provides the visible `<h1>`.

## VR baselines

Stories for both components are tagged `vr`, but **baseline capture is deferred this PR** — VR CI is disabled during the redesign (`RUN_VISUAL_REGRESSION` gated off). Baselines will be generated when the VR chain is re-enabled at the end of the redesign series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
