### PR TITLE
refactor(ui): delete orphaned legacy CSS rules — Phase 9B clear deletes (#1531)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -718,16 +718,8 @@
   }
 
   /* Font Family Utilities */
-  .font-title {
-    font-family: var(--font-family-title);
-  }
-
   .font-body {
     font-family: var(--font-family-body);
-  }
-
-  .font-alt {
-    font-family: var(--font-family-alt);
   }
 
   .font-mono {
@@ -822,38 +814,6 @@
   margin-bottom: -6rem;
   margin-left: -6.5rem;
   overflow: hidden;
-}
-
-/* Editorial card overlay gradients — reference design tokens for consistency.
-   Fallback rgba() line for browsers without relative color syntax support. */
-.editorial-card-overlay--default {
-  background: linear-gradient(
-    to top,
-    rgba(30, 32, 36, 0.95) 0%,
-    rgba(30, 32, 36, 0.5) 40%,
-    rgba(30, 32, 36, 0.1) 100%
-  );
-  background: linear-gradient(
-    to top,
-    rgb(from var(--color-kcvv-black) r g b / 0.95) 0%,
-    rgb(from var(--color-kcvv-black) r g b / 0.5) 40%,
-    rgb(from var(--color-kcvv-black) r g b / 0.1) 100%
-  );
-}
-
-.editorial-card-overlay--nav {
-  background: linear-gradient(
-    to top,
-    rgba(30, 32, 36, 0.95) 0%,
-    rgba(30, 40, 54, 0.6) 40%,
-    rgba(30, 40, 54, 0.2) 100%
-  );
-  background: linear-gradient(
-    to top,
-    rgb(from var(--color-kcvv-black) r g b / 0.95) 0%,
-    rgb(from var(--color-kcvv-dark-blue) r g b / 0.6) 40%,
-    rgb(from var(--color-kcvv-dark-blue) r g b / 0.2) 100%
-  );
 }
 
 /* Full-bleed breakout utility — pulls an element to viewport width */


### PR DESCRIPTION
**The zero-doubt clear-delete subset of #1531 Phase B.** Everything that needs a migrate-vs-remove judgment is deferred to the owner-reviewed follow-ups below.

## Deleted (verified orphans, `globals.css`)
- `.editorial-card-overlay--default` / `--nav` gradient rules — orphaned when `<EditorialCard>` was deleted in #2121 (zero consumers).
- `.font-title` / `.font-alt` font-family utilities — zero consumers since the font spin-out (#2116).

The `--font-family-title`/`--font-family-alt` token defs stay for now (`h1–h6` still consumes `--font-family-title`) — handled under #2154.

## Deliberately NOT here (deferred to owner-reviewed follow-ups)
Per owner direction, anything requiring a migrate-vs-remove call gets a hands-on review (dev server + Storybook) rather than an autonomous sweep:
- **#2154** — Phase 9 migrate-vs-remove deep-dive (`--color-kcvv-*` token removal, `body`/`h1–h6`/`.prose blockquote` global-rule rewrites, `SectionTransition`/`SectionStack` diagonal-system removal + `--footer-diagonal`, `Icon` color map / Lucide→Phosphor, the ~13 stories/tests, Adobe-kit trim).
- **#2155** — full component-usage audit (reconcile Storybook to live-website components).
- **#2156** — redesign the `/share` Instagram match-share graphics (skipped by the redesign).

## Testing
- `pnpm --filter @kcvv/web check-all` green. Review gate was light by design — these are two provably zero-consumer dead-CSS rules.

Part of #1531 (does not close it — the remaining Phase B work lives in #2154).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up unused CSS styles from the application stylesheet, removing obsolete font and overlay utility classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->