### PR TITLE
refactor(analytics): extract shared useDelegatedClick for the analytics-shell wrappers (#2114)

### DIFF
--- a/apps/web/src/app/(main)/club/ultras/UltrasAnalytics.tsx
+++ b/apps/web/src/app/(main)/club/ultras/UltrasAnalytics.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, type ReactNode } from "react";
 import { useUltrasAnalytics } from "@/hooks/useUltrasAnalytics";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
 
 export interface UltrasAnalyticsProps {
   children: ReactNode;
@@ -22,20 +23,10 @@ export function UltrasAnalytics({ children }: UltrasAnalyticsProps) {
     trackUltrasView();
   }, [trackUltrasView]);
 
-  useEffect(() => {
-    const node = ref.current;
-    if (!node) return;
-
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      if (target?.closest("[data-ultras-join]")) {
-        trackUltrasJoinClick();
-      }
-    };
-
-    node.addEventListener("click", handleClick);
-    return () => node.removeEventListener("click", handleClick);
-  }, [trackUltrasJoinClick]);
+  useDelegatedClick(ref, {
+    selector: "[data-ultras-join]",
+    onMatch: () => trackUltrasJoinClick(),
+  });
 
   return <div ref={ref}>{children}</div>;
 }

--- a/apps/web/src/components/analytics/ErrorAnalytics.tsx
+++ b/apps/web/src/components/analytics/ErrorAnalytics.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, type ReactNode } from "react";
 import { trackEvent } from "@/lib/analytics/track-event";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
 
 export interface ErrorAnalyticsProps {
   /** HTTP error code as a string, e.g. `"404"` | `"500"`. */
@@ -24,6 +25,9 @@ export interface ErrorAnalyticsProps {
  */
 export function ErrorAnalytics({ code, children }: ErrorAnalyticsProps) {
   const ref = useRef<HTMLDivElement>(null);
+  // `path` is read once at mount (the URL the visitor hit) and shared with the
+  // delegated click handler below, which fires after mount.
+  const pathRef = useRef("");
 
   useEffect(() => {
     // `pathname` only (never `search`) — a page-path identifier, the same field
@@ -32,23 +36,23 @@ export function ErrorAnalytics({ code, children }: ErrorAnalyticsProps) {
     // (lowercase + truncate-50) and would corrupt long 404 URLs — the very data
     // this event exists to capture — without redacting anything.
     const path = window.location.pathname;
+    pathRef.current = path;
     trackEvent("error_view", { error_code: code, path });
+  }, [code]);
 
-    const node = ref.current;
-    if (!node) return;
-
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const el = target?.closest<HTMLElement>("[data-error-action]");
-      const action = el?.dataset.errorAction;
+  useDelegatedClick(ref, {
+    selector: "[data-error-action]",
+    onMatch: (el) => {
+      const action = el.dataset.errorAction;
       if (!action) return;
 
-      trackEvent("error_action_click", { error_code: code, path, action });
-    };
-
-    node.addEventListener("click", handleClick);
-    return () => node.removeEventListener("click", handleClick);
-  }, [code]);
+      trackEvent("error_action_click", {
+        error_code: code,
+        path: pathRef.current,
+        action,
+      });
+    },
+  });
 
   return <div ref={ref}>{children}</div>;
 }

