### PR TITLE
feat(search): /zoeken dark masthead + page shell (#2105)

### DIFF
--- a/apps/web/src/app/(main)/zoeken/loading.tsx
+++ b/apps/web/src/app/(main)/zoeken/loading.tsx
@@ -1,44 +1,44 @@
 /**
  * Search Page — Loading Skeleton
- * Matches the hero with search input + results grid layout
+ *
+ * Mirrors the 8s1 shell: the real `<SearchMasthead>` band (heading + inert
+ * field) over a cream results-area skeleton. No legacy gray/green tokens.
  */
+
+import { SearchMastheadSkeleton } from "@/components/search/SearchMastheadSkeleton";
 
 export default function SearchLoading() {
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="bg-cream min-h-screen pb-[var(--footer-diagonal)]">
       <span role="status" aria-live="polite" className="sr-only">
         Zoekpagina laden...
       </span>
-      {/* Hero with search bar */}
-      <div className="from-green-main via-green-hover to-green-dark-hover bg-linear-to-br px-4 py-12 text-white">
-        <div className="mx-auto max-w-3xl animate-pulse space-y-4">
-          <div className="h-10 w-40 rounded bg-white/10" />
-          <div className="h-12 w-full rounded-lg bg-white/10" />
-        </div>
-      </div>
 
-      {/* Filter chips */}
-      <div className="mx-auto max-w-5xl px-4 pt-6">
+      <SearchMastheadSkeleton />
+
+      <div className="mx-auto max-w-5xl px-4 py-12">
+        {/* Filter chips */}
         <div className="flex animate-pulse gap-2">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="h-8 w-20 rounded-full bg-gray-200" />
-          ))}
-        </div>
-      </div>
-
-      {/* Results grid */}
-      <div className="mx-auto max-w-5xl px-4 py-6">
-        <div className="grid animate-pulse grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="overflow-hidden rounded-sm border border-gray-200 bg-white shadow-sm"
+              className="border-ink/15 bg-ink/5 h-9 w-20 rounded-none border-2"
+            />
+          ))}
+        </div>
+
+        {/* Result rows */}
+        <div className="mt-8 animate-pulse space-y-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="border-ink/15 flex gap-4 rounded-none border-2 bg-white p-4 shadow-[2px_2px_0_0_var(--color-ink)]"
             >
-              <div className="aspect-[3/2] bg-gray-200" />
-              <div className="space-y-2 p-4">
-                <div className="h-4 w-16 rounded bg-gray-200" />
-                <div className="h-5 w-full rounded bg-gray-200" />
-                <div className="h-3 w-1/2 rounded bg-gray-200" />
+              <div className="bg-ink/10 h-16 w-16 flex-none" />
+              <div className="flex-1 space-y-2">
+                <div className="bg-ink/10 h-3 w-24" />
+                <div className="bg-ink/10 h-4 w-3/4" />
+                <div className="bg-ink/10 h-3 w-1/2" />
               </div>
             </div>
           ))}

