### PR TITLE
refactor(ui): extract shared <JerseyIllustration> from PlayerHero / PlayerCard (#2118)

### DIFF
--- a/apps/web/src/components/design-system/JerseyIllustration/JerseyIllustration.stories.tsx
+++ b/apps/web/src/components/design-system/JerseyIllustration/JerseyIllustration.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { JerseyIllustration } from "./JerseyIllustration";
+
+const meta = {
+  title: "UI/JerseyIllustration",
+  component: JerseyIllustration,
+  tags: ["autodocs", "vr"],
+  parameters: { layout: "padded" },
+  decorators: [
+    // The illustration fills its parent (hero: h-full/w-full, card: inset-0),
+    // so frame it in a sized, relative 3:4 box mirroring both consumers.
+    (Story) => (
+      <div className="border-paper-edge relative aspect-[3/4] w-[260px] overflow-hidden border">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof JerseyIllustration>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Hero variant — the `/spelers/[slug]` no-photo fallback. `relative h-full
+ * w-full` inside the polaroid frame, 3/2px overprint registration.
+ */
+export const Hero: Story = {
+  args: { variant: "hero" },
+};
+
+/**
+ * Card variant — the squad-grid `<PlayerCard>` no-photo fallback. `absolute
+ * inset-0` inside the bordered 3:4 figure, 2/1px overprint registration.
+ */
+export const Card: Story = {
+  args: { variant: "card" },
+};

--- a/apps/web/src/components/design-system/JerseyIllustration/JerseyIllustration.test.tsx
+++ b/apps/web/src/components/design-system/JerseyIllustration/JerseyIllustration.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { JerseyIllustration } from "./JerseyIllustration";
+
+describe("JerseyIllustration", () => {
+  it("renders an aria-hidden wrapper with the default test id and cream-soft ground", () => {
+    render(<JerseyIllustration variant="hero" />);
+    const wrapper = screen.getByTestId("jersey-illustration");
+    expect(wrapper).toHaveAttribute("aria-hidden", "true");
+    expect(wrapper).toHaveClass("bg-cream-soft");
+  });
+
+  it("forwards a custom data-testid (so each consumer keeps its existing id)", () => {
+    render(
+      <JerseyIllustration
+        variant="card"
+        data-testid="player-card-illustration"
+      />,
+    );
+    expect(screen.getByTestId("player-card-illustration")).toBeInTheDocument();
+    expect(screen.queryByTestId("jersey-illustration")).toBeNull();
+  });
+
+  it("renders the full two-pass figure geometry from the shared paths module", () => {
+    const { container } = render(<JerseyIllustration variant="hero" />);
+    // underprint: torso fill + 2 shoulder bumps = 3 paths
+    // overprint: torso outline + V-collar + 4 stripes = 6 paths
+    expect(container.querySelectorAll("path")).toHaveLength(9);
+    // head ellipse drawn once per pass
+    expect(container.querySelectorAll("ellipse")).toHaveLength(2);
+  });
+
+  it("applies the hero variant positioning + 3/2px overprint offset", () => {
+    render(<JerseyIllustration variant="hero" />);
+    const wrapper = screen.getByTestId("jersey-illustration");
+    expect(wrapper).toHaveClass("relative", "h-full", "w-full");
+    const hasHeroOffset = Array.from(wrapper.querySelectorAll("div")).some(
+      (d) =>
+        d.className.includes("translate-x-[3px]") &&
+        d.className.includes("translate-y-[2px]"),
+    );
+    expect(hasHeroOffset).toBe(true);
+  });
+
+  it("applies the card variant positioning + 2/1px overprint offset", () => {
+    render(<JerseyIllustration variant="card" />);
+    const wrapper = screen.getByTestId("jersey-illustration");
+    expect(wrapper).toHaveClass("absolute", "inset-0");
+    const hasCardOffset = Array.from(wrapper.querySelectorAll("div")).some(
+      (d) =>
+        d.className.includes("translate-x-[2px]") &&
+        d.className.includes("translate-y-[1px]"),
+    );
+    expect(hasCardOffset).toBe(true);
+  });
+
+  it("merges a custom className onto the wrapper", () => {
+    render(<JerseyIllustration variant="card" className="opacity-50" />);
+    expect(screen.getByTestId("jersey-illustration")).toHaveClass("opacity-50");
+  });
+});

--- a/apps/web/src/components/design-system/JerseyIllustration/JerseyIllustration.tsx
+++ b/apps/web/src/components/design-system/JerseyIllustration/JerseyIllustration.tsx
@@ -1,0 +1,110 @@
+/**
+ * <JerseyIllustration> — the no-photo player illustration fallback (UI primitive).
+ *
+ * Two-pass print figure (jersey-deep underprint + ink overprint outline) drawn
+ * from the canonical `_jersey-paths` geometry — head ellipse + torso
+ * fill/outline + both shoulder bumps + V-collar + 4 vertical stripes, in the
+ * viewBox `0 0 220 300`. Extracted (#2118) from the byte-identical inline
+ * renderers that lived in `<PlayerHero>` (`HeroIllustration`) and
+ * `team/SquadGrid/<PlayerCard>` (`CardIllustration`); zero domain knowledge, so
+ * it lives in the neutral design-system rather than under either domain.
+ *
+ * Not to be confused with `<JerseyShirt>`: that is a torso-only crop with the
+ * inverted palette (ink fill / jersey-deep outline) — left untouched.
+ *
+ * The two consumers differed only in the overprint registration offset and the
+ * outer positioning, captured by `variant`:
+ *
+ * | variant | overprint offset                      | positioning              |
+ * | ------- | ------------------------------------- | ------------------------ |
+ * | "hero"  | `translate-x-[3px] translate-y-[2px]` | `relative h-full w-full` |
+ * | "card"  | `translate-x-[2px] translate-y-[1px]` | `absolute inset-0`       |
+ *
+ * Path provenance: `_jersey-paths.ts` (shared with `<JerseyShirt>`).
+ */
+import { cn } from "@/lib/utils/cn";
+import {
+  JERSEY_FIGURE_VIEWBOX,
+  JERSEY_HEAD_ELLIPSE,
+  JERSEY_SHOULDER_BUMP_LEFT_PATH,
+  JERSEY_SHOULDER_BUMP_RIGHT_PATH,
+  JERSEY_TORSO_FILL_PATH,
+  JERSEY_TORSO_OUTLINE_PATH,
+  JERSEY_V_COLLAR_PATH,
+  JERSEY_VERTICAL_STRIPE_PATHS,
+} from "../_jersey-paths";
+
+const STRIPE_STROKE_WIDTH = 2;
+const OUTLINE_STROKE_WIDTH = 3;
+
+export interface JerseyIllustrationProps {
+  /**
+   * Consumer context — selects the overprint registration offset + outer
+   * positioning. `"hero"` for the `<PlayerHero>` figure (relative, 3/2px
+   * offset); `"card"` for the squad-grid `<PlayerCard>` figure (absolute
+   * inset-0, 2/1px offset).
+   */
+  variant: "hero" | "card";
+  /** Extra classes merged onto the outer wrapper, after the variant classes. */
+  className?: string;
+  /** Forwarded test id. Defaults to `"jersey-illustration"`. */
+  "data-testid"?: string;
+}
+
+export function JerseyIllustration({
+  variant,
+  className,
+  "data-testid": dataTestId = "jersey-illustration",
+}: JerseyIllustrationProps) {
+  const overprintOffset =
+    variant === "hero"
+      ? "translate-x-[3px] translate-y-[2px]"
+      : "translate-x-[2px] translate-y-[1px]";
+  const positioning =
+    variant === "hero" ? "relative h-full w-full" : "absolute inset-0";
+
+  return (
+    <div
+      data-testid={dataTestId}
+      aria-hidden="true"
+      className={cn("bg-cream-soft", positioning, className)}
+    >
+      <div className="absolute inset-0 opacity-95 mix-blend-multiply">
+        <svg
+          viewBox={JERSEY_FIGURE_VIEWBOX}
+          preserveAspectRatio="xMidYMid meet"
+          className="block h-full w-full"
+        >
+          <g fill="var(--color-jersey-deep)">
+            <ellipse {...JERSEY_HEAD_ELLIPSE} />
+            <path d={JERSEY_TORSO_FILL_PATH} />
+            <path d={JERSEY_SHOULDER_BUMP_LEFT_PATH} />
+            <path d={JERSEY_SHOULDER_BUMP_RIGHT_PATH} />
+          </g>
+        </svg>
+      </div>
+      <div className={cn("absolute inset-0", overprintOffset)}>
+        <svg
+          viewBox={JERSEY_FIGURE_VIEWBOX}
+          preserveAspectRatio="xMidYMid meet"
+          className="block h-full w-full"
+        >
+          <g
+            fill="none"
+            stroke="var(--color-ink)"
+            strokeWidth={OUTLINE_STROKE_WIDTH}
+            strokeLinejoin="miter"
+            strokeLinecap="square"
+          >
+            <ellipse {...JERSEY_HEAD_ELLIPSE} />
+            <path d={JERSEY_TORSO_OUTLINE_PATH} />
+            <path d={JERSEY_V_COLLAR_PATH} />
+            {JERSEY_VERTICAL_STRIPE_PATHS.map((d) => (
+              <path key={d} d={d} strokeWidth={STRIPE_STROKE_WIDTH} />
+            ))}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/design-system/JerseyIllustration/index.ts
+++ b/apps/web/src/components/design-system/JerseyIllustration/index.ts
@@ -1,0 +1,4 @@
+export {
+  JerseyIllustration,
+  type JerseyIllustrationProps,
+} from "./JerseyIllustration";

--- a/apps/web/src/components/design-system/index.ts
+++ b/apps/web/src/components/design-system/index.ts
@@ -117,6 +117,10 @@ export type {
   ErrorStateActionVariant,
 } from "./ErrorState";
 
+// JerseyIllustration
+export { JerseyIllustration } from "./JerseyIllustration";
+export type { JerseyIllustrationProps } from "./JerseyIllustration";
+
 // JerseyShirt
 export { JerseyShirt } from "./JerseyShirt";
 export type { JerseyShirtProps } from "./JerseyShirt";

--- a/apps/web/src/components/player/PlayerHero/PlayerHero.tsx
+++ b/apps/web/src/components/player/PlayerHero/PlayerHero.tsx
@@ -10,8 +10,8 @@
  * - **6.d2 — Hero figure:** `<TapedFigure aspect="portrait-3-4">`. When
  *   `photoUrl` is present, renders the photo inside the polaroid frame
  *   with the global newsprint filter + paper-grain. When missing, renders
- *   the canonical `<PlayerFigure>` illustration paths (head + torso +
- *   V-collar + 4 stripes) from `_jersey-paths.ts`. Never a hybrid — see
+ *   the shared `<JerseyIllustration variant="hero">` fallback (head + torso +
+ *   V-collar + 4 stripes, from `_jersey-paths.ts`). Never a hybrid — see
  *   `[[feedback_playerfigure_no_hybrid]]`.
  * - **6.d3 — NIEUW badge dropped:** no `<MonoLabel>NIEUW</MonoLabel>` here.
  * - **6.d9 — Cross-age meta row:** `position · birthDate` only. Adults
@@ -46,20 +46,9 @@ import { cn } from "@/lib/utils/cn";
 import { TapedFigure } from "@/components/design-system/TapedFigure";
 import { NumberDisplay } from "@/components/design-system/NumberDisplay";
 import { MonoLabel } from "@/components/design-system/MonoLabel";
-import {
-  JERSEY_FIGURE_VIEWBOX,
-  JERSEY_HEAD_ELLIPSE,
-  JERSEY_SHOULDER_BUMP_LEFT_PATH,
-  JERSEY_SHOULDER_BUMP_RIGHT_PATH,
-  JERSEY_TORSO_FILL_PATH,
-  JERSEY_TORSO_OUTLINE_PATH,
-  JERSEY_V_COLLAR_PATH,
-  JERSEY_VERTICAL_STRIPE_PATHS,
-} from "@/components/design-system/_jersey-paths";
+import { JerseyIllustration } from "@/components/design-system/JerseyIllustration";
 
 const ADULT_AGE_THRESHOLD = 18;
-const STRIPE_STROKE_WIDTH = 2;
-const OUTLINE_STROKE_WIDTH = 3;
 
 export interface PlayerHeroProps {
   firstName: string;
@@ -134,53 +123,6 @@ function formatAgeGradedBirthDate(iso: string, now: Date): string | undefined {
   }
   const yy = pad2(birth.getUTCFullYear() % 100);
   return `${age} jaar · '${yy}`;
-}
-
-function HeroIllustration() {
-  return (
-    <div
-      data-testid="player-hero-illustration"
-      aria-hidden="true"
-      className="bg-cream-soft relative h-full w-full"
-    >
-      <div className="absolute inset-0 opacity-95 mix-blend-multiply">
-        <svg
-          viewBox={JERSEY_FIGURE_VIEWBOX}
-          preserveAspectRatio="xMidYMid meet"
-          className="block h-full w-full"
-        >
-          <g fill="var(--color-jersey-deep)">
-            <ellipse {...JERSEY_HEAD_ELLIPSE} />
-            <path d={JERSEY_TORSO_FILL_PATH} />
-            <path d={JERSEY_SHOULDER_BUMP_LEFT_PATH} />
-            <path d={JERSEY_SHOULDER_BUMP_RIGHT_PATH} />
-          </g>
-        </svg>
-      </div>
-      <div className="absolute inset-0 translate-x-[3px] translate-y-[2px]">
-        <svg
-          viewBox={JERSEY_FIGURE_VIEWBOX}
-          preserveAspectRatio="xMidYMid meet"
-          className="block h-full w-full"
-        >
-          <g
-            fill="none"
-            stroke="var(--color-ink)"
-            strokeWidth={OUTLINE_STROKE_WIDTH}
-            strokeLinejoin="miter"
-            strokeLinecap="square"
-          >
-            <ellipse {...JERSEY_HEAD_ELLIPSE} />
-            <path d={JERSEY_TORSO_OUTLINE_PATH} />
-            <path d={JERSEY_V_COLLAR_PATH} />
-            {JERSEY_VERTICAL_STRIPE_PATHS.map((d) => (
-              <path key={d} d={d} strokeWidth={STRIPE_STROKE_WIDTH} />
-            ))}
-          </g>
-        </svg>
-      </div>
-    </div>
-  );
 }
 
 export function PlayerHero({
@@ -300,7 +242,10 @@ export function PlayerHero({
               className="block h-full w-full object-cover"
             />
           ) : (
-            <HeroIllustration />
+            <JerseyIllustration
+              variant="hero"
+              data-testid="player-hero-illustration"
+            />
           )}
         </TapedFigure>
       </div>

--- a/apps/web/src/components/team/SquadGrid/PlayerCard.tsx
+++ b/apps/web/src/components/team/SquadGrid/PlayerCard.tsx
@@ -1,19 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
-import {
-  JERSEY_FIGURE_VIEWBOX,
-  JERSEY_HEAD_ELLIPSE,
-  JERSEY_SHOULDER_BUMP_LEFT_PATH,
-  JERSEY_SHOULDER_BUMP_RIGHT_PATH,
-  JERSEY_TORSO_FILL_PATH,
-  JERSEY_TORSO_OUTLINE_PATH,
-  JERSEY_V_COLLAR_PATH,
-  JERSEY_VERTICAL_STRIPE_PATHS,
-} from "@/components/design-system/_jersey-paths";
-
-const STRIPE_STROKE_WIDTH = 2;
-const OUTLINE_STROKE_WIDTH = 3;
+import { JerseyIllustration } from "@/components/design-system/JerseyIllustration";
 
 export interface PlayerCardProps {
   firstName: string;
@@ -26,54 +14,6 @@ export interface PlayerCardProps {
   /** Detail-page href. When absent the card is not a link. */
   href?: string;
   className?: string;
-}
-
-/** Canonical jersey illustration fill — shared with <PlayerHero> / <PlayerFigure>. */
-function CardIllustration() {
-  return (
-    <div
-      data-testid="player-card-illustration"
-      aria-hidden="true"
-      className="bg-cream-soft absolute inset-0"
-    >
-      <div className="absolute inset-0 opacity-95 mix-blend-multiply">
-        <svg
-          viewBox={JERSEY_FIGURE_VIEWBOX}
-          preserveAspectRatio="xMidYMid meet"
-          className="block h-full w-full"
-        >
-          <g fill="var(--color-jersey-deep)">
-            <ellipse {...JERSEY_HEAD_ELLIPSE} />
-            <path d={JERSEY_TORSO_FILL_PATH} />
-            <path d={JERSEY_SHOULDER_BUMP_LEFT_PATH} />
-            <path d={JERSEY_SHOULDER_BUMP_RIGHT_PATH} />
-          </g>
-        </svg>
-      </div>
-      <div className="absolute inset-0 translate-x-[2px] translate-y-[1px]">
-        <svg
-          viewBox={JERSEY_FIGURE_VIEWBOX}
-          preserveAspectRatio="xMidYMid meet"
-          className="block h-full w-full"
-        >
-          <g
-            fill="none"
-            stroke="var(--color-ink)"
-            strokeWidth={OUTLINE_STROKE_WIDTH}
-            strokeLinejoin="miter"
-            strokeLinecap="square"
-          >
-            <ellipse {...JERSEY_HEAD_ELLIPSE} />
-            <path d={JERSEY_TORSO_OUTLINE_PATH} />
-            <path d={JERSEY_V_COLLAR_PATH} />
-            {JERSEY_VERTICAL_STRIPE_PATHS.map((d) => (
-              <path key={d} d={d} strokeWidth={STRIPE_STROKE_WIDTH} />
-            ))}
-          </g>
-        </svg>
-      </div>
-    </div>
-  );
 }
 
 export function PlayerCard({
@@ -112,7 +52,10 @@ export function PlayerCard({
             style={{ filter: "var(--filter-photo-newsprint)" }}
           />
         ) : (
-          <CardIllustration />
+          <JerseyIllustration
+            variant="card"
+            data-testid="player-card-illustration"
+          />
         )}
 
         {jerseyNumber !== undefined ? (


### PR DESCRIPTION
Closes #2118

## Changes

Extracts the two byte-identical inline jersey-illustration renderers into a single neutral design-system primitive.

- **New `<JerseyIllustration>`** (`design-system/JerseyIllustration/`) — the two-pass print figure (jersey-deep underprint + ink overprint outline) drawn from `_jersey-paths` (head ellipse + torso fill/outline + both shoulder bumps + V-collar + 4 vertical stripes). Props: `variant: "hero" | "card"` (maps the only two differences — overprint registration offset + outer positioning), `className?`, and a forwarded `data-testid`.
- **`PlayerHero`** — deleted inline `HeroIllustration()`; renders `<JerseyIllustration variant="hero" data-testid="player-hero-illustration" />`. Dropped the now-unused `_jersey-paths` import + stroke-width consts. Updated the stale `<PlayerFigure>` reference in the 6.d2 docstring.
- **`team/SquadGrid/PlayerCard`** — deleted inline `CardIllustration()`; renders `<JerseyIllustration variant="card" data-testid="player-card-illustration" />`. Same import cleanup.
- Barrel export added to `design-system/index.ts`. Story `UI/JerseyIllustration` (both variants, `tags: ["autodocs", "vr"]`). Component test added.

**Zero visual change** — both overprint offsets (hero 3/2px, card 2/1px), positioning, `bg-cream-soft`, colour tokens, and both existing `data-testid`s are preserved. `PlayerFigure` (orphan deleted by #1531) and `JerseyShirt` (different geometry/palette) are untouched.

## VR

`UI/JerseyIllustration` is `vr`-tagged; **baseline capture deferred** per the redesign VR policy — no baselines committed in this PR.

## Testing

- `pnpm --filter @kcvv/web check-all` — green (lint, tsgo type-check, **3206 tests / 278 files**, build).
- Existing `PlayerHero` / `PlayerCard` tests pass **unmodified** (data-testids preserved).
- 6 new `JerseyIllustration` unit tests (geometry, both variants, testid forwarding, className merge).

## Pre-PR review gate

`/code-review` (high) + `/simplify` angles run on the branch diff — both returned **no findings** (faithful pure extraction; conventions mirror the sibling `JerseyShirt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable Jersey Illustration component available in hero and card display variants.

* **Tests**
  * Added comprehensive test suite for the Jersey Illustration component with variant coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->