### PR TITLE
docs(ui): Phase 8 design checkpoint + PRD — search, privacy, error pages

### DIFF
--- a/docs/design/mockups/phase-8-data-reality-locked.md
+++ b/docs/design/mockups/phase-8-data-reality-locked.md
@@ -1,0 +1,90 @@
+# Phase 8 — Data-reality lock (search · privacy · errors)
+
+Anchors every Phase 8 mockup to fields the app actually has, so no mockup renders
+data we can't ship. Read before any `8s*` / `8p*` / `8e*` round.
+
+Re-scope note (2026-06-08): `/hulp` left Phase 8 → delivered in Phase 7 (#1529).
+Phase 8 = three edge surfaces only: `/zoeken`, `/privacy`, 404/500.
+
+---
+
+## 1. `/zoeken` — search results
+
+Source of truth: `apps/web/src/types/search.ts`, `SearchInterface.tsx`,
+`SearchResult.tsx`, `/api/search/route.ts`.
+
+`SearchResult`:
+
+| Field         | Type                                          | Notes                                  |
+| ------------- | --------------------------------------------- | -------------------------------------- |
+| `id`          | string                                        | Sanity/internal id — hash if analytics |
+| `type`        | `"article" \| "player" \| "staff" \| "team"`  | drives icon + label                    |
+| `title`       | string                                        | always present                         |
+| `description` | string?                                       | snippet — articles/teams mostly        |
+| `url`         | string                                        | result link                            |
+| `imageUrl`    | string?                                       | ~most articles + players; teams often none |
+| `tags`        | string[]?                                     | **articles only**                      |
+| `date`        | string?                                       | **articles only**                      |
+
+`SearchResponse`: `{ query, count, results }`. Counts per type computed
+client-side for the filter row (`all / article / player / staff / team`).
+
+States that must be designed (all real, all in current code):
+
+1. **Pre-search** (`query < 2 chars`) — help/suggestions block.
+2. **Loading** — spinner during fetch.
+3. **Error** — fetch failed message.
+4. **No-results** — valid query, 0 hits (after type-filter too).
+5. **Results** — mixed-type grid + type-filter row with counts.
+
+Type labels (locked, from `SearchResult.tsx`): Nieuws · Speler · Staf · Team.
+Search backend is bge-m3 semantic search (Vectorize) — already shipped #2057,
+**not** in Phase 8 scope. Phase 8 reskins the *presentation* only.
+
+Must-avoid: a full taped-card grid of results reads "seasick" (master-design
+rotation-pool lesson, #1672). Result vocabulary round (8s2) weighs this.
+
+---
+
+## 2. `/privacy` — long-form legal prose
+
+Source: `apps/web/src/app/(main)/privacy/page.tsx`. Static copy, no CMS.
+
+- `LAST_UPDATED` constant (currently `"februari 2026"`).
+- ~11 H2 sections: Contactgegevens · Welke gegevens · Waarvoor · Rechtsgrond ·
+  Delen we je gegevens · Bewaartermijn · Jouw rechten · Cookiebeleid ·
+  Beveiliging · Wijzigingen · Vragen over privacy.
+- Club address: Driesstraat 30, 1982 Elewijt. Emails info@ / kevin@.
+- Master-design directive: **clean prose, no chrome flourishes.** This is the
+  one Phase 8 surface explicitly told to stay restrained.
+- Cross-links to `/hulp` (now the unified hub) — keep.
+
+Must-avoid: magazine chrome / fabricated edition data (memory: no-magazine-chrome).
+
+---
+
+## 3. 404 / 500 — error pages
+
+Source: `apps/web/src/app/not-found.tsx` (404), `apps/web/src/app/error.tsx` (500, `"use client"`).
+
+- **404** — copy "Pagina niet gevonden"; one CTA → home.
+- **500** — copy "Er ging iets mis"; two CTAs → `reset()` + home. `error.tsx`
+  receives `{ error, reset }`; `reset` must stay wired to a real button.
+- Master-design directive: **football-themed pun + cream-bg + `<JerseyShirt>`
+  taped artefact.** `<JerseyShirt>` is a shipped Phase 4.5 primitive.
+- These render OUTSIDE `(main)` route group → no guaranteed SiteHeader/Footer
+  context on `error.tsx` (root segment). Keep self-contained.
+
+Must-avoid: fabricated stamnummer/score chrome; real club voice only.
+
+---
+
+## Shared vocabulary available (no new primitives this phase)
+
+`<EditorialHeading>`, `<MonoLabel>` / `<MonoLabelRow>`, `<TapedCard>`,
+`<TapedFigure>`, `<TapeStrip>`, `<JerseyShirt>`, `<NumberDisplay>`,
+`<FilterTabs>`, `<DottedDivider>` / `<DashedDivider>` / `<SolidDivider>`,
+`<StripedSeam>`, `<LinkButton>` / `<Button>` (Phase 2 retro tokens),
+Phosphor Fill icons via `@/lib/icons.redesign`. Master-design §7 line 587:
+migrate `<SectionTransition type="diagonal">` consumers (hulp + privacy) to
+`<StripedSeam>` in this phase.

--- a/docs/design/mockups/phase-8-errors/8e1-composition-compare.html
+++ b/docs/design/mockups/phase-8-errors/8e1-composition-compare.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — 404/500 · Round 1: composition</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 20px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 92ch; line-height: 1.6; }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+      .stage { padding: 40px 28px 44px; display:flex; justify-content:center; }
+
+      /* jersey artefact */
+      .jersey { position:relative; width:160px; height:178px; flex:0 0 auto; }
+      .jersey .shirt { position:absolute; inset:0; background: repeating-linear-gradient(90deg, var(--jersey-deep) 0 18px, var(--jersey-deep-dark) 18px 36px);
+        border:2.5px solid var(--ink); box-shadow:6px 6px 0 0 var(--ink);
+        clip-path: polygon(30% 0, 70% 0, 100% 16%, 86% 34%, 86% 100%, 14% 100%, 14% 34%, 0 16%); }
+      .jersey .num { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-family:var(--font-body); font-weight:900; font-size:54px; color:var(--cream); letter-spacing:-2px; padding-top:18px; }
+      .jersey .tape { position:absolute; top:-14px; left:50%; transform:translateX(-50%) rotate(-5deg); width:78px; height:26px; background:var(--warm); border:1.5px solid var(--ink); opacity:.92; }
+      .jersey.small { width:108px; height:122px; }
+      .jersey.small .num { font-size:34px; padding-top:12px; }
+
+      .pun { font-family:var(--font-display); font-style:italic; font-weight:900; font-size:clamp(34px,5vw,56px); line-height:.95; margin:0; }
+      .pun .acc { color:var(--jersey-deep); }
+      .sub { font-size:15.5px; color:var(--ink-soft); line-height:1.55; margin:14px 0 0; max-width:46ch; }
+      .code { font-family:var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.14em; text-transform:uppercase; color:var(--ink-muted); }
+      .btns { display:flex; gap:12px; flex-wrap:wrap; margin-top:22px; }
+      .btn { font-family:var(--font-mono); font-weight:700; font-size:13px; letter-spacing:.06em; text-transform:uppercase; border:2px solid var(--ink); padding:12px 18px; box-shadow:3px 3px 0 0 var(--ink); background:var(--jersey-deep); color:var(--cream); text-decoration:none; display:inline-block; }
+      .btn.ghost { background:var(--cream); color:var(--ink); }
+
+      /* A centered */
+      .A .inner { max-width:520px; text-align:center; }
+      .A .jersey { margin:0 auto 24px; }
+      .A .btns { justify-content:center; }
+      /* B split */
+      .B .inner { max-width:760px; display:grid; grid-template-columns:auto 1fr; gap:42px; align-items:center; }
+      .B .jersey { transform:rotate(-3deg); }
+      /* C scoreboard */
+      .C .inner { max-width:640px; text-align:center; }
+      .C .board { font-family:var(--font-display); font-weight:900; font-size:clamp(90px,18vw,168px); line-height:.8; letter-spacing:-4px; margin:0; }
+      .C .board .acc { color:var(--jersey-deep); }
+      .C .jersey.small { display:inline-block; vertical-align:middle; transform:rotate(4deg); margin-left:8px; }
+      .C .btns { justify-content:center; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · 404 / 500 — Round 1: composition</h1>
+      <p>Master-design brief: <b style="color:var(--warm)">football pun + cream bg + JerseyShirt taped artefact</b>.
+        One shared component renders both pages (404 + 500) parameterised by code, pun, body, and buttons (500 adds a
+        "probeer opnieuw" reset). Idea worth a look: the HTTP code lives <b style="color:var(--warm)">as the jersey
+        number</b>. 404 shown in all three layouts; a 500 example confirms the family. Pun copy + button labels are
+        decided next (8e2) — placeholders here. Voice should rhyme with "Geen treffers" (8s4).</p>
+    </div>
+
+    <!-- A -->
+    <div class="direction-bar"><span class="tag">A</span> Centered, code-as-jersey-number <span class="note">taped shirt with "404" as the number, pun below — symmetric</span></div>
+    <div class="stage A"><div class="inner">
+      <div class="jersey"><div class="tape"></div><div class="shirt"></div><div class="num">404</div></div>
+      <div class="code">Fout 404 · pagina niet gevonden</div>
+      <h1 class="pun">Buiten de <span class="acc">lijnen</span>.</h1>
+      <p class="sub" style="margin-left:auto;margin-right:auto">Deze pagina staat niet (meer) op het veld. Misschien is ze verplaatst of bestaat de link niet.</p>
+      <div class="btns"><a class="btn">Naar de homepage</a></div>
+    </div></div>
+    <div class="note-strip">A — clean, the code-as-number ties artefact + error elegantly; works identically for 404/500. RISK: centered + symmetric is the <b>most conventional</b> error layout.</div>
+
+    <!-- B -->
+    <div class="direction-bar"><span class="tag">B</span> Split editorial <span class="note">taped shirt left, copy right — matches the no-results card vibe</span></div>
+    <div class="stage B"><div class="inner">
+      <div class="jersey"><div class="tape"></div><div class="shirt"></div><div class="num">404</div></div>
+      <div>
+        <div class="code">Fout 404 · pagina niet gevonden</div>
+        <h1 class="pun">Buiten de <span class="acc">lijnen</span>.</h1>
+        <p class="sub">Deze pagina staat niet (meer) op het veld. Misschien is ze verplaatst of bestaat de link niet.</p>
+        <div class="btns"><a class="btn">Naar de homepage</a></div>
+      </div>
+    </div></div>
+    <div class="note-strip">B — asymmetric + editorial, sits in the same family as the search "Geen treffers" card. RISK: split layout <b>centres awkwardly</b> on a short 500 message; needs care on mobile (stacks).</div>
+
+    <!-- C -->
+    <div class="direction-bar"><span class="tag">C</span> Scoreboard <span class="note">giant serif code as hero + small jersey flourish — code-forward</span></div>
+    <div class="stage C"><div class="inner">
+      <div class="board"><span>4</span><span class="jersey small"><div class="tape"></div><div class="shirt"></div><div class="num">0</div></span><span>4</span></div>
+      <div class="code" style="margin-top:10px">Fout 404 · pagina niet gevonden</div>
+      <h1 class="pun" style="font-size:34px;margin-top:6px">Buiten de <span class="acc">lijnen</span>.</h1>
+      <p class="sub" style="margin:12px auto 0">Deze pagina staat niet (meer) op het veld.</p>
+      <div class="btns"><a class="btn">Naar de homepage</a></div>
+    </div></div>
+    <div class="note-strip">C — boldest, the "0" of 404 becomes the jersey (scoreboard energy). RISK: the middle-digit-as-shirt trick <b>only reads for codes with a middle 0</b> (404/500 both work, but it's a gimmick); biggest furniture.</div>
+
+    <!-- 500 family check -->
+    <div class="direction-bar"><span class="tag">500</span> Family check (layout A) <span class="note">same component, 500 copy + reset button</span></div>
+    <div class="stage A"><div class="inner">
+      <div class="jersey"><div class="tape"></div><div class="shirt"></div><div class="num">500</div></div>
+      <div class="code">Fout 500 · er ging iets mis</div>
+      <h1 class="pun">Technische <span class="acc">panne</span>.</h1>
+      <p class="sub" style="margin-left:auto;margin-right:auto">Er ging iets mis aan onze kant. Probeer het zo dadelijk opnieuw.</p>
+      <div class="btns" style="justify-content:center"><a class="btn">Probeer opnieuw</a><a class="btn ghost">Naar de homepage</a></div>
+    </div></div>
+    <div class="note-strip">500 reuses the chosen layout with two buttons (reset + home). The <code>reset()</code> callback from <code>error.tsx</code> must stay wired to "Probeer opnieuw".</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-errors/8e1-composition-compare.html
+++ b/docs/design/mockups/phase-8-errors/8e1-composition-compare.html
@@ -103,7 +103,7 @@
     <!-- C -->
     <div class="direction-bar"><span class="tag">C</span> Scoreboard <span class="note">giant serif code as hero + small jersey flourish — code-forward</span></div>
     <div class="stage C"><div class="inner">
-      <div class="board"><span>4</span><span class="jersey small"><div class="tape"></div><div class="shirt"></div><div class="num">0</div></span><span>4</span></div>
+      <div class="board"><span>4</span><div class="jersey small"><div class="tape"></div><div class="shirt"></div><div class="num">0</div></div><span>4</span></div>
       <div class="code" style="margin-top:10px">Fout 404 · pagina niet gevonden</div>
       <h1 class="pun" style="font-size:34px;margin-top:6px">Buiten de <span class="acc">lijnen</span>.</h1>
       <p class="sub" style="margin:12px auto 0">Deze pagina staat niet (meer) op het veld.</p>

--- a/docs/design/mockups/phase-8-errors/8e1-composition-locked.md
+++ b/docs/design/mockups/phase-8-errors/8e1-composition-locked.md
@@ -1,0 +1,41 @@
+# 8e1 — 404/500 composition · DEFERRED to a Storybook A/B
+
+**Decision:** Do **not** pick the layout from the static mockup. Owner wants to see
+the scoreboard (C) rendered live before choosing. Build **both** A and C as
+Storybook stories, owner picks in Storybook, then **delete the unpicked variant**
+before wiring into the routes (memory: storybook-checkpoint-on-delivery).
+
+This is an explicit acceptance-criterion for the error-page implementation issue:
+
+1. Build one shared `<ErrorState>` component (`apps/web/src/components/error/` or
+   `design-system/`) that renders both `not-found.tsx` (404) and `error.tsx` (500),
+   parameterised by `code`, `pun`, `body`, and `actions` (500 adds a "Probeer
+   opnieuw" button wired to `reset()`).
+2. Ship it with a `layout: "centered" | "scoreboard"` prop and a Storybook story
+   per layout × per page (404-centered, 404-scoreboard, 500-centered,
+   500-scoreboard).
+3. **Pause for owner Storybook review.** Owner picks one layout.
+4. Remove the losing layout branch + its stories; wire the winner into both routes.
+
+## Candidate A — Centered, code-as-jersey-number
+
+Taped `<JerseyShirt>` with the HTTP **code as the shirt number** (404/500), mono
+code line, serif italic pun headline, body line, centered button(s). Clean;
+identical for both pages. Lowest risk.
+
+## Candidate C — Scoreboard
+
+Giant Freight Display code as the hero; the **middle `0` becomes the jersey**
+(scoreboard energy). Boldest. Only reads for codes with a middle `0` (404 + 500
+both qualify); biggest furniture. The variant the owner most wants to see live.
+
+## Shared (both layouts, LOCKED)
+
+- Cream bg + paper-grain; the canonical retro tokens.
+- `<JerseyShirt>` is the shipped Phase 4.5 primitive — reuse, don't redraw.
+- Buttons are **plain/clear, not punny** ("Naar de homepage" + "Probeer opnieuw")
+  so the action stays obvious — the wink lives in the headline only.
+- 500's "Probeer opnieuw" MUST stay wired to the `reset()` callback from
+  `error.tsx`. `error.tsx` is `"use client"` and renders at the root segment
+  (no guaranteed SiteHeader/Footer) — keep `<ErrorState>` self-contained.
+- Pun copy → locked in 8e2 (layout-independent; the Storybook prototype uses it).

--- a/docs/design/mockups/phase-8-errors/8e2-copy-locked.md
+++ b/docs/design/mockups/phase-8-errors/8e2-copy-locked.md
@@ -1,0 +1,38 @@
+# 8e2 — 404/500 copy + actions · LOCKED
+
+Layout (A vs C) is still a Storybook A/B (see 8e1). Copy below is
+layout-independent and renders in the Storybook prototype.
+
+## 404 — not found
+
+- **Code line** (mono): `Fout 404 · pagina niet gevonden`
+- **Headline:** **"Buiten de lijnen."** — accent on "lijnen" (jersey-deep on
+  cream / warm on dark). Out of bounds = the page is off the pitch. Owner did not
+  object to the recommended line; revisitable at the Storybook review.
+- **Body:** `Deze pagina staat niet (meer) op het veld. Misschien is de link
+  verplaatst of bestaat ze niet meer.`
+- **Actions (two):**
+  1. `Naar de homepage` (primary, jersey) → `/`
+  2. **`Zoeken`** (secondary, ghost) → `/zoeken` — owner add: give a lost visitor
+     a way to *search* instead of only bouncing home. May also surface inline in
+     the body ("…of zoek meteen wat je nodig hebt.") — copy detail at build.
+
+## 500 — server error
+
+- **Code line** (mono): `Fout 500 · er ging iets mis`
+- **Headline:** **"Technische panne."** — accent on "panne". A breakdown on our
+  side; grown-up, pairs with the 404 voice.
+- **Body:** `Er ging iets mis aan onze kant. Probeer het zo dadelijk opnieuw.`
+- **Actions (two):**
+  1. `Probeer opnieuw` (primary) → wired to the `reset()` callback from
+     `error.tsx` (must stay functional).
+  2. `Naar de homepage` (ghost) → `/`
+
+## Notes
+
+- Both pages now carry **two actions** → the shared `<ErrorState>` always renders
+  an action pair; clean for the component API.
+- Buttons stay plain/clear — the wink is in the headline only (memory: owner
+  rejected childish copy; "Geen treffers" register).
+- The `/zoeken` secondary on 404 is the only asymmetry vs 500 (which has reset +
+  home). Both fit a two-button row.

--- a/docs/design/mockups/phase-8-errors/8e2-copy-locked.md
+++ b/docs/design/mockups/phase-8-errors/8e2-copy-locked.md
@@ -14,8 +14,9 @@ layout-independent and renders in the Storybook prototype.
 - **Actions (two):**
   1. `Naar de homepage` (primary, jersey) → `/`
   2. **`Zoeken`** (secondary, ghost) → `/zoeken` — owner add: give a lost visitor
-     a way to *search* instead of only bouncing home. May also surface inline in
-     the body ("…of zoek meteen wat je nodig hebt.") — copy detail at build.
+     a way to *search* instead of only bouncing home. Keep this as the **single**
+     search affordance in the action row — do not also surface it inline in the
+     body (avoids a duplicate search affordance).
 
 ## 500 — server error
 

--- a/docs/design/mockups/phase-8-privacy/8p1-prose-compare.html
+++ b/docs/design/mockups/phase-8-privacy/8p1-prose-compare.html
@@ -85,7 +85,7 @@
       <div class="prose">
         <hr class="dotdiv" />
         <h2>Contactgegevens</h2>
-        <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="#">info@kcvvelewijt.be</a></p>
+        <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="mailto:info@kcvvelewijt.be">info@kcvvelewijt.be</a></p>
         <hr class="dotdiv" />
         <h2>Welke gegevens verzamelen we?</h2>
         <p>We verzamelen alleen gegevens die noodzakelijk zijn voor het functioneren van onze club en website:</p>
@@ -117,7 +117,7 @@
         </nav>
         <div class="prose">
           <h2 style="margin-top:0">Contactgegevens</h2>
-          <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="#">info@kcvvelewijt.be</a></p>
+          <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="mailto:info@kcvvelewijt.be">info@kcvvelewijt.be</a></p>
           <h2>Welke gegevens verzamelen we?</h2>
           <p>We verzamelen alleen gegevens die noodzakelijk zijn voor het functioneren van onze club en website:</p>
           <ul><li><strong>Leden en spelers:</strong> naam, adres, geboortedatum, contactgegevens…</li><li><strong>Websitebezoekers:</strong> technische gegevens zoals IP-adres, browsertype…</li></ul>
@@ -136,7 +136,7 @@
         <div class="prose">
           <hr class="dotdiv" />
           <h2>Contactgegevens</h2>
-          <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="#">info@kcvvelewijt.be</a></p>
+          <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="mailto:info@kcvvelewijt.be">info@kcvvelewijt.be</a></p>
           <hr class="dotdiv" />
           <h2>Welke gegevens verzamelen we?</h2>
           <p>We verzamelen alleen gegevens die noodzakelijk zijn voor het functioneren van onze club en website:</p>

--- a/docs/design/mockups/phase-8-privacy/8p1-prose-compare.html
+++ b/docs/design/mockups/phase-8-privacy/8p1-prose-compare.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /privacy · Round 1: hero + prose treatment</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 20px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 92ch; line-height: 1.6; }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1000px; margin: 0 auto; padding: 0 28px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+
+      /* shared header */
+      .kicker { font-family: var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; color: var(--jersey-deep); }
+      .ptitle { font-family: var(--font-display); font-style:italic; font-weight:900; font-size: clamp(34px,5vw,58px); line-height:.92; margin:10px 0 0; }
+      .ptitle .acc { color: var(--jersey-deep); }
+      .updated { font-family:var(--font-mono); font-size:11px; color:var(--ink-muted); letter-spacing:.04em; margin-top:14px; }
+      .intro { font-family:var(--font-display); font-size:18px; line-height:1.55; color:var(--ink-soft); margin:16px 0 0; max-width:60ch; }
+
+      /* prose */
+      .prose h2 { font-family:var(--font-display); font-weight:700; font-size:23px; margin:30px 0 10px; }
+      .prose p, .prose li { font-size:15px; line-height:1.62; color:var(--ink-soft); }
+      .prose a { color:var(--jersey-deep); font-weight:600; }
+      .prose ul { padding-left:20px; }
+      .dotdiv { border:0; border-top:2px dotted var(--paper-edge); margin:26px 0; }
+
+      /* P1 minimal */
+      .p1 { padding:40px 0 34px; }
+      .p1 .col { max-width:680px; }
+
+      /* P2 sticky ToC */
+      .p2 { padding:40px 0 34px; }
+      .p2 .grid { display:grid; grid-template-columns: 220px 1fr; gap:40px; align-items:start; }
+      .toc { position:sticky; top:18px; border-left:3px solid var(--paper-edge); padding-left:14px; }
+      .toc .tl { font-family:var(--font-mono); font-size:10px; font-weight:700; letter-spacing:.14em; text-transform:uppercase; color:var(--ink-muted); margin-bottom:10px; }
+      .toc a { display:block; font-size:13px; color:var(--ink-soft); text-decoration:none; padding:4px 0; line-height:1.3; }
+      .toc a.on { color:var(--jersey-deep); font-weight:700; border-left:3px solid var(--jersey-deep); margin-left:-17px; padding-left:14px; }
+
+      /* P3 document sheet */
+      .p3 { padding:40px 0 34px; }
+      .sheet { background:#fffdf6; border:2px solid var(--ink); box-shadow:6px 6px 0 0 var(--ink); padding:40px 44px; max-width:760px; margin:0 auto; }
+      .sheet .stamp { position:relative; }
+      .sheet .stamp::after { content:"AVG · GDPR"; position:absolute; top:-8px; right:0; font-family:var(--font-mono); font-size:10px; font-weight:700; letter-spacing:.1em; color:var(--brick); border:1.5px solid var(--brick); padding:4px 8px; transform:rotate(4deg); opacity:.7; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /privacy — Round 1: hero + prose treatment</h1>
+      <p>Master-design directive for this surface: <b style="color:var(--warm)">clean prose, no chrome flourishes</b>.
+        Current page uses a dark InteriorPageHero + gray <code>prose</code> + a diagonal transition. Three retro-terrace
+        treatments, restrained → navigable, rendering the real copy (11 H2 sections; first two shown). All migrate the
+        legacy diagonal seam away and swap gray prose for cream/ink.</p>
+    </div>
+
+    <!-- ============ P1 ============ -->
+    <div class="direction-bar"><span class="tag">P1</span> Cream minimal <span class="note">no hero band — kicker + serif title + plain prose column, dotted section rules</span></div>
+    <div class="wrap"><div class="p1"><div class="col">
+      <div class="kicker">Juridisch</div>
+      <h1 class="ptitle">Privacyverklaring<span class="acc">.</span></h1>
+      <div class="updated">Laatst bijgewerkt · februari 2026</div>
+      <p class="intro">KCVV Elewijt respecteert je privacy en behandelt je persoonsgegevens vertrouwelijk. Hieronder lees je welke gegevens we verzamelen, waarom, en welke rechten je hebt.</p>
+      <div class="prose">
+        <hr class="dotdiv" />
+        <h2>Contactgegevens</h2>
+        <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="#">info@kcvvelewijt.be</a></p>
+        <hr class="dotdiv" />
+        <h2>Welke gegevens verzamelen we?</h2>
+        <p>We verzamelen alleen gegevens die noodzakelijk zijn voor het functioneren van onze club en website:</p>
+        <ul><li><strong>Leden en spelers:</strong> naam, adres, geboortedatum, contactgegevens…</li><li><strong>Websitebezoekers:</strong> technische gegevens zoals IP-adres, browsertype…</li></ul>
+      </div>
+    </div></div></div>
+    <div class="note-strip">P1 — most faithful to "no chrome". Calm, fast, exactly what a legal page should be. RISK: 11 sections is a <b>long scroll with no jump-nav</b>.</div>
+
+    <!-- ============ P2 ============ -->
+    <div class="direction-bar"><span class="tag">P2</span> Prose + sticky ToC <span class="note">same minimal header, adds a left section index for the 11 sections</span></div>
+    <div class="wrap"><div class="p2">
+      <div class="kicker">Juridisch</div>
+      <h1 class="ptitle">Privacyverklaring<span class="acc">.</span></h1>
+      <div class="updated">Laatst bijgewerkt · februari 2026</div>
+      <div class="grid" style="margin-top:24px">
+        <nav class="toc">
+          <div class="tl">Op deze pagina</div>
+          <a class="on">Contactgegevens</a>
+          <a>Welke gegevens</a>
+          <a>Waarvoor gebruiken we ze</a>
+          <a>Rechtsgrond</a>
+          <a>Delen we je gegevens</a>
+          <a>Bewaartermijn</a>
+          <a>Jouw rechten</a>
+          <a>Cookiebeleid</a>
+          <a>Beveiliging</a>
+          <a>Wijzigingen</a>
+          <a>Vragen</a>
+        </nav>
+        <div class="prose">
+          <h2 style="margin-top:0">Contactgegevens</h2>
+          <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="#">info@kcvvelewijt.be</a></p>
+          <h2>Welke gegevens verzamelen we?</h2>
+          <p>We verzamelen alleen gegevens die noodzakelijk zijn voor het functioneren van onze club en website:</p>
+          <ul><li><strong>Leden en spelers:</strong> naam, adres, geboortedatum, contactgegevens…</li><li><strong>Websitebezoekers:</strong> technische gegevens zoals IP-adres, browsertype…</li></ul>
+        </div>
+      </div>
+    </div></div>
+    <div class="note-strip">P2 — most usable for long legal text; people jump straight to "cookies" or "rechten". The ToC is structure, not decoration. RISK: a sidebar is arguably "chrome"; needs a sensible mobile collapse.</div>
+
+    <!-- ============ P3 ============ -->
+    <div class="direction-bar"><span class="tag">P3</span> Document sheet <span class="note">prose inside one paper "official document" card + AVG stamp</span></div>
+    <div class="wrap"><div class="p3">
+      <div class="sheet stamp">
+        <div class="kicker">Juridisch</div>
+        <h1 class="ptitle">Privacyverklaring<span class="acc">.</span></h1>
+        <div class="updated">Laatst bijgewerkt · februari 2026</div>
+        <div class="prose">
+          <hr class="dotdiv" />
+          <h2>Contactgegevens</h2>
+          <p><strong>Verantwoordelijke:</strong> KCVV Elewijt vzw<br/><strong>Adres:</strong> Driesstraat 30, 1982 Elewijt<br/><strong>E-mail:</strong> <a href="#">info@kcvvelewijt.be</a></p>
+          <hr class="dotdiv" />
+          <h2>Welke gegevens verzamelen we?</h2>
+          <p>We verzamelen alleen gegevens die noodzakelijk zijn voor het functioneren van onze club en website:</p>
+        </div>
+      </div>
+    </div></div>
+    <div class="note-strip">P3 — the "official document on the desk" metaphor; a bit of personality. RISK: a big taped sheet is exactly the <b>chrome flourish the directive warns against</b>; the AVG stamp risks reading as magazine furniture.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-privacy/8p1-prose-locked.md
+++ b/docs/design/mockups/phase-8-privacy/8p1-prose-locked.md
@@ -14,9 +14,11 @@ Rejected:
 ## Spec (LOCKED)
 
 - **No hero band.** Header is: mono kicker `JURIDISCH` (jersey-deep) → serif italic
-  title **"Privacyverklaring."** (Freight Display, accent dot jersey-deep) → mono
-  last-updated line (`Laatst bijgewerkt · {LAST_UPDATED}`) → a Freight Display
-  intro lead paragraph.
+  title **"Privacyverklaring."** (the production display font is **Freight Display**;
+  the mockups stand it in with Fraunces via `--font-display`, since Freight Display
+  ships through Adobe Typekit and can't load in a standalone HTML; accent dot
+  jersey-deep) → mono last-updated line (`Laatst bijgewerkt · {LAST_UPDATED}`) → a
+  Freight Display intro lead paragraph.
 - **Prose column** ≈`max-w-2xl` (≈680px), cream background, **ink/cream prose —
   not the legacy gray `prose-gray`.** H2s in Freight Display (700), body in
   Archivo, links jersey-deep. `<DottedDivider>` between H2 sections.

--- a/docs/design/mockups/phase-8-privacy/8p1-prose-locked.md
+++ b/docs/design/mockups/phase-8-privacy/8p1-prose-locked.md
@@ -1,0 +1,32 @@
+# 8p1 — /privacy hero + prose · LOCKED
+
+**Decision:** P1 — **cream minimal**. Honours the master-design directive
+("clean prose, no chrome flourishes") most faithfully.
+
+Rejected:
+
+- **P2 (prose + sticky ToC)** — most usable for long legal text, but a sidebar is
+  arguably chrome and adds mobile-collapse + scroll-spy complexity for a
+  rarely-read page. Parked; revisit only if the page grows.
+- **P3 (document sheet + AVG stamp)** — the taped sheet + stamp are exactly the
+  chrome flourishes the directive warns against.
+
+## Spec (LOCKED)
+
+- **No hero band.** Header is: mono kicker `JURIDISCH` (jersey-deep) → serif italic
+  title **"Privacyverklaring."** (Freight Display, accent dot jersey-deep) → mono
+  last-updated line (`Laatst bijgewerkt · {LAST_UPDATED}`) → a Freight Display
+  intro lead paragraph.
+- **Prose column** ≈`max-w-2xl` (≈680px), cream background, **ink/cream prose —
+  not the legacy gray `prose-gray`.** H2s in Freight Display (700), body in
+  Archivo, links jersey-deep. `<DottedDivider>` between H2 sections.
+- **Remove** the dark `<InteriorPageHero>`, the `<SectionStack>` `diagonal`
+  transition, and `prose prose-gray`. No `<StripedSeam>` needed — the page is a
+  single prose section with no inter-section seam (satisfies the master-design
+  line-587 "migrate the diagonal consumer" by *removing* it here).
+- Keep all real content + the `/hulp` cross-link + the `LAST_UPDATED` constant +
+  the existing SEO metadata.
+
+Reskin target: `apps/web/src/app/(main)/privacy/page.tsx`. Likely drops the
+`SectionStack`/`InteriorPageHero` composition for a plain server component with a
+cream container + the header + prose.

--- a/docs/design/mockups/phase-8-search/8s1-1-heading-compare.html
+++ b/docs/design/mockups/phase-8-search/8s1-1-heading-compare.html
@@ -48,11 +48,13 @@
   <body>
     <div class="harness-head">
       <h1>Phase 8 · /zoeken — 8s1.1: heading copy + accent</h1>
-      <p>Architecture is locked to S1 (lean, results-first): <b style="color:var(--warm)">no mono kicker</b>,
-        serif title with an accent-colour part, and the search button is a <b style="color:var(--warm)">magnifier
-        icon</b> (no "ZOEK" word) so nothing duplicates "zoek". Pick the heading copy + which word carries the
-        jersey-deep accent. All four render on the identical locked layout. See
-        <a href="./8s1-architecture-locked.md">8s1 lock</a>.</p>
+      <p><b style="color:var(--warm)">Note:</b> this heading round predates the S1→S3 correction — the lean
+        layout shown below was superseded. The chosen heading ("Wat zoek je?") was re-rendered on the locked
+        <b style="color:var(--warm)">S3 dark masthead</b> in 8s1-2. Round goal here: <b style="color:var(--warm)">no
+        mono kicker</b>, serif title with an accent-colour part, magnifier-<b style="color:var(--warm)">icon</b>
+        button (no "ZOEK" word) so nothing duplicates "zoek". On S3's dark ground the accent is warm-gold, not the
+        jersey-deep shown here. See <a href="./8s1-architecture-locked.md">8s1 architecture lock (S3)</a> and
+        <a href="./8s1-2-darkmasthead-compare.html">8s1-2 (on S3)</a>.</p>
     </div>
 
     <!-- H_A -->

--- a/docs/design/mockups/phase-8-search/8s1-1-heading-compare.html
+++ b/docs/design/mockups/phase-8-search/8s1-1-heading-compare.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · 8s1.1 heading copy + accent</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 88ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1040px; margin: 0 auto; padding: 0 28px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+
+      .block { padding: 38px 0 30px; }
+      h1.title { font-family: var(--font-display); font-style:italic; font-weight:900; font-size: clamp(38px,5.6vw,68px); line-height:.92; margin:0 0 20px; letter-spacing:-0.01em; }
+      h1.title .acc { color: var(--jersey-deep); }
+      /* searchbar with magnifier icon button (no "ZOEK" text) */
+      .searchbar { display:flex; align-items:stretch; border:2px solid var(--ink); border-radius:8px; background:#fff; box-shadow: 4px 4px 0 0 var(--ink); max-width:660px; overflow:hidden; }
+      .searchbar input { flex:1; border:0; padding:15px 18px; font-size:17px; font-family:var(--font-body); background:transparent; outline:none; }
+      .searchbar .go { background:var(--jersey-deep); color:var(--cream); border:0; border-left:2px solid var(--ink); padding:0 20px; display:flex; align-items:center; cursor:pointer; }
+      .searchbar .go svg { width:22px; height:22px; }
+      .subnote { font-family:var(--font-mono); font-size:11.5px; color:var(--ink-muted); margin-top:12px; letter-spacing:.03em; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — 8s1.1: heading copy + accent</h1>
+      <p>Architecture is locked to S1 (lean, results-first): <b style="color:var(--warm)">no mono kicker</b>,
+        serif title with an accent-colour part, and the search button is a <b style="color:var(--warm)">magnifier
+        icon</b> (no "ZOEK" word) so nothing duplicates "zoek". Pick the heading copy + which word carries the
+        jersey-deep accent. All four render on the identical locked layout. See
+        <a href="./8s1-architecture-locked.md">8s1 lock</a>.</p>
+    </div>
+
+    <!-- H_A -->
+    <div class="direction-bar"><span class="tag">A</span> "Zoeken." <span class="note">literal, one word — accent on the dot only</span></div>
+    <div class="wrap"><div class="block">
+      <h1 class="title">Zoeken<span class="acc">.</span></h1>
+      <div class="searchbar"><input value="elewijt" /><button class="go" aria-label="Zoek"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 1 0-11.31 11.31l50.06 50.07a8 8 0 0 0 11.32-11.32ZM40 112a72 72 0 1 1 72 72 72.08 72.08 0 0 1-72-72Z"/></svg></button></div>
+      <div class="subnote">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+    </div></div>
+    <div class="note-strip">A — most literal, matches the URL. Calm, but the least personality of the four.</div>
+
+    <!-- H_B -->
+    <div class="direction-bar"><span class="tag">B</span> "Wat zoek je?" <span class="note">friendly question — accent on "zoek"</span></div>
+    <div class="wrap"><div class="block">
+      <h1 class="title">Wat <span class="acc">zoek</span> je?</h1>
+      <div class="searchbar"><input value="elewijt" /><button class="go" aria-label="Zoek"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 1 0-11.31 11.31l50.06 50.07a8 8 0 0 0 11.32-11.32ZM40 112a72 72 0 1 1 72 72 72.08 72.08 0 0 1-72-72Z"/></svg></button></div>
+      <div class="subnote">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+    </div></div>
+    <div class="note-strip">B — the question a search page asks; warmest, most human. "zoek" appears once (heading only — button is an icon).</div>
+
+    <!-- H_C -->
+    <div class="direction-bar"><span class="tag">C</span> "Vind je weg." <span class="note">warm, no verb "zoek" at all — accent on "weg"</span></div>
+    <div class="wrap"><div class="block">
+      <h1 class="title">Vind je <span class="acc">weg</span>.</h1>
+      <div class="searchbar"><input value="elewijt" /><button class="go" aria-label="Zoek"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 1 0-11.31 11.31l50.06 50.07a8 8 0 0 0 11.32-11.32ZM40 112a72 72 0 1 1 72 72 72.08 72.08 0 0 1-72-72Z"/></svg></button></div>
+      <div class="subnote">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+    </div></div>
+    <div class="note-strip">C — avoids "zoek" entirely, more editorial. RISK: slightly indirect for a pure utility page.</div>
+
+    <!-- H_D -->
+    <div class="direction-bar"><span class="tag">D</span> "Zoek mee." <span class="note">short, communal "plezante compagnie" voice — accent on "mee"</span></div>
+    <div class="wrap"><div class="block">
+      <h1 class="title">Zoek <span class="acc">mee</span>.</h1>
+      <div class="searchbar"><input value="elewijt" /><button class="go" aria-label="Zoek"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 1 0-11.31 11.31l50.06 50.07a8 8 0 0 0 11.32-11.32ZM40 112a72 72 0 1 1 72 72 72.08 72.08 0 0 1-72-72Z"/></svg></button></div>
+      <div class="subnote">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+    </div></div>
+    <div class="note-strip">D — short + club-voice, but "Zoek mee" implies collaboration the feature doesn't really have.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s1-2-darkmasthead-compare.html
+++ b/docs/design/mockups/phase-8-search/8s1-2-darkmasthead-compare.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · 8s1.1 softened S3 + accent colour</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 90ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1040px; margin: 0 auto; padding: 0 28px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+
+      /* softened S3 masthead */
+      .mast { background: var(--jersey-deep-dark); color: var(--cream); padding: 50px 0 46px; border-bottom:2px solid var(--ink); position:relative; overflow:hidden; }
+      .mast::before { content:""; position:absolute; inset:0; background: repeating-linear-gradient(135deg, rgba(245,241,230,0.045) 0 18px, transparent 18px 36px); }
+      .mast::after { content:""; position:absolute; inset:0; background: radial-gradient(120% 90% at 18% -10%, rgba(74,207,82,.14), transparent 60%); }
+      .mast .inner { position:relative; }
+      .mast h1 { font-family: var(--font-display); font-style:italic; font-weight:900; font-size: clamp(40px,6vw,74px); line-height:.9; margin:0 0 22px; letter-spacing:-0.01em; color: var(--cream); }
+      .searchbar { display:flex; align-items:stretch; border:2px solid var(--ink); border-radius:8px; background:#fff; box-shadow: 5px 5px 0 0 #000; max-width:680px; overflow:hidden; }
+      .searchbar input { flex:1; border:0; padding:16px 18px; font-size:17px; font-family:var(--font-body); background:var(--cream); outline:none; color:var(--ink); }
+      .searchbar .go { border:0; border-left:2px solid var(--ink); padding:0 22px; display:flex; align-items:center; cursor:pointer; color:var(--ink); }
+      .searchbar .go svg { width:23px; height:23px; }
+      .mast .hint { font-family:var(--font-mono); font-size:12px; color:rgba(245,241,230,.72); margin-top:14px; letter-spacing:.03em; }
+
+      /* glimpse of results on cream */
+      .results { display:grid; gap:10px; padding: 22px 0 30px; }
+      .res { display:flex; gap:14px; align-items:center; background:#fff; border:1px solid var(--paper-edge); border-radius:6px; padding:12px 14px; }
+      .res .thumb { width:48px; height:48px; flex:0 0 auto; border-radius:4px; background:var(--cream-deep); display:flex; align-items:center; justify-content:center; font-family:var(--font-mono); font-size:10px; color:var(--ink-muted); }
+      .res .tlabel { font-family:var(--font-mono); font-size:10px; font-weight:600; letter-spacing:.12em; text-transform:uppercase; color:var(--jersey-deep); }
+      .res .ttl { font-weight:700; font-size:15px; margin:2px 0 0; }
+      .res .snip { font-size:12.5px; color:var(--ink-muted); margin:2px 0 0; }
+      .glasshint { font-family:var(--font-mono); font-size:11px; color:var(--ink-muted); padding-top:14px; }
+
+      /* accent variants */
+      .warm h1 .acc { color: var(--warm); }
+      .warm .searchbar .go { background: var(--warm); }
+      .bright h1 .acc { color: var(--jersey); }
+      .bright .searchbar .go { background: var(--jersey); }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — 8s1.1: softened S3 + accent colour</h1>
+      <p>Corrected base: <b style="color:var(--warm)">S3 dark masthead</b>, softened — no kicker, serif italic
+        title "Wat <em>zoek</em> je?", magnifier-icon button. On the dark ground the accent can't be jersey-deep,
+        so pick the light accent for the "zoek" word + the icon-button cell: <b>warm gold</b> or <b>bright jersey</b>.
+        Both render the identical masthead; result rows below are still neutral placeholders (vocabulary = 8s2).
+        See <a href="./8s1-architecture-locked.md">8s1 lock</a>.</p>
+    </div>
+
+    <!-- WARM -->
+    <div class="direction-bar"><span class="tag">W</span> Warm-gold accent <span class="note">matches the dark-band heading accent on /club/ultras + clubshop</span></div>
+    <div class="warm">
+      <div class="mast"><div class="wrap inner">
+        <h1>Wat <span class="acc">zoek</span> je?</h1>
+        <div class="searchbar"><input value="elewijt" /><button class="go" aria-label="Zoek"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 1 0-11.31 11.31l50.06 50.07a8 8 0 0 0 11.32-11.32ZM40 112a72 72 0 1 1 72 72 72.08 72.08 0 0 1-72-72Z"/></svg></button></div>
+        <div class="hint">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+      </div></div>
+      <div class="wrap"><div class="results">
+        <div class="res"><div class="thumb">FOTO</div><div><div class="tlabel">Nieuws</div><div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div><div class="snip">Een late kopbal bezorgt de A-ploeg een deugddoende zege…</div></div></div>
+        <div class="res"><div class="thumb">FOTO</div><div><div class="tlabel">Speler</div><div class="ttl">Wout Van Elewijt</div><div class="snip">Middenvelder · A-ploeg</div></div></div>
+      </div><div class="glasshint">— result-card vocabulary decided in 8s2 —</div></div>
+    </div>
+    <div class="note-strip">W — warm gold reads as the established "dark-hero accent" across the site; calmer, a bit vintage.</div>
+
+    <!-- BRIGHT -->
+    <div class="direction-bar"><span class="tag">J</span> Bright-jersey accent <span class="note">the bright pitch green — louder, more "live"</span></div>
+    <div class="bright">
+      <div class="mast"><div class="wrap inner">
+        <h1>Wat <span class="acc">zoek</span> je?</h1>
+        <div class="searchbar"><input value="elewijt" /><button class="go" aria-label="Zoek"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M229.66 218.34l-50.07-50.06a88.11 88.11 0 1 0-11.31 11.31l50.06 50.07a8 8 0 0 0 11.32-11.32ZM40 112a72 72 0 1 1 72 72 72.08 72.08 0 0 1-72-72Z"/></svg></button></div>
+        <div class="hint">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+      </div></div>
+      <div class="wrap"><div class="results">
+        <div class="res"><div class="thumb">FOTO</div><div><div class="tlabel">Nieuws</div><div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div><div class="snip">Een late kopbal bezorgt de A-ploeg een deugddoende zege…</div></div></div>
+        <div class="res"><div class="thumb">FOTO</div><div><div class="tlabel">Speler</div><div class="ttl">Wout Van Elewijt</div><div class="snip">Middenvelder · A-ploeg</div></div></div>
+      </div><div class="glasshint">— result-card vocabulary decided in 8s2 —</div></div>
+    </div>
+    <div class="note-strip">J — bright jersey is punchier and more "matchday", but it competes harder with the green result-type labels below.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s1-architecture-compare.html
+++ b/docs/design/mockups/phase-8-search/8s1-architecture-compare.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · Round 1: page architecture</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 88ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 1040px; margin: 0 auto; padding: 0 28px; }
+      .seckick { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: .16em; text-transform: uppercase; color: var(--ink-muted); display:flex; align-items:center; gap:10px; margin: 26px 0 12px; }
+      .seckick::after { content:""; height:2px; flex:1; background: var(--paper-edge); }
+      .note-strip { background: var(--cream-deep); border-top:1px dashed var(--ink); border-bottom:1px dashed var(--ink); padding:10px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+
+      /* shared neutral result rows (vocabulary decided in 8s2 — kept plain here) */
+      .results { display:grid; gap:10px; padding: 6px 0 30px; }
+      .res { display:flex; gap:14px; align-items:center; background: #fff; border:1px solid var(--paper-edge); border-radius:6px; padding:12px 14px; }
+      .res .thumb { width:54px; height:54px; flex:0 0 auto; border-radius:4px; background: var(--cream-deep); display:flex; align-items:center; justify-content:center; font-family:var(--font-mono); font-size:10px; color:var(--ink-muted); }
+      .res .meta { min-width:0; }
+      .res .tlabel { font-family:var(--font-mono); font-size:10px; font-weight:600; letter-spacing:.12em; text-transform:uppercase; color: var(--jersey-deep); }
+      .res .ttl { font-weight:700; font-size:15px; margin:2px 0 0; }
+      .res .snip { font-size:12.5px; color:var(--ink-muted); margin:2px 0 0; max-width:64ch; }
+      .fakefilter { display:flex; gap:8px; flex-wrap:wrap; margin: 4px 0 14px; }
+      .chip { font-family:var(--font-mono); font-size:11px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; border:1.5px solid var(--ink); padding:6px 11px; border-radius:999px; background:var(--cream); }
+      .chip.on { background:var(--ink); color:var(--cream); }
+      .chip .n { opacity:.6; margin-left:5px; }
+
+      /* ---- S1 lean utility ---- */
+      .s1 { padding: 40px 0 6px; }
+      .s1 .kicker { font-family: var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; color: var(--jersey-deep); }
+      .s1 h1 { font-family: var(--font-display); font-style:italic; font-weight:900; font-size: clamp(34px,5vw,58px); line-height:.92; margin:10px 0 18px; }
+      .s1 h1 .dot { color: var(--jersey-deep); }
+      .searchbar { display:flex; align-items:center; gap:0; border:2px solid var(--ink); border-radius:8px; background:#fff; box-shadow: 4px 4px 0 0 var(--ink); max-width:680px; overflow:hidden; }
+      .searchbar input { flex:1; border:0; padding:16px 18px; font-size:17px; font-family:var(--font-body); background:transparent; outline:none; }
+      .searchbar .go { background:var(--jersey-deep); color:var(--cream); border:0; border-left:2px solid var(--ink); padding:0 22px; align-self:stretch; font-family:var(--font-mono); font-weight:700; font-size:13px; letter-spacing:.08em; text-transform:uppercase; cursor:pointer; }
+
+      /* ---- S2 editorial hero band ---- */
+      .s2 { padding: 48px 0 24px; position:relative; overflow:hidden; }
+      .s2 .inner { display:grid; grid-template-columns: 1.3fr .7fr; gap:28px; align-items:center; }
+      .s2 .kicker { font-family: var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; color: var(--jersey-deep); }
+      .s2 h1 { font-family: var(--font-display); font-style:italic; font-weight:900; font-size: clamp(44px,6.6vw,86px); line-height:.86; margin:12px 0 0; }
+      .s2 h1 .dot { color: var(--jersey-deep); }
+      .s2 .lead { font-family: var(--font-display); font-size:18px; line-height:1.5; margin:16px 0 20px; color: var(--ink-soft); max-width:42ch; }
+      .s2 .jersey { aspect-ratio: 4/5; border:2px solid var(--ink); background:
+        repeating-linear-gradient(90deg, var(--jersey-deep) 0 14px, var(--jersey-deep-dark) 14px 28px);
+        box-shadow:5px 5px 0 0 var(--ink); transform: rotate(-1.4deg); display:flex; align-items:flex-end; padding:10px;
+        font-family:var(--font-mono); font-size:10px; color:rgba(245,241,230,.7); text-transform:uppercase; }
+      .s2 .tape { position:absolute; }
+
+      /* ---- S3 dark masthead ---- */
+      .s3 { background: var(--jersey-deep-dark); color: var(--cream); padding: 52px 0; border-bottom:2px solid var(--ink); position:relative; overflow:hidden; }
+      .s3::before { content:""; position:absolute; inset:0; background: repeating-linear-gradient(135deg, rgba(245,241,230,0.05) 0 18px, transparent 18px 36px); }
+      .s3 .inner { position:relative; }
+      .s3 .kicker { font-family: var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.2em; text-transform:uppercase; color: var(--warm); }
+      .s3 h1 { font-family: var(--font-body); font-weight:900; font-size: clamp(46px,8vw,104px); line-height:.82; margin:10px 0 18px; text-transform:uppercase; letter-spacing:-0.02em; }
+      .s3 .searchbar { box-shadow:5px 5px 0 0 #000; max-width:720px; }
+      .s3 .searchbar input { background:var(--cream); }
+      .s3 .searchbar .go { background:var(--warm); color:var(--ink); }
+      .s3 .hint { font-family:var(--font-mono); font-size:12px; color:rgba(245,241,230,.7); margin-top:14px; letter-spacing:.04em; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — Round 1: page architecture (register)</h1>
+      <p>How editorial vs. utilitarian should the search page feel? Search is a <em>tool</em> — but it
+        still lives in the retro-terrace world. Three registers for the masthead + search field. The
+        result rows below each are intentionally <b style="color:var(--warm)">neutral placeholders</b> —
+        result-card vocabulary is decided next, in round <a href="#">8s2</a>. Same query
+        (<em>"elewijt"</em>) and same 5 mixed results under every option so you compare the chrome only.
+        See <a href="../phase-8-data-reality-locked.md">data-reality lock</a>.</p>
+    </div>
+
+    <!-- ============ S1 ============ -->
+    <div class="direction-bar"><span class="tag">S1</span> Lean utility · results-first <span class="note">calmest, gets out of the way — consistent cream</span></div>
+    <div class="wrap"><div class="s1">
+      <div class="kicker">Zoeken op kcvvelewijt.be</div>
+      <h1>Wat zoek je<span class="dot">?</span></h1>
+      <div class="searchbar">
+        <input value="elewijt" />
+        <button class="go">Zoek</button>
+      </div>
+    </div>
+    <div class="fakefilter">
+      <span class="chip on">Alles <span class="n">5</span></span>
+      <span class="chip">Nieuws <span class="n">2</span></span>
+      <span class="chip">Spelers <span class="n">1</span></span>
+      <span class="chip">Staf <span class="n">1</span></span>
+      <span class="chip">Teams <span class="n">1</span></span>
+    </div>
+    <div class="results">
+      <div class="res"><div class="thumb">FOTO</div><div class="meta"><div class="tlabel">Nieuws</div><div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div><div class="snip">Een late kopbal bezorgt de A-ploeg een deugddoende zege…</div></div></div>
+      <div class="res"><div class="thumb">FOTO</div><div class="meta"><div class="tlabel">Speler</div><div class="ttl">Wout Van Elewijt</div><div class="snip">Middenvelder · A-ploeg</div></div></div>
+      <div class="res"><div class="thumb">⚽</div><div class="meta"><div class="tlabel">Team</div><div class="ttl">A-ploeg</div><div class="snip">Eerste elftal · 2e Provinciale</div></div></div>
+    </div></div>
+    <div class="note-strip">S1 — least friction, fastest to a result. RISK: reads almost <b>generic</b>; little of the fanzine personality the rest of the site now has.</div>
+
+    <!-- ============ S2 ============ -->
+    <div class="direction-bar"><span class="tag">S2</span> Editorial hero band <span class="note">branded landing — kicker + big italic display + jersey flourish</span></div>
+    <div class="wrap"><div class="s2"><div class="inner">
+      <div>
+        <div class="kicker">Zoeken</div>
+        <h1>Vind je weg<span class="dot">.</span></h1>
+        <p class="lead">Nieuws, spelers, ploegen en staf — alles op één plek doorzoekbaar.</p>
+        <div class="searchbar">
+          <input value="elewijt" />
+          <button class="go">Zoek</button>
+        </div>
+      </div>
+      <div class="jersey">geen sponsor · twee-pass print</div>
+    </div></div>
+    <div class="fakefilter">
+      <span class="chip on">Alles <span class="n">5</span></span>
+      <span class="chip">Nieuws <span class="n">2</span></span>
+      <span class="chip">Spelers <span class="n">1</span></span>
+      <span class="chip">Staf <span class="n">1</span></span>
+      <span class="chip">Teams <span class="n">1</span></span>
+    </div>
+    <div class="results">
+      <div class="res"><div class="thumb">FOTO</div><div class="meta"><div class="tlabel">Nieuws</div><div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div><div class="snip">Een late kopbal bezorgt de A-ploeg een deugddoende zege…</div></div></div>
+      <div class="res"><div class="thumb">FOTO</div><div class="meta"><div class="tlabel">Speler</div><div class="ttl">Wout Van Elewijt</div><div class="snip">Middenvelder · A-ploeg</div></div></div>
+      <div class="res"><div class="thumb">⚽</div><div class="meta"><div class="tlabel">Team</div><div class="ttl">A-ploeg</div><div class="snip">Eerste elftal · 2e Provinciale</div></div></div>
+    </div></div>
+    <div class="note-strip">S2 — most on-brand, matches the other interior heroes. RISK: a tall hero <b>pushes results below the fold</b> on a page whose whole job is to show results fast.</div>
+
+    <!-- ============ S3 ============ -->
+    <div class="direction-bar"><span class="tag">S3</span> Dark search masthead <span class="note">loud poster energy — search on jersey-deep-dark</span></div>
+    <div class="s3"><div class="wrap inner">
+      <div class="kicker">Zoeken op de site</div>
+      <h1>Zoeken.</h1>
+      <div class="searchbar">
+        <input value="elewijt" />
+        <button class="go">Zoek</button>
+      </div>
+      <div class="hint">Typ minstens 2 letters · nieuws · spelers · ploegen · staf</div>
+    </div></div>
+    <div class="wrap">
+    <div class="fakefilter" style="margin-top:18px">
+      <span class="chip on">Alles <span class="n">5</span></span>
+      <span class="chip">Nieuws <span class="n">2</span></span>
+      <span class="chip">Spelers <span class="n">1</span></span>
+      <span class="chip">Staf <span class="n">1</span></span>
+      <span class="chip">Teams <span class="n">1</span></span>
+    </div>
+    <div class="results">
+      <div class="res"><div class="thumb">FOTO</div><div class="meta"><div class="tlabel">Nieuws</div><div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div><div class="snip">Een late kopbal bezorgt de A-ploeg een deugddoende zege…</div></div></div>
+      <div class="res"><div class="thumb">FOTO</div><div class="meta"><div class="tlabel">Speler</div><div class="ttl">Wout Van Elewijt</div><div class="snip">Middenvelder · A-ploeg</div></div></div>
+      <div class="res"><div class="thumb">⚽</div><div class="meta"><div class="tlabel">Team</div><div class="ttl">A-ploeg</div><div class="snip">Eerste elftal · 2e Provinciale</div></div></div>
+    </div></div>
+    <div class="note-strip">S3 — strongest personality, the search field is the hero. RISK: a dark full-bleed band is <b>heavy chrome for a utility page</b>; can feel like a different site section.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s1-architecture-locked.md
+++ b/docs/design/mockups/phase-8-search/8s1-architecture-locked.md
@@ -1,0 +1,37 @@
+# 8s1 — /zoeken page architecture · LOCKED
+
+**Decision:** S3 — **dark search masthead**, softened (see refinements).
+
+The search field is the hero, on a `jersey-deep-dark` full-bleed band with subtle
+diagonal stripe texture; results render on cream below the band.
+
+Rejected:
+
+- **S1 (lean utility)** — calmest and results-first, but reads almost generic;
+  too little of the fanzine personality the rest of the site now carries.
+- **S2 (editorial hero band)** — on-brand, but a tall two-column hero pushes the
+  result list below the fold.
+
+## Owner refinements — "softened S3" (carried into all later search rounds)
+
+1. **No mono kicker.** Drop the `Zoeken op de site` eyebrow entirely (removes the
+   eyebrow↔heading "zoeken" duplication).
+2. **Serif heading, not loud uppercase.** Replace S3's big uppercase Archivo with
+   a Freight Display (Fraunces in mockups) **italic** title — "less aggressive".
+3. **Accent-colour part.** One word carries an accent colour, as on our other
+   hero titles. On the dark ground the accent flips light (jersey-deep is
+   invisible on jersey-deep-dark) → **warm gold** or **bright jersey**, decided in
+   8s1.1.
+4. **Heading copy = B "Wat zoek je?"** — accent on "zoek".
+5. **No duplicate "zoeken".** Search-field button is a **magnifier icon** (Phosphor
+   `MagnifyingGlass` Fill via `@/lib/icons.redesign`), not the word "ZOEK".
+6. **Hard-shadow search field** — cream input, ink border, offset shadow; the
+   button cell carries the chosen accent.
+
+**Accent colour = warm gold** (LOCKED 8s1.1). Reads as the established dark-hero
+accent (ultras + clubshop); stays clear of the green result-type labels below.
+So: "zoek" in `--warm`, the magnifier-icon button cell in `--warm` with an ink
+border. Bright jersey rejected — competes with the green type labels.
+
+Result-card vocabulary / filter row / empty-state rounds → 8s2 / 8s3 / 8s4,
+all rendering on the cream area below the dark masthead.

--- a/docs/design/mockups/phase-8-search/8s2-1-refined-aligned.html
+++ b/docs/design/mockups/phase-8-search/8s2-1-refined-aligned.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · 8s2 refined (uniform square thumbs)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 20px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 90ch; line-height: 1.6; }
+      .wrap { max-width: 820px; margin: 0 auto; padding: 0 28px; }
+      .countline { font-family:var(--font-mono); font-size:12px; color:var(--ink-muted); margin:24px 0 12px; letter-spacing:.04em; }
+      .stack { display:grid; gap:12px; padding-bottom:40px; }
+
+      .row { display:flex; gap:14px; align-items:center; background:#fff; border:1.5px solid var(--ink); border-left:5px solid var(--jersey-deep); border-radius:6px; padding:13px 16px 13px 13px;
+        box-shadow:2px 2px 0 0 var(--ink); transition:all .25s; text-decoration:none; color:inherit; }
+      .row:hover { box-shadow:none; transform:translate(2px,2px); }
+      /* uniform square thumb on EVERY type */
+      .thumb { width:64px; height:64px; flex:0 0 64px; border-radius:6px; border:1.5px solid var(--ink); overflow:hidden; background:var(--cream-deep);
+        display:flex; align-items:center; justify-content:center; font-family:var(--font-mono); font-size:9px; color:var(--ink-muted); }
+      .thumb.crest { background:var(--jersey-deep); color:var(--cream); font-family:var(--font-display); font-style:italic; font-weight:900; font-size:26px; }
+      .thumb img { width:100%; height:100%; object-fit:cover; }
+      .body { min-width:0; flex:1; }
+      .tlabel { font-family:var(--font-mono); font-size:10px; font-weight:600; letter-spacing:.13em; text-transform:uppercase; color:var(--jersey-deep); }
+      .tlabel .date { color:var(--ink-muted); }
+      .ttl { font-weight:800; font-size:16px; margin:3px 0 0; line-height:1.18; }
+      .snip { font-size:13px; color:var(--ink-muted); margin:4px 0 0; line-height:1.45; }
+      .tags { display:flex; gap:6px; margin-top:7px; flex-wrap:wrap; }
+      .tags span { font-family:var(--font-mono); font-size:9.5px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; border:1px solid var(--paper-edge); border-radius:999px; padding:2px 7px; color:var(--ink-soft); background:var(--cream); }
+      .ar { margin-left:auto; width:18px; height:18px; color:var(--ink-muted); flex:0 0 auto; }
+      .ruler { border-top:1px dashed var(--paper-edge); }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — 8s2 refined: uniform square thumbnails</h1>
+      <p>Locked vocabulary A, alignment fix: <b style="color:var(--warm)">every</b> result type uses the same 64×64
+        rounded-square thumb — article (square crop), player/staff (square photo), team (jersey-deep crest disc).
+        Rows are now identical height with a flush left edge. Compare to <a href="./8s2-result-vocabulary-compare.html">8s2 option A</a>.</p>
+    </div>
+    <div class="wrap">
+      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="stack">
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><div class="tlabel">Nieuws · <span class="date">9 nov 2025</span></div>
+            <div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div>
+            <div class="snip">Een late kopbal van invaller bezorgt de A-ploeg een deugddoende thuiszege…</div>
+            <div class="tags"><span>Eerste ploeg</span><span>Verslag</span></div></div>
+          <svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><div class="tlabel">Speler</div>
+            <div class="ttl">Wout Van Elewijt</div>
+            <div class="snip">Middenvelder · A-ploeg</div></div>
+          <svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg>
+        </a>
+        <a class="row">
+          <div class="thumb crest">A</div>
+          <div class="body"><div class="tlabel">Team</div>
+            <div class="ttl">A-ploeg</div>
+            <div class="snip">Eerste elftal · 2e Provinciale B</div></div>
+          <svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><div class="tlabel">Staf</div>
+            <div class="ttl">Jan Peeters</div>
+            <div class="snip">Hoofdtrainer · A-ploeg</div></div>
+          <svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><div class="tlabel">Nieuws · <span class="date">2 nov 2025</span></div>
+            <div class="ttl">Sponsoravond groot succes in kantine De Dries</div>
+            <div class="snip">Ruim honderd sympathisanten zakten af naar Elewijt voor de jaarlijkse…</div>
+            <div class="tags"><span>Club</span></div></div>
+          <svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg>
+        </a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s2-result-vocabulary-compare.html
+++ b/docs/design/mockups/phase-8-search/8s2-result-vocabulary-compare.html
@@ -87,7 +87,7 @@
     <!-- ============ A ============ -->
     <div class="direction-bar"><span class="tag">A</span> Clean paper rows <span class="note">thin card + jersey-deep left edge, mono micro-label — most scannable</span></div>
     <div class="wrap A">
-      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="countline">4 resultaten voor "elewijt"</div>
       <div class="stack">
         <a class="row">
           <div class="thumb">FOTO 16:9</div>
@@ -125,7 +125,7 @@
     <!-- ============ B ============ -->
     <div class="direction-bar"><span class="tag">B</span> TapedCard index rows <span class="note">full paper card + MonoLabel pill — pinned-to-a-board feel</span></div>
     <div class="wrap B">
-      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="countline">4 resultaten voor "elewijt"</div>
       <div class="stack">
         <a class="row">
           <div class="thumb" style="width:96px;height:74px">FOTO 16:9</div>
@@ -159,7 +159,7 @@
     <!-- ============ C ============ -->
     <div class="direction-bar"><span class="tag">C</span> Ticket-stub rows <span class="note">perforated type-stub left — ties to the events/ticket motif</span></div>
     <div class="wrap C">
-      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="countline">4 resultaten voor "elewijt"</div>
       <div class="stack">
         <a class="row">
           <div class="stub"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M232 64H24a8 8 0 0 0-8 8v112a8 8 0 0 0 8 8h208a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8Zm-8 112H32V80h192ZM56 104h80a8 8 0 0 1 0 16H56a8 8 0 0 1 0-16Zm0 32h64a8 8 0 0 1 0 16H56a8 8 0 0 1 0-16Z"/></svg>Nieuws</div>

--- a/docs/design/mockups/phase-8-search/8s2-result-vocabulary-compare.html
+++ b/docs/design/mockups/phase-8-search/8s2-result-vocabulary-compare.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · 8s2 result-card vocabulary</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 90ch; line-height: 1.6; }
+      .harness-head a { color: var(--warm); }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 880px; margin: 0 auto; padding: 0 28px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+      .mini-mast { background: var(--jersey-deep-dark); color: var(--cream); font-family:var(--font-mono); font-size:12px; padding:10px 28px; letter-spacing:.04em; }
+      .mini-mast .acc { color: var(--warm); }
+      .countline { font-family:var(--font-mono); font-size:12px; color:var(--ink-muted); margin:22px 0 12px; letter-spacing:.04em; }
+      .stack { display:grid; gap:12px; padding-bottom:34px; }
+      .tlabel { font-family:var(--font-mono); font-size:10px; font-weight:600; letter-spacing:.13em; text-transform:uppercase; color:var(--jersey-deep); }
+      .ttl { font-family:var(--font-body); font-weight:800; font-size:16px; margin:3px 0 0; line-height:1.18; }
+      .snip { font-size:13px; color:var(--ink-muted); margin:4px 0 0; line-height:1.45; }
+      .date { font-family:var(--font-mono); font-size:10px; color:var(--ink-muted); }
+      .tags { display:flex; gap:6px; margin-top:7px; flex-wrap:wrap; }
+      .tags span { font-family:var(--font-mono); font-size:9.5px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; border:1px solid var(--paper-edge); border-radius:999px; padding:2px 7px; color:var(--ink-soft); background:var(--cream); }
+      .thumb { flex:0 0 auto; border-radius:5px; background:var(--cream-deep); display:flex; align-items:center; justify-content:center; font-family:var(--font-mono); font-size:9px; color:var(--ink-muted); overflow:hidden; }
+      .crest { background: var(--jersey-deep); color: var(--cream); font-family:var(--font-display); font-style:italic; font-weight:900; }
+      svg.ar { width:18px; height:18px; color:var(--ink-muted); }
+
+      /* ---------- A: clean paper rows ---------- */
+      .A .row { display:flex; gap:14px; align-items:center; background:#fff; border:1.5px solid var(--ink); border-left:5px solid var(--jersey-deep); border-radius:6px; padding:13px 16px 13px 13px;
+        box-shadow:2px 2px 0 0 var(--ink); transition:all .25s; }
+      .A .row:hover { box-shadow:none; transform:translate(2px,2px); }
+      .A .thumb { width:60px; height:60px; }
+      .A .body { min-width:0; flex:1; }
+      .A .right { margin-left:auto; }
+
+      /* ---------- B: TapedCard index rows ---------- */
+      .B .row { position:relative; display:flex; gap:16px; align-items:flex-start; background:var(--cream-soft); border:2px solid var(--ink); border-radius:4px; padding:15px 16px;
+        box-shadow:3px 3px 0 0 var(--ink); transition:all .25s; }
+      .B .row:hover { box-shadow:none; transform:translate(3px,3px); }
+      .B .thumb { width:74px; height:74px; border:1.5px solid var(--ink); }
+      .B .pill { display:inline-block; font-family:var(--font-mono); font-size:10px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; background:var(--jersey-deep); color:var(--cream); border:1.5px solid var(--ink); border-radius:999px; padding:3px 10px; }
+      .B .ttl { margin-top:8px; }
+      .B .body { flex:1; min-width:0; }
+
+      /* ---------- C: ticket-stub rows ---------- */
+      .C .row { display:flex; align-items:stretch; background:#fff; border:2px solid var(--ink); border-radius:5px; box-shadow:3px 3px 0 0 var(--ink); overflow:hidden; transition:all .25s; }
+      .C .row:hover { box-shadow:none; transform:translate(3px,3px); }
+      .C .stub { flex:0 0 64px; background:var(--jersey-deep); color:var(--cream); display:flex; flex-direction:column; align-items:center; justify-content:center; gap:6px; border-right:2px dashed var(--cream);
+        font-family:var(--font-mono); font-size:9px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; text-align:center; position:relative; }
+      .C .stub svg { width:22px; height:22px; }
+      .C .main { display:flex; gap:14px; align-items:center; padding:13px 16px; flex:1; min-width:0; }
+      .C .thumb { width:56px; height:56px; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — 8s2: result-card vocabulary</h1>
+      <p>The masthead is locked (warm-gold softened S3). Now the result list. Three vocabularies, each rendering the
+        <b style="color:var(--warm)">same 4 mixed result types</b> so you see how each handles the rich case (article: image
+        + date + tags) and the lean case (team: <em>no image</em> → fallback). Single-column only — a rotated card grid reads
+        "seasick" (#1672). Press-down hover on all. See <a href="./8s1-architecture-locked.md">8s1 lock</a>.</p>
+    </div>
+    <div class="mini-mast">mast locked: Wat <span class="acc">zoek</span> je? · 🔍 · cream results below</div>
+
+    <!-- ============ A ============ -->
+    <div class="direction-bar"><span class="tag">A</span> Clean paper rows <span class="note">thin card + jersey-deep left edge, mono micro-label — most scannable</span></div>
+    <div class="wrap A">
+      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="stack">
+        <a class="row">
+          <div class="thumb">FOTO 16:9</div>
+          <div class="body"><div class="tlabel">Nieuws · <span class="date">9 nov 2025</span></div>
+            <div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div>
+            <div class="snip">Een late kopbal van invaller bezorgt de A-ploeg een deugddoende thuiszege…</div>
+            <div class="tags"><span>Eerste ploeg</span><span>Verslag</span></div></div>
+          <div class="right"><svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg></div>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><div class="tlabel">Speler</div>
+            <div class="ttl">Wout Van Elewijt</div>
+            <div class="snip">Middenvelder · A-ploeg</div></div>
+          <div class="right"><svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg></div>
+        </a>
+        <a class="row">
+          <div class="thumb crest">A</div>
+          <div class="body"><div class="tlabel">Team</div>
+            <div class="ttl">A-ploeg</div>
+            <div class="snip">Eerste elftal · 2e Provinciale B</div></div>
+          <div class="right"><svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg></div>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><div class="tlabel">Staf</div>
+            <div class="ttl">Jan Peeters</div>
+            <div class="snip">Hoofdtrainer · A-ploeg</div></div>
+          <div class="right"><svg class="ar" viewBox="0 0 256 256" fill="currentColor"><path d="M221.66 133.66l-72 72a8 8 0 0 1-11.32-11.32L196.69 136H40a8 8 0 0 1 0-16h156.69l-58.35-58.34a8 8 0 0 1 11.32-11.32l72 72a8 8 0 0 1 0 11.32Z"/></svg></div>
+        </a>
+      </div>
+    </div>
+    <div class="note-strip">A — calmest, fastest to scan, the left edge gives just enough colour. Closest to the current card but on retro tokens. RISK: a touch <b>plain</b>.</div>
+
+    <!-- ============ B ============ -->
+    <div class="direction-bar"><span class="tag">B</span> TapedCard index rows <span class="note">full paper card + MonoLabel pill — pinned-to-a-board feel</span></div>
+    <div class="wrap B">
+      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="stack">
+        <a class="row">
+          <div class="thumb" style="width:96px;height:74px">FOTO 16:9</div>
+          <div class="body"><span class="pill">Nieuws</span><span class="date" style="margin-left:8px">9 nov 2025</span>
+            <div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div>
+            <div class="snip">Een late kopbal van invaller bezorgt de A-ploeg een deugddoende thuiszege…</div>
+            <div class="tags"><span>Eerste ploeg</span><span>Verslag</span></div></div>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><span class="pill">Speler</span>
+            <div class="ttl">Wout Van Elewijt</div>
+            <div class="snip">Middenvelder · A-ploeg</div></div>
+        </a>
+        <a class="row">
+          <div class="thumb crest">A</div>
+          <div class="body"><span class="pill">Team</span>
+            <div class="ttl">A-ploeg</div>
+            <div class="snip">Eerste elftal · 2e Provinciale B</div></div>
+        </a>
+        <a class="row">
+          <div class="thumb">FOTO</div>
+          <div class="body"><span class="pill">Staf</span>
+            <div class="ttl">Jan Peeters</div>
+            <div class="snip">Hoofdtrainer · A-ploeg</div></div>
+        </a>
+      </div>
+    </div>
+    <div class="note-strip">B — most substantial + fanzine, the MonoLabel pill clearly tags each type. RISK: heavier; a long result list becomes a tall stack of <b>chunky cards</b>.</div>
+
+    <!-- ============ C ============ -->
+    <div class="direction-bar"><span class="tag">C</span> Ticket-stub rows <span class="note">perforated type-stub left — ties to the events/ticket motif</span></div>
+    <div class="wrap C">
+      <div class="countline">5 resultaten voor "elewijt"</div>
+      <div class="stack">
+        <a class="row">
+          <div class="stub"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M232 64H24a8 8 0 0 0-8 8v112a8 8 0 0 0 8 8h208a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8Zm-8 112H32V80h192ZM56 104h80a8 8 0 0 1 0 16H56a8 8 0 0 1 0-16Zm0 32h64a8 8 0 0 1 0 16H56a8 8 0 0 1 0-16Z"/></svg>Nieuws</div>
+          <div class="main"><div class="thumb" style="width:64px;height:50px">FOTO</div>
+            <div class="body"><span class="date">9 nov 2025</span>
+              <div class="ttl">Elewijt pakt de drie punten tegen Kampenhout</div>
+              <div class="snip">Een late kopbal bezorgt de A-ploeg een deugddoende thuiszege…</div></div></div>
+        </a>
+        <a class="row">
+          <div class="stub"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M230.92 212c-15.23-26.33-38.7-45.21-66.09-54.16a72 72 0 1 0-73.66 0C63.78 166.78 40.31 185.66 25.08 212a8 8 0 1 0 13.85 8c18.84-32.56 52.14-52 89.07-52s70.23 19.44 89.07 52a8 8 0 1 0 13.85-8Z"/></svg>Speler</div>
+          <div class="main"><div class="thumb" style="width:50px;height:50px">FOTO</div>
+            <div class="body"><div class="ttl">Wout Van Elewijt</div><div class="snip">Middenvelder · A-ploeg</div></div></div>
+        </a>
+        <a class="row">
+          <div class="stub"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M164.47 195.63a8 8 0 0 1-6.7 12.37H10.23a8 8 0 0 1-6.7-12.37 95.83 95.83 0 0 1 47.22-37.71 60 60 0 1 1 66.5 0 95.83 95.83 0 0 1 47.22 37.71Zm87.91-.15a95.87 95.87 0 0 0-47.13-37.56A60 60 0 0 0 144.7 54.59a4 4 0 0 0-1.33 6.45 76 76 0 0 1 4 28.93 4 4 0 0 0 2.84 4.1 60 60 0 0 1 25.66 91.7Z"/></svg>Team</div>
+          <div class="main"><div class="thumb crest" style="width:50px;height:50px">A</div>
+            <div class="body"><div class="ttl">A-ploeg</div><div class="snip">Eerste elftal · 2e Provinciale B</div></div></div>
+        </a>
+        <a class="row">
+          <div class="stub"><svg viewBox="0 0 256 256" fill="currentColor"><path d="M230.92 212c-15.23-26.33-38.7-45.21-66.09-54.16a72 72 0 1 0-73.66 0C63.78 166.78 40.31 185.66 25.08 212a8 8 0 1 0 13.85 8c18.84-32.56 52.14-52 89.07-52s70.23 19.44 89.07 52a8 8 0 1 0 13.85-8Z"/></svg>Staf</div>
+          <div class="main"><div class="thumb" style="width:50px;height:50px">FOTO</div>
+            <div class="body"><div class="ttl">Jan Peeters</div><div class="snip">Hoofdtrainer · A-ploeg</div></div></div>
+        </a>
+      </div>
+    </div>
+    <div class="note-strip">C — most distinctive, the type-stub doubles as icon + label and ties into the ticket/events vocabulary. RISK: the fixed stub <b>eats horizontal room</b> on mobile + the article image shrinks.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s2-result-vocabulary-locked.md
+++ b/docs/design/mockups/phase-8-search/8s2-result-vocabulary-locked.md
@@ -1,0 +1,36 @@
+# 8s2 — /zoeken result-card vocabulary · LOCKED
+
+**Decision:** A — **clean paper rows**, single column.
+
+Each result: white card, `1.5px` ink border, **5px `jersey-deep` left edge**,
+`2px 2px` offset shadow, canonical press-down hover (`shadow-none` +
+`translate(2px,2px)`). Mono micro-label (type · date), bold title, muted snippet,
+article tags as tiny mono chips, arrow glyph on the right.
+
+Rejected:
+
+- **B (TapedCard index rows)** — substantial + fanzine, but a long result list
+  becomes a tall stack of chunky cards; too heavy for a utility list.
+- **C (ticket-stub rows)** — most distinctive, but the fixed left stub eats
+  horizontal room on mobile and shrinks the article thumbnail.
+
+The dark masthead (8s1) already supplies the personality; results stay calm and
+fast to scan.
+
+## Owner refinement — uniform thumbnail (LOCKED)
+
+Mixed aspect ratios across result types look misaligned. **All result types use a
+single uniform thumbnail**: a fixed **square** (≈`64×64`), same shape on every row,
+so rows are equal height and the left edge stays clean.
+
+- **Article** → square *crop* of the article image (not 16:9 in-row).
+- **Player / Staff** → square photo (`psdImage`), same box.
+- **Team** → square `jersey-deep` crest disc with the team initial (teams usually
+  have no image — this is the locked fallback, not an empty box).
+- Missing player/staff photo → same `jersey-deep` initial disc fallback.
+
+Rounded-square (not circle) on all, so people and article/team thumbs share one
+shape. Verified in `8s2-1-refined-aligned.html`.
+
+Reskin target: `apps/web/src/components/search/SearchResult.tsx` (currently a
+`bg-white` legacy card with a 16:9-ish image slot + green-bright top accent).

--- a/docs/design/mockups/phase-8-search/8s3-filter-row-locked.md
+++ b/docs/design/mockups/phase-8-search/8s3-filter-row-locked.md
@@ -1,0 +1,21 @@
+# 8s3 — /zoeken type-filter row · LOCKED (reuse, no redesign)
+
+**Decision:** Keep `<FilterTabs>` — no new design.
+
+`apps/web/src/components/search/SearchFilters.tsx` **already** renders the type
+filter via the canonical `<FilterTabs>` (Phase 2 Track B, Direction D "paper
+chrome, ink emphasis"): sharp-cornered paper chips (`border-2 border-ink` +
+`bg-cream-soft` + `shadow-paper-sm`), active inverts to `bg-ink text-cream`, mono
+uppercase labels, **counts inline after a 1px hairline pipe** (no pill/badge),
+canonical press-down hover. Tabs: `Alles · Nieuws · Spelers · Staf · Teams`.
+
+So this round is a reuse-lock, not a redesign. Implications:
+
+- The rounded-pill chips sketched in the earlier `8s2`/`8s1` placeholders are
+  **not** the real treatment — production already uses the sharp paper chips.
+  All later Phase 8 mockups should draw the filter row as `<FilterTabs>`.
+- The reskin work for `/zoeken` does **not** touch `SearchFilters` — it's already
+  on the design system. Phase 8 only needs a small note that the filter row sits
+  unchanged below the new dark masthead, on cream.
+
+Reuse-mandate compliance (memory: reuse-approved-primitives). Nothing to build.

--- a/docs/design/mockups/phase-8-search/8s4-1-noresult-copy-compare.html
+++ b/docs/design/mockups/phase-8-search/8s4-1-noresult-copy-compare.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · 8s4.1 no-results headline copy</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 20px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 92ch; line-height: 1.6; }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 10px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 760px; margin: 0 auto; padding: 18px 28px 6px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:8px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+
+      .card { background:var(--cream-soft); border:2px solid var(--ink); box-shadow:4px 4px 0 0 var(--ink); padding:26px; }
+      .punrow { display:flex; gap:24px; align-items:center; }
+      .jersey { width:104px; aspect-ratio:4/5; border:2px solid var(--ink); background: repeating-linear-gradient(90deg, var(--jersey-deep) 0 12px, var(--jersey-deep-dark) 12px 24px); box-shadow:4px 4px 0 0 var(--ink); transform:rotate(-3deg); position:relative; flex:0 0 auto; }
+      .jersey .tape { position:absolute; top:-11px; left:50%; transform:translateX(-50%) rotate(-4deg); width:54px; height:20px; background:var(--warm); border:1.5px solid var(--ink); opacity:.92; }
+      .display { font-family:var(--font-display); font-style:italic; font-weight:900; font-size:34px; line-height:1; margin:0; }
+      .display .acc { color:var(--jersey-deep); }
+      .lead { font-size:14.5px; color:var(--ink-soft); margin:11px 0 0; max-width:50ch; line-height:1.55; }
+      .lead a { color:var(--jersey-deep); font-weight:700; text-decoration:none; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — 8s4.1: no-results headline copy</h1>
+      <p>E2 structure is locked (jersey artefact + way-forward links). Only the headline word changes. All four render
+        the identical locked card. <b style="color:var(--warm)">"Geen treffers"</b> is the clever one — <em>treffer</em>
+        means both a search hit and a goal. Pick the line (it should rhyme with the 404/500 voice in round 8e).</p>
+    </div>
+
+    <!-- A -->
+    <div class="direction-bar"><span class="tag">A</span> "Geen treffers." <span class="note">treffer = search hit AND goal — real wordplay, grown-up</span></div>
+    <div class="wrap"><div class="card"><div class="punrow">
+      <div class="jersey"><div class="tape"></div></div>
+      <div><h2 class="display">Geen treffers<span class="acc">.</span></h2>
+        <p class="lead">Niets gevonden voor <strong>"xyzqr"</strong>. Probeer een andere term — of spring meteen naar <a href="#">nieuws</a>, <a href="#">ploegen</a> of <a href="#">spelers</a>.</p></div>
+    </div></div></div>
+    <div class="note-strip">A — double meaning lands without being silly. Recommended.</div>
+
+    <!-- B -->
+    <div class="direction-bar"><span class="tag">B</span> "Niets in de netten." <span class="note">fishing/goal-net image — warmer, a touch folksy</span></div>
+    <div class="wrap"><div class="card"><div class="punrow">
+      <div class="jersey"><div class="tape"></div></div>
+      <div><h2 class="display">Niets in de <span class="acc">netten</span>.</h2>
+        <p class="lead">Niets gevonden voor <strong>"xyzqr"</strong>. Probeer een andere term — of spring meteen naar <a href="#">nieuws</a>, <a href="#">ploegen</a> of <a href="#">spelers</a>.</p></div>
+    </div></div></div>
+    <div class="note-strip">B — football "netten" + a calm image; slightly folksier than A.</div>
+
+    <!-- C -->
+    <div class="direction-bar"><span class="tag">C</span> "Buiten bereik." <span class="note">neutral, understated — barely a pun</span></div>
+    <div class="wrap"><div class="card"><div class="punrow">
+      <div class="jersey"><div class="tape"></div></div>
+      <div><h2 class="display">Buiten <span class="acc">bereik</span>.</h2>
+        <p class="lead">Niets gevonden voor <strong>"xyzqr"</strong>. Probeer een andere term — of spring meteen naar <a href="#">nieuws</a>, <a href="#">ploegen</a> of <a href="#">spelers</a>.</p></div>
+    </div></div></div>
+    <div class="note-strip">C — driest, most restrained; works but loses the football wink.</div>
+
+    <!-- D -->
+    <div class="direction-bar"><span class="tag">D</span> "Niets gevonden." <span class="note">plain, no pun — the safe fallback</span></div>
+    <div class="wrap"><div class="card"><div class="punrow">
+      <div class="jersey"><div class="tape"></div></div>
+      <div><h2 class="display">Niets <span class="acc">gevonden</span>.</h2>
+        <p class="lead">Geen resultaten voor <strong>"xyzqr"</strong>. Probeer een andere term — of spring meteen naar <a href="#">nieuws</a>, <a href="#">ploegen</a> of <a href="#">spelers</a>.</p></div>
+    </div></div></div>
+    <div class="note-strip">D — neutral; keep as fallback if every pun feels off on the day.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s4-states-compare.html
+++ b/docs/design/mockups/phase-8-search/8s4-states-compare.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 8 — /zoeken · 8s4 empty / no-result / pre-search states</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 20px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; max-width: 92ch; line-height: 1.6; }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase;
+        display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); border-top:2px solid var(--ink); }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .wrap { max-width: 880px; margin: 0 auto; padding: 0 28px; }
+      .note-strip { background: var(--cream-deep); border-bottom:1px dashed var(--ink); padding:9px 28px; font-family: var(--font-mono); font-size:12px; color: var(--ink-soft); }
+      .note-strip b { color: var(--brick); }
+      .statelabel { font-family:var(--font-mono); font-size:11px; font-weight:600; letter-spacing:.14em; text-transform:uppercase; color:var(--ink-muted); margin:24px 0 10px; display:flex; align-items:center; gap:10px; }
+      .statelabel::after { content:""; height:1px; flex:1; background:var(--paper-edge); }
+
+      /* real FilterTabs paper chips (reference) */
+      .ftabs { display:flex; gap:12px; flex-wrap:wrap; margin:4px 0 0; }
+      .fchip { font-family:var(--font-mono); font-size:12px; font-weight:600; letter-spacing:.08em; text-transform:uppercase; border:2px solid var(--ink); border-radius:0; background:var(--cream-soft); color:var(--ink); padding:8px 13px; box-shadow:2px 2px 0 0 var(--ink); display:inline-flex; gap:8px; align-items:center; }
+      .fchip.on { background:var(--ink); color:var(--cream); }
+      .fchip .n { opacity:.55; border-left:1px solid currentColor; padding-left:8px; }
+
+      /* paper card base */
+      .card { background:var(--cream-soft); border:2px solid var(--ink); box-shadow:4px 4px 0 0 var(--ink); padding:30px 28px; }
+      .display { font-family:var(--font-display); font-style:italic; font-weight:900; font-size:clamp(26px,3.4vw,38px); line-height:1; margin:0; }
+      .display .acc { color:var(--jersey-deep); }
+      .lead { font-size:14.5px; color:var(--ink-soft); margin:12px 0 0; max-width:54ch; line-height:1.55; }
+      .typehints { display:flex; gap:8px; flex-wrap:wrap; margin-top:16px; }
+      .typehints span { font-family:var(--font-mono); font-size:11px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; border:1.5px solid var(--ink); background:var(--cream); padding:6px 11px; box-shadow:2px 2px 0 0 var(--ink); }
+      .browsegrid { display:grid; grid-template-columns:repeat(4,1fr); gap:12px; margin-top:18px; }
+      .browse { border:2px solid var(--ink); background:var(--cream); box-shadow:3px 3px 0 0 var(--ink); padding:16px 12px; text-align:center; }
+      .browse .ic { width:30px;height:30px;color:var(--jersey-deep); margin:0 auto 8px; display:block; }
+      .browse .bl { font-family:var(--font-mono); font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+      .jersey { width:120px; aspect-ratio:4/5; border:2px solid var(--ink); background: repeating-linear-gradient(90deg, var(--jersey-deep) 0 13px, var(--jersey-deep-dark) 13px 26px); box-shadow:5px 5px 0 0 var(--ink); transform:rotate(-3deg); position:relative; flex:0 0 auto; }
+      .jersey .tape { position:absolute; top:-12px; left:50%; transform:translateX(-50%) rotate(-4deg); width:60px; height:22px; background:var(--warm); border:1.5px solid var(--ink); opacity:.92; }
+      .punrow { display:flex; gap:26px; align-items:center; }
+      .blocksub { padding-bottom:14px; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 8 · /zoeken — 8s4: empty / no-result / pre-search states</h1>
+      <p>Masthead + result rows + FilterTabs are locked. This is the last search decision: the non-result states.
+        Three directions, each showing <b style="color:var(--warm)">pre-search</b> (query &lt; 2 chars) and
+        <b style="color:var(--warm)">no-results</b> (valid query, 0 hits) so the voice is cohesive. Loading (Spinner) +
+        error (Alert reskin) are minor and noted at the bottom. The football-pun choice here should rhyme with the
+        404/500 pages (round 8e).</p>
+    </div>
+
+    <!-- ============ E1 ============ -->
+    <div class="direction-bar"><span class="tag">E1</span> Calm paper notes <span class="note">restrained — a quiet note + type hints, no artefact</span></div>
+    <div class="wrap">
+      <div class="statelabel">Pre-search (nog niets getypt)</div>
+      <div class="card blocksub">
+        <h2 class="display">Waar ben je naar op <span class="acc">zoek</span>?</h2>
+        <p class="lead">Typ minstens 2 letters. Je doorzoekt nieuws, spelers, ploegen en staf in één keer.</p>
+        <div class="typehints"><span>Een spelersnaam</span><span>Een ploeg</span><span>Een nieuwsbericht</span></div>
+      </div>
+      <div class="statelabel">No results ("xyzqr")</div>
+      <div class="card">
+        <h2 class="display">Niets gevonden<span class="acc">.</span></h2>
+        <p class="lead">Geen resultaten voor <strong>"xyzqr"</strong>. Controleer je spelling of probeer een kortere, algemenere term.</p>
+      </div>
+    </div>
+    <div class="note-strip">E1 — calmest + most consistent with the privacy page. RISK: a no-result dead end with <b>no way forward</b> (no links to browse).</div>
+
+    <!-- ============ E2 ============ -->
+    <div class="direction-bar"><span class="tag">E2</span> Football voice + JerseyShirt <span class="note">pun + taped jersey artefact — ties to the 404/500 family</span></div>
+    <div class="wrap">
+      <div class="statelabel">Pre-search (nog niets getypt)</div>
+      <div class="card blocksub">
+        <h2 class="display">Waar ben je naar op <span class="acc">zoek</span>?</h2>
+        <p class="lead">Typ minstens 2 letters — nieuws, spelers, ploegen en staf, allemaal doorzoekbaar.</p>
+        <div class="typehints"><span>Een spelersnaam</span><span>Een ploeg</span><span>Een nieuwsbericht</span></div>
+      </div>
+      <div class="statelabel">No results ("xyzqr")</div>
+      <div class="card"><div class="punrow">
+        <div class="jersey"><div class="tape"></div></div>
+        <div>
+          <h2 class="display">Naast de bal<span class="acc">.</span></h2>
+          <p class="lead">Niets gevonden voor <strong>"xyzqr"</strong>. Probeer een andere term — of spring meteen naar
+            <a href="#" style="color:var(--jersey-deep);font-weight:700">nieuws</a>,
+            <a href="#" style="color:var(--jersey-deep);font-weight:700">ploegen</a> of
+            <a href="#" style="color:var(--jersey-deep);font-weight:700">spelers</a>.</p>
+        </div>
+      </div></div>
+    </div>
+    <div class="note-strip">E2 — most personality, the pun + jersey rhyme with the error pages and give the dead end a way forward. RISK: the jersey artefact is <b>a lot of furniture</b> for a transient state.</div>
+
+    <!-- ============ E3 ============ -->
+    <div class="direction-bar"><span class="tag">E3</span> Browse-instead shortcuts <span class="note">never a dead end — quick links to the main sections</span></div>
+    <div class="wrap">
+      <div class="statelabel">Pre-search (nog niets getypt)</div>
+      <div class="card blocksub">
+        <h2 class="display">Of blader er gewoon <span class="acc">doorheen</span>.</h2>
+        <p class="lead">Typ minstens 2 letters om te zoeken — of ga direct naar:</p>
+        <div class="browsegrid">
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M232 64H24a8 8 0 0 0-8 8v112a8 8 0 0 0 8 8h208a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8Zm-8 112H32V80h192Zm-32-72H56a8 8 0 0 0 0 16h136a8 8 0 0 0 0-16Z"/></svg><div class="bl">Nieuws</div></div>
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M164.47 195.63a8 8 0 0 1-6.7 12.37H10.23a8 8 0 0 1-6.7-12.37 95.83 95.83 0 0 1 47.22-37.71 60 60 0 1 1 66.5 0 95.83 95.83 0 0 1 47.22 37.71Z"/></svg><div class="bl">Spelers</div></div>
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M223.68 66.15 135.68 18a16 16 0 0 0-15.36 0l-88 48.18a16 16 0 0 0-8.32 14v95.64a16 16 0 0 0 8.32 14l88 48.17a16 16 0 0 0 15.36 0l88-48.17a16 16 0 0 0 8.32-14V80.18a16 16 0 0 0-8.32-14.03Z"/></svg><div class="bl">Ploegen</div></div>
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M208 32h-24v-8a8 8 0 0 0-16 0v8H88v-8a8 8 0 0 0-16 0v8H48a16 16 0 0 0-16 16v160a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16Zm0 176H48V96h160Z"/></svg><div class="bl">Kalender</div></div>
+        </div>
+      </div>
+      <div class="statelabel">No results ("xyzqr")</div>
+      <div class="card">
+        <h2 class="display">Geen resultaten voor <span class="acc">"xyzqr"</span></h2>
+        <p class="lead">Pas je zoekterm aan — of blader verder:</p>
+        <div class="browsegrid">
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M232 64H24a8 8 0 0 0-8 8v112a8 8 0 0 0 8 8h208a8 8 0 0 0 8-8V72a8 8 0 0 0-8-8Zm-8 112H32V80h192Zm-32-72H56a8 8 0 0 0 0 16h136a8 8 0 0 0 0-16Z"/></svg><div class="bl">Nieuws</div></div>
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M164.47 195.63a8 8 0 0 1-6.7 12.37H10.23a8 8 0 0 1-6.7-12.37 95.83 95.83 0 0 1 47.22-37.71 60 60 0 1 1 66.5 0 95.83 95.83 0 0 1 47.22 37.71Z"/></svg><div class="bl">Spelers</div></div>
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M223.68 66.15 135.68 18a16 16 0 0 0-15.36 0l-88 48.18a16 16 0 0 0-8.32 14v95.64a16 16 0 0 0 8.32 14l88 48.17a16 16 0 0 0 15.36 0l88-48.17a16 16 0 0 0 8.32-14V80.18a16 16 0 0 0-8.32-14.03Z"/></svg><div class="bl">Ploegen</div></div>
+          <div class="browse"><svg class="ic" viewBox="0 0 256 256" fill="currentColor"><path d="M208 32h-24v-8a8 8 0 0 0-16 0v8H88v-8a8 8 0 0 0-16 0v8H48a16 16 0 0 0-16 16v160a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16Zm0 176H48V96h160Z"/></svg><div class="bl">Kalender</div></div>
+        </div>
+      </div>
+    </div>
+    <div class="note-strip">E3 — most useful, turns every empty state into navigation. RISK: <b>least personality</b>; reads more "app" than "fanzine", and duplicates the main nav.</div>
+
+    <div class="note-strip" style="background:var(--cream-soft);border-bottom:2px solid var(--ink)">Loading = existing <b>&lt;Spinner&gt;</b> (kept). Error = paper <b>&lt;Alert&gt;</b> reskin ("Er ging iets mis bij het zoeken — probeer opnieuw"). Neither needs a direction choice.</div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-8-search/8s4-states-locked.md
+++ b/docs/design/mockups/phase-8-search/8s4-states-locked.md
@@ -19,7 +19,12 @@ Rejected:
 - **No-results** (valid query, 0 hits): paper card with a small taped
   `<JerseyShirt>` artefact + a football-pun headline + a body line that names the
   missing query and offers **inline way-forward links** (nieuws · ploegen ·
-  spelers). The links resolve E1's dead-end problem.
+  spelers). **Contract:** these are plain `next/link` navigations to the section
+  index routes (`/nieuws`, `/ploegen`, and the players index) — escape hatches out
+  of the dead end. They are **NOT** `/zoeken?type=…` filter shortcuts: a
+  no-results query stays empty when re-filtered by type, so a filter shortcut
+  would lead nowhere. Exact players-index target confirmed at build (#2106). The
+  links resolve E1's dead-end problem.
 - **Loading**: existing `<Spinner>` kept — no redesign.
 - **Error**: paper `<Alert>` reskin ("Er ging iets mis bij het zoeken — probeer
   opnieuw"). No direction choice.

--- a/docs/design/mockups/phase-8-search/8s4-states-locked.md
+++ b/docs/design/mockups/phase-8-search/8s4-states-locked.md
@@ -1,0 +1,37 @@
+# 8s4 — /zoeken empty / no-result / pre-search states · LOCKED
+
+**Decision:** E2 — **football voice + JerseyShirt artefact**, with grown-up copy.
+
+Rejected:
+
+- **E1 (calm paper notes)** — calmest, but the no-result is a dead end with no way
+  forward.
+- **E3 (browse-instead shortcuts)** — most useful, but least personality; reads
+  "app" not "fanzine" and duplicates the main nav.
+
+## Structure (LOCKED)
+
+- **Pre-search** (`query < 2 chars`): a single paper card — italic display
+  "Waar ben je naar op **zoek**?" (accent on "zoek", jersey-deep on cream) + a
+  one-line explainer + three mono type-hint chips (*Een spelersnaam · Een ploeg ·
+  Een nieuwsbericht*). Replaces the current emoji "Nieuwsartikelen/Spelers/Teams"
+  help block.
+- **No-results** (valid query, 0 hits): paper card with a small taped
+  `<JerseyShirt>` artefact + a football-pun headline + a body line that names the
+  missing query and offers **inline way-forward links** (nieuws · ploegen ·
+  spelers). The links resolve E1's dead-end problem.
+- **Loading**: existing `<Spinner>` kept — no redesign.
+- **Error**: paper `<Alert>` reskin ("Er ging iets mis bij het zoeken — probeer
+  opnieuw"). No direction choice.
+
+## Owner refinement — copy
+
+"Naast de bal" was **too childish**. Final no-results headline = **"Geen
+treffers."** (LOCKED 8s4.1) — *treffer* is both the Dutch word for a search hit
+and a football goal; genuine double meaning, grown-up. Rejected: "Niets in de
+netten." (folksier), "Buiten bereik." (loses the football wink), plain "Niets
+gevonden." (kept only as the fallback if the wink ever feels off). The 404/500
+voice (round 8e) should rhyme with this register.
+
+The JerseyShirt artefact stays (owner objected only to the copy, not the
+furniture); render it modest, not dominant.

--- a/docs/prd/redesign-phase-8.md
+++ b/docs/prd/redesign-phase-8.md
@@ -106,13 +106,13 @@ meatier search + error work.
 
 ## 5. Phases (one issue = one worktree = one PR)
 
-| # | Issue | Depends on |
-| - | ----- | ---------- |
-| 8.1 | **Tracer:** `/privacy` cream-minimal reskin | — |
-| 8.2 | `/zoeken` dark masthead + page shell (SearchForm → hard-shadow + icon) | 8.1 |
-| 8.3 | `/zoeken` paper result rows + football-voice empty states | 8.2 |
-| 8.4 | 404/500 `<ErrorState>` — Storybook A/B, pick, wire-in, retire loser | 8.1 |
-| 8.5 | Phase 8 final pass — SEO/analytics/e2e/VR sweep + master-design closeout | 8.2, 8.3, 8.4 |
+| # | Issue | GitHub | Depends on |
+| - | ----- | ------ | ---------- |
+| 8.1 | **Tracer:** `/privacy` cream-minimal reskin | #2104 | — |
+| 8.2 | `/zoeken` dark masthead + page shell (SearchForm → hard-shadow + icon) | #2105 | #2104 |
+| 8.3 | `/zoeken` paper result rows + football-voice empty states | #2106 | #2105 |
+| 8.4 | 404/500 `<ErrorState>` — Storybook A/B, pick, wire-in, retire loser | #2107 | #2104 |
+| 8.5 | Phase 8 final pass — SEO/analytics/e2e/VR sweep + master-design closeout | #2108 | #2105, #2106, #2107 |
 
 ## 6. Acceptance criteria per phase
 

--- a/docs/prd/redesign-phase-8.md
+++ b/docs/prd/redesign-phase-8.md
@@ -1,8 +1,8 @@
 # PRD: Redesign Phase 8 — Search, Privacy, Error pages
 
 **Status:** Ready · **Milestone:** `redesign-retro-terrace-fanzine` (the redesign
-series umbrella — Phase 8 inherits it, not a new milestone) · **Umbrella issue:**
-#1530
+series umbrella — Phase 8 inherits it, not a new milestone) · **Umbrella
+issue:** #1530
 
 **Design checkpoint:** complete. Locked decisions + mockups in
 `docs/design/mockups/phase-8-{search,privacy,errors}/` and the phase

--- a/docs/prd/redesign-phase-8.md
+++ b/docs/prd/redesign-phase-8.md
@@ -1,0 +1,233 @@
+# PRD: Redesign Phase 8 — Search, Privacy, Error pages
+
+**Status:** Ready · **Milestone:** `redesign-retro-terrace-fanzine` (the redesign
+series umbrella — Phase 8 inherits it, not a new milestone) · **Umbrella issue:**
+#1530
+
+**Design checkpoint:** complete. Locked decisions + mockups in
+`docs/design/mockups/phase-8-{search,privacy,errors}/` and the phase
+`docs/design/mockups/phase-8-data-reality-locked.md`.
+
+Master design: `docs/plans/2026-04-27-redesign-master-design.md` (§7 roadmap line
+587, §6 shape notes, open-question 7 already resolved in Phase 7 #1529). Phase 8
+is the **last design-gated batch** before the Phase 9 cleanup (#1531).
+
+> **Re-scope (2026-06-08):** `/hulp` left Phase 8 → shipped in Phase 7 (#1529).
+> Phase 8 = three edge surfaces only: `/zoeken`, `/privacy`, 404/500.
+
+---
+
+## 1. Problem statement
+
+Three "edge" surfaces still render in the **legacy** visual language while the
+rest of the site is on retro-terrace-fanzine tokens:
+
+- **`/zoeken`** — green-gradient hero, white cards, gray background, lucide icons,
+  emoji help block. The semantic search backend (bge-m3 / Vectorize, #2057) is
+  fine; only the presentation is legacy.
+- **`/privacy`** — dark `<InteriorPageHero>`, gray `prose prose-gray`,
+  `<SectionStack>` `diagonal` transition.
+- **404 / 500** — gray lucide-icon error states with no club character.
+
+Phase 8 reskins all three onto the design system, retiring their legacy-token and
+`diagonal`-seam usage (master design §7 line 587), so Phase 9 can delete the
+legacy tokens with zero remaining consumers on these pages.
+
+## 2. Scope
+
+### In scope (`apps/web` only — no schema, no api-contract, no BFF)
+
+- `/zoeken`: dark search masthead, paper result rows, football-voice empty states.
+- `/privacy`: cream-minimal prose reskin.
+- 404/500: shared `<ErrorState>` (football pun + `<JerseyShirt>` artefact).
+- Diagonal→removal/StripedSeam migration for the privacy consumer.
+- VR baselines for new component stories; e2e smoke for each route; analytics +
+  SEO checklist per surface.
+
+### Out of scope
+
+- The search **backend** / ranking / Vectorize (shipped, #2057). No `/api/search`
+  change.
+- `<FilterTabs>` — already the canonical Phase 2 component; **reused unchanged**
+  (8s3 lock).
+- New design tokens — **zero** added this phase.
+- `/hulp` (Phase 7), and the Phase 9 legacy-token deletion (#1531).
+
+## 3. Locked design decisions (source of truth = the `8*-locked.md` files)
+
+### `/zoeken`
+
+- **Masthead (8s1):** softened **S3 dark masthead** — `jersey-deep-dark` full-bleed
+  band (diagonal stripe + radial glow), **no kicker**, serif italic
+  **"Wat _zoek_ je?"** (`<EditorialHeading>` accent, **warm-gold** on dark),
+  hard-shadow search field (cream input, ink border), **magnifier-icon button**
+  (Phosphor `MagnifyingGlass` Fill, warm-gold cell) — no "ZOEK" word. Results on
+  cream below.
+- **Result rows (8s2):** **clean paper rows**, single column. White card, `1.5px`
+  ink border, **5px `jersey-deep` left edge**, `2px 2px` offset shadow, canonical
+  press-down hover. Mono micro-label (type · date), bold title, snippet, article
+  tags as mono chips, arrow right. **Uniform `64×64` square thumbnail** on every
+  type (article = square crop; player/staff = square photo; **team = `jersey-deep`
+  crest disc**; missing photo = same initial-disc fallback).
+- **Filter row (8s3):** **reuse `<FilterTabs>`** as-is — no redesign.
+- **Empty states (8s4):** football voice. **Pre-search** = paper card,
+  "Waar ben je naar op **zoek**?" + explainer + three mono type-hint chips.
+  **No-results** = paper card + small taped `<JerseyShirt>` + **"Geen treffers."**
+  (8s4.1) + body naming the query + inline way-forward links (nieuws · ploegen ·
+  spelers). **Loading** = existing `<Spinner>`. **Error** = paper `<Alert>` reskin.
+
+### `/privacy` (8p1)
+
+- **Cream minimal**, no hero band: mono kicker `JURIDISCH` → serif italic
+  **"Privacyverklaring."** → mono `Laatst bijgewerkt · {LAST_UPDATED}` → Freight
+  Display intro lead → prose column ≈`max-w-2xl`, **ink/cream prose (not gray)**,
+  `<DottedDivider>` between H2 sections. Remove `<InteriorPageHero>`,
+  `<SectionStack>` `diagonal`, and `prose-gray`. Keep all copy + `/hulp` link +
+  `LAST_UPDATED` + SEO metadata.
+
+### 404 / 500 (8e1/8e2)
+
+- **One shared `<ErrorState>`** renders both pages, parameterised by
+  `code` / `pun` / `body` / `actions`. Cream bg, reuse the shipped `<JerseyShirt>`.
+- **Layout = Storybook A/B (deferred):** build **both** "centered code-as-jersey-
+  number" (A) and "scoreboard" (C) as stories → **pause for owner pick** → delete
+  the loser → wire the winner into the routes.
+- **Copy:** 404 **"Buiten de lijnen."** + actions `Naar de homepage` (→ `/`) and
+  **`Zoeken`** (→ `/zoeken`); 500 **"Technische panne."** + actions
+  `Probeer opnieuw` (wired to `reset()`) and `Naar de homepage`. Buttons plain;
+  wink lives in the headline only.
+
+## 4. Tracer bullet
+
+**`/privacy` cream-minimal reskin** — smallest, lowest-risk vertical slice.
+Validates the phase-wide conventions (cream/ink prose tokens, legacy-token +
+diagonal removal, e2e smoke contract, `Pages/*` story without VR) before the
+meatier search + error work.
+
+## 5. Phases (one issue = one worktree = one PR)
+
+| # | Issue | Depends on |
+| - | ----- | ---------- |
+| 8.1 | **Tracer:** `/privacy` cream-minimal reskin | — |
+| 8.2 | `/zoeken` dark masthead + page shell (SearchForm → hard-shadow + icon) | 8.1 |
+| 8.3 | `/zoeken` paper result rows + football-voice empty states | 8.2 |
+| 8.4 | 404/500 `<ErrorState>` — Storybook A/B, pick, wire-in, retire loser | 8.1 |
+| 8.5 | Phase 8 final pass — SEO/analytics/e2e/VR sweep + master-design closeout | 8.2, 8.3, 8.4 |
+
+## 6. Acceptance criteria per phase
+
+### 8.1 — Tracer: `/privacy`
+
+- [ ] `privacy/page.tsx` reskinned per 8p1: mono kicker, serif `<EditorialHeading>`
+      "Privacyverklaring.", last-updated mono line, intro lead, cream/ink prose,
+      `<DottedDivider>` between H2 sections.
+- [ ] `<InteriorPageHero>`, `<SectionStack>` `diagonal`, and `prose-gray` removed
+      from this page; no legacy `--color-kcvv-*` / `green-*` / `gray-*` classes
+      remain in the file.
+- [ ] All existing copy, the `/hulp` cross-link, `LAST_UPDATED`, and SEO metadata
+      preserved.
+- [ ] e2e smoke (`/privacy`) still green; `Pages/Privacy` story updated (no VR tag).
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### 8.2 — `/zoeken` masthead + page shell
+
+- [ ] `zoeken/page.tsx` renders the softened-S3 dark masthead per 8s1: no kicker,
+      serif `<EditorialHeading>` "Wat _zoek_ je?" warm-gold accent on
+      `jersey-deep-dark`, hint line.
+- [ ] `SearchForm` reskinned to the hard-shadow field (cream input, ink border,
+      offset shadow) with a **`MagnifyingGlass` Fill** icon button (warm-gold
+      cell) — no "ZOEK" text. `@/lib/icons.redesign` only (no lucide).
+- [ ] Results region renders on cream below the band; `<FilterTabs>` unchanged.
+- [ ] Story for the masthead (`Features/Search/*` or `Pages/Search`); e2e smoke
+      green; legacy green-gradient hero removed.
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### 8.3 — `/zoeken` result rows + empty states
+
+- [ ] `SearchResult` reskinned per 8s2: paper row, jersey-deep left edge, uniform
+      `64×64` square thumb, crest-disc fallback for team / missing photo, mono
+      micro-label, tags, arrow, press-down hover. Lucide → Phosphor.
+- [ ] `SearchInterface` empty states per 8s4: pre-search paper card (replaces emoji
+      help block), no-results card with `<JerseyShirt>` + "Geen treffers." + inline
+      links, error `<Alert>` reskin, loading `<Spinner>` kept.
+- [ ] Analytics unchanged in shape (existing `search_*`; `trackNoResults` still
+      fires on the redesigned no-results state — privacy: query sanitised as today).
+- [ ] `Features/Search/*` stories cover every state (pre-search, results, no-results,
+      error) and acquire **VR baselines** (`vr` tag, captured in Docker).
+- [ ] e2e smoke green; `pnpm --filter @kcvv/web check-all` passes.
+
+### 8.4 — 404/500 `<ErrorState>` (Storybook A/B)
+
+- [ ] One shared `<ErrorState>` (`code`, `pun`, `body`, `actions`) with a
+      `layout: "centered" | "scoreboard"` prop; reuses `<JerseyShirt>`; Phosphor
+      icons; no lucide.
+- [ ] Stories for **both** layouts × both pages (404/500). **Pause for owner
+      Storybook review** (build TDD-first, do not wire into routes yet).
+- [ ] After owner picks: remove the losing layout branch + its stories; wire the
+      winner into `not-found.tsx` (404, copy "Buiten de lijnen." + `/` + `/zoeken`)
+      and `error.tsx` (500, "Technische panne." + `reset()` + `/`). `reset()` stays
+      wired; `error.tsx` stays `"use client"` + self-contained at the root segment.
+- [ ] `UI/ErrorState` (or `Features/*`) story for the chosen layout acquires **VR
+      baselines**; e2e smoke for the 404 route still green.
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+### 8.5 — Final pass
+
+- [ ] SEO: titles/OG verified on all three surfaces; 404/500 carry `noindex` as
+      appropriate; no JSON-LD entity needed (none represent a Schema.org entity).
+- [ ] Analytics: optional `error_view` event wired (see §7); search events
+      unchanged. Any new param/prefix appended to the GTM regex documented in the
+      PR body + tracked in #1974.
+- [ ] VR baselines for all new component stories committed; no unexpected diffs on
+      unrelated stories.
+- [ ] Grep: zero legacy `--color-kcvv-*` / `green-main` / `gray-*` / `prose-gray` /
+      lucide on `/zoeken`, `/privacy`, `not-found.tsx`, `error.tsx`.
+- [ ] Master-design decision-log entry: "Phase 8 complete — search/privacy/errors
+      migrated; only Phase 9 cleanup (#1531) remains."
+- [ ] `pnpm --filter @kcvv/web check-all` passes.
+
+## 7. Analytics
+
+`/zoeken` is already instrumented (`useSearchAnalytics`: `search_submitted`,
+`search_results_shown`, `search_no_results`, `search_filter_changed`,
+`search_result_clicked`). The reskin **keeps the event shape** — the
+"Geen treffers." state is still the `search_no_results` path; the new inline
+way-forward links can reuse `search_result_clicked` semantics or a small
+`search_browse_click` (param `target`). Query text stays sanitised via
+`sanitizeQuery`; no PII.
+
+`/privacy` is static — no events.
+
+404/500 (new, user-facing): propose a light **`error_`** prefix —
+`error_view` (params `error_code` ∈ {404,500}, `path`) on mount, and
+`error_action_click` (param `action` ∈ {home, search, retry}). New prefix →
+append `error_` to the live GTM Custom-Event trigger regex; new params need DLVs +
+GA4 dimensions. **Manual GTM/GA4 wiring tracked in #1974** (call it out in the 8.5
+PR body — events do not reach GA4 until wired). If the owner deems error-page
+analytics unnecessary, drop this and note it.
+
+## 8. VR baselines
+
+Per the master-design VR contract (every PR adding a `UI/*` or `Features/*` story
+captures baselines in Docker):
+
+- 8.3 — `Features/Search/*` (SearchResult + each SearchInterface state) acquire
+  `vr` tag + baselines.
+- 8.4 — the chosen `<ErrorState>` layout story acquires `vr` tag + baselines.
+- `Pages/Privacy` and `Pages/Search` are **not** VR-tagged (Pages/* are
+  e2e-covered, per `docs/prd/page-level-testing-rework.md`).
+
+## 9. Open questions
+
+- **Error-page analytics** (§7): wire `error_*`, or leave error pages
+  un-instrumented? Owner call at 8.5.
+- **404 search affordance**: a secondary `Zoeken` button vs. an inline body link
+  vs. both — final at build (8.4); the lock allows either.
+
+## 10. Discovered unknowns
+
+- `SearchMasthead` as an extracted component vs. inline in `page.tsx` — decide at
+  8.2 build (favor extraction if a story is warranted).
+- Whether `error.tsx` (root segment) has the fonts/`globals.css` loaded — verify
+  the cream/Freight-Display render works without the `(main)` layout; if not,
+  ensure the root layout supplies tokens.


### PR DESCRIPTION
Phase 8 of the editorial-redesign series — the **last design-gated batch** before the Phase 9 cleanup (#1531). Docs only (mockups + PRD); no code.

> Re-scope (2026-06-08): `/hulp` left Phase 8 → shipped in Phase 7 (#1529). Phase 8 = three edge surfaces: `/zoeken`, `/privacy`, 404/500.

## What's here

- **Design checkpoint** — `docs/design/mockups/phase-8-{search,privacy,errors}/` + `phase-8-data-reality-locked.md`. Per-decision `*-compare.html` + `*-locked.md` records.
- **PRD** — `docs/prd/redesign-phase-8.md` (tracer = `/privacy`; 5 phases mapped to issues 8.1–8.5; zero new tokens).

## Locked decisions

| Surface | Locked |
| --- | --- |
| `/zoeken` masthead | Softened dark masthead, serif *"Wat zoek je?"*, warm-gold accent, magnifier-icon button |
| `/zoeken` results | Clean paper rows, jersey-deep left edge, uniform 64×64 square thumb (team→crest disc) |
| `/zoeken` filter | Reuse `<FilterTabs>` — no redesign |
| `/zoeken` empty states | Football voice — pre-search hints + no-results *"Geen treffers."* + JerseyShirt + way-forward links |
| `/privacy` | Cream-minimal prose, dotted rules, drop dark hero + diagonal + gray prose |
| 404/500 | Shared `<ErrorState>`; layout A vs C → **Storybook A/B**; 404 *"Buiten de lijnen."* (+`/zoeken`), 500 *"Technische panne."* |

Implementation issues 8.1–8.5 created under the `redesign-retro-terrace-fanzine` milestone (umbrella #1530).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Phase 8 design specs and mockups for search (/zoeken), privacy (/privacy) and error pages (404/500).
  * Locked visual and copy decisions: dark search masthead, consistent 64×64 thumbnails, unified result-card style, and no-results headline “Geen treffers.”
  * Defined error-page compositions and actions (including “Probeer opnieuw” retry and “Naar de homepage”), and a minimal/privacy prose layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->