### PR TITLE
docs(ui): Phase 10 cookie banner reskin mockup (#2125)

### DIFF
--- a/docs/design/mockups/phase-10-cookie/10ck1-cookie-reskin.html
+++ b/docs/design/mockups/phase-10-cookie/10ck1-cookie-reskin.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Phase 10 · cookie banner · 10ck1: retro reskin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400;1,9..144,500;1,9..144,900&family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey: #4acf52; --jersey-deep: #008755; --jersey-deep-dark: #133d28;
+        --warm: #f0c264; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif; --font-body: "Archivo", system-ui, sans-serif; --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body);
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E"); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 96ch; } .harness-head b { color: var(--warm); }
+      .direction-bar { background: var(--jersey-deep); color: var(--cream); padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); flex-wrap: wrap; } .direction-bar .tag { background: var(--warm); color: var(--ink); padding: 2px 9px; font-weight: 700; border: 1.5px solid var(--ink); } .direction-bar .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 30px 28px 40px; border-bottom: 1px dashed var(--paper-edge); display: flex; gap: 30px; flex-wrap: wrap; align-items: flex-start; }
+
+      .eh { font-family: var(--font-display); font-weight: 900; line-height: 0.98; } .dot { color: var(--warm); }
+      .btn { font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; border: 2px solid var(--ink); padding: 10px 16px; cursor: pointer; transition: all .25s; }
+      .btn.primary { background: var(--jersey-deep); color: var(--cream); box-shadow: 3px 3px 0 0 var(--ink); }
+      .btn.ghost { background: var(--cream); color: var(--ink); box-shadow: 3px 3px 0 0 var(--ink); }
+      .btn.link { border: none; box-shadow: none; background: none; color: var(--ink-muted); text-decoration: underline; text-underline-offset: 3px; padding: 10px 4px; }
+
+      /* BANNER (box, bottom-left) */
+      .banner { width: 420px; max-width: 100%; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 7px 0 0 var(--ink); position: relative; }
+      .banner .tape { position: absolute; top: -12px; left: 26px; width: 88px; height: 21px; background: var(--warm); border: 2px solid var(--ink); transform: rotate(-3deg); }
+      .banner .pad { padding: 24px 22px; }
+      .banner .eh { font-size: 1.5rem; margin: 0 0 8px; }
+      .banner p { font-size: 0.95rem; line-height: 1.55; color: var(--ink-soft); margin: 0 0 18px; }
+      .banner p a { color: var(--jersey-deep); font-weight: 600; }
+      .banner .btns { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+
+      /* PREFERENCES MODAL */
+      .modal { width: 460px; max-width: 100%; background: var(--cream); border: 2px solid var(--ink); box-shadow: 6px 7px 0 0 var(--ink); }
+      .modal .head { display: flex; justify-content: space-between; align-items: center; padding: 18px 20px; border-bottom: 2px solid var(--ink); }
+      .modal .head .eh { font-size: 1.3rem; } .modal .x { font-family: var(--font-mono); font-weight: 700; border: 2px solid var(--ink); width: 28px; height: 28px; display: grid; place-items: center; background: var(--cream); box-shadow: 2px 2px 0 0 var(--ink); }
+      .modal .body { padding: 18px 20px; max-height: 320px; overflow: auto; }
+      .cat { border: 2px solid var(--ink); background: var(--cream-soft); padding: 14px 15px; margin-bottom: 12px; }
+      .cat .top { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+      .cat .nm { font-weight: 700; color: var(--ink); }
+      .cat p { font-size: 0.85rem; color: var(--ink-soft); margin: 6px 0 0; line-height: 1.5; }
+      /* toggle */
+      .tog { width: 42px; height: 24px; border: 2px solid var(--ink); background: var(--cream); position: relative; flex: none; }
+      .tog .knob { position: absolute; top: 1px; left: 1px; width: 18px; height: 18px; background: var(--ink); transition: all .2s; }
+      .tog.on { background: var(--jersey-deep); } .tog.on .knob { left: 19px; background: var(--cream); }
+      .tog.locked { background: var(--ink-muted); } .tog.locked .knob { left: 19px; background: var(--cream); }
+      .modal .foot { padding: 16px 20px; border-top: 2px solid var(--ink); display: flex; gap: 10px; flex-wrap: wrap; }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 44px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; } .legend b { color: var(--jersey-deep); }
+      .legend ul { margin: 6px 0 14px; padding-left: 18px; } .legend code { background: var(--cream); border: 1px solid var(--paper-edge); padding: 0 4px; }
+      .legend .q { background: var(--ink); color: var(--cream); padding: 14px 18px; margin-top: 10px; } .legend .q b { color: var(--warm); }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Phase 10 · Cookie consent banner (#2125) · 10ck1 — retro reskin</h1>
+      <p>vanilla-cookieconsent re-themed via its ~60 <b>--cc-*</b> CSS vars → retro tokens. Same library + structure + behaviour; new skin only. <b>Sharp corners</b> (border-radius → 0), paper chrome, jersey-deep accept, paper-stamp press-down buttons. Replaces the legacy dark (<code>--cc-bg: kcvv-black</code>) theme.</p>
+    </div>
+
+    <div class="direction-bar"><span class="tag">→</span> Consent banner + preferences modal <span class="note">retro skin (placeholders for the real copy)</span></div>
+    <div class="stage">
+      <!-- BANNER -->
+      <div class="banner"><span class="tape"></span><div class="pad">
+        <h2 class="eh">Koekjes<span class="dot">?</span></h2>
+        <p>We gebruiken cookies om de site te laten werken en — met jouw toestemming — om te zien hoe ze gebruikt wordt. <a>Lees ons privacybeleid</a>.</p>
+        <div class="btns">
+          <button class="btn primary">Alles aanvaarden</button>
+          <button class="btn ghost">Weigeren</button>
+          <button class="btn link">Voorkeuren</button>
+        </div>
+      </div></div>
+
+      <!-- MODAL -->
+      <div class="modal">
+        <div class="head"><h2 class="eh">Cookievoorkeuren<span class="dot">.</span></h2><span class="x">✕</span></div>
+        <div class="body">
+          <div class="cat"><div class="top"><span class="nm">Noodzakelijk</span><span class="tog locked"><span class="knob"></span></span></div><p>Nodig om de site te laten werken. Altijd aan.</p></div>
+          <div class="cat"><div class="top"><span class="nm">Analytics</span><span class="tog on"><span class="knob"></span></span></div><p>Anonieme statistieken over hoe de site gebruikt wordt (Google Analytics).</p></div>
+          <div class="cat"><div class="top"><span class="nm">Embeds &amp; media</span><span class="tog"><span class="knob"></span></span></div><p>YouTube/Vimeo-video's en kaarten. Uit tenzij je ze toelaat.</p></div>
+        </div>
+        <div class="foot">
+          <button class="btn primary">Bewaar voorkeuren</button>
+          <button class="btn ghost">Alles aanvaarden</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="legend">
+      <h3>--cc-* token mapping (re-point, no structure change)</h3>
+      <ul>
+        <li><code>--cc-bg</code> kcvv-black → <b>cream</b> · <code>--cc-primary-color</code> → <b>ink</b> · <code>--cc-secondary-color</code> → <b>ink-muted</b> · surface gets <code>border:2px ink</code> + hard shadow.</li>
+        <li><code>--cc-btn-primary-bg</code> → <b>jersey-deep</b>, <code>-color</code> → cream · <code>--cc-btn-secondary</code> → cream/ink ghost · both get the press-down hover.</li>
+        <li><code>--cc-toggle-on-bg</code> → <b>jersey-deep</b> · off → cream/ink · readonly (necessary) → ink-muted · category blocks → cream-soft + ink border.</li>
+        <li><code>--cc-link-color</code> → <b>jersey-deep</b> · <code>--cc-modal-border-radius</code> / <code>--cc-btn-border-radius</code> → <b>0</b> (sharp corners).</li>
+      </ul>
+      <h3>Decisions</h3>
+      <ul>
+        <li><b>1 · Banner shape</b> — corner box (shown) or full-width bottom bar? (vanilla-cookieconsent supports both; box reads more "paper card".)</li>
+        <li><b>2 · Tape on the banner</b> — keep the warm tape strip (shown) for character, or plain card?</li>
+        <li><b>3 · Copy</b> — heading "Koekjes?" (playful) vs "Cookies" (plain); placeholder body — your wording.</li>
+      </ul>
+      <div class="q"><b>Confirm the reskin + answer 1–3.</b> Then #2125 locks and Phase 10 design is complete.</div>
+      <p class="micro">phase-10 · 10ck1 · cookie consent retro reskin · vanilla-cookieconsent --cc-* re-theme</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Design-checkpoint mockup for the cookie consent reskin (#2125). Full retro reskin of vanilla-cookieconsent via the `--cc-*` vars: corner-box banner (cream paper + ink border + hard shadow + warm tape), jersey-deep accept, paper-stamp press-down buttons, sharp corners, jersey-deep toggles. Heading "Koekjes?". Re-points ~60 `--cc-*` vars off legacy `kcvv-*`. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)