### PR TITLE
feat(ui): 404/500 ErrorState — centered layout + route wire-in (#2107)

### DIFF
--- a/apps/web/src/app/error.test.tsx
+++ b/apps/web/src/app/error.test.tsx
@@ -26,33 +26,33 @@ describe("Global Error page", () => {
     mockReset.mockReset();
   });
 
-  it("renders a Dutch error heading", () => {
+  it("renders the locked 500 pun heading", () => {
     render(<ErrorPage error={defaultError} reset={mockReset} />);
     expect(
-      screen.getByRole("heading", { name: /er ging iets mis/i }),
+      screen.getByRole("heading", { level: 1, name: /technische panne/i }),
     ).toBeInTheDocument();
   });
 
-  it("renders a description", () => {
+  it("renders the 500 body copy", () => {
     render(<ErrorPage error={defaultError} reset={mockReset} />);
     expect(
-      screen.getByText(/er is een onverwachte fout opgetreden/i),
+      screen.getByText(/er ging iets mis aan onze kant/i),
     ).toBeInTheDocument();
   });
 
-  it("renders a retry button that calls reset", async () => {
+  it("renders a retry button wired to reset()", async () => {
     const user = userEvent.setup();
     render(<ErrorPage error={defaultError} reset={mockReset} />);
     const retryButton = screen.getByRole("button", {
-      name: /probeer opnieuw/i,
+      name: "Probeer opnieuw",
     });
     await user.click(retryButton);
     expect(mockReset).toHaveBeenCalledOnce();
   });
 
-  it("renders a link to the homepage", () => {
+  it("renders a ghost link to the homepage", () => {
     render(<ErrorPage error={defaultError} reset={mockReset} />);
-    const homeLink = screen.getByRole("link", { name: /naar home/i });
+    const homeLink = screen.getByRole("link", { name: "Naar de homepage" });
     expect(homeLink).toHaveAttribute("href", "/");
   });
 

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { AlertTriangle, Home, RefreshCcw } from "lucide-react";
-import { Button, LinkButton } from "@/components/design-system";
+import { ErrorState } from "@/components/design-system";
 
+/**
+ * Global 500 error boundary (Phase 8.4). Renders the shared `<ErrorState>` in
+ * the chosen "centered" layout with the locked 500 copy + actions
+ * (`8e2-copy-locked.md`). Stays `"use client"` and self-contained at the root
+ * segment (outside the `(main)` layout); the `reset()` callback is wired to the
+ * primary "Probeer opnieuw" action.
+ */
 export default function ErrorPage({
   reset,
 }: {
@@ -10,37 +16,15 @@ export default function ErrorPage({
   reset: () => void;
 }) {
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-16">
-      <div className="max-w-md text-center">
-        <div className="mb-6">
-          <AlertTriangle
-            className="text-kcvv-gray mx-auto h-24 w-24 opacity-50"
-            strokeWidth={1.5}
-            aria-hidden="true"
-          />
-        </div>
-
-        <h1 className="text-kcvv-gray-dark mb-4 text-3xl font-bold">
-          Er ging iets mis
-        </h1>
-
-        <p className="text-kcvv-gray mb-8">
-          Er is een onverwachte fout opgetreden. Probeer de pagina opnieuw te
-          laden of keer terug naar de homepage.
-        </p>
-
-        <div className="flex flex-col justify-center gap-4 sm:flex-row">
-          <Button type="button" onClick={reset} size="lg">
-            <RefreshCcw className="h-5 w-5" aria-hidden="true" />
-            Probeer opnieuw
-          </Button>
-
-          <LinkButton href="/" size="lg" variant="ghost">
-            <Home className="h-5 w-5" aria-hidden="true" />
-            Naar home
-          </LinkButton>
-        </div>
-      </div>
-    </div>
+    <ErrorState
+      code="500"
+      codeLine="Fout 500 · er ging iets mis"
+      pun="Technische panne"
+      body="Er ging iets mis aan onze kant. Probeer het zo dadelijk opnieuw."
+      actions={[
+        { label: "Probeer opnieuw", onClick: reset, variant: "primary" },
+        { label: "Naar de homepage", href: "/", variant: "ghost" },
+      ]}
+    />
   );
 }

--- a/apps/web/src/app/not-found.test.tsx
+++ b/apps/web/src/app/not-found.test.tsx
@@ -18,24 +18,30 @@ vi.mock("next/link", () => ({
 }));
 
 describe("Global NotFound page", () => {
-  it("renders a Dutch heading", () => {
+  it("renders the locked 404 pun heading", () => {
     render(<NotFound />);
     expect(
-      screen.getByRole("heading", { name: /pagina niet gevonden/i }),
+      screen.getByRole("heading", { level: 1, name: /buiten de lijnen/i }),
     ).toBeInTheDocument();
   });
 
-  it("renders a description", () => {
+  it("renders the 404 body copy", () => {
     render(<NotFound />);
     expect(
-      screen.getByText(/de pagina die je zoekt bestaat niet/i),
+      screen.getByText(/deze pagina staat niet \(meer\) op het veld/i),
     ).toBeInTheDocument();
   });
 
-  it("renders a link to the homepage", () => {
+  it("renders a primary link to the homepage", () => {
     render(<NotFound />);
-    const homeLink = screen.getByRole("link", { name: /naar home/i });
+    const homeLink = screen.getByRole("link", { name: "Naar de homepage" });
     expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  it("renders a secondary search affordance to /zoeken", () => {
+    render(<NotFound />);
+    const searchLink = screen.getByRole("link", { name: "Zoeken" });
+    expect(searchLink).toHaveAttribute("href", "/zoeken");
   });
 
   it("does not render header or footer landmarks", () => {

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,34 +1,22 @@
-import { CircleHelp, Home } from "lucide-react";
-import { LinkButton } from "@/components/design-system";
+import { ErrorState } from "@/components/design-system";
 
+/**
+ * Global 404 page (Phase 8.4). Renders the shared `<ErrorState>` in the chosen
+ * "centered" layout with the locked 404 copy + actions (`8e2-copy-locked.md`):
+ * a way home plus a search affordance for a lost visitor. Self-contained on
+ * cream — the SiteHeader/Footer come from the root layout.
+ */
 export default function NotFound() {
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-16">
-      <div className="max-w-md text-center">
-        <div className="mb-6">
-          <CircleHelp
-            className="text-kcvv-gray mx-auto h-24 w-24 opacity-50"
-            strokeWidth={1.5}
-            aria-hidden="true"
-          />
-        </div>
-
-        <h1 className="text-kcvv-gray-dark mb-4 text-3xl font-bold">
-          Pagina niet gevonden
-        </h1>
-
-        <p className="text-kcvv-gray mb-8">
-          De pagina die je zoekt bestaat niet of is verplaatst. Controleer de
-          URL of keer terug naar de homepage.
-        </p>
-
-        <div className="flex flex-col justify-center gap-4 sm:flex-row">
-          <LinkButton href="/" size="lg">
-            <Home className="h-5 w-5" aria-hidden="true" />
-            Naar home
-          </LinkButton>
-        </div>
-      </div>
-    </div>
+    <ErrorState
+      code="404"
+      codeLine="Fout 404 · pagina niet gevonden"
+      pun="Buiten de lijnen"
+      body="Deze pagina staat niet (meer) op het veld. Misschien is de link verplaatst of bestaat ze niet meer."
+      actions={[
+        { label: "Naar de homepage", href: "/", variant: "primary" },
+        { label: "Zoeken", href: "/zoeken", variant: "ghost" },
+      ]}
+    />
   );
 }

--- a/apps/web/src/components/design-system/ErrorState/ErrorState.stories.tsx
+++ b/apps/web/src/components/design-system/ErrorState/ErrorState.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { fn } from "storybook/test";
-import { ErrorState } from "./ErrorState";
+import { ErrorState, type ErrorStateProps } from "./ErrorState";
 
 /**
  * Phase 8.4 — 404 / 500 error pages. The "centered" layout was chosen over the
@@ -19,18 +19,25 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const NOT_FOUND_ARGS = {
+  code: "404",
+  codeLine: "Fout 404 · pagina niet gevonden",
+  pun: "Buiten de lijnen",
+  body: "Deze pagina staat niet (meer) op het veld. Misschien is de link verplaatst of bestaat ze niet meer.",
+  actions: [
+    { label: "Naar de homepage", href: "/", variant: "primary" },
+    { label: "Zoeken", href: "/zoeken", variant: "ghost" },
+  ],
+} satisfies ErrorStateProps;
+
+/** Controls baseline — the shipped 404 composition. */
+export const Playground: Story = {
+  args: NOT_FOUND_ARGS,
+};
+
 export const NotFound404: Story = {
   name: "404 — Buiten de lijnen",
-  args: {
-    code: "404",
-    codeLine: "Fout 404 · pagina niet gevonden",
-    pun: "Buiten de lijnen",
-    body: "Deze pagina staat niet (meer) op het veld. Misschien is de link verplaatst of bestaat ze niet meer.",
-    actions: [
-      { label: "Naar de homepage", href: "/", variant: "primary" },
-      { label: "Zoeken", href: "/zoeken", variant: "ghost" },
-    ],
-  },
+  args: NOT_FOUND_ARGS,
 };
 
 export const ServerError500: Story = {

--- a/apps/web/src/components/design-system/ErrorState/ErrorState.stories.tsx
+++ b/apps/web/src/components/design-system/ErrorState/ErrorState.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { fn } from "storybook/test";
+import { ErrorState } from "./ErrorState";
+
+/**
+ * Phase 8.4 — 404 / 500 error pages. The "centered" layout was chosen over the
+ * "scoreboard" candidate in the Storybook A/B and is the shipped composition;
+ * the loser was removed before route wire-in (`8e1-composition-locked.md`).
+ * `vr`-tagged so the surviving layout acquires VR baselines per the
+ * master-design VR contract.
+ */
+const meta = {
+  title: "UI/ErrorState",
+  component: ErrorState,
+  tags: ["autodocs", "vr"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ErrorState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotFound404: Story = {
+  name: "404 — Buiten de lijnen",
+  args: {
+    code: "404",
+    codeLine: "Fout 404 · pagina niet gevonden",
+    pun: "Buiten de lijnen",
+    body: "Deze pagina staat niet (meer) op het veld. Misschien is de link verplaatst of bestaat ze niet meer.",
+    actions: [
+      { label: "Naar de homepage", href: "/", variant: "primary" },
+      { label: "Zoeken", href: "/zoeken", variant: "ghost" },
+    ],
+  },
+};
+
+export const ServerError500: Story = {
+  name: "500 — Technische panne",
+  args: {
+    code: "500",
+    codeLine: "Fout 500 · er ging iets mis",
+    pun: "Technische panne",
+    body: "Er ging iets mis aan onze kant. Probeer het zo dadelijk opnieuw.",
+    actions: [
+      { label: "Probeer opnieuw", onClick: fn(), variant: "primary" },
+      { label: "Naar de homepage", href: "/", variant: "ghost" },
+    ],
+  },
+};

--- a/apps/web/src/components/design-system/ErrorState/ErrorState.test.tsx
+++ b/apps/web/src/components/design-system/ErrorState/ErrorState.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorState, type ErrorStateAction } from "./ErrorState";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const notFoundActions: ErrorStateAction[] = [
+  { label: "Naar de homepage", href: "/", variant: "primary" },
+  { label: "Zoeken", href: "/zoeken", variant: "ghost" },
+];
+
+function renderNotFound() {
+  return render(
+    <ErrorState
+      code="404"
+      codeLine="Fout 404 · pagina niet gevonden"
+      pun="Buiten de lijnen"
+      body="Deze pagina staat niet (meer) op het veld."
+      actions={notFoundActions}
+    />,
+  );
+}
+
+describe("ErrorState", () => {
+  it("renders the mono code line", () => {
+    renderNotFound();
+    expect(
+      screen.getByText("Fout 404 · pagina niet gevonden"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the pun as an h1 with a trailing period", () => {
+    const { container } = renderNotFound();
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: /buiten de lijnen/i,
+    });
+    expect(heading).toBeInTheDocument();
+    // textContent concatenates inline nodes without the a11y-name spacing,
+    // so the locked trailing period is verifiable here verbatim.
+    expect(container.querySelector("h1")).toHaveTextContent(
+      "Buiten de lijnen.",
+    );
+  });
+
+  it("emphasises the last word of the pun by default", () => {
+    const { container } = renderNotFound();
+    const em = container.querySelector("h1 em");
+    expect(em).not.toBeNull();
+    expect(em).toHaveTextContent("lijnen");
+  });
+
+  it("emphasises an explicit punAccent when supplied", () => {
+    const { container } = render(
+      <ErrorState
+        code="500"
+        codeLine="Fout 500 · er ging iets mis"
+        pun="Technische panne"
+        punAccent="panne"
+        body="Er ging iets mis aan onze kant."
+        actions={[{ label: "Naar de homepage", href: "/" }]}
+      />,
+    );
+    const em = container.querySelector("h1 em");
+    expect(em).toHaveTextContent("panne");
+  });
+
+  it("renders the body copy", () => {
+    renderNotFound();
+    expect(
+      screen.getByText("Deze pagina staat niet (meer) op het veld."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the HTTP code as the jersey shirt number", () => {
+    renderNotFound();
+    const figure = screen.getByRole("figure", { name: "KCVV-shirt" });
+    expect(figure).toBeInTheDocument();
+    expect(within(figure).getByText("404")).toBeInTheDocument();
+  });
+
+  it("renders link actions with their hrefs", () => {
+    renderNotFound();
+    expect(
+      screen.getByRole("link", { name: "Naar de homepage" }),
+    ).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: "Zoeken" })).toHaveAttribute(
+      "href",
+      "/zoeken",
+    );
+  });
+
+  it("renders a button action and fires its onClick (e.g. reset)", async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+    render(
+      <ErrorState
+        code="500"
+        codeLine="Fout 500 · er ging iets mis"
+        pun="Technische panne"
+        body="Er ging iets mis aan onze kant."
+        actions={[
+          { label: "Probeer opnieuw", onClick: reset, variant: "primary" },
+          { label: "Naar de homepage", href: "/", variant: "ghost" },
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Probeer opnieuw" }));
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it("is self-contained — renders no header or footer landmarks", () => {
+    const { container } = renderNotFound();
+    expect(container.querySelector("header")).toBeNull();
+    expect(container.querySelector("footer")).toBeNull();
+  });
+
+  it("defaults to the primary variant when an action omits one", () => {
+    render(
+      <ErrorState
+        code="404"
+        codeLine="Fout 404 · pagina niet gevonden"
+        pun="Buiten de lijnen"
+        body="Deze pagina staat niet (meer) op het veld."
+        actions={[{ label: "Naar de homepage", href: "/" }]}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Naar de homepage" });
+    expect(link.className).toContain("bg-jersey-deep");
+  });
+
+  it("renders exactly the supplied actions", () => {
+    renderNotFound();
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/design-system/ErrorState/ErrorState.tsx
+++ b/apps/web/src/components/design-system/ErrorState/ErrorState.tsx
@@ -1,0 +1,135 @@
+/**
+ * <ErrorState> — shared 404 / 500 error-page composition (Phase 8.4).
+ *
+ * One component renders both the not-found and server-error pages, parameterised
+ * by `code` / `codeLine` / `pun` / `body` / `actions`. Self-contained on a cream
+ * full-bleed surface (no SiteHeader/Footer of its own — those come from the root
+ * layout) so it works at the root segment where `error.tsx` renders outside the
+ * `(main)` layout.
+ *
+ * Composition: a taped `<JerseyShirt>` carrying the HTTP code as its shirt number,
+ * a mono code line, a serif italic pun, body, and a centred action row. This is
+ * Candidate A ("centered") from the Phase 8.4 Storybook A/B — the owner picked it
+ * over the scoreboard candidate, which was removed before route wire-in.
+ *
+ * Copy + actions are locked in `8e2-copy-locked.md`; buttons stay plain (the wink
+ * lives in the headline only). The 500 "Probeer opnieuw" action is wired to the
+ * `reset()` callback from `error.tsx` via an `onClick` action.
+ *
+ * Spec: `docs/design/mockups/phase-8-errors/8e1-composition-locked.md` + `8e2`.
+ */
+import { Button } from "../Button";
+import { EditorialHeading } from "../EditorialHeading";
+import { JerseyShirt } from "../JerseyShirt";
+import { LinkButton } from "../LinkButton";
+import { TapedCard } from "../TapedCard";
+
+export type ErrorStateActionVariant = "primary" | "ghost";
+
+/**
+ * A single call-to-action in the error page's action row. Exactly one of `href`
+ * (renders a `<LinkButton>`) or `onClick` (renders a `<Button>`, e.g. the 500
+ * `reset()`) is expected.
+ */
+export interface ErrorStateAction {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  variant?: ErrorStateActionVariant;
+}
+
+export interface ErrorStateProps {
+  /** HTTP code, e.g. `"404"` — rendered as the jersey shirt number. */
+  code: string;
+  /** Mono descriptor line, e.g. `"Fout 404 · pagina niet gevonden"`. */
+  codeLine: string;
+  /** Headline without a trailing period, e.g. `"Buiten de lijnen"`. */
+  pun: string;
+  /** Accented substring of `pun`. Defaults to the last word of `pun`. */
+  punAccent?: string;
+  body: string;
+  actions: readonly ErrorStateAction[];
+}
+
+const CODE_LINE_CLASS =
+  "text-ink-muted font-mono text-[length:var(--text-mono-sm)] font-semibold tracking-[0.14em] uppercase";
+
+function lastWord(value: string): string {
+  const words = value.trim().split(/\s+/);
+  return words[words.length - 1] ?? value;
+}
+
+function ActionRow({ actions }: { actions: readonly ErrorStateAction[] }) {
+  return (
+    <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+      {actions.map((action) => {
+        const variant = action.variant ?? "primary";
+        return action.href !== undefined ? (
+          <LinkButton key={action.label} href={action.href} variant={variant}>
+            {action.label}
+          </LinkButton>
+        ) : (
+          <Button
+            key={action.label}
+            type="button"
+            variant={variant}
+            onClick={action.onClick}
+          >
+            {action.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ErrorState({
+  code,
+  codeLine,
+  pun,
+  punAccent,
+  body,
+  actions,
+}: ErrorStateProps) {
+  const accent = punAccent ?? lastWord(pun);
+
+  return (
+    <div className="bg-cream flex min-h-[70vh] flex-col items-center justify-center px-4 py-16 text-center md:py-20">
+      <div className="mx-auto flex max-w-[40rem] flex-col items-center">
+        <TapedCard
+          bg="cream"
+          rotation="b"
+          shadow="md"
+          padding="md"
+          tape={{ color: "warm", length: "md" }}
+          className="mb-7"
+        >
+          <JerseyShirt
+            letterOverlay={code}
+            // Generic label — the code itself is already announced by the mono
+            // code line, so the decorative shirt avoids re-announcing it.
+            ariaLabel="KCVV-shirt"
+            className="h-40 w-40"
+          />
+        </TapedCard>
+
+        <p className={CODE_LINE_CLASS}>{codeLine}</p>
+
+        <EditorialHeading
+          level={1}
+          size="display-xl"
+          emphasis={{ text: accent }}
+          className="mt-2 mb-0"
+        >
+          {pun}
+        </EditorialHeading>
+
+        <p className="text-ink-soft mt-3.5 max-w-[46ch] text-[length:var(--text-body-md)] leading-[var(--text-body-md--lh)]">
+          {body}
+        </p>
+
+        <ActionRow actions={actions} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/design-system/ErrorState/ErrorState.tsx
+++ b/apps/web/src/components/design-system/ErrorState/ErrorState.tsx
@@ -26,17 +26,30 @@ import { TapedCard } from "../TapedCard";
 
 export type ErrorStateActionVariant = "primary" | "ghost";
 
-/**
- * A single call-to-action in the error page's action row. Exactly one of `href`
- * (renders a `<LinkButton>`) or `onClick` (renders a `<Button>`, e.g. the 500
- * `reset()`) is expected.
- */
-export interface ErrorStateAction {
+interface ErrorStateActionBase {
   label: string;
-  href?: string;
-  onClick?: () => void;
   variant?: ErrorStateActionVariant;
 }
+
+/** A navigation action — renders a `<LinkButton>` to `href`. */
+export interface ErrorStateLinkAction extends ErrorStateActionBase {
+  href: string;
+  onClick?: never;
+}
+
+/** A button action — renders a `<Button>` (e.g. the 500 `reset()`). */
+export interface ErrorStateButtonAction extends ErrorStateActionBase {
+  onClick: () => void;
+  href?: never;
+}
+
+/**
+ * A single call-to-action in the error page's action row. Exactly one of a
+ * `href` (link) or an `onClick` (button) — the mutually-exclusive `never`
+ * fields make "both" and "neither" compile errors, so the row can never render
+ * a no-op button or silently drop an `onClick`.
+ */
+export type ErrorStateAction = ErrorStateLinkAction | ErrorStateButtonAction;
 
 export interface ErrorStateProps {
   /** HTTP code, e.g. `"404"` — rendered as the jersey shirt number. */

--- a/apps/web/src/components/design-system/ErrorState/index.ts
+++ b/apps/web/src/components/design-system/ErrorState/index.ts
@@ -1,0 +1,6 @@
+export {
+  ErrorState,
+  type ErrorStateProps,
+  type ErrorStateAction,
+  type ErrorStateActionVariant,
+} from "./ErrorState";

--- a/apps/web/src/components/design-system/index.ts
+++ b/apps/web/src/components/design-system/index.ts
@@ -126,6 +126,14 @@ export type {
   HighlighterStrokeColor,
 } from "./HighlighterStroke";
 
+// ErrorState
+export { ErrorState } from "./ErrorState";
+export type {
+  ErrorStateProps,
+  ErrorStateAction,
+  ErrorStateActionVariant,
+} from "./ErrorState";
+
 // JerseyShirt
 export { JerseyShirt } from "./JerseyShirt";
 export type { JerseyShirtProps } from "./JerseyShirt";


### PR DESCRIPTION
Closes #2107

Phase 8.4 of the redesign. Adds a shared `<ErrorState>` design-system primitive and wires it into the 404 + 500 pages.

## Storybook A/B (resolved)

Per the `8e1` lock, the layout pick was deferred to a live Storybook A/B. Both **centered (A)** and **scoreboard (C)** layouts were built TDD-first with stories for both pages, then the owner picked **centered (A)** in Storybook. The scoreboard branch + its two stories were removed before route wire-in.

## Changes

- **New `<ErrorState>`** (`apps/web/src/components/design-system/ErrorState/`) — props `code` / `codeLine` / `pun` / `punAccent?` / `body` / `actions`. Composes the shipped `<JerseyShirt>` (HTTP code as the shirt number) inside a taped `<TapedCard>`, a mono code line, a serif italic `<EditorialHeading>` pun, body, and a centered action row built from `<Button>` / `<LinkButton>`. Phosphor-only — no lucide. Self-contained on cream.
- **`not-found.tsx` (404)** — "Buiten de lijnen." · `Naar de homepage` (`/`) + `Zoeken` (`/zoeken`). The `/zoeken` secondary is the single search affordance (no duplicate inline body link), per `8e2`.
- **`error.tsx` (500)** — "Technische panne." · `Probeer opnieuw` (wired to `reset()`) + `Naar de homepage` (`/`). Stays `"use client"` and self-contained at the root segment (outside the `(main)` layout).
- Barrel export + `UI/ErrorState` stories (404 + 500) + unit tests; route tests updated to the locked copy.

## PRD §10 discovered-unknown — verified

The root `app/layout.tsx` (not the `(main)` layout) supplies the font variables + `globals.css` tokens and wraps both `not-found.tsx` and `error.tsx`, so cream + Freight-Display render correctly without the `(main)` layout. `<ErrorState>` is intentionally a **shared** component (no `"use client"`): the 404 page stays server-rendered, while `error.tsx` bundles it client-side and passes `reset()` as an action `onClick`.

## VR baselines

`UI/ErrorState` is `vr`-tagged. Per the active redesign VR policy (`feedback_vr_baselines_deferred_during_redesign`; CI VR gated off behind `RUN_VISUAL_REGRESSION`), baseline capture is **deferred to the redesign batch capture** rather than committed per-PR — consistent with the recent Phase 8.3 search PR. No baseline PNGs are added here.

## Analytics

No new events in this PR. The optional `error_*` taxonomy (`error_view` / `error_action_click`) is explicitly scoped to **Phase 8.5** per PRD §7 (owner call on whether to instrument error pages at all) — not wired here.

## Testing

- `pnpm --filter @kcvv/web check-all` — green (lint, type-check, 11 ErrorState + updated route tests, build).
- 404 e2e smoke (`playwright … -g "unknown route"`) — green.
- Pre-PR gate: `/code-review` (high) + `/simplify` run on the branch diff. Applied: generic decorative-jersey `aria-label` (avoids re-announcing the code already in the code line); removed a dead `inline-block` class on a flex item. Refuted with reasons: button `size` (intentional reskin to the locked mockup proportions, owner-approved in the A/B), `CODE_LINE_CLASS`/`lastWord`/barrel-import "duplication" (established precedents / no shared util), and the missing-`"use client"` suggestion (would force the 404 page client-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the 404 and 500 error pages using a shared, consistent error-page component with updated Dutch copy.
  * Updated actions: primary “Probeer opnieuw” on server error and improved navigation links (“Naar de homepage”, “Zoeken”) on not-found.
* **Documentation**
  * Added Storybook documentation with interactive 404/500 examples for the new error-page component.
* **Tests**
  * Updated UI tests to match the revised Dutch text and accessible link/button names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->