### PR TITLE
docs(ui): Phase 10 generic page-hero design mockups (#2120)

### DIFF
--- a/docs/design/mockups/phase-10-page-hero/10h1-voice-register-compare.html
+++ b/docs/design/mockups/phase-10-page-hero/10h1-voice-register-compare.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 10 · generic page-hero · 10h1: VOICE / REGISTER compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; background: var(--cream); color: var(--ink);
+        font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 96ch; }
+      .harness-head b { color: var(--warm); }
+      .direction-bar {
+        position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em;
+        text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); flex-wrap: wrap;
+      }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 26px 28px 40px; border-bottom: 1px dashed var(--paper-edge); }
+      .wrap { max-width: 1080px; margin: 0 auto; }
+      .statelabel { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-muted); margin: 0 0 8px; }
+      .two { display: grid; grid-template-columns: 1fr; gap: 26px; }
+
+      /* ===== shared content kit (maps to real primitives) ===== */
+      .kicker { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); display: inline-block; }
+      .kicker.cream { color: var(--cream); }
+      .eh { font-family: var(--font-display); font-weight: 900; font-style: normal; line-height: 0.94; margin: 12px 0 0; letter-spacing: -0.01em; font-size: clamp(2.4rem, 6vw, 4.2rem); }
+      .eh .accent { font-style: italic; color: var(--jersey-deep); font-weight: 900; }
+      .eh.cream { color: var(--cream); } .eh.cream .accent { color: var(--warm); }
+      .eh .dot { color: var(--warm); font-style: normal; }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; line-height: 1.4; font-size: clamp(1.05rem, 2vw, 1.4rem); margin: 16px 0 0; max-width: 40ch; color: var(--ink-soft); }
+      .lead.cream { color: rgba(245,241,230,0.85); }
+
+      /* taped figure (newsprint photo + tape) */
+      .tfig { position: relative; border: 2px solid var(--ink); background: var(--cream-soft); padding: 8px; box-shadow: 3px 4px 0 0 var(--ink); }
+      .tfig .photo { display: block; width: 100%; aspect-ratio: 4 / 3; background:
+        linear-gradient(135deg, #6b8f7a 0%, #3f6b54 55%, #244536 100%);
+        filter: sepia(0.32) saturate(0.82) contrast(1.02); }
+      .tfig.dark { background: var(--cream); }
+      .tape { position: absolute; top: -11px; left: 28px; width: 78px; height: 22px; background: var(--warm); border: 1.5px solid var(--ink); transform: rotate(-4deg); opacity: 0.92; }
+      .tape.r { left: auto; right: 30px; transform: rotate(3deg); }
+
+      /* ===== Variant A — cream-minimal ===== */
+      .vA { background: var(--cream); padding: 40px 34px; border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); }
+      .vA .belowfig { margin-top: 24px; max-width: 620px; }
+
+      /* ===== Variant B — dark band ===== */
+      .vB { background: var(--jersey-deep-dark); padding: 40px 34px; border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); position: relative; overflow: hidden; }
+      .vB::before { content: ""; position: absolute; inset: 0; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.06'/%3E%3C/svg%3E"); pointer-events: none; }
+      .vB .grid { position: relative; display: grid; grid-template-columns: 1.5fr 1fr; gap: 30px; align-items: center; }
+      .vB .grid.solo { grid-template-columns: 1fr; }
+      .vB .jersey-fallback { display: grid; place-items: center; aspect-ratio: 4/3; border: 2px solid var(--cream); background: var(--jersey-deep); }
+      .vB .jersey-fallback span { font-family: var(--font-display); font-weight: 900; font-size: 3rem; color: var(--cream); }
+
+      /* ===== Variant C — cream paper-card ===== */
+      .vC { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 7px 0 0 var(--ink); padding: 38px 34px; }
+      .vC .grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 30px; align-items: center; }
+      .vC .grid.solo { grid-template-columns: 1fr; }
+      .vC .cardtape { position: absolute; top: -13px; left: 50%; transform: translateX(-50%) rotate(-2deg); width: 150px; height: 26px; background: var(--warm); border: 2px solid var(--ink); }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 40px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 14px; padding-left: 18px; }
+      .legend .q { background: var(--ink); color: var(--cream); padding: 14px 18px; margin-top: 10px; }
+      .legend .q b { color: var(--warm); }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 10 · Generic page-hero · 10h1 — VOICE / REGISTER compare</h1>
+      <p>
+        Replaces the legacy dark-gradient <b>&lt;InteriorPageHero&gt;</b> on /kalender, /club, /club/[slug], /scheurkalender.
+        Round 1 locks the <b>chrome register</b> only — fields, image rules and per-element details come in later rounds.
+        Same content kit in all three (mono <b>kicker</b> + Freight <b>EditorialHeading</b> with "." accent + italic
+        <b>lead</b> + <b>TapedFigure</b> newsprint photo). Each register is shown in its two real states:
+        <b>WITH image</b> (kalender marquee) and <b>NO image</b> (club-index motto, with a one-word accent).
+      </p>
+    </div>
+
+    <!-- ============ VARIANT A ============ -->
+    <div class="direction-bar">
+      <span class="tag">A</span> Cream-minimal
+      <span class="note">bg-cream · ink text · no band · photo drops to a TapedFigure below — the /privacy register</span>
+    </div>
+    <div class="stage"><div class="wrap two">
+      <div>
+        <p class="statelabel">State 1 · WITH image (kalender)</p>
+        <div class="vA">
+          <span class="kicker">Kalender</span>
+          <h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1>
+          <p class="lead">Alle wedstrijden en activiteiten van KCVV Elewijt, seizoen na seizoen.</p>
+          <div class="belowfig tfig"><span class="tape"></span><span class="photo"></span></div>
+        </div>
+      </div>
+      <div>
+        <p class="statelabel">State 2 · NO image (club index)</p>
+        <div class="vA">
+          <span class="kicker">Onze club</span>
+          <h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1>
+          <p class="lead">Er is maar één plezante compagnie.</p>
+        </div>
+      </div>
+    </div></div>
+
+    <!-- ============ VARIANT B ============ -->
+    <div class="direction-bar">
+      <span class="tag">B</span> Dark band
+      <span class="note">bg-jersey-deep-dark · cream text · warm "." · TapedFigure pops on dark / JerseyShirt fallback — the BoardHero register</span>
+    </div>
+    <div class="stage"><div class="wrap two">
+      <div>
+        <p class="statelabel">State 1 · WITH image (kalender)</p>
+        <div class="vB"><div class="grid">
+          <div>
+            <span class="kicker cream">Kalender</span>
+            <h1 class="eh cream">Wedstrijd&shy;kalender<span class="dot">.</span></h1>
+            <p class="lead cream">Alle wedstrijden en activiteiten van KCVV Elewijt, seizoen na seizoen.</p>
+          </div>
+          <div class="tfig dark"><span class="tape r"></span><span class="photo"></span></div>
+        </div></div>
+      </div>
+      <div>
+        <p class="statelabel">State 2 · NO image (club index → JerseyShirt fallback)</p>
+        <div class="vB"><div class="grid">
+          <div>
+            <span class="kicker cream">Onze club</span>
+            <h1 class="eh cream">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1>
+            <p class="lead cream">Er is maar één plezante compagnie.</p>
+          </div>
+          <div class="jersey-fallback"><span>KCVV</span></div>
+        </div></div>
+      </div>
+    </div></div>
+
+    <!-- ============ VARIANT C ============ -->
+    <div class="direction-bar">
+      <span class="tag">C</span> Cream paper-card
+      <span class="note">cream TapedCard · ink border + hard shadow + tape · TapedFigure inset — the memorabilia register</span>
+    </div>
+    <div class="stage"><div class="wrap two">
+      <div>
+        <p class="statelabel">State 1 · WITH image (kalender)</p>
+        <div class="vC"><span class="cardtape"></span><div class="grid">
+          <div>
+            <span class="kicker">Kalender</span>
+            <h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1>
+            <p class="lead">Alle wedstrijden en activiteiten van KCVV Elewijt, seizoen na seizoen.</p>
+          </div>
+          <div class="tfig"><span class="tape r"></span><span class="photo"></span></div>
+        </div></div>
+      </div>
+      <div>
+        <p class="statelabel">State 2 · NO image (club index)</p>
+        <div class="vC"><span class="cardtape"></span><div class="grid solo">
+          <div>
+            <span class="kicker">Onze club</span>
+            <h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1>
+            <p class="lead">Er is maar één plezante compagnie.</p>
+          </div>
+        </div></div>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Primitive mapping (no new vocabulary)</h3>
+      <ul>
+        <li><b>Kicker</b> → <code>&lt;MonoLabel variant="plain"&gt;</code> (jersey-deep raw label-token span on cream; cream on dark).</li>
+        <li><b>Headline</b> → <code>&lt;EditorialHeading level=1&gt;</code> — Freight, upright, italic jersey-deep/warm accent word + warm "." terminator.</li>
+        <li><b>Lead</b> → italic <code>font-display</code> (auto-hides when absent — see club/[slug] + scheurkalender).</li>
+        <li><b>Photo</b> → <code>&lt;TapedFigure&gt;</code> newsprint (colour, not greyscale) + one tape strip; <b>no photo</b> → text-only (A) / <code>&lt;JerseyShirt&gt;</code> (B) / text-only (C).</li>
+      </ul>
+      <h3>Trade-offs</h3>
+      <ul>
+        <li><b>A cream-minimal</b> — calmest, perfect for plain/CMS pages; but light presence on marquee pages, and the photo reads as "below the title" rather than part of the hero.</li>
+        <li><b>B dark band</b> — strongest marquee presence + best photo pop; but a dark band on <em>every</em> interior page (incl. utility ones) can feel heavy/repetitive, and it's the closest to the legacy dark hero it replaces.</li>
+        <li><b>C cream paper-card</b> — most retro-terrace character, one shape handles image/no-image; but a bordered card hero is the heaviest chrome and must not read as just another content card.</li>
+      </ul>
+      <div class="q">
+        <b>ROUND 1 — pick the voice.</b> Which chrome register should the generic page-hero adopt? (A cream-minimal · B dark band · C cream paper-card · or a hybrid — e.g. "C with a register prop that flips to B's dark fill for marquee pages".) Once locked, Round 2 drills the real fields + image rules.
+      </div>
+      <p class="micro">phase-10 · 10h1 · generic page-hero voice · placeholder content expected at this stage</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-10-page-hero/10h2-layout-compare.html
+++ b/docs/design/mockups/phase-10-page-hero/10h2-layout-compare.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 10 · generic page-hero · 10h2: LAYOUT / IA compare (voice C locked)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 96ch; }
+      .harness-head b { color: var(--warm); }
+      .lockbar { background: var(--cream-deep); color: var(--ink); border-bottom: 2px solid var(--ink); padding: 9px 28px; font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.04em; }
+      .lockbar b { background: var(--jersey-deep); color: var(--cream); padding: 2px 8px; }
+      .direction-bar {
+        position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream);
+        padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em;
+        text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); flex-wrap: wrap;
+      }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 24px 28px 36px; border-bottom: 1px dashed var(--paper-edge); }
+      .wrap { max-width: 1180px; margin: 0 auto; }
+      .states { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+      .statelabel { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-muted); margin: 0 0 8px; }
+
+      /* ===== shared content kit ===== */
+      .kicker { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); display: inline-block; }
+      .eh { font-family: var(--font-display); font-weight: 900; font-style: normal; line-height: 0.95; margin: 9px 0 0; letter-spacing: -0.01em; font-size: clamp(1.5rem, 3vw, 2.3rem); }
+      .eh .accent { font-style: italic; color: var(--jersey-deep); }
+      .eh .dot { color: var(--warm); }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; line-height: 1.38; font-size: clamp(0.95rem, 1.3vw, 1.1rem); margin: 12px 0 0; color: var(--ink-soft); }
+
+      /* card shell (voice C — locked) */
+      .card { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); padding: 26px 24px; }
+      .cardtape { position: absolute; top: -12px; left: 28px; width: 96px; height: 22px; background: var(--warm); border: 2px solid var(--ink); transform: rotate(-3deg); }
+      .cardtape.c { left: 50%; transform: translateX(-50%) rotate(-2deg); }
+
+      /* taped figure */
+      .tfig { position: relative; border: 2px solid var(--ink); background: var(--cream-soft); padding: 6px; box-shadow: 3px 3px 0 0 var(--ink); }
+      .tfig .photo { display: block; width: 100%; background: linear-gradient(135deg, #6b8f7a 0%, #3f6b54 55%, #244536 100%); filter: sepia(0.32) saturate(0.82) contrast(1.02); }
+      .tfig .photo.r43 { aspect-ratio: 4/3; } .tfig .photo.wide { aspect-ratio: 16/7; }
+      .tape2 { position: absolute; top: -9px; right: 18px; width: 60px; height: 17px; background: var(--warm); border: 1.5px solid var(--ink); transform: rotate(3deg); }
+
+      /* α split */
+      .lay-split { display: grid; grid-template-columns: 1.35fr 1fr; gap: 20px; align-items: center; }
+      .lay-split.solo { grid-template-columns: 1fr; }
+      /* β broadsheet */
+      .lay-broad .head { } .lay-broad .fig { margin-top: 16px; } .lay-broad .lead { max-width: 52ch; }
+      /* γ poster */
+      .lay-poster { text-align: center; } .lay-poster .kicker, .lay-poster .eh, .lay-poster .lead { } .lay-poster .lead { margin-left: auto; margin-right: auto; max-width: 46ch; } .lay-poster .fig { margin: 16px auto 0; max-width: 460px; }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 40px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 14px; padding-left: 18px; }
+      .legend .q { background: var(--ink); color: var(--cream); padding: 14px 18px; margin-top: 10px; }
+      .legend .q b { color: var(--warm); }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+      @media (max-width: 900px) { .states { grid-template-columns: 1fr; } .lay-split { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 10 · Generic page-hero · 10h2 — LAYOUT / IA compare</h1>
+      <p>
+        Round 2 drills how the <b>cream paper-card</b> composes its real fields, using the genuine content of the 4 surfaces.
+        Columns are the three content states every surface degrades through: <b>① marquee</b> (image + lead — kalender),
+        <b>② motto</b> (no image, lead + one-word accent — club index), <b>③ bare</b> (no image, no lead — scheurkalender / a CMS title).
+        Pick the layout system; it must read well in all three.
+      </p>
+    </div>
+    <div class="lockbar">ROUND 1 LOCKED → <b>Voice C · cream paper-card</b> (TapedCard · ink border + hard shadow + tape · ink text · TapedFigure inset).</div>
+
+    <!-- ===== α SPLIT ===== -->
+    <div class="direction-bar"><span class="tag">α</span> Split &nbsp;<span class="note">text-left · TapedFigure right · no-image collapses to full-width text</span></div>
+    <div class="stage"><div class="wrap states">
+      <div><p class="statelabel">① marquee (kalender)</p>
+        <div class="card"><span class="cardtape"></span><div class="lay-split">
+          <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p></div>
+          <div class="tfig"><span class="tape2"></span><span class="photo r43"></span></div>
+        </div></div>
+      </div>
+      <div><p class="statelabel">② motto (club index)</p>
+        <div class="card"><span class="cardtape"></span><div class="lay-split solo">
+          <div><span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1><p class="lead">Er is maar één plezante compagnie.</p></div>
+        </div></div>
+      </div>
+      <div><p class="statelabel">③ bare (scheurkalender)</p>
+        <div class="card"><span class="cardtape"></span><div class="lay-split solo">
+          <div><span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1></div>
+        </div></div>
+      </div>
+    </div></div>
+
+    <!-- ===== β BROADSHEET ===== -->
+    <div class="direction-bar"><span class="tag">β</span> Broadsheet &nbsp;<span class="note">headline full-width top · wide TapedFigure band beneath · lead column</span></div>
+    <div class="stage"><div class="wrap states">
+      <div><p class="statelabel">① marquee (kalender)</p>
+        <div class="card"><span class="cardtape"></span><div class="lay-broad">
+          <div class="head"><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1></div>
+          <div class="fig tfig"><span class="tape2"></span><span class="photo wide"></span></div>
+          <p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p>
+        </div></div>
+      </div>
+      <div><p class="statelabel">② motto (club index)</p>
+        <div class="card"><span class="cardtape"></span><div class="lay-broad">
+          <div class="head"><span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1></div>
+          <p class="lead">Er is maar één plezante compagnie.</p>
+        </div></div>
+      </div>
+      <div><p class="statelabel">③ bare (scheurkalender)</p>
+        <div class="card"><span class="cardtape"></span><div class="lay-broad">
+          <div class="head"><span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1></div>
+        </div></div>
+      </div>
+    </div></div>
+
+    <!-- ===== γ POSTER ===== -->
+    <div class="direction-bar"><span class="tag">γ</span> Poster &nbsp;<span class="note">centered kicker + headline + lead · TapedFigure centered below</span></div>
+    <div class="stage"><div class="wrap states">
+      <div><p class="statelabel">① marquee (kalender)</p>
+        <div class="card"><span class="cardtape c"></span><div class="lay-poster">
+          <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p></div>
+          <div class="fig tfig"><span class="tape2"></span><span class="photo r43"></span></div>
+        </div></div>
+      </div>
+      <div><p class="statelabel">② motto (club index)</p>
+        <div class="card"><span class="cardtape c"></span><div class="lay-poster">
+          <span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1><p class="lead">Er is maar één plezante compagnie.</p>
+        </div></div>
+      </div>
+      <div><p class="statelabel">③ bare (scheurkalender)</p>
+        <div class="card"><span class="cardtape c"></span><div class="lay-poster">
+          <span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1>
+        </div></div>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>What's being decided</h3>
+      <ul>
+        <li><b>α Split</b> — asymmetric editorial; photo is a true hero partner. No-image cleanly collapses to full-width text. Long CMS titles get less width. Most like TeamHero/BoardHero IA.</li>
+        <li><b>β Broadsheet</b> — headline owns the full card width (best for long CMS titles + the motto); photo is a wide landscape band. No-image/no-lead states are very clean. Photo feels more "figure" than "hero partner".</li>
+        <li><b>γ Poster</b> — symmetrical, ceremonial; great for the club-index marquee. But centered editorial fights the left-aligned system used everywhere else in the redesign, and bare titles can look stranded.</li>
+      </ul>
+      <h3>Fields the hero exposes (same in all layouts)</h3>
+      <ul>
+        <li><code>kicker</code> (req) · <code>headline</code> + optional one-word <code>accent</code> + "." (req) · <code>lead</code> (opt, auto-hides) · <code>image</code> (opt) · <code>cta</code> (opt — none of the 4 pass it today, but kept for parity).</li>
+      </ul>
+      <div class="q"><b>ROUND 2 — pick the layout</b> (α split · β broadsheet · γ poster · or a note). Round 3 then drills per-element details: image aspect + tape, accent rules, compact size for utility/loading pages, CTA.</div>
+      <p class="micro">phase-10 · 10h2 · generic page-hero layout · voice C locked · real surface content</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-10-page-hero/10h3-responsive-sizing-compare.html
+++ b/docs/design/mockups/phase-10-page-hero/10h3-responsive-sizing-compare.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 10 · generic page-hero · 10h3: RESPONSIVE + SIZING (voice C + split α locked)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+      }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 96ch; }
+      .harness-head b { color: var(--warm); }
+      .lockbar { background: var(--cream-deep); color: var(--ink); border-bottom: 2px solid var(--ink); padding: 9px 28px; font-family: var(--font-mono); font-size: 12px; }
+      .lockbar b { background: var(--jersey-deep); color: var(--cream); padding: 2px 8px; }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream); padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); flex-wrap: wrap; }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 24px 28px 36px; border-bottom: 1px dashed var(--paper-edge); }
+      .wrap { max-width: 1180px; margin: 0 auto; }
+      .statelabel { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-muted); margin: 0 0 8px; }
+      .phones { display: flex; gap: 30px; flex-wrap: wrap; }
+      .phone { width: 360px; max-width: 100%; }
+      .phone .frame { border: 2px solid var(--ink); box-shadow: 4px 5px 0 0 var(--ink); background: var(--cream-soft); padding: 10px; }
+
+      /* content kit */
+      .kicker { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); display: inline-block; }
+      .eh { font-family: var(--font-display); font-weight: 900; line-height: 0.95; margin: 9px 0 0; letter-spacing: -0.01em; font-size: clamp(1.6rem, 3vw, 2.4rem); }
+      .eh.sm { font-size: clamp(1.3rem, 2.2vw, 1.7rem); }
+      .eh .accent { font-style: italic; color: var(--jersey-deep); } .eh .dot { color: var(--warm); }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; line-height: 1.38; font-size: 1.05rem; margin: 12px 0 0; color: var(--ink-soft); }
+      .lead.sm { font-size: 0.95rem; margin-top: 8px; }
+
+      .card { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); padding: 26px 24px; }
+      .card.compact { padding: 18px 20px; box-shadow: 4px 4px 0 0 var(--ink); }
+      .cardtape { position: absolute; top: -12px; left: 28px; width: 92px; height: 21px; background: var(--warm); border: 2px solid var(--ink); transform: rotate(-3deg); }
+      .tfig { position: relative; border: 2px solid var(--ink); background: var(--cream-soft); padding: 6px; box-shadow: 3px 3px 0 0 var(--ink); }
+      .tfig .photo { display: block; width: 100%; aspect-ratio: 4/3; background: linear-gradient(135deg, #6b8f7a 0%, #3f6b54 55%, #244536 100%); filter: sepia(0.32) saturate(0.82) contrast(1.02); }
+      .tape2 { position: absolute; top: -9px; right: 18px; width: 58px; height: 16px; background: var(--warm); border: 1.5px solid var(--ink); transform: rotate(3deg); }
+
+      .split { display: grid; grid-template-columns: 1.35fr 1fr; gap: 20px; align-items: center; }
+      .stackTP { display: flex; flex-direction: column; gap: 16px; }   /* text then photo */
+      .stackPT { display: flex; flex-direction: column-reverse; gap: 16px; } /* photo then text (reverse) */
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 40px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 14px; padding-left: 18px; }
+      .legend .q { background: var(--ink); color: var(--cream); padding: 14px 18px; margin-top: 10px; }
+      .legend .q b { color: var(--warm); }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 10 · Generic page-hero · 10h3 — RESPONSIVE + SIZING</h1>
+      <p>Round 3 holds the locked hero (cream card + split) and drills two things the split opened: the <b>mobile stack order</b> and an optional <b>compact size</b> for loading/utility surfaces. Per-element polish (image aspect, tape, accent, CTA) follows in Round 4.</p>
+    </div>
+    <div class="lockbar">LOCKED → <b>C cream paper-card</b> + <b>α split</b> (desktop side-by-side, collapses on mobile).</div>
+
+    <!-- desktop reference -->
+    <div class="direction-bar"><span class="tag">REF</span> Desktop · the locked split <span class="note">(unchanged — for reference)</span></div>
+    <div class="stage"><div class="wrap">
+      <div class="card"><span class="cardtape"></span><div class="split">
+        <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p></div>
+        <div class="tfig"><span class="tape2"></span><span class="photo"></span></div>
+      </div></div>
+    </div></div>
+
+    <!-- mobile order -->
+    <div class="direction-bar"><span class="tag">?</span> Mobile collapse — stack ORDER <span class="note">(360px width · which comes first?)</span></div>
+    <div class="stage"><div class="wrap phones">
+      <div class="phone">
+        <p class="statelabel">m1 · TEXT first, photo below</p>
+        <div class="frame"><div class="card"><span class="cardtape"></span><div class="stackTP">
+          <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p></div>
+          <div class="tfig"><span class="tape2"></span><span class="photo"></span></div>
+        </div></div></div>
+      </div>
+      <div class="phone">
+        <p class="statelabel">m2 · PHOTO first, text below</p>
+        <div class="frame"><div class="card"><span class="cardtape"></span><div class="stackPT">
+          <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p></div>
+          <div class="tfig"><span class="tape2"></span><span class="photo"></span></div>
+        </div></div></div>
+      </div>
+    </div></div>
+
+    <!-- compact -->
+    <div class="direction-bar"><span class="tag">?</span> Compact size <span class="note">for loading skeletons + utility pages (scheurkalender, club/[slug] loading)</span></div>
+    <div class="stage"><div class="wrap">
+      <p class="statelabel">Compact variant — tighter padding, smaller headline, no photo (vs the default above)</p>
+      <div class="card compact"><span class="cardtape"></span>
+        <span class="kicker">Kalender</span><h1 class="eh sm">Scheurkalender<span class="dot">.</span></h1>
+      </div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Decisions in this round</h3>
+      <ul>
+        <li><b>Mobile stack order</b> — <b>m1</b> text-first (headline leads, photo as support — matches reading order + the redesign's text-forward heroes) vs <b>m2</b> photo-first (visual hook leads, more magazine-like).</li>
+        <li><b>Compact size</b> — yes/no. A <code>size="compact"</code> for loading skeletons + bare utility pages (tighter padding, smaller headline, photo suppressed), or one single size everywhere.</li>
+      </ul>
+      <div class="q"><b>ROUND 3 — pick:</b> mobile order (<b>m1</b> / <b>m2</b>) + compact (<b>yes</b> / <b>one size</b>). Round 4 = image aspect + tape, accent rules, optional CTA.</div>
+      <p class="micro">phase-10 · 10h3 · responsive + sizing · voice C + split α locked</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-10-page-hero/10h4-no-image-compare.html
+++ b/docs/design/mockups/phase-10-page-hero/10h4-no-image-compare.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 10 · generic page-hero · 10h4: NO-IMAGE rendering (C + split α + compact locked)</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 96ch; } .harness-head b { color: var(--warm); }
+      .lockbar { background: var(--cream-deep); color: var(--ink); border-bottom: 2px solid var(--ink); padding: 9px 28px; font-family: var(--font-mono); font-size: 12px; } .lockbar b { background: var(--jersey-deep); color: var(--cream); padding: 2px 8px; }
+      .direction-bar { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream); padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); flex-wrap: wrap; }
+      .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 24px 28px 36px; border-bottom: 1px dashed var(--paper-edge); }
+      .wrap { max-width: 1180px; margin: 0 auto; }
+      .two { display: grid; grid-template-columns: 1.3fr 1fr; gap: 22px; align-items: start; }
+      .statelabel { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-muted); margin: 0 0 8px; }
+
+      .kicker { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); display: inline-block; }
+      .eh { font-family: var(--font-display); font-weight: 900; line-height: 0.95; margin: 9px 0 0; letter-spacing: -0.01em; }
+      .eh .accent { font-style: italic; color: var(--jersey-deep); } .eh .dot { color: var(--warm); }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; line-height: 1.38; margin: 12px 0 0; color: var(--ink-soft); }
+
+      .card { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); padding: 26px 24px; }
+      .card.compact { padding: 18px 20px; box-shadow: 4px 4px 0 0 var(--ink); }
+      .cardtape { position: absolute; top: -12px; left: 28px; width: 92px; height: 21px; background: var(--warm); border: 2px solid var(--ink); transform: rotate(-3deg); }
+      .split { display: grid; grid-template-columns: 1.25fr 1fr; gap: 22px; align-items: center; }
+
+      /* n1 typographic — headline scales up, no slot */
+      .n1 .eh { font-size: clamp(2.4rem, 5.5vw, 4rem); }
+      .n1 .lead { font-size: 1.25rem; max-width: 36ch; }
+      .n1 .divider { margin-top: 18px; height: 0; border-top: 2px dotted var(--ink); width: 120px; }
+      .n1.compact .eh { font-size: clamp(1.7rem, 3vw, 2.2rem); }
+
+      /* n2 JerseyShirt fallback in the photo slot */
+      .jersey-slot { border: 2px solid var(--ink); background: var(--cream-soft); box-shadow: 3px 3px 0 0 var(--ink); aspect-ratio: 4/3; display: grid; place-items: center; position: relative; overflow: hidden; }
+      .jersey-slot svg { width: 62%; height: 62%; }
+      .n2 .eh { font-size: clamp(1.7rem, 3vw, 2.4rem); } .n2 .lead { font-size: 1.05rem; }
+
+      /* n3 paper ornament in the slot */
+      .ornament { border: 2px solid var(--ink); background: var(--jersey-deep); box-shadow: 3px 3px 0 0 var(--ink); aspect-ratio: 4/3; display: grid; place-items: center; position: relative; overflow: hidden; }
+      .ornament .glyph { font-family: var(--font-display); font-style: italic; font-weight: 900; font-size: 8rem; color: var(--warm); line-height: 0.6; }
+      .ornament .seam { position: absolute; left: 0; right: 0; bottom: 0; height: 12px; background: repeating-linear-gradient(135deg, var(--ink) 0 8px, var(--cream) 8px 16px); border-top: 2px solid var(--ink); }
+      .n3 .eh { font-size: clamp(1.7rem, 3vw, 2.4rem); } .n3 .lead { font-size: 1.05rem; }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 40px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; } .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 14px; padding-left: 18px; }
+      .legend .q { background: var(--ink); color: var(--cream); padding: 14px 18px; margin-top: 10px; } .legend .q b { color: var(--warm); }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 10 · Generic page-hero · 10h4 — NO-IMAGE rendering</h1>
+      <p>"If you don't have an image, what are you rendering anyway?" — 2 of 4 surfaces are usually image-less. Each option below is shown for the <b>club-index motto</b> (default size) and the <b>scheurkalender bare title</b> (compact). The locked split only applies when an image exists; this round decides what the no-image hero is.</p>
+    </div>
+    <div class="lockbar">LOCKED → <b>C cream paper-card</b> · <b>α split</b> (image only) · <b>m1</b> mobile · <b>compact</b> size for utility/loading.</div>
+
+    <!-- n1 -->
+    <div class="direction-bar"><span class="tag">n1</span> Typographic — headline owns the space <span class="note">no slot · headline scales up · dotted rule for texture</span></div>
+    <div class="stage"><div class="wrap two">
+      <div><p class="statelabel">club index · default</p>
+        <div class="card n1"><span class="cardtape"></span>
+          <span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1>
+          <p class="lead">Er is maar één plezante compagnie.</p><div class="divider"></div>
+        </div></div>
+      <div><p class="statelabel">scheurkalender · compact</p>
+        <div class="card compact n1"><span class="cardtape"></span>
+          <span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1>
+        </div></div>
+    </div></div>
+
+    <!-- n2 -->
+    <div class="direction-bar"><span class="tag">n2</span> JerseyShirt fallback <span class="note">keep the split · fill the slot with the &lt;JerseyShirt&gt; illustration</span></div>
+    <div class="stage"><div class="wrap two">
+      <div><p class="statelabel">club index · default</p>
+        <div class="card n2"><span class="cardtape"></span><div class="split">
+          <div><span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1><p class="lead">Er is maar één plezante compagnie.</p></div>
+          <div class="jersey-slot"><svg viewBox="0 0 100 110" aria-hidden="true"><g fill="var(--jersey-deep)"><ellipse cx="50" cy="20" rx="13" ry="14"/><path d="M20 44 L38 32 L62 32 L80 44 L72 60 L72 104 L28 104 L28 60 Z"/></g><g fill="none" stroke="var(--ink)" stroke-width="3"><path d="M20 44 L38 32 L62 32 L80 44 L72 60 L72 104 L28 104 L28 60 Z"/><path d="M44 33 L50 44 L56 33"/></g><g stroke="var(--ink)" stroke-width="2"><line x1="40" y1="46" x2="40" y2="104"/><line x1="50" y1="46" x2="50" y2="104"/><line x1="60" y1="46" x2="60" y2="104"/></g></svg></div>
+        </div></div></div>
+      <div><p class="statelabel">scheurkalender · compact (slot suppressed in compact)</p>
+        <div class="card compact n2"><span class="cardtape"></span>
+          <span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1>
+        </div></div>
+    </div></div>
+
+    <!-- n3 -->
+    <div class="direction-bar"><span class="tag">n3</span> Paper ornament <span class="note">fill the slot with a jersey-deep panel + oversized Freight quote glyph + seam</span></div>
+    <div class="stage"><div class="wrap two">
+      <div><p class="statelabel">club index · default</p>
+        <div class="card n3"><span class="cardtape"></span><div class="split">
+          <div><span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1><p class="lead">Er is maar één plezante compagnie.</p></div>
+          <div class="ornament"><span class="glyph">,,</span><span class="seam"></span></div>
+        </div></div></div>
+      <div><p class="statelabel">scheurkalender · compact (slot suppressed in compact)</p>
+        <div class="card compact n3"><span class="cardtape"></span>
+          <span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1>
+        </div></div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Trade-offs</h3>
+      <ul>
+        <li><b>n1 typographic</b> — honest + calm; the headline becomes the hero, no faux-filler. Scales perfectly to compact. Risk: a no-lead bare page is still quiet (but that's arguably correct for /scheurkalender).</li>
+        <li><b>n2 JerseyShirt</b> — keeps the split rhythm + adds the brand illustration. Risk: a jersey on /kalender or a CMS page can read as random/off-topic (JerseyShirt "means" player/team elsewhere).</li>
+        <li><b>n3 ornament</b> — adds paper character + colour pop without claiming to be a photo. Risk: an oversized quote glyph is decorative filler; needs a motif that doesn't feel arbitrary.</li>
+      </ul>
+      <div class="q"><b>ROUND 4 — pick the no-image rendering</b> (n1 / n2 / n3). After this the hero is fully locked; remaining micro-bits (image aspect 4:3, single tape strip, accent = one word italic jersey-deep + warm ".", optional CTA slot) I'll lock as defaults in the spec unless you flag one.</div>
+      <p class="micro">phase-10 · 10h4 · no-image rendering · C + α + compact locked</p>
+    </div>
+  </body>
+</html>

--- a/docs/design/mockups/phase-10-page-hero/10h5-locked.html
+++ b/docs/design/mockups/phase-10-page-hero/10h5-locked.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 10 · generic page-hero · LOCKED reference</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --brick: #c93f1c; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Archivo", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 96ch; } .harness-head b { color: var(--warm); }
+      .lockbar { background: var(--jersey-deep); color: var(--cream); border-bottom: 2px solid var(--ink); padding: 10px 28px; font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.04em; display: flex; gap: 10px; flex-wrap: wrap; }
+      .lockbar b { background: var(--warm); color: var(--ink); padding: 2px 8px; }
+      .stage { padding: 26px 28px 38px; border-bottom: 1px dashed var(--paper-edge); }
+      .wrap { max-width: 1180px; margin: 0 auto; }
+      .statelabel { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-muted); margin: 0 0 10px; }
+      .statelabel b { color: var(--jersey-deep); }
+
+      .kicker { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--jersey-deep); display: inline-block; }
+      .eh { font-family: var(--font-display); font-weight: 900; line-height: 0.95; margin: 9px 0 0; letter-spacing: -0.01em; }
+      .eh .accent { font-style: italic; color: var(--jersey-deep); } .eh .dot { color: var(--warm); }
+      .lead { font-family: var(--font-display); font-style: italic; font-weight: 400; line-height: 1.38; margin: 14px 0 0; color: var(--ink-soft); }
+
+      .card { position: relative; background: var(--cream); border: 2px solid var(--ink); box-shadow: 5px 6px 0 0 var(--ink); padding: 28px 26px; }
+      .card.compact { padding: 18px 20px; box-shadow: 4px 4px 0 0 var(--ink); }
+      .cardtape { position: absolute; top: -12px; left: 30px; width: 96px; height: 22px; background: var(--warm); border: 2px solid var(--ink); transform: rotate(-3deg); }
+      .tfig { position: relative; border: 2px solid var(--ink); background: var(--cream-soft); padding: 6px; box-shadow: 3px 3px 0 0 var(--ink); }
+      .tfig .photo { display: block; width: 100%; aspect-ratio: 4/3; background: linear-gradient(135deg, #6b8f7a 0%, #3f6b54 55%, #244536 100%); filter: sepia(0.32) saturate(0.82) contrast(1.02); }
+      .tape2 { position: absolute; top: -9px; right: 18px; width: 58px; height: 16px; background: var(--warm); border: 1.5px solid var(--ink); transform: rotate(3deg); }
+
+      .split { display: grid; grid-template-columns: 1.3fr 1fr; gap: 22px; align-items: center; }
+      .cta { display: inline-flex; align-items: center; gap: 8px; margin-top: 18px; font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; border: 2px solid var(--ink); background: var(--jersey-deep); color: var(--cream); padding: 9px 15px; box-shadow: 3px 3px 0 0 var(--ink); }
+
+      /* no-image typographic */
+      .typo .eh { font-size: clamp(2.4rem, 5.5vw, 4rem); } .typo .lead { font-size: 1.25rem; max-width: 38ch; }
+      .typo .divider { margin-top: 18px; height: 0; border-top: 2px dotted var(--ink); width: 120px; }
+      /* with-image headline */
+      .withimg .eh { font-size: clamp(1.8rem, 3.2vw, 2.6rem); } .withimg .lead { font-size: 1.05rem; }
+      .compact .eh { font-size: clamp(1.5rem, 2.6vw, 2rem); }
+
+      .phone { width: 360px; max-width: 100%; } .phone .frame { border: 2px solid var(--ink); box-shadow: 4px 5px 0 0 var(--ink); background: var(--cream-soft); padding: 10px; }
+      .stackTP { display: flex; flex-direction: column; gap: 16px; }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 40px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; } .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 14px; padding-left: 18px; }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 10 · Generic page-hero (#2120) — LOCKED reference</h1>
+      <p>The redesigned generic page-hero that replaces the legacy dark-gradient <b>&lt;InteriorPageHero&gt;</b> on /kalender, /club, /club/[slug], /scheurkalender. Canonical reference for implementation. Drill rounds: 10h1 (voice) → 10h2 (layout) → 10h3 (responsive+size) → 10h4 (no-image).</p>
+    </div>
+    <div class="lockbar">
+      <span><b>C</b> cream paper-card</span><span><b>α</b> split (image)</span><span><b>m1</b> mobile text→photo</span><span><b>compact</b> for utility</span><span><b>n1</b> typographic no-image</span>
+    </div>
+
+    <!-- 1. marquee with image -->
+    <div class="stage"><div class="wrap">
+      <p class="statelabel"><b>1 · /kalender</b> — image + lead (desktop split)</p>
+      <div class="card withimg"><span class="cardtape"></span><div class="split">
+        <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten van KCVV Elewijt, seizoen na seizoen.</p></div>
+        <div class="tfig"><span class="tape2"></span><span class="photo"></span></div>
+      </div></div>
+    </div></div>
+
+    <!-- 2. motto no image -->
+    <div class="stage"><div class="wrap">
+      <p class="statelabel"><b>2 · /club</b> — no image, lead + one-word accent (n1 typographic)</p>
+      <div class="card typo"><span class="cardtape"></span>
+        <span class="kicker">Onze club</span><h1 class="eh">De plezantste <span class="accent">compagnie</span><span class="dot">.</span></h1>
+        <p class="lead">Er is maar één plezante compagnie.</p><div class="divider"></div>
+      </div>
+    </div></div>
+
+    <!-- 3. CMS title with optional image + CTA -->
+    <div class="stage"><div class="wrap">
+      <p class="statelabel"><b>3 · /club/[slug]</b> — CMS title, optional image, optional CTA slot</p>
+      <div class="card withimg"><span class="cardtape"></span><div class="split">
+        <div><span class="kicker">Club</span><h1 class="eh">Het verhaal van <span class="accent">de Klakkei</span><span class="dot">.</span></h1>
+          <a class="cta">Lees meer →</a></div>
+        <div class="tfig"><span class="tape2"></span><span class="photo"></span></div>
+      </div></div>
+    </div></div>
+
+    <!-- 4. bare compact -->
+    <div class="stage"><div class="wrap">
+      <p class="statelabel"><b>4 · /scheurkalender</b> (+ loading skeletons) — bare title, compact, no image</p>
+      <div class="card compact typo"><span class="cardtape"></span>
+        <span class="kicker">Kalender</span><h1 class="eh">Scheurkalender<span class="dot">.</span></h1>
+      </div>
+    </div></div>
+
+    <!-- 5. mobile -->
+    <div class="stage"><div class="wrap">
+      <p class="statelabel"><b>5 · mobile</b> — split collapses to m1 (text → photo)</p>
+      <div class="phone"><div class="frame"><div class="card withimg"><span class="cardtape"></span><div class="stackTP">
+        <div><span class="kicker">Kalender</span><h1 class="eh">Wedstrijd&shy;kalender<span class="dot">.</span></h1><p class="lead">Alle wedstrijden en activiteiten, seizoen na seizoen.</p></div>
+        <div class="tfig"><span class="tape2"></span><span class="photo"></span></div>
+      </div></div></div></div>
+    </div></div>
+
+    <div class="legend">
+      <h3>Locked spec — primitive composition (no new vocabulary)</h3>
+      <ul>
+        <li><b>Shell</b> → <code>&lt;TapedCard&gt;</code> cream, <code>border-2 border-ink</code> + hard offset shadow + one <code>&lt;TapeStrip&gt;</code> (warm, top-left). Sharp corners.</li>
+        <li><b>Kicker</b> → <code>&lt;MonoLabel variant="plain"&gt;</code> (jersey-deep raw label-token span).</li>
+        <li><b>Headline</b> → <code>&lt;EditorialHeading level=1&gt;</code> Freight upright; optional one-word italic jersey-deep <b>accent</b>; warm "." terminator. Scales up in the no-image (typographic) state.</li>
+        <li><b>Lead</b> → italic <code>font-display</code>, auto-hides when absent.</li>
+        <li><b>Image</b> → <code>&lt;TapedFigure aspect="landscape-4-3"&gt;</code> newsprint (colour), single tape strip; desktop right column, mobile below (m1). Absent → typographic (n1): no slot, headline owns the card, <code>&lt;DottedDivider&gt;</code> for texture.</li>
+        <li><b>CTA</b> → optional <code>&lt;LinkButton&gt;</code> slot (parity with legacy; none of the 4 pass it today).</li>
+        <li><b>size</b> → <code>"default" | "compact"</code> (compact: tighter padding, smaller headline, image suppressed) for loading skeletons + utility pages.</li>
+      </ul>
+      <h3>Consumers to migrate (then delete &lt;InteriorPageHero&gt;)</h3>
+      <ul>
+        <li>/kalender (page + loading) · /club (getClubSections) · /club/[slug] (page + loading) · /scheurkalender (loading).</li>
+      </ul>
+      <p class="micro">phase-10 · 10h5 · generic page-hero LOCKED · all decisions resolved 2026-06-14</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Committed design-checkpoint mockups for the redesigned generic page-hero (#2120) — the keystone that replaces the legacy `<InteriorPageHero>` across /kalender, /club, /club/[slug], /scheurkalender.

Drill: **10h1** voice/register → **10h2** layout/IA → **10h3** responsive+sizing → **10h4** no-image rendering → **10h5** locked reference.

**Owner-approved locks (2026-06-14):** cream paper-card voice · split layout (image present) · typographic no-image · compact variant for utility/loading · m1 mobile (text→photo). Built in the established mockup vocabulary (Fraunces/Archivo/IBM Plex Mono, retro palette, paper grain, border-2 ink + hard shadow, tape). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)