### PR TITLE
feat(search): /zoeken paper result rows + football-voice empty states (#2106)

### DIFF
--- a/apps/web/src/components/search/SearchInterface.stories.tsx
+++ b/apps/web/src/components/search/SearchInterface.stories.tsx
@@ -123,7 +123,7 @@ const SEARCH_NAVIGATION_PARAMS = {
 
 /**
  * Initial idle state — no query entered yet.
- * Shows the "Wat wil je zoeken?" help panel with category hints.
+ * Shows the "Waar ben je naar op zoek?" pre-search card with type hints (8s4).
  */
 export const Idle: Story = {
   args: {

--- a/apps/web/src/components/search/SearchInterface.stories.tsx
+++ b/apps/web/src/components/search/SearchInterface.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "vr"],
 } satisfies Meta<typeof SearchInterface>;
 
 export default meta;

--- a/apps/web/src/components/search/SearchInterface.test.tsx
+++ b/apps/web/src/components/search/SearchInterface.test.tsx
@@ -67,8 +67,9 @@ describe("SearchInterface", () => {
     it("should display help text initially when no query", () => {
       render(<SearchInterface />);
 
-      expect(screen.getByText(/wat wil je zoeken/i)).toBeInTheDocument();
-      expect(screen.getByText(/typ minimaal 2 karakters/i)).toBeInTheDocument();
+      expect(screen.getByText(/niet zeker waar te/i)).toBeInTheDocument();
+      // A type-hint chip, unique to the pre-search card.
+      expect(screen.getByText("Een spelersnaam")).toBeInTheDocument();
     });
 
     it("should not display filters initially", () => {
@@ -284,9 +285,7 @@ describe("SearchInterface", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/er is een fout opgetreden/i),
-        ).toBeInTheDocument();
+        expect(screen.getByText(/er ging iets mis/i)).toBeInTheDocument();
       });
     });
 
@@ -306,9 +305,7 @@ describe("SearchInterface", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/er is een fout opgetreden/i),
-        ).toBeInTheDocument();
+        expect(screen.getByText(/er ging iets mis/i)).toBeInTheDocument();
       });
     });
 
@@ -381,7 +378,7 @@ describe("SearchInterface", () => {
       // Results should be hidden, help text shown
       await waitFor(() => {
         expect(screen.queryByText(/resultaten voor/i)).not.toBeInTheDocument();
-        expect(screen.getByText(/wat wil je zoeken/i)).toBeInTheDocument();
+        expect(screen.getByText(/niet zeker waar te/i)).toBeInTheDocument();
       });
     });
   });
@@ -486,7 +483,7 @@ describe("SearchInterface", () => {
       await waitFor(
         () => {
           expect(
-            screen.queryByText(/er is een fout opgetreden/i),
+            screen.queryByText(/er ging iets mis/i),
           ).not.toBeInTheDocument();
         },
         { timeout: 1000 },
@@ -743,9 +740,7 @@ describe("SearchInterface", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/er is een fout opgetreden/i),
-        ).toBeInTheDocument();
+        expect(screen.getByText(/er ging iets mis/i)).toBeInTheDocument();
       });
 
       // Second search succeeds
@@ -760,9 +755,7 @@ describe("SearchInterface", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(
-          screen.queryByText(/er is een fout opgetreden/i),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText(/er ging iets mis/i)).not.toBeInTheDocument();
       });
     });
   });
@@ -823,7 +816,7 @@ describe("SearchInterface", () => {
     it("should show help text when query is empty", () => {
       render(<SearchInterface />);
 
-      expect(screen.getByText(/wat wil je zoeken/i)).toBeInTheDocument();
+      expect(screen.getByText(/niet zeker waar te/i)).toBeInTheDocument();
     });
 
     it("should show help text when query is 1 character", async () => {
@@ -834,7 +827,7 @@ describe("SearchInterface", () => {
       const input = screen.getByRole("textbox");
       await user.type(input, "a");
 
-      expect(screen.getByText(/wat wil je zoeken/i)).toBeInTheDocument();
+      expect(screen.getByText(/niet zeker waar te/i)).toBeInTheDocument();
     });
 
     it("should hide help text when query is 2+ characters", async () => {
@@ -855,7 +848,7 @@ describe("SearchInterface", () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByText(/wat wil je zoeken/i),
+          screen.queryByText(/niet zeker waar te/i),
         ).not.toBeInTheDocument();
       });
     });
@@ -896,9 +889,7 @@ describe("SearchInterface", () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/er is een fout opgetreden/i),
-        ).toBeInTheDocument();
+        expect(screen.getByText(/er ging iets mis/i)).toBeInTheDocument();
       });
 
       expect(screen.queryByText(/resultaten voor/i)).not.toBeInTheDocument();

