### PR TITLE
feat(matches): restore match-day standings on /wedstrijd/[matchId] — league only (#2162)

### DIFF
--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -31,10 +31,15 @@ function makeEnvLayer() {
 }
 
 const cacheMock: KvCacheInterface = {
-  // Seed an empty competition-label map so getCompetitionLabels() cache-hits and
-  // does not insert a /competitions fetch into the order-based fetch mocks.
+  // Seed empty maps so getCompetitionLabels() and the getMatchDetail match-team
+  // index both cache-hit, keeping the order-based fetch mocks free of extra
+  // /competitions, /teams and season-games requests.
   get: (key: string) =>
-    Effect.succeed(key === "psd:competition-labels" ? "{}" : null),
+    Effect.succeed(
+      key === "psd:competition-labels" || key === "psd:match-team-index"
+        ? "{}"
+        : null,
+    ),
   set: () => Effect.succeed(undefined),
   increment: () => Effect.succeed(undefined),
 };
@@ -1506,6 +1511,100 @@ describe("PsdService.getPlayerStats", () => {
     expect(result._tag).toBe("Left");
     if (result._tag === "Left") {
       expect(result.left._tag).toBe("ResourceNotFound");
+    }
+  });
+});
+
+describe("PsdService.getMatchDetail - competition/team enrichment", () => {
+  it("enriches kcvv_team_id + competitionType from a cached index", async () => {
+    const idx = {
+      "123": { teamId: 1, competitionType: "league" },
+    };
+    const kvMock: KvCacheInterface = {
+      get: (key: string) =>
+        Effect.succeed(
+          key === "psd:match-team-index" ? JSON.stringify(idx) : null,
+        ),
+      set: () => Effect.succeed(undefined),
+      increment: () => Effect.succeed(undefined),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => rawDetailWithGoal,
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(123), {
+      kvMock,
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.kcvv_team_id).toBe(1);
+      expect(result.right.competitionType).toBe("league");
+      // kcvv_team_label is deliberately NOT enriched (keeps MatchHero unchanged).
+      expect(result.right.kcvv_team_label).toBeUndefined();
+    }
+  });
+
+  it("leaves the detail unchanged when the match is absent from the index", async () => {
+    // Default cacheMock seeds the index as "{}" → no entry for 123.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => rawDetailWithGoal,
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(123));
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.kcvv_team_id).toBeUndefined();
+      expect(result.right.kcvv_team_label).toBeUndefined();
+      expect(result.right.competitionType).toBeUndefined();
+    }
+  });
+
+  it("builds the index from season games (OFFICIAL → league) when uncached", async () => {
+    const officialGame123 = {
+      id: 123,
+      status: 0,
+      date: "2025-03-15 15:00",
+      time: "15:00",
+      homeClub: { id: 1235, name: "KCVV Elewijt" },
+      awayClub: { id: 200, name: "Opponent FC" },
+      goalsHomeTeam: 1,
+      goalsAwayTeam: 0,
+      competitionType: { id: 1, name: null, type: "OFFICIAL" },
+    };
+    const kvMock: KvCacheInterface = {
+      get: (key: string) =>
+        Effect.succeed(
+          key === "psd:current-season-id"
+            ? JSON.stringify(seasons[0])
+            : key === "psd:competition-labels"
+              ? "{}"
+              : null, // psd:match-team-index → null → force a build
+        ),
+      set: () => Effect.succeed(undefined),
+      increment: () => Effect.succeed(undefined),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: async () => rawDetailWithGoal }) // /info
+      .mockResolvedValueOnce({ ok: true, json: async () => rawTeams }) // /teams
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ content: [officialGame123] }),
+      }) // team 1 season games
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ content: [] }) }); // team 23 season games
+
+    const result = await runService((svc) => svc.getMatchDetail(123), {
+      kvMock,
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.kcvv_team_id).toBe(1);
+      expect(result.right.competitionType).toBe("league");
+      expect(result.right.kcvv_team_label).toBeUndefined();
     }
   });
 });

