### PR TITLE
fix(search): consolidate multi-position people in the hub search

### DIFF
--- a/apps/web/src/components/organigram/HubSearch/HubSearch.tsx
+++ b/apps/web/src/components/organigram/HubSearch/HubSearch.tsx
@@ -262,6 +262,10 @@ export function HubSearch({
                     </span>
                     <span className="text-ink-muted block truncate font-mono text-[11px] tracking-wide uppercase">
                       {result.member.title}
+                      {result.extraPositions > 0 &&
+                        ` · +${result.extraPositions} ${
+                          result.extraPositions === 1 ? "functie" : "functies"
+                        }`}
                     </span>
                   </span>
                 </button>

--- a/apps/web/src/components/organigram/HubSearch/hub-search.test.ts
+++ b/apps/web/src/components/organigram/HubSearch/hub-search.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { searchMembers, searchResponsibilities, searchHub } from "./hub-search";
+import {
+  searchMembers,
+  searchResponsibilities,
+  searchHub,
+  dedupeMembersByPerson,
+} from "./hub-search";
+import type { HubMemberResult } from "./hub-search";
 import type { OrgChartNode } from "@/types/organigram";
 import type { ResponsibilityPath } from "@/types/responsibility";
 
@@ -76,6 +82,79 @@ describe("searchMembers", () => {
 
   it("caps results to maxResults", () => {
     expect(searchMembers("bestuur", members, 1)).toHaveLength(1);
+  });
+
+  it("consolidates a person who holds several positions into one result", () => {
+    // A multi-position person (primary holder of 3 nodes) must surface once,
+    // not 3× — the bug owner-reported on the live hub search.
+    const multi: OrgChartNode[] = [
+      {
+        id: "node-a",
+        title: "Secretaris",
+        department: "hoofdbestuur",
+        members: [{ id: "kvr", name: "Kevin Van Ransbeeck" }],
+      },
+      {
+        id: "node-b",
+        title: "Website & Communicatie",
+        department: "algemeen",
+        members: [{ id: "kvr", name: "Kevin Van Ransbeeck" }],
+      },
+      {
+        id: "node-c",
+        title: "Gerechtelijk Correspondent",
+        department: "hoofdbestuur",
+        members: [{ id: "kvr", name: "Kevin Van Ransbeeck" }],
+      },
+    ];
+    const results = searchMembers("kevin", multi, 10);
+    expect(results).toHaveLength(1);
+    expect(results[0].member.members[0]?.id).toBe("kvr");
+    expect(results[0].extraPositions).toBe(2);
+  });
+
+  it("does not consolidate distinct people who both match", () => {
+    const results = searchMembers("a", members, 10); // matches several names
+    const personIds = results.map((r) => r.member.members[0]?.id);
+    expect(new Set(personIds).size).toBe(personIds.length);
+    expect(results.every((r) => r.extraPositions === 0)).toBe(true);
+  });
+});
+
+describe("dedupeMembersByPerson", () => {
+  const result = (
+    nodeId: string,
+    personId: string | undefined,
+    score: number,
+  ): HubMemberResult => ({
+    type: "member",
+    score,
+    matchedFields: [],
+    extraPositions: 0,
+    member: {
+      id: nodeId,
+      title: nodeId,
+      members: personId ? [{ id: personId, name: personId }] : [],
+    },
+  });
+
+  it("keeps the highest-scoring position as the representative", () => {
+    const deduped = dedupeMembersByPerson([
+      result("low", "p1", 50),
+      result("high", "p1", 80),
+    ]);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0].member.id).toBe("high");
+    expect(deduped[0].extraPositions).toBe(1);
+  });
+
+  it("passes vacant / holder-less matches through untouched", () => {
+    const deduped = dedupeMembersByPerson([
+      result("vacant-1", undefined, 10),
+      result("vacant-2", undefined, 10),
+    ]);
+    expect(deduped).toHaveLength(2);
+    expect(deduped.every((r) => r.extraPositions === 0)).toBe(true);
   });
 });
 

