### PR TITLE
feat(ui): rebuild /club/[slug] CMS pages on the retro-terrace system (#2122)

### DIFF
--- a/apps/studio-staging/migrations/page-image-to-articleimage/index.ts
+++ b/apps/studio-staging/migrations/page-image-to-articleimage/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Staging counterpart to `apps/studio/migrations/page-image-to-articleimage/`.
+ * See `packages/sanity-studio/src/migrations/page-image-to-articleimage.ts`
+ * for the full contract — both studios share the same source.
+ *
+ * Phase 10 (#2122): converts every legacy `image` body block on `page`
+ * documents (the `/club/[slug]` CMS pages) to `articleImage` with a
+ * `width: 'prose'` default. Idempotent — re-runs are safe.
+ *
+ * Run against staging first:
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset staging --dry-run
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset staging --no-dry-run
+ */
+import {pageImageToArticleImageMigration} from '@kcvv/sanity-studio/migrations'
+
+export default pageImageToArticleImageMigration

--- a/apps/studio/migrations/page-image-to-articleimage/index.ts
+++ b/apps/studio/migrations/page-image-to-articleimage/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Production counterpart to `apps/studio-staging/migrations/page-image-to-articleimage/`.
+ * See `packages/sanity-studio/src/migrations/page-image-to-articleimage.ts`
+ * for the full contract.
+ *
+ * Phase 10 (#2122): converts every legacy `image` body block on `page`
+ * documents (the `/club/[slug]` CMS pages) to `articleImage` with a
+ * `width: 'prose'` default. Reuses the Phase 5 (#1850) transform, retargeted
+ * to `documentTypes: ['page']`. Idempotent — re-runs are safe.
+ *
+ * MUST run before deploying the page.tsx switch (`<SanityArticleBody>` →
+ * `<ArticleBody>`); the new PT serializer only registers `articleImage`, so
+ * any unmigrated `image` block silently drops from the rendered body after
+ * the switch.
+ *
+ * Run against production AFTER staging has been verified:
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset production --dry-run
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset production --no-dry-run
+ */
+import {pageImageToArticleImageMigration} from '@kcvv/sanity-studio/migrations'
+
+export default pageImageToArticleImageMigration

--- a/apps/web/scripts/seed-issue-2122-club-page.mjs
+++ b/apps/web/scripts/seed-issue-2122-club-page.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/*
+ * apps/web/scripts/seed-issue-2122-club-page.mjs
+ *
+ * Phase 10 (#2122) — seed one generic CMS `page` document so the rebuilt
+ * `/club/[slug]` surface (PageHero + ArticleBody) can be verified end-to-end
+ * on staging. The body exercises every block the page schema now declares:
+ *   - intro paragraph (renders as the <DropCapParagraph>)
+ *   - `h2` headings (Freight + warm ".")
+ *   - an `articleImage` (width: prose) → <TapedFigure> with caption
+ *   - a bullet list
+ *   - a `fileAttachment` → <DownloadButton variant="card">
+ *
+ * The `articleImage` block is authored in its post-migration shape directly,
+ * so a freshly-seeded page needs no migration pass to render correctly.
+ *
+ * Exports `seed(client)` returning {pageId, slug}. Reuses the Phase 5 seed
+ * helpers (client construction, asset upsert, PT constructors).
+ *
+ * Standalone usage (staging is the default dataset):
+ *   SANITY_API_TOKEN=<token> node scripts/seed-issue-2122-club-page.mjs
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  COVER_IMAGE_ASSET_REF,
+  assertProductionGuard,
+  fileRef,
+  heading,
+  imageRef,
+  makeClient,
+  paragraph,
+  upsertFileAsset,
+} from "./seeds/phase-5-shared.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const PAGE_ID = "page-issue-2122-praktische-info";
+const PAGE_SLUG = "praktische-info-2122-seed";
+
+// Reuse an existing public PDF so the seed has no external filesystem deps.
+const FILE_ATTACHMENT_FILENAME = "seed-issue-2122-wegbeschrijving.pdf";
+const FILE_ATTACHMENT_SOURCE = join(
+  __dirname,
+  "..",
+  "public",
+  "downloads",
+  "reglement_inwendige_orde_2022.pdf",
+);
+
+/** A bullet-list item block (the shared module only ships paragraph/heading). */
+function bullet(key, text) {
+  return {
+    _key: key,
+    _type: "block",
+    style: "normal",
+    listItem: "bullet",
+    level: 1,
+    markDefs: [],
+    children: [{ _type: "span", _key: `${key}-s`, text, marks: [] }],
+  };
+}
+
+/** An `articleImage` body block in its post-#2122 shape. */
+function articleImage(key, assetRef, alt, width = "prose") {
+  return {
+    _key: key,
+    _type: "articleImage",
+    image: imageRef(assetRef),
+    alt,
+    width,
+  };
+}
+
+function buildPage(fileAssetRef) {
+  return {
+    _id: PAGE_ID,
+    _type: "page",
+    title: "Praktische info",
+    slug: { _type: "slug", current: PAGE_SLUG },
+    heroImage: imageRef(COVER_IMAGE_ASSET_REF),
+    metaDescription:
+      "Alles wat je moet weten voor een bezoek aan Sportpark Elewijt — bereikbaarheid, kantine-uren en meer.",
+    body: [
+      paragraph(
+        "p-intro",
+        "Alles wat je moet weten voor een bezoek aan Sportpark Elewijt — van bereikbaarheid tot de kantine-uren. Heb je nog vragen? De mensen aan de toog helpen je graag verder.",
+      ),
+      heading("h-bereik", "Bereikbaarheid"),
+      paragraph(
+        "p-bereik",
+        "Het sportpark ligt aan de Driesstraat in Elewijt. Parkeren kan gratis op het terrein. Met het openbaar vervoer neem je bus 285 tot halte Elewijt Dorp, op vijf minuten wandelen.",
+      ),
+      articleImage(
+        "img-ingang",
+        COVER_IMAGE_ASSET_REF,
+        "De ingang van Sportpark Elewijt",
+      ),
+      heading("h-kantine", "Kantine"),
+      paragraph(
+        "p-kantine",
+        "De kantine is open op wedstrijddagen en tijdens trainingen. Een greep uit het aanbod:",
+      ),
+      bullet("li-1", "Vers getapte pint en frisdrank"),
+      bullet("li-2", "Croque, frikandel en de befaamde KCVV-hotdog"),
+      bullet("li-3", "Koffie en taart op zondagvoormiddag"),
+      {
+        _key: "file-wegbeschrijving",
+        _type: "fileAttachment",
+        file: fileRef(fileAssetRef),
+        label: "Wegbeschrijving (PDF)",
+      },
+    ],
+  };
+}
+
+export async function seed(client) {
+  const fileAssetRef = await upsertFileAsset(
+    client,
+    FILE_ATTACHMENT_FILENAME,
+    FILE_ATTACHMENT_SOURCE,
+    "application/pdf",
+  );
+  const doc = buildPage(fileAssetRef);
+  await client.createOrReplace(doc);
+  console.log(`  ✓ ${doc.title.padEnd(20)} → /club/${doc.slug.current}`);
+  return { pageId: doc._id, slug: doc.slug.current };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  assertProductionGuard();
+  const client = makeClient();
+  console.log(`Seeding /club/[slug] CMS page into ${client.config().dataset}…`);
+  const { slug } = await seed(client);
+  console.log("\nDone:");
+  console.log(`  /club/${slug}`);
+}

--- a/apps/web/src/app/(main)/club/[slug]/loading.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/loading.tsx
@@ -1,27 +1,39 @@
 /**
  * Club Page (Dynamic) — Loading Skeleton
- * Matches the PageHero (compact, no image) + article body layout.
+ * Mirrors the page: compact <PageHero> → <StripedSeam> → <ArticleBody>'s
+ * cream shell + prose column → <FooterSafeArea>.
  */
 
 import { PageHero } from "@/components/layout/PageHero";
+import { FooterSafeArea, StripedSeam } from "@/components/design-system";
 
 export default function ClubPageLoading() {
   return (
     <div className="bg-cream min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 pt-10">
+      <div className="mx-auto max-w-5xl px-4 pt-10 pb-12">
         <PageHero kicker="Club" headline="Laden…" size="compact" />
       </div>
 
-      {/* Article body prose */}
-      <div className="max-w-inner-lg mx-auto animate-pulse space-y-4 px-4 py-8">
-        <div className="bg-cream-soft h-5 w-full rounded" />
-        <div className="bg-cream-soft h-5 w-full rounded" />
-        <div className="bg-cream-soft h-5 w-4/5 rounded" />
-        <div className="bg-cream-soft mt-6 h-48 w-full rounded-sm" />
-        <div className="bg-cream-soft mt-6 h-5 w-full rounded" />
-        <div className="bg-cream-soft h-5 w-full rounded" />
-        <div className="bg-cream-soft h-5 w-2/3 rounded" />
+      <StripedSeam colorPair="ink-cream" height="md" />
+
+      {/* Body skeleton — mirrors <ArticleBody>'s `bg-cream` shell + the
+          `--container-prose` reading column. */}
+      <div className="bg-cream w-full px-4 py-12 lg:px-0 lg:py-16">
+        <div
+          className="mx-auto w-full animate-pulse space-y-4"
+          style={{ maxWidth: "var(--container-prose)" }}
+        >
+          <div className="bg-cream-soft h-5 w-full rounded" />
+          <div className="bg-cream-soft h-5 w-full rounded" />
+          <div className="bg-cream-soft h-5 w-4/5 rounded" />
+          <div className="bg-cream-soft mt-6 h-48 w-full rounded-sm" />
+          <div className="bg-cream-soft mt-6 h-5 w-full rounded" />
+          <div className="bg-cream-soft h-5 w-full rounded" />
+          <div className="bg-cream-soft h-5 w-2/3 rounded" />
+        </div>
       </div>
+
+      <FooterSafeArea />
     </div>
   );
 }

--- a/apps/web/src/app/(main)/club/[slug]/page.test.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.test.tsx
@@ -107,4 +107,74 @@ describe("/club/[slug] page", () => {
       "image",
     );
   });
+
+  it("renders the body through <ArticleBody>", async () => {
+    mockFindBySlug.mockReturnValue(Effect.succeed(makePage()));
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "downloads" }),
+    });
+    const { container } = render(page);
+
+    // The Phase-5 body column renders the page body (first paragraph as the
+    // drop-cap), so the body text is on the page.
+    expect(screen.getByText("Page content")).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-article-body="true"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an articleImage body block as a captioned figure", async () => {
+    mockFindBySlug.mockReturnValue(
+      Effect.succeed(
+        makePage({
+          body: [
+            {
+              _key: "img-1",
+              _type: "articleImage" as const,
+              width: "prose" as const,
+              alt: "Sportpark Elewijt",
+              fileUrl: null,
+              fileSize: null,
+              fileMimeType: null,
+              fileOriginalFilename: null,
+              asset: {
+                url: "https://cdn.sanity.io/images/proj/dataset/ground.jpg?w=800&q=80&fm=webp&fit=max",
+                title: null,
+                description: "De ingang van Sportpark Elewijt",
+                creditLine: null,
+                metadata: { dimensions: null, lqip: null },
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "praktische-info" }),
+    });
+    const { container } = render(page);
+
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("alt", "Sportpark Elewijt");
+    // Caption pulled from `asset.description` by the <ArticleBody> renderer.
+    expect(
+      screen.getByText("De ingang van Sportpark Elewijt"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render SanityArticleBody / InteriorPageHero artefacts", async () => {
+    mockFindBySlug.mockReturnValue(Effect.succeed(makePage()));
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "downloads" }),
+    });
+    const { container } = render(page);
+
+    // The legacy renderer wrapped the body in `.prose`; the new ArticleBody
+    // ships a `data-article-body` cream shell instead.
+    expect(container.querySelector(".prose")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(main)/club/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.tsx
@@ -6,7 +6,8 @@ import type { PortableTextBlock } from "@portabletext/react";
 import { runPromise } from "@/lib/effect/runtime";
 import { PageRepository } from "@/lib/repositories/page.repository";
 import { PageHero } from "@/components/layout/PageHero";
-import { SanityArticleBody } from "@/components/article/SanityArticleBody/SanityArticleBody";
+import { ArticleBody } from "@/components/article/ArticleBody";
+import { FooterSafeArea, StripedSeam } from "@/components/design-system";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -54,9 +55,14 @@ export default async function DynamicClubPage({ params }: Props) {
 
   if (!page) return notFound();
 
+  const body = (page.body ?? []) as PortableTextBlock[];
+
   return (
     <div className="bg-cream min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 pt-10">
+      {/* Hero — kicker "Club", headline = page.title, optional heroImage
+          (typographic state when absent). `pb-12` reserves the rhythm before
+          the full-bleed seam (StripedSeam carries no margin of its own). */}
+      <div className="mx-auto max-w-5xl px-4 pt-10 pb-12">
         <PageHero
           kicker="Club"
           headline={page.title}
@@ -64,9 +70,18 @@ export default async function DynamicClubPage({ params }: Props) {
           imageAlt={page.title}
         />
       </div>
-      <div className="max-w-inner-lg content mx-auto px-4 pt-8 pb-[calc(2rem+var(--footer-diagonal))]">
-        <SanityArticleBody content={(page.body ?? []) as PortableTextBlock[]} />
-      </div>
+
+      <StripedSeam colorPair="ink-cream" height="md" />
+
+      {/* Body — the Phase-5 editorial column (same vocabulary as
+          /nieuws/[slug]). <ArticleBody> ships its own `bg-cream w-full`
+          edge-to-edge shell + prose container + top/bottom padding, so it
+          renders bare here (no max-w wrapper would box the cream into a band). */}
+      {body.length > 0 ? (
+        <ArticleBody className="article-body" content={body} />
+      ) : null}
+
+      <FooterSafeArea />
     </div>
   );
 }

--- a/apps/web/src/lib/repositories/page.repository.test.ts
+++ b/apps/web/src/lib/repositories/page.repository.test.ts
@@ -96,6 +96,39 @@ describe("PageRepository", () => {
       expect(page?.title).toBe("");
     });
 
+    it("passes through an articleImage block with its dereferenced asset", async () => {
+      // Post-#2122 the page body serves `articleImage` (not plain `image`);
+      // the GROQ projection dereferences `image.asset->` into the flat `asset`
+      // shape <ArticleBody>'s renderer consumes (url + caption + credit + dims).
+      const articleImage = {
+        _key: "img-1",
+        _type: "articleImage" as const,
+        width: "prose" as const,
+        fileUrl: null,
+        fileSize: null,
+        fileMimeType: null,
+        fileOriginalFilename: null,
+        asset: {
+          url: "https://cdn.sanity.io/images/proj/dataset/abc.jpg?w=800&q=80&fm=webp&fit=max",
+          title: null,
+          description: "De ingang van Sportpark Elewijt",
+          creditLine: null,
+          metadata: { dimensions: null, lqip: null },
+        },
+      };
+      const row = makePageRow({ body: [articleImage] });
+      mockFetch.mockResolvedValueOnce(row);
+
+      const page = await runWithRepo(
+        Effect.gen(function* () {
+          const repo = yield* PageRepository;
+          return yield* repo.findBySlug("praktische-info");
+        }),
+      );
+
+      expect(page?.body).toEqual([articleImage]);
+    });
+
     it("null body stays null (consumer handles with ?? [])", async () => {
       mockFetch.mockResolvedValueOnce(makePageRow({ body: null }));
 

--- a/apps/web/src/lib/repositories/page.repository.ts
+++ b/apps/web/src/lib/repositories/page.repository.ts
@@ -11,7 +11,7 @@ export const PAGE_BY_SLUG_QUERY =
   "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",
   metaDescription,
   "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),
-  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }
+  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }) }
 }`);
 
 // ─── View Models ─────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -615,14 +615,9 @@ export type Page = {
         _type: "block";
         _key: string;
       }
-    | {
-        asset?: SanityImageAssetReference;
-        media?: unknown;
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: "image";
+    | ({
         _key: string;
-      }
+      } & ArticleImage)
     | ({
         _key: string;
       } & FileAttachment)
@@ -2172,7 +2167,7 @@ export type JEUGD_LANDING_PAGE_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/page.repository.ts
 // Variable: PAGE_BY_SLUG_QUERY
-// Query: *[_type == "page" && slug.current == $slug][0] {  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",  metaDescription,  "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }}
+// Query: *[_type == "page" && slug.current == $slug][0] {  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",  metaDescription,  "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }) }}
 export type PAGE_BY_SLUG_QUERY_RESULT = {
   id: string;
   title: string | "";
@@ -2181,6 +2176,33 @@ export type PAGE_BY_SLUG_QUERY_RESULT = {
   metaDescription: string | null;
   ogImageUrl: string | null;
   body: Array<
+    | {
+        _key: string;
+        _type: "articleImage";
+        image?: {
+          asset?: SanityImageAssetReference;
+          media?: unknown;
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        };
+        alt?: string;
+        width?: "bleed" | "prose" | "wide";
+        fileUrl: null;
+        fileSize: null;
+        fileMimeType: null;
+        fileOriginalFilename: null;
+        asset: {
+          url: string | null;
+          title: string | null;
+          description: string | null;
+          creditLine: null;
+          metadata: {
+            dimensions: SanityImageDimensions | null;
+            lqip: string | null;
+          } | null;
+        } | null;
+      }
     | {
         children?: Array<{
           marks?: Array<string>;
@@ -2226,20 +2248,6 @@ export type PAGE_BY_SLUG_QUERY_RESULT = {
         fileMimeType: string | null;
         fileOriginalFilename: string | null;
         asset: null;
-      }
-    | {
-        asset: {
-          url: string | null;
-        } | null;
-        media?: unknown;
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: "image";
-        _key: string;
-        fileUrl: null;
-        fileSize: null;
-        fileMimeType: null;
-        fileOriginalFilename: null;
       }
   > | null;
 } | null;
@@ -2670,7 +2678,7 @@ declare module "@sanity/client" {
     '*[_type == "homePage"][0] {\n    "bannerSlotA": bannerSlotA-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotB": bannerSlotB-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    },\n    "bannerSlotC": bannerSlotC-> {\n      "imageUrl": image.asset->url + "?w=1200&q=80&fm=webp&fit=max",\n      alt,\n      href\n    }\n  }': HOMEPAGE_BANNERS_QUERY_RESULT;
     '*[_type == "homePage"][0] {\n    "matchesSliderPlaceholder": matchesSliderPlaceholder {\n      nextSeasonKickoff,\n      announcementText,\n      announcementHref,\n      "highlightImage": highlightImage {\n        alt,\n        "asset": asset->{\n          _id,\n          url,\n          "lqip": metadata.lqip,\n          "dimensions": metadata.dimensions\n        }\n      }\n    }\n  }': HOMEPAGE_PLACEHOLDER_QUERY_RESULT;
     '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
-    '*[_type == "page" && slug.current == $slug][0] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  metaDescription,\n  "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max" }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
+    '*[_type == "page" && slug.current == $slug][0] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  metaDescription,\n  "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
     '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio,\n  "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {\n    name, season\n  }\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "player" && keeper == true && archived != true].psdId': KEEPER_PSD_IDS_QUERY_RESULT;

--- a/packages/sanity-schemas/src/page.ts
+++ b/packages/sanity-schemas/src/page.ts
@@ -28,7 +28,7 @@ export const page = defineType({
       name: 'body',
       title: 'Body',
       type: 'array',
-      of: [{type: 'block'}, {type: 'image', options: {hotspot: true}}, {type: 'fileAttachment'}],
+      of: [{type: 'block'}, {type: 'articleImage'}, {type: 'fileAttachment'}],
     }),
     defineField({
       name: 'metaDescription',

--- a/packages/sanity-studio/src/migrations/index.ts
+++ b/packages/sanity-studio/src/migrations/index.ts
@@ -55,6 +55,8 @@ export type {
   LegacyImageBlock as ImageToArticleImageLegacyBlock,
 } from './image-to-articleimage'
 
+export {default as pageImageToArticleImageMigration} from './page-image-to-articleimage'
+
 export {
   default as dropPlayerUnusedFieldsMigration,
   migrateDropPlayerUnusedFields,

--- a/packages/sanity-studio/src/migrations/page-image-to-articleimage.test.ts
+++ b/packages/sanity-studio/src/migrations/page-image-to-articleimage.test.ts
@@ -1,0 +1,75 @@
+import type {SanityDocument} from 'sanity'
+import {at, set, unset} from 'sanity/migrate'
+import {describe, expect, it} from 'vitest'
+import {migrateImageToArticleImage} from './image-to-articleimage'
+import pageImageToArticleImageMigration from './page-image-to-articleimage'
+
+// Sanity's `migrate.document` callback is typed against a full `SanityDocument`
+// — stamp the system fields every real document carries so the synthetic
+// fixtures satisfy the signature without an `as never` escape hatch.
+const SYSTEM_FIELDS = {
+  _createdAt: '2026-01-01T00:00:00Z',
+  _updatedAt: '2026-01-01T00:00:00Z',
+  _rev: 'rev-1',
+} satisfies Pick<SanityDocument, '_createdAt' | '_updatedAt' | '_rev'>
+
+describe('pageImageToArticleImageMigration', () => {
+  it('targets only `page` documents', () => {
+    expect(pageImageToArticleImageMigration.documentTypes).toEqual(['page'])
+  })
+
+  it('references the issue in its title', () => {
+    expect(pageImageToArticleImageMigration.title).toContain('#2122')
+  })
+
+  it('delegates to the shared `migrateImageToArticleImage` transform', () => {
+    // The page body uses the identical `image` → `articleImage` rule as the
+    // article backfill, so the wrapper must emit exactly what the shared pure
+    // function does for the same document.
+    const doc = {
+      ...SYSTEM_FIELDS,
+      _id: 'page-1',
+      _type: 'page',
+      body: [
+        {
+          _type: 'image',
+          _key: 'img-1',
+          asset: {_ref: 'image-abc123', _type: 'reference'},
+          alt: 'Sportpark Elewijt',
+        },
+      ],
+    }
+
+    expect(pageImageToArticleImageMigration.migrate.document?.(doc)).toEqual([
+      at('body[_key=="img-1"]._type', set('articleImage')),
+      at(
+        'body[_key=="img-1"].image',
+        set({_type: 'image', asset: {_ref: 'image-abc123', _type: 'reference'}}),
+      ),
+      at('body[_key=="img-1"].alt', set('Sportpark Elewijt')),
+      at('body[_key=="img-1"].width', set('prose')),
+      at('body[_key=="img-1"].asset', unset()),
+    ])
+    // Sanity check: identical output to the shared transform.
+    expect(pageImageToArticleImageMigration.migrate.document?.(doc)).toEqual(
+      migrateImageToArticleImage(doc),
+    )
+  })
+
+  it('emits no patches for an already-migrated page (idempotent)', () => {
+    const doc = {
+      ...SYSTEM_FIELDS,
+      _id: 'page-migrated',
+      _type: 'page',
+      body: [
+        {
+          _type: 'articleImage',
+          _key: 'img-1',
+          image: {asset: {_ref: 'image-abc123', _type: 'reference'}},
+          width: 'prose',
+        },
+      ],
+    }
+    expect(pageImageToArticleImageMigration.migrate.document?.(doc)).toBeUndefined()
+  })
+})

--- a/packages/sanity-studio/src/migrations/page-image-to-articleimage.ts
+++ b/packages/sanity-studio/src/migrations/page-image-to-articleimage.ts
@@ -1,0 +1,42 @@
+import {defineMigration} from 'sanity/migrate'
+import {
+  type ArticleWithImageBlocksDoc,
+  migrateImageToArticleImage,
+} from './image-to-articleimage'
+
+/**
+ * Phase 10 (#2122): converts legacy `image` body blocks → `articleImage`
+ * on `page` documents (the generic CMS pages served at `/club/[slug]` via
+ * `PageRepository`).
+ *
+ * The translation rule is identical to the Phase 5 article-body backfill
+ * (#1850) — only the targeted document type differs — so this migration
+ * reuses the tested `migrateImageToArticleImage` pure function and simply
+ * retargets `documentTypes` to `['page']`. See
+ * `./image-to-articleimage.ts` for the full shape-detection / patch
+ * contract.
+ *
+ * MUST run before deploying the `club/[slug]/page.tsx` switch from
+ * `<SanityArticleBody>` → `<ArticleBody>`: the new PT serializer only
+ * registers `articleImage`, so any unmigrated plain `image` block silently
+ * drops from the rendered body after the switch.
+ *
+ * Idempotent — blocks already `_type === 'articleImage'` are left alone, so
+ * re-runs are safe.
+ *
+ * Run against staging first, then production after staging is verified:
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset staging --dry-run
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset staging --no-dry-run
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset production --dry-run
+ *   npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset production --no-dry-run
+ */
+export default defineMigration({
+  title: 'Migrate legacy `image` body blocks → `articleImage` on page docs (#2122)',
+  documentTypes: ['page'],
+
+  migrate: {
+    document(doc) {
+      return migrateImageToArticleImage(doc as ArticleWithImageBlocksDoc)
+    },
+  },
+})


### PR DESCRIPTION
Closes #2122

Phase 10 — rebuilds the generic `/club/[slug]` CMS pages (PageRepository `page` docs) on the retro-terrace-fanzine system. **Pure reuse** of locked primitives: `<PageHero>` + `<StripedSeam>` + the Phase-5 `<ArticleBody>` editorial body column (same vocabulary as `/nieuws/[slug]`). Owner pick: **(a) schema-align** so `<ArticleBody>` drops in.

## Changes

- **Schema** — `packages/sanity-schemas/src/page.ts`: `body.of` plain `{type:'image'}` → `{type:'articleImage'}` (shared `@kcvv/sanity-schemas`, applies to both studios).
- **Migration** — `page-image-to-articleimage`: reuses the tested #1850 `migrateImageToArticleImage` transform retargeted to `documentTypes:['page']`. Shared source + barrel export + both studio entries (`apps/studio`, `apps/studio-staging`) + focused wrapper test. Idempotent.
- **GROQ** — `PAGE_BY_SLUG_QUERY` body projection now dereferences `articleImage` (`image.asset->{url,title,description,creditLine,metadata{dimensions,lqip}}`), keeping a legacy `image` branch for the pre-migration window. `sanity.types.ts` regenerated.
- **Page** — `app/(main)/club/[slug]/page.tsx` → `<PageHero>` + `<StripedSeam>` + `<ArticleBody>`; `<InteriorPageHero>` + `<SanityArticleBody>` usage removed. `loading.tsx` mirrors the new layout (compact PageHero → seam → ArticleBody-shell skeleton).
- **Seed** — `apps/web/scripts/seed-issue-2122-club-page.mjs`: authors one `page` doc (paragraphs + h2 + articleImage + bullet list + fileAttachment) for staging verification.

Retires `<SanityArticleBody>` on this surface — last consumer alongside #2124, both feed the #1531 Phase A deletion.

## Testing

- `pnpm --filter @kcvv/web check-all` ✅ (lint + type-check + full vitest + `next build`; `/club/[slug]` builds as `ƒ` ISR).
- `pnpm turbo lint type-check test` on `@kcvv/sanity-schemas`, `@kcvv/sanity-studio`, `@kcvv/studio`, `@kcvv/studio-staging` ✅ (incl. `sanity typegen`).
- New tests: page-migration wrapper (`documentTypes`/delegation/idempotency), repo articleImage projection pass-through, page renders body via `<ArticleBody>` (paragraph + captioned articleImage figure) and no longer emits the legacy `.prose` wrapper.
- **Pre-PR review gate** (`/code-review` high + `/simplify`): 6 correctness candidates all refuted (null-safe optional chaining, pre-existing global patterns, test-fidelity nitpicks); cleanup candidates skipped with reasons (GROQ-fragment extraction would break `sanity typegen` static analysis — the codebase deliberately inlines, `article.repository.ts` duplicates it twice itself; seed helpers are one-off). No fixes needed.

## Staging verification

- **Seed run on staging** ✅ → page `_id: page-issue-2122-praktische-info`, URL path **`/club/praktische-info-2122-seed`** (reads the `staging` dataset; view on the Vercel preview deploy for this branch).
- **Migration run on staging** ✅ — `--no-dry-run --no-confirm`; finds zero legacy `image` blocks on `page` docs (no-op, as expected — the seeded doc is authored in post-migration shape).

## Manual step before/after merge

Run the migration on **production** (`--no-confirm` for non-interactive):

```bash
cd apps/studio
npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset production --dry-run
npx sanity@latest migration run page-image-to-articleimage --project vhb33jaz --dataset production --no-dry-run --no-confirm
```

## Acceptance criteria

- [x] `page.body` schema migrated to `articleImage`; migration written + run on staging (`--no-dry-run`); prod documented as a manual step; staging `page` doc seeded + URL above.
- [x] `/club/[slug]` rebuilt on `<PageHero>` + `<ArticleBody>`; `<InteriorPageHero>` + `<SanityArticleBody>` removed; `loading.tsx` matches.
- [x] No `font-title` / `kcvv-*` on the surface.
- [x] `pnpm --filter @kcvv/web check-all` green (incl. `sanity typegen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