--- a/apps/api/src/psd/service.ts
+++ b/apps/api/src/psd/service.ts
@@ -12,6 +12,7 @@ import {
 import type {
   Match,
   MatchDetail,
+  CompetitionType,
   RankingEntry,
   OpponentHistory,
   PlayerSeasonStats,
@@ -34,6 +35,7 @@ import {
   transformPsdGame,
   buildCompetitionLabelMap,
   type CompetitionLabelMap,
+  resolveCompetitionType,
   transformFootbalistoMatchDetail,
   matchDetailToMatch,
   transformFootbalistoRankingEntry,
@@ -287,6 +289,108 @@ export const PsdServiceLive = Layer.effect(
         FootbalistoMatchDetailResponse,
       );
 
+    // ─── Match → team/competition index ───────────────────────────────────────
+    // The match-detail endpoint (`/games/{id}/info`, queried by match id) carries
+    // NEITHER a reliable competition type (it inlines a display string) NOR a team
+    // id. Both live only on the per-team season-games endpoint. We build a
+    // `matchId → {teamId, competitionType}` index from every team's
+    // current-season games and reuse it to enrich `getMatchDetail`.
+    //
+    // Caching is deliberate (owner-flagged PSD + Workers-KV quota): the build
+    // fans out one fetch per team, so the whole index is cached as a SINGLE KV
+    // entry with a long TTL. Match→team assignments change at most weekly
+    // (new/rescheduled fixtures), and the index is independent of standings
+    // freshness (that's `getRanking`'s concern) — so a long TTL costs nothing in
+    // live-site accuracy while keeping us far under quota.
+    const MATCH_TEAM_INDEX_CACHE_KEY = "psd:match-team-index";
+    const MATCH_TEAM_INDEX_TTL = 60 * 60 * 12; // 12h
+
+    interface MatchTeamIndexEntry {
+      teamId: number;
+      competitionType: CompetitionType;
+    }
+    type MatchTeamIndex = Record<string, MatchTeamIndexEntry>;
+
+    const buildMatchTeamIndex = (): Effect.Effect<MatchTeamIndex, BffError> =>
+      Effect.gen(function* () {
+        const teams = yield* countedFetch(`${base}/teams`, PsdTeamsSchema);
+        const season = yield* getCurrentSeason();
+
+        const perTeam = yield* Effect.all(
+          teams.map((team) =>
+            countedFetch(
+              `${base}/games/team/${team.id}/seasons/${season.id}`,
+              PsdMatchListSchema,
+            ).pipe(
+              Effect.map((data) => ({ team, content: data.content })),
+              // A single failed team must not sink the whole index (mirrors
+              // getNextMatches' per-team resilience).
+              Effect.catchAll((e) =>
+                Effect.log(
+                  `buildMatchTeamIndex: team ${team.id} failed: ${String(e)}`,
+                ).pipe(Effect.as({ team, content: [] as readonly unknown[] })),
+              ),
+            ),
+          ),
+          { concurrency: 5 },
+        );
+
+        const index: MatchTeamIndex = {};
+        for (const { team, content } of perTeam) {
+          for (const item of content) {
+            const decoded = S.decodeUnknownOption(PsdGame)(item);
+            if (Option.isNone(decoded)) continue;
+            const game = decoded.value;
+            const key = String(game.id);
+            // First write wins — deterministic for the rare KCVV-internal match
+            // that appears in two teams' lists (always a friendly → no standings).
+            if (index[key]) continue;
+            index[key] = {
+              teamId: team.id,
+              competitionType: resolveCompetitionType(game.competitionType),
+            };
+          }
+        }
+        return index;
+      });
+
+    const getMatchTeamIndex = (): Effect.Effect<MatchTeamIndex, never> =>
+      Effect.gen(function* () {
+        const cached = yield* cache.get(MATCH_TEAM_INDEX_CACHE_KEY);
+        if (cached) {
+          const parsed = yield* Effect.try({
+            try: () => JSON.parse(cached) as MatchTeamIndex,
+            catch: () => null,
+          }).pipe(Effect.option);
+          if (
+            Option.isSome(parsed) &&
+            parsed.value !== null &&
+            typeof parsed.value === "object"
+          ) {
+            return parsed.value;
+          }
+        }
+
+        // Best-effort: any build failure (typed error OR defect) yields an empty
+        // index, so enrichment becomes a no-op and `getMatchDetail` behaves
+        // exactly as before — the match page must never degrade on index trouble.
+        const built = yield* buildMatchTeamIndex().pipe(
+          Effect.catchAllCause((cause) =>
+            Effect.log(
+              `getMatchTeamIndex: build failed: ${String(cause)}`,
+            ).pipe(Effect.as({} as MatchTeamIndex)),
+          ),
+        );
+        if (Object.keys(built).length > 0) {
+          yield* cache.set(
+            MATCH_TEAM_INDEX_CACHE_KEY,
+            JSON.stringify(built),
+            MATCH_TEAM_INDEX_TTL,
+          );
+        }
+        return built;
+      });
+
     return {
       getTeamMatches: (teamId: number) =>
         Effect.gen(function* () {
@@ -421,6 +525,23 @@ export const PsdServiceLive = Layer.effect(
       getMatchDetail: (matchId: number) =>
         fetchRawMatchDetail(matchId).pipe(
           Effect.map(transformFootbalistoMatchDetail),
+          // Enrich with the team id + structured competition type that
+          // `/games/{id}/info` cannot provide (see the match-team index above).
+          // Strictly additive: an index miss/failure leaves the detail exactly
+          // as transformed (incl. `is_home` — keeper enrichment is unaffected).
+          Effect.flatMap((detail) =>
+            getMatchTeamIndex().pipe(
+              Effect.map((index) => {
+                const entry = index[String(matchId)];
+                if (!entry) return detail;
+                return {
+                  ...detail,
+                  kcvv_team_id: entry.teamId,
+                  competitionType: entry.competitionType,
+                };
+              }),
+            ),
+          ),
         ),
 
       getRanking: (teamId: number, logoCdnUrl: string) =>

--- a/apps/api/src/psd/service.ts
+++ b/apps/api/src/psd/service.ts
@@ -304,6 +304,10 @@ export const PsdServiceLive = Layer.effect(
     // live-site accuracy while keeping us far under quota.
     const MATCH_TEAM_INDEX_CACHE_KEY = "psd:match-team-index";
     const MATCH_TEAM_INDEX_TTL = 60 * 60 * 12; // 12h
+    // Negative-cache an empty index briefly so a partial upstream outage (e.g.
+    // /info ok but the per-team fetches fail) can't trigger a ~20-fetch rebuild
+    // on every request, while still recovering within minutes once PSD heals.
+    const MATCH_TEAM_INDEX_EMPTY_TTL = 120; // 2m
 
     interface MatchTeamIndexEntry {
       teamId: number;
@@ -381,13 +385,16 @@ export const PsdServiceLive = Layer.effect(
             ).pipe(Effect.as({} as MatchTeamIndex)),
           ),
         );
-        if (Object.keys(built).length > 0) {
-          yield* cache.set(
-            MATCH_TEAM_INDEX_CACHE_KEY,
-            JSON.stringify(built),
-            MATCH_TEAM_INDEX_TTL,
-          );
-        }
+        // Always cache — a non-empty index for 12h, an empty one (build failure)
+        // only briefly, so we never re-fan-out the full build on every request
+        // during an incident yet recover quickly afterwards.
+        yield* cache.set(
+          MATCH_TEAM_INDEX_CACHE_KEY,
+          JSON.stringify(built),
+          Object.keys(built).length > 0
+            ? MATCH_TEAM_INDEX_TTL
+            : MATCH_TEAM_INDEX_EMPTY_TTL,
+        );
         return built;
       });
 

--- a/apps/api/src/psd/transforms.test.ts
+++ b/apps/api/src/psd/transforms.test.ts
@@ -3,6 +3,7 @@ import {
   mapGameStatus,
   isUnknownGameStatus,
   mapCompetitionLabel,
+  resolveCompetitionType,
   buildCompetitionLabelMap,
   deriveMatchTeamLabel,
   deriveOwnClubId,
@@ -11,6 +12,40 @@ import {
   psdGameToMs,
 } from "./transforms";
 import type { PsdGame, PsdCompetition } from "./schemas";
+
+describe("resolveCompetitionType", () => {
+  const obj = (type: string): PsdGame["competitionType"] =>
+    ({ id: 1, name: null, type }) as PsdGame["competitionType"];
+
+  it("maps OFFICIAL (PSD's league code) to 'league'", () => {
+    expect(resolveCompetitionType(obj("OFFICIAL"))).toBe("league");
+  });
+
+  it("maps LEAGUE synonym to 'league'", () => {
+    expect(resolveCompetitionType(obj("LEAGUE"))).toBe("league");
+  });
+
+  it("maps CUP to 'cup' and FRIENDLY to 'friendly'", () => {
+    expect(resolveCompetitionType(obj("CUP"))).toBe("cup");
+    expect(resolveCompetitionType(obj("FRIENDLY"))).toBe("friendly");
+  });
+
+  it("maps an unknown object type to 'other'", () => {
+    expect(resolveCompetitionType(obj("TOURNAMENT"))).toBe("other");
+  });
+
+  it("maps a plain-string (inlined match-detail label) to 'other'", () => {
+    // The /games/{id}/info endpoint returns a resolved display string like
+    // "Croky Cup"/"Competitie" — unclassifiable without banned label-matching.
+    expect(resolveCompetitionType("Competitie")).toBe("other");
+    expect(resolveCompetitionType("Croky Cup")).toBe("other");
+  });
+
+  it("maps null/undefined to 'other'", () => {
+    expect(resolveCompetitionType(null)).toBe("other");
+    expect(resolveCompetitionType(undefined)).toBe("other");
+  });
+});
 
 describe("mapGameStatus", () => {
   it("returns 'finished' for status 0 with goals", () => {

--- a/apps/api/src/psd/transforms.ts
+++ b/apps/api/src/psd/transforms.ts
@@ -5,6 +5,7 @@ import type {
   MatchLineupPlayer,
   RankingEntry,
   CardType,
+  CompetitionType,
   OpponentHistory,
   MatchEvent,
 } from "@kcvv/api-contract";
@@ -95,6 +96,37 @@ function resolveCompetitionLabel(
   const specific = competitionLabels?.[ct.id];
   if (specific) return specific;
   return mapCompetitionLabel(ct.type ?? "UNKNOWN", ct.name);
+}
+
+/**
+ * Resolve a PSD competitionType field to the normalized league/cup/friendly
+ * classification used by the UI gate (e.g. match-day standings).
+ *
+ * Only the **object** form carries a reliable `.type`. The match-detail
+ * endpoint (`/games/{id}/info`) inlines a display *string* (e.g. "Croky Cup"),
+ * which can't be classified without string-matching Dutch labels (banned) — so
+ * the string and null forms fall through to `"other"`. The match-detail page
+ * therefore sources a reliable type from the season-games object form via the
+ * match-team index, not from `/games/{id}/info` directly.
+ *
+ * PSD uses `type: "OFFICIAL"` (Dutch "Competitie") for league play; `"LEAGUE"`
+ * is accepted as a forward-compat synonym.
+ */
+export function resolveCompetitionType(
+  ct: PsdCompetitionType | string | null | undefined,
+): CompetitionType {
+  if (ct == null || typeof ct === "string") return "other";
+  switch (ct.type.toUpperCase()) {
+    case "OFFICIAL":
+    case "LEAGUE":
+      return "league";
+    case "CUP":
+      return "cup";
+    case "FRIENDLY":
+      return "friendly";
+    default:
+      return "other";
+  }
 }
 
 /**

--- a/apps/api/src/psd/transforms.ts
+++ b/apps/api/src/psd/transforms.ts
@@ -596,6 +596,7 @@ export function transformFootbalistoRankingEntry(
   return {
     position: entry.rank,
     team_id: entry.team.id,
+    club_id: entry.team.club.id,
     team_name: teamName,
     team_logo: `${cdn}/extra_groot/${entry.team.club.id}.png`,
     played: entry.matchesPlayed,

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -349,6 +349,8 @@ export default async function MatchPage({ params }: MatchPageProps) {
         >
           <MatchStandingsSection
             entries={standings}
+            homeClubId={match.home_team.id}
+            awayClubId={match.away_team.id}
             highlightTeamId={match.kcvv_team_id}
           />
         </TrackInView>

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -39,7 +39,7 @@ import {
   ArticleRepository,
   type MatchArticleVM,
 } from "@/lib/repositories/article.repository";
-import type { MatchDetail, MatchEvent } from "@kcvv/api-contract";
+import type { MatchDetail, MatchEvent, RankingEntry } from "@kcvv/api-contract";
 import { JsonLd } from "@/components/seo/JsonLd";
 import {
   buildBreadcrumbJsonLd,
@@ -48,6 +48,7 @@ import {
 import { MatchHero } from "@/components/match/MatchHero";
 import { MatchLineupSection } from "@/components/match/MatchLineupSection";
 import { MatchEventsSection } from "@/components/match/MatchEventsSection";
+import { MatchStandingsSection } from "@/components/match/MatchStandingsSection";
 import {
   MatchArticleLinkCard,
   selectMatchArticle,
@@ -226,6 +227,30 @@ export default async function MatchPage({ params }: MatchPageProps) {
   const articleSelection = selectMatchArticle(linkedArticles, match.status);
   const hasArticle = articleSelection !== null;
 
+  // Match-day standings (#2162) — league matches only. A cup/friendly/other
+  // match has no meaningful league table, so we gate on the BFF-surfaced
+  // structured `competitionType` (never on string-matching the Dutch label) and
+  // a resolved `kcvv_team_id`; anything else triggers no ranking fetch at all.
+  // Resilient: a BFF failure degrades to an empty table (auto-hidden), never a
+  // 500 — mirrors the `/ploegen/[slug]` standings fetch.
+  let standings: readonly RankingEntry[] = [];
+  if (match.competitionType === "league" && match.kcvv_team_id != null) {
+    const standingsTeamId = match.kcvv_team_id;
+    standings = await runPromise(
+      Effect.gen(function* () {
+        const bff = yield* BffService;
+        return yield* bff
+          .getRanking(standingsTeamId)
+          .pipe(
+            Effect.catchAll(() =>
+              Effect.succeed([] as readonly RankingEntry[]),
+            ),
+          );
+      }),
+    );
+  }
+  const hasStandings = standings.length > 0;
+
   const matchLabel = formatMatchTitle(match);
 
   const analyticsParams = {
@@ -272,7 +297,7 @@ export default async function MatchPage({ params }: MatchPageProps) {
         kcvvTeamLabel={match.kcvv_team_label}
       />
 
-      {(hasLineup || hasEvents || hasArticle) && (
+      {(hasLineup || hasEvents || hasStandings || hasArticle) && (
         <StripedSeam colorPair="ink-cream" height="md" />
       )}
 
@@ -309,9 +334,29 @@ export default async function MatchPage({ params }: MatchPageProps) {
         </TrackInView>
       )}
 
+      {/* Seam before the standings when a body section preceded it. */}
+      {hasStandings && (hasLineup || hasEvents) && (
+        <StripedSeam colorPair="ink-cream" height="md" />
+      )}
+
+      {/* Match-day standings (#2162) — league matches only; <TrackInView> only
+          mounts when the section renders, so `match_standings_in_view` never
+          fires on the auto-hide (cup/friendly/off-season) branch. */}
+      {hasStandings && (
+        <TrackInView
+          eventName="match_standings_in_view"
+          params={analyticsParams}
+        >
+          <MatchStandingsSection
+            entries={standings}
+            highlightTeamId={match.kcvv_team_id}
+          />
+        </TrackInView>
+      )}
+
       {/* Seam before the article card when a body section preceded it, so the
-          card isn't flush against the lineup/events block. */}
-      {hasArticle && (hasLineup || hasEvents) && (
+          card isn't flush against the lineup/events/standings block. */}
+      {hasArticle && (hasLineup || hasEvents || hasStandings) && (
         <StripedSeam colorPair="ink-cream" height="md" />
       )}
 

--- a/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.stories.tsx
+++ b/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.stories.tsx
@@ -17,6 +17,9 @@ function entry(
   return {
     position,
     team_id,
+    // Mock: club_id mirrors team_id so the head-to-head filter (by club id) and
+    // the KCVV highlight (by team id) line up on the same numbers.
+    club_id: team_id,
     team_name,
     played,
     won,
@@ -53,14 +56,22 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** League match — full division with the KCVV row tinted. */
+/**
+ * League match KCVV (6th) vs VK Weerde (3rd) — the full division is passed but
+ * only the two teams playing render, each at its real position; KCVV tinted.
+ */
 export const Default: Story = {
-  args: { entries: fullDivision, highlightTeamId: 1235 },
+  args: {
+    entries: fullDivision,
+    homeClubId: 1235,
+    awayClubId: 103,
+    highlightTeamId: 1235,
+  },
 };
 
-/** Without a highlight (e.g. team id unresolved) — no row is tinted. */
+/** Without a highlight (e.g. team id unresolved) — neither row is tinted. */
 export const NoHighlight: Story = {
-  args: { entries: fullDivision },
+  args: { entries: fullDivision, homeClubId: 1235, awayClubId: 103 },
 };
 
 /**
@@ -68,6 +79,6 @@ export const NoHighlight: Story = {
  * story renders nothing. Tagged `vr-skip` since there's no visual to capture.
  */
 export const EmptyAutoHides: Story = {
-  args: { entries: [] },
+  args: { entries: [], homeClubId: 1235, awayClubId: 103 },
   tags: ["vr-skip"],
 };

--- a/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.stories.tsx
+++ b/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { RankingEntry } from "@kcvv/api-contract";
+import { MatchStandingsSection } from "./MatchStandingsSection";
+
+function entry(
+  position: number,
+  team_id: number,
+  team_name: string,
+  played: number,
+  won: number,
+  drawn: number,
+  lost: number,
+  goals_for: number,
+  goals_against: number,
+  points: number,
+): RankingEntry {
+  return {
+    position,
+    team_id,
+    team_name,
+    played,
+    won,
+    drawn,
+    lost,
+    goals_for,
+    goals_against,
+    goal_difference: goals_for - goals_against,
+    points,
+  } as RankingEntry;
+}
+
+// A realistic provincial division with KCVV mid-table (team_id 1235).
+const fullDivision: RankingEntry[] = [
+  entry(1, 101, "KSK Kampenhout", 18, 13, 3, 2, 41, 17, 42),
+  entry(2, 102, "FC Perk", 18, 12, 4, 2, 38, 19, 40),
+  entry(3, 103, "VK Weerde", 18, 11, 3, 4, 35, 22, 36),
+  entry(4, 104, "Eppegem B", 18, 9, 5, 4, 30, 24, 32),
+  entry(5, 105, "SK Kampenhout B", 18, 8, 6, 4, 28, 23, 30),
+  entry(6, 1235, "KCVV Elewijt", 18, 8, 4, 6, 27, 25, 28),
+  entry(7, 107, "Hofstade VV", 18, 7, 5, 6, 26, 26, 26),
+  entry(8, 108, "FC Mollem", 18, 6, 4, 8, 22, 28, 22),
+  entry(9, 109, "SK Relegem", 18, 5, 5, 8, 21, 30, 20),
+  entry(10, 110, "VK Humbeek", 18, 4, 4, 10, 18, 35, 16),
+];
+
+const meta = {
+  title: "Features/Matches/MatchStandingsSection",
+  component: MatchStandingsSection,
+  tags: ["autodocs", "vr"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof MatchStandingsSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** League match — full division with the KCVV row tinted. */
+export const Default: Story = {
+  args: { entries: fullDivision, highlightTeamId: 1235 },
+};
+
+/** Without a highlight (e.g. team id unresolved) — no row is tinted. */
+export const NoHighlight: Story = {
+  args: { entries: fullDivision },
+};
+
+/**
+ * Empty ranking (off-season / cup / friendly) — the section auto-hides, so the
+ * story renders nothing. Tagged `vr-skip` since there's no visual to capture.
+ */
+export const EmptyAutoHides: Story = {
+  args: { entries: [] },
+  tags: ["vr-skip"],
+};

--- a/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.test.tsx
+++ b/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { RankingEntry } from "@kcvv/api-contract";
+import { MatchStandingsSection } from "./MatchStandingsSection";
+
+function entry(
+  position: number,
+  team_id: number,
+  team_name: string,
+): RankingEntry {
+  return {
+    position,
+    team_id,
+    team_name,
+    played: 10,
+    won: 5,
+    drawn: 2,
+    lost: 3,
+    goals_for: 18,
+    goals_against: 14,
+    goal_difference: 4,
+    points: 17,
+  } as RankingEntry;
+}
+
+const ranking: RankingEntry[] = [
+  entry(1, 101, "KSK Kampenhout"),
+  entry(2, 1235, "KCVV Elewijt"),
+  entry(3, 103, "VK Weerde"),
+];
+
+describe("MatchStandingsSection", () => {
+  it("renders the KLASSEMENT chrome + heading + table for a populated ranking", () => {
+    render(<MatchStandingsSection entries={ranking} highlightTeamId={1235} />);
+    expect(screen.getByText("KLASSEMENT")).toBeInTheDocument();
+    expect(screen.getByText(/In de stand/i)).toBeInTheDocument();
+    expect(screen.getByText("KCVV Elewijt")).toBeInTheDocument();
+    expect(screen.getByText("KSK Kampenhout")).toBeInTheDocument();
+  });
+
+  it("auto-hides (renders nothing) when the ranking is empty", () => {
+    const { container } = render(<MatchStandingsSection entries={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("forwards highlightTeamId so the KCVV row is tinted", () => {
+    render(<MatchStandingsSection entries={ranking} highlightTeamId={1235} />);
+    // StandingsTable marks the highlighted row with data-testid="standings-kcvv-row".
+    const kcvvRow = screen.getByTestId("standings-kcvv-row");
+    expect(kcvvRow.textContent).toContain("KCVV Elewijt");
+  });
+});

--- a/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.test.tsx
+++ b/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.test.tsx
@@ -11,6 +11,7 @@ function entry(
   return {
     position,
     team_id,
+    club_id: team_id, // mock: club_id mirrors team_id
     team_name,
     played: 10,
     won: 5,
@@ -23,29 +24,83 @@ function entry(
   } as RankingEntry;
 }
 
-const ranking: RankingEntry[] = [
+const fullDivision: RankingEntry[] = [
   entry(1, 101, "KSK Kampenhout"),
-  entry(2, 1235, "KCVV Elewijt"),
   entry(3, 103, "VK Weerde"),
+  entry(6, 1235, "KCVV Elewijt"),
 ];
 
 describe("MatchStandingsSection", () => {
-  it("renders the KLASSEMENT chrome + heading + table for a populated ranking", () => {
-    render(<MatchStandingsSection entries={ranking} highlightTeamId={1235} />);
+  it("renders the KLASSEMENT chrome + heading for a league match", () => {
+    render(
+      <MatchStandingsSection
+        entries={fullDivision}
+        homeClubId={1235}
+        awayClubId={103}
+        highlightTeamId={1235}
+      />,
+    );
     expect(screen.getByText("KLASSEMENT")).toBeInTheDocument();
     expect(screen.getByText(/In de stand/i)).toBeInTheDocument();
-    expect(screen.getByText("KCVV Elewijt")).toBeInTheDocument();
-    expect(screen.getByText("KSK Kampenhout")).toBeInTheDocument();
   });
 
-  it("auto-hides (renders nothing) when the ranking is empty", () => {
-    const { container } = render(<MatchStandingsSection entries={[]} />);
+  it("shows only the two teams playing this match — not the whole division", () => {
+    render(
+      <MatchStandingsSection
+        entries={fullDivision}
+        homeClubId={1235}
+        awayClubId={103}
+        highlightTeamId={1235}
+      />,
+    );
+    expect(screen.getByText("KCVV Elewijt")).toBeInTheDocument();
+    expect(screen.getByText("VK Weerde")).toBeInTheDocument();
+    // The uninvolved third team is filtered out.
+    expect(screen.queryByText("KSK Kampenhout")).toBeNull();
+  });
+
+  it("keeps each team's real league position (sorted ascending)", () => {
+    render(
+      <MatchStandingsSection
+        entries={fullDivision}
+        homeClubId={1235}
+        awayClubId={103}
+      />,
+    );
+    const positions = screen
+      .getAllByRole("row")
+      .slice(1) // drop the header row
+      .map((r) => r.querySelector("td")?.textContent);
+    expect(positions).toEqual(["3", "6"]); // VK Weerde (3) before KCVV (6)
+  });
+
+  it("auto-hides when neither team is in the ranking", () => {
+    const { container } = render(
+      <MatchStandingsSection
+        entries={fullDivision}
+        homeClubId={999}
+        awayClubId={998}
+      />,
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("forwards highlightTeamId so the KCVV row is tinted", () => {
-    render(<MatchStandingsSection entries={ranking} highlightTeamId={1235} />);
-    // StandingsTable marks the highlighted row with data-testid="standings-kcvv-row".
+  it("auto-hides on an empty ranking", () => {
+    const { container } = render(
+      <MatchStandingsSection entries={[]} homeClubId={1235} awayClubId={103} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("tints the KCVV row via highlightTeamId", () => {
+    render(
+      <MatchStandingsSection
+        entries={fullDivision}
+        homeClubId={1235}
+        awayClubId={103}
+        highlightTeamId={1235}
+      />,
+    );
     const kcvvRow = screen.getByTestId("standings-kcvv-row");
     expect(kcvvRow.textContent).toContain("KCVV Elewijt");
   });

--- a/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.tsx
+++ b/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.tsx
@@ -1,0 +1,54 @@
+import type { RankingEntry } from "@kcvv/api-contract";
+import { EditorialHeading, MonoLabelRow } from "@/components/design-system";
+import { cn } from "@/lib/utils/cn";
+import { StandingsTable } from "@/components/team/StandingsTable";
+
+export interface MatchStandingsSectionProps {
+  /** League-table rows for the KCVV team's competition. */
+  entries: readonly RankingEntry[];
+  /** PSD team id of the KCVV side, so its row tints in the table. */
+  highlightTeamId?: number;
+  className?: string;
+}
+
+/**
+ * Section wrapper around `<StandingsTable>` for the match-detail page (#2162) —
+ * restores the match-day standings snapshot dropped in the #1913 redesign,
+ * **league matches only** (the page gates on `competitionType === "league"`).
+ *
+ * Mirrors the `<MatchLineupSection>` / `<MatchEventsSection>` chrome: mono caps
+ * kicker (`KLASSEMENT`) + display-md italic heading (`In de stand.`) + paper
+ * container, around the already-redesigned `<StandingsTable>` (KCVV row tinted
+ * via `highlightTeamId`).
+ *
+ * Auto-hide: returns `null` when there are no entries (off-season / empty
+ * ranking). The caller mounts this unconditionally; this component owns the
+ * "render or not" decision (`<StandingsTable>` also no-ops on empty).
+ */
+export function MatchStandingsSection({
+  entries,
+  highlightTeamId,
+  className,
+}: MatchStandingsSectionProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <section
+      data-component="match-standings-section"
+      className={cn(
+        "bg-cream mx-auto w-full max-w-[var(--container-wide)] px-4 py-10 md:py-14",
+        className,
+      )}
+    >
+      <MonoLabelRow
+        items={[{ label: "KLASSEMENT" }]}
+        className="text-ink mb-3"
+      />
+      <EditorialHeading level={2} size="display-md" className="mb-8 md:mb-10">
+        In de stand.
+      </EditorialHeading>
+
+      <StandingsTable entries={entries} highlightTeamId={highlightTeamId} />
+    </section>
+  );
+}

--- a/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.tsx
+++ b/apps/web/src/components/match/MatchStandingsSection/MatchStandingsSection.tsx
@@ -4,8 +4,13 @@ import { cn } from "@/lib/utils/cn";
 import { StandingsTable } from "@/components/team/StandingsTable";
 
 export interface MatchStandingsSectionProps {
-  /** League-table rows for the KCVV team's competition. */
+  /** Full league-table rows for the competition. Filtered to the two teams
+   * playing this match (a match-day head-to-head snapshot). */
   entries: readonly RankingEntry[];
+  /** PSD club id of the home side (`match.home_team.id`). */
+  homeClubId: number;
+  /** PSD club id of the away side (`match.away_team.id`). */
+  awayClubId: number;
   /** PSD team id of the KCVV side, so its row tints in the table. */
   highlightTeamId?: number;
   className?: string;
@@ -16,21 +21,33 @@ export interface MatchStandingsSectionProps {
  * restores the match-day standings snapshot dropped in the #1913 redesign,
  * **league matches only** (the page gates on `competitionType === "league"`).
  *
+ * Shows **only the two teams playing this match** — a head-to-head standings
+ * snapshot (the legacy behaviour), matched by club id against the full ranking
+ * and keeping each team's real league position. Not the whole division.
+ *
  * Mirrors the `<MatchLineupSection>` / `<MatchEventsSection>` chrome: mono caps
  * kicker (`KLASSEMENT`) + display-md italic heading (`In de stand.`) + paper
  * container, around the already-redesigned `<StandingsTable>` (KCVV row tinted
  * via `highlightTeamId`).
  *
- * Auto-hide: returns `null` when there are no entries (off-season / empty
- * ranking). The caller mounts this unconditionally; this component owns the
- * "render or not" decision (`<StandingsTable>` also no-ops on empty).
+ * Auto-hide: returns `null` when neither team is found in the ranking
+ * (off-season / empty ranking). The caller mounts this unconditionally; this
+ * component owns the "render or not" decision.
  */
 export function MatchStandingsSection({
   entries,
+  homeClubId,
+  awayClubId,
   highlightTeamId,
   className,
 }: MatchStandingsSectionProps) {
-  if (entries.length === 0) return null;
+  // `.filter` returns a fresh array, so the in-place `.sort` never mutates the
+  // caller's `entries`.
+  const involved = entries
+    .filter((e) => e.club_id === homeClubId || e.club_id === awayClubId)
+    .sort((a, b) => a.position - b.position);
+
+  if (involved.length === 0) return null;
 
   return (
     <section
@@ -48,7 +65,7 @@ export function MatchStandingsSection({
         In de stand.
       </EditorialHeading>
 
-      <StandingsTable entries={entries} highlightTeamId={highlightTeamId} />
+      <StandingsTable entries={involved} highlightTeamId={highlightTeamId} />
     </section>
   );
 }

--- a/apps/web/src/components/match/MatchStandingsSection/index.ts
+++ b/apps/web/src/components/match/MatchStandingsSection/index.ts
@@ -1,0 +1,2 @@
+export { MatchStandingsSection } from "./MatchStandingsSection";
+export type { MatchStandingsSectionProps } from "./MatchStandingsSection";

--- a/apps/web/src/components/match/index.ts
+++ b/apps/web/src/components/match/index.ts
@@ -17,6 +17,9 @@ export type { MatchLineupSectionProps } from "./MatchLineupSection";
 export { MatchEventsSection } from "./MatchEventsSection";
 export type { MatchEventsSectionProps } from "./MatchEventsSection";
 
+export { MatchStandingsSection } from "./MatchStandingsSection";
+export type { MatchStandingsSectionProps } from "./MatchStandingsSection";
+
 export type {
   UpcomingMatch,
   MatchStatus,

--- a/apps/web/src/components/team/StandingsTable/StandingsTable.tsx
+++ b/apps/web/src/components/team/StandingsTable/StandingsTable.tsx
@@ -26,7 +26,7 @@ export function StandingsTable({
           <tr className="border-ink border-b-2">
             <th
               scope="col"
-              className="text-ink-muted py-2 pr-2 text-left tracking-wider uppercase"
+              className="text-ink-muted py-2 pr-2 pl-4 text-left tracking-wider uppercase"
             >
               #
             </th>
@@ -69,7 +69,7 @@ export function StandingsTable({
             </th>
             <th
               scope="col"
-              className="text-ink-muted py-2 text-right tracking-wider uppercase"
+              className="text-ink-muted py-2 pr-4 text-right tracking-wider uppercase"
             >
               Ptn
             </th>
@@ -89,7 +89,7 @@ export function StandingsTable({
                 )}
               >
                 {/* Position */}
-                <td className="text-ink-muted py-2 pr-2 tabular-nums">
+                <td className="text-ink-muted py-2 pr-2 pl-4 tabular-nums">
                   {entry.position}
                 </td>
 
@@ -137,7 +137,7 @@ export function StandingsTable({
                 </td>
 
                 {/* Points — display-big black */}
-                <td className="font-display-big text-ink py-2 text-right font-black tabular-nums">
+                <td className="font-display-big text-ink py-2 pr-4 text-right font-black tabular-nums">
                   {entry.points}
                 </td>
               </tr>

--- a/packages/api-contract/src/schemas/match.test.ts
+++ b/packages/api-contract/src/schemas/match.test.ts
@@ -133,4 +133,26 @@ describe("MatchDetail schema", () => {
   it("throws on missing hasReport", () => {
     expect(() => S.decodeUnknownSync(MatchDetail)(validMatch)).toThrow();
   });
+
+  it("decodes an optional competitionType", () => {
+    const result = S.decodeUnknownSync(MatchDetail)({
+      ...validDetail,
+      competitionType: "league",
+    });
+    expect(result.competitionType).toBe("league");
+  });
+
+  it("leaves competitionType undefined when absent", () => {
+    const result = S.decodeUnknownSync(MatchDetail)(validDetail);
+    expect(result.competitionType).toBeUndefined();
+  });
+
+  it("rejects an unknown competitionType literal", () => {
+    expect(() =>
+      S.decodeUnknownSync(MatchDetail)({
+        ...validDetail,
+        competitionType: "playoff",
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/api-contract/src/schemas/match.ts
+++ b/packages/api-contract/src/schemas/match.ts
@@ -130,10 +130,26 @@ export class MatchEvent extends S.Class<MatchEvent>("MatchEvent")({
   isOwnGoal: S.optional(S.Boolean),
 }) {}
 
+/**
+ * Normalized league/cup/friendly classification for a match.
+ *
+ * Surfaced so consumers can gate behaviour on the *structured* competition type
+ * instead of string-matching the Dutch `competition` label. Derived by the BFF
+ * from PSD's `competitionType.type` (`OFFICIAL`/`LEAGUE` → `"league"`,
+ * `CUP` → `"cup"`, `FRIENDLY` → `"friendly"`, anything else → `"other"`).
+ *
+ * Lives on `MatchDetail` only (not `BaseMatchFields`) — per "only declare the
+ * fields you use", the match list / share autocomplete don't need it.
+ */
+export const CompetitionType = S.Literal("league", "cup", "friendly", "other");
+export type CompetitionType = S.Schema.Type<typeof CompetitionType>;
+
 /** Normalized match detail (extended Match with lineup and events) */
 export class MatchDetail extends S.Class<MatchDetail>("MatchDetail")({
   ...BaseMatchFields,
   lineup: S.optional(MatchLineup),
   events: S.optional(S.Array(MatchEvent)),
   hasReport: S.Boolean,
+  /** League/cup/friendly classification. Absent when the BFF can't resolve it. */
+  competitionType: S.optional(CompetitionType),
 }) {}

--- a/packages/api-contract/src/schemas/ranking.ts
+++ b/packages/api-contract/src/schemas/ranking.ts
@@ -5,6 +5,9 @@ import { DateFromStringOrDate } from "./common";
 export class RankingEntry extends S.Class<RankingEntry>("RankingEntry")({
   position: S.Number,
   team_id: S.Number,
+  /** PSD club id (e.g. 1235 for KCVV). Lets consumers match a ranking row to a
+   * match side, whose home/away ids are club ids — not PSD team ids. */
+  club_id: S.optional(S.Number),
   team_name: S.String,
   team_logo: S.optional(S.String),
   played: S.Number,


### PR DESCRIPTION
Closes #2162

Restores the match-day league-table snapshot dropped in the #1913 match redesign — **league matches only**, rendered with the redesigned `<StandingsTable>`.

## ⚠️ Re-spec: the issue's data premises were wrong

Verified against real PSD data (season 8, 2025-2026). Findings recorded in [this issue comment](https://github.com/soniCaH/www.kcvvelewijt.be/issues/2162#issuecomment-4727647699):

- **League type code is `OFFICIAL`, not `LEAGUE`** — the issue's `LEAGUE → "league"` map would have missed every league match.
- The match-detail endpoint (`/games/{id}/info`) returns `competitionType` as a **display string**, not the `{type}` object, and carries **no team id** — so neither the gate nor `getRanking` could work as specced. The reliable structured data lives only on the season-games endpoint.

## Changes

- **api-contract** — `competitionType` (`"league" | "cup" | "friendly" | "other"`) on `MatchDetail` (additive).
- **BFF** (`apps/api`):
  - `resolveCompetitionType()` — `OFFICIAL`/`LEAGUE` → `league`, `CUP` → `cup`, `FRIENDLY` → `friendly`, else/string/null → `other` (never string-matches Dutch labels).
  - A cached `matchId → {teamId, competitionType}` index built from every team's season games (the reliable object form). `getMatchDetail` enriches `kcvv_team_id` + `competitionType` from it.
  - **Caching** (per the PSD/Workers-KV quota concern): single KV entry `psd:match-team-index`, **12h TTL** — one build per ~12h fans out one fetch per team; the map is independent of standings freshness, so a long TTL costs nothing in accuracy. Mirrors the existing `getCurrentSeason`/`getCompetitionLabels` cache pattern (incl. don't-cache-empty).
  - **No regression**: `getMatchTeamIndex` is bulletproof (`catchAllCause` → empty index on any error/defect), so an index miss/failure leaves `getMatchDetail` byte-identical to before. **`is_home` + `kcvv_team_label` are deliberately left untouched** → keeper enrichment and the `MatchHero` meta line are unchanged.
- **web** — `/wedstrijd/[matchId]` gates on `competitionType === "league" && kcvv_team_id != null` → `getRanking(kcvv_team_id)` (`catchAll → []`) → new `<MatchStandingsSection>` (`KLASSEMENT` kicker + `In de stand.` heading + `<StandingsTable>` with `highlightTeamId`), auto-hiding on empty. `<StripedSeam>` conditions updated.

## Analytics

`match_standings_in_view` fires via `<TrackInView>` only when the section renders. The `match_` prefix is **already** in the live GTM Custom Event trigger regex — **no GTM trigger change needed**. New event should be added to the GA4 event/report config (manual step, mirrors the other `match_*_in_view` events).

## Testing

- `pnpm --filter @kcvv/web check-all` — green (lint, tsgo, **3209 tests / 279 files**, next build).
- `@kcvv/api` — lint + type-check + **344 tests** (incl. `resolveCompetitionType` mapping + the full index build path `OFFICIAL → league` + additive-enrichment + no-op-on-miss).
- `@kcvv/api-contract` — build + **90 tests** (incl. `competitionType` decode/reject).
- New `MatchStandingsSection` component test + `Features/Matches/MatchStandingsSection` story (`tags: ["autodocs","vr"]`; VR baselines deferred per redesign policy).
- Existing `getMatchDetail` / match-page behaviour unchanged (no-regression locked by tests asserting `is_home`/`kcvv_team_label` stay untouched).

## Pre-PR review gate

`/code-review` (high) + `/simplify` angles run on the branch diff — correctness clean across index build, enrichment additivity, the league gate, seam logic, and `getRanking` wiring; one doc-drift comment found and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Match standings now display on league match pages, including team highlighting and a “KLASSEMENT” section.
  * Match details now expose normalized competition type (league/cup/friendly/other) to power league-only standings.
  * Ranking rows now support an optional `club_id` to improve home/away team mapping.
* **Tests**
  * Added/extended tests for competition type resolution and match standings rendering (including empty/edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->