### PR TITLE
fix(search): dedupe staff results by member.id (#2140)

### DIFF
--- a/apps/web/src/app/api/search/route.test.ts
+++ b/apps/web/src/app/api/search/route.test.ts
@@ -404,6 +404,68 @@ describe("GET /api/search", () => {
       expect(body.query).toBe("test");
       expect(Array.isArray(body.results)).toBe(true);
     });
+
+    it("should dedupe a member appearing in multiple org-nodes into one result with combined roles", async () => {
+      // Regression for #2140: a staff member referenced by N organigramNodes
+      // produced N near-identical /staf/{psdId} rows (one per role). The fix
+      // dedupes by member.id and combines the roleCodes into one description.
+      // The third node repeats "PRES" to assert duplicate roleCodes are dropped.
+      const member = {
+        id: "staff-1",
+        name: "Jan Janssens",
+        imageUrl: "https://cdn.sanity.io/jan.webp",
+        email: null,
+        phone: null,
+        psdId: "123",
+      };
+      mockSanityFetch.mockResolvedValue([
+        {
+          _id: "node-1",
+          title: "Voorzitter",
+          roleCode: "PRES",
+          department: "hoofdbestuur",
+          parentId: null,
+          description: null,
+          members: [member],
+        },
+        {
+          _id: "node-2",
+          title: "Secretaris",
+          roleCode: "SEC",
+          department: "hoofdbestuur",
+          parentId: null,
+          description: null,
+          members: [member],
+        },
+        {
+          _id: "node-3",
+          title: "Voorzitter (duplicate role)",
+          roleCode: "PRES",
+          department: "hoofdbestuur",
+          parentId: null,
+          description: null,
+          members: [member],
+        },
+      ]);
+
+      const request = createRequest("/api/search?q=jan&type=staff");
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.count).toBe(1);
+      expect(body.results).toHaveLength(1);
+      expect(body.results[0]).toEqual(
+        expect.objectContaining({
+          id: "staff-1",
+          type: "staff",
+          title: "Jan Janssens",
+          description: "PRES · SEC",
+          url: "/staf/123",
+          imageUrl: "https://cdn.sanity.io/jan.webp",
+        }),
+      );
+    });
   });
 
   describe("Error Handling", () => {

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -148,12 +148,35 @@ const searchStaff = (query: string) =>
 
     debugLog(`[Search API] Found ${filtered.length} staff matches`);
 
-    return filtered.map(
-      ({ member, roleCode }): SearchResult => ({
+    // A staff member can sit in several org-chart nodes (one per role they
+    // hold). Without dedup that yields one near-identical /staf/{psdId} row per
+    // node (#2140). Group by member.id, keeping the first occurrence's canonical
+    // fields and combining the distinct roleCodes (in GROQ node order) into the
+    // description.
+    const byMember = new Map<
+      string,
+      { member: (typeof filtered)[number]["member"]; roles: string[] }
+    >();
+    for (const { member, roleCode } of filtered) {
+      const existing = byMember.get(member.id);
+      if (existing) {
+        if (roleCode && !existing.roles.includes(roleCode)) {
+          existing.roles.push(roleCode);
+        }
+      } else {
+        byMember.set(member.id, {
+          member,
+          roles: roleCode ? [roleCode] : [],
+        });
+      }
+    }
+
+    return Array.from(byMember.values()).map(
+      ({ member, roles }): SearchResult => ({
         id: member.id,
         type: "staff",
         title: member.name,
-        description: roleCode,
+        description: roles.join(" · ") || undefined,
         url: member.href,
         imageUrl: member.imageUrl,
       }),


### PR DESCRIPTION
Closes #2140

## Problem

Searching a staff member's name in `/zoeken` returned that person **once per org-chart role they hold** — a member sitting in 6 `organigramNode`s showed up 6× (near-identical rows: same name, photo, and `/staf/{psdId}` link, differing only in the role label). `searchStaff()` produced one result per (member × node) via `flatMap`, with no dedup anywhere in the path.

## Fix

Dedupe `searchStaff()` results by `member.id`:

- keep the first occurrence's canonical `id` / `title` / `url` / `imageUrl`
- combine the **distinct** `roleCode`s (in GROQ node order, repeats dropped) into one `description`, joined with ` · ` (e.g. `"PRES · SEC"`)
- `count` now reflects the deduped result set

Single-role members render exactly as before. Other search types (player / team / article) are untouched — staff is the only type with the many-nodes-per-entity fan-out. The BFF semantic/Vectorize POST path is out of scope (the live keyword search never uses it).

## Testing

- **Regression test** added in `route.test.ts`: a member in 3 org-nodes (one `roleCode` repeated) → exactly **one** result, `description: "PRES · SEC"`, `count: 1`. Fails on the old code (3 results), passes on the new.
- `pnpm --filter @kcvv/web check-all` green (lint + type-check + 3174 tests + `next build`).

## Pre-PR review gate

- **`/code-review` (correctness):** no issues — verified `member.id` is stable across nodes (it's the `staffMember` `_id`), Map insertion order = GROQ node order, `roles.join(...) || undefined` matches the prior empty-description contract, no aliasing/mutation hazard, downstream relevance sort unaffected, and the regression test is a genuine red→green guard.
- **`/simplify` (cleanup):** at the right altitude, nothing applied — confirmed the existing private `deduplicateById` helper can't be reused (it drops duplicate data, whereas this fix must *merge* roles), and the sibling search functions intentionally don't dedupe.

## Scope

`apps/web` only — `apps/web/src/app/api/search/route.ts` + `route.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed staff search to eliminate duplicate member entries. Staff members holding multiple roles or appearing across organizational nodes now display as a single result with combined role information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->