### PR TITLE
refactor(ui): migrate residual kcvv-* colour consumers → retro-terrace tokens (#2117)

### DIFF
--- a/apps/web/src/app/(landing)/nieuws/NewsListingClient.tsx
+++ b/apps/web/src/app/(landing)/nieuws/NewsListingClient.tsx
@@ -217,7 +217,7 @@ export function NewsListingClient({
   return (
     <div className="w-full">
       {/* Sticky filter bar */}
-      <div className="bg-kcvv-dark-bg/95 sticky top-0 z-30 border-b border-white/10 py-3 backdrop-blur-sm">
+      <div className="bg-ink/95 sticky top-0 z-30 border-b border-white/10 py-3 backdrop-blur-sm">
         <div className="max-w-inner-lg mx-auto px-3 lg:px-0">
           <CategoryFilters
             categories={categories}
@@ -272,7 +272,7 @@ export function NewsListingClient({
             <p className="mb-2 text-red-400">{error.message}</p>
             <button
               type="button"
-              className="text-kcvv-green-bright text-sm underline hover:no-underline"
+              className="text-jersey-deep text-sm underline hover:no-underline"
               onClick={error.retry}
             >
               Opnieuw proberen
@@ -290,7 +290,7 @@ export function NewsListingClient({
         {/* Loading indicator */}
         {isLoading && (
           <div className="flex justify-center py-8" role="status">
-            <div className="border-kcvv-green-bright h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
+            <div className="border-jersey-deep h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
             <span className="sr-only">Laden...</span>
           </div>
         )}

--- a/apps/web/src/app/(landing)/nieuws/loading.tsx
+++ b/apps/web/src/app/(landing)/nieuws/loading.tsx
@@ -7,7 +7,7 @@ export default function NewsLoading() {
   return (
     <div className="w-full">
       {/* Sticky filter bar skeleton */}
-      <div className="bg-kcvv-dark-bg/95 sticky top-0 z-30 border-b border-white/10 py-3 backdrop-blur-sm">
+      <div className="bg-ink/95 sticky top-0 z-30 border-b border-white/10 py-3 backdrop-blur-sm">
         <div className="max-w-inner-lg mx-auto flex gap-2 px-3 lg:px-0">
           {Array.from({ length: 5 }).map((_, i) => (
             <div

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -273,7 +273,7 @@ export default async function HomePage() {
   if (articles.length === 0 && matches.length === 0) {
     return (
       <div className="max-w-inner-lg mx-auto px-3 py-16 text-center lg:px-0">
-        <h1 className="text-kcvv-green-dark mb-4 text-3xl font-bold lg:text-4xl">
+        <h1 className="text-jersey-deep mb-4 text-3xl font-bold lg:text-4xl">
           Welkom bij KCVV Elewijt
         </h1>
         <p className="text-lg text-gray-600">

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/loading.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/loading.tsx
@@ -7,7 +7,7 @@ export default function OpponentLoading() {
   return (
     <div className="min-h-screen bg-gray-100">
       {/* Opponent header */}
-      <div className="bg-kcvv-dark-bg px-4 py-8 text-white">
+      <div className="bg-ink px-4 py-8 text-white">
         <div className="mx-auto flex max-w-3xl animate-pulse items-center gap-4">
           <div className="h-16 w-16 rounded-full bg-white/10" />
           <div className="space-y-2">

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/page.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/page.tsx
@@ -49,9 +49,9 @@ function getMatchResult(match: Match): "win" | "draw" | "loss" | null {
 }
 
 const resultBorderClass: Record<"win" | "draw" | "loss", string> = {
-  win: "border-l-4 border-l-kcvv-success",
-  draw: "border-l-4 border-l-kcvv-warning",
-  loss: "border-l-4 border-l-kcvv-alert",
+  win: "border-l-4 border-l-jersey-deep",
+  draw: "border-l-4 border-l-transparent",
+  loss: "border-l-4 border-l-alert",
 };
 
 async function fetchOpponentData(clubId: number): Promise<{
@@ -157,34 +157,32 @@ export default async function OpponentPage({ params }: OpponentPageProps) {
           />
         )}
         <div>
-          <p className="text-sm text-[var(--color-muted)]">Tegenstander</p>
+          <p className="text-ink-muted text-sm">Tegenstander</p>
           <h1 className="text-2xl font-bold">{opponentName}</h1>
         </div>
       </div>
 
       {/* W/D/L summary */}
-      <div className="mb-8 grid grid-cols-5 gap-2 rounded-xl bg-[var(--color-surface)] p-4 text-center">
+      <div className="bg-cream-soft mb-8 grid grid-cols-5 gap-2 rounded-xl p-4 text-center">
         <div>
-          <p className="text-kcvv-success text-2xl font-bold">{summary.wins}</p>
-          <p className="text-xs text-[var(--color-muted)]">W</p>
+          <p className="text-jersey-deep text-2xl font-bold">{summary.wins}</p>
+          <p className="text-ink-muted text-xs">W</p>
         </div>
         <div>
-          <p className="text-kcvv-warning text-2xl font-bold">
-            {summary.draws}
-          </p>
-          <p className="text-xs text-[var(--color-muted)]">G</p>
+          <p className="text-2xl font-bold">{summary.draws}</p>
+          <p className="text-ink-muted text-xs">G</p>
         </div>
         <div>
-          <p className="text-kcvv-alert text-2xl font-bold">{summary.losses}</p>
-          <p className="text-xs text-[var(--color-muted)]">V</p>
+          <p className="text-alert text-2xl font-bold">{summary.losses}</p>
+          <p className="text-ink-muted text-xs">V</p>
         </div>
         <div>
           <p className="text-2xl font-bold">{summary.goalsFor}</p>
-          <p className="text-xs text-[var(--color-muted)]">Doelpunten voor</p>
+          <p className="text-ink-muted text-xs">Doelpunten voor</p>
         </div>
         <div>
           <p className="text-2xl font-bold">{summary.goalsAgainst}</p>
-          <p className="text-xs text-[var(--color-muted)]">Doelpunten tegen</p>
+          <p className="text-ink-muted text-xs">Doelpunten tegen</p>
         </div>
       </div>
 
@@ -209,10 +207,10 @@ export default async function OpponentPage({ params }: OpponentPageProps) {
             <li key={match.id}>
               <Link
                 href={`/wedstrijd/${match.id}`}
-                className={`flex items-center justify-between rounded-lg bg-[var(--color-surface)] px-4 py-3 transition-colors hover:bg-[var(--color-surface-hover)] ${borderClass}`}
+                className={`bg-cream-soft hover:bg-cream-deep flex items-center justify-between rounded-lg px-4 py-3 transition-colors ${borderClass}`}
               >
                 <div className="flex flex-col gap-0.5">
-                  <span className="text-xs text-[var(--color-muted)]">
+                  <span className="text-ink-muted text-xs">
                     {formatMatchDate(match.date)}
                     {match.competition ? ` · ${match.competition}` : ""}
                   </span>
@@ -220,7 +218,7 @@ export default async function OpponentPage({ params }: OpponentPageProps) {
                     {match.home_team.name} vs {match.away_team.name}
                   </span>
                   {match.kcvv_team_label && (
-                    <span className="text-xs text-[var(--color-muted)]">
+                    <span className="text-ink-muted text-xs">
                       {match.kcvv_team_label}
                     </span>
                   )}
@@ -231,9 +229,7 @@ export default async function OpponentPage({ params }: OpponentPageProps) {
                       {homeScore} – {awayScore}
                     </span>
                   ) : (
-                    <span className="text-sm text-[var(--color-muted)]">
-                      Gepland
-                    </span>
+                    <span className="text-ink-muted text-sm">Gepland</span>
                   )}
                 </div>
               </Link>

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.test.tsx
@@ -60,11 +60,11 @@ describe("ArticleMetadata", () => {
     expect(nav).toHaveAttribute("aria-label", "Artikelinfo");
   });
 
-  it("applies border-y kcvv-gray-light so rules appear above AND below", () => {
+  it("applies border-y border-paper-edge so rules appear above AND below", () => {
     const { container } = render(<ArticleMetadata {...defaultProps} />);
     const nav = container.querySelector("nav");
     expect(nav).toHaveClass("border-y");
-    expect(nav).toHaveClass("border-kcvv-gray-light");
+    expect(nav).toHaveClass("border-paper-edge");
   });
 
   it("applies custom className", () => {

--- a/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
+++ b/apps/web/src/components/article/ArticleMetadata/ArticleMetadata.tsx
@@ -40,7 +40,7 @@ const FACEBOOK_SHARER = "https://www.facebook.com/sharer/sharer.php?u=";
 const DEFAULT_AUTHOR = "KCVV Elewijt";
 
 /**
- * Design §7.6 — article metadata bar. Single row with 1px `kcvv-gray-light`
+ * Design §7.6 — article metadata bar. Single row with 1px `paper-edge`
  * rules above and below. Left cluster: date · author · reading time, mono
  * small-caps. Right cluster: share icons (Share2 for the Web Share API,
  * Facebook for direct sharing). No breadcrumb — that role belongs to the
@@ -103,14 +103,14 @@ export const ArticleMetadata = ({
   return (
     <nav
       aria-label="Artikelinfo"
-      className={cn("border-kcvv-gray-light w-full border-y py-3", className)}
+      className={cn("border-paper-edge w-full border-y py-3", className)}
     >
       <div className="max-w-inner-lg mx-auto flex w-full flex-wrap items-center justify-between gap-y-2 px-6">
-        <ul className="text-kcvv-gray flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+        <ul className="text-ink-muted flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
           {facts.map((fact, i) => (
             <li key={`${i}-${fact}`} className="flex items-center gap-x-3">
               {i > 0 && (
-                <span aria-hidden="true" className="text-kcvv-gray-light">
+                <span aria-hidden="true" className="text-paper-edge">
                   ·
                 </span>
               )}
@@ -125,7 +125,7 @@ export const ArticleMetadata = ({
               type="button"
               onClick={handleNativeShare}
               aria-label="Delen"
-              className="text-kcvv-gray-blue hover:text-kcvv-green-dark transition-colors"
+              className="text-ink-soft hover:text-jersey-deep transition-colors"
             >
               <Icon icon={Share2} size="xs" />
             </button>
@@ -135,7 +135,7 @@ export const ArticleMetadata = ({
               rel="noopener noreferrer"
               aria-label="Delen op Facebook"
               onClick={() => trackShare("facebook")}
-              className="text-kcvv-gray-blue hover:text-kcvv-green-dark transition-colors"
+              className="text-ink-soft hover:text-jersey-deep transition-colors"
             >
               <Icon icon={Facebook} size="xs" />
             </a>

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.test.tsx
@@ -26,7 +26,7 @@ describe("EventFactOverview", () => {
       />,
     );
     const section = container.querySelector("[data-testid='event-overview']");
-    expect(section).toHaveClass("bg-kcvv-gray-dark");
+    expect(section).toHaveClass("bg-ink");
     expect(section).toHaveClass("full-bleed");
   });
 

--- a/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/EventFact/EventFactOverview.tsx
@@ -62,8 +62,8 @@ export const EventFactOverview = ({
         // Consecutive eventFact overviews fuse into one continuous
         // section via the sibling rules in globals.css (same pattern as
         // transferFact overview).
-        "full-bleed not-prose bg-kcvv-gray-dark py-6",
-        "border-kcvv-white/10 border-t",
+        "full-bleed not-prose bg-ink py-6",
+        "border-cream/10 border-t",
         className,
       )}
     >
@@ -81,13 +81,13 @@ export const EventFactOverview = ({
           <time
             data-testid="event-overview-date"
             dateTime={range.date.dateIso}
-            className="text-kcvv-white flex flex-col"
+            className="text-cream flex flex-col"
           >
             <span className="font-display text-xl leading-[0.95] font-bold">
               {range.date.day}{" "}
               <span className="uppercase">{range.date.monthShort}</span>
             </span>
-            <span className="text-kcvv-gray-light mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+            <span className="text-cream/60 mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
               {range.date.weekday}
             </span>
           </time>
@@ -95,7 +95,7 @@ export const EventFactOverview = ({
         {(range.kind === "range" || range.kind === "sessions") && (
           <div
             data-testid="event-overview-date"
-            className="text-kcvv-white flex flex-col"
+            className="text-cream flex flex-col"
           >
             <span className="font-display text-xl leading-[0.95] font-bold">
               <time dateTime={range.start.dateIso}>
@@ -104,7 +104,7 @@ export const EventFactOverview = ({
                   <span className="uppercase"> {range.start.monthShort}</span>
                 )}
               </time>
-              <span className="text-kcvv-white/40 mx-1">–</span>
+              <span className="text-cream/40 mx-1">–</span>
               <time dateTime={range.end.dateIso}>
                 {range.end.day}{" "}
                 <span className="uppercase">
@@ -114,7 +114,7 @@ export const EventFactOverview = ({
                 </span>
               </time>
             </span>
-            <span className="text-kcvv-gray-light mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+            <span className="text-cream/60 mt-1 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
               {/* 3-letter weekday abbreviations so ranges stay on one
                   line in the narrow date column (e.g. "vr – zo" vs
                   "vrijdag – zondag"). */}
@@ -126,9 +126,9 @@ export const EventFactOverview = ({
         {range.kind === "none" && (
           <div
             data-testid="event-overview-date"
-            className="text-kcvv-white flex flex-col"
+            className="text-cream flex flex-col"
           >
-            <span className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
+            <span className="text-cream/60 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase">
               Datum volgt
             </span>
           </div>
@@ -138,7 +138,7 @@ export const EventFactOverview = ({
           {value.title && (
             <span
               data-testid="event-overview-title"
-              className="font-display text-kcvv-white text-lg font-bold"
+              className="font-display text-cream text-lg font-bold"
             >
               {value.title}
             </span>
@@ -146,7 +146,7 @@ export const EventFactOverview = ({
           {metaParts.length > 0 && (
             <span
               data-testid="event-overview-meta"
-              className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
+              className="text-cream/60 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
             >
               {metaParts.map((part, i) => (
                 // Composite key — two parts could collide on the same
@@ -154,10 +154,7 @@ export const EventFactOverview = ({
                 // duplicates a label).
                 <span key={`${i}-${part}`}>
                   {i > 0 && (
-                    <span
-                      aria-hidden="true"
-                      className="text-kcvv-white/30 mx-2"
-                    >
+                    <span aria-hidden="true" className="text-cream/30 mx-2">
                       ·
                     </span>
                   )}
@@ -176,7 +173,7 @@ export const EventFactOverview = ({
             rel="noopener noreferrer"
             className={cn(
               "font-display inline-flex items-baseline gap-1 text-sm font-bold tracking-[var(--letter-spacing-caps)] uppercase",
-              "text-kcvv-green-bright decoration-kcvv-green-bright underline decoration-1 underline-offset-4",
+              "text-jersey decoration-jersey underline decoration-1 underline-offset-4",
               "transition-[text-decoration-thickness] duration-150 hover:decoration-2",
             )}
           >

--- a/apps/web/src/components/article/blocks/QaBlock/QaBlock.tsx
+++ b/apps/web/src/components/article/blocks/QaBlock/QaBlock.tsx
@@ -150,7 +150,7 @@ function mapStandardRespondents(
  * Dispatches each qaPair to its Phase-5 renderer. Separator rules between
  * units:
  *   - Between two consecutive `standard` (QARow) pairs: 1 px
- *     `kcvv-gray-light` rule.
+ *     `paper-edge` rule.
  *   - Before/after `key`, `quote`, or `rapid-fire` units: no rule — those
  *     blocks provide their own visual boundary.
  */
@@ -173,10 +173,7 @@ export const QaBlock = ({ value, subjects = null }: QaBlockProps) => {
       rendered.push(
         <Fragment key={unit.pair._key ?? `std-${i}`}>
           {needsRule && (
-            <hr
-              aria-hidden="true"
-              className="border-kcvv-gray-light m-0 border-t"
-            />
+            <hr aria-hidden="true" className="border-paper-edge m-0 border-t" />
           )}
           <QARow
             question={unit.pair.question ?? ""}

--- a/apps/web/src/components/article/blocks/TransferFact/TransferFactOverview.test.tsx
+++ b/apps/web/src/components/article/blocks/TransferFact/TransferFactOverview.test.tsx
@@ -14,11 +14,11 @@ describe("TransferFactOverview", () => {
       />,
     );
     const kicker = screen.getByTestId("transfer-overview-kicker");
-    expect(kicker).toHaveClass("text-kcvv-green-bright");
+    expect(kicker).toHaveClass("text-jersey");
     expect(kicker).toHaveTextContent(/Inkomend/i);
   });
 
-  it("outgoing: kicker uses kcvv-warning (amber) — reported, not alarmed", () => {
+  it("outgoing: kicker uses warm (amber) — reported, not alarmed", () => {
     render(
       <TransferFactOverview
         value={{
@@ -29,8 +29,8 @@ describe("TransferFactOverview", () => {
       />,
     );
     const kicker = screen.getByTestId("transfer-overview-kicker");
-    expect(kicker).toHaveClass("text-kcvv-warning");
-    expect(kicker).not.toHaveClass("text-kcvv-green-bright");
+    expect(kicker).toHaveClass("text-warm");
+    expect(kicker).not.toHaveClass("text-jersey");
     expect(kicker).toHaveTextContent(/Uitgaand/i);
   });
 
@@ -47,7 +47,7 @@ describe("TransferFactOverview", () => {
     const section = container.querySelector(
       "[data-testid='transfer-overview']",
     );
-    expect(section).toHaveClass("bg-kcvv-gray-dark");
+    expect(section).toHaveClass("bg-ink");
     expect(section).toHaveClass("full-bleed");
   });
 

--- a/apps/web/src/components/article/blocks/TransferFact/TransferFactOverview.tsx
+++ b/apps/web/src/components/article/blocks/TransferFact/TransferFactOverview.tsx
@@ -23,10 +23,10 @@ export interface TransferFactOverviewProps {
  * "moment" treatment the interview qaBlock cream bands use, inverted.
  *
  * Colour rules per direction:
- *   - `incoming`  kicker + arrow = `kcvv-green-bright` (pops on dark).
- *   - `outgoing`  kicker + arrow = `kcvv-warning` (amber — reported, not
+ *   - `incoming`  kicker + arrow = `jersey` (bright — pops on dark).
+ *   - `outgoing`  kicker + arrow = `warm` (amber — reported, not
  *     alarmed).
- *   - `extension` kicker = `kcvv-green-bright`. No arrow — single KCVV
+ *   - `extension` kicker = `jersey`. No arrow — single KCVV
  *     row + `TOT {until}` status label on the right.
  */
 export const TransferFactOverview = ({
@@ -42,10 +42,8 @@ export const TransferFactOverview = ({
   ].filter((x): x is string => typeof x === "string" && x.length > 0);
 
   const isOutgoing = resolved.direction === "outgoing";
-  const accentClass = isOutgoing
-    ? "text-kcvv-warning"
-    : "text-kcvv-green-bright";
-  const accentBgClass = isOutgoing ? "bg-kcvv-warning" : "bg-kcvv-green-bright";
+  const accentClass = isOutgoing ? "text-warm" : "text-jersey";
+  const accentBgClass = isOutgoing ? "bg-warm" : "bg-jersey";
 
   const statusLabel =
     resolved.kind === "extension"
@@ -62,9 +60,9 @@ export const TransferFactOverview = ({
         // Break out of the 65 ch prose column so consecutive rows share
         // one continuous dark band. Each row uses the same `max-w-outer`
         // inner container, so the column grid aligns row-to-row.
-        "full-bleed not-prose bg-kcvv-gray-dark py-6",
-        // White-alpha top rule separates stacked rows without shouting.
-        "border-kcvv-white/10 border-t",
+        "full-bleed not-prose bg-ink py-6",
+        // Cream-alpha top rule separates stacked rows without shouting.
+        "border-cream/10 border-t",
         className,
       )}
     >
@@ -93,7 +91,7 @@ export const TransferFactOverview = ({
           {playerName && (
             <span
               data-testid="transfer-overview-name"
-              className="font-display text-kcvv-white text-xl font-bold"
+              className="font-display text-cream text-xl font-bold"
             >
               {playerName}
             </span>
@@ -101,15 +99,12 @@ export const TransferFactOverview = ({
           {metaParts.length > 0 && (
             <span
               data-testid="transfer-overview-meta"
-              className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
+              className="text-cream/60 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase"
             >
               {metaParts.map((part, i) => (
                 <span key={part}>
                   {i > 0 && (
-                    <span
-                      aria-hidden="true"
-                      className="text-kcvv-white/30 mx-2"
-                    >
+                    <span aria-hidden="true" className="text-cream/30 mx-2">
                       ·
                     </span>
                   )}
@@ -123,7 +118,7 @@ export const TransferFactOverview = ({
         {resolved.kind === "extension" ? (
           <div
             data-testid="transfer-overview-kcvv-only"
-            className="text-kcvv-white flex items-center gap-2 text-base"
+            className="text-cream flex items-center gap-2 text-base"
           >
             {resolved.kcvvOnly.logoUrl && (
               <Image
@@ -139,7 +134,7 @@ export const TransferFactOverview = ({
         ) : (
           <div
             data-testid="transfer-overview-clubs"
-            className="text-kcvv-white flex flex-wrap items-center gap-x-2 gap-y-1 text-base"
+            className="text-cream flex flex-wrap items-center gap-x-2 gap-y-1 text-base"
           >
             <span className="flex items-center gap-2">
               {resolved.from.logoUrl && (
@@ -171,7 +166,7 @@ export const TransferFactOverview = ({
 
         <p
           data-testid="transfer-overview-status"
-          className="text-kcvv-gray-light font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase md:text-right"
+          className="text-cream/60 font-mono text-xs tracking-[var(--letter-spacing-caps)] uppercase md:text-right"
         >
           {statusLabel}
         </p>

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.test.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.test.tsx
@@ -34,20 +34,20 @@ describe("SectionCta", () => {
   });
 
   describe("Typography", () => {
-    it("should style heading with font-display font-extrabold text-kcvv-black", () => {
+    it("should style heading with font-display font-extrabold text-ink-soft", () => {
       render(<SectionCta {...defaultProps} />);
       const heading = screen.getByRole("heading");
       expect(heading).toHaveClass(
         "font-display",
         "font-extrabold",
-        "text-kcvv-black",
+        "text-ink-soft",
       );
     });
 
-    it("should style body with text-sm text-kcvv-gray leading-relaxed", () => {
+    it("should style body with text-sm text-ink-muted leading-relaxed", () => {
       render(<SectionCta {...defaultProps} />);
       const body = screen.getByText(defaultProps.body);
-      expect(body).toHaveClass("text-sm", "text-kcvv-gray", "leading-relaxed");
+      expect(body).toHaveClass("text-sm", "text-ink-muted", "leading-relaxed");
     });
   });
 
@@ -69,12 +69,12 @@ describe("SectionCta", () => {
   });
 
   describe("Variants", () => {
-    it("defaults to light variant — heading is text-kcvv-black, body is text-kcvv-gray", () => {
+    it("defaults to light variant — heading is text-ink-soft, body is text-ink-muted", () => {
       render(<SectionCta {...defaultProps} />);
       const heading = screen.getByRole("heading");
-      expect(heading).toHaveClass("text-kcvv-black");
+      expect(heading).toHaveClass("text-ink-soft");
       const body = screen.getByText(defaultProps.body);
-      expect(body).toHaveClass("text-kcvv-gray");
+      expect(body).toHaveClass("text-ink-muted");
     });
 
     it("dark variant uses white text for heading and white/75 for body", () => {
@@ -85,10 +85,10 @@ describe("SectionCta", () => {
       expect(body).toHaveClass("text-white/75");
     });
 
-    it("dark variant heading does NOT use the light text-kcvv-black class", () => {
+    it("dark variant heading does NOT use the light text-ink-soft class", () => {
       render(<SectionCta {...defaultProps} variant="dark" />);
       const heading = screen.getByRole("heading");
-      expect(heading).not.toHaveClass("text-kcvv-black");
+      expect(heading).not.toHaveClass("text-ink-soft");
     });
   });
 });

--- a/apps/web/src/components/design-system/SectionCta/SectionCta.tsx
+++ b/apps/web/src/components/design-system/SectionCta/SectionCta.tsx
@@ -7,7 +7,7 @@ export interface SectionCtaProps {
   buttonHref: string;
   /**
    * Visual variant. "light" (default) renders dark text on a light background.
-   * "dark" renders white text — use on dark sections (kcvv-black, kcvv-green-dark)
+   * "dark" renders white text — use on dark sections (ink, jersey-deep)
    * to keep the heading and body legible.
    */
   variant?: "light" | "dark";
@@ -25,7 +25,7 @@ export function SectionCta({
     <div className="mx-auto max-w-[40rem] px-4 text-center md:px-10">
       <h2
         className={`font-display mb-3 font-extrabold ${
-          isDark ? "text-white" : "text-kcvv-black"
+          isDark ? "text-white" : "text-ink-soft"
         }`}
         style={{ fontSize: "clamp(1.5rem, 3vw, 2rem)" }}
       >
@@ -34,7 +34,7 @@ export function SectionCta({
 
       <p
         className={`mb-8 text-sm leading-relaxed ${
-          isDark ? "text-white/75" : "text-kcvv-gray"
+          isDark ? "text-white/75" : "text-ink-muted"
         }`}
       >
         {body}

--- a/apps/web/src/components/layout/AccentStrip/AccentStrip.tsx
+++ b/apps/web/src/components/layout/AccentStrip/AccentStrip.tsx
@@ -1,12 +1,12 @@
 /**
  * AccentStrip
- * A 3px kcvv-green decorative bar pinned to the top of the viewport.
+ * A 3px jersey-deep decorative bar pinned to the top of the viewport.
  * Sits above the sticky nav (z-[51] > nav z-50).
  * Purely decorative — hidden from screen readers.
  */
 export const AccentStrip = () => (
   <div
     aria-hidden="true"
-    className="bg-kcvv-green-bright fixed top-0 right-0 left-0 z-[51] h-[3px]"
+    className="bg-jersey-deep fixed top-0 right-0 left-0 z-[51] h-[3px]"
   />
 );

--- a/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.tsx
+++ b/apps/web/src/components/related/RelatedArticlesSection/RelatedArticlesSection.tsx
@@ -46,7 +46,7 @@ export const RelatedArticlesSection = ({
           <Link
             key={article.id}
             href={`/nieuws/${article.slug}`}
-            className="group hover:border-kcvv-green-bright block overflow-hidden rounded-lg border border-gray-200 transition-colors"
+            className="group hover:border-jersey-deep block overflow-hidden rounded-lg border border-gray-200 transition-colors"
             onClick={() => {
               trackEvent("related_content_click", {
                 source: "reference",
@@ -70,7 +70,7 @@ export const RelatedArticlesSection = ({
               </div>
             )}
             <div className="p-3">
-              <h4 className="group-hover:text-kcvv-green-dark line-clamp-2 text-sm font-semibold transition-colors">
+              <h4 className="group-hover:text-jersey-deep line-clamp-2 text-sm font-semibold transition-colors">
                 {article.title}
               </h4>
               {article.publishedAt && (

--- a/apps/web/src/components/share/SharePage/SharePage.tsx
+++ b/apps/web/src/components/share/SharePage/SharePage.tsx
@@ -356,13 +356,13 @@ export function SharePage({ matches, players }: SharePageProps) {
   };
 
   const inputClass =
-    "w-full border-2 border-gray-200 rounded-sm px-4 py-3 font-montserrat text-base focus:border-kcvv-green focus:outline-none";
+    "w-full border-2 border-gray-200 rounded-sm px-4 py-3 font-montserrat text-base focus:border-jersey-deep focus:outline-none";
   const labelClass =
-    "font-montserrat font-semibold text-sm uppercase tracking-wide text-kcvv-black";
+    "font-montserrat font-semibold text-sm uppercase tracking-wide text-ink-soft";
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-8">
-      <h1 className="font-montserrat text-kcvv-black text-3xl font-black">
+      <h1 className="font-montserrat text-ink-soft text-3xl font-black">
         Story Generator
       </h1>
 
@@ -379,8 +379,8 @@ export function SharePage({ matches, players }: SharePageProps) {
               aria-pressed={selectedTemplateId === t.id}
               className={`font-montserrat flex min-h-[72px] flex-col items-center gap-1 rounded-sm border-2 p-3 text-sm font-semibold transition-colors ${
                 selectedTemplateId === t.id
-                  ? "border-kcvv-green bg-kcvv-green/10 text-kcvv-green"
-                  : "text-kcvv-black hover:border-kcvv-green/50 border-gray-200 bg-white"
+                  ? "border-jersey-deep bg-jersey-deep/10 text-jersey-deep"
+                  : "text-ink-soft hover:border-jersey-deep/50 border-gray-200 bg-white"
               }`}
             >
               <t.icon
@@ -486,8 +486,8 @@ export function SharePage({ matches, players }: SharePageProps) {
                 onClick={() => setSelectedPlayerId(p.id)}
                 className={`font-montserrat flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors ${
                   selectedPlayerId === p.id
-                    ? "bg-kcvv-green/10 text-kcvv-green"
-                    : "text-kcvv-black hover:bg-gray-50"
+                    ? "bg-jersey-deep/10 text-jersey-deep"
+                    : "text-ink-soft hover:bg-gray-50"
                 }`}
               >
                 <span className="min-w-[2rem] text-center text-lg font-bold">
@@ -564,7 +564,7 @@ export function SharePage({ matches, players }: SharePageProps) {
       <button
         onClick={handleGenerate}
         disabled={isGenerating}
-        className="bg-kcvv-green-bright hover:bg-kcvv-green-hover font-montserrat rounded-sm px-10 py-4 text-lg font-bold text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        className="bg-jersey-deep font-montserrat rounded-sm px-10 py-4 text-lg font-bold text-white transition-all duration-300 hover:translate-x-1 hover:translate-y-1 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isGenerating ? "Generating…" : "Genereer"}
       </button>
@@ -581,14 +581,14 @@ export function SharePage({ matches, players }: SharePageProps) {
           {canShareFiles ? (
             <button
               onClick={handleShare}
-              className="bg-kcvv-green-bright hover:bg-kcvv-green-hover font-montserrat rounded-sm px-10 py-4 text-lg font-bold text-white transition-colors"
+              className="bg-jersey-deep font-montserrat rounded-sm px-10 py-4 text-lg font-bold text-white transition-all duration-300 hover:translate-x-1 hover:translate-y-1"
             >
               Delen
             </button>
           ) : (
             <button
               onClick={handleDownload}
-              className="bg-kcvv-green-bright hover:bg-kcvv-green-hover font-montserrat rounded-sm px-10 py-4 text-lg font-bold text-white transition-colors"
+              className="bg-jersey-deep font-montserrat rounded-sm px-10 py-4 text-lg font-bold text-white transition-all duration-300 hover:translate-x-1 hover:translate-y-1"
             >
               Download PNG
             </button>


### PR DESCRIPTION
Closes #2117

Phase 9 spin-out of #1531. Migrates the ~13 structurally-unchanged surfaces off legacy `kcvv-*` colour classes onto retro-terrace tokens, applying the issue's **locked context-aware conventions**.

## Mapping applied

| Context | Rule |
|---|---|
| Dark bands (EventFact/TransferFact overviews → `bg-ink`; news filter bar; tegenstander loading skeleton) | `kcvv-white` → `cream` (+ `/40`,`/30` alphas); muted mono → `cream/60`; green accent on dark → **bright `jersey`**; amber → `warm` |
| Light/cream surfaces (ArticleMetadata, QaBlock rule, RelatedArticles, SectionCta light variant, AccentStrip, page empty-state, SharePage) | green accent → `jersey-deep`; text → `ink-soft`/`ink-muted`; rules → `paper-edge` |
| Status colours (tegenstander W/D/L + transfer direction) | win → `jersey-deep`, draw → none/neutral, loss → `--color-alert` (mirrors `TeamAgendaRow`) |
| Dangling tokens (latent bugs) | `bg-kcvv-dark-bg` → `bg-ink`; `--color-muted` → `ink-muted`; `--color-surface` → `cream-soft`; `--color-surface-hover` → `cream-deep` |
| SharePage buttons | `hover:bg-kcvv-green-hover` colour-darken → canonical press-down (`transition-all duration-300 hover:translate-x-1 hover:translate-y-1`) |

## Design decision flagged for review

- **Bright `jersey` on dark bands** (EventFact CTA, TransferFact incoming accent): per the issue's *context-aware green* rule (dark → bright `#4acf52`, light → `jersey-deep` `#008755`). Bright green on near-black is high-contrast; `jersey-deep` on `bg-ink` would be the contrast-risky direction. Precedent: `NavDropdown` uses `text-jersey-bright` on its dark panel. Both tokens exist; the older "no bright jersey" feedback is about card fills on light surfaces, not on-dark accents.

## Out of scope (intentional)

- `page.tsx` `bg: "kcvv-green-dark"` SectionBg value — **gated on #1701** (`SectionTransition`), per the issue note.
- `globals.css` legacy-token removal — deferred to the **#1531 capstone**.
- The tegenstander **loading skeleton** header is now `bg-ink` (issue's latent-bug fix; white skeleton text was previously invisible on the dangling token). It does not pixel-match the light real-page header — a pre-existing skeleton-approximation, not changed here.

## Testing

- `pnpm --filter @kcvv/web check-all` green — lint + type-check + **3346 tests** + build (exit 0).
- Component tests (ArticleMetadata, EventFact, TransferFact, SectionCta) updated to assert the new tokens.
- VR baselines deferred to the end-of-series batch capture.

## Review gate

- `/code-review` (3 focused finders: utility-resolution · surface/contrast/semantics · line-by-line+test-sync) → **`[]`**. Every new utility resolves to a real `--color-*` token; no surface mis-classification; tests match source.
- `/simplify` → already clean (migration *removed* two multi-line ternaries; canonical tokens; correct depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