--- a/apps/web/src/components/organigram/HubSearch/hub-search.ts
+++ b/apps/web/src/components/organigram/HubSearch/hub-search.ts
@@ -30,6 +30,14 @@ export interface HubMemberResult {
   member: OrgChartNode;
   score: number;
   matchedFields: MatchedFields;
+  /**
+   * How many *other* positions the same person holds among the matches. When a
+   * person primarily holds several positions, their rows are consolidated into
+   * one (their best-scoring position is the representative) and this is the count
+   * of the rest — driving a "+N functies" hint. 0 for a single-position person
+   * or a position-only/vacant match (no primary holder to consolidate by).
+   */
+  extraPositions: number;
 }
 
 export interface HubResponsibilityResult {
@@ -90,11 +98,60 @@ export function searchMembers(
     }
 
     if (score > 0) {
-      results.push({ type: "member", member, score, matchedFields });
+      results.push({
+        type: "member",
+        member,
+        score,
+        matchedFields,
+        extraPositions: 0,
+      });
     }
   }
 
-  return results.sort((a, b) => b.score - a.score).slice(0, maxResults);
+  // Consolidate before capping: a person who primarily holds several positions
+  // would otherwise return one row per position (e.g. searching a name surfaces
+  // them 3×). De-duping here, not after the slice, keeps the cap honest.
+  return dedupeMembersByPerson(results)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxResults);
+}
+
+/**
+ * Collapse multiple position-rows for the same person into a single result,
+ * keeping their highest-scoring position as the representative and counting the
+ * rest into `extraPositions`. Position-only matches (vacant nodes, or title /
+ * role / department hits with no primary holder) have no person to key on and
+ * pass through untouched.
+ */
+export function dedupeMembersByPerson(
+  results: HubMemberResult[],
+): HubMemberResult[] {
+  const byPerson = new Map<string, HubMemberResult>();
+  const passthrough: HubMemberResult[] = [];
+
+  for (const result of results) {
+    const personId = result.member.members[0]?.id;
+    if (personId === undefined) {
+      passthrough.push(result);
+      continue;
+    }
+
+    const existing = byPerson.get(personId);
+    if (existing === undefined) {
+      byPerson.set(personId, result);
+      continue;
+    }
+
+    // Keep the higher-scoring position as the representative; either way the
+    // person now has one more position folded in.
+    const representative = result.score > existing.score ? result : existing;
+    byPerson.set(personId, {
+      ...representative,
+      extraPositions: existing.extraPositions + 1,
+    });
+  }
+
+  return [...byPerson.values(), ...passthrough];
 }
 
 /**


### PR DESCRIPTION
## Problem (owner-reported)

Searching a name in the unified `/hulp` hub search returned the **same person multiple times** — once per organigram position they hold. On live data, 3 people trigger this: searching "Kevin" returns **Kevin Van Ransbeeck 3×** (Gerechtelijk Correspondent · Secretaris · Website & Communicatie), plus Kevin Schutijser (×3) and Ilona Trouwkens (×2).

**Root cause:** `searchMembers` scores and emits **one result per position node** (keyed by node id), with no person-level de-duplication.

## Fix

- New `dedupeMembersByPerson` consolidates member results by the **primary holder's id**: keeps their **highest-scoring position** as the representative and folds the rest into a new `HubMemberResult.extraPositions` count.
- The dropdown renders that count as a **"+N functies"** hint on the subtitle line, so the consolidation is legible (you see the role + that the person holds others).
- De-dupes **before** the `maxResults` cap so duplicates can't crowd out other results.
- **Position-only matches** (vacant nodes, or title/role/department hits with no primary holder) have no person to key on and pass through untouched.

## Testing

- `pnpm --filter @kcvv/web check-all` — green (lint + type-check + **3296 tests** + build).
- New unit tests: a 3-position person → one result with `extraPositions: 2`; distinct people stay separate; `dedupeMembersByPerson` keeps the higher-scoring representative and passes holder-less matches through.

## Out of scope

People who hold a position **only as a non-primary (shared) member** are still not matched by name — `searchMembers` checks `members[0]` only. That's a separate, pre-existing search gap (the audit found 7 such people, e.g. several `Bestuursorgaan` co-members) and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member search results now display an "extra positions" indicator when a person holds multiple roles, with proper singular/plural formatting.

* **Tests**
  * Extended test coverage for member deduplication behavior and extra positions counting in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->