### PR TITLE
feat(ui): rebuild /scheurkalender as a private A+B league season table (#2137)

### DIFF
--- a/apps/api/src/psd/transforms.test.ts
+++ b/apps/api/src/psd/transforms.test.ts
@@ -460,6 +460,30 @@ describe("transformPsdGame — competition label + team designation", () => {
     );
   });
 
+  it("surfaces the normalized competitionType from the season-games object form", () => {
+    // League play carries a division name in `competition` (not "Competitie"),
+    // so list consumers must gate on the structured `competitionType` instead.
+    const league = makePsdGame({
+      competitionType: {
+        id: 5,
+        name: "3de Nationale",
+        type: "OFFICIAL",
+      } as PsdGame["competitionType"],
+    });
+    const leagueMatch = transformPsdGame(league);
+    expect(leagueMatch.competition).toBe("3de Nationale");
+    expect(leagueMatch.competitionType).toBe("league");
+
+    const cup = makePsdGame({
+      competitionType: {
+        id: 9,
+        name: null,
+        type: "CUP",
+      } as PsdGame["competitionType"],
+    });
+    expect(transformPsdGame(cup).competitionType).toBe("cup");
+  });
+
   it("attaches the opponent team designation, omitting the own numeric code", () => {
     // KCVV (home, code "1") vs opponent away "U23"
     const match = transformPsdGame(

--- a/apps/api/src/psd/transforms.ts
+++ b/apps/api/src/psd/transforms.ts
@@ -314,6 +314,10 @@ export function transformPsdGame(
       game.competitionType,
       options?.competitionLabels,
     ),
+    // Normalized league/cup/friendly classification — the season-games object
+    // form carries a reliable `.type`, so this is the canonical league gate for
+    // list consumers (the `competition` label is a division name, not "Competitie").
+    competitionType: resolveCompetitionType(game.competitionType),
     kcvv_team_id: game.teamId ?? undefined,
     is_home: isHome,
   };

--- a/apps/web/src/app/(main)/scheurkalender/loading.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/loading.tsx
@@ -1,43 +1,30 @@
 /**
  * Scheurkalender Page — Loading Skeleton
- * Matches the PageHero (compact, no image) + date-grouped upcoming matches layout.
+ * Mirrors the Treatment A sheet: masthead bar + weekend fixture rows.
  */
-
-import { PageHero } from "@/components/layout/PageHero";
 
 export default function ScheurkalenderLoading() {
   return (
     <div className="bg-cream min-h-screen">
-      <div className="mx-auto max-w-5xl px-4 pt-10">
-        <PageHero kicker="Kalender" headline="Scheurkalender" size="compact" />
-      </div>
-
-      <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
-        {Array.from({ length: 4 }).map((_, day) => (
-          <div key={day} className="animate-pulse">
-            {/* Date header */}
-            <div className="bg-paper-edge mb-3 h-5 w-40 rounded" />
-            {/* Match rows */}
-            <div className="space-y-2">
-              {Array.from({ length: 3 }).map((_, match) => (
-                <div
-                  key={match}
-                  className="border-paper-edge bg-cream-soft flex items-center gap-4 border-2 p-3"
-                >
-                  <div className="bg-cream h-4 w-12 rounded" />
-                  <div className="bg-cream h-4 w-20 rounded" />
-                  <div className="flex flex-1 items-center gap-2">
-                    <div className="bg-cream h-6 w-6 rounded-full" />
-                    <div className="bg-cream h-4 w-24 rounded" />
-                    <div className="bg-cream h-4 w-4 rounded" />
-                    <div className="bg-cream h-6 w-6 rounded-full" />
-                    <div className="bg-cream h-4 w-24 rounded" />
-                  </div>
-                </div>
-              ))}
-            </div>
+      <div className="mx-auto max-w-3xl px-4 pt-12 pb-12">
+        <div className="border-ink border-2 bg-white">
+          {/* Masthead */}
+          <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
+            <div className="bg-ink/10 h-4 w-56 animate-pulse rounded" />
+            <div className="bg-ink/10 h-3 w-32 animate-pulse rounded" />
           </div>
-        ))}
+          {/* Fixture rows */}
+          <div className="divide-ink/10 divide-y">
+            {Array.from({ length: 8 }).map((_, row) => (
+              <div key={row} className="flex items-center gap-4 px-2.5 py-2">
+                <div className="bg-ink/10 h-3 w-16 animate-pulse rounded" />
+                <div className="bg-ink/10 h-3 w-10 animate-pulse rounded" />
+                <div className="bg-ink/10 h-3 flex-1 animate-pulse rounded" />
+                <div className="bg-ink/10 h-3 flex-1 animate-pulse rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/(main)/scheurkalender/page.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/page.tsx
@@ -80,8 +80,12 @@ async function fetchScheurkalenderData(): Promise<ScheurkalenderData> {
         (team) => team.age === "A" && team.psdId !== null,
       );
 
-      // Full-season fixtures per team, in parallel. One team failing degrades
-      // to an empty list rather than taking down the whole table.
+      // Full-season fixtures per team, in parallel. Catch broadly (the
+      // CLAUDE.md "broader catch when necessary" exception): this ISR page is
+      // prerendered at build, where the BFF can be unreachable — a transport
+      // error (not just HttpNotFound) must degrade to an empty sheet rather
+      // than fail the build. ISR self-heals once the BFF recovers on the next
+      // revalidation. Errors are still logged via tapError above.
       const matchArrays = yield* Effect.all(
         seniorTeams.map((team) =>
           bff.getMatches(Number(team.psdId)).pipe(
@@ -121,15 +125,7 @@ async function fetchScheurkalenderData(): Promise<ScheurkalenderData> {
       );
 
       return { matches, season };
-    }).pipe(
-      Effect.catchAll((error) => {
-        console.error("[Scheurkalender] Failed to build fixture table:", error);
-        return Effect.succeed({
-          matches: [],
-          season: seasonLabel(DateTime.now().setZone(TZ).toISODate()!),
-        } satisfies ScheurkalenderData);
-      }),
-    ),
+    }),
   );
 }
 

--- a/apps/web/src/app/(main)/scheurkalender/page.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/page.tsx
@@ -1,88 +1,143 @@
 /**
- * Scheurkalender Page
- * Print-friendly upcoming matches calendar for kiosk / display use
+ * Scheurkalender — private InDesign-poster data source (#2137).
+ *
+ * Not a public page: `noindex` + unlinked (no nav/footer/sitemap entry,
+ * reachable only by typing the URL). Renders the full-season A + B *league*
+ * fixture table the club screenshots into the A2 season poster.
+ * See `docs/design/mockups/phase-10-scheurkalender/`.
  */
 
 import type { Metadata } from "next";
 import { Effect } from "effect";
+import { DateTime } from "luxon";
 import { runPromise } from "@/lib/effect/runtime";
 import { BffService } from "@/lib/effect/services/BffService";
+import { TeamRepository } from "@/lib/repositories/team.repository";
 import type { Match } from "@/lib/effect/schemas/match.schema";
+import { KCVV_CLUB_ID } from "@/lib/constants";
 import {
   ScheurkalenderPage,
-  type ScheurkalenderDay,
+  type ScheurkalenderMatch,
 } from "@/components/scheurkalender/ScheurkalenderPage";
 
 export const metadata: Metadata = {
   title: "Scheurkalender | KCVV Elewijt",
   description:
-    "Printbare wedstrijdkalender van KCVV Elewijt met alle aankomende wedstrijden.",
+    "Interne wedstrijdkalender (competitie A + B) — bron voor de seizoensposter.",
+  // Private tool: keep it out of search indexes (also unlinked everywhere).
+  robots: { index: false, follow: false },
 };
 
-async function fetchUpcomingMatches(): Promise<Match[]> {
-  const matches = await runPromise(
+const TZ = "Europe/Brussels";
+
+interface ScheurkalenderData {
+  matches: ScheurkalenderMatch[];
+  season: string;
+}
+
+/** "B" for the squad whose name ends in " B", "A" for the first team. */
+function squadLabel(name: string): "A" | "B" {
+  return name.trim().endsWith(" B") ? "B" : "A";
+}
+
+/** Belgian season label (e.g. "25/26") for the calendar day in `isoDate`. */
+function seasonLabel(isoDate: string): string {
+  const dt = DateTime.fromISO(isoDate, { zone: TZ });
+  const startYear = dt.month >= 7 ? dt.year : dt.year - 1;
+  const twoDigit = (year: number) => String(year % 100).padStart(2, "0");
+  return `${twoDigit(startYear)}/${twoDigit(startYear + 1)}`;
+}
+
+function toScheurkalenderMatch(
+  match: Match,
+  label: "A" | "B",
+): ScheurkalenderMatch {
+  // getMatchesByTeam sets `is_home`; fall back to an exact club-id check on the
+  // rare null (home_team.id is the club id; KCVV is 1235).
+  const kcvvIsHome = match.is_home ?? match.home_team.id === KCVV_CLUB_ID;
+  const opponent = kcvvIsHome ? match.away_team.name : match.home_team.name;
+  return {
+    id: match.id,
+    // The BFF encodes the local kickoff wall-clock into the Date's UTC fields,
+    // so read the calendar day off UTC — re-zoning a late kickoff (≥22:00)
+    // to Brussels would roll it to the next day (and possibly next weekend).
+    date: DateTime.fromJSDate(match.date, { zone: "utc" }).toISODate() ?? "",
+    ...(match.time ? { time: match.time } : {}),
+    opponent,
+    kcvvLabel: label,
+    kcvvIsHome,
+  };
+}
+
+async function fetchScheurkalenderData(): Promise<ScheurkalenderData> {
+  return runPromise(
     Effect.gen(function* () {
       const bff = yield* BffService;
-      return yield* bff.getNextMatches();
+      const teamRepo = yield* TeamRepository;
+
+      // Senior A + B squads (age "A"); the one whose name ends " B" is the B-team.
+      const seniorTeams = (yield* teamRepo.findAll()).filter(
+        (team) => team.age === "A" && team.psdId !== null,
+      );
+
+      // Full-season fixtures per team, in parallel. One team failing degrades
+      // to an empty list rather than taking down the whole table.
+      const matchArrays = yield* Effect.all(
+        seniorTeams.map((team) =>
+          bff.getMatches(Number(team.psdId)).pipe(
+            Effect.tapError((error) =>
+              Effect.log(
+                `[Scheurkalender] Failed to fetch matches for ${team.name} (psdId: ${team.psdId}): ${String(error)}`,
+              ),
+            ),
+            Effect.catchAll(() => Effect.succeed([] as readonly Match[])),
+          ),
+        ),
+        { concurrency: 5 },
+      );
+
+      // League only, labelled by the queried squad (getMatches doesn't set
+      // kcvv_team_label), deduped by match id. Gate on the structured
+      // competitionType — `competition` is a division name, not "Competitie".
+      const byId = new Map<number, ScheurkalenderMatch>();
+      matchArrays.forEach((matches, index) => {
+        const label = squadLabel(seniorTeams[index]!.name);
+        for (const match of matches) {
+          if (match.competitionType !== "league") continue;
+          if (byId.has(match.id)) continue;
+          byId.set(match.id, toScheurkalenderMatch(match, label));
+        }
+      });
+
+      // Sort by date, then kickoff time.
+      const matches = [...byId.values()].sort(
+        (a, b) =>
+          a.date.localeCompare(b.date) ||
+          (a.time ?? "").localeCompare(b.time ?? ""),
+      );
+
+      const season = seasonLabel(
+        matches[0]?.date ?? DateTime.now().setZone(TZ).toISODate()!,
+      );
+
+      return { matches, season };
     }).pipe(
       Effect.catchAll((error) => {
-        console.error("[Scheurkalender] Failed to fetch matches:", error);
-        return Effect.succeed([]);
+        console.error("[Scheurkalender] Failed to build fixture table:", error);
+        return Effect.succeed({
+          matches: [],
+          season: seasonLabel(DateTime.now().setZone(TZ).toISODate()!),
+        } satisfies ScheurkalenderData);
       }),
     ),
   );
-
-  return [...matches]
-    .filter((m) => m.status === "scheduled")
-    .sort((a, b) => a.date.getTime() - b.date.getTime());
-}
-
-function toLocalDateKey(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
-function formatFullDate(date: Date): string {
-  return date.toLocaleDateString("nl-BE", {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
 }
 
 export default async function ScheurkalenderPageRoute() {
-  const matches = await fetchUpcomingMatches();
-
-  // Group by date and build ScheurkalenderDay array
-  const grouped = new Map<string, Match[]>();
-  for (const match of matches) {
-    const key = toLocalDateKey(match.date);
-    if (!grouped.has(key)) grouped.set(key, []);
-    grouped.get(key)!.push(match);
-  }
-
-  const days: ScheurkalenderDay[] = [...grouped.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, dayMatches]) => ({
-      key,
-      label: formatFullDate(new Date(key + "T12:00:00")),
-      matches: dayMatches.map((m) => ({
-        id: m.id,
-        time: m.time,
-        squadLabel: m.squadLabel,
-        homeTeam: { name: m.home_team.name, logo: m.home_team.logo },
-        awayTeam: { name: m.away_team.name, logo: m.away_team.logo },
-      })),
-    }));
-
-  return (
-    <>
-      <ScheurkalenderPage days={days} />
-    </>
-  );
+  const { matches, season } = await fetchScheurkalenderData();
+  return <ScheurkalenderPage matches={matches} season={season} />;
 }
 
-export const revalidate = 300; // 5 minutes
+// Season fixtures change rarely — cache long (6h ISR). Never generateStaticParams
+// (PSD rate limits); ISR keeps per-request rendering fast without build fan-out.
+export const revalidate = 21600;

--- a/apps/web/src/components/scheurkalender/PrintButton.tsx
+++ b/apps/web/src/components/scheurkalender/PrintButton.tsx
@@ -5,7 +5,7 @@ export function PrintButton() {
     <button
       type="button"
       onClick={() => window.print()}
-      className="text-green-main shrink-0 rounded-lg bg-white px-5 py-2.5 font-semibold transition-colors hover:bg-gray-50 print:hidden"
+      className="border-ink text-ink hover:bg-cream-soft shrink-0 border-2 bg-white px-5 py-2 font-mono text-xs font-semibold tracking-wider uppercase transition-colors print:hidden"
     >
       Afdrukken
     </button>

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
@@ -1,106 +1,83 @@
 /**
  * ScheurkalenderPage Stories
  *
- * Print-friendly upcoming-matches calendar, grouped by date.
- * The print layout (print: classes) is visible when using the browser's
- * print preview; the screen layout is shown by default in Storybook.
+ * Private (noindex, unlinked) full-season A + B league fixture table — the data
+ * source the club screenshots into the A2 InDesign season poster. Treatment A:
+ * a print-clean white sheet (Montserrat), date·time·home·away with the KCVV side
+ * bolded and the squad label inline, grouped per weekend. See #2137.
+ *
+ * Pages/* stories are design references and are not VR-tested (page composition
+ * is the e2e suite's concern).
  */
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import {
   ScheurkalenderPage,
-  type ScheurkalenderDay,
+  type ScheurkalenderMatch,
 } from "./ScheurkalenderPage";
 import ScheurkalenderLoading from "@/app/(main)/scheurkalender/loading";
 
 // ---------------------------------------------------------------------------
-// Mock data
+// Mock data — real fixtures (subset of the locked mock), A + B league across
+// several weekends, mixing home/away for each squad.
 // ---------------------------------------------------------------------------
 
-function daysFromNow(n: number): Date {
-  const d = new Date();
-  d.setDate(d.getDate() + n);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
-function toKey(date: Date): string {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-}
-
-function toLabel(date: Date): string {
-  return date.toLocaleDateString("nl-BE", {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-}
-
-const day1 = daysFromNow(3);
-const day2 = daysFromNow(7);
-const day3 = daysFromNow(14);
-
-const mockDays: ScheurkalenderDay[] = [
+const seasonFixtures: ScheurkalenderMatch[] = [
   {
-    key: toKey(day1),
-    label: toLabel(day1),
-    matches: [
-      {
-        id: 1,
-        time: "15:00",
-        squadLabel: "A-Ploeg",
-        homeTeam: { name: "KCVV Elewijt" },
-        awayTeam: { name: "Strombeek" },
-      },
-      {
-        id: 2,
-        time: "11:00",
-        squadLabel: "U15A",
-        homeTeam: { name: "KCVV Elewijt U15" },
-        awayTeam: { name: "FC Kampenhout U15" },
-      },
-    ],
+    id: 1,
+    date: "2025-08-30",
+    time: "20:00",
+    opponent: "Fc Zemst Sportief",
+    kcvvLabel: "B",
+    kcvvIsHome: true,
   },
   {
-    key: toKey(day2),
-    label: toLabel(day2),
-    matches: [
-      {
-        id: 3,
-        time: "15:00",
-        squadLabel: "A-Ploeg",
-        homeTeam: { name: "Racing Mechelen" },
-        awayTeam: { name: "KCVV Elewijt" },
-      },
-      {
-        id: 4,
-        time: "10:00",
-        squadLabel: "U13B",
-        homeTeam: { name: "KCVV Elewijt U13" },
-        awayTeam: { name: "Diegem Sport U13" },
-      },
-      {
-        id: 5,
-        time: "14:00",
-        squadLabel: "U17A",
-        homeTeam: { name: "Jeugd Zemst U17" },
-        awayTeam: { name: "KCVV Elewijt U17" },
-      },
-    ],
+    id: 2,
+    date: "2025-08-31",
+    time: "15:00",
+    opponent: "Sc City Pirates Antwerpen",
+    kcvvLabel: "A",
+    kcvvIsHome: true,
   },
   {
-    key: toKey(day3),
-    label: toLabel(day3),
-    matches: [
-      {
-        id: 6,
-        time: "15:00",
-        squadLabel: "A-Ploeg",
-        homeTeam: { name: "KCVV Elewijt" },
-        awayTeam: { name: "FC Kampenhout" },
-      },
-    ],
+    id: 3,
+    date: "2025-09-07",
+    time: "20:00",
+    opponent: "As Verbroedering Geel",
+    kcvvLabel: "A",
+    kcvvIsHome: false,
+  },
+  {
+    id: 4,
+    date: "2025-09-13",
+    time: "14:30",
+    opponent: "Peutie Fc",
+    kcvvLabel: "B",
+    kcvvIsHome: true,
+  },
+  {
+    id: 5,
+    date: "2025-09-14",
+    time: "15:00",
+    opponent: "Herleving Red Star Haasdonk",
+    kcvvLabel: "A",
+    kcvvIsHome: true,
+  },
+  {
+    id: 6,
+    date: "2025-09-20",
+    time: "19:30",
+    opponent: "Ksc Keerbergen",
+    kcvvLabel: "B",
+    kcvvIsHome: false,
+  },
+  {
+    id: 7,
+    date: "2025-09-21",
+    time: "15:00",
+    opponent: "Fc Turkse Rangers Waterschei",
+    kcvvLabel: "A",
+    kcvvIsHome: false,
   },
 ];
 
@@ -116,10 +93,11 @@ const meta = {
     docs: {
       description: {
         component:
-          "Print-friendly upcoming-matches calendar for /scheurkalender. Matches are grouped by date. The green header and back link are hidden on print; a minimal print header with the current date is shown instead.",
+          "Private InDesign-poster data source for /scheurkalender. Full-season A + B league fixtures grouped per weekend; KCVV side bolded with the squad label inline. The screen toolbar (print button) is hidden on print; the white sheet composites cleanly into the poster screenshot.",
       },
     },
   },
+  args: { season: "25/26" },
   tags: ["autodocs"],
 } satisfies Meta<typeof ScheurkalenderPage>;
 
@@ -130,32 +108,24 @@ type Story = StoryObj<typeof meta>;
 // Stories
 // ---------------------------------------------------------------------------
 
-/**
- * Upcoming matches across three match days.
- */
+/** Full-season A + B league table across several weekends. */
 export const Default: Story = {
-  args: { days: mockDays },
+  args: { matches: seasonFixtures },
 };
 
-/**
- * Single match day.
- */
-export const SingleDay: Story = {
-  args: { days: mockDays.slice(0, 1) },
+/** A single weekend (two fixtures). */
+export const SingleWeekend: Story = {
+  args: { matches: seasonFixtures.slice(0, 2) },
 };
 
-/**
- * No matches — empty state.
- */
+/** No published league fixtures — empty state. */
 export const NoMatches: Story = {
-  args: { days: [] },
+  args: { matches: [] },
 };
 
-/**
- * Mobile viewport.
- */
+/** Mobile viewport. */
 export const MobileViewport: Story = {
-  args: { days: mockDays },
+  args: { matches: seasonFixtures },
   globals: { viewport: { value: "kcvvMobile" } },
 };
 

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
@@ -1,150 +1,179 @@
 /**
  * ScheurkalenderPage Component Tests
+ *
+ * Treatment A (#2137): weekend grouping, inline A/B + bold KCVV side,
+ * no-year date, single weekend rule (no boundary doubling), empty state.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import {
   ScheurkalenderPage,
-  type ScheurkalenderDay,
+  type ScheurkalenderMatch,
 } from "./ScheurkalenderPage";
 
-vi.mock("next/image", () => ({
-  default: ({ src, alt }: { src: string; alt: string }) => (
-    <img src={src} alt={alt} />
-  ),
-}));
-
-vi.mock("next/link", () => ({
-  default: ({
-    children,
-    href,
-  }: {
-    children: React.ReactNode;
-    href: string;
-  }) => <a href={href}>{children}</a>,
-}));
-
-const mockDays: ScheurkalenderDay[] = [
+// Real fixtures (subset of the locked mock). Three weekends (ISO weeks):
+//   wk 35: za 30/08 + zo 31/08   wk 36: zo 07/09   wk 37: za 13/09
+const fixtures: ScheurkalenderMatch[] = [
   {
-    key: "2026-03-15",
-    label: "zondag 15 maart 2026",
-    matches: [
-      {
-        id: 1,
-        time: "15:00",
-        squadLabel: "A-Ploeg",
-        homeTeam: { name: "KCVV Elewijt", logo: "/kcvv.png" },
-        awayTeam: { name: "Strombeek" },
-      },
-      {
-        id: 2,
-        time: "11:00",
-        squadLabel: "U15A",
-        homeTeam: { name: "KCVV Elewijt U15" },
-        awayTeam: { name: "FC Kampenhout U15" },
-      },
-    ],
+    id: 1,
+    date: "2025-08-30",
+    time: "20:00",
+    opponent: "Fc Zemst Sportief",
+    kcvvLabel: "B",
+    kcvvIsHome: true,
   },
   {
-    key: "2026-03-22",
-    label: "zondag 22 maart 2026",
-    matches: [
-      {
-        id: 3,
-        homeTeam: { name: "Racing Mechelen" },
-        awayTeam: { name: "KCVV Elewijt" },
-      },
-    ],
+    id: 2,
+    date: "2025-08-31",
+    time: "15:00",
+    opponent: "Sc City Pirates Antwerpen",
+    kcvvLabel: "A",
+    kcvvIsHome: true,
+  },
+  {
+    id: 3,
+    date: "2025-09-07",
+    time: "20:00",
+    opponent: "As Verbroedering Geel",
+    kcvvLabel: "A",
+    kcvvIsHome: false,
+  },
+  {
+    id: 4,
+    date: "2025-09-13",
+    time: "14:30",
+    opponent: "Peutie Fc",
+    kcvvLabel: "B",
+    kcvvIsHome: false,
   },
 ];
 
 describe("ScheurkalenderPage", () => {
-  describe("empty state", () => {
-    it("renders empty state message when no days", () => {
-      render(<ScheurkalenderPage days={[]} />);
-      expect(
-        screen.getByText("Geen aankomende wedstrijden gevonden."),
-      ).toBeInTheDocument();
-    });
-
-    it("does not render day sections when no days", () => {
-      render(<ScheurkalenderPage days={[]} />);
-      expect(
-        screen.queryByText("zondag 15 maart 2026"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("day sections", () => {
-    it("renders a section for each day", () => {
-      render(<ScheurkalenderPage days={mockDays} />);
-      expect(screen.getByText("zondag 15 maart 2026")).toBeInTheDocument();
-      expect(screen.getByText("zondag 22 maart 2026")).toBeInTheDocument();
-    });
-
-    it("renders all matches across all days", () => {
-      render(<ScheurkalenderPage days={mockDays} />);
-      expect(screen.getAllByText("KCVV Elewijt").length).toBeGreaterThanOrEqual(
-        1,
+  describe("masthead", () => {
+    it("renders the season + A & B subtitle", () => {
+      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        "KCVV Elewijt — Competitie 25/26",
       );
-      expect(screen.getByText("Strombeek")).toBeInTheDocument();
-      expect(screen.getByText("FC Kampenhout U15")).toBeInTheDocument();
-      expect(screen.getByText("Racing Mechelen")).toBeInTheDocument();
+      expect(screen.getByText("A & B · Wedstrijdkalender")).toBeInTheDocument();
     });
   });
 
-  describe("match rows", () => {
-    it("renders match time when provided", () => {
-      render(<ScheurkalenderPage days={[mockDays[0]]} />);
-      expect(screen.getByText("15:00")).toBeInTheDocument();
-      expect(screen.getByText("11:00")).toBeInTheDocument();
-    });
-
-    it("renders em-dash when no time provided", () => {
-      render(<ScheurkalenderPage days={[mockDays[1]]} />);
-      expect(screen.getByText("—")).toBeInTheDocument();
-    });
-
-    it("renders squad label badge when squadLabel is provided", () => {
-      render(<ScheurkalenderPage days={[mockDays[0]]} />);
-      expect(screen.getByText("A-Ploeg")).toBeInTheDocument();
-      expect(screen.getByText("U15A")).toBeInTheDocument();
-    });
-
-    it("does not render squad label badge when squadLabel is absent", () => {
-      render(<ScheurkalenderPage days={[mockDays[1]]} />);
-      expect(screen.queryByText("A-Ploeg")).not.toBeInTheDocument();
-    });
-
-    it("renders home team logo when provided", () => {
-      const { container } = render(<ScheurkalenderPage days={[mockDays[0]]} />);
-      // First match has a home logo (alt="" → role="presentation")
-      const images = container.querySelectorAll("img");
-      expect(images.length).toBeGreaterThanOrEqual(1);
-      expect(images[0]).toHaveAttribute("src", "/kcvv.png");
-    });
-
-    it("does not render away team logo when absent", () => {
-      const { container } = render(<ScheurkalenderPage days={[mockDays[0]]} />);
-      // Only the home logo of match 1 is present; away has no logo
-      const images = container.querySelectorAll("img");
-      expect(images).toHaveLength(1);
+  describe("empty state", () => {
+    it("renders the empty message and no table when there are no fixtures", () => {
+      render(<ScheurkalenderPage matches={[]} season="25/26" />);
+      expect(
+        screen.getByText("Geen competitiewedstrijden gevonden."),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("table")).not.toBeInTheDocument();
     });
   });
 
-  describe("chrome elements", () => {
+  describe("weekend grouping", () => {
+    it("buckets fixtures per weekend (ISO week) into separate <tbody>s", () => {
+      const { container } = render(
+        <ScheurkalenderPage matches={fixtures} season="25/26" />,
+      );
+      const tbodies = container.querySelectorAll("tbody");
+      expect(tbodies).toHaveLength(3);
+      expect(tbodies[0].querySelectorAll("tr")).toHaveLength(2); // 30+31 Aug
+      expect(tbodies[1].querySelectorAll("tr")).toHaveLength(1); // 7 Sep
+      expect(tbodies[2].querySelectorAll("tr")).toHaveLength(1); // 13 Sep
+    });
+
+    it("renders a single 2px rule between weekends with no hairline doubling", () => {
+      const { container } = render(
+        <ScheurkalenderPage matches={fixtures} season="25/26" />,
+      );
+      const tbodies = container.querySelectorAll("tbody");
+
+      // First weekend's first row has no top rule (no doubling at the very top).
+      const firstWeekendRows = tbodies[0].querySelectorAll("tr");
+      firstWeekendRows[0]
+        .querySelectorAll("td")
+        .forEach((td) => expect(td.className).not.toContain("border-t-2"));
+
+      // Last row of a weekend drops its bottom hairline (no doubling at the seam).
+      firstWeekendRows[firstWeekendRows.length - 1]
+        .querySelectorAll("td")
+        .forEach((td) => expect(td.className).not.toContain("border-b"));
+
+      // Each subsequent weekend opens with the single 2px ink rule.
+      tbodies[1]
+        .querySelectorAll("tr")[0]
+        .querySelectorAll("td")
+        .forEach((td) => expect(td.className).toContain("border-t-2"));
+    });
+  });
+
+  describe("rows", () => {
+    it("formats dates as Dutch weekday + DD/MM with no year", () => {
+      const { container } = render(
+        <ScheurkalenderPage matches={fixtures} season="25/26" />,
+      );
+      expect(screen.getByText("za 30/08")).toBeInTheDocument();
+      expect(screen.getByText("zo 31/08")).toBeInTheDocument();
+      expect(screen.getByText("zo 07/09")).toBeInTheDocument();
+      expect(screen.getByText("za 13/09")).toBeInTheDocument();
+      // No 4-digit year anywhere in the fixture table.
+      const table = container.querySelector("table");
+      expect(table?.textContent).not.toMatch(/20\d{2}/);
+    });
+
+    it("renders kickoff times", () => {
+      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
+      expect(screen.getAllByText("20:00")).toHaveLength(2); // ids 1 & 3
+      expect(screen.getByText("14:30")).toBeInTheDocument();
+    });
+
+    it("renders the KCVV squad inline (A/B) from the queried team", () => {
+      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
+      expect(screen.getAllByText("KCVV Elewijt A")).toHaveLength(2);
+      expect(screen.getAllByText("KCVV Elewijt B")).toHaveLength(2);
+    });
+
+    it("bolds the KCVV side and leaves the opponent unbolded", () => {
+      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
+      screen
+        .getAllByText(/^KCVV Elewijt [AB]$/)
+        .forEach((cell) => expect(cell.className).toContain("font-extrabold"));
+      expect(screen.getByText("Fc Zemst Sportief").className).not.toContain(
+        "font-extrabold",
+      );
+      expect(screen.getByText("As Verbroedering Geel").className).not.toContain(
+        "font-extrabold",
+      );
+    });
+
+    it("places KCVV in the home column when home, away column when away", () => {
+      const { container } = render(
+        <ScheurkalenderPage matches={fixtures} season="25/26" />,
+      );
+      const rows = container.querySelectorAll("tbody tr");
+      // Match 1: KCVV B home → home cell (3rd <td>) is the KCVV cell.
+      expect(rows[0].querySelectorAll("td")[2]).toHaveTextContent(
+        "KCVV Elewijt B",
+      );
+      // Match 3 (weekend 2, first row): KCVV A away → away cell (4th <td>).
+      expect(rows[2].querySelectorAll("td")[3]).toHaveTextContent(
+        "KCVV Elewijt A",
+      );
+    });
+
+    it("renders no logos, squad pills, or scores", () => {
+      const { container } = render(
+        <ScheurkalenderPage matches={fixtures} season="25/26" />,
+      );
+      expect(container.querySelectorAll("img")).toHaveLength(0);
+    });
+  });
+
+  describe("chrome", () => {
     it("renders the print button", () => {
-      render(<ScheurkalenderPage days={mockDays} />);
+      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
       expect(
         screen.getByRole("button", { name: "Afdrukken" }),
       ).toBeInTheDocument();
-    });
-
-    it("renders the back link to /kalender", () => {
-      render(<ScheurkalenderPage days={mockDays} />);
-      expect(
-        screen.getByRole("link", { name: /terug naar kalender/i }),
-      ).toHaveAttribute("href", "/kalender");
     });
   });
 });

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -1,156 +1,164 @@
 /**
  * ScheurkalenderPage Component
  *
- * Presentational layout for /scheurkalender.
- * Renders a print-friendly upcoming-matches calendar grouped by date.
+ * Private InDesign-poster data source (#2137) — Treatment A, locked in
+ * `docs/design/mockups/phase-10-scheurkalender/sk1-poster-table-compare.html`.
+ *
+ * Renders the full-season A + B *league* fixture table the club screenshots
+ * into the A2 season poster: a print-clean white sheet, Montserrat, columns
+ * date·time·home·away with the KCVV side bolded and the squad label inline,
+ * fixtures grouped per weekend (ISO week) with a single 2px rule between groups.
+ * No logos, no squad pills, no scores.
  */
 
-import Image from "next/image";
-import Link from "next/link";
+import { DateTime } from "luxon";
 import { PrintButton } from "./PrintButton";
 import { PrintDate } from "./PrintDate";
 
+// KCVV is in Belgium — pin date/week derivation to Europe/Brussels so the
+// weekday, DD/MM, and ISO-week bucket are stable across server/DST.
+const TZ = "Europe/Brussels";
+
 export interface ScheurkalenderMatch {
   id: number;
-  /** Match time as HH:MM string */
+  /** ISO calendar date (`YYYY-MM-DD`); kickoff time lives in `time`. */
+  date: string;
+  /** Kickoff time as `HH:MM`. */
   time?: string;
-  /** Squad label — identifies which KCVV team plays (e.g. "A-Ploeg", "U21") */
-  squadLabel?: string;
-  homeTeam: { name: string; logo?: string };
-  awayTeam: { name: string; logo?: string };
+  /** Opponent club name, exactly as PSD returns it. */
+  opponent: string;
+  /** Which KCVV squad plays — rendered inline ("KCVV Elewijt A" / "… B"). */
+  kcvvLabel: "A" | "B";
+  /** True when KCVV plays at home (KCVV occupies the home column). */
+  kcvvIsHome: boolean;
 }
 
-export interface ScheurkalenderDay {
-  /** Label shown as section heading (full Dutch date string) */
-  label: string;
-  /** ISO date string used as stable key (YYYY-MM-DD) */
+export interface ScheurkalenderPageProps {
+  /** Full-season A + B league fixtures, pre-sorted by date then time. */
+  matches: ScheurkalenderMatch[];
+  /** Season label for the masthead, e.g. "25/26". */
+  season: string;
+}
+
+interface Weekend {
   key: string;
   matches: ScheurkalenderMatch[];
 }
 
-export interface ScheurkalenderPageProps {
-  days: ScheurkalenderDay[];
+/** Bucket fixtures per weekend (ISO week — Mon–Sun share a `<tbody>`). */
+function groupByWeekend(matches: ScheurkalenderMatch[]): Weekend[] {
+  const order: string[] = [];
+  const buckets = new Map<string, ScheurkalenderMatch[]>();
+  for (const match of matches) {
+    const dt = DateTime.fromISO(match.date, { zone: TZ });
+    const key = `${dt.weekYear}-W${String(dt.weekNumber).padStart(2, "0")}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+      order.push(key);
+    }
+    bucket.push(match);
+  }
+  return order.map((key) => ({ key, matches: buckets.get(key)! }));
 }
 
-export function ScheurkalenderPage({ days }: ScheurkalenderPageProps) {
-  const hasMatches = days.length > 0;
+/** "za 30/08" — lowercase Dutch weekday abbrev + DD/MM, no year. */
+function formatShortDate(isoDate: string): string {
+  const dt = DateTime.fromISO(isoDate, { zone: TZ }).setLocale("nl");
+  return dt.isValid ? dt.toFormat("ccc dd/MM") : isoDate;
+}
+
+export function ScheurkalenderPage({
+  matches,
+  season,
+}: ScheurkalenderPageProps) {
+  const hasMatches = matches.length > 0;
+  const weekends = groupByWeekend(matches);
 
   return (
-    <div className="min-h-screen bg-white">
-      {/* Screen header (hidden on print) */}
-      <div className="from-green-main via-green-hover to-green-dark-hover bg-linear-to-br px-4 py-10 text-white print:hidden">
-        <div className="mx-auto flex max-w-3xl items-start justify-between gap-4">
-          <div>
-            <h1 className="font-body mb-2 text-3xl font-bold md:text-5xl">
-              Scheurkalender
-            </h1>
-            <p className="text-white/90">
-              Printbare versie van de wedstrijdkalender
-            </p>
-          </div>
-          <PrintButton />
-        </div>
+    <div className="bg-cream min-h-screen print:bg-white">
+      {/* Screen-only toolbar — hidden on print and cropped out of poster screenshots. */}
+      <div className="mx-auto flex max-w-3xl justify-end px-4 pt-6 print:hidden">
+        <PrintButton />
       </div>
 
-      <div className="mx-auto max-w-3xl px-4 py-8 print:px-0 print:py-4">
-        {/* Print header (visible only on print) */}
-        <div className="mb-6 hidden border-b-2 border-black pb-4 text-center print:block">
-          <h1 className="text-2xl font-bold">
-            KCVV Elewijt — Wedstrijdkalender
-          </h1>
-          <p className="text-sm text-gray-500">
-            Afgedrukt op <PrintDate />
-          </p>
-        </div>
-
-        {!hasMatches ? (
-          <div className="py-16 text-center">
-            <p className="text-gray-500">
-              Geen aankomende wedstrijden gevonden.
+      <div className="mx-auto max-w-3xl px-4 pt-4 pb-12 print:p-0">
+        {/* The "sheet" — this is what gets screenshotted into the InDesign poster. */}
+        <div className="border-ink border-2 bg-white print:border-0">
+          {/* Masthead */}
+          <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
+            <h1 className="font-body text-ink text-lg font-extrabold tracking-[0.02em] uppercase">
+              KCVV Elewijt — Competitie {season}
+            </h1>
+            <p className="text-ink-muted font-mono text-[10px] tracking-[0.08em] uppercase">
+              A &amp; B · Wedstrijdkalender
             </p>
           </div>
-        ) : (
-          <div className="space-y-6 print:space-y-4">
-            {days.map(({ key, label, matches }) => (
-              <div key={key} className="print:break-inside-avoid">
-                {/* Date header */}
-                <div className="bg-green-main mb-2 rounded-lg px-4 py-2 text-white print:rounded-none print:bg-gray-800">
-                  <span className="font-bold capitalize">{label}</span>
-                </div>
 
-                {/* Matches for this day */}
-                <div className="space-y-2 print:space-y-1">
-                  {matches.map((match) => (
-                    <div
-                      key={match.id}
-                      className="flex items-center gap-3 rounded-lg bg-gray-50 px-4 py-3 print:rounded-none print:border-b print:border-gray-200 print:bg-white"
-                    >
-                      {/* Time */}
-                      <div className="w-12 shrink-0 font-mono text-sm text-gray-500">
-                        {match.time ?? "—"}
-                      </div>
-
-                      {/* Squad label */}
-                      {match.squadLabel && (
-                        <div className="w-20 shrink-0">
-                          <span className="text-green-main bg-green-main/10 rounded px-2 py-0.5 text-xs font-semibold print:bg-transparent print:text-black">
-                            {match.squadLabel}
-                          </span>
-                        </div>
-                      )}
-
-                      {/* Home team */}
-                      <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                        {match.homeTeam.logo && (
-                          <Image
-                            src={match.homeTeam.logo}
-                            alt=""
-                            aria-hidden="true"
-                            width={20}
-                            height={20}
-                            className="shrink-0 object-contain print:hidden"
-                          />
-                        )}
-                        <span className="truncate text-sm font-medium">
-                          {match.homeTeam.name}
-                        </span>
-                      </div>
-
-                      <span className="shrink-0 text-xs text-gray-400">vs</span>
-
-                      {/* Away team */}
-                      <div className="flex min-w-0 flex-1 items-center justify-end gap-1.5">
-                        <span className="truncate text-right text-sm font-medium">
-                          {match.awayTeam.name}
-                        </span>
-                        {match.awayTeam.logo && (
-                          <Image
-                            src={match.awayTeam.logo}
-                            alt=""
-                            aria-hidden="true"
-                            width={20}
-                            height={20}
-                            className="shrink-0 object-contain print:hidden"
-                          />
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Back link (screen only) */}
-        <div className="mt-8 print:hidden">
-          <Link
-            href="/kalender"
-            className="hover:text-green-main text-sm text-gray-500 transition-colors"
-          >
-            ← Terug naar kalender
-          </Link>
+          {hasMatches ? (
+            <table className="w-full border-collapse text-[13px]">
+              {weekends.map((weekend, weekendIndex) => (
+                <tbody key={weekend.key}>
+                  {weekend.matches.map((match, rowIndex) => {
+                    const isLastRow = rowIndex === weekend.matches.length - 1;
+                    // Hairline between rows within a weekend; none on the last
+                    // row; a single 2px ink rule opens each subsequent weekend.
+                    const isWeekendBoundary =
+                      weekendIndex > 0 && rowIndex === 0;
+                    const cell = [
+                      "px-2.5 py-1.5 align-baseline",
+                      isLastRow ? "" : "border-b border-b-ink/15",
+                      isWeekendBoundary ? "border-t-ink border-t-2" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ");
+                    const kcvvName = `KCVV Elewijt ${match.kcvvLabel}`;
+                    const homeName = match.kcvvIsHome
+                      ? kcvvName
+                      : match.opponent;
+                    const awayName = match.kcvvIsHome
+                      ? match.opponent
+                      : kcvvName;
+                    return (
+                      <tr key={match.id}>
+                        <td
+                          className={`${cell} font-body text-ink-soft w-[88px] whitespace-nowrap`}
+                        >
+                          {formatShortDate(match.date)}
+                        </td>
+                        <td
+                          className={`${cell} text-ink-muted w-[56px] text-right font-mono whitespace-nowrap`}
+                        >
+                          {match.time ?? ""}
+                        </td>
+                        <td
+                          className={`${cell} text-ink ${match.kcvvIsHome ? "font-extrabold" : ""}`}
+                        >
+                          {homeName}
+                        </td>
+                        <td
+                          className={`${cell} text-ink ${match.kcvvIsHome ? "" : "font-extrabold"}`}
+                        >
+                          {awayName}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              ))}
+            </table>
+          ) : (
+            <p className="text-ink-muted px-4 py-16 text-center font-mono text-sm">
+              Geen competitiewedstrijden gevonden.
+            </p>
+          )}
         </div>
+
+        {/* Print-only footer — kiosk prints get a date; the screen sheet stays clean. */}
+        <p className="text-ink-muted mt-4 hidden text-center font-mono text-[10px] uppercase print:block">
+          KCVV Elewijt · Competitie {season} · afgedrukt op <PrintDate />
+        </p>
       </div>
     </div>
   );

--- a/docs/design/mockups/phase-10-scheurkalender/sk1-poster-table-compare.html
+++ b/docs/design/mockups/phase-10-scheurkalender/sk1-poster-table-compare.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Scheurkalender · sk1 — poster-source table compare</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,900&family=Montserrat:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --cream: #f5f1e6; --cream-soft: #ede8da; --cream-deep: #e1d7bf;
+        --ink: #0a0a0a; --ink-soft: #1f1f1f; --ink-muted: #6b6b6b;
+        --jersey-deep: #008755; --jersey-deep-dark: #133d28; --warm: #f0c264; --paper-edge: #d9d2bd;
+        --font-display: "Fraunces", georgia, serif;
+        --font-body: "Montserrat", system-ui, sans-serif;
+        --font-mono: "IBM Plex Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: var(--cream); color: var(--ink); font-family: var(--font-body); }
+      .harness-head { background: var(--ink); color: var(--cream); padding: 22px 28px; font-family: var(--font-mono); }
+      .harness-head h1 { margin: 0 0 6px; font-size: 15px; letter-spacing: 0.04em; text-transform: uppercase; }
+      .harness-head p { margin: 0 0 6px; font-size: 13px; color: #b9b9b9; line-height: 1.6; max-width: 100ch; }
+      .harness-head b { color: var(--warm); }
+      .dir { position: sticky; top: 0; z-index: 50; background: var(--jersey-deep); color: var(--cream); padding: 11px 28px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.05em; text-transform: uppercase; display: flex; gap: 14px; align-items: baseline; border-bottom: 2px solid var(--ink); flex-wrap: wrap; }
+      .dir .tag { background: var(--warm); color: var(--ink); padding: 2px 10px; font-weight: 700; border: 1.5px solid var(--ink); }
+      .dir .note { color: #cfeede; text-transform: none; letter-spacing: 0; font-size: 12px; }
+      .stage { padding: 30px 28px 44px; display: flex; gap: 40px; flex-wrap: wrap; justify-content: center; align-items: flex-start; }
+      .col { width: 460px; max-width: 100%; }
+      .col > .cap { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-muted); margin: 0 0 10px; text-align: center; }
+      .sheet { border: 2px solid var(--ink); box-shadow: 6px 7px 0 0 var(--ink); }
+
+      /* ===== shared table base ===== */
+      table.fix { width: 100%; border-collapse: collapse; }
+      table.fix td { padding: 6px 10px; vertical-align: baseline; }
+      .kcvv { font-weight: 800; }
+      .col-date { white-space: nowrap; }
+      .col-time { white-space: nowrap; text-align: right; }
+      .wk-sep td { padding: 0; }
+      .wk-rule { height: 0; border-top: 2px solid var(--ink); }
+
+      /* ===== Treatment A — print-clean (drop straight into InDesign) ===== */
+      .A .sheet { background: #ffffff; }
+      .A .masthead { padding: 14px 16px; border-bottom: 2px solid var(--ink); display: flex; align-items: baseline; justify-content: space-between; }
+      .A .masthead .ttl { font-family: var(--font-body); font-weight: 800; font-size: 18px; letter-spacing: 0.02em; text-transform: uppercase; }
+      .A .masthead .sub { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.08em; }
+      .A table.fix { font-size: 13px; }
+      .A table.fix td { border-bottom: 1px solid #d8d8d8; }
+      /* one clean 2px rule between weekends — no hairline doubling */
+      .A tbody.wk tr:last-child td { border-bottom: none; }
+      .A tbody.wk:not(:first-child) tr:first-child td { border-top: 2px solid var(--ink); }
+      .A .col-date { font-family: var(--font-body); color: var(--ink-soft); width: 88px; }
+      .A .col-time { font-family: var(--font-mono); color: var(--ink-muted); width: 56px; }
+
+      /* ===== Treatment B — poster-matched (brand type, still clean) ===== */
+      .B .sheet { background: var(--cream); }
+      .B .masthead { padding: 16px 18px 12px; border-bottom: 2px solid var(--ink); }
+      .B .masthead .kick { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--jersey-deep); }
+      .B .masthead .ttl { font-family: var(--font-display); font-weight: 900; font-size: 30px; line-height: 0.9; margin-top: 2px; }
+      .B .masthead .ttl .dot { color: var(--warm); }
+      .B .masthead .sub { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 6px; }
+      .B .wk-head td { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--jersey-deep); padding: 12px 10px 3px; }
+      .B table.fix { font-size: 13px; }
+      .B table.fix tbody tr.match td { border-bottom: 1px dotted var(--paper-edge); }
+      .B .col-date { font-family: var(--font-mono); font-size: 11px; color: var(--ink-soft); width: 104px; letter-spacing: 0.02em; }
+      .B .col-time { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); width: 50px; }
+      .B tr.match.is-kcvv-row td { background: color-mix(in srgb, var(--jersey-deep) 6%, transparent); }
+
+      .legend { background: var(--cream-deep); border-top: 2px solid var(--ink); padding: 24px 28px 46px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.7; }
+      .legend h3 { margin: 0 0 8px; font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; }
+      .legend b { color: var(--jersey-deep); } .legend ul { margin: 6px 0 14px; padding-left: 18px; }
+      .legend .q { background: var(--ink); color: var(--cream); padding: 16px 20px; margin-top: 10px; line-height: 1.65; } .legend .q b { color: var(--warm); }
+      .micro { font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.05em; text-transform: uppercase; margin-top: 14px; }
+    </style>
+  </head>
+  <body>
+    <div class="harness-head">
+      <h1>Scheurkalender · sk1 — poster-source table</h1>
+      <p>
+        Re-scoped per the brief: a <b>private, never-linked</b> page whose job is to be the clean <b>full-season A + B league</b>
+        fixture table you screenshot into the A2 InDesign poster. Columns: <b>date · time · home · away</b>, KCVV bolded with the
+        <b>A/B inline</b> in the name, grouped per weekend. No logos, no pills, no scores. Real fixtures below (subset of your screenshot).
+      </p>
+      <p>Two table treatments to pick from — the only real design choice here.</p>
+    </div>
+
+    <div class="dir">
+      <span class="tag">A</span> Print-clean
+      <span class="note">white bg · Montserrat · thin rules · heavier rule between weekends — composites cleanest onto the textured poster bg</span>
+      &nbsp;&nbsp;<span class="tag">B</span> Poster-matched
+      <span class="note">cream · brand type (mono date/time, Freight title) · per-weekend label · faint tint on the KCVV row</span>
+    </div>
+
+    <div class="stage">
+      <!-- ============ Treatment A ============ -->
+      <div class="col A">
+        <p class="cap">A · print-clean</p>
+        <div class="sheet">
+          <div class="masthead">
+            <span class="ttl">KCVV Elewijt — Competitie 25/26</span>
+            <span class="sub">A &amp; B · Wedstrijdkalender</span>
+          </div>
+          <table class="fix">
+            <tbody class="wk">
+              <tr class="match"><td class="col-date">za 30/08</td><td class="col-time">20:00</td><td class="kcvv">KCVV Elewijt B</td><td>Fc Zemst Sportief</td></tr>
+              <tr class="match"><td class="col-date">zo 31/08</td><td class="col-time">15:00</td><td class="kcvv">KCVV Elewijt A</td><td>Sc City Pirates Antwerpen</td></tr>
+            </tbody>
+            <tbody class="wk">
+              <tr class="match"><td class="col-date">zo 07/09</td><td class="col-time">20:00</td><td>As Verbroedering Geel</td><td class="kcvv">KCVV Elewijt A</td></tr>
+            </tbody>
+            <tbody class="wk">
+              <tr class="match"><td class="col-date">za 13/09</td><td class="col-time">14:30</td><td class="kcvv">KCVV Elewijt B</td><td>Peutie Fc</td></tr>
+              <tr class="match"><td class="col-date">zo 14/09</td><td class="col-time">15:00</td><td class="kcvv">KCVV Elewijt A</td><td>Herleving Red Star Haasdonk</td></tr>
+            </tbody>
+            <tbody class="wk">
+              <tr class="match"><td class="col-date">za 20/09</td><td class="col-time">19:30</td><td>Ksc Keerbergen</td><td class="kcvv">KCVV Elewijt B</td></tr>
+              <tr class="match"><td class="col-date">zo 21/09</td><td class="col-time">15:00</td><td>Fc Turkse Rangers Waterschei</td><td class="kcvv">KCVV Elewijt A</td></tr>
+            </tbody>
+            <tbody class="wk">
+              <tr class="match"><td class="col-date">za 27/09</td><td class="col-time">19:30</td><td>Ews Schoonbeek-beverst</td><td class="kcvv">KCVV Elewijt A</td></tr>
+              <tr class="match"><td class="col-date">zo 28/09</td><td class="col-time">15:00</td><td>K Sp Amicii Tange</td><td class="kcvv">KCVV Elewijt B</td></tr>
+            </tbody>
+            <tbody class="wk">
+              <tr class="match"><td class="col-date">za 04/10</td><td class="col-time">20:00</td><td class="kcvv">KCVV Elewijt B</td><td>Ac Bormstraat Kapelle</td></tr>
+              <tr class="match"><td class="col-date">zo 05/10</td><td class="col-time">15:00</td><td class="kcvv">KCVV Elewijt A</td><td>Kfc De Kempen Tielen-lichtaart</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ============ Treatment B ============ -->
+      <div class="col B">
+        <p class="cap">B · poster-matched</p>
+        <div class="sheet">
+          <div class="masthead">
+            <span class="kick">Competitie · seizoen 25/26 · A &amp; B</span>
+            <div class="ttl">Wedstrijd&shy;kalender<span class="dot">.</span></div>
+            <div class="sub">KCVV Elewijt</div>
+          </div>
+          <table class="fix">
+            <tbody>
+              <tr class="wk-head"><td colspan="4">Weekend 30–31 aug</td></tr>
+              <tr class="match is-kcvv-row"><td class="col-date">za 30/08</td><td class="col-time">20:00</td><td class="kcvv">KCVV Elewijt B</td><td>Fc Zemst Sportief</td></tr>
+              <tr class="match is-kcvv-row"><td class="col-date">zo 31/08</td><td class="col-time">15:00</td><td class="kcvv">KCVV Elewijt A</td><td>Sc City Pirates Antwerpen</td></tr>
+              <tr class="wk-head"><td colspan="4">Weekend 7 sep</td></tr>
+              <tr class="match"><td class="col-date">zo 07/09</td><td class="col-time">20:00</td><td>As Verbroedering Geel</td><td class="kcvv">KCVV Elewijt A</td></tr>
+              <tr class="wk-head"><td colspan="4">Weekend 13–14 sep</td></tr>
+              <tr class="match is-kcvv-row"><td class="col-date">za 13/09</td><td class="col-time">14:30</td><td class="kcvv">KCVV Elewijt B</td><td>Peutie Fc</td></tr>
+              <tr class="match is-kcvv-row"><td class="col-date">zo 14/09</td><td class="col-time">15:00</td><td class="kcvv">KCVV Elewijt A</td><td>Herleving Red Star Haasdonk</td></tr>
+              <tr class="wk-head"><td colspan="4">Weekend 20–21 sep</td></tr>
+              <tr class="match"><td class="col-date">za 20/09</td><td class="col-time">19:30</td><td>Ksc Keerbergen</td><td class="kcvv">KCVV Elewijt B</td></tr>
+              <tr class="match"><td class="col-date">zo 21/09</td><td class="col-time">15:00</td><td>Fc Turkse Rangers Waterschei</td><td class="kcvv">KCVV Elewijt A</td></tr>
+              <tr class="wk-head"><td colspan="4">Weekend 27–28 sep</td></tr>
+              <tr class="match"><td class="col-date">za 27/09</td><td class="col-time">19:30</td><td>Ews Schoonbeek-beverst</td><td class="kcvv">KCVV Elewijt A</td></tr>
+              <tr class="match"><td class="col-date">zo 28/09</td><td class="col-time">15:00</td><td>K Sp Amicii Tange</td><td class="kcvv">KCVV Elewijt B</td></tr>
+              <tr class="wk-head"><td colspan="4">Weekend 4–5 okt</td></tr>
+              <tr class="match is-kcvv-row"><td class="col-date">za 04/10</td><td class="col-time">20:00</td><td class="kcvv">KCVV Elewijt B</td><td>Ac Bormstraat Kapelle</td></tr>
+              <tr class="match is-kcvv-row"><td class="col-date">zo 05/10</td><td class="col-time">15:00</td><td class="kcvv">KCVV Elewijt A</td><td>Kfc De Kempen Tielen-lichtaart</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="legend">
+      <h3>What's fixed either way</h3>
+      <ul>
+        <li><b>Data:</b> full-season <b>A + B league</b> fixtures (played + upcoming), via <code>bff.getMatches(aTeamId)</code> + <code>getMatches(bTeamId)</code>, filtered to league only (<code>competitionType === "league"</code> — the <code>competition</code> field is a division name like "3de Nationale", not "Competitie"), A/B labelled by which team was queried, merged + sorted by date.</li>
+        <li><b>Columns:</b> date (za/zo DD/MM[/YY]) · time · home · away. KCVV bolded with the A/B inline in the name. No logos, no pills, no scores.</li>
+        <li><b>Private:</b> <code>robots: noindex</code>, no nav/footer/sitemap link — reachable only by typing the URL.</li>
+      </ul>
+      <h3>The difference</h3>
+      <ul>
+        <li><b>A print-clean</b> — white, Montserrat, hairline rules, a heavier rule splitting each weekend. Pastes onto the textured poster bg with zero brand colour fighting it. Closest to what you screenshot today.</li>
+        <li><b>B poster-matched</b> — cream, a per-weekend mono label, Freight masthead, faint jersey-deep tint on the rows where KCVV is home. More "on-brand" on screen, but the tint/labels are extra marks you'd be cropping around in InDesign.</li>
+      </ul>
+      <div class="q">
+        <b>LOCKED — Treatment A.</b> Single 2px rule between weekends (no hairline doubling at the boundary), <b>year dropped</b> from the rows (season lives in the masthead). B kept below only as decision history. Re-spec'ing #2137 now: the data rebuild (full-season A+B league via <code>getMatches</code>) + this table + the private/<code>noindex</code>/never-linked route.
+      </div>
+      <p class="micro">scheurkalender · sk1 · poster-source table · Fraunces stands in for Freight · real fixtures (subset)</p>
+    </div>
+  </body>
+</html>

--- a/packages/api-contract/src/schemas/match.ts
+++ b/packages/api-contract/src/schemas/match.ts
@@ -47,6 +47,18 @@ export const MATCH_STATUS_VALUES = [
 export const MatchStatus = S.Literal(...MATCH_STATUS_VALUES);
 export type MatchStatus = S.Schema.Type<typeof MatchStatus>;
 
+/**
+ * Normalized league/cup/friendly classification for a match.
+ *
+ * Surfaced so consumers can gate behaviour on the *structured* competition type
+ * instead of string-matching the Dutch `competition` label (which is a division
+ * name like "3de Nationale", not "Competitie"). Derived by the BFF from PSD's
+ * `competitionType.type` (`OFFICIAL`/`LEAGUE` → `"league"`, `CUP` → `"cup"`,
+ * `FRIENDLY` → `"friendly"`, anything else → `"other"`).
+ */
+export const CompetitionType = S.Literal("league", "cup", "friendly", "other");
+export type CompetitionType = S.Schema.Type<typeof CompetitionType>;
+
 /** Shared fields between Match and MatchDetail */
 const BaseMatchFields = {
   id: S.Number,
@@ -58,6 +70,8 @@ const BaseMatchFields = {
   status: MatchStatus,
   squadLabel: S.optional(S.String),
   competition: S.optional(S.String),
+  /** League/cup/friendly classification. Absent when the BFF can't resolve it. */
+  competitionType: S.optional(CompetitionType),
   /** PSD team ID identifying which KCVV team plays (A-team, B-team, U21, etc.) */
   kcvv_team_id: S.optional(S.Number),
   /** Human-readable label for the KCVV team (e.g. "A-Ploeg", "U21") */
@@ -130,26 +144,10 @@ export class MatchEvent extends S.Class<MatchEvent>("MatchEvent")({
   isOwnGoal: S.optional(S.Boolean),
 }) {}
 
-/**
- * Normalized league/cup/friendly classification for a match.
- *
- * Surfaced so consumers can gate behaviour on the *structured* competition type
- * instead of string-matching the Dutch `competition` label. Derived by the BFF
- * from PSD's `competitionType.type` (`OFFICIAL`/`LEAGUE` → `"league"`,
- * `CUP` → `"cup"`, `FRIENDLY` → `"friendly"`, anything else → `"other"`).
- *
- * Lives on `MatchDetail` only (not `BaseMatchFields`) — per "only declare the
- * fields you use", the match list / share autocomplete don't need it.
- */
-export const CompetitionType = S.Literal("league", "cup", "friendly", "other");
-export type CompetitionType = S.Schema.Type<typeof CompetitionType>;
-
 /** Normalized match detail (extended Match with lineup and events) */
 export class MatchDetail extends S.Class<MatchDetail>("MatchDetail")({
   ...BaseMatchFields,
   lineup: S.optional(MatchLineup),
   events: S.optional(S.Array(MatchEvent)),
   hasReport: S.Boolean,
-  /** League/cup/friendly classification. Absent when the BFF can't resolve it. */
-  competitionType: S.optional(CompetitionType),
 }) {}


### PR DESCRIPTION
Closes #2137

Rebuilds `/scheurkalender` from the broken `getNextMatches()` implementation (empty between fixtures, all teams grouped per day, undefined `green-*` tokens) into the locked **Treatment A** poster-source table — the private data source the club screenshots into the A2 InDesign season poster. Design ref: `docs/design/mockups/phase-10-scheurkalender/sk1-poster-table-compare.html` (committed here).

## Changes

**`apps/web` — the page**
- **Data:** resolve A + B senior squads from `TeamRepository.findAll()` (`age === "A"`; name ending `" B"` → B-team). Fetch each team's full season via `bff.getMatches(psdId)`, label A/B per queried team (getMatches doesn't set `kcvv_team_label`), merge + dedupe by match id + sort by date then time.
- **League gate:** filter on the structured `competitionType === "league"` (see the BFF note below).
- **Table (Treatment A):** weekend-grouped (`ISO week`) `<tbody>`s; columns date·time·home·away; date = Dutch weekday abbrev + `DD/MM` **no year** (`za 30/08`); KCVV side **bold** with the squad label inline (`KCVV Elewijt A`/`B`); opponent name as PSD returns it; **no logos/pills/scores**; single 2px rule between weekends with no hairline doubling; masthead `KCVV Elewijt — Competitie {season}` + `A & B · Wedstrijdkalender`; clean print view preserved.
- **Private:** `robots: { index: false, follow: false }`; ISR `revalidate = 21600` (6h); no `generateStaticParams`. Verified absent from nav/footer/sitemap.
- Dropped all undefined legacy green tokens (incl. `PrintButton`); reskinned the loading skeleton to the new sheet.

**`packages/api-contract` + `apps/api` — league-gate enablement (1st commit)**
- Promoted the normalized `competitionType` (`"league"|"cup"|"friendly"|"other"`) from `MatchDetail` into `BaseMatchFields`, and populate it in `transformPsdGame` via the existing `resolveCompetitionType` helper. Additive + optional — existing `Match`/`MatchDetail` consumers are unaffected.

## ⚠️ Deviation from the issue spec (with evidence)

The issue specified filtering league fixtures via `match.competition === "Competitie"`. **This is factually wrong and would render an empty table in production.** The BFF's `mapCompetitionLabel` returns `name.trim()` first when present (`apps/api/src/psd/transforms.ts:28`), and for league play PSD populates the division name — so `competition` is `"3de Nationale"`/`"Tweede Provinciale B"`, **never** the literal `"Competitie"` (confirmed by `apps/api/src/psd/service.test.ts:176` asserting `"3de Nationale"` for a `type: "LEAGUE"` game). String-matching the Dutch label is also explicitly banned in this codebase.

The correct, non-brittle gate is the structured `competitionType === "league"` — the same gate the match-detail page already uses (`wedstrijd/[matchId]/page.tsx:237`). That field only existed on `MatchDetail`, so it's promoted to the shared base and populated on the list path. The design-mock data-spec note was corrected to match.

**Deploy ordering:** the web filter depends on the BFF emitting `competitionType` on the matches list. Both deploy from `main` on merge; the field is additive and the filter degrades to an empty (non-crashing) table until the BFF is live, so there is no hard ordering requirement.

## Pre-PR review gate (`/code-review` + `/simplify`)

Ran both adversarial passes on the branch diff. Findings applied:
- **[blocker] `competition === "Competitie"` → empty table** — fixed via the `competitionType` league gate above.
- **[latent bug] late-kickoff date shift** — `parseDateString` bakes the local wall-clock into the Date's UTC fields, so re-zoning a ≥22:00 kickoff to Brussels rolled it to the next day (and possibly next weekend). Now read the calendar day off **UTC**.
- **[robustness] `is_home` fallback** — switched the rare-null fallback from a name substring check to the exact `home_team.id === KCVV_CLUB_ID` (1235).
- **[cosmetic] weekend-boundary hairline** — `border-t-ink` instead of `border-ink` so the boundary row's bottom hairline stays at `ink/15`.

Considered and intentionally skipped: reusing `dates.ts`/`kalender/utils.ts` helpers (different format/grouping — local helpers justified); the `showInNavigation` coupling (the issue explicitly scopes to "visible teams").

## Testing

- `pnpm --filter @kcvv/web check-all` ✅ (lint + type-check + **3212** tests + build; `/scheurkalender` prerenders as static with 6h ISR).
- `pnpm --filter @kcvv/api type-check` + full api suite (**353** tests) ✅; api-contract rebuilt + type-checked.
- New component tests cover weekend grouping, inline A/B + bold KCVV side, no-year date, single-weekend-rule (no boundary doubling), KCVV home/away column placement, empty state, no logos. New BFF test asserts `competitionType` surfaces on the list path (league + cup).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added normalized competition classification to match data (e.g., league vs cup), improving how the fixture UI labels competition types.

* **Refactor**
  * Repurposed the fixture calendar into a full-season A+B league poster-style table (with updated sorting, filtering, and weekend grouping).
  * Updated the loading skeleton and print-related table presentation to match the new layout.

* **Tests**
  * Added coverage for competition type normalization and refreshed fixture-table component tests for the new “matches” table model.

* **Documentation**
  * Added a design mockup comparing poster table treatments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->