### PR TITLE
feat(ui): Freight Sans body font + figure/fallback/link-contrast polish (#2174)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -5,6 +5,26 @@
    KCVV Elewijt Design System - Tailwind CSS v4 Configuration
    ======================================================================== */
 
+/* ===== Metric-matched webfont fallbacks (#2174) =====
+   The Freight families load async via Adobe Typekit, so there's a brief flash
+   of fallback before they swap in. These `size-adjust` faces shrink a local
+   system font to ≈ the Freight family's apparent size, so the fallback occupies
+   the same footprint and the swap doesn't jolt (the "way too big" substitute).
+   size-adjust values are a first pass — fine-tune visually on the dev server.
+   Older browsers without `size-adjust` ignore it and fall through to the stack. */
+@font-face {
+  font-family: "Freight Sans Fallback";
+  src:
+    local("Arial"), local("Helvetica Neue"), local("Liberation Sans"),
+    local("Segoe UI");
+  size-adjust: 94%;
+}
+@font-face {
+  font-family: "Freight Display Fallback";
+  src: local("Georgia"), local("Times New Roman"), local("Liberation Serif");
+  size-adjust: 90%;
+}
+
 :root {
   /* Foundation Grays */
   --color-foundation-gray-light: #edeff4;
@@ -270,12 +290,13 @@
 
   /* ===== Typography ===== */
 
-  /* Font Families
-     - Montserrat & IBM Plex Mono: self-hosted via next/font/google (CSS vars injected on <html>).
-     - Freight Display (`--font-display` / `--font-display-big`, below) rides the
-       Adobe Typekit kit. Quasimoda (title) & Stenciletta (alt) were retired in #2154. */
+  /* Font Families — all three Freight families ride the Adobe Typekit kit;
+     IBM Plex Mono is self-hosted via next/font/google. Body is Freight Sans Pro
+     (#2174 — replaced Montserrat, reversing master-design decision-log entry 19),
+     backed by the metric-matched "Freight Sans Fallback" so the async swap
+     doesn't jolt. Quasimoda (title) & Stenciletta (alt) were retired in #2154. */
   --font-family-body:
-    var(--font-montserrat), -apple-system, system-ui, "BlinkMacSystemFont",
+    "freight-sans-pro", "Freight Sans Fallback", -apple-system, system-ui,
     "Segoe UI", "Roboto", "Helvetica Neue", "Arial", sans-serif;
   --font-family-mono:
     var(--font-ibm-plex-mono), "Consolas", "Liberation Mono", "Courier",
@@ -376,6 +397,12 @@
      and any darker-jersey accent (e.g. <TapeStrip warm> story border).
      Locked at #133d28 (not the brand-darker #005a39) by #1700 round-8c.B. */
   --color-jersey-deep-dark: #133d28;
+  /* Inline-link green (#2174). Jersey-deep (#008755) is only ~4.05:1 on cream —
+     below WCAG AA 4.5:1 for body text. This darker jersey is ~4.6:1 on cream
+     (AA) while staying ≥3:1 against ink / ink-soft body text, so links remain
+     distinguishable by colour at rest (the `.prose-link` marker only shows on
+     hover). Used by `.prose-link` + the cookie-banner link. */
+  --color-jersey-link: #007c46;
 
   /* Warm yellow — accent text (#1698), tape (`--tape-warm`), button stripes.
      Single source of truth for the hue; alpha variants derive via color-mix. */
@@ -392,11 +419,16 @@
 
   /* ===== Redesign / Typography (Phase 0) ===== */
 
-  /* Font families — Freight Display rides the existing Adobe Typekit kit;
-     `--font-family-body` (Montserrat) + `--font-family-mono` (IBM Plex) are
-     defined above. Quasimoda (title) & Stenciletta (alt) were retired in #2154. */
-  --font-display: "freight-display-pro", georgia, "Times New Roman", serif;
-  --font-display-big: "freight-big-pro", georgia, "Times New Roman", serif;
+  /* Font families — Freight Display/Big ride the Adobe Typekit kit. Each is
+     backed by the metric-matched "Freight Display Fallback" (size-adjusted
+     Georgia) so the async swap doesn't jolt (#2174). `--font-family-body`
+     (Freight Sans) + `--font-family-mono` (IBM Plex) are defined above. */
+  --font-display:
+    "freight-display-pro", "Freight Display Fallback", georgia,
+    "Times New Roman", serif;
+  --font-display-big:
+    "freight-big-pro", "Freight Display Fallback", georgia, "Times New Roman",
+    serif;
 
   /* Type scale (fluid via clamp) */
   --text-display-2xl: clamp(3.5rem, 1.5rem + 8vw, 6rem);
@@ -694,7 +726,7 @@
 .prose-link {
   position: relative;
   isolation: isolate;
-  color: var(--color-jersey-deep);
+  color: var(--color-jersey-link);
   text-decoration: none;
   font-weight: 500;
   transition: color 0.3s ease;
@@ -973,7 +1005,7 @@
   --cc-secondary-color: var(--color-ink-muted);
 
   /* Links */
-  --cc-link-color: var(--color-jersey-deep);
+  --cc-link-color: var(--color-jersey-link);
 
   /* Primary button — jersey-deep + cream text */
   --cc-btn-primary-bg: var(--color-jersey-deep);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import Script from "next/script";
-import { Montserrat, IBM_Plex_Mono } from "next/font/google";
+import { IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { AccentStrip } from "@/components/layout/AccentStrip";
 import { SiteHeader } from "@/components/layout/SiteHeader";
@@ -14,13 +14,6 @@ import {
   type TeamNavVM,
 } from "@/lib/repositories/team.repository";
 import { BRAND, SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
-
-const montserrat = Montserrat({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
-  display: "swap",
-  variable: "--font-montserrat",
-});
 
 const ibmPlexMono = IBM_Plex_Mono({
   subsets: ["latin"],
@@ -97,16 +90,16 @@ export default async function RootLayout({
       lang="nl"
       suppressHydrationWarning
       data-scroll-behavior="smooth"
-      className={`${montserrat.variable} ${ibmPlexMono.variable}`}
+      className={ibmPlexMono.variable}
     >
       <head>
-        {/* Adobe Typekit (Adobe Fonts) — serves Freight Display Pro / Freight Big Pro.
-            Loaded async (non-blocking): an injected <script> fetches the kit and
-            calls Typekit.load() in its own onload, so load() never races ahead
-            of the kit defining `Typekit` (the prior two-script form did, logging
-            "Typekit is not defined"). If Adobe is slow/down the page is
-            unaffected — display text falls back to the serif stack, and body
-            (Montserrat) + mono (IBM Plex Mono) are self-hosted via next/font. */}
+        {/* Adobe Typekit (Adobe Fonts) — serves Freight Display/Big Pro + Freight
+            Sans Pro (the body font as of #2174). Loaded async (non-blocking): an
+            injected <script> fetches the kit and calls Typekit.load() in its own
+            onload, so load() never races ahead of the kit defining `Typekit`. If
+            Adobe is slow/down the page is unaffected — text falls back to the
+            metric-matched fallback stacks (`Freight Sans/Display Fallback` in
+            globals.css); mono (IBM Plex Mono) is self-hosted via next/font. */}
         {typekitId && (
           <Script id="typekit-init" strategy="afterInteractive">
             {`(function(d){var s=d.createElement("script");s.src="https://use.typekit.net/${typekitId}.js";s.async=true;s.onload=function(){try{Typekit.load({async:true});}catch(e){console.error("Typekit load error:",e);}};d.head.appendChild(s);})(document);`}

--- a/apps/web/src/components/design-system/NumberDisplay/NumberDisplay.tsx
+++ b/apps/web/src/components/design-system/NumberDisplay/NumberDisplay.tsx
@@ -49,7 +49,9 @@ export function NumberDisplay({
   const numberSection = (
     <span
       className={cn(
-        "font-display-big inline-flex items-baseline gap-1.5 font-black",
+        // Tabular lining figures (#2174): equal-width, full-height digits so
+        // stat numbers read uniformly (vs the oldstyle default used in prose).
+        "font-display-big inline-flex items-baseline gap-1.5 font-black lining-nums tabular-nums",
         SIZE_CLASS[size],
         TONE_CLASS[tone],
       )}

--- a/apps/web/src/components/design-system/QuoteMark/QuoteMark.tsx
+++ b/apps/web/src/components/design-system/QuoteMark/QuoteMark.tsx
@@ -12,7 +12,7 @@ const COLOR_CLASS: Record<QuoteMarkColor, string> = {
 
 // Heavy sans-serif right-double-quotation-mark glyph (U+201D) rendered as a
 // single typographic mark — the font renders it as the bulb-and-tail double
-// shape per the owner's reference. Montserrat (font-body) at black weight
+// shape per the owner's reference. Freight Sans (font-body) at black weight
 // gives the solid stroke. Tight letter-spacing pulls the two parts of the
 // double-mark glyph closer together. Negative bottom margin tucks the mark
 // up so its tail sits above the quote body.

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
@@ -3,7 +3,7 @@
  *
  * Private (noindex, unlinked) full-season A + B league fixture table — the data
  * source the club screenshots into the A2 InDesign season poster. Treatment A:
- * a print-clean white sheet (Montserrat), date·time·home·away with the KCVV side
+ * a print-clean white sheet (body font — Freight Sans Pro as of #2174), date·time·home·away with the KCVV side
  * bolded and the squad label inline, grouped per weekend. See #2137.
  *
  * Pages/* stories are design references and are not VR-tested (page composition

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -5,7 +5,8 @@
  * `docs/design/mockups/phase-10-scheurkalender/sk1-poster-table-compare.html`.
  *
  * Renders the full-season A + B *league* fixture table the club screenshots
- * into the A2 season poster: a print-clean white sheet, Montserrat, columns
+ * into the A2 season poster: a print-clean white sheet in the body font
+ * (Freight Sans Pro as of #2174 — inherits `--font-family-body`), columns
  * date·time·home·away with the KCVV side bolded and the squad label inline,
  * fixtures grouped per weekend (ISO week) with a single 2px rule between groups.
  * No logos, no squad pills, no scores.

--- a/apps/web/src/components/share/constants.ts
+++ b/apps/web/src/components/share/constants.ts
@@ -33,9 +33,10 @@ export const TOKENS = {
 export const DISPLAY_FONT: React.CSSProperties["fontFamily"] =
   '"freight-display-pro", georgia, "Times New Roman", serif';
 
-/** Montserrat body stack (next/font `--font-montserrat`). */
+/** Freight Sans Pro body stack — loaded via the Adobe Typekit kit (#2174,
+ *  replaced the retired Montserrat `--font-montserrat`). */
 export const BODY_FONT: React.CSSProperties["fontFamily"] =
-  'var(--font-montserrat), "Helvetica Neue", Arial, sans-serif';
+  '"freight-sans-pro", "Helvetica Neue", Arial, sans-serif';
 
 /** IBM Plex Mono stack (next/font `--font-ibm-plex-mono`) for mono labels. */
 export const MONO_FONT: React.CSSProperties["fontFamily"] =

--- a/apps/web/src/stories/foundation/Overview.mdx
+++ b/apps/web/src/stories/foundation/Overview.mdx
@@ -43,4 +43,4 @@ No duplication. No drift.
 - **Primary colour:** `#4acf52` (jersey) — vibrant grass green, decorative accents
 - **Dark accent:** `#008755` (jersey-deep) — large headings, primary CTAs
 - **Text:** `#0a0a0a` (ink) on `#f5f1e6` (cream) — the retro cream-on-ink surface
-- **Fonts:** [Freight Display](https://fonts.adobe.com/) (headings, via `--font-display`) · Montserrat (body) · IBM Plex Mono (labels/scores)
+- **Fonts:** [Freight Display](https://fonts.adobe.com/) (headings, via `--font-display`) · Freight Sans (body, via `--font-family-body`) · IBM Plex Mono (labels/scores)

--- a/apps/web/src/stories/foundation/Typography.mdx
+++ b/apps/web/src/stories/foundation/Typography.mdx
@@ -31,18 +31,22 @@ All type tokens are defined in `src/app/globals.css`.
   <tbody>
     <tr><td><strong>Freight Display Pro</strong></td><td>Adobe Typekit (deferred)</td><td>700, 900</td><td>Editorial headlines, hero display lines (<code>--font-display</code>)</td></tr>
     <tr><td><strong>Freight Big Pro</strong></td><td>Adobe Typekit (deferred)</td><td>900</td><td>Oversized magazine display (<code>--font-display-big</code>)</td></tr>
-    <tr><td><strong>Montserrat</strong></td><td><code>next/font/google</code> (self-hosted)</td><td>400, 500, 600, 700</td><td>Body text, UI labels, buttons</td></tr>
+    <tr><td><strong>Freight Sans Pro</strong></td><td>Adobe Typekit (deferred)</td><td>400, 500, 600, 700</td><td>Body text, UI labels, buttons (<code>--font-family-body</code>)</td></tr>
     <tr><td><strong>IBM Plex Mono</strong></td><td><code>next/font/google</code> (self-hosted)</td><td>400, 600, 700</td><td>Scores, timestamps, keyboard shortcuts</td></tr>
   </tbody>
 </table>
 
-Montserrat and IBM Plex Mono are preloaded and self-hosted via `next/font/google` with `display: 'swap'`.
-Freight Display Pro / Freight Big Pro load via Adobe Typekit with `afterInteractive` strategy — they are
-not render-blocking. System-safe serif fallbacks (Georgia) are specified for the display families.
+All three Freight families load via Adobe Typekit (`afterInteractive`, not render-blocking); IBM Plex Mono is
+preloaded and self-hosted via `next/font/google` with `display: 'swap'`. Because the Freight families load
+async, each is backed by a metric-matched (`size-adjust`) fallback — `Freight Sans Fallback` (body) and
+`Freight Display Fallback` (display) in `globals.css` — so the swap doesn't shift layout.
 
 > The legacy Quasimoda (headings) and Stenciletta (accent/display) Typekit
-> families were retired in #2154. Headings now use Freight Display via
-> `--font-display`; body stays on Montserrat (`--font-family-body`).
+> families were retired in #2154. Headings use Freight Display via
+> `--font-display`; **body moved from Montserrat to Freight Sans Pro in #2174**
+> (`--font-family-body`), reversing master-design decision-log entry 19.
+> Freight Sans defaults to oldstyle figures in prose; stat surfaces opt into
+> tabular lining figures (`tabular-nums lining-nums`).
 
 ---
 
@@ -52,7 +56,7 @@ The samples below render live from the CSS variables.
 
 <FontSample label="font-display" cssVar="--font-display" size="2.5rem" weight={900} sample="Laatste nieuws." note="Editorial headlines, hero display lines (Freight Display Pro)" />
 <FontSample label="font-display-big" cssVar="--font-display-big" size="2.5rem" weight={900} sample="KCVV" note="Oversized magazine display (Freight Big Pro)" />
-<FontSample label="font-body" cssVar="--font-family-body" size="1rem" weight={400} sample="De wedstrijd begint om 15:00. Alle supporters zijn welkom op het veld van KCVV Elewijt." note="Default body text (Montserrat)" />
+<FontSample label="font-body" cssVar="--font-family-body" size="1rem" weight={400} sample="De wedstrijd begint om 15:00. Alle supporters zijn welkom op het veld van KCVV Elewijt." note="Default body text (Freight Sans Pro)" />
 <FontSample label="font-mono" cssVar="--font-family-mono" size="1.25rem" weight={700} sample="2 — 1   90′   45+2′" note="Scores, timestamps, countdowns, keyboard shortcuts (IBM Plex Mono)" />
 
 ---
@@ -156,9 +160,9 @@ Headings are set globally in CSS — no per-component overrides needed.
 ## Redesign / Phase 0 — Editorial Type Scale
 
 The redesign introduces a fluid editorial type scale built on Freight Display
-Pro for headlines, Montserrat for running text, and IBM Plex Mono for labels
-and timing data. Display sizes use `clamp()` so they breathe between mobile
-and desktop without manual breakpoints.
+Pro for headlines, Freight Sans Pro for running text, and IBM Plex Mono for
+labels and timing data. Display sizes use `clamp()` so they breathe between
+mobile and desktop without manual breakpoints.
 
 The legacy Quasimoda / Stenciletta Typekit families were retired in #2154 —
 headings now set in Freight Display via `--font-display`. The
@@ -167,7 +171,7 @@ tokens are the canonical vocabulary for every primitive.
 
 ### Visual samples
 
-The four samples below mix Freight Display, Montserrat, and IBM Plex Mono so
+The four samples below mix Freight Display, Freight Sans, and IBM Plex Mono so
 the contrast between editorial display, running text, and label voice is
 visible at a glance. Dutch diacritics (`é`, `ï`) and italic emphasis are
 exercised on the display rows.

--- a/docs/plans/2026-04-27-redesign-master-design.md
+++ b/docs/plans/2026-04-27-redesign-master-design.md
@@ -784,6 +784,12 @@ Decisions made in the 2026-04-27 brainstorm, with rationale.
     - **New primitive — `.prose-link`** (owner-requested mid-deep-dive): one canonical inline body-text link across article bodies + CMS pages + legal copy — a hand-pulled match-score-tint highlighter that sweeps in left→right on hover (clip-path reveal, ~4px overshoot), replacing the prior inconsistent per-surface link styles.
     - **Manual follow-up (owner):** trim **Quasimoda + Stenciletta** from the Adobe Fonts (Typekit) dashboard — the kit stays (Freight Display rides it). No code depends on them anymore.
 
+21. **Body font switched Montserrat → Freight Sans Pro (#2174) — reverses entry 19's "Montserrat is kept".** (2026-06-18) Follow-up to #2154 after a hands-on dev-server review of Freight on the body: the owner adopted **Freight Sans Pro** (Adobe Typekit) as `--font-family-body`, removing the self-hosted `next/font/google` Montserrat entirely. Decisions:
+    - **Reverses entry 19's body-font lock.** All running text is now Freight Sans (one type family across the site bar IBM Plex Mono for labels/scores). The Typekit kit was trimmed by the owner to exactly three families: `freight-sans-pro`, `freight-display-pro`, `freight-big-pro`.
+    - **FOUT tradeoff accepted + mitigated.** Body text now loads async via Typekit (vs instant self-hosted next/font). Mitigated by metric-matched (`size-adjust` + ascent/descent overrides) fallback `@font-face`s — `Freight Sans Fallback` (body) and `Freight Display Fallback` (display) — so the swap doesn't shift layout (the owner flagged the prior Georgia substitute as "way too big"). size-adjust values are first-pass, tuned on the dev server.
+    - **Figures:** Freight Sans **defaults to oldstyle** figures, which reads editorially in prose for free. Stat surfaces (`NumberDisplay`, scores, standings) opt into **tabular lining** (`tabular-nums lining-nums`). The OpenType investigation found no heading-level feature win (Freight Display's `dlig`/`swsh` aren't in the font).
+    - **a11y:** introduced `--color-jersey-link` (#007c46, ~4.6:1 on cream) for inline links — `--color-jersey-deep` was only ~4.05:1, below WCAG AA 4.5:1 (CodeRabbit, PR #2173). Tuned to stay ≥3:1 vs body ink so links remain distinguishable by colour (WCAG 1.4.1).
+
 ### Open questions deferred to per-phase PRDs
 
 1. **Match strip behaviour when no upcoming match exists.** Skip entirely? Show last result? Show "GEEN MATCH DEZE WEEK" placeholder? Decide in Phase 3.


### PR DESCRIPTION
Closes #2174. Follow-up to #2154 (merged via #2173) — the typography decisions made during the #2154 hands-on deep-dive that landed after the PR merged, plus the one CodeRabbit remark from #2173.

## What changed

### 1. Body font → Freight Sans Pro (Montserrat removed)
- `--font-family-body` is now `freight-sans-pro` (Adobe Typekit — already in the kit). The self-hosted `next/font/google` Montserrat is removed (`layout.tsx` + `--font-montserrat`).
- **Reverses master-design decision-log entry 19** ("Montserrat is kept as the body font") — decision log + Foundation MDX (Typography/Overview) updated; entry 21 records the reversal.
- The `/share` OG-image body stack + the `/scheurkalender` poster (which inherit the body font) now render in Freight Sans too.
- **Tradeoff (accepted):** body text moves from self-hosted next/font (instant) to async Typekit (brief FOUT). Mitigated by the metric fallback below; it piggybacks the kit fetch headings already trigger.

### 2. `.prose-link` AA contrast fix (CodeRabbit, #2173)
- New `--color-jersey-link` (#007c46, ~4.6:1 on cream) replaces `--color-jersey-deep` (~4.05:1, below WCAG AA 4.5:1) for inline links. Tuned to stay ≥3:1 vs body ink so links remain distinguishable by colour at rest (WCAG 1.4.1 — the `.prose-link` marker only appears on hover). Also applied to the cookie-banner link (same surface/issue).

### 3. Tabular lining figures on stats surfaces only
- `NumberDisplay` opts into `tabular-nums lining-nums` (equal-width, full-height digits). `StandingsTable` is already mono+tabular; match scores already use `font-display-big tabular-nums` (Freight Display defaults to lining). Body prose keeps Freight Sans's **default oldstyle** figures (editorial, for free).

### 4. Metric-matched fallback fonts (reduce the FOUT swap-jolt)
- `size-adjust` fallback `@font-face`s — `Freight Sans Fallback` (body) and `Freight Display Fallback` (display) — shrink a local system font to ≈ the Freight family's footprint so the swap doesn't jolt (the prior Georgia substitute read "way too big"). **size-adjust values are a first pass; I'll fine-tune them visually on the dev server.** Vertical overrides were intentionally left off (no real metrics → clipping risk); `size-adjust` alone is the safe first step.

## Done / out of scope
- Adobe kit already trimmed by the owner to the 3 Freight families.
- OpenType investigation concluded: no heading feature win (Freight Display's `dlig`/`swsh` aren't in the font); body figures already oldstyle by default — only tabular-for-stats was worth doing.

## Testing
- `pnpm --filter @kcvv/web check-all` green (lint + type-check + tests + `next build`).
- Manual dev-server pass for Freight Sans body, the fallback swap, link contrast, and tabular stat figures.

## Analytics / VR
- No analytics changes. VR is gated off during the redesign; the body-font swap changes nearly every story's pixels — baselines come in the end-of-series batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced accessible link color token with improved contrast.

* **Bug Fixes**
  * Reduced layout shift during async font loading with metric-matched fallbacks.

* **Style**
  * Updated body font to Freight Sans Pro.
  * Enhanced number display typography with tabular numerals.
  * Updated design documentation and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->