--- a/apps/web/src/app/(main)/zoeken/page.tsx
+++ b/apps/web/src/app/(main)/zoeken/page.tsx
@@ -1,13 +1,18 @@
 /**
  * Search Page
- * Global search across articles, players, and teams
+ *
+ * Global search across articles, players, teams and staff. Phase 8 (8s1)
+ * reskin: a `jersey-deep-dark` `<SearchMasthead>` band wears the search field
+ * as its hero; results render on cream below. Replaces the legacy
+ * green-gradient hero (master design §7 line 587). Backend (bge-m3 / Vectorize,
+ * #2057) unchanged — presentation only.
  */
 
 import type { Metadata } from "next";
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { Suspense } from "react";
+import { DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { SearchInterface } from "@/components/search";
-import { Spinner } from "@/components/design-system";
+import { SearchMastheadSkeleton } from "@/components/search/SearchMastheadSkeleton";
 
 export const metadata: Metadata = {
   title: "Zoeken | KCVV Elewijt",
@@ -23,35 +28,18 @@ export const metadata: Metadata = {
 };
 
 /**
- * Search page with client-side search interface
+ * Search page with client-side search interface.
+ *
+ * `<SearchInterface>` reads `useSearchParams`, so it sits behind a `<Suspense>`
+ * boundary; the fallback renders the masthead skeleton (heading + inert field)
+ * so the band and `<h1>` ship in the initial HTML with no layout shift.
  */
 export default function SearchPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white pb-[var(--footer-diagonal)]">
-      {/* Hero Section */}
-      <div className="from-green-main via-green-hover to-green-dark-hover bg-gradient-to-br px-4 py-16 text-white">
-        <div className="mx-auto max-w-5xl">
-          <h1 className="font-title mb-4 text-4xl font-bold md:text-6xl">
-            Zoeken
-          </h1>
-          <p className="max-w-3xl text-xl text-white/90 md:text-2xl">
-            Vind nieuws, spelers, teams en meer
-          </p>
-        </div>
-      </div>
-
-      {/* Search Interface */}
-      <div className="mx-auto max-w-5xl px-4 py-12">
-        <Suspense
-          fallback={
-            <div className="flex justify-center py-12">
-              <Spinner size="lg" />
-            </div>
-          }
-        >
-          <SearchInterface />
-        </Suspense>
-      </div>
+    <div className="bg-cream min-h-screen pb-[var(--footer-diagonal)]">
+      <Suspense fallback={<SearchMastheadSkeleton />}>
+        <SearchInterface />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/app/__tests__/loading-envelope.test.tsx
+++ b/apps/web/src/app/__tests__/loading-envelope.test.tsx
@@ -133,7 +133,7 @@ describe("loading.tsx envelope drift guard", () => {
     {
       name: "/zoeken",
       Loading: ZoekenLoading,
-      expectedRootClass: "min-h-screen bg-gray-100",
+      expectedRootClass: "bg-cream min-h-screen pb-[var(--footer-diagonal)]",
     },
     {
       name: "/club/[slug]",

--- a/apps/web/src/components/search/SearchForm.stories.tsx
+++ b/apps/web/src/components/search/SearchForm.stories.tsx
@@ -1,20 +1,32 @@
 /**
  * SearchForm Storybook Stories
+ *
+ * The 8s1 hard-shadow search field. Rendered on a `jersey-deep-dark` ground
+ * (its real context inside `<SearchMasthead>`); the cream input + warm-gold
+ * magnifier cell read against the dark band.
  */
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "storybook/test";
 import { SearchForm } from "./SearchForm";
 
 const meta = {
   title: "Features/Search/SearchForm",
   component: SearchForm,
   parameters: {
-    layout: "padded",
+    layout: "fullscreen",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "vr"],
   args: {
-    onSearch: () => {},
+    onSearch: fn(),
   },
+  decorators: [
+    (Story) => (
+      <div className="bg-jersey-deep-dark p-8">
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof SearchForm>;
 
 export default meta;
@@ -31,7 +43,7 @@ export const Default: Story = {
 };
 
 /**
- * With initial value
+ * With initial value (clear affordance visible)
  */
 export const WithInitialValue: Story = {
   args: {

--- a/apps/web/src/components/search/SearchForm.test.tsx
+++ b/apps/web/src/components/search/SearchForm.test.tsx
@@ -19,7 +19,7 @@ describe("SearchForm", () => {
     it("should render submit button", () => {
       render(<SearchForm onSearch={vi.fn()} />);
 
-      const button = screen.getByRole("button", { name: /zoek/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).toBeInTheDocument();
     });
 
@@ -101,7 +101,7 @@ describe("SearchForm", () => {
     it("should disable submit button when input is empty", () => {
       render(<SearchForm onSearch={vi.fn()} />);
 
-      const button = screen.getByRole("button", { name: /zoek/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).toBeDisabled();
     });
 
@@ -112,7 +112,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "   ");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).toBeDisabled();
     });
 
@@ -123,7 +123,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "a");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).toBeDisabled();
     });
 
@@ -134,52 +134,8 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "ab");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).not.toBeDisabled();
-    });
-
-    it("should show hint text when input has 1 character", async () => {
-      const user = userEvent.setup();
-      render(<SearchForm onSearch={vi.fn()} />);
-
-      const input = screen.getByRole("textbox");
-      await user.type(input, "a");
-
-      expect(
-        screen.getByText("Typ minimaal 2 karakters om te zoeken"),
-      ).toBeInTheDocument();
-    });
-
-    it("should not show hint text when input is empty", () => {
-      render(<SearchForm onSearch={vi.fn()} />);
-
-      expect(
-        screen.queryByText("Typ minimaal 2 karakters om te zoeken"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("should not show hint text when input has 2+ characters", async () => {
-      const user = userEvent.setup();
-      render(<SearchForm onSearch={vi.fn()} />);
-
-      const input = screen.getByRole("textbox");
-      await user.type(input, "abc");
-
-      expect(
-        screen.queryByText("Typ minimaal 2 karakters om te zoeken"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("should not show hint text when input only has whitespace", async () => {
-      const user = userEvent.setup();
-      render(<SearchForm onSearch={vi.fn()} />);
-
-      const input = screen.getByRole("textbox");
-      await user.type(input, "  ");
-
-      expect(
-        screen.queryByText("Typ minimaal 2 karakters om te zoeken"),
-      ).not.toBeInTheDocument();
     });
   });
 
@@ -260,7 +216,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "  test query  ");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(button);
 
       expect(handleSearch).toHaveBeenCalledWith("test query");
@@ -286,7 +242,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "a");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       // Button should be disabled, so click won't work
       expect(button).toBeDisabled();
       expect(handleSearch).not.toHaveBeenCalled();
@@ -300,7 +256,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "   ");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       // Button should be disabled, so click won't work
       expect(button).toBeDisabled();
       expect(handleSearch).not.toHaveBeenCalled();
@@ -343,7 +299,7 @@ describe("SearchForm", () => {
         <SearchForm onSearch={vi.fn()} isLoading={true} initialValue="test" />,
       );
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).toBeDisabled();
     });
 
@@ -354,7 +310,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       expect(button).not.toBeDisabled();
     });
   });
@@ -387,7 +343,7 @@ describe("SearchForm", () => {
       await user.tab();
 
       // Next tab should focus the submit button
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       expect(submitButton).toHaveFocus();
     });
 
@@ -399,7 +355,7 @@ describe("SearchForm", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const button = screen.getByRole("button", { name: /^zoek$/i });
+      const button = screen.getByRole("button", { name: /^zoeken$/i });
       button.focus();
       await user.keyboard("{Enter}");
 

--- a/apps/web/src/components/search/SearchForm.tsx
+++ b/apps/web/src/components/search/SearchForm.tsx
@@ -2,12 +2,17 @@
 
 /**
  * SearchForm Component
- * Search input field with submit button
+ *
+ * 8s1 "hard-shadow" search field: a cream input + warm-gold magnifier-icon
+ * submit cell inside a 2px-ink border with an offset paper shadow. Designed to
+ * sit on the `<SearchMasthead>` dark band (the input surface stays cream so it
+ * reads on any ground). No "ZOEK" word — the magnifier carries the action.
  */
 
 import { useState, FormEvent } from "react";
-import { Icon } from "@/components/design-system";
-import { Search, X } from "lucide-react";
+import { MagnifyingGlass, X } from "@/lib/icons.redesign";
+import { cn } from "@/lib/utils/cn";
+import { searchFieldShellClasses } from "./search-field-styles";
 
 export interface SearchFormProps {
   /**
@@ -29,7 +34,7 @@ export interface SearchFormProps {
 }
 
 /**
- * Search form with input and submit button
+ * Search form with input and magnifier submit button
  */
 export const SearchForm = ({
   initialValue = "",
@@ -58,53 +63,50 @@ export const SearchForm = ({
     onSearch("");
   };
 
+  const canSubmit = value.trim().length >= 2 && !isLoading;
+
   return (
-    <form onSubmit={handleSubmit} className="w-full">
-      <div className="relative">
-        {/* Search Icon */}
-        <div className="absolute top-1/2 left-5 -translate-y-1/2 text-gray-400">
-          <Icon icon={Search} size="md" />
-        </div>
-
-        {/* Input */}
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder={placeholder}
-          className="focus:border-green-main focus:ring-green-main/20 w-full rounded-lg border-2 border-gray-200 py-5 pr-28 pl-14 text-xl transition-colors focus:ring-2 focus:outline-none"
-          disabled={isLoading}
-          autoFocus
-        />
-
-        {/* Clear Button */}
-        {value.length > 0 && (
-          <button
-            type="button"
-            onClick={handleClear}
-            className="absolute top-1/2 right-24 -translate-y-1/2 text-gray-400 transition-colors hover:text-gray-600"
-            aria-label="Wis zoekopdracht"
-          >
-            <Icon icon={X} size="md" />
-          </button>
-        )}
-
-        {/* Submit Button */}
-        <button
-          type="submit"
-          disabled={isLoading || value.trim().length < 2}
-          className="bg-green-main hover:bg-green-hover absolute top-1/2 right-2 -translate-y-1/2 rounded-md px-5 py-3 text-base font-semibold text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Zoek
-        </button>
-      </div>
-
-      {/* Hint Text */}
-      {value.trim().length > 0 && value.trim().length < 2 && (
-        <p className="mt-2 text-sm text-gray-500">
-          Typ minimaal 2 karakters om te zoeken
-        </p>
+    <form
+      onSubmit={handleSubmit}
+      className={cn(
+        searchFieldShellClasses,
+        "focus-within:ring-warm transition-shadow focus-within:ring-2",
       )}
+    >
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={placeholder}
+        aria-label="Zoekterm"
+        className="text-ink placeholder:text-ink-muted bg-cream min-w-0 flex-1 px-4 py-4 text-[length:var(--text-body-lg)] outline-none focus:outline-hidden disabled:opacity-60 md:px-5"
+        disabled={isLoading}
+        autoFocus
+      />
+
+      {/* Clear — ghost cell blended into the cream input, left of the warm
+          magnifier cell. Always enabled (resets even while a fetch is in
+          flight and the input is disabled). */}
+      {value.length > 0 && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="text-ink-muted hover:text-ink bg-cream flex items-center px-2 transition-colors"
+          aria-label="Wis zoekopdracht"
+        >
+          <X className="h-5 w-5" aria-hidden />
+        </button>
+      )}
+
+      {/* Submit — warm-gold accent cell; magnifier replaces the "ZOEK" word. */}
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="bg-warm text-ink border-ink flex items-center border-l-2 px-5 transition-[filter] hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Zoeken"
+      >
+        <MagnifyingGlass className="h-[23px] w-[23px]" aria-hidden />
+      </button>
     </form>
   );
 };

--- a/apps/web/src/components/search/SearchInterface.stories.tsx
+++ b/apps/web/src/components/search/SearchInterface.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   title: "Features/Search/SearchInterface",
   component: SearchInterface,
   parameters: {
-    layout: "padded",
+    layout: "fullscreen",
   },
   tags: ["autodocs"],
 } satisfies Meta<typeof SearchInterface>;

--- a/apps/web/src/components/search/SearchInterface.test.tsx
+++ b/apps/web/src/components/search/SearchInterface.test.tsx
@@ -60,7 +60,7 @@ describe("SearchInterface", () => {
 
       expect(screen.getByRole("textbox")).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /^zoek$/i }),
+        screen.getByRole("button", { name: /^zoeken$/i }),
       ).toBeInTheDocument();
     });
 
@@ -155,7 +155,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -179,7 +179,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -224,7 +224,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "  trimmed  ");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -251,7 +251,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       // Should show loading spinner
@@ -280,7 +280,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -302,7 +302,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -325,7 +325,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -342,7 +342,7 @@ describe("SearchInterface", () => {
       await user.type(input, "a");
 
       // Submit button should be disabled
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       expect(submitButton).toBeDisabled();
 
       // Attempt submission via Enter key (should be prevented by validation)
@@ -365,7 +365,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -400,7 +400,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -437,7 +437,7 @@ describe("SearchInterface", () => {
 
       render(<SearchInterface />);
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
 
       // First search - type directly (input is empty initially)
       const input = screen.getByRole("textbox");
@@ -479,7 +479,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       // Should not display error for aborted request
@@ -508,7 +508,7 @@ describe("SearchInterface", () => {
 
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -666,7 +666,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       // Input should be disabled
@@ -697,7 +697,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -718,7 +718,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -739,7 +739,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -781,7 +781,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -803,7 +803,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -850,7 +850,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "ab");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -873,7 +873,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -892,7 +892,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "test");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {
@@ -921,7 +921,7 @@ describe("SearchInterface", () => {
       await user.type(input, "football");
 
       // 2. Submit search
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       // 3. Wait for results
@@ -957,7 +957,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "first");
 
-      const submitButton = screen.getByRole("button", { name: /^zoek$/i });
+      const submitButton = screen.getByRole("button", { name: /^zoeken$/i });
       await user.click(submitButton);
 
       await waitFor(() => {

--- a/apps/web/src/components/search/SearchInterface.tsx
+++ b/apps/web/src/components/search/SearchInterface.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { SearchForm } from "./SearchForm";
+import { SearchMasthead } from "./SearchMasthead";
 import { SearchFilters } from "./SearchFilters";
 import { SearchResults } from "./SearchResults";
 import { Spinner } from "@/components/design-system";
@@ -255,90 +256,97 @@ export const SearchInterface = ({
   }, []);
 
   return (
-    <div className="space-y-8">
-      {/* Search Form */}
-      <SearchForm
-        initialValue={query}
-        onSearch={handleSearch}
-        isLoading={isLoading}
-      />
+    <>
+      {/* Dark search masthead — the field is the hero (8s1). */}
+      <SearchMasthead>
+        <SearchForm
+          initialValue={query}
+          onSearch={handleSearch}
+          isLoading={isLoading}
+        />
+      </SearchMasthead>
 
-      {/* Show results only if query is valid (>= 2 chars) */}
-      {query.trim().length >= 2 && (
-        <>
-          {/* Filters */}
-          <SearchFilters
-            activeType={activeType}
-            onFilterChange={handleFilterChange}
-            resultCounts={{
-              all: totalCount,
-              article: results.filter((r) => r.type === "article").length,
-              player: results.filter((r) => r.type === "player").length,
-              staff: results.filter((r) => r.type === "staff").length,
-              team: results.filter((r) => r.type === "team").length,
-            }}
-          />
-
-          {/* Loading State */}
-          {isLoading && (
-            <div className="flex justify-center py-12">
-              <Spinner size="lg" />
-            </div>
-          )}
-
-          {/* Error State */}
-          {error && !isLoading && (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
-              <p className="text-red-800">{error}</p>
-            </div>
-          )}
-
-          {/* Results */}
-          {!isLoading && !error && (
-            <SearchResults
-              results={results}
-              query={query}
+      {/* Results region on cream, below the band. */}
+      <div className="mx-auto max-w-5xl space-y-8 px-4 py-12">
+        {/* Show results only if query is valid (>= 2 chars) */}
+        {query.trim().length >= 2 && (
+          <>
+            {/* Filters */}
+            <SearchFilters
               activeType={activeType}
-              onResultClick={analytics.trackResultClicked}
+              onFilterChange={handleFilterChange}
+              resultCounts={{
+                all: totalCount,
+                article: results.filter((r) => r.type === "article").length,
+                player: results.filter((r) => r.type === "player").length,
+                staff: results.filter((r) => r.type === "staff").length,
+                team: results.filter((r) => r.type === "team").length,
+              }}
             />
-          )}
-        </>
-      )}
 
-      {/* Help Text - Show when query is too short */}
-      {query.trim().length < 2 && (
-        <div className="rounded-xl bg-white p-8 text-center shadow-sm">
-          <h2 className="text-gray-blue mb-4 text-xl font-bold">
-            Wat wil je zoeken?
-          </h2>
-          <p className="text-gray-dark mb-6">
-            Typ minimaal 2 karakters om te zoeken naar nieuws, spelers, teams en
-            meer.
-          </p>
-          <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
-            <div className="rounded-lg bg-gray-50 p-4">
-              <h3 className="text-gray-blue mb-2 font-semibold">
-                📰 Nieuwsartikelen
-              </h3>
-              <p className="text-gray-dark text-sm">
-                Zoek op titel, inhoud of tags
-              </p>
-            </div>
-            <div className="rounded-lg bg-gray-50 p-4">
-              <h3 className="text-gray-blue mb-2 font-semibold">⚽ Spelers</h3>
-              <p className="text-gray-dark text-sm">
-                Vind spelers op naam of positie
-              </p>
-            </div>
-            <div className="rounded-lg bg-gray-50 p-4">
-              <h3 className="text-gray-blue mb-2 font-semibold">🏆 Teams</h3>
-              <p className="text-gray-dark text-sm">
-                Zoek teams op naam of leeftijdsgroep
-              </p>
+            {/* Loading State */}
+            {isLoading && (
+              <div className="flex justify-center py-12">
+                <Spinner size="lg" />
+              </div>
+            )}
+
+            {/* Error State */}
+            {error && !isLoading && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+                <p className="text-red-800">{error}</p>
+              </div>
+            )}
+
+            {/* Results */}
+            {!isLoading && !error && (
+              <SearchResults
+                results={results}
+                query={query}
+                activeType={activeType}
+                onResultClick={analytics.trackResultClicked}
+              />
+            )}
+          </>
+        )}
+
+        {/* Help Text - Show when query is too short */}
+        {query.trim().length < 2 && (
+          <div className="rounded-xl bg-white p-8 text-center shadow-sm">
+            <h2 className="text-gray-blue mb-4 text-xl font-bold">
+              Wat wil je zoeken?
+            </h2>
+            <p className="text-gray-dark mb-6">
+              Typ minimaal 2 karakters om te zoeken naar nieuws, spelers, teams
+              en meer.
+            </p>
+            <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+              <div className="rounded-lg bg-gray-50 p-4">
+                <h3 className="text-gray-blue mb-2 font-semibold">
+                  📰 Nieuwsartikelen
+                </h3>
+                <p className="text-gray-dark text-sm">
+                  Zoek op titel, inhoud of tags
+                </p>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-4">
+                <h3 className="text-gray-blue mb-2 font-semibold">
+                  ⚽ Spelers
+                </h3>
+                <p className="text-gray-dark text-sm">
+                  Vind spelers op naam of positie
+                </p>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-4">
+                <h3 className="text-gray-blue mb-2 font-semibold">🏆 Teams</h3>
+                <p className="text-gray-dark text-sm">
+                  Zoek teams op naam of leeftijdsgroep
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </>
   );
 };

--- a/apps/web/src/components/search/SearchMasthead.stories.tsx
+++ b/apps/web/src/components/search/SearchMasthead.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * SearchMasthead Storybook Stories
+ *
+ * The softened-S3 `/zoeken` dark masthead band (8s1). Rendered with a live
+ * `<SearchForm>` slot so the field-on-dark composition is visible.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "storybook/test";
+import { SearchMasthead } from "./SearchMasthead";
+import { SearchForm } from "./SearchForm";
+
+const meta = {
+  title: "Features/Search/SearchMasthead",
+  component: SearchMasthead,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs", "vr"],
+  args: {
+    children: <SearchForm onSearch={fn()} />,
+  },
+} satisfies Meta<typeof SearchMasthead>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default masthead — empty field, persistent hint line.
+ */
+export const Default: Story = {};
+
+/**
+ * Masthead with a populated query (clear affordance visible).
+ */
+export const WithQuery: Story = {
+  args: {
+    children: <SearchForm onSearch={fn()} initialValue="elewijt" />,
+  },
+};

--- a/apps/web/src/components/search/SearchMasthead.test.tsx
+++ b/apps/web/src/components/search/SearchMasthead.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * SearchMasthead Component Tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SearchMasthead } from "./SearchMasthead";
+
+describe("SearchMasthead", () => {
+  it("renders the level-1 search prompt heading", () => {
+    render(
+      <SearchMasthead>
+        <div>field</div>
+      </SearchMasthead>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Wat zoek je?");
+  });
+
+  it("renders the accent word as a warm-gold emphasis", () => {
+    render(
+      <SearchMasthead>
+        <div>field</div>
+      </SearchMasthead>,
+    );
+
+    const accent = screen.getByText("zoek");
+    expect(accent.tagName).toBe("EM");
+    expect(accent.className).toContain("text-warm");
+  });
+
+  it("renders the field slot", () => {
+    render(
+      <SearchMasthead>
+        <div data-testid="field">field</div>
+      </SearchMasthead>,
+    );
+
+    expect(screen.getByTestId("field")).toBeInTheDocument();
+  });
+
+  it("renders the persistent mono hint line", () => {
+    render(
+      <SearchMasthead>
+        <div>field</div>
+      </SearchMasthead>,
+    );
+
+    expect(screen.getByText(/typ minstens 2 letters/i)).toBeInTheDocument();
+  });
+
+  it("supports custom heading, accent and hint", () => {
+    render(
+      <SearchMasthead heading="Zoek iets" accent="iets" hint="Custom hint">
+        <div>field</div>
+      </SearchMasthead>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent("Zoek iets.");
+    expect(screen.getByText("iets").tagName).toBe("EM");
+    expect(screen.getByText("Custom hint")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/search/SearchMasthead.tsx
+++ b/apps/web/src/components/search/SearchMasthead.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+import { EditorialHeading } from "@/components/design-system";
+
+export interface SearchMastheadProps {
+  /**
+   * The interactive search field rendered inside the band (typically a
+   * `<SearchForm>`). Passed as a slot so the masthead stays a presentational,
+   * server-renderable shell while the field owns its own client state.
+   */
+  children: ReactNode;
+  /** Display heading. The `accent` substring carries the warm-gold emphasis. */
+  heading?: string;
+  /** Substring of `heading` rendered in the warm italic accent. */
+  accent?: string;
+  /** Persistent mono hint line below the field. */
+  hint?: string;
+}
+
+/**
+ * <SearchMasthead> — the softened-S3 `/zoeken` masthead (design lock 8s1):
+ * a `jersey-deep-dark` full-bleed band (diagonal stripe texture + radial jersey
+ * wash) wearing the search field as its hero. No mono kicker; a serif
+ * `<EditorialHeading>` "Wat _zoek_ je?" with a **warm-gold** accent on "zoek"
+ * (jersey-deep is invisible on the dark ground, 8s1.1); a persistent mono hint
+ * line under the field. Results render on cream below the band (8s2/8s4).
+ */
+export function SearchMasthead({
+  children,
+  heading = "Wat zoek je?",
+  accent = "zoek",
+  hint = "Typ minstens 2 letters · nieuws · spelers · ploegen · staf",
+}: SearchMastheadProps) {
+  return (
+    <header className="bg-jersey-deep-dark border-ink relative overflow-hidden border-b-2">
+      {/* Diagonal stripe texture — decorative (8s1). */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "repeating-linear-gradient(135deg, rgba(245,241,230,0.045) 0 18px, transparent 18px 36px)",
+        }}
+      />
+      {/* Radial jersey wash — decorative (8s1). */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(120% 90% at 18% -10%, rgba(74,207,82,0.14), transparent 60%)",
+        }}
+      />
+
+      <div className="relative mx-auto max-w-5xl px-4 py-12 md:py-14">
+        <EditorialHeading
+          level={1}
+          size="display-xl"
+          tone="cream"
+          emphasis={{ text: accent, tone: "warm" }}
+          className="mb-6"
+        >
+          {heading}
+        </EditorialHeading>
+
+        {children}
+
+        <p className="text-cream/70 mt-3.5 font-mono text-[length:var(--text-mono-sm)] tracking-[0.03em]">
+          {hint}
+        </p>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/components/search/SearchMastheadSkeleton.tsx
+++ b/apps/web/src/components/search/SearchMastheadSkeleton.tsx
@@ -1,0 +1,27 @@
+import { SearchMasthead } from "./SearchMasthead";
+import { searchFieldShellClasses } from "./search-field-styles";
+
+/**
+ * Server-renderable loading shell for `/zoeken`: the real `<SearchMasthead>`
+ * band (so the `<h1>` ships in the initial HTML, no layout shift) wrapping an
+ * inert skeleton of the search field. Used by both `loading.tsx` (route loading
+ * UI) and the page's `<Suspense>` fallback while the client `<SearchInterface>`
+ * (which reads `useSearchParams`) hydrates.
+ *
+ * No icon is rendered: a Phosphor import here would pull `createElement`/context
+ * into the server bundle and break `next build` (see
+ * `reference_phosphor_data_module_use_client`). The warm cell stands in for the
+ * magnifier button.
+ */
+export function SearchMastheadSkeleton() {
+  return (
+    <SearchMasthead>
+      <div aria-hidden className={`${searchFieldShellClasses} animate-pulse`}>
+        {/* 3.625rem ≈ SearchForm's input height (py-4 + body-lg line box) so
+            the skeleton reserves the same space as the real field. */}
+        <div className="h-[3.625rem] flex-1" />
+        <div className="bg-warm border-ink w-14 border-l-2" />
+      </div>
+    </SearchMasthead>
+  );
+}

--- a/apps/web/src/components/search/index.test.ts
+++ b/apps/web/src/components/search/index.test.ts
@@ -17,6 +17,11 @@ describe("search/index exports", () => {
     expect(typeof SearchModule.SearchForm).toBe("function");
   });
 
+  it("should export SearchMasthead component", () => {
+    expect(SearchModule.SearchMasthead).toBeDefined();
+    expect(typeof SearchModule.SearchMasthead).toBe("function");
+  });
+
   it("should export SearchFilters component", () => {
     expect(SearchModule.SearchFilters).toBeDefined();
     expect(typeof SearchModule.SearchFilters).toBe("function");
@@ -38,6 +43,7 @@ describe("search/index exports", () => {
       "SearchFilters",
       "SearchForm",
       "SearchInterface",
+      "SearchMasthead",
       "SearchResult",
       "SearchResults",
     ]);

--- a/apps/web/src/components/search/index.ts
+++ b/apps/web/src/components/search/index.ts
@@ -5,6 +5,7 @@
 
 export { SearchInterface } from "./SearchInterface";
 export { SearchForm } from "./SearchForm";
+export { SearchMasthead } from "./SearchMasthead";
 export { SearchFilters } from "./SearchFilters";
 export { SearchResults } from "./SearchResults";
 export { SearchResult } from "./SearchResult";
@@ -16,6 +17,7 @@ export type {
   SearchResultType,
 } from "./SearchInterface";
 export type { SearchFormProps } from "./SearchForm";
+export type { SearchMastheadProps } from "./SearchMasthead";
 export type { SearchFiltersProps } from "./SearchFilters";
 export type { SearchResultsProps } from "./SearchResults";
 export type { SearchResultProps } from "./SearchResult";

--- a/apps/web/src/components/search/search-field-styles.ts
+++ b/apps/web/src/components/search/search-field-styles.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared chrome for the 8s1 "hard-shadow search field".
+ *
+ * Lives in a plain (non-`"use client"`) module so both the interactive
+ * `<SearchForm>` (client) and the server-rendered `<SearchMastheadSkeleton>`
+ * render a pixel-identical field shell without the field markup drifting between
+ * the two — mirroring the `button-styles.ts` split. Importing a value from a
+ * `"use client"` module into a server component would yield a client reference,
+ * not the string, so the constant cannot live in `SearchForm.tsx`.
+ *
+ * Cream input surface, 2px ink border, sharp (square) corners — matching the
+ * design-system field/button convention (`fieldChrome` "sharp corners",
+ * `Button`/`FilterTabs` `rounded-none`) — with a `5px` offset paper shadow.
+ * (The 8s1 mockup's 8px radius is not carried over; the shipped system is
+ * square-cornered.)
+ */
+export const searchFieldShellClasses =
+  "border-ink bg-cream flex w-full max-w-[680px] items-stretch overflow-hidden rounded-none border-2 shadow-[5px_5px_0_0_var(--color-ink)]";


### PR DESCRIPTION
Closes #2105

Reskins `/zoeken` to the softened-S3 **dark search masthead** (design lock `docs/design/mockups/phase-8-search/8s1-architecture-locked.md`). Backend (bge-m3 / Vectorize, #2057) unchanged — presentation only.

## Changes

- **New `<SearchMasthead>`** (`Features/Search/SearchMasthead`) — a `jersey-deep-dark` full-bleed band (135° diagonal stripe texture + radial jersey wash) with a serif `<EditorialHeading>` **"Wat _zoek_ je?"** (warm-gold accent on "zoek", `tone="cream"`), a `children` slot for the field, and a persistent mono hint line. Server-renderable presentational shell (no hooks, no Phosphor).
- **`<SearchForm>` reskinned** to the 8s1 hard-shadow field — cream input, 2px ink border, `5px` offset paper shadow, warm-gold **`MagnifyingGlass` Fill** icon submit cell (`aria-label="Zoeken"`, no "ZOEK" word). Lucide → `@/lib/icons.redesign`. Clear (X) affordance kept. Shared shell classes extracted to `search-field-styles.ts` (plain module so the server skeleton can import the string without a `"use client"` client-reference).
- **`<SearchMastheadSkeleton>`** — renders the real masthead band + an inert field skeleton (no icon, so it stays server-safe). Reused by both `loading.tsx` and the page's `<Suspense>` fallback, so the band + `<h1>` ship in the initial HTML with no layout shift.
- **`SearchInterface`** wraps the field in `<SearchMasthead>` and renders filters/results on **cream below the band**; its fetch / analytics / URL-sync logic is unchanged. `<FilterTabs>` reused unchanged (via `<SearchFilters>`).
- **`page.tsx` / `loading.tsx`** drop the legacy green-gradient hero for a `bg-cream` shell.

## Acceptance criteria

- [x] Softened-S3 dark masthead: no kicker, serif `<EditorialHeading>` "Wat zoek je?" warm-gold accent on `jersey-deep-dark` (diagonal stripe + radial glow), mono hint line.
- [x] `SearchForm` hard-shadow field + `MagnifyingGlass` Fill icon button (warm-gold cell), no "ZOEK", `@/lib/icons.redesign` only (no lucide).
- [x] Results region renders on cream below the band; `<FilterTabs>` reused unchanged.
- [x] Story for the masthead (`Features/Search/SearchMasthead`); legacy green-gradient hero removed.
- [x] `pnpm --filter @kcvv/web check-all` passes.

## Testing

- `pnpm --filter @kcvv/web check-all` green: lint, type-check, **3316 tests**, and `next build` all pass. `/zoeken` prerenders as static (`○`).
- Updated tests: SearchForm submit-button name (`/^zoeken$/i`), removed the now-obsolete inline-hint assertions (hint moved to the masthead's persistent line), added `SearchMasthead.test.tsx`, updated the search barrel surface test and the `/zoeken` `loading-envelope` root-className guard.
- e2e `/zoeken` smoke contract unchanged (visible `<h1>`, nav/footer, no broken images / console errors).

## Analytics

No change — the `search_*` event shape (`useSearchAnalytics`) is untouched; the field still calls the same `handleSearch`/`handleFilterChange` paths.

## VR baselines

Per the redesign VR convention (baselines batch-captured at the end of the series; VR CI gated off), the new `Features/Search/SearchMasthead` + reskinned `Features/Search/SearchForm` stories carry the `vr` tag but **no PNG baselines are committed here** — they'll be captured in the Phase 8 VR sweep (8.5).

## Visual review

Best reviewed in Storybook (`Features/Search/SearchMasthead`, `SearchForm`) and on the Vercel preview (`/zoeken`).

## Follow-up (not in scope)

The radial jersey-wash gradient + 135° stripe texture are now hand-rolled inline in several dark bands (`OrganigramHero`, `MatchArticleLinkCard`, `NewsCard`, this masthead). Worth consolidating into a shared decorative utility in a later dark-band pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dark masthead component and a matching masthead loading skeleton; clear (×) control for the search field.

* **Visual Updates**
  * Redesigned search page to a cream background with centered masthead and updated search-field shell; replaced text submit with magnifying-glass icon; refreshed loading placeholders.

* **Tests & Stories**
  * Updated tests and Storybook stories to reflect new layout, button label, and fullscreen presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->