### PR TITLE
feat(api): matchday-aware /share match autocomplete (#2160)

### DIFF
--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -5,6 +5,7 @@ import { WorkerEnvTag } from "../env";
 export const TTL = {
   MATCHES_TEAM: 60 * 60 * 24, // 24 hours — season schedule rarely changes mid-week
   NEXT_MATCHES: 60 * 60 * 4, // 4 hours — no live scores, schedule is stable for hours
+  MATCHES_WINDOW: 60 * 60 * 4, // 4 hours — matchday picker; in-window matches stay listed regardless of refresh
   MATCH_DETAIL_PAST: 60 * 60 * 24 * 7, // 7 days — historical, never changes
   MATCH_DETAIL_DEFAULT: 60 * 60 * 24, // 24 hours — upcoming/recent matches
   RANKING: 60 * 60 * 24, // 24 hours — updates only after a match day

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -3,6 +3,7 @@ import { Effect, Layer, Schema as S } from "effect";
 import {
   getMatchesByTeamHandler,
   getNextMatchesHandler,
+  getMatchesWindowHandler,
   getMatchByIdHandler,
   getMatchDetailHandler,
   getPlayerStatsHandler,
@@ -50,6 +51,7 @@ function makeServiceMock(
   return {
     getTeamMatches: (_teamId) => Effect.succeed([baseMatch]),
     getNextMatches: () => Effect.succeed([baseMatch]),
+    getMatchesWindow: () => Effect.succeed([baseMatch]),
     getMatchById: (_matchId) => Effect.succeed({ ...baseMatch, id: 99 }),
     getMatchDetail: (_matchId) => Effect.succeed(baseDetail),
     getRanking: () => Effect.die("not needed"),
@@ -143,6 +145,35 @@ describe("getNextMatchesHandler", () => {
       Effect.either(
         provide(getNextMatchesHandler(), {
           getNextMatches: () =>
+            Effect.fail(
+              new UpstreamUnavailableError({
+                message: "All teams failed",
+                status: 503,
+              }),
+            ),
+        }),
+      ),
+    );
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("UpstreamUnavailable");
+    }
+  });
+});
+
+describe("getMatchesWindowHandler", () => {
+  it("returns windowed matches from PsdService", async () => {
+    const result = await Effect.runPromise(provide(getMatchesWindowHandler()));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(1);
+    expect(() => S.decodeUnknownSync(MatchesArray)(result)).not.toThrow();
+  });
+
+  it("propagates UpstreamUnavailableError from service", async () => {
+    const result = await Effect.runPromise(
+      Effect.either(
+        provide(getMatchesWindowHandler(), {
+          getMatchesWindow: () =>
             Effect.fail(
               new UpstreamUnavailableError({
                 message: "All teams failed",

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -60,6 +60,26 @@ export const getNextMatchesHandler = (): Effect.Effect<
   );
 };
 
+export const getMatchesWindowHandler = (): Effect.Effect<
+  readonly Match[],
+  BffError,
+  PsdService | KvCacheService | WorkerEnvTag
+> => {
+  const cacheKey = "matches:window";
+  const fetchMatches = Effect.gen(function* () {
+    const service = yield* PsdService;
+    return yield* service.getMatchesWindow();
+  });
+
+  return matchesCache.getOrFetch(
+    cacheKey,
+    fetchMatches,
+    TTL.MATCHES_WINDOW,
+    undefined,
+    { shouldServeStale },
+  );
+};
+
 export const getMatchByIdHandler = (
   matchId: number,
 ): Effect.Effect<Match, BffError, PsdService> =>
@@ -134,6 +154,9 @@ export const MatchesApiLive = HttpApiBuilder.group(
         withErrorMapping(getMatchesByTeamHandler(teamId)),
       )
       .handle("getNextMatches", () => withErrorMapping(getNextMatchesHandler()))
+      .handle("getMatchesWindow", () =>
+        withErrorMapping(getMatchesWindowHandler()),
+      )
       .handle("getMatchById", ({ path: { matchId } }) =>
         withErrorMapping(getMatchByIdHandler(matchId)),
       )

--- a/apps/api/src/handlers/ranking.test.ts
+++ b/apps/api/src/handlers/ranking.test.ts
@@ -31,6 +31,7 @@ function makeServiceMock(
   return {
     getTeamMatches: () => Effect.fail(new Error("not needed") as never),
     getNextMatches: () => Effect.fail(new Error("not needed") as never),
+    getMatchesWindow: () => Effect.fail(new Error("not needed") as never),
     getMatchById: () => Effect.fail(new Error("not needed") as never),
     getMatchDetail: () => Effect.fail(new Error("not needed") as never),
     getRanking: () => Effect.succeed(rankingEntries),

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Effect, Layer, Logger, Schema as S } from "effect";
 import { PsdService, PsdServiceLive } from "./service";
 import { Match, MatchDetail, RankingEntry } from "@kcvv/api-contract";
@@ -680,6 +680,272 @@ describe("PsdService.getNextMatches", () => {
 
     // Sanity should NOT be called when KV has cached data
     expect(sanityCallCount).toBe(0);
+  });
+});
+
+describe("PsdService.getMatchesWindow", () => {
+  // Pin "now" to a fixed instant so the [start of today, now + 7d] window is
+  // deterministic. Fake only `Date` (timers stay real) so Effect's fiber
+  // scheduler is unaffected. Brussels in June is UTC+2, so 14:00Z is the same
+  // calendar day in both UTC and Brussels.
+  const NOW = "2026-06-17T14:00:00.000Z";
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(NOW));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Self-contained season covering the pinned NOW — independent of the real
+  // clock, unlike the module-level `seasons` fixture.
+  const windowSeasons = [
+    {
+      id: 42,
+      name: "2026-2027",
+      start: "2026-06-01T00:00:00.000Z",
+      end: "2026-12-31T00:00:00.000Z",
+    },
+  ];
+
+  const game = (overrides: {
+    id: number;
+    date: string;
+    time: string;
+    goalsHomeTeam?: number | null;
+    goalsAwayTeam?: number | null;
+  }) => ({
+    status: 0,
+    homeClub: { id: 123, name: "KCVV Elewijt" },
+    awayClub: { id: 456, name: "Opponent FC" },
+    goalsHomeTeam: null,
+    goalsAwayTeam: null,
+    competitionType: { id: 1, name: "3de Nationale", type: "LEAGUE" },
+    ...overrides,
+  });
+
+  // Relative to NOW (2026-06-17 14:00Z):
+  const yesterdayGame = game({
+    id: 200,
+    date: "2026-06-16 15:00",
+    time: "15:00",
+  }); // before today — excluded
+  const startedTodayGame = game({
+    id: 201,
+    date: "2026-06-17 11:00", // kicked off 3h before now — getNextMatches drops it
+    time: "11:00",
+    goalsHomeTeam: 1,
+    goalsAwayTeam: 0,
+  });
+  const upcomingThisWeekGame = game({
+    id: 202,
+    date: "2026-06-20 15:00",
+    time: "15:00",
+  }); // +3d — in window
+  const farFutureGame = game({
+    id: 203,
+    date: "2026-06-30 15:00",
+    time: "15:00",
+  }); // +13d — excluded
+
+  const windowFixtureList = {
+    content: [
+      yesterdayGame,
+      startedTodayGame,
+      upcomingThisWeekGame,
+      farFutureGame,
+    ],
+  };
+
+  it("includes an already-started match from today and excludes out-of-window matches", async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => windowFixtureList,
+        });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => windowSeasons });
+      }
+      return Promise.resolve({ ok: true, json: async () => [rawTeams[0]] });
+    });
+
+    const result = await runService((svc) => svc.getMatchesWindow());
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      // started-today (201) is the key regression vs getNextMatches; upcoming
+      // (202) is in window; yesterday (200) and far-future (203) are excluded.
+      // Sorted by kickoff ascending → [201, 202].
+      expect(result.right.map((m) => m.id)).toEqual([201, 202]);
+      expect(result.right[0]?.kcvv_team_id).toBe(1);
+      expect(result.right[0]?.kcvv_team_label).toBe("A-Ploeg");
+      for (const match of result.right) {
+        expect(() => S.decodeUnknownSync(Match)(match)).not.toThrow();
+      }
+    }
+  });
+
+  it("getNextMatches drops the already-started match that getMatchesWindow keeps", async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => windowFixtureList,
+        });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => windowSeasons });
+      }
+      return Promise.resolve({ ok: true, json: async () => [rawTeams[0]] });
+    });
+
+    const next = await runService((svc) => svc.getNextMatches());
+
+    expect(next._tag).toBe("Right");
+    if (next._tag === "Right") {
+      // Only the next upcoming fixture (>= now) survives — the started-today
+      // match (201) is gone, leaving the +3d fixture (202).
+      expect(next.right.map((m) => m.id)).toEqual([202]);
+    }
+  });
+
+  it("flattens in-window games across teams and sorts by kickoff ascending", async () => {
+    const teamB = {
+      id: 2,
+      name: "KCVV Elewijt B",
+      age: "A",
+      gender: "mannen",
+      footbelId: null,
+      active: true,
+    };
+    const teamAList = { content: [upcomingThisWeekGame] }; // 2026-06-20
+    const teamBList = {
+      content: [game({ id: 302, date: "2026-06-18 14:30", time: "14:30" })], // 2026-06-18
+    };
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/1/")) {
+        return Promise.resolve({ ok: true, json: async () => teamAList });
+      }
+      if (url.includes("/games/team/2/")) {
+        return Promise.resolve({ ok: true, json: async () => teamBList });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => windowSeasons });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => [rawTeams[0], teamB],
+      });
+    });
+
+    const result = await runService((svc) => svc.getMatchesWindow(), {
+      sanityMock: makeSanityMock(["1", "2"]),
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      // 2026-06-18 (team B, 302) before 2026-06-20 (team A, 202).
+      expect(result.right.map((m) => m.id)).toEqual([302, 202]);
+      expect(result.right[0]?.kcvv_team_label).toBe("B-Ploeg");
+      expect(result.right[1]?.kcvv_team_label).toBe("A-Ploeg");
+    }
+  });
+
+  it("does not fail the whole list when a single team fetch fails", async () => {
+    const teamB = {
+      id: 2,
+      name: "KCVV Elewijt B",
+      age: "A",
+      gender: "mannen",
+      footbelId: null,
+      active: true,
+    };
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/1/")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => windowFixtureList,
+        });
+      }
+      if (url.includes("/games/team/2/")) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+        });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => windowSeasons });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => [rawTeams[0], teamB],
+      });
+    });
+
+    const result = await runService((svc) => svc.getMatchesWindow(), {
+      sanityMock: makeSanityMock(["1", "2"]),
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      // Team 2 failed, team 1's in-window matches still returned.
+      expect(result.right.map((m) => m.id)).toEqual([201, 202]);
+    }
+  });
+
+  it("fails with UpstreamUnavailableError when all team fetches fail", async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/")) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+        });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => windowSeasons });
+      }
+      return Promise.resolve({ ok: true, json: async () => [rawTeams[0]] });
+    });
+
+    const result = await runService((svc) => svc.getMatchesWindow());
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("UpstreamUnavailable");
+    }
+  });
+
+  it("returns an empty list when no matches fall in the window", async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/games/team/")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ content: [yesterdayGame, farFutureGame] }),
+        });
+      }
+      if (url.includes("/seasons")) {
+        return Promise.resolve({ ok: true, json: async () => windowSeasons });
+      }
+      return Promise.resolve({ ok: true, json: async () => [rawTeams[0]] });
+    });
+
+    const result = await runService((svc) => svc.getMatchesWindow());
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right).toHaveLength(0);
+    }
   });
 });
 

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -813,7 +813,7 @@ describe("PsdService.getMatchesWindow", () => {
     }
   });
 