--- a/apps/web/src/components/editorial/EditorialHubAnalytics/EditorialHubAnalytics.tsx
+++ b/apps/web/src/components/editorial/EditorialHubAnalytics/EditorialHubAnalytics.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { trackEvent } from "@/lib/analytics/track-event";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
 
 export interface EditorialHubAnalyticsProps {
   /** Event fired on a card click, e.g. `jeugd_card_click`. */
@@ -29,15 +30,9 @@ export function EditorialHubAnalytics({
 }: EditorialHubAnalyticsProps) {
   const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const node = ref.current;
-    if (!node) return;
-
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const card = target?.closest<HTMLElement>("[data-card-type]");
-      if (!card) return;
-
+  useDelegatedClick(ref, {
+    selector: "[data-card-type]",
+    onMatch: (card) => {
       const cardType = card.dataset.cardType;
       if (!cardType) return;
 
@@ -47,11 +42,8 @@ export function EditorialHubAnalytics({
         tag: card.dataset.tag ?? "",
         ...(articleIdHashed ? { article_id_hashed: articleIdHashed } : {}),
       });
-    };
-
-    node.addEventListener("click", handleClick);
-    return () => node.removeEventListener("click", handleClick);
-  }, [eventName]);
+    },
+  });
 
   return (
     <div ref={ref} className={className}>

--- a/apps/web/src/components/organigram/HubMemberPanel/HubMemberPanel.tsx
+++ b/apps/web/src/components/organigram/HubMemberPanel/HubMemberPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { OrgChartMember, OrgChartNode } from "@/types/organigram";
 import type { ResponsibilityPath } from "@/types/responsibility";
 import { useOrganigramAnalytics } from "@/hooks/useOrganigramAnalytics";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
 import { MemberDetailPanel } from "@/components/organigram/MemberDetailPanel";
 
 /**
@@ -133,21 +134,16 @@ export function HubMemberPanel({
   }, []);
 
   // Directory delegation: one listener, target only `data-member-card` cards.
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const onClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const card = target?.closest<HTMLElement>("[data-member-card]");
-      const id = card?.dataset.nodeId;
+  useDelegatedClick(containerRef, {
+    selector: "[data-member-card]",
+    onMatch: (card) => {
+      const id = card.dataset.nodeId;
       if (!id) return;
       const node = nodeById.get(id);
       if (!node) return;
       openMember(node, { trigger: card, view: "cards" });
-    };
-    el.addEventListener("click", onClick);
-    return () => el.removeEventListener("click", onClick);
-  }, [nodeById, openMember]);
+    },
+  });
 
   // Deep-link restore on first mount: a one-time read of the URL (an external
   // system) — the panel is closed during SSR and opens after hydration when

--- a/apps/web/src/components/sponsors/SponsorsAnalytics/SponsorsAnalytics.tsx
+++ b/apps/web/src/components/sponsors/SponsorsAnalytics/SponsorsAnalytics.tsx
@@ -5,6 +5,7 @@ import {
   useSponsorAnalytics,
   type SponsorTier,
 } from "@/hooks/useSponsorAnalytics";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
 
 export interface SponsorsAnalyticsProps {
   children: ReactNode;
@@ -36,17 +37,9 @@ export function SponsorsAnalytics({ children }: SponsorsAnalyticsProps) {
     trackSponsorView();
   }, [trackSponsorView]);
 
-  useEffect(() => {
-    const node = ref.current;
-    if (!node) return;
-
-    const handleClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null;
-      const el = target?.closest<HTMLElement>(
-        "[data-sponsor-id], [data-sponsor-cta]",
-      );
-      if (!el) return;
-
+  useDelegatedClick(ref, {
+    selector: "[data-sponsor-id], [data-sponsor-cta]",
+    onMatch: (el) => {
       if (el.hasAttribute("data-sponsor-cta")) {
         trackSponsorCtaClick();
         return;
@@ -63,11 +56,8 @@ export function SponsorsAnalytics({ children }: SponsorsAnalyticsProps) {
       } else {
         trackSponsorClick({ sponsorId, tier });
       }
-    };
-
-    node.addEventListener("click", handleClick);
-    return () => node.removeEventListener("click", handleClick);
-  }, [trackSponsorClick, trackSponsorFeaturedClick, trackSponsorCtaClick]);
+    },
+  });
 
   return <div ref={ref}>{children}</div>;
 }

--- a/apps/web/src/hooks/useDelegatedClick.test.ts
+++ b/apps/web/src/hooks/useDelegatedClick.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, fireEvent } from "@testing-library/react";
+import type { RefObject } from "react";
+import { useDelegatedClick } from "./useDelegatedClick";
+
+/**
+ * Build a real container with a marked element (holding a nested child) and an
+ * unmarked sibling, append it to the document, and return a stable ref to it.
+ */
+function setup() {
+  const container = document.createElement("div");
+
+  const marked = document.createElement("button");
+  marked.setAttribute("data-match", "");
+  const inner = document.createElement("span");
+  inner.textContent = "inner";
+  marked.appendChild(inner);
+
+  const outside = document.createElement("p");
+  outside.textContent = "outside";
+
+  container.append(marked, outside);
+  document.body.appendChild(container);
+
+  const ref: RefObject<HTMLElement | null> = { current: container };
+  return { container, marked, inner, outside, ref };
+}
+
+describe("useDelegatedClick", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("adds a click listener on mount and removes it on unmount", () => {
+    const { container, ref } = setup();
+    const addSpy = vi.spyOn(container, "addEventListener");
+    const removeSpy = vi.spyOn(container, "removeEventListener");
+
+    const { unmount } = renderHook(() =>
+      useDelegatedClick(ref, { selector: "[data-match]", onMatch: vi.fn() }),
+    );
+
+    expect(addSpy).toHaveBeenCalledWith("click", expect.any(Function));
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("click", expect.any(Function));
+  });
+
+  it("invokes onMatch with the matched ancestor when a descendant is clicked", () => {
+    const { marked, inner, ref } = setup();
+    const onMatch = vi.fn();
+
+    renderHook(() =>
+      useDelegatedClick(ref, { selector: "[data-match]", onMatch }),
+    );
+
+    fireEvent.click(inner);
+
+    expect(onMatch).toHaveBeenCalledTimes(1);
+    expect(onMatch).toHaveBeenCalledWith(marked);
+  });
+
+  it("does not invoke onMatch for clicks outside the selector", () => {
+    const { outside, ref } = setup();
+    const onMatch = vi.fn();
+
+    renderHook(() =>
+      useDelegatedClick(ref, { selector: "[data-match]", onMatch }),
+    );
+
+    fireEvent.click(outside);
+
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+
+  it("does not crash and attaches no listener when the ref is null", () => {
+    const ref: RefObject<HTMLElement | null> = { current: null };
+    const onMatch = vi.fn();
+
+    expect(() =>
+      renderHook(() =>
+        useDelegatedClick(ref, { selector: "[data-match]", onMatch }),
+      ),
+    ).not.toThrow();
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+
+  it("invokes the latest onMatch after a re-render without re-subscribing", () => {
+    const { container, marked, ref } = setup();
+    const addSpy = vi.spyOn(container, "addEventListener");
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ onMatch }) =>
+        useDelegatedClick(ref, { selector: "[data-match]", onMatch }),
+      { initialProps: { onMatch: first } },
+    );
+
+    expect(addSpy).toHaveBeenCalledTimes(1);
+    fireEvent.click(marked);
+    expect(first).toHaveBeenCalledTimes(1);
+
+    rerender({ onMatch: second });
+
+    // Listener subscribed exactly once — no re-subscribe churn on re-render.
+    expect(addSpy).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(marked);
+    expect(second).toHaveBeenCalledTimes(1);
+    // The stale callback is never invoked again.
+    expect(first).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/useDelegatedClick.ts
+++ b/apps/web/src/hooks/useDelegatedClick.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface UseDelegatedClickOptions {
+  /** CSS selector resolved from the click target via `closest()`. */
+  selector: string;
+  /** Invoked with the matched element when a click resolves to `selector`. */
+  onMatch: (el: HTMLElement) => void;
+}
+
+/**
+ * Delegate clicks within a container to the nearest element matching
+ * `selector`. One native `click` listener on `ref.current` (not per-child
+ * `onClick`) resolves `event.target.closest(selector)`, early-returns when
+ * nothing matches, and invokes `onMatch` with the matched element — so the
+ * content beneath the container can stay server-rendered.
+ *
+ * The hook is analytics-agnostic: it does delegation only. The consumer's
+ * `onMatch` owns every `data-*` read, branch, hash, and `trackEvent` call.
+ *
+ * `onMatch` is held in a ref refreshed each render, so the listener subscribes
+ * **once** (deps `[ref, selector]`) — consumers may pass an inline `onMatch`
+ * without `useCallback` and never get a stale closure or a re-subscribe churn.
+ * SSR-safe: the listener is wired in an effect and guards a null `ref.current`.
+ */
+export function useDelegatedClick(
+  ref: RefObject<HTMLElement | null>,
+  { selector, onMatch }: UseDelegatedClickOptions,
+): void {
+  // Keep the latest callback out of the effect deps so a new `onMatch` identity
+  // never re-subscribes the listener. The sync runs after every render, before
+  // any click can read it.
+  const onMatchRef = useRef(onMatch);
+  useEffect(() => {
+    onMatchRef.current = onMatch;
+  });
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const el = target?.closest<HTMLElement>(selector);
+      if (!el) return;
+      onMatchRef.current(el);
+    };
+
+    node.addEventListener("click", handleClick);
+    return () => node.removeEventListener("click", handleClick);
+  }, [ref, selector]);
+}


### PR DESCRIPTION
Closes #2114

## Changes

Extracts the duplicated page-scoped click-delegation idiom (`useRef` → native `click` listener → `closest(selector)` → null guard → handler) into one analytics-agnostic hook and migrates the 5 consumers to it.

- **`hooks/useDelegatedClick.ts`** — delegation only, no `trackEvent` coupling. Holds `onMatch` in a ref refreshed each render, so the listener subscribes **once** (`[ref, selector]`) and consumers pass an inline `onMatch` without `useCallback`; SSR-safe (effect-only, guards a null `ref.current`). Mirrors the repo's established latest-callback-ref idiom (`MemberDetailPanel`, `NewsListingClient`).
- **Migrated consumers:** `EditorialHubAnalytics`, `SponsorsAnalytics`, `ErrorAnalytics`, `UltrasAnalytics`, and `HubMemberPanel`'s `[data-member-card]` delegation effect (its deep-link + `onMemberShown` effects untouched).
- **Mount-time events** (`sponsor_view`, `ultras_view`, `error_view`) stay as their own effect per consumer. `ErrorAnalytics` keeps reading `path` **once at mount**, now via a ref shared with the delegated handler.

**Zero behavioural change** — every event name, param (incl. `hashMemberId`, the conditional `article_id_hashed`, the Sponsors 3-way branch, Error `path`/`error_code`), and SSR guard is preserved. Net −27 lines in the consumers; the click-delegation logic now lives in one tested place.

## Testing

- New `useDelegatedClick.test.ts` (5 cases): listener add-on-mount / remove-on-unmount; `onMatch` with the matched ancestor on a descendant click; not invoked outside the selector; null-ref no-crash; latest-`onMatch`-after-rerender with a single subscription.
- All 5 consumer test files pass **unmodified**.
- `pnpm --filter @kcvv/web check-all` ✅ (280 files / 3217 tests, lint, type-check, `next build` all green).
- Pre-PR review gate: `/code-review` (high) → no correctness findings; `/simplify` angles → clean (the hook removes duplication and improves efficiency via subscribe-once). One borderline `pathRef` nit was considered and deliberately kept to preserve the documented "read `path` once at mount" semantic (removing it would be a behavioural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized click event handling across analytics components to improve performance and maintainability.

* **Tests**
  * Added comprehensive test coverage for delegated click event functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->