### PR TITLE
refactor(ui): migrate font-title (Quasimoda) consumers → Freight / Montserrat (#2116)

### DIFF
--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
@@ -83,7 +83,7 @@ export const EventFactOverview = ({
             dateTime={range.date.dateIso}
             className="text-kcvv-white flex flex-col"
           >
-            <span className="font-title text-xl leading-[0.95] font-bold">
+            <span className="font-display text-xl leading-[0.95] font-bold">
               {range.date.day}{" "}
               <span className="uppercase">{range.date.monthShort}</span>
             </span>
@@ -97,7 +97,7 @@ export const EventFactOverview = ({
             data-testid="event-overview-date"
             className="text-kcvv-white flex flex-col"
           >
-            <span className="font-title text-xl leading-[0.95] font-bold">
+            <span className="font-display text-xl leading-[0.95] font-bold">
               <time dateTime={range.start.dateIso}>
                 {range.start.day}
                 {!range.sameMonth && (
@@ -138,7 +138,7 @@ export const EventFactOverview = ({
           {value.title && (
             <span
               data-testid="event-overview-title"
-              className="font-title text-kcvv-white text-lg font-bold"
+              className="font-display text-kcvv-white text-lg font-bold"
             >
               {value.title}
             </span>
@@ -175,7 +175,7 @@ export const EventFactOverview = ({
             target="_blank"
             rel="noopener noreferrer"
             className={cn(
-              "font-title inline-flex items-baseline gap-1 text-sm font-bold tracking-[var(--letter-spacing-caps)] uppercase",
+              "font-display inline-flex items-baseline gap-1 text-sm font-bold tracking-[var(--letter-spacing-caps)] uppercase",
               "text-kcvv-green-bright decoration-kcvv-green-bright underline decoration-1 underline-offset-4",
               "transition-[text-decoration-thickness] duration-150 hover:decoration-2",
             )}

--- a/apps/web/src/components/article/blocks/TransferFact/TransferFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/TransferFact/TransferFactOverview.tsx
@@ -64,13 +64,13 @@ export const TransferFactOverview = ({
         // inner container, so the column grid aligns row-to-row.
         "full-bleed not-prose bg-kcvv-gray-dark py-6",
         // White-alpha top rule separates stacked rows without shouting.
-        "border-t border-kcvv-white/10",
+        "border-kcvv-white/10 border-t",
         className,
       )}
     >
       <div
         className={cn(
-          "mx-auto grid max-w-outer px-6",
+          "max-w-outer mx-auto grid px-6",
           "gap-x-6 gap-y-3",
           "md:grid-cols-[8rem_minmax(0,1fr)_minmax(0,1.2fr)_auto] md:items-center md:gap-x-8",
         )}
@@ -78,7 +78,7 @@ export const TransferFactOverview = ({
         <div
           data-testid="transfer-overview-kicker"
           className={cn(
-            "flex items-center gap-2 text-xs font-semibold uppercase tracking-[var(--letter-spacing-label)]",
+            "flex items-center gap-2 text-xs font-semibold tracking-[var(--letter-spacing-label)] uppercase",
             accentClass,
           )}
         >
@@ -93,7 +93,7 @@ export const TransferFactOverview = ({
           {playerName && (
             <span
               data-testid="transfer-overview-name"
-              className="font-title font-bold text-xl text-kcvv-white"
+              className="font-display text-kcvv-white text-xl font-bold"
             >
               {playerName}
             </span>
@@ -101,14 +101,14 @@ export const TransferFactOverview = ({
           {metaParts.length > 0 && (
             <span
               data-testid="transfer-overview-meta"
-              className="font-mono text-xs uppercase tracking-[var(--letter-spacing-caps)] text-kcvv-gray-light"
+              className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
             >
               {metaParts.map((part, i) => (
                 <span key={part}>
                   {i > 0 && (
                     <span
                       aria-hidden="true"
-                      className="mx-2 text-kcvv-white/30"
+                      className="text-kcvv-white/30 mx-2"
                     >
                       ·
                     </span>
@@ -123,7 +123,7 @@ export const TransferFactOverview = ({
         {resolved.kind === "extension" ? (
           <div
             data-testid="transfer-overview-kcvv-only"
-            className="flex items-center gap-2 text-base text-kcvv-white"
+            className="text-kcvv-white flex items-center gap-2 text-base"
           >
             {resolved.kcvvOnly.logoUrl && (
               <Image
@@ -139,7 +139,7 @@ export const TransferFactOverview = ({
         ) : (
           <div
             data-testid="transfer-overview-clubs"
-            className="flex flex-wrap items-center gap-x-2 gap-y-1 text-base text-kcvv-white"
+            className="text-kcvv-white flex flex-wrap items-center gap-x-2 gap-y-1 text-base"
           >
             <span className="flex items-center gap-2">
               {resolved.from.logoUrl && (
@@ -171,7 +171,7 @@ export const TransferFactOverview = ({
 
         <p
           data-testid="transfer-overview-status"
-          className="font-mono text-xs uppercase tracking-[var(--letter-spacing-caps)] text-kcvv-gray-light md:text-right"
+          className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase md:text-right"
         >
           {statusLabel}
         </p>

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.test.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.test.tsx
@@ -34,11 +34,11 @@ describe("SectionCta", () => {
   });
 
   describe("Typography", () => {
-    it("should style heading with font-title font-extrabold text-kcvv-black", () => {
+    it("should style heading with font-display font-extrabold text-kcvv-black", () => {
       render(<SectionCta {...defaultProps} />);
       const heading = screen.getByRole("heading");
       expect(heading).toHaveClass(
-        "font-title",
+        "font-display",
         "font-extrabold",
         "text-kcvv-black",
       );

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.tsx
@@ -24,7 +24,7 @@ export function SectionCta({
   return (
     <div className="mx-auto max-w-[40rem] px-4 text-center md:px-10">
       <h2
-        className={`font-title mb-3 font-extrabold ${
+        className={`font-display mb-3 font-extrabold ${
           isDark ? "text-white" : "text-kcvv-black"
         }`}
         style={{ fontSize: "clamp(1.5rem, 3vw, 2rem)" }}

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -41,7 +41,7 @@ export function ScheurkalenderPage({ days }: ScheurkalenderPageProps) {
       <div className="from-green-main via-green-hover to-green-dark-hover bg-linear-to-br px-4 py-10 text-white print:hidden">
         <div className="mx-auto flex max-w-3xl items-start justify-between gap-4">
           <div>
-            <h1 className="font-title mb-2 text-3xl font-bold md:text-5xl">
+            <h1 className="font-body mb-2 text-3xl font-bold md:text-5xl">
               Scheurkalender
             </h1>
             <p className="text-white/90">


### PR DESCRIPTION
Closes #2116

Phase 9 spin-out of #1531 (Phase 9 capstone). Migrates the remaining in-scope `font-title` (Quasimoda) consumers off the legacy class so Quasimoda can be retired and trimmed from the Adobe Fonts kit.

Locked principle: **Freight for shipped-redesign-debt, Montserrat for never-redesigned.**

## Changes

| File | `font-title` → | Why |
|---|---|---|
| `EventFact/EventFactOverview.tsx` (×4) | `font-display` (Freight) | Phase 5 debt — restores intended display voice |
| `TransferFact/TransferFactOverview.tsx` | `font-display` (Freight) | Phase 5 debt |
| `design-system/SectionCta/SectionCta.tsx` | `font-display` (Freight) | live on redesigned `BestuurPage` — debt |
| `scheurkalender/ScheurkalenderPage.tsx` (h1) | `font-body` (Montserrat) | never-redesigned niche page, kept simple |

- `SectionCta` typography test updated to assert `font-display`.
- No `font-title` / `var(--font-family-title)` references remain in the 4 files.
- `globals.css` token/utility removal stays **deferred to the #1531 capstone** (out of scope here).

## Testing

- `pnpm --filter @kcvv/web check-all` green (lint + type-check + 3346 tests + build, exit 0).
- TDD: updated the `SectionCta` assertion first (red), then migrated (green).
- VR baselines deferred to the end-of-series batch capture (per the redesign convention).

## Review gate

- `/code-review` (xhigh): `[]` — pure token swap, every sibling class preserved, no logic/call-site impact.
- `/simplify`: code already clean — `font-display`/`font-body` are the canonical retro utilities; nothing to dedup or generalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
