### PR TITLE
feat(ui): /privacy cream-minimal reskin (Phase 8 tracer) (#2104)

### DIFF
--- a/apps/web/src/app/(main)/privacy/Privacy.stories.tsx
+++ b/apps/web/src/app/(main)/privacy/Privacy.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import PrivacyPage from "./page";
+
+/**
+ * Design reference for the Phase 8 (8p1) cream-minimal `/privacy` reskin:
+ * mono kicker → serif `<EditorialHeading>` title → mono last-updated line →
+ * Freight Display intro lead → cream/ink prose column with a `<DottedDivider>`
+ * between H2 sections.
+ *
+ * `Pages/*` stories are design references only and are intentionally **not**
+ * VR-tagged — page-composition correctness is the e2e suite's job
+ * (`docs/prd/page-level-testing-rework.md`). The privacy page is a pure,
+ * synchronous server component with no data dependencies, so it renders
+ * directly here.
+ */
+const meta = {
+  title: "Pages/Privacy",
+  component: PrivacyPage,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof PrivacyPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/web/src/app/(main)/privacy/page.test.tsx
+++ b/apps/web/src/app/(main)/privacy/page.test.tsx
@@ -6,8 +6,8 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PrivacyPage from "./page";
 
-describe("PrivacyPage", () => {
-  it("renders the InteriorPageHero with the Juridisch label and headline", () => {
+describe("PrivacyPage (Phase 8 cream-minimal reskin)", () => {
+  it("renders the jersey-deep mono kicker and the serif h1 title", () => {
     render(<PrivacyPage />);
     expect(screen.getByText("Juridisch")).toBeInTheDocument();
     expect(
@@ -15,12 +15,32 @@ describe("PrivacyPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the prose container inside the gray section", () => {
+  it("renders the mono last-updated line in the header", () => {
+    render(<PrivacyPage />);
+    expect(
+      screen.getByText(/laatst bijgewerkt · februari 2026/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the intro lead with the original privacy copy", () => {
+    render(<PrivacyPage />);
+    expect(
+      screen.getByText(
+        /respecteert je privacy en behandelt je persoonsgegevens vertrouwelijk/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not use the legacy gray prose treatment", () => {
     const { container } = render(<PrivacyPage />);
-    const prose = container.querySelector("article.prose");
-    expect(prose).not.toBeNull();
-    expect(prose).toHaveClass("max-w-2xl");
-    expect(prose).toHaveClass("mx-auto");
+    expect(container.querySelector(".prose")).toBeNull();
+    expect(container.querySelector(".prose-gray")).toBeNull();
+  });
+
+  it("places a dotted divider before each H2 section", () => {
+    render(<PrivacyPage />);
+    // 11 legal sections → one separator before each.
+    expect(screen.getAllByRole("separator").length).toBeGreaterThanOrEqual(11);
   });
 
   it("displays all required legal sections", () => {
@@ -96,7 +116,7 @@ describe("PrivacyPage", () => {
     expect(screen.getByText(/GDPR\/AVG/i)).toBeInTheDocument();
   });
 
-  it("displays the last updated date", () => {
+  it("displays the last updated date in the Wijzigingen section", () => {
     render(<PrivacyPage />);
     expect(
       screen.getByText(/laatst bijgewerkt:\s*februari 2026/i),

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -1,19 +1,18 @@
 /**
  * Privacy Policy Page
  *
- * GDPR-compliant privacy policy for KCVV Elewijt. Wraps the legal copy in
- * the standard SectionStack + InteriorPageHero layout used across the redesigned
- * pages — compact dark hero followed by a single gray-100 prose section.
+ * GDPR-compliant privacy policy for KCVV Elewijt. Phase 8 (8p1) reskin:
+ * cream-minimal — no hero band. A mono kicker + serif `<EditorialHeading>`
+ * title + mono last-updated line + Freight Display intro lead introduce a
+ * single cream/ink prose column with a `<DottedDivider>` between H2 sections.
+ * Replaces the legacy `<InteriorPageHero>` + `<SectionStack>` diagonal +
+ * `prose prose-gray` composition (master design §7 line 587).
  */
 
 import type { Metadata } from "next";
 import Link from "next/link";
 import { DEFAULT_OG_IMAGE } from "@/lib/constants";
-import {
-  SectionStack,
-  type SectionConfig,
-} from "@/components/design-system/SectionStack/SectionStack";
-import { InteriorPageHero } from "@/components/layout/InteriorPageHero";
+import { EditorialHeading, DottedDivider } from "@/components/design-system";
 
 /**
  * Last updated date for the privacy policy.
@@ -43,36 +42,58 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Cream/ink prose styling for the legal copy. Replaces the typography-plugin
+ * `prose prose-gray` treatment: H2s in Freight Display 700, body in Archivo
+ * (ink-soft), links jersey-deep, dotted section rules spaced via the
+ * `[role=separator]` child selector. No legacy `--color-kcvv-*` / gray / green
+ * classes.
+ */
+const proseClasses = [
+  "text-ink-soft",
+  "[&_[role=separator]]:my-7",
+  "[&_h2]:mt-0 [&_h2]:mb-2.5 [&_h2]:font-display [&_h2]:font-bold [&_h2]:text-ink",
+  "[&_h2]:text-[length:var(--text-display-sm)] [&_h2]:leading-[var(--text-display-sm--lh)]",
+  "[&_p]:mt-3 [&_p]:text-[length:var(--text-body-md)] [&_p]:leading-[var(--text-body-md--lh)]",
+  "[&_ul]:mt-3 [&_ul]:list-disc [&_ul]:space-y-1.5 [&_ul]:pl-5",
+  "[&_li]:text-[length:var(--text-body-md)] [&_li]:leading-[var(--text-body-md--lh)]",
+  "[&_a]:font-semibold [&_a]:text-jersey-deep [&_a]:underline-offset-2 [&_a:hover]:underline",
+  "[&_strong]:font-semibold [&_strong]:text-ink",
+].join(" ");
+
 export default function PrivacyPage() {
-  const sections: SectionConfig[] = [
-    {
-      key: "hero",
-      bg: "kcvv-black",
-      paddingTop: "pt-0",
-      paddingBottom: "pb-0",
-      content: (
-        <InteriorPageHero
-          size="compact"
-          gradient="dark"
-          label="Juridisch"
-          headline="Privacyverklaring"
-          body="Hoe wij omgaan met jouw gegevens."
-        />
-      ),
-      transition: { type: "diagonal", direction: "right", overlap: "full" },
-    },
-    {
-      key: "content",
-      bg: "gray-100",
-      content: (
-        <article className="prose prose-gray mx-auto max-w-2xl px-4 md:px-10">
-          <p>
+  return (
+    <div className="bg-cream">
+      <div className="mx-auto max-w-2xl px-4 py-16 md:px-10 md:py-20">
+        <header className="flex flex-col">
+          {/* Raw styled span rather than <MonoLabel>: the 8p1 lock calls for a
+              jersey-deep kicker, but MonoLabel's `plain` variant only supports
+              ink/cream tones. Reuses the canonical label-token kicker vocabulary
+              (cf. EditorialHubCard / MatchArticleLinkCard). */}
+          <span className="text-jersey-deep font-mono text-[length:var(--text-label)] font-semibold tracking-[var(--text-label--tracking)] uppercase">
+            Juridisch
+          </span>
+          <EditorialHeading
+            level={1}
+            size="display-2xl"
+            emphasis={{ text: "." }}
+            className="mt-3"
+          >
+            Privacyverklaring
+          </EditorialHeading>
+          <p className="text-ink-muted mt-3.5 font-mono text-[length:var(--text-mono-sm)] tracking-[0.04em]">
+            Laatst bijgewerkt · {LAST_UPDATED}
+          </p>
+          <p className="text-ink-soft font-display mt-5 max-w-[60ch] text-[length:var(--text-body-lg)] leading-[var(--text-body-lg--lh)]">
             KCVV Elewijt, gevestigd aan Driesstraat 30, 1982 Elewijt,
             respecteert je privacy en behandelt je persoonsgegevens
             vertrouwelijk. Deze privacyverklaring legt uit welke gegevens we
             verzamelen, waarom we dat doen en welke rechten je hebt.
           </p>
+        </header>
 
+        <div className={`mt-10 ${proseClasses}`}>
+          <DottedDivider color="paper-edge" />
           <h2>Contactgegevens</h2>
           <p>
             <strong>Verantwoordelijke:</strong> KCVV Elewijt vzw
@@ -86,6 +107,7 @@ export default function PrivacyPage() {
             <a href="mailto:kevin@kcvvelewijt.be">kevin@kcvvelewijt.be</a>
           </p>
 
+          <DottedDivider color="paper-edge" />
           <h2>Welke gegevens verzamelen we?</h2>
           <p>
             We verzamelen alleen gegevens die noodzakelijk zijn voor het
@@ -112,6 +134,7 @@ export default function PrivacyPage() {
             </li>
           </ul>
 
+          <DottedDivider color="paper-edge" />
           <h2>Waarvoor gebruiken we je gegevens?</h2>
           <ul>
             <li>
@@ -126,6 +149,7 @@ export default function PrivacyPage() {
             <li>Voldoen aan wettelijke verplichtingen</li>
           </ul>
 
+          <DottedDivider color="paper-edge" />
           <h2>Rechtsgrond</h2>
           <p>We verwerken je gegevens op basis van:</p>
           <ul>
@@ -143,6 +167,7 @@ export default function PrivacyPage() {
             </li>
           </ul>
 
+          <DottedDivider color="paper-edge" />
           <h2>Delen we je gegevens?</h2>
           <p>We verkopen je gegevens nooit. We delen alleen gegevens met:</p>
           <ul>
@@ -160,6 +185,7 @@ export default function PrivacyPage() {
             </li>
           </ul>
 
+          <DottedDivider color="paper-edge" />
           <h2>Hoe lang bewaren we je gegevens?</h2>
           <ul>
             <li>
@@ -175,6 +201,7 @@ export default function PrivacyPage() {
             </li>
           </ul>
 
+          <DottedDivider color="paper-edge" />
           <h2>Jouw rechten</h2>
           <p>Volgens de GDPR/AVG heb je volgende rechten:</p>
           <ul>
@@ -200,6 +227,7 @@ export default function PrivacyPage() {
             <a href="mailto:info@kcvvelewijt.be">info@kcvvelewijt.be</a>.
           </p>
 
+          <DottedDivider color="paper-edge" />
           <h2>Cookiebeleid</h2>
           <p>
             Onze website gebruikt cookies om de gebruikerservaring te
@@ -217,6 +245,7 @@ export default function PrivacyPage() {
           </ul>
           <p>Je kan cookies beheren via je browserinstellingen.</p>
 
+          <DottedDivider color="paper-edge" />
           <h2>Beveiliging</h2>
           <p>
             We nemen passende technische en organisatorische maatregelen om je
@@ -225,6 +254,7 @@ export default function PrivacyPage() {
             opgeslagen op beveiligde servers.
           </p>
 
+          <DottedDivider color="paper-edge" />
           <h2>Wijzigingen</h2>
           <p>
             We kunnen deze privacyverklaring van tijd tot tijd aanpassen. De
@@ -232,6 +262,7 @@ export default function PrivacyPage() {
             bijgewerkt: {LAST_UPDATED}.
           </p>
 
+          <DottedDivider color="paper-edge" />
           <h2>Vragen over privacy?</h2>
           <p>
             Heb je vragen over hoe we met je gegevens omgaan? Neem gerust
@@ -239,10 +270,8 @@ export default function PrivacyPage() {
             stuur een e-mail naar{" "}
             <a href="mailto:info@kcvvelewijt.be">info@kcvvelewijt.be</a>.
           </p>
-        </article>
-      ),
-    },
-  ];
-
-  return <SectionStack sections={sections} />;
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -63,8 +63,8 @@ const proseClasses = [
 
 export default function PrivacyPage() {
   return (
-    <div className="bg-cream">
-      <div className="mx-auto max-w-2xl px-4 py-16 md:px-10 md:py-20">
+    <div className="bg-cream px-4 py-16 md:px-10 md:py-20">
+      <div className="mx-auto max-w-2xl">
         <header className="flex flex-col">
           {/* Raw styled span rather than <MonoLabel>: the 8p1 lock calls for a
               jersey-deep kicker, but MonoLabel's `plain` variant only supports
@@ -75,9 +75,9 @@ export default function PrivacyPage() {
           </span>
           <EditorialHeading
             level={1}
-            size="display-2xl"
-            emphasis={{ text: "." }}
-            className="mt-3"
+            size="display-xl"
+            emphasis={{ text: "verklaring." }}
+            className="mt-3 mb-0 break-words hyphens-auto"
           >
             Privacyverklaring
           </EditorialHeading>


### PR DESCRIPTION
Closes #2104

Phase 8 **tracer bullet** — reskins `/privacy` from the legacy dark `<InteriorPageHero>` + gray `prose prose-gray` + `<SectionStack>` `diagonal` composition onto the retro-terrace cream/ink design language, per the **8p1 "cream minimal" lock** (`docs/design/mockups/phase-8-privacy/8p1-prose-locked.md`). Validates the phase-wide conventions (cream/ink prose, legacy-token + diagonal-seam removal, e2e smoke contract, `Pages/*` story without VR) before the search + error work.

## Changes

- **Header (no hero band):** jersey-deep mono kicker `Juridisch` → `<EditorialHeading level={1} size="display-2xl" emphasis={{ text: "." }}>` serif title `Privacyverklaring.` (accent dot jersey-deep) → mono `Laatst bijgewerkt · {LAST_UPDATED}` → Freight Display intro lead. Title + lead match the established `ploegen` / `club/geschiedenis` page-header convention.
- **Prose:** dropped `prose prose-gray`; cream/ink styling via child-selector utilities (H2 Freight Display 700, body Archivo `ink-soft`, links `jersey-deep`), `<DottedDivider color="paper-edge" />` before each of the 11 H2 sections (precedent: `BioBlock`'s local `[&_p]:…` pattern).
- **Removed:** `<InteriorPageHero>` and the `<SectionStack>` `diagonal` seam — satisfies the master-design line-587 "migrate the diagonal consumer" by *removing* it here. Verified zero legacy `--color-kcvv-*` / `green-*` / `gray-*` / `prose-gray` / `InteriorPageHero` classes remain in the prerendered HTML.
- **Preserved verbatim:** all legal copy, the `/hulp` cross-link, the `LAST_UPDATED` constant (rendered in both the header line and the Wijzigingen section), and the SEO `metadata` export.
- **Story:** new `Pages/Privacy` story (autodocs, **not** VR-tagged — `Pages/*` are e2e-covered per `docs/prd/page-level-testing-rework.md`).
- **Tests:** rewrote the unit suite for the new layout (kicker, serif h1, mono last-updated line, intro lead, no-`prose` assertion, ≥11 dotted separators, all legal-section/contact/GDPR/cookie/hulp assertions retained).

## Kicker note

The kicker is a raw styled `<span>` rather than `<MonoLabel>`: the 8p1 lock requires a **jersey-deep** kicker, but `MonoLabel`'s `plain` variant only supports `ink`/`cream` tones. The span reuses the canonical label-token kicker vocabulary (cf. `EditorialHubCard` / `MatchArticleLinkCard`) and carries an inline comment explaining this. No locked primitive was modified (avoids slipping net-new vocabulary into a tracer).

## Out of scope (noted, not changed)

- The page `metadata.title` is `"Privacyverklaring | KCVV Elewijt"`, and the root layout's `title.template` (`"%s | KCVV Elewijt"`) doubles the suffix → `"Privacyverklaring | KCVV Elewijt | KCVV Elewijt"`. This is **pre-existing** (unchanged by this PR) and the AC requires preserving the existing metadata. Worth a follow-up cleanup (drop the page-level suffix) but left untouched here.
- The old hero subtitle `body="Hoe wij omgaan met jouw gegevens."` is dropped — it was hero chrome, not policy copy, and the 8p1 lock replaces the hero with the kicker/title/last-updated/lead header.

## Testing

- `pnpm --filter @kcvv/web check-all` (lint + type-check + vitest + `next build`) passes; `/privacy` prerenders as `○ (Static)`.
- Privacy unit tests: **13/13 green**.
- e2e smoke (`/privacy`) — existing `routes.spec.ts` smoke test; the structural contract (single `<h1>`, layout `<nav>`/`<footer>`, no broken images, no `console.error`) is unchanged and satisfied (verified against the prerendered HTML). CI's e2e job runs it on this PR.
- Pre-PR review gate: ran `/code-review` (high) + `/simplify` — no correctness/a11y/Tailwind bugs; copy fully preserved; one cleanup applied (kicker-rationale comment). The "extract `proseClasses` to a shared lib" / "map dividers over a data array" suggestions were skipped as YAGNI (single consumer; heterogeneous section content reads clearer inline).

## VR baselines

None — `Pages/Privacy` is intentionally not VR-tagged (PRD §8). No `UI/*` or `Features/*` stories added.

## Analytics & SEO

`/privacy` is static with no events (PRD §7). SEO metadata preserved; no JSON-LD entity applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
