### PR TITLE
fix(ui): load Typekit async without the load() race

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -100,17 +100,17 @@ export default async function RootLayout({
       className={`${montserrat.variable} ${ibmPlexMono.variable}`}
     >
       <head>
-        {/* Adobe Typekit Fonts — deferred (only serves quasimoda + stenciletta) */}
+        {/* Adobe Typekit (Adobe Fonts) — serves Freight Display + Quasimoda.
+            Loaded async (non-blocking): an injected <script> fetches the kit and
+            calls Typekit.load() in its own onload, so load() never races ahead
+            of the kit defining `Typekit` (the prior two-script form did, logging
+            "Typekit is not defined"). If Adobe is slow/down the page is
+            unaffected — display text falls back to the serif stack, and body
+            (Montserrat) + mono (IBM Plex Mono) are self-hosted via next/font. */}
         {typekitId && (
-          <>
-            <Script
-              src={`https://use.typekit.net/${typekitId}.js`}
-              strategy="afterInteractive"
-            />
-            <Script id="typekit-init" strategy="afterInteractive">
-              {`try{Typekit.load({ async: true });}catch(e){console.error('Typekit load error:', e);}`}
-            </Script>
-          </>
+          <Script id="typekit-init" strategy="afterInteractive">
+            {`(function(d){var s=d.createElement("script");s.src="https://use.typekit.net/${typekitId}.js";s.async=true;s.onload=function(){try{Typekit.load({async:true});}catch(e){console.error("Typekit load error:",e);}};d.head.appendChild(s);})(document);`}
+          </Script>
         )}
       </head>
       <body suppressHydrationWarning>


### PR DESCRIPTION
Fixes the `Typekit is not defined` console error and the resulting **Freight-falls-back-to-serif** behaviour (most visible on exported `/share` graphics).

## Root cause
`layout.tsx` loaded Typekit as **two** `afterInteractive` scripts: the kit `.js` and a separate inline `Typekit.load({async:true})`. The inline script could run before the kit finished defining the `Typekit` global → `ReferenceError: Typekit is not defined` → Freight sometimes never applied.

## Fix
One injected `<script>` that fetches the kit and calls `Typekit.load()` in **its own `onload`**, so `load()` can't race ahead of the kit. Same `afterInteractive`, **async, non-blocking** behaviour.

## Why not the CSS embed
A synchronous `<link rel="stylesheet" href="…typekit.css">` would be **render-blocking** and couple every page's first paint to Adobe's latency — strictly worse if Typekit is slow/down. This keeps the resilient async model.

## Resilience (Typekit down/slow)
- **Non-blocking** — never delays first paint, even if Adobe hangs.
- Only the **display font (Freight)** is from Typekit; it degrades gracefully to the serif fallback stack.
- **Body (Montserrat) + mono (IBM Plex Mono)** are self-hosted via `next/font/google` — fully independent of Typekit.

## Testing
- `pnpm --filter @kcvv/web check-all` ✅ (lint + type-check + 3200 tests + build)
- Storybook keeps its own (dev-only) synchronous Typekit CSS embed — render-blocking is fine in a dev tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Adobe Typekit font loading reliability by fixing a race condition that could prevent fonts from displaying correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->