### PR TITLE
feat(ui): reskin /tegenstander opponent-history page (#2141)

### DIFF
--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -34,7 +34,7 @@ import { SponsorsSection } from "@/components/home/SponsorsSection";
 import { RelatedArticlesSection } from "@/components/related/RelatedArticlesSection";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import { hasRenderableBioContent } from "@/lib/portable-text/findPullquoteText";
-import { transformMatchToSchedule } from "./utils";
+import { transformMatchToSchedule } from "@/components/match";
 import { TeamSectionNav, type TeamSectionNavItem } from "./TeamSectionNav";
 
 interface TeamPageProps {

--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
@@ -12,7 +12,7 @@ import { EditorialHeading } from "@/components/design-system/EditorialHeading";
 import { FooterSafeArea } from "@/components/design-system";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd, buildSportsTeamJsonLd } from "@/lib/seo/jsonld";
-import { transformMatchToSchedule } from "../utils";
+import { transformMatchToSchedule } from "@/components/match";
 import type { ScheduleMatch } from "@/components/match/types";
 import { AgendaScrollToNext } from "./AgendaScrollToNext";
 

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/OpponentSummaryCard.stories.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/OpponentSummaryCard.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { OpponentSummaryCard } from "./OpponentSummaryCard";
+
+const meta = {
+  title: "Pages/Opponent/OpponentSummaryCard",
+  component: OpponentSummaryCard,
+  parameters: { layout: "padded" },
+  tags: ["vr"],
+  decorators: [
+    (Story) => (
+      <div className="bg-cream-deep mx-auto max-w-2xl p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof OpponentSummaryCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** OHR Huldenberg (746) — the locked reference fixture (W3 · G2 · V1). */
+export const Default: Story = {
+  args: {
+    summary: { wins: 3, draws: 2, losses: 1, goalsFor: 13, goalsAgainst: 7 },
+  },
+};
+
+/** A goal-shy, winless history — losses in alert, zeroes still render. */
+export const Winless: Story = {
+  args: {
+    summary: { wins: 0, draws: 1, losses: 4, goalsFor: 2, goalsAgainst: 11 },
+  },
+};
+
+/** Double-digit goal columns keep the five-cell grid balanced. */
+export const HighScoring: Story = {
+  args: {
+    summary: { wins: 12, draws: 4, losses: 3, goalsFor: 58, goalsAgainst: 29 },
+  },
+};

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/OpponentSummaryCard.test.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/OpponentSummaryCard.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { OpponentSummaryCard } from "./OpponentSummaryCard";
+
+const SUMMARY = {
+  wins: 3,
+  draws: 2,
+  losses: 1,
+  goalsFor: 13,
+  goalsAgainst: 7,
+};
+
+describe("OpponentSummaryCard", () => {
+  it("renders all five tallies", () => {
+    render(<OpponentSummaryCard summary={SUMMARY} />);
+    const card = screen.getByTestId("opponent-summary");
+    expect(card.textContent).toContain("3");
+    expect(card.textContent).toContain("2");
+    expect(card.textContent).toContain("1");
+    expect(card.textContent).toContain("13");
+    expect(card.textContent).toContain("7");
+  });
+
+  it("labels each cell (W · G · V · DV · DT)", () => {
+    render(<OpponentSummaryCard summary={SUMMARY} />);
+    for (const label of ["W", "G", "V", "DV", "DT"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("exposes the full Dutch term to assistive tech", () => {
+    render(<OpponentSummaryCard summary={SUMMARY} />);
+    expect(screen.getByText("winst")).toBeInTheDocument();
+    expect(screen.getByText("doelpunten tegen")).toBeInTheDocument();
+  });
+
+  it("tones the win cell jersey-deep and the loss cell alert", () => {
+    const { container } = render(<OpponentSummaryCard summary={SUMMARY} />);
+    expect(container.querySelector("dd.text-jersey-deep")).toHaveTextContent(
+      "3",
+    );
+    expect(container.querySelector("dd.text-alert")).toHaveTextContent("1");
+  });
+
+  it("still renders zero tallies", () => {
+    render(
+      <OpponentSummaryCard
+        summary={{ wins: 0, draws: 0, losses: 0, goalsFor: 0, goalsAgainst: 0 }}
+      />,
+    );
+    expect(screen.getAllByText("0")).toHaveLength(5);
+  });
+});

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/OpponentSummaryCard.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/OpponentSummaryCard.tsx
@@ -1,0 +1,89 @@
+import { cn } from "@/lib/utils/cn";
+
+/** W/D/L + goals tally for the opponent-history hero, computed by the BFF. */
+export interface OpponentSummary {
+  wins: number;
+  draws: number;
+  losses: number;
+  goalsFor: number;
+  goalsAgainst: number;
+}
+
+export interface OpponentSummaryCardProps {
+  summary: OpponentSummary;
+  className?: string;
+}
+
+/**
+ * Bordered paper stat card — five cells (W · G · V · DV · DT) computed from
+ * finished matches only. Reuses the design-system paper-card vocabulary
+ * (`border-2 border-ink` + `shadow-paper-sm`, sharp corners); no existing
+ * primitive covers a divided stat row. Win is `jersey-deep`, loss is `alert`,
+ * everything else neutral `ink` — the status colour lock from #2117.
+ *
+ * Each cell is a `<dt>`/`<dd>` pair (the abbreviation is the term, the count the
+ * description) rendered value-on-top via `flex-col-reverse`, with the full Dutch
+ * word exposed to assistive tech via an `.sr-only` span.
+ */
+export function OpponentSummaryCard({
+  summary,
+  className,
+}: OpponentSummaryCardProps) {
+  const cells: ReadonlyArray<{
+    value: number;
+    label: string;
+    a11y: string;
+    tone: string;
+  }> = [
+    {
+      value: summary.wins,
+      label: "W",
+      a11y: "winst",
+      tone: "text-jersey-deep",
+    },
+    { value: summary.draws, label: "G", a11y: "gelijk", tone: "text-ink" },
+    { value: summary.losses, label: "V", a11y: "verlies", tone: "text-alert" },
+    {
+      value: summary.goalsFor,
+      label: "DV",
+      a11y: "doelpunten voor",
+      tone: "text-ink",
+    },
+    {
+      value: summary.goalsAgainst,
+      label: "DT",
+      a11y: "doelpunten tegen",
+      tone: "text-ink",
+    },
+  ];
+
+  return (
+    <dl
+      data-testid="opponent-summary"
+      className={cn(
+        "border-ink bg-cream shadow-paper-sm grid grid-cols-5 border-2",
+        className,
+      )}
+    >
+      {cells.map((cell) => (
+        <div
+          key={cell.label}
+          className="border-ink flex flex-col-reverse items-center gap-2 border-r-2 px-1.5 py-4 last:border-r-0"
+        >
+          <dt className="text-ink-muted font-mono text-[9px] tracking-[0.1em] uppercase">
+            <span aria-hidden="true">{cell.label}</span>
+            <span className="sr-only">{cell.a11y}</span>
+          </dt>
+          <dd
+            className={cn(
+              "font-display-big text-[28px] leading-none",
+              cell.tone,
+            )}
+          >
+            {cell.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/loading.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/loading.tsx
@@ -1,46 +1,76 @@
 /**
  * Opponent History Page — Loading Skeleton
- * Matches the opponent header + W/D/L summary + match history layout
+ *
+ * Paper-register skeleton mirroring the #2141 reskin: a light hero card, the
+ * five-cell summary, a striped seam, and a season-grouped row placeholder.
+ * Card chrome (borders + paper shadow) stays solid; only the gray content bars
+ * pulse.
  */
+
+import { StripedSeam } from "@/components/design-system";
 
 export default function OpponentLoading() {
   return (
-    <div className="min-h-screen bg-gray-100">
-      {/* Opponent header */}
-      <div className="bg-ink px-4 py-8 text-white">
-        <div className="mx-auto flex max-w-3xl animate-pulse items-center gap-4">
-          <div className="h-16 w-16 rounded-full bg-white/10" />
-          <div className="space-y-2">
-            <div className="h-8 w-48 rounded bg-white/10" />
-            <div className="h-4 w-32 rounded bg-white/15" />
+    <div className="bg-cream-deep min-h-screen pb-[var(--footer-diagonal)]">
+      <div className="container mx-auto max-w-3xl px-4 pt-8 pb-8">
+        {/* Hero card */}
+        <div className="border-ink bg-cream shadow-paper-md border-2 p-6">
+          <div className="animate-pulse">
+            <div className="flex items-center gap-4">
+              <div className="bg-ink/10 h-16 w-16 shrink-0 rounded-full" />
+              <div className="flex-1 space-y-3">
+                <div className="bg-ink/10 h-3 w-40" />
+                <div className="bg-ink/15 h-9 w-2/3" />
+              </div>
+            </div>
+            <div className="bg-ink/10 mt-4 h-3 w-3/4" />
           </div>
         </div>
-      </div>
 
-      <div className="mx-auto max-w-3xl px-4 py-8">
-        {/* W/D/L/GF/GA summary */}
-        <div className="mb-8 grid animate-pulse grid-cols-5 gap-2">
+        {/* W/D/L summary */}
+        <div className="border-ink bg-cream shadow-paper-sm mt-7 grid grid-cols-5 border-2">
           {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}
-              className="space-y-2 rounded-sm border border-gray-200 bg-white p-4 text-center shadow-sm"
+              className="border-ink flex animate-pulse flex-col items-center gap-2 border-r-2 px-1.5 py-4 last:border-r-0"
             >
-              <div className="mx-auto h-8 w-8 rounded bg-gray-200" />
-              <div className="mx-auto h-3 w-16 rounded bg-gray-200" />
+              <div className="bg-ink/15 h-6 w-6" />
+              <div className="bg-ink/10 h-2 w-6" />
             </div>
           ))}
         </div>
 
-        {/* Match list */}
-        <div className="animate-pulse space-y-2">
-          {Array.from({ length: 8 }).map((_, i) => (
+        {/* Seam */}
+        <div className="mt-8 mb-5">
+          <StripedSeam height="sm" />
+        </div>
+
+        {/* List header */}
+        <div className="bg-ink/15 mb-4 h-6 w-44 animate-pulse" />
+
+        {/* Season band */}
+        <div className="mb-2.5 flex animate-pulse items-center gap-2.5">
+          <div className="bg-ink/15 h-5 w-28" />
+          <div className="border-ink/30 h-0 flex-1 border-t-2 border-dotted" />
+          <div className="bg-ink/10 h-2 w-16" />
+        </div>
+
+        {/* Rows */}
+        <div className="flex flex-col gap-2.5">
+          {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}
-              className="flex items-center gap-4 rounded-sm border border-l-4 border-gray-200 border-l-gray-300 bg-white p-3 shadow-sm"
+              className="border-ink bg-cream flex items-stretch border-2 shadow-[2px_2px_0_0_var(--color-ink)]"
             >
-              <div className="h-4 w-20 rounded bg-gray-200" />
-              <div className="h-4 w-32 flex-1 rounded bg-gray-200" />
-              <div className="h-5 w-12 rounded bg-gray-200" />
+              <div className="border-ink/30 flex w-[56px] shrink-0 animate-pulse flex-col items-center justify-center gap-1 border-r-2 border-dashed py-3">
+                <div className="bg-ink/15 h-4 w-5" />
+                <div className="bg-ink/10 h-2 w-6" />
+              </div>
+              <div className="flex flex-1 animate-pulse items-center justify-between px-3 py-3">
+                <div className="bg-ink/10 h-3 w-24" />
+                <div className="bg-ink/15 h-5 w-10" />
+                <div className="bg-ink/10 h-3 w-24" />
+              </div>
             </div>
           ))}
         </div>

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/page.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/page.tsx
@@ -1,21 +1,33 @@
 /**
  * Opponent History Page — /tegenstander/[clubId]
  *
- * Shows all historical KCVV senior-team matches against a specific opponent club,
- * with W/D/L summary and a chronological match list.
+ * Shows all historical KCVV senior-team matches against a specific opponent
+ * club, with a W/D/L summary and a season-grouped match list on the
+ * retro-terrace system (#2141).
  *
  * Not in navigation. Noindex — personal statistics/preview tool.
+ *
+ * Design lock: docs/design/mockups/phase-10-tegenstander/10t4-locked.html
  */
 
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
 import { runPromise } from "@/lib/effect/runtime";
 import { BffService } from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import type { Match, OpponentHistory } from "@kcvv/api-contract";
+import {
+  Crest,
+  EditorialHeading,
+  StripedSeam,
+} from "@/components/design-system";
+import { PageHero } from "@/components/layout/PageHero";
+import { TeamAgendaRow } from "@/components/team/TeamMatchesSection";
+import { transformMatchToSchedule } from "@/components/match";
+import { getResultColor } from "@/lib/utils/match-display";
+import { groupBySeason } from "@/lib/utils/season";
+import { OpponentSummaryCard } from "./OpponentSummaryCard";
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -25,34 +37,63 @@ interface OpponentPageProps {
   params: Promise<{ clubId: string }>;
 }
 
-/** Transform a Match from api-contract into display-ready values. */
-function formatMatchDate(date: Date | string): string {
-  return new Date(date).toLocaleDateString("nl-BE", {
-    weekday: "short",
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
-}
-
-function getMatchResult(match: Match): "win" | "draw" | "loss" | null {
-  if (match.status !== "finished") return null;
-  if (match.is_home == null) return null;
+/**
+ * KCVV-perspective result of a single match. Finished matches only — the locked
+ * status vocabulary from #2117 (scheduled/postponed/… never count toward a
+ * tally). Mirrors the BFF summary computation so per-season tallies sum to the
+ * hero card totals.
+ */
+function getMatchOutcome(match: Match): "win" | "draw" | "loss" | null {
+  if (match.status !== "finished" || match.is_home == null) return null;
   const homeScore = match.home_team.score;
   const awayScore = match.away_team.score;
   if (homeScore == null || awayScore == null) return null;
-  const kcvvGoals = match.is_home ? homeScore : awayScore;
-  const oppGoals = match.is_home ? awayScore : homeScore;
-  if (kcvvGoals > oppGoals) return "win";
-  if (kcvvGoals < oppGoals) return "loss";
-  return "draw";
+  return getResultColor(homeScore, awayScore, match.is_home);
 }
 
-const resultBorderClass: Record<"win" | "draw" | "loss", string> = {
-  win: "border-l-4 border-l-jersey-deep",
-  draw: "border-l-4 border-l-transparent",
-  loss: "border-l-4 border-l-alert",
-};
+/** Per-season tally caption, e.g. `"2W · 1G"` or `"1 gepland"`. */
+function seasonTally(matches: readonly Match[]): string {
+  let wins = 0;
+  let draws = 0;
+  let losses = 0;
+  let scheduled = 0;
+  for (const match of matches) {
+    const outcome = getMatchOutcome(match);
+    if (outcome === "win") wins += 1;
+    else if (outcome === "draw") draws += 1;
+    else if (outcome === "loss") losses += 1;
+    else if (match.status === "scheduled") scheduled += 1;
+  }
+  const parts: string[] = [];
+  if (wins) parts.push(`${wins}W`);
+  if (draws) parts.push(`${draws}G`);
+  if (losses) parts.push(`${losses}V`);
+  if (scheduled) parts.push(`${scheduled} gepland`);
+  return parts.join(" · ");
+}
+
+/** Warm mono band that opens each season group. */
+function SeasonBand({ label, tally }: { label: string; tally: string }) {
+  return (
+    <div className="mb-2.5 flex items-center gap-2.5">
+      <span className="border-ink bg-warm text-ink border-2 px-2.5 py-1 font-mono text-[10px] font-bold tracking-[0.12em] uppercase">
+        {label}
+      </span>
+      {/* Raw dotted rule rather than <DottedDivider>: the divider hardcodes
+          role="separator" + full width and takes no flex-grow, which doesn't
+          fit this decorative chip · rule · tally row. */}
+      <span
+        aria-hidden="true"
+        className="border-ink h-0 flex-1 border-t-2 border-dotted"
+      />
+      {tally ? (
+        <span className="text-ink-muted font-mono text-[9px] tracking-wide uppercase">
+          {tally}
+        </span>
+      ) : null}
+    </div>
+  );
+}
 
 async function fetchOpponentData(clubId: number): Promise<{
   opponentName: string;
@@ -107,7 +148,7 @@ async function fetchOpponentData(clubId: number): Promise<{
         0,
       );
 
-      // Sort all matches descending by date
+      // Sort all matches descending by date (scheduled future matches surface first)
       const sortedMatches = [...allMatches].sort(
         (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
       );
@@ -140,103 +181,72 @@ export default async function OpponentPage({ params }: OpponentPageProps) {
   if (!data) notFound();
 
   const { opponentName, opponentLogo, summary, matches } = data;
-  const totalPlayed = summary.wins + summary.draws + summary.losses;
+  const seasons = groupBySeason(matches, (m) => m.date);
+  const matchCountLabel = `${matches.length} ${
+    matches.length === 1 ? "wedstrijd" : "wedstrijden"
+  }`;
 
   return (
-    <div className="container mx-auto max-w-3xl px-4 pt-8 pb-[calc(2rem+var(--footer-diagonal))]">
-      {/* Opponent header */}
-      <div className="mb-6 flex items-center gap-4">
-        {opponentLogo && (
-          <Image
-            src={opponentLogo}
-            alt={`Logo ${opponentName}`}
-            width={64}
-            height={64}
-            className="rounded-full object-contain"
-            unoptimized
-          />
+    <div className="bg-cream-deep min-h-screen pb-[var(--footer-diagonal)]">
+      <div className="container mx-auto max-w-3xl px-4 pt-8 pb-8">
+        <PageHero
+          kicker="Onderlinge geschiedenis"
+          headline={opponentName}
+          lead={`Alle onderlinge duels tussen KCVV Elewijt en ${opponentName}, per seizoen.`}
+          adornment={
+            <Crest
+              name={opponentName}
+              logo={opponentLogo}
+              size={64}
+              className="border-ink bg-cream-soft shadow-paper-sm rounded-full border-2"
+            />
+          }
+        />
+
+        <OpponentSummaryCard summary={summary} className="mt-7" />
+
+        <div className="mt-8 mb-5">
+          <StripedSeam height="sm" />
+        </div>
+
+        <EditorialHeading
+          level={2}
+          size="display-sm"
+          emphasis={{ text: ".", tone: "warm" }}
+          className="mb-4"
+        >
+          {matchCountLabel}
+        </EditorialHeading>
+
+        {seasons.length === 0 ? (
+          <p className="text-ink-muted font-display italic">
+            Nog geen onderlinge duels gespeeld.
+          </p>
+        ) : (
+          seasons.map((group) => (
+            <section
+              key={group.season.key}
+              aria-label={group.season.label}
+              className="mt-5 first:mt-0"
+            >
+              <SeasonBand
+                label={group.season.label}
+                tally={seasonTally(group.items)}
+              />
+              <div className="flex flex-col gap-2.5">
+                {group.items.map((match) => (
+                  <TeamAgendaRow
+                    key={match.id}
+                    match={transformMatchToSchedule(match)}
+                    captionLabel={match.kcvv_team_label}
+                    upcomingLabel="Gepland"
+                  />
+                ))}
+              </div>
+            </section>
+          ))
         )}
-        <div>
-          <p className="text-ink-muted text-sm">Tegenstander</p>
-          <h1 className="text-2xl font-bold">{opponentName}</h1>
-        </div>
       </div>
-
-      {/* W/D/L summary */}
-      <div className="bg-cream-soft mb-8 grid grid-cols-5 gap-2 rounded-xl p-4 text-center">
-        <div>
-          <p className="text-jersey-deep text-2xl font-bold">{summary.wins}</p>
-          <p className="text-ink-muted text-xs">W</p>
-        </div>
-        <div>
-          <p className="text-2xl font-bold">{summary.draws}</p>
-          <p className="text-ink-muted text-xs">G</p>
-        </div>
-        <div>
-          <p className="text-alert text-2xl font-bold">{summary.losses}</p>
-          <p className="text-ink-muted text-xs">V</p>
-        </div>
-        <div>
-          <p className="text-2xl font-bold">{summary.goalsFor}</p>
-          <p className="text-ink-muted text-xs">Doelpunten voor</p>
-        </div>
-        <div>
-          <p className="text-2xl font-bold">{summary.goalsAgainst}</p>
-          <p className="text-ink-muted text-xs">Doelpunten tegen</p>
-        </div>
-      </div>
-
-      {/* Match list */}
-      <h2 className="mb-3 text-lg font-semibold">
-        {totalPlayed === 0
-          ? "Alle wedstrijden"
-          : `${matches.length} wedstrijd${matches.length !== 1 ? "en" : ""}`}
-      </h2>
-      <ul className="space-y-2">
-        {matches.map((match) => {
-          const result = getMatchResult(match);
-          const homeScore = match.home_team.score;
-          const awayScore = match.away_team.score;
-          const hasScore =
-            match.status === "finished" &&
-            homeScore != null &&
-            awayScore != null;
-          const borderClass = result ? resultBorderClass[result] : "";
-
-          return (
-            <li key={match.id}>
-              <Link
-                href={`/wedstrijd/${match.id}`}
-                className={`bg-cream-soft hover:bg-cream-deep flex items-center justify-between rounded-lg px-4 py-3 transition-colors ${borderClass}`}
-              >
-                <div className="flex flex-col gap-0.5">
-                  <span className="text-ink-muted text-xs">
-                    {formatMatchDate(match.date)}
-                    {match.competition ? ` · ${match.competition}` : ""}
-                  </span>
-                  <span className="text-sm font-medium">
-                    {match.home_team.name} vs {match.away_team.name}
-                  </span>
-                  {match.kcvv_team_label && (
-                    <span className="text-ink-muted text-xs">
-                      {match.kcvv_team_label}
-                    </span>
-                  )}
-                </div>
-                <div className="text-right">
-                  {hasScore ? (
-                    <span className="text-lg font-bold tabular-nums">
-                      {homeScore} – {awayScore}
-                    </span>
-                  ) : (
-                    <span className="text-ink-muted text-sm">Gepland</span>
-                  )}
-                </div>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
     </div>
   );
 }

--- a/apps/web/src/app/__tests__/loading-envelope.test.tsx
+++ b/apps/web/src/app/__tests__/loading-envelope.test.tsx
@@ -197,7 +197,10 @@ describe("loading.tsx envelope drift guard", () => {
     {
       name: "/tegenstander/[clubId]",
       Loading: TegenstanderLoading,
-      expectedRootClass: "min-h-screen bg-gray-100",
+      // Phase 10 (#2141): reskinned to the cream-deep paper register, matching
+      // the page's `bg-cream-deep` wrapper + footer-safe area.
+      expectedRootClass:
+        "bg-cream-deep min-h-screen pb-[var(--footer-diagonal)]",
     },
     {
       name: "/wedstrijd/[matchId]",

--- a/apps/web/src/components/layout/PageHero/PageHero.stories.tsx
+++ b/apps/web/src/components/layout/PageHero/PageHero.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Crest } from "@/components/design-system";
 import { PageHero } from "./PageHero";
 
 const meta = {
@@ -90,6 +91,22 @@ export const LongHeadline: Story = {
     lead: "Van de allerkleinsten tot het eerste elftal — bij KCVV is iedereen welkom.",
     image: "/images/youth-trainers.jpg",
     imageAlt: "KCVV jeugdtraining",
+  },
+};
+
+/** /tegenstander — typographic hero with an opponent crest adornment. */
+export const WithAdornment: Story = {
+  args: {
+    kicker: "Onderlinge geschiedenis",
+    headline: "OHR Huldenberg",
+    lead: "Alle onderlinge duels tussen KCVV Elewijt en deze tegenstander, per seizoen.",
+    adornment: (
+      <Crest
+        name="OHR Huldenberg"
+        size={64}
+        className="border-ink bg-cream-soft shadow-paper-sm rounded-full border-2"
+      />
+    ),
   },
 };
 

--- a/apps/web/src/components/layout/PageHero/PageHero.test.tsx
+++ b/apps/web/src/components/layout/PageHero/PageHero.test.tsx
@@ -137,6 +137,23 @@ describe("PageHero", () => {
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
+  it("renders an adornment beside the heading when provided", () => {
+    render(
+      <PageHero
+        {...defaultProps}
+        adornment={<span data-testid="hero-adornment">crest</span>}
+      />,
+    );
+    expect(screen.getByTestId("hero-adornment")).toBeInTheDocument();
+    // The heading still renders alongside it.
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+  });
+
+  it("does not render an adornment slot when the prop is omitted", () => {
+    render(<PageHero {...defaultProps} />);
+    expect(screen.queryByTestId("hero-adornment")).not.toBeInTheDocument();
+  });
+
   it("renders one warm shell tape strip in the typographic state", () => {
     const { container } = render(<PageHero {...defaultProps} />);
     const warmTapes = container.querySelectorAll('[data-color="warm"]');

--- a/apps/web/src/components/layout/PageHero/PageHero.tsx
+++ b/apps/web/src/components/layout/PageHero/PageHero.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import Image from "next/image";
 import { cn } from "@/lib/utils/cn";
 import { TapedCard } from "@/components/design-system/TapedCard";
@@ -56,6 +57,14 @@ export interface PageHeroProps {
   /** Optional CTA rendered as a primary `<LinkButton>`. */
   cta?: { label: string; href: string };
   /**
+   * Optional adornment rendered beside the kicker + headline (e.g. an opponent
+   * `<Crest>` on the `/tegenstander` hero). Sits left of the heading block in a
+   * centred flex row; the lead and divider stay full-width below. Primarily for
+   * the typographic state — pairs uneasily with an `image` and no consumer
+   * combines the two.
+   */
+  adornment?: ReactNode;
+  /**
    * `"default"` — full hero with optional image.
    * `"compact"` — tighter padding, smaller headline, image suppressed.
    *   Used by loading skeletons and bare utility pages.
@@ -72,6 +81,7 @@ export function PageHero({
   image,
   imageAlt = "",
   cta,
+  adornment,
   size = "default",
   className,
 }: PageHeroProps) {
@@ -100,7 +110,7 @@ export function PageHero({
       ? undefined
       : { text: ".", tone: "warm" };
 
-  const textColumn = (
+  const headingBlock = (
     <div>
       {/* Jersey-deep mono kicker as a raw label-token span — MonoLabel's plain
           variant only renders ink/cream tone. `tracking-[0.18em]` is the 10h5
@@ -121,6 +131,19 @@ export function PageHero({
       >
         {headline}
       </EditorialHeading>
+    </div>
+  );
+
+  const textColumn = (
+    <div>
+      {adornment ? (
+        <div className="flex items-center gap-4">
+          {adornment}
+          {headingBlock}
+        </div>
+      ) : (
+        headingBlock
+      )}
 
       {showLead ? (
         <p

--- a/apps/web/src/components/match/index.ts
+++ b/apps/web/src/components/match/index.ts
@@ -23,3 +23,5 @@ export type {
   ScheduleMatch,
   ScheduleTeam,
 } from "./types";
+
+export { transformMatchToSchedule } from "./transform";

--- a/apps/web/src/components/match/transform.test.ts
+++ b/apps/web/src/components/match/transform.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for team detail utility functions
+ * Tests for the shared Match → ScheduleMatch adapter.
  */
 
 import { describe, it, expect } from "vitest";
-import { transformMatchToSchedule } from "./utils";
+import { transformMatchToSchedule } from "./transform";
 import type { Match } from "@/lib/effect/schemas";
 
 // Mock Match factory
@@ -47,6 +47,13 @@ describe("transformMatchToSchedule", () => {
     expect(result.awayScore).toBe(1);
     expect(result.status).toBe("finished");
     expect(result.competition).toBe("3e Nationale");
+  });
+
+  it("carries the opponent team designation through as teamLabel", () => {
+    const match = createMockMatch({
+      away_team: { id: 2, name: "Opponent", team_label: "U23" },
+    });
+    expect(transformMatchToSchedule(match).awayTeam.teamLabel).toBe("U23");
   });
 
   it("handles scheduled match without scores", () => {

--- a/apps/web/src/components/match/transform.ts
+++ b/apps/web/src/components/match/transform.ts
@@ -1,17 +1,12 @@
-/**
- * Shared utilities for team detail pages
- *
- * BFF transform functions only — Sanity transforms are now in TeamRepository.
- */
-
 import type { Match } from "@/lib/effect/schemas";
-import type { ScheduleMatch, ScheduleTeam } from "@/components/match/types";
+import type { ScheduleMatch, ScheduleTeam } from "./types";
 
 /**
- * Transform a BFF Match into the `ScheduleMatch` shape consumed by the
- * Phase 6.C match-agenda components (`<TeamMatchesSection>` / `<TeamAgendaRow>`).
+ * Transform a BFF `Match` into the `ScheduleMatch` shape consumed by the
+ * match-agenda components (`<TeamMatchesSection>` / `<TeamAgendaRow>`). Shared
+ * by the team-detail pages and the opponent-history (`/tegenstander`) page.
  *
- * @param match - Match from PSD API via BFF
+ * @param match - Match from PSD API via the BFF
  * @returns ScheduleMatch object for display
  */
 export function transformMatchToSchedule(match: Match): ScheduleMatch {

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.test.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.test.tsx
@@ -132,6 +132,23 @@ describe("TeamAgendaRow", () => {
         "15:00",
       );
     });
+
+    it("never shows the upcoming label for a finished match with missing scores", () => {
+      render(
+        <TeamAgendaRow
+          match={{
+            ...BASE,
+            status: "finished",
+            homeScore: undefined,
+            awayScore: undefined,
+          }}
+          upcomingLabel="Gepland"
+        />,
+      );
+      const row = screen.getByTestId("team-agenda-row");
+      expect(row.textContent).toContain("15:00");
+      expect(row.textContent).not.toContain("Gepland");
+    });
   });
 
   describe("Outcome underline (box-shadow)", () => {

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.test.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.test.tsx
@@ -111,6 +111,29 @@ describe("TeamAgendaRow", () => {
     });
   });
 
+  describe("upcomingLabel", () => {
+    it("shows the upcoming label instead of the kickoff time for a scheduled match", () => {
+      render(<TeamAgendaRow match={BASE} upcomingLabel="Gepland" />);
+      const row = screen.getByTestId("team-agenda-row");
+      expect(row.textContent).toContain("Gepland");
+      expect(row.textContent).not.toContain("15:00");
+    });
+
+    it("still shows the scoreline for a finished match even when set", () => {
+      render(<TeamAgendaRow match={FINISHED_WIN} upcomingLabel="Gepland" />);
+      const row = screen.getByTestId("team-agenda-row");
+      expect(row.textContent).toContain("3");
+      expect(row.textContent).not.toContain("Gepland");
+    });
+
+    it("falls back to the kickoff time when no upcoming label is given", () => {
+      render(<TeamAgendaRow match={BASE} />);
+      expect(screen.getByTestId("team-agenda-row").textContent).toContain(
+        "15:00",
+      );
+    });
+  });
+
   describe("Outcome underline (box-shadow)", () => {
     it("applies win shadow on the score span", () => {
       const { container } = render(<TeamAgendaRow match={FINISHED_WIN} />);
@@ -200,6 +223,49 @@ describe("TeamAgendaRow", () => {
       render(<TeamAgendaRow match={{ ...BASE, competition: undefined }} />);
       expect(screen.getByTestId("team-agenda-row").textContent).not.toContain(
         "Provinciale",
+      );
+    });
+  });
+
+  describe("captionLabel (KCVV squad in the caption, P2)", () => {
+    it("renders the caption label joined to the competition", () => {
+      render(<TeamAgendaRow match={BASE} captionLabel="A-Ploeg" />);
+      // Appears once per layout (desktop + mobile).
+      expect(screen.getAllByText("A-Ploeg").length).toBeGreaterThan(0);
+      const row = screen.getByTestId("team-agenda-row");
+      expect(row.textContent).toContain("A-Ploeg");
+      expect(row.textContent).toContain("·");
+      expect(row.textContent).toContain("3e Provinciale A");
+    });
+
+    it("renders the caption label in jersey-deep on a normal row", () => {
+      const { container } = render(
+        <TeamAgendaRow match={BASE} captionLabel="A-Ploeg" />,
+      );
+      const label = container.querySelector("span.text-jersey-deep");
+      expect(label).not.toBeNull();
+      expect(label).toHaveTextContent("A-Ploeg");
+    });
+
+    it("renders the caption label alone when there is no competition", () => {
+      render(
+        <TeamAgendaRow
+          match={{ ...BASE, competition: undefined }}
+          captionLabel="U21"
+        />,
+      );
+      const row = screen.getByTestId("team-agenda-row");
+      expect(row.textContent).toContain("U21");
+      expect(row.textContent).not.toContain("·");
+    });
+
+    it("renders only the competition when no caption label is given", () => {
+      const { container } = render(<TeamAgendaRow match={BASE} />);
+      expect(
+        container.querySelector("span.text-jersey-deep"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("team-agenda-row").textContent).toContain(
+        "3e Provinciale A",
       );
     });
   });

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
@@ -173,9 +173,11 @@ export function TeamAgendaRow({
     isPlayed &&
     typeof match.homeScore === "number" &&
     typeof match.awayScore === "number";
-  // Show the upcoming label ("Gepland") only when one was supplied and there is
-  // no scoreline; otherwise fall back to the kickoff time (team-detail default).
-  const showUpcomingLabel = !hasScoreline && upcomingLabel != null;
+  // Show the upcoming label ("Gepland") only for not-yet-played matches when one
+  // was supplied. Gating on status (not merely the absence of a scoreline) keeps
+  // a finished match with missing scores on the kickoff time rather than wrongly
+  // reading "Gepland".
+  const showUpcomingLabel = !isPlayed && upcomingLabel != null;
   const scoreOrTime = hasScoreline
     ? `${match.homeScore} – ${match.awayScore}`
     : showUpcomingLabel

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
@@ -39,6 +39,22 @@ export interface TeamAgendaRowProps {
    * `kalender_item_click` analytics) without re-implementing the row.
    */
   onNavigate?: () => void;
+  /**
+   * Optional jersey-deep label prepended to the competition caption (P2), e.g.
+   * the KCVV squad that played ("A-Ploeg" · 3e Prov.). Used by the
+   * opponent-history (`/tegenstander`) page, where one opponent can mix
+   * A-Ploeg / B-Ploeg / youth and the team must be named on the row. Distinct
+   * from `team.teamLabel` (the opponent's designation chip beside its name).
+   */
+  captionLabel?: string;
+  /**
+   * Label shown in the score slot for not-yet-played matches instead of the
+   * kickoff time (e.g. "Gepland" on the opponent-history page, where a precise
+   * future kickoff is irrelevant). Rendered in the mono caption register. When
+   * omitted, the kickoff time is shown — the team-detail default, where the
+   * next fixture's start time matters.
+   */
+  upcomingLabel?: string;
   className?: string;
 }
 
@@ -137,6 +153,8 @@ export function TeamAgendaRow({
   featured = false,
   showDateStub = true,
   onNavigate,
+  captionLabel,
+  upcomingLabel,
   className,
 }: TeamAgendaRowProps) {
   // Prefer match.is_home (provided by BFF); fall back to comparing kcvvTeamId
@@ -148,12 +166,29 @@ export function TeamAgendaRow({
   const outcome = computeOutcome(match, isHome);
   const isPlayed = isPlayedMatch(match.status);
 
-  const scoreOrTime =
+  // White on jersey-deep (4.56:1) passes WCAG AA; cream (#f5f1e6 → 4.04:1) does not.
+  const monoClass = featured ? "text-white" : "text-ink-muted";
+
+  const hasScoreline =
     isPlayed &&
     typeof match.homeScore === "number" &&
-    typeof match.awayScore === "number"
-      ? `${match.homeScore} – ${match.awayScore}`
+    typeof match.awayScore === "number";
+  // Show the upcoming label ("Gepland") only when one was supplied and there is
+  // no scoreline; otherwise fall back to the kickoff time (team-detail default).
+  const showUpcomingLabel = !hasScoreline && upcomingLabel != null;
+  const scoreOrTime = hasScoreline
+    ? `${match.homeScore} – ${match.awayScore}`
+    : showUpcomingLabel
+      ? upcomingLabel
       : formatKickoff(match);
+
+  // Scorelines and kickoff times use the big display face; the "Gepland" label
+  // drops to the mono caption register (cf. the mockup `.score.sched`).
+  const scoreToneClass = showUpcomingLabel
+    ? monoClass
+    : featured
+      ? "text-white"
+      : "text-ink";
 
   const outlineShadow = outcome ? OUTCOME_SHADOW[outcome] : undefined;
 
@@ -174,13 +209,30 @@ export function TeamAgendaRow({
     ? "border-r-2 border-dashed border-cream/40"
     : "border-r-2 border-dashed border-ink/30";
 
-  // White on jersey-deep (4.56:1) passes WCAG AA; cream (#f5f1e6 → 4.04:1) does not.
-  const monoClass = featured ? "text-white" : "text-ink-muted";
-
   const day = formatDay(match.date);
   const month = formatMonth(match.date);
 
   const matchLabel = `${match.homeTeam.name} – ${match.awayTeam.name}, ${day} ${month}`;
+
+  // Caption (P2) shared by both layouts: an optional jersey-deep squad label
+  // (e.g. "A-Ploeg") followed by the competition. Rendered once, reused below.
+  const captionContent =
+    captionLabel || match.competition ? (
+      <>
+        {captionLabel ? (
+          <span
+            className={cn(
+              "font-semibold",
+              featured ? "text-warm" : "text-jersey-deep",
+            )}
+          >
+            {captionLabel}
+          </span>
+        ) : null}
+        {captionLabel && match.competition ? " · " : null}
+        {match.competition}
+      </>
+    ) : null;
 
   return (
     <Link
@@ -242,8 +294,11 @@ export function TeamAgendaRow({
           <div className="flex shrink-0 flex-col items-center gap-0.5 px-3">
             <span
               className={cn(
-                "font-display-big text-[18px] leading-none tabular-nums",
-                featured ? "text-white" : "text-ink",
+                "leading-none",
+                showUpcomingLabel
+                  ? "font-mono text-[11px] font-semibold tracking-wider uppercase"
+                  : "font-display-big text-[18px] tabular-nums",
+                scoreToneClass,
               )}
               style={
                 outlineShadow
@@ -253,14 +308,14 @@ export function TeamAgendaRow({
             >
               {scoreOrTime}
             </span>
-            {match.competition ? (
+            {captionContent ? (
               <span
                 className={cn(
                   "font-mono text-[9px] tracking-wider uppercase",
                   monoClass,
                 )}
               >
-                {match.competition}
+                {captionContent}
               </span>
             ) : null}
           </div>
@@ -291,14 +346,14 @@ export function TeamAgendaRow({
                 <Crest name={opponent.name} logo={opponent.logo} />
                 <div className="min-w-0 flex-1" title={opponent.name}>
                   <TeamName team={opponent} featured={featured} bold />
-                  {match.competition ? (
+                  {captionContent ? (
                     <span
                       className={cn(
                         "font-mono text-[9px] tracking-wider uppercase",
                         monoClass,
                       )}
                     >
-                      {match.competition}
+                      {captionContent}
                     </span>
                   ) : null}
                 </div>
@@ -312,8 +367,11 @@ export function TeamAgendaRow({
                 />
                 <span
                   className={cn(
-                    "font-display-big shrink-0 text-[16px] leading-none tabular-nums",
-                    featured ? "text-white" : "text-ink",
+                    "shrink-0 leading-none",
+                    showUpcomingLabel
+                      ? "font-mono text-[11px] font-semibold tracking-wider uppercase"
+                      : "font-display-big text-[16px] tabular-nums",
+                    scoreToneClass,
                   )}
                   style={
                     outlineShadow

--- a/apps/web/src/lib/utils/season.test.ts
+++ b/apps/web/src/lib/utils/season.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { deriveSeason, groupBySeason } from "./season";
+
+describe("deriveSeason", () => {
+  it("places a spring match (Jan–Jun) in the season that started the prior July", () => {
+    expect(deriveSeason(new Date(2026, 4, 18))).toEqual({
+      key: "2025-2026",
+      label: "Seizoen '25–'26",
+    });
+  });
+
+  it("places an autumn match (Jul–Dec) in the season that starts that July", () => {
+    expect(deriveSeason(new Date(2025, 10, 24))).toEqual({
+      key: "2025-2026",
+      label: "Seizoen '25–'26",
+    });
+  });
+
+  it("treats July as the start of the new season (boundary)", () => {
+    expect(deriveSeason(new Date(2025, 6, 1)).key).toBe("2025-2026");
+  });
+
+  it("treats June as still belonging to the prior season (boundary)", () => {
+    expect(deriveSeason(new Date(2025, 5, 30)).key).toBe("2024-2025");
+  });
+
+  it("lands an August cup match in the upcoming season", () => {
+    expect(deriveSeason(new Date(2026, 7, 5))).toEqual({
+      key: "2026-2027",
+      label: "Seizoen '26–'27",
+    });
+  });
+
+  it("formats the label with two-digit years and an en-dash", () => {
+    expect(deriveSeason(new Date(2024, 8, 1)).label).toBe("Seizoen '24–'25");
+  });
+});
+
+describe("groupBySeason", () => {
+  const make = (iso: string, id: number) => ({ id, date: new Date(iso) });
+
+  it("groups items by season preserving input order across and within groups", () => {
+    const items = [
+      make("2026-08-05T12:00:00", 1), // '26–'27
+      make("2026-05-18T12:00:00", 2), // '25–'26
+      make("2026-04-12T12:00:00", 3), // '25–'26
+      make("2024-08-25T12:00:00", 4), // '24–'25
+    ];
+    const groups = groupBySeason(items, (m) => m.date);
+
+    expect(groups.map((g) => g.season.key)).toEqual([
+      "2026-2027",
+      "2025-2026",
+      "2024-2025",
+    ]);
+    expect(groups[1]?.items.map((m) => m.id)).toEqual([2, 3]);
+  });
+
+  it("returns an empty array for no items", () => {
+    expect(groupBySeason([], (m: { date: Date }) => m.date)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/utils/season.ts
+++ b/apps/web/src/lib/utils/season.ts
@@ -1,0 +1,60 @@
+import { DateTime } from "luxon";
+
+/** A football season spanning roughly Aug→May (e.g. 2025–2026). */
+export interface Season {
+  /** Stable sort/group key, e.g. `"2025-2026"`. */
+  key: string;
+  /** Display label, e.g. `"Seizoen '25–'26"`. */
+  label: string;
+}
+
+/** A group of items sharing one season, preserving the input order. */
+export interface SeasonGroup<T> {
+  season: Season;
+  items: T[];
+}
+
+function twoDigit(year: number): string {
+  return String(year % 100).padStart(2, "0");
+}
+
+/**
+ * Derive the football season a date belongs to. The Belgian amateur season
+ * runs roughly August→May, with cup fixtures already in July, so the boundary
+ * is month ≥ 7 (July) → the *new* season: an August Beker match lands in the
+ * upcoming season rather than the one that just ended.
+ */
+export function deriveSeason(date: Date): Season {
+  const { year, month } = DateTime.fromJSDate(date);
+  const startYear = month >= 7 ? year : year - 1;
+  const endYear = startYear + 1;
+  return {
+    key: `${startYear}-${endYear}`,
+    label: `Seizoen '${twoDigit(startYear)}–'${twoDigit(endYear)}`,
+  };
+}
+
+/**
+ * Group items by season, preserving the input order both across groups and
+ * within each group. Callers pass an already-sorted list (the opponent-history
+ * page sorts date-descending) so the first group is the most recent season.
+ */
+export function groupBySeason<T>(
+  items: readonly T[],
+  getDate: (item: T) => Date,
+): SeasonGroup<T>[] {
+  const groups: SeasonGroup<T>[] = [];
+  const byKey = new Map<string, SeasonGroup<T>>();
+  for (const item of items) {
+    const season = deriveSeason(getDate(item));
+    const existing = byKey.get(season.key);
+    if (existing) {
+      existing.items.push(item);
+    } else {
+      const group: SeasonGroup<T> = { season, items: [item] };
+      byKey.set(season.key, group);
+      groups.push(group);
+    }
+  }
+  return groups;
+}


### PR DESCRIPTION
Closes #2141

Reskins the `/tegenstander/[clubId]` opponent-history page on the retro-terrace fanzine system, replacing the half-migrated generic chrome (`rounded-*`, `bg-gray-*`, dark header) with the locked composition (`docs/design/mockups/phase-10-tegenstander/10t4-locked.html`).

## Changes

- **Hero** — `PageHero` typographic state + opponent crest. Added an optional `adornment` ReactNode slot to `PageHero` (renders beside the kicker+headline; lead/divider stay full-width below). The framed crest reuses the existing `Crest` primitive styled via `className` (bordered circle + `shadow-paper-sm`). Lead now names the opponent: _"Alle onderlinge duels tussen KCVV Elewijt en {opponent}, per seizoen."_
- **Summary** — new `OpponentSummaryCard` (bordered paper `dl`, 5 cells W·G·V·DV·DT). Win `jersey-deep`, loss `alert`, rest neutral `ink` (status lock from #2117). Uses the BFF-computed aggregate; full Dutch terms exposed to assistive tech via `.sr-only`.
- **Divider** — `StripedSeam` between summary and list.
- **List header** — `EditorialHeading` "N wedstrijden" + warm `.`.
- **Match list** — season-grouped `TeamAgendaRow` rows. Each season opens with a warm mono band (`Seizoen 'YY–'YY` + dotted rule + per-season `W·G·V` / `N gepland` tally). KCVV squad label rides the caption (P2); scheduled matches render `Gepland`.
- **Season util** — new `lib/utils/season.ts` (`deriveSeason` / `groupBySeason`), unit-tested incl. the Jul/Aug boundary.
- **Adapter promotion** — `transformMatchToSchedule` moved from the route-local `ploegen/[slug]/utils.ts` to the shared `components/match/transform.ts` (git tracks it as a rename); both ploegen consumers repointed.
- **Loading** — `loading.tsx` reskinned to the paper register (dropped the dark `bg-ink` header).

## Row-reuse decision (per the issue's open choice)

Chose **Option (a)** — reuse `TeamAgendaRow` via two opt-in props rather than extracting a new scoreboard primitive (smaller diff, lower risk):

- `captionLabel?: string` — jersey-deep squad label prepended to the competition caption (distinct from `team.teamLabel`, the opponent's designation chip).
- `upcomingLabel?: string` — shown in the score slot for not-yet-played matches instead of the kickoff time (`"Gepland"` here; team pages still show the time).

Both default to the prior behavior, so existing consumers (team-detail, kalender) are unchanged. **`OUTCOME_SHADOW` is not duplicated.**

## Testing

- `pnpm --filter @kcvv/web check-all` green (lint + type-check + 3369 tests + `next build`).
- New/updated tests: `season.test.ts`, `transform.test.ts` (relocated + extended), `OpponentSummaryCard.test.tsx`, plus `captionLabel`/`upcomingLabel` cases on `TeamAgendaRow` and an `adornment` case on `PageHero`.
- Stories: `OpponentSummaryCard` (vr-tagged) and a `PageHero` `WithAdornment` variant.
- Manual QA opponents: `/tegenstander/746` (OHR Huldenberg), 93, 1307, 10.
- VR baselines deferred to the end-of-series batch (redesign policy).

## Pre-PR review gate

Ran `/code-review` (correctness) + `/simplify` (quality) on the branch diff.

**Applied:** removed the duplicate adapter (the original `ploegen/[slug]/utils.ts` + test were deleted, not just copied); snapped off-scale arbitrary spacing (`mt-[30px]`/`mb-[22px]`/`mt-[22px]`/`gap-[7px]`) to the Tailwind scale; documented why the season-band dotted rule is a raw span vs `DottedDivider`.

**Deferred (noted, out of scope):** `MatchHero.formatSeasonLabel` duplicates the season-boundary math and could delegate to the new `deriveSeason` — left as a follow-up to keep this PR focused on working pre-existing code. Rare non-finished statuses (forfeited/postponed/cancelled/stopped) follow the existing `isPlayedMatch` display rules; the issue scopes display to finished + scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Opponent history page now organizes matches by season with summary statistics card displaying wins, draws, losses, and goals.
  * Page hero component now supports optional visual adornment display.
  * Match rows support customizable labels for upcoming matches.

* **Tests**
  * Expanded test coverage for opponent summary display and season-based grouping utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->