--- a/apps/web/src/components/search/SearchInterface.tsx
+++ b/apps/web/src/components/search/SearchInterface.tsx
@@ -11,7 +11,8 @@ import { SearchForm } from "./SearchForm";
 import { SearchMasthead } from "./SearchMasthead";
 import { SearchFilters } from "./SearchFilters";
 import { SearchResults } from "./SearchResults";
-import { Spinner } from "@/components/design-system";
+import { SearchPreSearchCard } from "./SearchPreSearchCard";
+import { Alert, Spinner } from "@/components/design-system";
 import { useSearchAnalytics } from "@/hooks/useSearchAnalytics";
 import { filterByActiveType } from "./search-filter-utils";
 import type {
@@ -131,7 +132,7 @@ export const SearchInterface = ({
         return;
       }
 
-      setError("Er is een fout opgetreden bij het zoeken. Probeer opnieuw.");
+      setError("Er ging iets mis bij het zoeken — probeer opnieuw.");
       setResults([]);
       setTotalCount(0);
     } finally {
@@ -291,11 +292,11 @@ export const SearchInterface = ({
               </div>
             )}
 
-            {/* Error State */}
+            {/* Error State — paper ticket-stub Alert (8s4). */}
             {error && !isLoading && (
-              <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
-                <p className="text-red-800">{error}</p>
-              </div>
+              <Alert variant="error" title="Zoeken mislukt">
+                {error}
+              </Alert>
             )}
 
             {/* Results */}
@@ -310,42 +311,8 @@ export const SearchInterface = ({
           </>
         )}
 
-        {/* Help Text - Show when query is too short */}
-        {query.trim().length < 2 && (
-          <div className="rounded-xl bg-white p-8 text-center shadow-sm">
-            <h2 className="text-gray-blue mb-4 text-xl font-bold">
-              Wat wil je zoeken?
-            </h2>
-            <p className="text-gray-dark mb-6">
-              Typ minimaal 2 karakters om te zoeken naar nieuws, spelers, teams
-              en meer.
-            </p>
-            <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
-              <div className="rounded-lg bg-gray-50 p-4">
-                <h3 className="text-gray-blue mb-2 font-semibold">
-                  📰 Nieuwsartikelen
-                </h3>
-                <p className="text-gray-dark text-sm">
-                  Zoek op titel, inhoud of tags
-                </p>
-              </div>
-              <div className="rounded-lg bg-gray-50 p-4">
-                <h3 className="text-gray-blue mb-2 font-semibold">
-                  ⚽ Spelers
-                </h3>
-                <p className="text-gray-dark text-sm">
-                  Vind spelers op naam of positie
-                </p>
-              </div>
-              <div className="rounded-lg bg-gray-50 p-4">
-                <h3 className="text-gray-blue mb-2 font-semibold">🏆 Teams</h3>
-                <p className="text-gray-dark text-sm">
-                  Zoek teams op naam of leeftijdsgroep
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
+        {/* Pre-search state — football-voice paper card (8s4). */}
+        {query.trim().length < 2 && <SearchPreSearchCard />}
       </div>
     </>
   );

--- a/apps/web/src/components/search/SearchMasthead.stories.tsx
+++ b/apps/web/src/components/search/SearchMasthead.stories.tsx
@@ -26,9 +26,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
- * Default masthead — empty field, persistent hint line.
+ * Default masthead — empty field, no hint line (the `/zoeken` composition;
+ * guidance lives in the pre-search card below the band).
  */
 export const Default: Story = {};
+
+/**
+ * Optional hint line — opted into via the `hint` prop.
+ */
+export const WithHint: Story = {
+  args: {
+    hint: "Typ minstens 2 letters",
+  },
+};
 
 /**
  * Masthead with a populated query (clear affordance visible).

--- a/apps/web/src/components/search/SearchMasthead.test.tsx
+++ b/apps/web/src/components/search/SearchMasthead.test.tsx
@@ -40,14 +40,14 @@ describe("SearchMasthead", () => {
     expect(screen.getByTestId("field")).toBeInTheDocument();
   });
 
-  it("renders the persistent mono hint line", () => {
+  it("omits the hint line when no hint is provided", () => {
     render(
       <SearchMasthead>
         <div>field</div>
       </SearchMasthead>,
     );
 
-    expect(screen.getByText(/typ minstens 2 letters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/typ minstens/i)).not.toBeInTheDocument();
   });
 
   it("supports custom heading, accent and hint", () => {

--- a/apps/web/src/components/search/SearchMasthead.tsx
+++ b/apps/web/src/components/search/SearchMasthead.tsx
@@ -12,7 +12,12 @@ export interface SearchMastheadProps {
   heading?: string;
   /** Substring of `heading` rendered in the warm italic accent. */
   accent?: string;
-  /** Persistent mono hint line below the field. */
+  /**
+   * Optional mono hint line below the field. Omitted by default — the `/zoeken`
+   * page renders no hint (the pre-search card carries the guidance), so a
+   * persistent "Typ minstens 2 letters · …" line under the field read as
+   * redundant clutter (owner review #2106).
+   */
   hint?: string;
 }
 
@@ -21,14 +26,14 @@ export interface SearchMastheadProps {
  * a `jersey-deep-dark` full-bleed band (diagonal stripe texture + radial jersey
  * wash) wearing the search field as its hero. No mono kicker; a serif
  * `<EditorialHeading>` "Wat _zoek_ je?" with a **warm-gold** accent on "zoek"
- * (jersey-deep is invisible on the dark ground, 8s1.1); a persistent mono hint
+ * (jersey-deep is invisible on the dark ground, 8s1.1); an optional mono hint
  * line under the field. Results render on cream below the band (8s2/8s4).
  */
 export function SearchMasthead({
   children,
   heading = "Wat zoek je?",
   accent = "zoek",
-  hint = "Typ minstens 2 letters · nieuws · spelers · ploegen · staf",
+  hint,
 }: SearchMastheadProps) {
   return (
     <header className="bg-jersey-deep-dark border-ink relative overflow-hidden border-b-2">
@@ -64,9 +69,11 @@ export function SearchMasthead({
 
         {children}
 
-        <p className="text-cream/70 mt-3.5 font-mono text-[length:var(--text-mono-sm)] tracking-[0.03em]">
-          {hint}
-        </p>
+        {hint && (
+          <p className="text-cream/70 mt-3.5 font-mono text-[length:var(--text-mono-sm)] tracking-[0.03em]">
+            {hint}
+          </p>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/components/search/SearchNoResultsCard.stories.tsx
+++ b/apps/web/src/components/search/SearchNoResultsCard.stories.tsx
@@ -1,0 +1,39 @@
+/**
+ * SearchNoResultsCard Storybook Stories
+ *
+ * The `/zoeken` no-results state (8s4 E2, copy 8s4.1): taped jersey artefact +
+ * "Geen treffers." + a body line naming the query and inline way-forward links.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SearchNoResultsCard } from "./SearchNoResultsCard";
+
+const meta = {
+  title: "Features/Search/SearchNoResultsCard",
+  component: SearchNoResultsCard,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs", "vr"],
+} satisfies Meta<typeof SearchNoResultsCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Short query — the missing term is named inline.
+ */
+export const Default: Story = {
+  args: {
+    query: "elewijt",
+  },
+};
+
+/**
+ * A longer query, to check the body line wraps cleanly.
+ */
+export const LongQuery: Story = {
+  args: {
+    query: "kampioenschap tweede provinciale b",
+  },
+};

--- a/apps/web/src/components/search/SearchNoResultsCard.test.tsx
+++ b/apps/web/src/components/search/SearchNoResultsCard.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * SearchNoResultsCard Component Tests
+ */
+
+import type { ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SearchNoResultsCard } from "./SearchNoResultsCard";
+
+// Mock Next.js Link (Vitest hoisting requirement keeps this in-file).
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("SearchNoResultsCard", () => {
+  it("renders the football-pun headline", () => {
+    render(<SearchNoResultsCard query="elewijt" />);
+
+    // The trailing "." is an emphasis span, so the heading's own text node is
+    // "Geen treffers".
+    expect(screen.getByText("Geen treffers")).toBeInTheDocument();
+  });
+
+  it("names the missing query in the body", () => {
+    render(<SearchNoResultsCard query="zzqxptw" />);
+
+    expect(screen.getByText(/niets gevonden voor/i)).toBeInTheDocument();
+    expect(screen.getByText("zzqxptw")).toBeInTheDocument();
+  });
+
+  it("offers three inline way-forward links to section indexes", () => {
+    render(<SearchNoResultsCard query="elewijt" />);
+
+    expect(screen.getByRole("link", { name: "nieuws" })).toHaveAttribute(
+      "href",
+      "/nieuws",
+    );
+    // Players have no dedicated index — both ploegen and spelers resolve to
+    // /ploegen (owner decision, #2106).
+    expect(screen.getByRole("link", { name: "ploegen" })).toHaveAttribute(
+      "href",
+      "/ploegen",
+    );
+    expect(screen.getByRole("link", { name: "spelers" })).toHaveAttribute(
+      "href",
+      "/ploegen",
+    );
+  });
+
+  it("renders the taped jersey artefact", () => {
+    render(<SearchNoResultsCard query="elewijt" />);
+
+    // <JerseyShirt> renders a labelled <figure>.
+    expect(screen.getByLabelText("KCVV jersey")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/search/SearchNoResultsCard.tsx
+++ b/apps/web/src/components/search/SearchNoResultsCard.tsx
@@ -1,0 +1,71 @@
+/**
+ * SearchNoResultsCard — the `/zoeken` no-results state (8s4 E2, copy 8s4.1).
+ *
+ * Shown for a valid query that returned zero (filtered) hits. A cream paper
+ * card pairing a small taped `<JerseyShirt>` artefact with the football-pun
+ * headline "Geen treffers." (treffer = both a search hit and a goal) and a body
+ * line that names the missing query and offers inline way-forward links. The
+ * links are plain navigations to the section index routes — escape hatches out
+ * of the dead end (the "spelers" link resolves to /ploegen, since players live
+ * on the team pages; confirmed at build #2106).
+ */
+
+import Link from "next/link";
+import {
+  EditorialHeading,
+  JerseyShirt,
+  TapeStrip,
+} from "@/components/design-system";
+
+export interface SearchNoResultsCardProps {
+  /** The query that returned no results — named in the body line. */
+  query: string;
+}
+
+const WAY_FORWARD_LINK_CLASS =
+  "text-jersey-deep font-bold underline-offset-2 hover:underline";
+
+/**
+ * No-results paper card with taped jersey artefact + way-forward links.
+ */
+export function SearchNoResultsCard({ query }: SearchNoResultsCardProps) {
+  return (
+    <section className="border-ink bg-cream-soft shadow-paper-sm border-2 p-7 sm:p-8">
+      <div className="flex flex-col items-center gap-6 sm:flex-row sm:gap-7">
+        {/* Taped jersey artefact — modest, not dominant (8s4). */}
+        <div className="relative inline-block flex-shrink-0">
+          <TapeStrip color="warm" length="md" />
+          <JerseyShirt className="h-28 w-28 -rotate-3" />
+        </div>
+
+        <div className="text-center sm:text-left">
+          <EditorialHeading
+            level={2}
+            size="display-md"
+            emphasis={{ text: "." }}
+          >
+            Geen treffers
+          </EditorialHeading>
+
+          <p className="text-ink-soft mt-3 max-w-[52ch] text-[14.5px] leading-relaxed">
+            Niets gevonden voor &ldquo;
+            <strong className="text-ink font-semibold">{query}</strong>&rdquo;.
+            Probeer een andere term — of spring meteen naar{" "}
+            <Link href="/nieuws" className={WAY_FORWARD_LINK_CLASS}>
+              nieuws
+            </Link>
+            ,{" "}
+            <Link href="/ploegen" className={WAY_FORWARD_LINK_CLASS}>
+              ploegen
+            </Link>{" "}
+            of{" "}
+            <Link href="/ploegen" className={WAY_FORWARD_LINK_CLASS}>
+              spelers
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/search/SearchPreSearchCard.stories.tsx
+++ b/apps/web/src/components/search/SearchPreSearchCard.stories.tsx
@@ -1,0 +1,26 @@
+/**
+ * SearchPreSearchCard Storybook Stories
+ *
+ * The `/zoeken` pre-search state (8s4 E2): football-voice prompt + type hints,
+ * shown while the query is shorter than 2 characters.
+ */
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SearchPreSearchCard } from "./SearchPreSearchCard";
+
+const meta = {
+  title: "Features/Search/SearchPreSearchCard",
+  component: SearchPreSearchCard,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs", "vr"],
+} satisfies Meta<typeof SearchPreSearchCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default pre-search prompt with the three mono type-hint chips.
+ */
+export const Default: Story = {};

--- a/apps/web/src/components/search/SearchPreSearchCard.test.tsx
+++ b/apps/web/src/components/search/SearchPreSearchCard.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * SearchPreSearchCard Component Tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SearchPreSearchCard } from "./SearchPreSearchCard";
+
+describe("SearchPreSearchCard", () => {
+  it("renders the helper prompt heading", () => {
+    render(<SearchPreSearchCard />);
+
+    // "beginnen" is rendered as an emphasis span, so the heading's own text
+    // node is "Niet zeker waar te …?".
+    expect(screen.getByText(/niet zeker waar te/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /niet zeker waar te beginnen/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("frames the chips as examples", () => {
+    render(<SearchPreSearchCard />);
+
+    expect(screen.getByText(/zoek bijvoorbeeld naar/i)).toBeInTheDocument();
+  });
+
+  it("renders the three mono example chips", () => {
+    render(<SearchPreSearchCard />);
+
+    expect(screen.getByText("Een spelersnaam")).toBeInTheDocument();
+    expect(screen.getByText("Een ploeg")).toBeInTheDocument();
+    expect(screen.getByText("Een nieuwsbericht")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/search/SearchPreSearchCard.tsx
+++ b/apps/web/src/components/search/SearchPreSearchCard.tsx
@@ -1,0 +1,51 @@
+/**
+ * SearchPreSearchCard — the `/zoeken` pre-search state (8s4 E2).
+ *
+ * Shown while the query is shorter than 2 characters. Deliberately lightweight:
+ * the dark masthead already asks the question ("Wat _zoek_ je?"), so this card
+ * does NOT restate it — and the redundant "Typ minstens 2 letters · categories"
+ * helper line was dropped from the masthead entirely (that triple-repeat was
+ * flagged in owner review #2106). Its one job is to give concrete examples of
+ * what is searchable — a short helper heading plus three mono paper example
+ * chips. Replaces the legacy emoji help block.
+ */
+
+import { EditorialHeading } from "@/components/design-system";
+
+const TYPE_HINTS = [
+  "Een spelersnaam",
+  "Een ploeg",
+  "Een nieuwsbericht",
+] as const;
+
+/**
+ * Pre-search paper card with a helper prompt + example chips (8s4 E2).
+ */
+export function SearchPreSearchCard() {
+  return (
+    <section className="border-ink bg-cream-soft shadow-paper-sm border-2 p-7 sm:p-8">
+      <EditorialHeading
+        level={2}
+        size="display-sm"
+        emphasis={{ text: "beginnen" }}
+      >
+        Niet zeker waar te beginnen?
+      </EditorialHeading>
+
+      <p className="text-ink-soft mt-3 font-mono text-[11px] font-semibold tracking-[0.13em] uppercase">
+        Zoek bijvoorbeeld naar
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {TYPE_HINTS.map((hint) => (
+          <span
+            key={hint}
+            className="border-ink bg-cream text-ink border-[1.5px] px-[11px] py-1.5 font-mono text-[11px] font-semibold tracking-[0.06em] uppercase shadow-[2px_2px_0_0_var(--color-ink)]"
+          >
+            {hint}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/search/SearchResult.stories.tsx
+++ b/apps/web/src/components/search/SearchResult.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
   parameters: {
     layout: "padded",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "vr"],
 } satisfies Meta<typeof SearchResult>;
 
 export default meta;

--- a/apps/web/src/components/search/SearchResult.test.tsx
+++ b/apps/web/src/components/search/SearchResult.test.tsx
@@ -298,6 +298,46 @@ describe("SearchResult", () => {
     });
   });
 
+  describe("Thumbnail fallback (8s2 crest disc)", () => {
+    it("renders an initial-letter fallback disc when imageUrl is missing", () => {
+      const team = createMockTeam({ imageUrl: undefined, title: "A-Ploeg" });
+
+      render(<SearchResult result={team} />);
+
+      // No <img> is rendered — the jersey-deep initial disc takes its place.
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+      const fallback = screen.getByTestId("search-result-thumb-fallback");
+      expect(fallback).toHaveTextContent("A");
+    });
+
+    it("uppercases the fallback initial", () => {
+      const player = createMockPlayer({
+        imageUrl: undefined,
+        title: "wout van elewijt",
+      });
+
+      render(<SearchResult result={player} />);
+
+      expect(
+        screen.getByTestId("search-result-thumb-fallback"),
+      ).toHaveTextContent("W");
+    });
+
+    it("renders the photo (no fallback disc) when imageUrl is present", () => {
+      const team = createMockTeam({
+        imageUrl: "/images/team.jpg",
+        title: "A-Ploeg",
+      });
+
+      render(<SearchResult result={team} />);
+
+      expect(screen.getByAltText("A-Ploeg")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("search-result-thumb-fallback"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("Conditional Content", () => {
     it("should display description when provided", () => {
       const result = createMockArticle({
@@ -359,17 +399,6 @@ describe("SearchResult", () => {
 
       const image = screen.getByAltText("Article Title");
       expect(image).toBeInTheDocument();
-    });
-
-    it("should have aria-hidden on arrow icon", () => {
-      const result = createMockArticle();
-
-      render(<SearchResult result={result} />);
-
-      const arrowWrapper = screen.getByTestId("search-result-arrow");
-      const arrowIcon = arrowWrapper.querySelector("svg");
-      expect(arrowIcon).toBeInTheDocument();
-      expect(arrowIcon).toHaveAttribute("aria-hidden", "true");
     });
   });
 });

--- a/apps/web/src/components/search/SearchResult.tsx
+++ b/apps/web/src/components/search/SearchResult.tsx
@@ -1,13 +1,17 @@
 /**
  * SearchResult Component
- * Individual search result card
+ *
+ * 8s2-redux "postmark stamp" row (owner pick #2106): a cream paper card with a
+ * rotated rubber-stamp type badge pressed into the top-right corner, a
+ * newsprint-toned `64×64` square thumbnail (photo, or a jersey-deep initial disc
+ * for teams / missing photos), a serif (Freight) title, a muted snippet, and
+ * article tags as mono chips. Canonical paper press-down on hover.
  */
 
 import Link from "next/link";
 import Image from "next/image";
 import { SearchResult as SearchResultType } from "./SearchInterface";
-import { Icon } from "@/components/design-system";
-import { Newspaper, User, UserCog, Users, ArrowRight } from "lucide-react";
+import { MonoLabel, StampBadge } from "@/components/design-system";
 
 export interface SearchResultProps {
   /**
@@ -21,13 +25,6 @@ export interface SearchResultProps {
   // Note: query prop removed until highlighting feature is implemented (YAGNI)
 }
 
-const typeIcons = {
-  article: Newspaper,
-  player: User,
-  staff: UserCog,
-  team: Users,
-} as const;
-
 const typeLabels = {
   article: "Nieuws",
   player: "Speler",
@@ -35,101 +32,97 @@ const typeLabels = {
   team: "Team",
 } as const;
 
+const formatDate = (date: string) =>
+  new Date(date).toLocaleDateString("nl-BE", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
 /**
- * Individual search result card
+ * Individual search result row — postmark-stamp paper card (8s2-redux).
  */
 export const SearchResult = ({ result, onClick }: SearchResultProps) => {
+  const isArticle = result.type === "article";
+  const tags = isArticle ? result.tags : undefined;
+  const initial = result.title.trim().charAt(0).toUpperCase();
+
   return (
     <Link
       href={result.url}
       onClick={onClick}
-      className="group rounded-card hover:shadow-card-hover hover:border-green-main relative block overflow-hidden border border-gray-100 bg-white p-4 shadow-sm transition-all duration-300 hover:-translate-y-1"
+      className="group border-ink bg-cream-soft text-ink shadow-paper-sm relative flex gap-3.5 border-2 p-4 transition-all duration-300 hover:translate-x-1 hover:translate-y-1 hover:shadow-none"
     >
-      <div
-        className="bg-kcvv-green-bright pointer-events-none absolute inset-x-0 top-0 z-20 h-[3px] transition-[clip-path] duration-300 ease-out [clip-path:inset(0_50%)] group-hover:[clip-path:inset(0_0%)]"
-        aria-hidden="true"
-      />
-      <div className="flex gap-4">
-        {/* Image */}
-        {result.imageUrl && (
-          <div className="relative h-24 w-24 flex-shrink-0 overflow-hidden rounded-lg bg-gray-100">
-            <Image
-              src={result.imageUrl}
-              alt={result.title}
-              fill
-              className="object-cover"
-              sizes="96px"
-            />
-          </div>
+      {/* Rubber-stamp type badge, pressed into the top-right corner. */}
+      <StampBadge tone="jersey" position="top-right" rotation={-5}>
+        {typeLabels[result.type]}
+      </StampBadge>
+
+      {/* Uniform 64×64 square thumbnail — newsprint-toned photo when available,
+          else the jersey-deep initial disc (team crest / missing-photo
+          fallback). */}
+      <div className="border-ink bg-cream relative flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden border-[1.5px]">
+        {result.imageUrl ? (
+          <Image
+            src={result.imageUrl}
+            alt={result.title}
+            fill
+            className="object-cover"
+            sizes="64px"
+            // Newsprint colour treatment — matches squad/news/people photos
+            // across the site (photo-treatment-system-locked).
+            style={{ filter: "var(--filter-photo-newsprint)" }}
+          />
+        ) : (
+          <span
+            data-testid="search-result-thumb-fallback"
+            aria-hidden="true"
+            className="bg-jersey-deep text-cream font-display flex h-full w-full items-center justify-center text-[26px] leading-none font-black italic"
+          >
+            {initial}
+          </span>
+        )}
+      </div>
+
+      {/* Content — `pr-2` keeps the title clear of the corner stamp. */}
+      <div className="min-w-0 flex-1 pr-2">
+        {/* Date (articles only) */}
+        {isArticle && result.date && (
+          <span className="text-ink-muted font-mono text-[11px] tracking-[0.04em] uppercase">
+            {formatDate(result.date)}
+          </span>
         )}
 
-        {/* Content */}
-        <div className="min-w-0 flex-1">
-          {/* Type Badge */}
-          <div className="mb-2 flex items-center gap-2">
-            <span className="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">
-              <Icon icon={typeIcons[result.type]} size="xs" />
-              {typeLabels[result.type]}
-            </span>
+        {/* Title — Freight Display (the site's editorial card-title voice).
+            Rendered raw (not via <EditorialHeading>) so mixed-type result
+            titles — player/staff names especially — don't get a trailing
+            period appended. */}
+        <h3 className="font-display mt-1 line-clamp-2 text-[17px] leading-snug font-bold">
+          {result.title}
+        </h3>
 
-            {/* Date for articles */}
-            {result.type === "article" && result.date && (
-              <span className="text-xs text-gray-500">
-                {new Date(result.date).toLocaleDateString("nl-BE", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
+        {/* Snippet */}
+        {result.description && (
+          <p className="text-ink-soft mt-1 line-clamp-2 text-sm leading-snug">
+            {result.description}
+          </p>
+        )}
+
+        {/* Tags (articles only) */}
+        {tags && tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {tags.slice(0, 3).map((tag, index) => (
+              <MonoLabel key={`${tag}-${index}`} variant="pill-cream" size="sm">
+                {tag}
+              </MonoLabel>
+            ))}
+            {tags.length > 3 && (
+              <span className="text-ink-muted self-center font-mono text-[10px] tracking-[0.06em] uppercase">
+                +{tags.length - 3} meer
               </span>
             )}
           </div>
-
-          {/* Title */}
-          <h3 className="text-gray-blue group-hover:text-green-main mb-1 line-clamp-2 text-lg font-semibold transition-colors">
-            {result.title}
-          </h3>
-
-          {/* Description */}
-          {result.description && (
-            <p className="text-gray-dark mb-2 line-clamp-2 text-sm">
-              {result.description}
-            </p>
-          )}
-
-          {/* Tags (for articles) */}
-          {result.type === "article" &&
-            result.tags &&
-            result.tags.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-2">
-                {result.tags.slice(0, 3).map((tag, index) => (
-                  <span
-                    key={`${tag}-${index}`}
-                    className="rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700"
-                  >
-                    {tag}
-                  </span>
-                ))}
-                {result.tags.length > 3 && (
-                  <span className="px-2 py-1 text-xs text-gray-500">
-                    +{result.tags.length - 3} meer
-                  </span>
-                )}
-              </div>
-            )}
-        </div>
-
-        {/* Arrow Icon */}
-        <div
-          className="flex-shrink-0 self-center"
-          data-testid="search-result-arrow"
-        >
-          <Icon
-            icon={ArrowRight}
-            size="sm"
-            className="group-hover:text-green-main text-gray-400 transition-all group-hover:translate-x-1"
-            aria-hidden="true"
-          />
-        </div>
+        )}
       </div>
     </Link>
   );

--- a/apps/web/src/components/search/SearchResult.tsx
+++ b/apps/web/src/components/search/SearchResult.tsx
@@ -37,6 +37,9 @@ const formatDate = (date: string) =>
     day: "numeric",
     month: "short",
     year: "numeric",
+    // Pin to the club's zone so a date renders identically on the UTC
+    // SSR/build host and a Belgian client (no off-by-one / hydration drift).
+    timeZone: "Europe/Brussels",
   });
 
 /**

--- a/apps/web/src/components/search/SearchResults.stories.tsx
+++ b/apps/web/src/components/search/SearchResults.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
   parameters: {
     layout: "padded",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "vr"],
 } satisfies Meta<typeof SearchResults>;
 
 export default meta;
@@ -92,7 +92,7 @@ export const TeamsOnly: Story = {
 };
 
 /**
- * No results (empty state)
+ * No results — the 8s4 "Geen treffers." card (taped jersey + way-forward links).
  */
 export const NoResults: Story = {
   args: {

--- a/apps/web/src/components/search/SearchResults.test.tsx
+++ b/apps/web/src/components/search/SearchResults.test.tsx
@@ -169,7 +169,7 @@ describe("SearchResults", () => {
         <SearchResults results={results} query="test" activeType="player" />,
       );
 
-      expect(screen.getByText("Geen resultaten gevonden")).toBeInTheDocument();
+      expect(screen.getByText("Geen treffers")).toBeInTheDocument();
     });
   });
 
@@ -227,16 +227,14 @@ describe("SearchResults", () => {
     it("should display empty state when no results", () => {
       render(<SearchResults results={[]} query="nothing" activeType="all" />);
 
-      expect(screen.getByText("Geen resultaten gevonden")).toBeInTheDocument();
-      expect(
-        screen.getByText(/probeer een andere zoekopdracht/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Geen treffers")).toBeInTheDocument();
+      expect(screen.getByText(/niets gevonden voor/i)).toBeInTheDocument();
     });
 
-    it("should display empty state with emoji", () => {
+    it("should display the taped jersey artefact in the empty state", () => {
       render(<SearchResults results={[]} query="nothing" activeType="all" />);
 
-      expect(screen.getByText("🔍")).toBeInTheDocument();
+      expect(screen.getByLabelText("KCVV jersey")).toBeInTheDocument();
     });
 
     it("should not display count message when empty", () => {
@@ -252,7 +250,7 @@ describe("SearchResults", () => {
         <SearchResults results={results} query="test" activeType="player" />,
       );
 
-      expect(screen.getByText("Geen resultaten gevonden")).toBeInTheDocument();
+      expect(screen.getByText("Geen treffers")).toBeInTheDocument();
     });
   });
 
@@ -306,7 +304,7 @@ describe("SearchResults", () => {
     it("should handle empty array gracefully", () => {
       render(<SearchResults results={[]} query="test" activeType="all" />);
 
-      expect(screen.getByText("Geen resultaten gevonden")).toBeInTheDocument();
+      expect(screen.getByText("Geen treffers")).toBeInTheDocument();
     });
 
     it("should handle single result", () => {

--- a/apps/web/src/components/search/SearchResults.tsx
+++ b/apps/web/src/components/search/SearchResults.tsx
@@ -10,6 +10,7 @@ import type {
   SearchResultType,
 } from "./SearchInterface";
 import { SearchResult } from "./SearchResult";
+import { SearchNoResultsCard } from "./SearchNoResultsCard";
 import { filterByActiveType } from "./search-filter-utils";
 
 export interface SearchResultsProps {
@@ -50,32 +51,21 @@ export const SearchResults = ({
   const filteredResults = filterByActiveType(results, activeType);
 
   if (filteredResults.length === 0) {
-    return (
-      <div className="rounded-xl bg-white p-12 text-center shadow-sm">
-        <div className="mb-4 text-6xl">🔍</div>
-        <h3 className="text-gray-blue mb-2 text-xl font-bold">
-          Geen resultaten gevonden
-        </h3>
-        <p className="text-gray-dark">
-          Probeer een andere zoekopdracht of pas de filters aan
-        </p>
-      </div>
-    );
+    return <SearchNoResultsCard query={query} />;
   }
 
   return (
     <div className="space-y-6">
-      {/* Results Count */}
-      <div className="text-gray-dark">
-        <span className="text-gray-blue font-semibold">
-          {filteredResults.length}
-        </span>{" "}
-        {filteredResults.length === 1 ? "resultaat" : "resultaten"} voor &quot;
-        <span className="text-gray-blue font-semibold">{query}</span>&quot;
-      </div>
+      {/* Results count — mono meta line (8s2). */}
+      <p className="text-ink-muted font-mono text-xs tracking-[0.04em]">
+        <span className="text-ink font-semibold">{filteredResults.length}</span>{" "}
+        {filteredResults.length === 1 ? "resultaat" : "resultaten"} voor &ldquo;
+        <span className="text-ink font-semibold">{query}</span>&rdquo;
+      </p>
 
-      {/* Results List */}
-      <div className="space-y-4">
+      {/* Results list — generous gap so the corner stamps don't crowd the row
+          above (postmark stamps overhang the top edge). */}
+      <div className="space-y-6">
         {filteredResults.map((result, index) => (
           <SearchResult
             key={`${result.type}:${result.id}`}


### PR DESCRIPTION
Closes #2106

Reskins the `/zoeken` result list + non-result states onto the retro-terrace-fanzine design system (Phase 8.3). Builds on the 8.2 dark masthead / page shell (#2105).

## Changes

- **`SearchResult` — "postmark stamp" paper card**: cream paper, a rotated `<StampBadge>` type badge pressed into the corner, a uniform **64×64 newsprint-toned** photo thumbnail (or a **jersey-deep initial-disc** fallback for teams / missing photos), a **serif (Freight Display)** title, a mono date for articles, and article tags as `<MonoLabel pill-cream>` chips with a `+N meer` overflow. Lucide → Phosphor.
- **`SearchPreSearchCard`** (new): pre-search paper card — a helper heading + three mono example chips. Replaces the legacy emoji help block.
- **`SearchNoResultsCard`** (new): no-results card with a small taped `<JerseyShirt>` + **"Geen treffers."** (8s4.1) + a body line naming the query + inline way-forward links.
- **`SearchResults`**: renders the no-results card + a mono count line.
- **`SearchInterface`**: pre-search card + `<Alert variant="error">` error reskin; loading `<Spinner>` kept.
- **`SearchMasthead`**: `hint` made optional and dropped from `/zoeken` (de-duplicated the masthead/card/placeholder repetition).

## Owner decisions during build

- **No-results "spelers" link → `/ploegen`** — there is no `/spelers` index route (players live on the team pages), so the third escape-hatch link resolves to `/ploegen` (the 8s4 lock left this "confirmed at build").
- **Result-card direction** evolved beyond the 8s2 "clean rows" lock via Storybook review: clean rows → cream paper + newsprint photos + serif titles → an A/B/C exploration → the **postmark-stamp** card (owner pick).
- **Masthead hint removed** entirely (was a triple-repeat with the pre-search card + field placeholder).

## Analytics

Unchanged in shape — `trackNoResults` still fires on the redesigned no-results state and the query stays sanitised. The no-results way-forward links are plain `next/link` navigations (no new event), consistent with the deferred analytics wiring (#1974 / Phase 8.5).

## VR baselines

`Features/Search/*` stories cover every state (result rows incl. crest fallback, pre-search, no-results, error) and carry the `vr` tag. **Baseline capture is deferred** to the end-of-redesign batch per the VR gate (VR CI is gated off during the redesign) — this PR ships the `vr`-tagged stories only.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, 166 search tests, `next build`).
- Pre-PR `/code-review` (correctness) + `/simplify` (reuse/efficiency) run on the branch diff — both clean; applied two stale-comment fixes.
- Manual: review the Storybook stories under `Features/Search/*`, and the preview at `/zoeken` (try a query, a no-hit query, and the idle state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a pre-search suggestions card with example query chips.
  * Added a no-results card with navigation suggestions.
  * Made the search masthead hint text optional.

* **Bug Fixes**
  * Improved the search failure UI with clearer error wording and design-system alert styling.

* **Style**
  * Redesigned search result cards (updated stamp badge layout, hierarchy, and mono pill tags).
  * Improved thumbnails with a fallback initial when images are unavailable.
  * Updated empty-state “no results” copy and visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->