-  it("flattens in-window games across teams and sorts by kickoff ascending", async () => {
+  it("flattens in-window games across teams and sorts by kickoff (incl. same-day time)", async () => {
     const teamB = {
       id: 2,
       name: "KCVV Elewijt B",
@@ -822,9 +822,15 @@ describe("PsdService.getMatchesWindow", () => {
       footbelId: null,
       active: true,
     };
-    const teamAList = { content: [upcomingThisWeekGame] }; // 2026-06-20
+    const teamAList = { content: [upcomingThisWeekGame] }; // 2026-06-20 15:00
+    // Two same-day games (2026-06-18), deliberately stored later-then-earlier so
+    // the sort must reorder by *time*, not just date — a date-only comparator
+    // would leave them as [302, 301] and fail this assertion.
     const teamBList = {
-      content: [game({ id: 302, date: "2026-06-18 14:30", time: "14:30" })], // 2026-06-18
+      content: [
+        game({ id: 302, date: "2026-06-18 14:30", time: "14:30" }),
+        game({ id: 301, date: "2026-06-18 11:00", time: "11:00" }),
+      ],
     };
 
     const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
@@ -850,10 +856,11 @@ describe("PsdService.getMatchesWindow", () => {
 
     expect(result._tag).toBe("Right");
     if (result._tag === "Right") {
-      // 2026-06-18 (team B, 302) before 2026-06-20 (team A, 202).
-      expect(result.right.map((m) => m.id)).toEqual([302, 202]);
+      // 06-18 11:00 (301) < 06-18 14:30 (302) < 06-20 15:00 (202).
+      expect(result.right.map((m) => m.id)).toEqual([301, 302, 202]);
       expect(result.right[0]?.kcvv_team_label).toBe("B-Ploeg");
-      expect(result.right[1]?.kcvv_team_label).toBe("A-Ploeg");
+      expect(result.right[1]?.kcvv_team_label).toBe("B-Ploeg");
+      expect(result.right[2]?.kcvv_team_label).toBe("A-Ploeg");
     }
   });
 

--- a/apps/api/src/psd/service.ts
+++ b/apps/api/src/psd/service.ts
@@ -51,6 +51,7 @@ export interface PsdServiceInterface {
     teamId: number,
   ) => Effect.Effect<readonly Match[], BffError>;
   readonly getNextMatches: () => Effect.Effect<readonly Match[], BffError>;
+  readonly getMatchesWindow: () => Effect.Effect<readonly Match[], BffError>;
   readonly getMatchById: (matchId: number) => Effect.Effect<Match, BffError>;
   readonly getMatchDetail: (
     matchId: number,
@@ -520,6 +521,124 @@ export const PsdServiceLive = Layer.effect(
               });
             }
           }
+          return matches;
+        }),
+
+      getMatchesWindow: () =>
+        Effect.gen(function* () {
+          const visiblePsdIds = yield* getVisibleTeamIds();
+          const teams = yield* countedFetch(`${base}/teams`, PsdTeamsSchema);
+          const season = yield* getCurrentSeason();
+          const competitionLabels = yield* getCompetitionLabels();
+
+          // Window: [start of today (Brussels), now + 7 days].
+          // The lower bound is the start of the current Brussels calendar day,
+          // expressed in the same wall-clock-as-UTC space psdGameToMs uses
+          // (PSD stores wall-clock times as plain "YYYY-MM-DD HH:MM" strings),
+          // so a match that already kicked off earlier today still qualifies —
+          // the key difference from getNextMatches, which drops it once
+          // psdGameToMs(m) < now. The 7-day upper bound covers pre-game posts;
+          // a couple of hours of timezone fuzz at its far edge is immaterial.
+          const now = Date.now();
+          const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+          const brusselsToday = new Date(now).toLocaleDateString("en-CA", {
+            timeZone: "Europe/Brussels",
+          });
+          const [ty, tm, td] = brusselsToday.split("-").map(Number);
+          const startOfTodayMs = Date.UTC(ty!, tm! - 1, td!, 0, 0, 0);
+          const windowEndMs = now + SEVEN_DAYS_MS;
+
+          const visibleTeams = visiblePsdIds
+            ? teams.filter((t) => visiblePsdIds.includes(String(t.id)))
+            : teams;
+
+          const teamWindowMatches = yield* Effect.all(
+            visibleTeams.map((team) =>
+              countedFetch(
+                `${base}/games/team/${team.id}/seasons/${season.id}`,
+                PsdMatchListSchema,
+              ).pipe(
+                Effect.flatMap((data) =>
+                  Effect.gen(function* () {
+                    const [errors, games] = yield* Effect.partition(
+                      data.content,
+                      (item) =>
+                        S.decodeUnknown(PsdGame)(item).pipe(
+                          Effect.mapError((parseError) => ({
+                            id: extractId(item),
+                            parseError,
+                          })),
+                        ),
+                    );
+
+                    if (errors.length > 0) {
+                      const ids = errors.map((e) => e.id).join(", ");
+                      yield* Effect.log(
+                        `getMatchesWindow(${team.id}): filtered ${errors.length} invalid game(s) — IDs: [${ids}]`,
+                      );
+                    }
+
+                    const ownClubId = deriveOwnClubId(games);
+                    return games
+                      .filter((m) => {
+                        const ms = psdGameToMs(m);
+                        return ms >= startOfTodayMs && ms <= windowEndMs;
+                      })
+                      .map((game) =>
+                        transformPsdGame(
+                          { ...game, teamId: team.id },
+                          { ownClubId, competitionLabels },
+                        ),
+                      );
+                  }),
+                ),
+                Effect.map((windowed) => ({
+                  _tag: "ok" as const,
+                  matches: windowed,
+                })),
+                Effect.catchAll((e) =>
+                  Effect.log(
+                    `getMatchesWindow: team ${team.id} failed: ${String(e)}`,
+                  ).pipe(
+                    Effect.as({
+                      _tag: "failed" as const,
+                      matches: [] as Match[],
+                    }),
+                  ),
+                ),
+              ),
+            ),
+            { concurrency: 5 },
+          );
+
+          const allFailed =
+            visibleTeams.length > 0 &&
+            teamWindowMatches.every((r) => r._tag === "failed");
+
+          if (allFailed) {
+            return yield* Effect.fail(
+              new UpstreamUnavailableError({
+                message: `getMatchesWindow: all ${visibleTeams.length} team fetches failed`,
+              }),
+            );
+          }
+
+          // Flatten all in-window games across teams, tagging each with its
+          // KCVV team label, then sort by kickoff ascending.
+          const matches: Match[] = [];
+          for (let i = 0; i < teamWindowMatches.length; i++) {
+            const entry = teamWindowMatches[i]!;
+            if (entry._tag === "ok") {
+              const team = visibleTeams[i]!;
+              const label = derivePsdTeamLabel(team.name, team.age);
+              for (const match of entry.matches) {
+                matches.push({ ...match, kcvv_team_label: label });
+              }
+            }
+          }
+          matches.sort(
+            (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+          );
           return matches;
         }),
 

--- a/apps/web/src/app/(main)/share/page.tsx
+++ b/apps/web/src/app/(main)/share/page.tsx
@@ -51,28 +51,21 @@ async function fetchSharePageData(): Promise<{
       const bff = yield* BffService;
       const playerRepo = yield* PlayerRepository;
 
-      const [nextMatches, allPlayers] = yield* Effect.all(
+      const [windowMatches, allPlayers] = yield* Effect.all(
         [
+          // Matchday-aware window: includes matches that already kicked off /
+          // finished today (for goal/HT/FT/card posts) plus the next 7 days
+          // (for pre-game posts). Replaces the old getNextMatches + today-only
+          // filter, which dropped a match the moment it started (#2160).
           bff
-            .getNextMatches()
+            .getMatchesWindow()
             .pipe(Effect.catchTag("HttpNotFound", () => Effect.succeed([]))),
           playerRepo.findAll(),
         ],
         { concurrency: 2 },
       );
 
-      // en-CA locale gives YYYY-MM-DD format for reliable string comparison
-      const brusselsDate = new Date().toLocaleDateString("en-CA", {
-        timeZone: "Europe/Brussels",
-      });
-      const todayMatches = nextMatches.filter((m) => {
-        const kickoffDate = new Date(m.date).toLocaleDateString("en-CA", {
-          timeZone: "Europe/Brussels",
-        });
-        return kickoffDate === brusselsDate;
-      });
-
-      const matches = todayMatches.map(toMatchOption);
+      const matches = windowMatches.map(toMatchOption);
 
       const players: PlayerForShare[] = allPlayers.map((p) => ({
         id: p.id,

--- a/apps/web/src/lib/effect/services/BffService.test.ts
+++ b/apps/web/src/lib/effect/services/BffService.test.ts
@@ -92,6 +92,26 @@ describe("BffService", () => {
     );
   });
 
+  it("getMatchesWindow calls /matches/window", async () => {
+    mockFetchWith([sampleMatch]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const bff = yield* BffService;
+        return yield* bff.getMatchesWindow();
+      }).pipe(Effect.provide(BffServiceLive)),
+    );
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        href: expect.stringContaining("/matches/window"),
+      }),
+      expect.any(Object),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(1);
+  });
+
   it("getMatchDetail calls /match/:matchId/detail", async () => {
     const sampleDetail = {
       ...sampleMatch,

--- a/apps/web/src/lib/effect/services/BffService.ts
+++ b/apps/web/src/lib/effect/services/BffService.ts
@@ -29,6 +29,7 @@ export class BffService extends Context.Tag("BffService")<
   {
     getMatches: (teamId: number) => Effect.Effect<readonly Match[], BffError>;
     getNextMatches: () => Effect.Effect<readonly Match[], BffError>;
+    getMatchesWindow: () => Effect.Effect<readonly Match[], BffError>;
     getMatchById: (matchId: number) => Effect.Effect<Match, BffError>;
     getMatchDetail: (matchId: number) => Effect.Effect<MatchDetail, BffError>;
     getRanking: (
@@ -66,6 +67,10 @@ export const BffServiceLive = Layer.effect(
           .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
       getNextMatches: () =>
         client.matches.getNextMatches({}).pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+      getMatchesWindow: () =>
+        client.matches
+          .getMatchesWindow({})
+          .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
       getMatchById: (matchId: number) =>
         client.matches
           .getMatchById({ path: { matchId } })

--- a/packages/api-contract/src/api/matches.ts
+++ b/packages/api-contract/src/api/matches.ts
@@ -25,6 +25,16 @@ export class MatchesApi extends HttpApiGroup.make("matches")
       .addError(HttpNotFound),
   )
   .add(
+    // Matches with kickoff in a window around now ([start of today, now + 7d],
+    // Brussels) — includes already-started/finished matches, unlike
+    // getNextMatches. Powers the matchday-aware /share autocomplete.
+    HttpApiEndpoint.get("getMatchesWindow", "/matches/window")
+      .addSuccess(MatchesArray)
+      .addError(HttpServiceUnavailable)
+      .addError(HttpBadGateway)
+      .addError(HttpNotFound),
+  )
+  .add(
     HttpApiEndpoint.get("getMatchById", "/match/:matchId")
       .setPath(S.Struct({ matchId: S.NumberFromString }))
       .addSuccess(Match)


### PR DESCRIPTION
Closes #2160

## Problem

`/share` (the Story Generator) produces goal / rust / eindstand / card graphics — content posted **during and after** a match. Its match autocomplete was unusable for that job: `getNextMatches` returns only the *next upcoming* fixture per team and drops a match the moment it kicks off, and `/share` then further filtered to today only. Net effect: once a match started it could never appear in the picker — exactly when the tool is used.

## Solution

A new BFF endpoint `getMatchesWindow` (`/matches/window`) returns every visible-team match whose kickoff falls in `[start of today (Brussels), now + 7d]`, **including already-started/finished** matches:

- start-of-today lower bound → covers goal/HT/FT/card posts during & after the match;
- next-7-days upper bound → covers pre-game posts;
- all in-window games per team, flattened and **sorted by kickoff ascending**.

`/share` now uses it and drops the today-only filter. Selecting a match still prefills competition + kickoff + crests; manual entry remains the fallback.

## Changes

- **`packages/api-contract`** — new `getMatchesWindow` route (`/matches/window`), reuses the existing `Match` schema.
- **`apps/api`** — `PsdService.getMatchesWindow` mirrors `getNextMatches` (season fetch, competition labels, `transformPsdGame`, per-team `Effect.partition` + `catchAll` resilience, all-failed → `UpstreamUnavailableError`); `getMatchesWindowHandler` + `MATCHES_WINDOW` (4h) cache TTL.
- **`apps/web`** — `BffService.getMatchesWindow` client method; `/share` `page.tsx` rewired, today-only filter removed.

The window's lower bound is computed in the same wall-clock-as-UTC space `psdGameToMs` uses (Brussels calendar date → `Date.UTC(...,0,0)`), so it's DST-immune and reliably includes a match that already kicked off earlier today.

## Testing

- `pnpm --filter @kcvv/web check-all` ✅ (lint, type-check, test, build)
- `pnpm turbo build --filter=@kcvv/api-contract` ✅; api lint + type-check + test ✅; api-contract type-check + test ✅
- New service tests prove an **already-started-today** match is included (the key regression vs `getNextMatches`) and yesterday/+13d matches are excluded, plus cross-team flatten+sort, per-team resilience, all-fail, and empty-window cases. Handler + `BffService` wiring covered. Tests pin `Date` via fake timers + a self-contained season fixture, so they're deterministic regardless of run date.

## Review gate

Ran the Pre-PR review gate (correctness + simplification) against the branch diff: no correctness bugs found (window math, sort, resilience, and caching verified correct), and no simplification changes recommended — the structural overlap with `getNextMatches` is the codebase's intended "parallel sibling method" convention.

## Out of scope

- Analytics — `/share` is an internal `robots: noindex` tool.
- Live score/event auto-population — the manager still enters score/minute/player; this only populates the match picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `GET /matches/window` endpoint returning matchday-aware results from the start of today through the next 7 days.
  * The API and shared match selection now use this windowed data to improve match availability accuracy on the share page.
  * Implemented caching for the new windowed results to reduce repeated fetches.
* **Tests**
  * Added/updated tests across API contracts, backend service, and web BFF to validate window filtering, sorting, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->