### PR TITLE
feat(ui): /hulp hub — Structuur directory + person card states (#2053)

### DIFF
--- a/apps/web/src/app/(main)/hulp/page.tsx
+++ b/apps/web/src/app/(main)/hulp/page.tsx
@@ -34,6 +34,7 @@ import {
   OrganigramHero,
   deriveStructureIndex,
 } from "@/components/organigram/OrganigramHero";
+import { StructureDirectory } from "@/components/organigram/StructureDirectory";
 
 export const revalidate = 3600;
 
@@ -143,9 +144,11 @@ export default async function HulpHubPage() {
           </EditorialHeading>
           <p className="text-ink-soft mt-3 max-w-[60ch] text-base leading-relaxed">
             Het bestuur, de jeugdwerking en alle vrijwilligers per afdeling.
-            Hier vind je straks de volledige directory en open je de verkenner
-            om door de structuur te navigeren.
           </p>
+
+          <div className="mt-8">
+            <StructureDirectory nodes={members} />
+          </div>
         </section>
       </div>
 

--- a/apps/web/src/components/organigram/OrgPersonCard/OrgPersonCard.stories.tsx
+++ b/apps/web/src/components/organigram/OrgPersonCard/OrgPersonCard.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { OrgPersonCard } from "./OrgPersonCard";
+import type { OrgChartNode } from "@/types/organigram";
+
+const PHOTOS = {
+  a: "/player-fixtures/player-schulz.jpg",
+  b: "/player-fixtures/player-vartolomaios.jpg",
+};
+
+const single: OrgChartNode = {
+  id: "president",
+  title: "Voorzitter",
+  roleCode: "VZ",
+  department: "hoofdbestuur",
+  members: [
+    { id: "p-1", name: "Luc Boons", email: "voorzitter@kcvvelewijt.be" },
+  ],
+};
+
+const singlePhoto: OrgChartNode = {
+  id: "secretary",
+  title: "Secretaris",
+  department: "hoofdbestuur",
+  members: [{ id: "p-2", name: "Karel Vermeulen", imageUrl: PHOTOS.a }],
+};
+
+const shared: OrgChartNode = {
+  id: "match-secretariat",
+  title: "Wedstrijdsecretariaat",
+  roleCode: "WS",
+  department: "hoofdbestuur",
+  members: [
+    { id: "p-3", name: "Jan De Smet" },
+    { id: "p-4", name: "Paula Vos", imageUrl: PHOTOS.b },
+  ],
+};
+
+const sharedThreePlus: OrgChartNode = {
+  id: "party-committee",
+  title: "Feestcomité",
+  department: "algemeen",
+  members: [
+    { id: "p-5", name: "Els Claes" },
+    { id: "p-6", name: "Nina Bral" },
+    { id: "p-7", name: "Bert Aerts" },
+  ],
+};
+
+const vacant: OrgChartNode = {
+  id: "treasurer",
+  title: "Penningmeester",
+  roleCode: "PM",
+  department: "hoofdbestuur",
+  members: [],
+};
+
+const meta = {
+  title: "Features/Organigram/OrgPersonCard",
+  component: OrgPersonCard,
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="bg-cream w-[180px] p-2">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs", "vr"],
+} satisfies Meta<typeof OrgPersonCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Single holder, monogram fallback (~90% of positions have no photo) + roleCode pill. */
+export const SingleMonogram: Story = {
+  args: { node: single },
+};
+
+/** Single holder with a newsprint photo. */
+export const SinglePhoto: Story = {
+  args: { node: singlePhoto },
+};
+
+/** Shared position — two overlapping avatars + "N personen" (static cue, no hover). */
+export const Shared: Story = {
+  args: { node: shared },
+};
+
+/** Shared position with 3+ holders — two avatars + a "+N" chip. */
+export const SharedThreePlus: Story = {
+  args: { node: sharedThreePlus },
+};
+
+/** Vacant position — warm recruit card with the "Iets voor jou? →" CTA. */
+export const Vacant: Story = {
+  args: { node: vacant },
+};
+
+/** The smaller explorer-leaf chrome (Phase 3) — identical idiom at node scale. */
+export const NodeScale: Story = {
+  args: { node: single, scale: "node" },
+  decorators: [
+    (Story) => (
+      <div className="bg-cream w-[150px] p-2">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/apps/web/src/components/organigram/OrgPersonCard/OrgPersonCard.test.tsx
+++ b/apps/web/src/components/organigram/OrgPersonCard/OrgPersonCard.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * OrgPersonCard unit tests.
+ *
+ * Covers:
+ *  - deriveCardState: 0 → vacant, 1 → single, 2+ → shared
+ *  - splitDisplayName / monogramInitials helpers
+ *  - single: person name (first-bold + last-italic) + position as mono label + monogram fallback / photo
+ *  - shared: position in name slot + "N personen" + dual avatar + "+N" chip at 3+
+ *  - vacant: warm state · "deze plek is vrij" · CTA link to the configured href
+ *  - roleCode pill renders when present, absent when not
+ *  - data markers (data-node-id / data-card-state) for the Phase 4 delegation wrapper
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  OrgPersonCard,
+  deriveCardState,
+  splitDisplayName,
+  monogramInitials,
+} from "./OrgPersonCard";
+import type { OrgChartNode } from "@/types/organigram";
+
+function node(overrides: Partial<OrgChartNode> = {}): OrgChartNode {
+  return {
+    id: "n1",
+    title: "Voorzitter",
+    members: [{ id: "p1", name: "Luc Boons" }],
+    ...overrides,
+  };
+}
+
+describe("deriveCardState", () => {
+  it("maps holder count to occupancy state", () => {
+    expect(deriveCardState(0)).toBe("vacant");
+    expect(deriveCardState(1)).toBe("single");
+    expect(deriveCardState(2)).toBe("shared");
+    expect(deriveCardState(5)).toBe("shared");
+  });
+
+  it("treats negatives as vacant defensively", () => {
+    expect(deriveCardState(-1)).toBe("vacant");
+  });
+});
+
+describe("splitDisplayName", () => {
+  it("splits first token (lead) from the remainder (rest)", () => {
+    expect(splitDisplayName("Luc Boons")).toEqual({
+      lead: "Luc",
+      rest: "Boons",
+    });
+    expect(splitDisplayName("Jan De Smet")).toEqual({
+      lead: "Jan",
+      rest: "De Smet",
+    });
+  });
+
+  it("returns an empty rest for a single token", () => {
+    expect(splitDisplayName("Penningmeester")).toEqual({
+      lead: "Penningmeester",
+      rest: "",
+    });
+  });
+
+  it("tolerates extra whitespace and empty input", () => {
+    expect(splitDisplayName("  Els   Vos  ")).toEqual({
+      lead: "Els",
+      rest: "Vos",
+    });
+    expect(splitDisplayName("")).toEqual({ lead: "", rest: "" });
+  });
+});
+
+describe("monogramInitials", () => {
+  it("uses first + last token initials, upper-cased", () => {
+    expect(monogramInitials("Luc Boons")).toBe("LB");
+    expect(monogramInitials("Jan De Smet")).toBe("JS");
+  });
+
+  it("uses a single initial for a one-token value", () => {
+    expect(monogramInitials("Penningmeester")).toBe("P");
+  });
+
+  it("falls back to the middot glyph when empty/undefined", () => {
+    expect(monogramInitials(undefined)).toBe("·");
+    expect(monogramInitials("   ")).toBe("·");
+  });
+});
+
+describe("OrgPersonCard — single", () => {
+  it("renders the person name in the name slot and the position as the mono label", () => {
+    render(<OrgPersonCard node={node()} />);
+    const card = screen.getByTestId("org-person-card");
+    expect(card).toHaveAttribute("data-card-state", "single");
+    expect(card).toHaveAttribute("data-node-id", "n1");
+    // Name rhythm: first name bold, last name italic.
+    expect(screen.getByText("Luc")).toBeInTheDocument();
+    expect(screen.getByText("Boons")).toBeInTheDocument();
+    // Position renders as the mono function sub-label.
+    expect(screen.getByText("Voorzitter")).toBeInTheDocument();
+  });
+
+  it("shows a monogram fallback when the holder has no photo", () => {
+    render(<OrgPersonCard node={node()} />);
+    expect(screen.getByText("LB")).toBeInTheDocument();
+  });
+
+  it("renders a newsprint photo when imageUrl is present (no monogram)", () => {
+    render(
+      <OrgPersonCard
+        node={node({
+          members: [{ id: "p1", name: "Luc Boons", imageUrl: "/x/luc.jpg" }],
+        })}
+      />,
+    );
+    const img = screen.getByRole("img", { name: "Luc Boons" });
+    expect(img).toBeInTheDocument();
+    expect(screen.queryByText("LB")).not.toBeInTheDocument();
+  });
+});
+
+describe("OrgPersonCard — roleCode pill", () => {
+  it("renders the pill when roleCode is present", () => {
+    render(<OrgPersonCard node={node({ roleCode: "VZ" })} />);
+    expect(screen.getByTestId("org-person-card-rolepill")).toHaveTextContent(
+      "VZ",
+    );
+  });
+
+  it("auto-hides the pill when roleCode is absent", () => {
+    render(<OrgPersonCard node={node()} />);
+    expect(
+      screen.queryByTestId("org-person-card-rolepill"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("OrgPersonCard — shared", () => {
+  const shared = node({
+    title: "Wedstrijdsecretariaat",
+    members: [
+      { id: "p1", name: "Jan De Smet" },
+      { id: "p2", name: "Paula Vos", imageUrl: "/x/paula.jpg" },
+    ],
+  });
+
+  it("renders the position in the name slot and an 'N personen' label", () => {
+    render(<OrgPersonCard node={shared} />);
+    const card = screen.getByTestId("org-person-card");
+    expect(card).toHaveAttribute("data-card-state", "shared");
+    expect(screen.getByText("Wedstrijdsecretariaat")).toBeInTheDocument();
+    expect(screen.getByText("2 personen")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("org-person-card-dual-avatar"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a holder photo in the dual avatar and a monogram for the photo-less holder", () => {
+    render(<OrgPersonCard node={shared} />);
+    // The dual avatar is an aria-hidden decorative cue, so query the photo by
+    // its alt text (not by role) and the photo-less holder by its monogram.
+    expect(screen.getByAltText("Paula Vos")).toBeInTheDocument();
+    // Jan De Smet → first + last token initial ("JS", not "JD").
+    expect(screen.getByText("JS")).toBeInTheDocument();
+  });
+
+  it("adds a '+N' chip when there are 3 or more holders", () => {
+    render(
+      <OrgPersonCard
+        node={node({
+          title: "Feestcomité",
+          members: [
+            { id: "p1", name: "Els Claes" },
+            { id: "p2", name: "Nina Bral" },
+            { id: "p3", name: "Bert Aerts" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("3 personen")).toBeInTheDocument();
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+});
+
+describe("OrgPersonCard — vacant", () => {
+  const vacant = node({ title: "Penningmeester", members: [] });
+
+  it("renders the warm recruit state with the position and 'deze plek is vrij'", () => {
+    render(<OrgPersonCard node={vacant} />);
+    const card = screen.getByTestId("org-person-card");
+    expect(card).toHaveAttribute("data-card-state", "vacant");
+    expect(card.className).toContain("bg-warm");
+    expect(screen.getByText("Penningmeester")).toBeInTheDocument();
+    expect(screen.getByText("deze plek is vrij")).toBeInTheDocument();
+  });
+
+  it("links the CTA to the default club contact page", () => {
+    render(<OrgPersonCard node={vacant} />);
+    const cta = screen.getByTestId("org-person-card-vacant-cta");
+    expect(cta).toHaveTextContent("Iets voor jou?");
+    expect(cta).toHaveAttribute("href", "/club/contact");
+  });
+
+  it("honours a custom vacantCtaHref", () => {
+    render(<OrgPersonCard node={vacant} vacantCtaHref="/hulp#hulp" />);
+    expect(screen.getByTestId("org-person-card-vacant-cta")).toHaveAttribute(
+      "href",
+      "/hulp#hulp",
+    );
+  });
+});

--- a/apps/web/src/components/organigram/OrgPersonCard/OrgPersonCard.tsx
+++ b/apps/web/src/components/organigram/OrgPersonCard/OrgPersonCard.tsx
@@ -1,0 +1,370 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { OrgChartNode } from "@/types/organigram";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * `<OrgPersonCard>` — the Phase 7 `/hulp` structure card (design lock `7o4`).
+ *
+ * Extends the 6.C `<TeamStaff>` idiom (round newsprint photo OR jersey-deep
+ * monogram · first-semibold + last-italic name · mono function label) and
+ * parameterises it by **occupancy state** and **scale**:
+ *
+ *  - `single`  — one holder: photo/monogram · person name · the position as the
+ *                mono function label.
+ *  - `shared`  — 2+ holders: a static dual-avatar cue + "N personen" (3+ adds a
+ *                "+N" chip). The card shows the POSITION in the name slot; the
+ *                first-holder detail opens on click (panel wired in Phase 4).
+ *  - `vacant`  — 0 holders: a warm recruit card ("deze plek is vrij" + a soft
+ *                "Iets voor jou? →" CTA), never a dead placeholder.
+ *
+ * State is **derived from `node.members.length`** (not a prop) so it can never
+ * drift from the data. The whole card is one click target that opens the person
+ * detail (7o5 / Phase 4, #2055) — Phase 2 ships it presentational with
+ * `data-node-id` / `data-card-state` markers for the future delegation wrapper;
+ * only the vacant CTA is an interactive link today. No hover behaviour on the
+ * card or avatars (7o4: the dual-avatar is a static cue, not a hover target).
+ */
+
+export type OrgPersonCardState = "single" | "shared" | "vacant";
+export type OrgPersonCardScale = "directory" | "node";
+
+export interface OrgPersonCardProps {
+  /** The organigram position this card represents. */
+  node: OrgChartNode;
+  /**
+   * Render scale. `directory` (default) is the 64px-avatar browse card;
+   * `node` is the smaller explorer-leaf chrome (Phase 3, #2054).
+   */
+  scale?: OrgPersonCardScale;
+  /**
+   * Where the vacant-recruit CTA points. Defaults to the club contact page —
+   * the same destination the hub's closing `<CtaBand>` uses (7o4: "to
+   * contact/Hulp"; final route confirmed in 7o7).
+   */
+  vacantCtaHref?: string;
+  className?: string;
+}
+
+// ─── Pure helpers (exported for unit tests) ──────────────────────────────────
+
+/** Occupancy state from the holder count: 0 → vacant, 1 → single, 2+ → shared. */
+export function deriveCardState(memberCount: number): OrgPersonCardState {
+  if (memberCount <= 0) return "vacant";
+  if (memberCount === 1) return "single";
+  return "shared";
+}
+
+/**
+ * Split a display value into the 6.C name rhythm: the first whitespace token is
+ * the semibold "lead", the remainder is the italic "rest". Works for both a
+ * person name ("Luc Boons" → Luc / Boons) and a position title
+ * ("Wedstrijd secretariaat" → Wedstrijd / secretariaat); a single-token value
+ * has an empty rest and renders bold-only.
+ */
+export function splitDisplayName(value: string): {
+  lead: string;
+  rest: string;
+} {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { lead: "", rest: "" };
+  const [lead, ...others] = parts;
+  return { lead: lead ?? "", rest: others.join(" ") };
+}
+
+/**
+ * Monogram initials (max 2 chars) from a name/title: first + last token initial.
+ * Returns "·" when there is no usable text, mirroring 6.C's fallback glyph.
+ */
+export function monogramInitials(value: string | undefined): string {
+  const parts = (value ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "·";
+  const first = parts[0]?.charAt(0) ?? "";
+  const last = parts.length > 1 ? (parts.at(-1)?.charAt(0) ?? "") : "";
+  return `${first}${last}`.toLocaleUpperCase("nl-BE") || "·";
+}
+
+// ─── Scale config ────────────────────────────────────────────────────────────
+
+interface ScaleConfig {
+  avatarPx: number;
+  avatarClass: string;
+  monoClass: string;
+  dualWrapClass: string;
+  dualCirclePx: number;
+  dualCircleClass: string;
+  dualMonoClass: string;
+  plusNClass: string;
+  nameClass: string;
+}
+
+const SCALE_CONFIG: Record<OrgPersonCardScale, ScaleConfig> = {
+  directory: {
+    avatarPx: 64,
+    avatarClass: "h-16 w-16",
+    monoClass: "text-2xl",
+    dualWrapClass: "h-16 w-[78px]",
+    dualCirclePx: 52,
+    dualCircleClass: "h-[52px] w-[52px]",
+    dualMonoClass: "text-lg",
+    plusNClass: "h-[30px] w-[30px] text-[11px]",
+    nameClass: "text-base",
+  },
+  node: {
+    avatarPx: 48,
+    avatarClass: "h-12 w-12",
+    monoClass: "text-xl",
+    dualWrapClass: "h-12 w-[60px]",
+    dualCirclePx: 40,
+    dualCircleClass: "h-10 w-10",
+    dualMonoClass: "text-sm",
+    plusNClass: "h-6 w-6 text-[9px]",
+    nameClass: "text-sm",
+  },
+};
+
+// ─── Sub-parts ───────────────────────────────────────────────────────────────
+
+/** First-token-bold + remainder-italic name rhythm. */
+function NameRhythm({
+  value,
+  italicLead = false,
+  className,
+}: {
+  value: string;
+  /** Vacant cards render the whole title italic (no bold lead). */
+  italicLead?: boolean;
+  className?: string;
+}) {
+  const { lead, rest } = splitDisplayName(value);
+  if (italicLead) {
+    return (
+      <p className={cn("font-display text-ink leading-[1.05]", className)}>
+        <em className="font-normal italic">{value}</em>
+      </p>
+    );
+  }
+  return (
+    <p className={cn("font-display text-ink leading-[1.05]", className)}>
+      <span className="font-semibold">{lead}</span>
+      {rest !== "" && (
+        <>
+          {" "}
+          <em className="font-normal italic">{rest}</em>
+        </>
+      )}
+    </p>
+  );
+}
+
+const AVATAR_RING =
+  "border-ink bg-cream-soft flex items-center justify-center overflow-hidden rounded-full border-2";
+
+const MONO_GLYPH = "text-jersey-deep font-display-big font-black";
+
+/** Single round avatar: newsprint photo, or jersey-deep monogram fallback. */
+function SingleAvatar({
+  name,
+  imageUrl,
+  cfg,
+}: {
+  name: string;
+  imageUrl?: string;
+  cfg: ScaleConfig;
+}) {
+  const src = imageUrl?.trim() ?? "";
+  const hasPhoto = src !== "";
+  return (
+    <div className={cn(AVATAR_RING, cfg.avatarClass)}>
+      {hasPhoto ? (
+        <Image
+          src={src}
+          alt={name}
+          width={cfg.avatarPx}
+          height={cfg.avatarPx}
+          unoptimized
+          className="h-full w-full object-cover"
+          style={{ filter: "var(--filter-photo-newsprint)" }}
+        />
+      ) : (
+        <span aria-hidden="true" className={cn(MONO_GLYPH, cfg.monoClass)}>
+          {monogramInitials(name)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Overlapping dual-avatar cue for shared roles (static — no hover/tooltip). */
+function DualAvatar({
+  holders,
+  cfg,
+}: {
+  holders: OrgChartNode["members"];
+  cfg: ScaleConfig;
+}) {
+  const [a, b] = holders;
+  const extra = holders.length - 2;
+
+  const circle = (
+    member: OrgChartNode["members"][number] | undefined,
+    pos: "left" | "right",
+  ) => {
+    const src = member?.imageUrl?.trim() ?? "";
+    const hasPhoto = src !== "";
+    return (
+      <span
+        className={cn(
+          AVATAR_RING,
+          cfg.dualCircleClass,
+          "absolute top-[6px]",
+          pos === "left" ? "left-0 z-20" : "right-0 z-10",
+        )}
+      >
+        {hasPhoto ? (
+          <Image
+            src={src}
+            alt={member?.name ?? ""}
+            width={cfg.dualCirclePx}
+            height={cfg.dualCirclePx}
+            unoptimized
+            className="h-full w-full object-cover"
+            style={{ filter: "var(--filter-photo-newsprint)" }}
+          />
+        ) : (
+          <span
+            aria-hidden="true"
+            className={cn(MONO_GLYPH, cfg.dualMonoClass)}
+          >
+            {monogramInitials(member?.name)}
+          </span>
+        )}
+      </span>
+    );
+  };
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("relative", cfg.dualWrapClass)}
+      data-testid="org-person-card-dual-avatar"
+    >
+      {circle(a, "left")}
+      {circle(b, "right")}
+      {extra > 0 && (
+        <span
+          className={cn(
+            "border-ink bg-jersey-deep text-cream absolute top-[6px] -right-[6px] z-30 flex items-center justify-center rounded-full border-2 font-mono font-semibold",
+            cfg.plusNClass,
+          )}
+        >
+          +{extra}
+        </span>
+      )}
+    </div>
+  );
+}
+
+const SUBLABEL =
+  "text-ink-muted mt-1.5 font-mono text-[9px] tracking-[0.06em] uppercase";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function OrgPersonCard({
+  node,
+  scale = "directory",
+  vacantCtaHref = "/club/contact",
+  className,
+}: OrgPersonCardProps) {
+  const state = deriveCardState(node.members.length);
+  const cfg = SCALE_CONFIG[scale];
+
+  const baseCard =
+    "border-ink relative flex flex-col items-center border-2 p-3 text-center";
+
+  return (
+    <article
+      data-testid="org-person-card"
+      data-node-id={node.id}
+      data-card-state={state}
+      className={cn(
+        baseCard,
+        state === "vacant"
+          ? "bg-warm shadow-paper-sm"
+          : "bg-cream shadow-[3px_3px_0_0_var(--color-ink)]",
+        className,
+      )}
+    >
+      {/* roleCode pill — top-right, auto-hides when absent (7o4). */}
+      {node.roleCode && (
+        <span
+          data-testid="org-person-card-rolepill"
+          className="border-ink bg-jersey-deep text-cream absolute top-2 right-2 border-[1.5px] px-1.5 py-px font-mono text-[8px] font-semibold tracking-[0.05em] uppercase"
+        >
+          {node.roleCode}
+        </span>
+      )}
+
+      {/* Avatar */}
+      {state === "single" && (
+        <SingleAvatar
+          name={node.members[0]?.name ?? node.title}
+          imageUrl={node.members[0]?.imageUrl}
+          cfg={cfg}
+        />
+      )}
+      {state === "shared" && <DualAvatar holders={node.members} cfg={cfg} />}
+      {state === "vacant" && (
+        <div
+          className={cn(
+            AVATAR_RING,
+            cfg.avatarClass,
+            "border-dashed bg-white/45",
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              "text-jersey-deep font-display-big font-black italic",
+              cfg.monoClass,
+            )}
+          >
+            +
+          </span>
+        </div>
+      )}
+
+      {/* Name slot — person (single) or position (shared/vacant) */}
+      {state === "single" ? (
+        <NameRhythm
+          value={node.members[0]?.name ?? node.title}
+          className={cn("mt-2.5", cfg.nameClass)}
+        />
+      ) : (
+        <NameRhythm
+          value={node.title}
+          italicLead={state === "vacant"}
+          className={cn("mt-2.5", cfg.nameClass)}
+        />
+      )}
+
+      {/* Sub-label */}
+      {state === "single" && <p className={SUBLABEL}>{node.title}</p>}
+      {state === "shared" && (
+        <p className={SUBLABEL}>{node.members.length} personen</p>
+      )}
+      {state === "vacant" && (
+        <>
+          <p className={SUBLABEL}>deze plek is vrij</p>
+          <Link
+            href={vacantCtaHref}
+            data-testid="org-person-card-vacant-cta"
+            className="border-ink bg-cream text-ink shadow-paper-sm mt-2.5 border-[1.5px] px-2.5 py-1.5 font-mono text-[9px] font-bold tracking-[0.06em] uppercase transition-all duration-300 hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
+          >
+            Iets voor jou? →
+          </Link>
+        </>
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/components/organigram/OrgPersonCard/index.ts
+++ b/apps/web/src/components/organigram/OrgPersonCard/index.ts
@@ -1,0 +1,11 @@
+export {
+  OrgPersonCard,
+  deriveCardState,
+  splitDisplayName,
+  monogramInitials,
+} from "./OrgPersonCard";
+export type {
+  OrgPersonCardProps,
+  OrgPersonCardState,
+  OrgPersonCardScale,
+} from "./OrgPersonCard";

--- a/apps/web/src/components/organigram/StructureDirectory/StructureDirectory.stories.tsx
+++ b/apps/web/src/components/organigram/StructureDirectory/StructureDirectory.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { within, userEvent, expect } from "storybook/test";
+import { StructureDirectory } from "./StructureDirectory";
+import { staffMembersFixture } from "@/components/organigram/__fixtures__/staff-members.fixture";
+
+const meta = {
+  title: "Features/Organigram/StructureDirectory",
+  component: StructureDirectory,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="bg-cream mx-auto max-w-[64rem] p-6 sm:p-10">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["autodocs", "vr"],
+} satisfies Meta<typeof StructureDirectory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default compact directory — positions grouped by afdeling, each capped at
+ * `initialPerDepartment` with a single "Toon alle N →" control. Includes the
+ * fixture's real vacant (Sponsorverantwoordelijke) + shared (Co-Penningmeester)
+ * positions.
+ */
+export const Collapsed: Story = {
+  args: { nodes: staffMembersFixture },
+};
+
+/**
+ * Same data, fully expanded via the "Toon alle N →" control — every position
+ * visible and the control flipped to "Toon minder ←".
+ */
+export const Expanded: Story = {
+  args: { nodes: staffMembersFixture },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole("button", { name: /Toon alle/ });
+    await userEvent.click(toggle);
+    await expect(
+      canvas.getByRole("button", { name: /Toon minder/ }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/web/src/components/organigram/StructureDirectory/StructureDirectory.test.tsx
+++ b/apps/web/src/components/organigram/StructureDirectory/StructureDirectory.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * StructureDirectory unit tests.
+ *
+ * Covers:
+ *  - groupByDepartment: drops the synthetic "club" root · locked afdeling order ·
+ *    folds undefined department into Algemeen · preserves incoming order · drops
+ *    empty afdelingen
+ *  - renders an afdeling header + position count per group
+ *  - compact: caps each afdeling at initialPerDepartment until expanded
+ *  - "Toon alle N →" shows the total and toggles to "Toon minder ←"
+ *  - vacant positions render as real cards (no fabricated data)
+ *  - returns null when there are no positions
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StructureDirectory, groupByDepartment } from "./StructureDirectory";
+import type { OrgChartNode } from "@/types/organigram";
+
+const CLUB_ROOT: OrgChartNode = {
+  id: "club",
+  title: "KCVV Elewijt",
+  department: "algemeen",
+  members: [{ id: "club", name: "KCVV Elewijt" }],
+};
+
+function position(
+  id: string,
+  department: OrgChartNode["department"],
+  overrides: Partial<OrgChartNode> = {},
+): OrgChartNode {
+  return {
+    id,
+    title: `Functie ${id}`,
+    department,
+    members: [{ id: `p-${id}`, name: `Persoon ${id}` }],
+    ...overrides,
+  };
+}
+
+describe("groupByDepartment", () => {
+  it("drops the synthetic club root node", () => {
+    const groups = groupByDepartment([
+      CLUB_ROOT,
+      position("a", "hoofdbestuur"),
+    ]);
+    const allNodes = groups.flatMap((g) => g.nodes);
+    expect(allNodes.find((n) => n.id === "club")).toBeUndefined();
+    expect(allNodes).toHaveLength(1);
+  });
+
+  it("orders afdelingen Hoofdbestuur → Jeugdbestuur → Algemeen", () => {
+    const groups = groupByDepartment([
+      position("a", "algemeen"),
+      position("b", "jeugdbestuur"),
+      position("c", "hoofdbestuur"),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual([
+      "Hoofdbestuur",
+      "Jeugdbestuur",
+      "Algemeen",
+    ]);
+  });
+
+  it("folds positions with no department into Algemeen", () => {
+    const groups = groupByDepartment([
+      position("a", undefined),
+      position("b", "algemeen"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe("Algemeen");
+    expect(groups[0]?.nodes).toHaveLength(2);
+  });
+
+  it("preserves incoming order within an afdeling", () => {
+    const groups = groupByDepartment([
+      position("first", "hoofdbestuur"),
+      position("second", "hoofdbestuur"),
+      position("third", "hoofdbestuur"),
+    ]);
+    expect(groups[0]?.nodes.map((n) => n.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("drops empty afdelingen", () => {
+    const groups = groupByDepartment([position("a", "jeugdbestuur")]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toBe("Jeugdbestuur");
+  });
+});
+
+describe("StructureDirectory", () => {
+  it("renders an afdeling header with the position count", () => {
+    render(
+      <StructureDirectory
+        nodes={[position("a", "hoofdbestuur"), position("b", "hoofdbestuur")]}
+      />,
+    );
+    expect(screen.getByText("Hoofdbestuur")).toBeInTheDocument();
+    expect(screen.getByText("2 functies")).toBeInTheDocument();
+  });
+
+  it("uses the singular 'functie' label for a one-position afdeling", () => {
+    render(<StructureDirectory nodes={[position("a", "jeugdbestuur")]} />);
+    expect(screen.getByText("1 functie")).toBeInTheDocument();
+  });
+
+  it("caps each afdeling at initialPerDepartment until expanded", async () => {
+    const nodes = Array.from({ length: 6 }, (_, i) =>
+      position(`h${i}`, "hoofdbestuur"),
+    );
+    render(<StructureDirectory nodes={nodes} initialPerDepartment={4} />);
+
+    expect(screen.getAllByTestId("org-person-card")).toHaveLength(4);
+
+    await userEvent.click(screen.getByRole("button", { name: /Toon alle 6/ }));
+    expect(screen.getAllByTestId("org-person-card")).toHaveLength(6);
+  });
+
+  it("toggles the global control between 'Toon alle N →' and 'Toon minder ←'", async () => {
+    const nodes = Array.from({ length: 5 }, (_, i) =>
+      position(`h${i}`, "hoofdbestuur"),
+    );
+    render(<StructureDirectory nodes={nodes} initialPerDepartment={4} />);
+
+    const toggle = screen.getByRole("button", { name: /Toon alle 5/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(toggle);
+    const collapse = screen.getByRole("button", { name: /Toon minder/ });
+    expect(collapse).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("does not render the toggle when nothing is hidden", () => {
+    render(
+      <StructureDirectory
+        nodes={[position("a", "hoofdbestuur")]}
+        initialPerDepartment={4}
+      />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders vacant positions as real cards", () => {
+    render(
+      <StructureDirectory
+        nodes={[position("vac", "hoofdbestuur", { members: [] })]}
+      />,
+    );
+    const card = screen.getByTestId("org-person-card");
+    expect(card).toHaveAttribute("data-card-state", "vacant");
+    expect(screen.getByText("deze plek is vrij")).toBeInTheDocument();
+  });
+
+  it("returns null when there are no positions (only the club root)", () => {
+    const { container } = render(<StructureDirectory nodes={[CLUB_ROOT]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/organigram/StructureDirectory/StructureDirectory.tsx
+++ b/apps/web/src/components/organigram/StructureDirectory/StructureDirectory.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import type { OrgChartNode } from "@/types/organigram";
+import { cn } from "@/lib/utils/cn";
+import { MonoLabel } from "@/components/design-system";
+import { OrgPersonCard } from "@/components/organigram/OrgPersonCard";
+
+/**
+ * `<StructureDirectory>` — the Phase 7 `/hulp` "Structuur" browse (design lock
+ * `7o2` view model + `7o7` assembly).
+ *
+ * The calm, single-scroll people directory: every active organigram position
+ * grouped by **afdeling** (Hoofdbestuur · Jeugdbestuur · Algemeen) and rendered
+ * as an `<OrgPersonCard>` (single / shared / vacant). It stays **compact** — each
+ * afdeling shows a few cards until one global "Toon alle N →" toggle expands the
+ * whole directory — so it doesn't wall off the Hulp half above it.
+ *
+ * Data only: vacant cards are the real 0-members positions, never fabricated.
+ * The "Open verkenner ⤢" launcher and the click → `<MemberDetailPanel>` wiring
+ * arrive with the explorer (Phase 3, #2054) and the panel (Phase 4, #2055).
+ */
+
+export interface StructureDirectoryProps {
+  /**
+   * All organigram positions (the `StaffRepository.findAll()` shape). The
+   * synthetic "club" root node is filtered out internally.
+   */
+  nodes: OrgChartNode[];
+  /** Cards shown per afdeling before "Toon alle N →" expands. Default 4. */
+  initialPerDepartment?: number;
+  /** Forwarded to each vacant card's recruit CTA. */
+  vacantCtaHref?: string;
+  className?: string;
+}
+
+interface DirectoryGroup {
+  key: "hoofdbestuur" | "jeugdbestuur" | "algemeen";
+  label: string;
+  nodes: OrgChartNode[];
+}
+
+const DEPARTMENT_ORDER = [
+  { key: "hoofdbestuur", label: "Hoofdbestuur" },
+  { key: "jeugdbestuur", label: "Jeugdbestuur" },
+  { key: "algemeen", label: "Algemeen" },
+] as const;
+
+/**
+ * Narrow a raw department string to a known afdeling key. `department` is cast
+ * from Sanity in the repository, so an unexpected value could reach us at
+ * runtime — fold those into "Algemeen" rather than letting the position vanish.
+ */
+function isKnownDepartment(value: string): value is DirectoryGroup["key"] {
+  return DEPARTMENT_ORDER.some((entry) => entry.key === value);
+}
+
+/**
+ * Group positions by afdeling in the locked display order, dropping the
+ * synthetic "club" root and any empty afdeling. Incoming order (GROQ
+ * `sortOrder` → `title`) is preserved within each group. Positions with no
+ * department fold into "Algemeen".
+ */
+export function groupByDepartment(nodes: OrgChartNode[]): DirectoryGroup[] {
+  const buckets = new Map<DirectoryGroup["key"], OrgChartNode[]>();
+
+  for (const node of nodes) {
+    if (node.id === "club") continue; // synthetic root, never a directory card
+    const raw = node.department ?? "algemeen";
+    const dept: DirectoryGroup["key"] = isKnownDepartment(raw)
+      ? raw
+      : "algemeen";
+    const list = buckets.get(dept) ?? [];
+    list.push(node);
+    buckets.set(dept, list);
+  }
+
+  return DEPARTMENT_ORDER.map(({ key, label }) => ({
+    key,
+    label,
+    nodes: buckets.get(key) ?? [],
+  })).filter((group) => group.nodes.length > 0);
+}
+
+export function StructureDirectory({
+  nodes,
+  initialPerDepartment = 4,
+  vacantCtaHref,
+  className,
+}: StructureDirectoryProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const groups = groupByDepartment(nodes);
+  const total = groups.reduce((sum, group) => sum + group.nodes.length, 0);
+
+  if (total === 0) return null;
+
+  const hasHidden = groups.some(
+    (group) => group.nodes.length > initialPerDepartment,
+  );
+
+  return (
+    <div
+      data-testid="structure-directory"
+      data-expanded={expanded}
+      className={cn("flex flex-col gap-10", className)}
+    >
+      {groups.map((group) => {
+        const visible = expanded
+          ? group.nodes
+          : group.nodes.slice(0, initialPerDepartment);
+        return (
+          <section key={group.key} aria-label={group.label}>
+            <h3 className="flex flex-wrap items-center gap-3">
+              <MonoLabel variant="pill-ink" size="sm">
+                {group.label}
+              </MonoLabel>
+              <span
+                aria-hidden="true"
+                className="text-ink-muted font-mono text-[10px] tracking-[0.06em] uppercase"
+              >
+                {group.nodes.length}{" "}
+                {group.nodes.length === 1 ? "functie" : "functies"}
+              </span>
+            </h3>
+            <div className="mt-4 grid grid-cols-[repeat(auto-fill,minmax(160px,1fr))] gap-4">
+              {visible.map((node) => (
+                <OrgPersonCard
+                  key={node.id}
+                  node={node}
+                  {...(vacantCtaHref ? { vacantCtaHref } : {})}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      {hasHidden && (
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            aria-expanded={expanded}
+            className="border-ink bg-cream-soft text-ink shadow-paper-sm focus-visible:outline-ink border-2 px-4 py-3 font-mono text-sm font-bold tracking-wide uppercase transition-all duration-300 hover:translate-x-1 hover:translate-y-1 hover:shadow-none focus-visible:outline-2 focus-visible:outline-offset-2"
+          >
+            {expanded ? "Toon minder ←" : `Toon alle ${total} →`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/organigram/StructureDirectory/index.ts
+++ b/apps/web/src/components/organigram/StructureDirectory/index.ts
@@ -1,0 +1,2 @@
+export { StructureDirectory, groupByDepartment } from "./StructureDirectory";
+export type { StructureDirectoryProps } from "./StructureDirectory";


### PR DESCRIPTION
Closes #2053

Phase 2 of the `/hulp` hub redesign — the **Structuur** browse: a people directory grouped by afdeling + the reskinned person card with its three occupancy states. Built on top of the just-merged #2052 tracer. Design locks: `7o4` (card states), `7o2` (view model), `7o7` (assembly).

## Changes

- **`<OrgPersonCard>`** (`components/organigram/OrgPersonCard/`) — extends the 6.C `<TeamStaff>` idiom; **state derived from `node.members.length`** (never a prop, so it can't drift):
  - **single** — newsprint photo (`next/image` + `--filter-photo-newsprint`) or jersey-deep monogram fallback · person name (first-semibold + last-italic) · the position as the mono function label.
  - **shared** — static overlapping dual-avatar + "N personen"; 3+ adds a "+N" chip. Position in the name slot (first-holder detail opens in Phase 4).
  - **vacant** — warm recruit card · dashed "+" avatar · "deze plek is vrij" · "Iets voor jou? →" CTA (defaults to `/club/contact`).
  - Optional `roleCode` pill (top-right, auto-hides when absent — kept on all states per owner decision). `directory` / `node` scale param (node = Phase 3 explorer leaf).
- **`<StructureDirectory>`** (`components/organigram/StructureDirectory/`) — `"use client"`; groups positions by afdeling (**Hoofdbestuur → Jeugdbestuur → Algemeen**, locked order), excludes the synthetic `club` root, folds unknown departments into Algemeen, and stays **compact** with one global "Toon alle N →" / "Toon minder ←" toggle (caps each afdeling at 4). **Vacant = the real 0-members state — no fabricated data.**
- **Mounted into `/hulp#structuur`** — replaced the Phase-1 placeholder paragraph with `<StructureDirectory nodes={members} />`. The click → `<MemberDetailPanel>` wiring is **deferred to Phase 4 (#2055)**, so cards ship presentational with `data-node-id` / `data-card-state` markers for the future delegation wrapper; only the vacant CTA is interactive today.

## Owner checkpoint

Storybook visual review of the three card states + the directory (collapsed/expanded) was done before finalizing — **owner-approved**. Confirmed: keep the `roleCode` pill on vacant cards.

## Pre-PR review gate (`/code-review` + `/simplify`)

Ran both as targeted review passes on the branch diff.
- **Applied** (correctness): replaced an unguarded `as DirectoryGroup["key"]` cast with a `isKnownDepartment` type-guard that folds unexpected Sanity departments into Algemeen (a position could otherwise silently vanish from the directory); `aria-hidden` the afdeling-count span so heading-nav reads the clean afdeling name; added a unit test for the dual-avatar photo path.
- **Refuted / deferred** (simplify): `monogramInitials` vs HubSearch's private `initials` — different semantics (first+last vs first-2 tokens); mine deliberately mirrors **TeamStaff's** first+last (the idiom being extended), and merging would change the just-merged HubSearch avatars — out of scope. The "Toon alle N" button chrome matching `UpcomingMatchesClient` is the canonical inline press-down idiom (repeated across ~13 files by convention); no shared primitive carries the fanzine chrome.

## Testing

- `pnpm --filter @kcvv/web check-all` — green (lint + type-check + **3292 tests** + build).
- 31 new unit tests (19 `OrgPersonCard` + 12 `StructureDirectory`), incl. state derivation, monogram/name-split helpers, group ordering, the cap/expand toggle, and the vacant/no-fabricated-data path.

## VR baselines

**Deferred** — VR CI is gated off during the redesign (`RUN_VISUAL_REGRESSION` unset) and baselines are batch-captured once the redesign series completes. The two new story files are `vr`-tagged (`Features/Organigram/OrgPersonCard`, `Features/Organigram/StructureDirectory`) so they're picked up then; no baselines committed in this PR.

## Out of scope (later phases)

Explorer "Open verkenner ⤢" + node-scale consumption (#2054) · click → `<MemberDetailPanel>` + analytics (`organigram_member_clicked`) (#2055) · final assembly/SEO/analytics/legacy retirement (#2058).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an organizational structure directory displaying staff members grouped by department.
  * Introduced role cards showing individual positions, multiple position holders, and vacant openings.
  * Expandable interface allows viewing additional positions per department via a toggle control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->