### PR TITLE
feat(ui): /jeugd CTA band + empty states + shared CtaBand (#2041)

### DIFF
--- a/apps/web/src/app/(landing)/jeugd/loading.tsx
+++ b/apps/web/src/app/(landing)/jeugd/loading.tsx
@@ -51,6 +51,15 @@ export default function JeugdLoading() {
           ))}
         </div>
       </div>
+
+      {/* CTA band (full-bleed) */}
+      <div className="bg-jersey-deep-dark border-ink animate-pulse border-y-2">
+        <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-4 py-12 sm:py-16">
+          <div className="bg-cream/15 h-8 w-72 max-w-full rounded" />
+          <div className="bg-cream/15 h-4 w-96 max-w-full rounded" />
+          <div className="bg-cream/15 h-11 w-40 rounded" />
+        </div>
+      </div>
     </>
   );
 }

--- a/apps/web/src/app/(landing)/jeugd/page.test.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 // Mock the data layer so the async server component can render.
 vi.mock("@/lib/effect/runtime", () => ({
@@ -57,8 +57,12 @@ describe("/jeugd page — cream tracer composition", () => {
     const JeugdPage = (await import("./page")).default;
     const { container } = render(await JeugdPage());
 
-    expect(container.querySelector("section#visie")).toBeInTheDocument();
-    expect(screen.getByText("Onze jeugdvisie")).toBeInTheDocument();
+    const visie = container.querySelector("section#visie");
+    expect(visie).toBeInTheDocument();
+    // Scope to the section — "Onze jeugdvisie" is also a nav-hub card title.
+    expect(
+      within(visie as HTMLElement).getByText("Onze jeugdvisie"),
+    ).toBeInTheDocument();
   });
 
   it("no longer renders the legacy 'Word ook lid' CTA", async () => {
@@ -68,5 +72,37 @@ describe("/jeugd page — cream tracer composition", () => {
     expect(
       screen.queryByRole("link", { name: /word ook lid/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders the closing JeugdCtaBand linking to /hulp", async () => {
+    const JeugdPage = (await import("./page")).default;
+    render(await JeugdPage());
+
+    const cta = screen.getByRole("region", { name: "Schrijf je in" });
+    expect(
+      within(cta).getByRole("heading", {
+        level: 2,
+        name: /interesse in onze jeugd/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(cta).getByRole("link", { name: /schrijf je in/i }),
+    ).toHaveAttribute("href", "/hulp");
+  });
+
+  it("empty data: drops the divisions section, keeps a nav-only hub + the CTA", async () => {
+    const JeugdPage = (await import("./page")).default;
+    const { container } = render(await JeugdPage());
+
+    // 0 youth teams → <YouthDirectory> returns null (section dropped).
+    expect(
+      container.querySelector('[data-testid="youth-directory"]'),
+    ).not.toBeInTheDocument();
+    // 0 Jeugd articles → nav-only hub (the pinned nav cards remain).
+    expect(screen.getByText("Word lid van KCVV")).toBeInTheDocument();
+    // The CTA band still renders.
+    expect(
+      screen.getByRole("region", { name: "Schrijf je in" }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(landing)/jeugd/page.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.tsx
@@ -22,6 +22,7 @@ import { StripedSeam } from "@/components/design-system";
 import { JeugdHero } from "@/components/jeugd/JeugdHero/JeugdHero";
 import { JeugdVisie } from "@/components/jeugd/JeugdVisie/JeugdVisie";
 import { JeugdEditorialGrid } from "@/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid";
+import { JeugdCtaBand } from "@/components/jeugd/JeugdCtaBand/JeugdCtaBand";
 import { YouthDirectory } from "@/components/team/YouthDirectory";
 
 export const metadata: Metadata = {
@@ -81,9 +82,11 @@ async function fetchEditorialConfig(): Promise<EditorialCardConfig[] | null> {
 /**
  * `/jeugd` — Phase 7 redesign (PRD redesign-phase-7-jeugd). The route renders
  * on the cream vocabulary: `<JeugdHero>` (photo) → `<StripedSeam>` →
- * `<JeugdVisie>` (the `#visie` filosofie block) → the existing nav cards
- * (`<JeugdEditorialGrid>`) → the 6.C `<YouthDirectory>` division grid. The
- * nav-hub reskin and CTA band land in the remaining phases (#2040-#2042).
+ * `<JeugdVisie>` (the `#visie` filosofie block) → the `<JeugdEditorialGrid>`
+ * nav hub → the 6.C `<YouthDirectory>` division grid → the full-bleed
+ * `<JeugdCtaBand>`. Empty states: no youth teams → `<YouthDirectory>` drops the
+ * section (returns null); no Jeugd articles → the nav hub collapses to its
+ * pinned nav cards. Analytics + SEO land in #2042.
  */
 export default async function JeugdPage() {
   const [teams, articles, editorialConfig] = await Promise.all([
@@ -121,6 +124,8 @@ export default async function JeugdPage() {
 
         <YouthDirectory divisions={youthByDivision} className="mt-16" />
       </div>
+
+      <JeugdCtaBand />
     </>
   );
 }

--- a/apps/web/src/components/design-system/CtaBand/CtaBand.stories.tsx
+++ b/apps/web/src/components/design-system/CtaBand/CtaBand.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CtaBand } from "./CtaBand";
+
+const meta = {
+  title: "UI/CtaBand",
+  component: CtaBand,
+  tags: ["autodocs", "vr"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "The redesign's closing CTA band: a leading `<StripedSeam>` + a full-width `bg-jersey-deep-dark` section (`border-y-2 border-ink`) with an italic-display question + sub-line + a `warm` paper-stamp button. Shared by `<SponsorCtaBand>` and `<JeugdCtaBand>`. Render full-bleed as the last element of a page.",
+      },
+    },
+  },
+} satisfies Meta<typeof CtaBand>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Interactive playground — tweak the copy + href via Controls. */
+export const Playground: Story = {
+  args: {
+    ariaLabel: "Schrijf je in",
+    heading: "Interesse in onze jeugd?",
+    emphasis: { text: "onze jeugd", tone: "warm" },
+    lead: "Nieuwe spelers zijn altijd welkom — van U6 tot U21. Kom gerust eens langs op training.",
+    buttonLabel: "Schrijf je in +",
+    href: "/hulp",
+  },
+};
+
+/** Internal route target → renders a `<LinkButton>`. */
+export const InternalLink: Story = {
+  args: {
+    ariaLabel: "Word sponsor",
+    heading: "Jouw zaak ook langs de zijlijn?",
+    emphasis: { text: "langs de zijlijn", tone: "warm" },
+    lead: "Word partner van de plezantste compagnie en steun onze jeugd en eerste ploegen!",
+    buttonLabel: "Word sponsor +",
+    href: "/club/contact",
+  },
+};
+
+/** A `mailto:` target → renders a plain styled `<a>` (no new-tab target). */
+export const MailtoLink: Story = {
+  args: {
+    ariaLabel: "Schrijf je in",
+    heading: "Interesse in onze jeugd?",
+    emphasis: { text: "onze jeugd", tone: "warm" },
+    lead: "Nieuwe spelers zijn altijd welkom — van U6 tot U21.",
+    buttonLabel: "Schrijf je in +",
+    href: "mailto:jeugd@kcvvelewijt.be",
+  },
+};

--- a/apps/web/src/components/design-system/CtaBand/CtaBand.test.tsx
+++ b/apps/web/src/components/design-system/CtaBand/CtaBand.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: { children: React.ReactNode; href: string } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { CtaBand } from "./CtaBand";
+
+const base = {
+  ariaLabel: "Schrijf je in",
+  heading: "Interesse in onze jeugd?",
+  lead: "Nieuwe spelers zijn altijd welkom.",
+  buttonLabel: "Schrijf je in +",
+};
+
+describe("CtaBand", () => {
+  it("renders the heading (no spurious period on a question), lead and landmark", () => {
+    render(<CtaBand {...base} href="/hulp" />);
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveTextContent("Interesse in onze jeugd?");
+    expect(heading.textContent).not.toContain("?.");
+    expect(
+      screen.getByText("Nieuwe spelers zijn altijd welkom."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Schrijf je in" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an internal href as a link button", () => {
+    render(<CtaBand {...base} href="/hulp" />);
+    const link = screen.getByRole("link", { name: /schrijf je in/i });
+    expect(link).toHaveAttribute("href", "/hulp");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("renders a mailto href as a plain anchor (no new-tab target)", () => {
+    render(<CtaBand {...base} href="mailto:jeugd@kcvvelewijt.be" />);
+    const link = screen.getByRole("link", { name: /schrijf je in/i });
+    expect(link).toHaveAttribute("href", "mailto:jeugd@kcvvelewijt.be");
+    expect(link).not.toHaveAttribute("target");
+  });
+
+  it("opens an external http(s) href in a new tab with a safe rel", () => {
+    render(<CtaBand {...base} href="https://example.com/inschrijven" />);
+    const link = screen.getByRole("link", { name: /schrijf je in/i });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("forwards buttonData (analytics markers) onto the button", () => {
+    render(
+      <CtaBand
+        {...base}
+        href="/hulp"
+        buttonData={{ "data-jeugd-cta": "true" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /schrijf je in/i });
+    expect(link).toHaveAttribute("data-jeugd-cta", "true");
+  });
+});

--- a/apps/web/src/components/design-system/CtaBand/CtaBand.tsx
+++ b/apps/web/src/components/design-system/CtaBand/CtaBand.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react";
+import {
+  EditorialHeading,
+  type EditorialHeadingEmphasis,
+} from "../EditorialHeading";
+import { LinkButton } from "../LinkButton";
+import { StripedSeam } from "../StripedSeam";
+import { getButtonClasses } from "../Button/button-styles";
+
+const EXTERNAL_HREF = /^(https?:|mailto:|tel:)/i;
+
+export interface CtaBandProps {
+  /** Accessible name for the band's `<section>` landmark. */
+  ariaLabel: string;
+  /** The italic-display question (cream), with an optional warm emphasis. */
+  heading: string;
+  emphasis?: EditorialHeadingEmphasis;
+  /** Sub-line under the heading. */
+  lead: string;
+  /** Paper-stamp button label (e.g. `Word sponsor +`). */
+  buttonLabel: ReactNode;
+  /**
+   * Button target. Internal routes use `<LinkButton>`; `mailto:` / `tel:` /
+   * external `http(s):` hrefs render a plain styled `<a>` (next/link is for
+   * client-side route navigation only).
+   */
+  href: string;
+  /** Optional `data-*` attributes forwarded onto the button (analytics markers). */
+  buttonData?: Record<`data-${string}`, string>;
+}
+
+/**
+ * <CtaBand> — the redesign's closing CTA band: a leading `<StripedSeam>` + a
+ * full-width `bg-jersey-deep-dark` section (`border-y-2 border-ink`) carrying an
+ * italic-display question + sub-line + a `warm` paper-stamp button (the
+ * dark-surface `inverted` variant recoloured to `bg-warm`, canonical
+ * press-down). Shared by `<SponsorCtaBand>` and `<JeugdCtaBand>`.
+ *
+ * Render this full-bleed — as the last element of a page, outside its centered
+ * content container — so the band and its seam span the viewport.
+ */
+export function CtaBand({
+  ariaLabel,
+  heading,
+  emphasis,
+  lead,
+  buttonLabel,
+  href,
+  buttonData,
+}: CtaBandProps) {
+  const isExternal = EXTERNAL_HREF.test(href);
+  const isHttp = /^https?:/i.test(href);
+  const buttonClassName = "bg-warm hover:bg-warm";
+
+  return (
+    <>
+      <StripedSeam colorPair="ink-cream" height="md" />
+      <section
+        aria-label={ariaLabel}
+        className="bg-jersey-deep-dark border-ink border-y-2"
+      >
+        <div className="mx-auto max-w-5xl px-4 py-12 text-center sm:py-16">
+          <EditorialHeading
+            level={2}
+            size="display-lg"
+            tone="cream"
+            emphasis={emphasis}
+            className="mb-4"
+          >
+            {heading}
+          </EditorialHeading>
+
+          <p className="text-cream/90 mx-auto mb-7 max-w-xl text-base leading-relaxed">
+            {lead}
+          </p>
+
+          <div className="flex justify-center">
+            {isExternal ? (
+              <a
+                href={href}
+                className={getButtonClasses({
+                  variant: "inverted",
+                  className: buttonClassName,
+                })}
+                {...buttonData}
+                {...(isHttp
+                  ? { target: "_blank", rel: "noopener noreferrer" }
+                  : {})}
+              >
+                {buttonLabel}
+              </a>
+            ) : (
+              <LinkButton
+                href={href}
+                variant="inverted"
+                className={buttonClassName}
+                {...buttonData}
+              >
+                {buttonLabel}
+              </LinkButton>
+            )}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/components/design-system/CtaBand/index.ts
+++ b/apps/web/src/components/design-system/CtaBand/index.ts
@@ -1,0 +1,1 @@
+export { CtaBand, type CtaBandProps } from "./CtaBand";

--- a/apps/web/src/components/design-system/index.ts
+++ b/apps/web/src/components/design-system/index.ts
@@ -277,6 +277,10 @@ export type {
 export { ClippedCard } from "./ClippedCard";
 export type { ClippedCardProps, ClippedCardAs } from "./ClippedCard";
 
+// CtaBand
+export { CtaBand } from "./CtaBand";
+export type { CtaBandProps } from "./CtaBand";
+
 // StampBadge
 export { StampBadge } from "./StampBadge";
 export type {

--- a/apps/web/src/components/editorial/EditorialHubCard/EditorialHubCard.stories.tsx
+++ b/apps/web/src/components/editorial/EditorialHubCard/EditorialHubCard.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "The uniform 16:9 image-top card of a landing-page nav hub (7j3). Shared across the /jeugd nav hub and (later) /club. **news** = greyscale→hover cover photo + jersey-deep tag pill; **nav** = jersey-deep glyph panel (Phosphor-fill) + cream tag pill. Both share border-2 ink + shadow-paper + canonical press-down.",
+          "The uniform 16:9 image-top card of a landing-page nav hub (7j3). Shared across the /jeugd nav hub and (later) /club. **news** = newsprint-colour cover photo + jersey-deep tag pill; **nav** = jersey-deep glyph panel (Phosphor-fill) + cream tag pill. Both share border-2 ink + shadow-paper + canonical press-down. (Greyscale→hover is sponsor-logo-only — never news cards.)",
       },
     },
   },
@@ -45,7 +45,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** News variant — greyscale cover photo (resolves to colour on hover) + jersey-deep tag. */
+/** News variant — newsprint-colour cover photo + jersey-deep tag. */
 export const News: Story = {
   args: {
     variant: "news",

--- a/apps/web/src/components/editorial/EditorialHubCard/EditorialHubCard.tsx
+++ b/apps/web/src/components/editorial/EditorialHubCard/EditorialHubCard.tsx
@@ -17,7 +17,7 @@ export interface EditorialHubCardProps {
   title: string;
   arrowText: string;
   variant: EditorialHubCardVariant;
-  /** News variant cover photo (greyscale → hover-colour). */
+  /** News variant cover photo (newsprint colour — never greyscale). */
   imageUrl?: string;
   /** Alt text for the news cover photo. */
   imageAlt?: string;
@@ -41,8 +41,9 @@ const DEFAULT_NEWS_SIZES =
  * `/club` hub; supersedes the legacy full-bleed `<EditorialCard>`.
  *
  * Two variants:
- * - **news** — a greyscale→hover-colour cover photo with a jersey-deep tag pill
- *   (the "funeral card" greyscale exception). Bubbles in the latest articles.
+ * - **news** — a newsprint-colour cover photo with a jersey-deep tag pill.
+ *   Bubbles in the latest articles. (Greyscale→hover is reserved for sponsor
+ *   logos only — never news cards/listings.)
  * - **nav** — a `bg-jersey-deep` panel with a centered Phosphor-fill glyph and a
  *   cream tag pill; no photo. Pinned navigation links.
  *
@@ -93,12 +94,15 @@ export function EditorialHubCard({
         ) : (
           <>
             {imageUrl && (
+              // Newsprint COLOUR — news covers are never greyscale (that
+              // treatment is reserved for sponsor logos).
               <Image
                 src={imageUrl}
                 alt={imageAlt ?? ""}
                 fill
                 sizes={sizes ?? DEFAULT_NEWS_SIZES}
-                className="object-cover grayscale transition-all duration-300 ease-out group-hover:grayscale-0 group-focus-visible:grayscale-0 motion-reduce:transition-none"
+                className="object-cover"
+                style={{ filter: "var(--filter-photo-newsprint)" }}
               />
             )}
             <span className="relative z-10 m-2.5">

--- a/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { JeugdCtaBand } from "./JeugdCtaBand";
+
+const meta = {
+  title: "Features/Jeugd/JeugdCtaBand",
+  component: JeugdCtaBand,
+  tags: ["autodocs", "vr"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          'The `/jeugd` closing CTA band (Phase 7). The shared `<CtaBand>` with youth copy: "Interesse in onze jeugd?" + a warm paper-stamp "Schrijf je in +" → /hulp (until the membership form #1473 ships).',
+      },
+    },
+  },
+} satisfies Meta<typeof JeugdCtaBand>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default — links to /hulp. */
+export const Default: Story = {};

--- a/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: { children: React.ReactNode; href: string } & Record<string, unknown>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { JeugdCtaBand } from "./JeugdCtaBand";
+
+describe("JeugdCtaBand", () => {
+  it("renders the invitation heading without a spurious period", () => {
+    render(<JeugdCtaBand />);
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveTextContent("Interesse in onze jeugd?");
+    expect(heading.textContent).not.toContain("?.");
+  });
+
+  it('renders the "Schrijf je in" CTA linking to /hulp by default', () => {
+    render(<JeugdCtaBand />);
+    const link = screen.getByRole("link", { name: /schrijf je in/i });
+    expect(link).toHaveAttribute("href", "/hulp");
+  });
+
+  it("honours a custom href", () => {
+    render(<JeugdCtaBand href="mailto:jeugd@kcvvelewijt.be" />);
+    const link = screen.getByRole("link", { name: /schrijf je in/i });
+    expect(link).toHaveAttribute("href", "mailto:jeugd@kcvvelewijt.be");
+  });
+
+  it("exposes a named landmark for the CTA", () => {
+    render(<JeugdCtaBand />);
+    expect(
+      screen.getByRole("region", { name: "Schrijf je in" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.tsx
+++ b/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.tsx
@@ -1,0 +1,32 @@
+import { CtaBand } from "@/components/design-system";
+
+export interface JeugdCtaBandProps {
+  /**
+   * Where "Schrijf je in +" links. Defaults to `/hulp` until the membership
+   * intake form (#1473) ships (PRD redesign-phase-7-jeugd §7). A `mailto:` or
+   * external href renders a plain styled `<a>`.
+   */
+  href?: string;
+}
+
+/**
+ * <JeugdCtaBand> — the `/jeugd` closing CTA band (Phase 7 / Phase 4). The shared
+ * `<CtaBand>` with youth copy: "Interesse in onze jeugd?" + a `warm` paper-stamp
+ * "Schrijf je in +". Render full-bleed as the page's last element.
+ */
+export function JeugdCtaBand({ href = "/hulp" }: JeugdCtaBandProps) {
+  return (
+    <CtaBand
+      ariaLabel="Schrijf je in"
+      heading="Interesse in onze jeugd?"
+      emphasis={{ text: "onze jeugd", tone: "warm" }}
+      lead="Nieuwe spelers zijn altijd welkom — van U6 tot U21. Kom gerust eens langs op training."
+      buttonLabel={
+        <>
+          Schrijf je in <span aria-hidden="true">+</span>
+        </>
+      }
+      href={href}
+    />
+  );
+}

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.stories.tsx
@@ -42,7 +42,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "The /jeugd nav hub (7j3): a uniform grid of 16:9 image-top `<EditorialHubCard>`s. News slots bubble the latest Jeugd articles (greyscale→hover photo, jersey-deep tag); six nav cards stay pinned (jersey-deep glyph panel, cream tag). With no articles the hub collapses to the pinned nav cards.",
+          "The /jeugd nav hub (7j3): a uniform grid of 16:9 image-top `<EditorialHubCard>`s. News slots bubble the latest Jeugd articles (newsprint-colour photo, jersey-deep tag); six nav cards stay pinned (jersey-deep glyph panel, cream tag). With no articles the hub collapses to the pinned nav cards.",
       },
     },
   },

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.test.tsx
@@ -238,5 +238,10 @@ describe("JeugdEditorialGrid", () => {
       render(<JeugdEditorialGrid articles={[]} />);
       expect(screen.getByText("Word lid van KCVV")).toBeInTheDocument();
     });
+
+    it("falls back to hardcoded defaults when editorialConfig is empty (§4)", () => {
+      render(<JeugdEditorialGrid articles={[]} editorialConfig={[]} />);
+      expect(screen.getByText("Word lid van KCVV")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.tsx
+++ b/apps/web/src/components/jeugd/JeugdEditorialGrid/JeugdEditorialGrid.tsx
@@ -216,15 +216,16 @@ interface JeugdEditorialGridProps {
  * variant + bubbling.
  *
  * Content comes from the Sanity `editorialCards` singleton when set; otherwise
- * the hardcoded `NAV_CARDS` fallback ships (repointed targets). With no
- * articles, the hub collapses to the pinned nav cards.
+ * (null or empty) the hardcoded `NAV_CARDS` fallback ships (repointed targets,
+ * design-summary §4). With no articles, the hub collapses to the pinned nav
+ * cards.
  */
 export function JeugdEditorialGrid({
   articles,
   editorialConfig,
 }: JeugdEditorialGridProps) {
   const items =
-    editorialConfig != null
+    editorialConfig != null && editorialConfig.length > 0
       ? buildItemsFromConfig(editorialConfig, articles)
       : buildItemsFromHardcoded(articles);
 

--- a/apps/web/src/components/sponsors/SponsorCtaBand/SponsorCtaBand.tsx
+++ b/apps/web/src/components/sponsors/SponsorCtaBand/SponsorCtaBand.tsx
@@ -1,95 +1,34 @@
-import {
-  EditorialHeading,
-  LinkButton,
-  StripedSeam,
-} from "@/components/design-system";
-import { getButtonClasses } from "@/components/design-system/Button/button-styles";
+import { CtaBand } from "@/components/design-system";
 
 export interface SponsorCtaBandProps {
   /** Where "Word sponsor +" links. Defaults to the club contact page (which
    *  surfaces the sponsoring address). Internal routes use `<LinkButton>`;
-   *  `mailto:` / `tel:` / external `http(s):` hrefs render a plain styled `<a>`
-   *  (next/link is for client-side route navigation only). */
+   *  `mailto:` / `tel:` / external `http(s):` hrefs render a plain styled `<a>`. */
   href?: string;
 }
 
-const EXTERNAL_HREF = /^(https?:|mailto:|tel:)/i;
-
 /**
  * <SponsorCtaBand> — the `/sponsors` closing footer band (7.d4 · C1). After the
- * gratitude of the wall, the page turns the thanks into an invitation: a
- * full-width `bg-jersey-deep-dark` band (`border-y-2 border-ink`, with a leading
- * `<StripedSeam>`) carrying an italic question + sub-line + a `warm` paper-stamp
- * "Word sponsor +". Mirrors the homepage `<ClubshopBanner>` dark-band idiom.
- *
- * The button reuses `<LinkButton variant="inverted">` (the dark-surface
- * paper-stamp: soft offset shadow + canonical press-down) recoloured to
- * `bg-warm`; promote to a dedicated `warm` variant once a second CtaBand
- * (e.g. <JeugdCtaBand>, #2041) needs it.
+ * gratitude of the wall, the page turns the thanks into an invitation: the
+ * shared `<CtaBand>` with sponsor copy and a `warm` paper-stamp
+ * "Word sponsor +".
  */
 export function SponsorCtaBand({
   href = "/club/contact",
 }: SponsorCtaBandProps) {
-  const isExternal = EXTERNAL_HREF.test(href);
-  const isHttp = /^https?:/i.test(href);
-  const buttonClassName = "bg-warm hover:bg-warm";
-  const label = (
-    <>
-      Word sponsor <span aria-hidden="true">+</span>
-    </>
-  );
-
   return (
-    <>
-      <StripedSeam colorPair="ink-cream" height="md" />
-      <section
-        aria-label="Word sponsor"
-        className="bg-jersey-deep-dark border-ink border-y-2"
-      >
-        <div className="mx-auto max-w-5xl px-4 py-12 text-center sm:py-16">
-          <EditorialHeading
-            level={2}
-            size="display-lg"
-            tone="cream"
-            emphasis={{ text: "langs de zijlijn", tone: "warm" }}
-            className="mb-4"
-          >
-            Jouw zaak ook langs de zijlijn?
-          </EditorialHeading>
-
-          <p className="text-cream/90 mx-auto mb-7 max-w-xl text-base leading-relaxed">
-            Word partner van de plezantste compagnie en steun onze jeugd en
-            eerste ploegen!
-          </p>
-
-          <div className="flex justify-center">
-            {isExternal ? (
-              <a
-                href={href}
-                data-sponsor-cta="true"
-                className={getButtonClasses({
-                  variant: "inverted",
-                  className: buttonClassName,
-                })}
-                {...(isHttp
-                  ? { target: "_blank", rel: "noopener noreferrer" }
-                  : {})}
-              >
-                {label}
-              </a>
-            ) : (
-              <LinkButton
-                href={href}
-                variant="inverted"
-                className={buttonClassName}
-                {...{ "data-sponsor-cta": "true" }}
-              >
-                {label}
-              </LinkButton>
-            )}
-          </div>
-        </div>
-      </section>
-    </>
+    <CtaBand
+      ariaLabel="Word sponsor"
+      heading="Jouw zaak ook langs de zijlijn?"
+      emphasis={{ text: "langs de zijlijn", tone: "warm" }}
+      lead="Word partner van de plezantste compagnie en steun onze jeugd en eerste ploegen!"
+      buttonLabel={
+        <>
+          Word sponsor <span aria-hidden="true">+</span>
+        </>
+      }
+      href={href}
+      buttonData={{ "data-sponsor-cta": "true" }}
+    />
   );
 }

--- a/apps/web/src/lib/repositories/jeugd-landing-page.repository.test.ts
+++ b/apps/web/src/lib/repositories/jeugd-landing-page.repository.test.ts
@@ -75,6 +75,19 @@ describe("JeugdLandingPageRepository", () => {
       expect(result).toBeNull();
     });
 
+    it("returns null (not []) when editorialCards is an empty array", async () => {
+      mockFetch.mockResolvedValueOnce({ editorialCards: [] });
+
+      const result = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* JeugdLandingPageRepository;
+          return yield* repo.getEditorialCards();
+        }),
+      );
+
+      expect(result).toBeNull();
+    });
+
     it("maps a nav card correctly", async () => {
       mockFetch.mockResolvedValueOnce({
         editorialCards: [makeCard()],

--- a/apps/web/src/lib/repositories/jeugd-landing-page.repository.ts
+++ b/apps/web/src/lib/repositories/jeugd-landing-page.repository.ts
@@ -63,7 +63,10 @@ export function toEditorialCardsVM(
   const cards = data.editorialCards
     .map(toEditorialCardConfig)
     .filter((c): c is EditorialCardConfig => c !== null);
-  return cards;
+  // Honest contract: non-empty array or null, never `[]` — an unset singleton
+  // and an all-invalid card list both mean "no editor config" (→ the hardcoded
+  // nav fallback, design-summary §4).
+  return cards.length > 0 ? cards : null;
 }
 
 // ─── Repository ──────────────────────────────────────────────────────────────

--- a/docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j-design-summary-locked.md
@@ -47,7 +47,8 @@ The `/jeugd` redesign in the retro-terrace-fanzine system. Audience: **parents**
   `<TapedFigure>` youth photo (newsprint filter, `landscape-4-3` or `16-9`). Split mirrors the
   sponsors `<SponsorHero>` structure.
 - **Nav-hub cards (uniform 16:9 image-top):**
-  - **News variant** — `<TapedFigure>`-style 16:9 cover photo, greyscale→hover-colour,
+  - **News variant** — `<TapedFigure>`-style 16:9 cover photo, **newsprint colour**
+    (corrected 2026-06-10 — greyscale→hover is sponsor-logo-only, never news cards),
     jersey-deep tag pill, italic-display title, mono "Lees meer →".
   - **Nav variant** — 16:9 `bg-jersey-deep` panel (no photo) with a Phosphor-fill glyph
     (`@/lib/icons.redesign`) + cream tag pill + italic-display title + mono arrow. `text-white`

--- a/docs/design/mockups/phase-7-jeugd/7j3-navhub-locked.md
+++ b/docs/design/mockups/phase-7-jeugd/7j3-navhub-locked.md
@@ -13,8 +13,11 @@ into articles-first (N2-as-drawn rejected). Instead:
 
 - **Card chrome (uniform):** every card is identical — a **16:9 image-top** region + text below
   (MonoLabel tag · italic-display title · optional description · mono arrow link). Replaces today's
-  full-bleed-background + overlay model. TapedCard vocabulary, greyscale→hover-colour image,
+  full-bleed-background + overlay model. TapedCard vocabulary, newsprint-colour image,
   canonical press-down hover.
+  > **Correction (2026-06-10, owner):** news covers are **newsprint COLOUR**, not
+  > greyscale→hover. Greyscale→hover is reserved for sponsor logos only — never
+  > news cards/listings.
 - **Fixed-position template:** the 9 slots sit at **predetermined positions**. Some slots are
   **article slots**, the rest are **fixed nav slots**.
   - **Article slots bubble:** the latest Jeugd-category articles auto-fill the article slots in

--- a/docs/prd/redesign-phase-7-jeugd.md
+++ b/docs/prd/redesign-phase-7-jeugd.md
@@ -79,7 +79,8 @@ cream grid. Proves route + data + e2e before new components land.
 
 - [ ] `<JeugdEditorialGrid>` reskinned: uniform **16:9 image-top** cards; **fixed-position bubbling**
       preserved (article slots auto-fill latest Jeugd articles; nav cards pinned).
-- [ ] Two card variants: **news** (photographic, jersey-deep tag, greyscale→hover) vs **nav**
+- [ ] Two card variants: **news** (photographic, jersey-deep tag, **newsprint colour** —
+      greyscale→hover is sponsor-logo-only, corrected 2026-06-10) vs **nav**
       (jersey-deep glyph panel via `@/lib/icons.redesign`, cream tag, `text-white`, no photo).
 - [ ] Tag pill (both variants) is **editorially managed**: news/article cards use `article.tags[0]`
       → `Jeugd` (`editorialCards.tag` is **not** read for article slots); nav cards use


### PR DESCRIPTION
Closes #2041

Phase 4 of the `/jeugd` redesign: the closing CTA band + empty states. Also folds in an owner correction on news-card photo treatment.

## Changes

- **`<CtaBand>`** (NEW design-system primitive) — the redesign's closing CTA band: a leading `<StripedSeam>` + a full-width `bg-jersey-deep-dark` section (`border-y-2 border-ink`) with an italic-display question + sub-line + a `warm` paper-stamp button (internal `<LinkButton>` / external styled `<a>`). **Refactored `<SponsorCtaBand>` into a thin wrapper** over it (PRD §7 Q3 — `SponsorCtaBand`'s own JSDoc anticipated this; chrome shared cleanly, behaviour preserved incl. the `data-sponsor-cta` marker).
- **`<JeugdCtaBand>`** (NEW) — "Interesse in onze jeugd?" + a warm "Schrijf je in +" → `/hulp` (Open Q#1: defaults to `/hulp` until the membership form #1473 ships). Wired **full-bleed** as the jeugd page's last element.
- **Empty states:** 0 youth teams → `<YouthDirectory>` drops the section (returns null); 0 Jeugd articles → the nav hub collapses to its pinned nav cards. The grid now **also** falls back to the hardcoded nav set for an *empty* `editorialCards` array (design-summary §4), not just `null`/`undefined`. A page test covers the empty-data composition (no divisions section, nav-only hub, CTA still renders).

## ⚠️ Owner correction folded in — greyscale removed from news cards

Per your direction, the `/jeugd` nav-hub **news cards no longer use greyscale→hover**. `<EditorialHubCard>`'s news cover now renders in **newsprint colour** (`--filter-photo-newsprint`, like every other people/team photo). Greyscale→hover is reserved for **sponsor logos only**. I also corrected the stale design docs that specified greyscale (`7j3-navhub-locked.md`, `7j-design-summary-locked.md`, the PRD Phase 3 AC) and updated my memory so this doesn't recur.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, **283 test files**, `next build` — `/jeugd` statically generates).
- New unit tests: `CtaBand` (heading/landmark, internal/mailto/external href, `buttonData` forwarding), `JeugdCtaBand`, grid empty-config fallback, page-level empty-state + CTA composition. `SponsorCtaBand`'s existing tests pass unchanged against the refactor.

## VR baselines

Stories tagged `vr` (`CtaBand`, `JeugdCtaBand`). **Baseline capture deferred** — VR CI is disabled during the redesign. The greyscale→newsprint change also shifts the `EditorialHubCard`/`JeugdEditorialGrid` news-card appearance (baselines regenerate when the chain is re-enabled).

This was the last building block before the /jeugd final pass (#2042: analytics + SEO + legacy retirement), which unblocks once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
