### PR TITLE
refactor(api): remove dead code in BFF + api-contract + sanity-studio (#2165)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -24,7 +24,9 @@ src/
 ├── handlers/
 │   ├── matches.ts            ← MatchesApi HttpApiGroup
 │   ├── ranking.ts            ← RankingApi HttpApiGroup
-│   └── stats.ts              ← StatsApi HttpApiGroup
+│   ├── opponent.ts           ← OpponentApi HttpApiGroup
+│   ├── related.ts            ← RelatedApi HttpApiGroup
+│   └── search.ts             ← SearchApi HttpApiGroup
 └── sync/
     ├── psd-team-client.ts    ← PsdTeamClient (teams/members/staff fetch for sync)
     └── psd-sanity-sync.ts    ← PSD → Sanity player/team/staff sync

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -4,7 +4,6 @@ import {
   getMatchesByTeamHandler,
   getNextMatchesHandler,
   getMatchesWindowHandler,
-  getMatchByIdHandler,
   getMatchDetailHandler,
   getPlayerStatsHandler,
 } from "./matches";
@@ -16,7 +15,6 @@ import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
 import { testEnvLayer } from "../test-helpers/env-layer";
 import {
-  Match,
   MatchesArray,
   MatchDetail,
   PlayerSeasonStats,
@@ -52,7 +50,6 @@ function makeServiceMock(
     getTeamMatches: (_teamId) => Effect.succeed([baseMatch]),
     getNextMatches: () => Effect.succeed([baseMatch]),
     getMatchesWindow: () => Effect.succeed([baseMatch]),
-    getMatchById: (_matchId) => Effect.succeed({ ...baseMatch, id: 99 }),
     getMatchDetail: (_matchId) => Effect.succeed(baseDetail),
     getRanking: () => Effect.die("not needed"),
     getOpponentHistory: () => Effect.die("not needed"),
@@ -271,19 +268,6 @@ describe("getMatchDetailHandler", () => {
     if (result._tag === "Left") {
       expect(result.left._tag).toBe("ResourceNotFound");
     }
-  });
-});
-
-describe("getMatchByIdHandler", () => {
-  it("returns a basic Match (no lineup)", async () => {
-    const result = await Effect.runPromise(
-      getMatchByIdHandler(99).pipe(
-        Effect.provide(Layer.succeed(PsdService, makeServiceMock())),
-      ),
-    );
-    expect(result.id).toBe(99);
-    expect("lineup" in result).toBe(false);
-    expect(() => S.decodeUnknownSync(Match)(result)).not.toThrow();
   });
 });
 

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -80,14 +80,6 @@ export const getMatchesWindowHandler = (): Effect.Effect<
   );
 };
 
-export const getMatchByIdHandler = (
-  matchId: number,
-): Effect.Effect<Match, BffError, PsdService> =>
-  Effect.gen(function* () {
-    const service = yield* PsdService;
-    return yield* service.getMatchById(matchId);
-  });
-
 export const getMatchDetailHandler = (
   matchId: number,
 ): Effect.Effect<
@@ -156,9 +148,6 @@ export const MatchesApiLive = HttpApiBuilder.group(
       .handle("getNextMatches", () => withErrorMapping(getNextMatchesHandler()))
       .handle("getMatchesWindow", () =>
         withErrorMapping(getMatchesWindowHandler()),
-      )
-      .handle("getMatchById", ({ path: { matchId } }) =>
-        withErrorMapping(getMatchByIdHandler(matchId)),
       )
       .handle("getMatchDetail", ({ path: { matchId } }) =>
         withErrorMapping(getMatchDetailHandler(matchId)),

--- a/apps/api/src/handlers/ranking.test.ts
+++ b/apps/api/src/handlers/ranking.test.ts
@@ -32,7 +32,6 @@ function makeServiceMock(
     getTeamMatches: () => Effect.fail(new Error("not needed") as never),
     getNextMatches: () => Effect.fail(new Error("not needed") as never),
     getMatchesWindow: () => Effect.fail(new Error("not needed") as never),
-    getMatchById: () => Effect.fail(new Error("not needed") as never),
     getMatchDetail: () => Effect.fail(new Error("not needed") as never),
     getRanking: () => Effect.succeed(rankingEntries),
     getOpponentHistory: () => Effect.die("not needed"),

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -956,42 +956,6 @@ describe("PsdService.getMatchesWindow", () => {
   });
 });
 
-describe("PsdService.getMatchById", () => {
-  it("returns normalized Match (no lineup) from mocked HTTP response", async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => rawDetailResponse,
-    });
-
-    const result = await runService((svc) => svc.getMatchById(99));
-
-    expect(result._tag).toBe("Right");
-    if (result._tag === "Right") {
-      expect(result.right.id).toBe(99);
-      expect(result.right.status).toBe("finished");
-      expect(result.right.home_team.name).toBe("KCVV Elewijt");
-      expect("lineup" in result.right).toBe(false);
-      // Contract boundary: validate transform output against api-contract schema
-      expect(() => S.decodeUnknownSync(Match)(result.right)).not.toThrow();
-    }
-  });
-
-  it("fails with ResourceNotFoundError when match detail fetch returns HTTP 404", async () => {
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
-
-    const result = await runService((svc) => svc.getMatchById(99));
-
-    expect(result._tag).toBe("Left");
-    if (result._tag === "Left") {
-      expect(result.left._tag).toBe("ResourceNotFound");
-    }
-  });
-});
-
 const rawRankingCompetitions = [
   {
     name: "Beker van Brabant",

--- a/apps/api/src/psd/service.ts
+++ b/apps/api/src/psd/service.ts
@@ -37,7 +37,6 @@ import {
   type CompetitionLabelMap,
   resolveCompetitionType,
   transformFootbalistoMatchDetail,
-  matchDetailToMatch,
   transformFootbalistoRankingEntry,
   extractId,
   computeOpponentSummary,
@@ -52,7 +51,6 @@ export interface PsdServiceInterface {
   ) => Effect.Effect<readonly Match[], BffError>;
   readonly getNextMatches: () => Effect.Effect<readonly Match[], BffError>;
   readonly getMatchesWindow: () => Effect.Effect<readonly Match[], BffError>;
-  readonly getMatchById: (matchId: number) => Effect.Effect<Match, BffError>;
   readonly getMatchDetail: (
     matchId: number,
   ) => Effect.Effect<MatchDetail, BffError>;
@@ -641,12 +639,6 @@ export const PsdServiceLive = Layer.effect(
           );
           return matches;
         }),
-
-      getMatchById: (matchId: number) =>
-        fetchRawMatchDetail(matchId).pipe(
-          Effect.map(transformFootbalistoMatchDetail),
-          Effect.map(matchDetailToMatch),
-        ),
 
       getMatchDetail: (matchId: number) =>
         fetchRawMatchDetail(matchId).pipe(

--- a/apps/api/src/psd/transforms.ts
+++ b/apps/api/src/psd/transforms.ts
@@ -576,20 +576,6 @@ export function transformFootbalistoMatchDetail(
 
 // ─── Ranking transforms ──────────────────────────────────────────────────────
 
-/** Strip lineup from a MatchDetail to produce a basic Match */
-export function matchDetailToMatch(detail: MatchDetail): Match {
-  return {
-    id: detail.id,
-    date: detail.date,
-    time: detail.time,
-    venue: detail.venue,
-    home_team: detail.home_team,
-    away_team: detail.away_team,
-    status: detail.status,
-    competition: detail.competition,
-  };
-}
-
 export function transformFootbalistoRankingEntry(
   entry: FootbalistoRankingEntry,
   logoCdnUrl: string,

--- a/apps/api/src/webhooks/index-handler.ts
+++ b/apps/api/src/webhooks/index-handler.ts
@@ -139,7 +139,7 @@ function buildDocumentIndex(
   return typeDescriptors[_type].buildIndex(doc);
 }
 
-export function queryForType(type: AllowedType): string {
+function queryForType(type: AllowedType): string {
   return typeDescriptors[type].query;
 }
 

--- a/apps/web/src/lib/effect/services/BffService.test.ts
+++ b/apps/web/src/lib/effect/services/BffService.test.ts
@@ -153,23 +153,6 @@ describe("BffService", () => {
     expect(result[0]?.team_name).toBe("KCVV Elewijt");
   });
 
-  it("getMatchById calls /match/:matchId and returns decoded match", async () => {
-    mockFetchWith(sampleMatch);
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* bff.getMatchById(42);
-      }).pipe(Effect.provide(BffServiceLive)),
-    );
-
-    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
-      expect.objectContaining({ href: expect.stringContaining("/match/42") }),
-      expect.any(Object),
-    );
-    expect(result.id).toBe(1);
-  });
-
   it("propagates errors as Effect failures (not exceptions)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/src/lib/effect/services/BffService.ts
+++ b/apps/web/src/lib/effect/services/BffService.ts
@@ -30,7 +30,6 @@ export class BffService extends Context.Tag("BffService")<
     getMatches: (teamId: number) => Effect.Effect<readonly Match[], BffError>;
     getNextMatches: () => Effect.Effect<readonly Match[], BffError>;
     getMatchesWindow: () => Effect.Effect<readonly Match[], BffError>;
-    getMatchById: (matchId: number) => Effect.Effect<Match, BffError>;
     getMatchDetail: (matchId: number) => Effect.Effect<MatchDetail, BffError>;
     getRanking: (
       teamId: number,
@@ -70,10 +69,6 @@ export const BffServiceLive = Layer.effect(
       getMatchesWindow: () =>
         client.matches
           .getMatchesWindow({})
-          .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
-      getMatchById: (matchId: number) =>
-        client.matches
-          .getMatchById({ path: { matchId } })
           .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
       getMatchDetail: (matchId: number) =>
         client.matches

--- a/packages/api-contract/CLAUDE.md
+++ b/packages/api-contract/CLAUDE.md
@@ -10,12 +10,14 @@ src/
 │   ├── common.ts     ← DateFromStringOrDate
 │   ├── match.ts      ← Match, MatchDetail, MatchTeam, MatchStatus, MatchLineup, MatchLineupPlayer, CardType
 │   ├── ranking.ts    ← RankingEntry, RankingArray, RankingResponse
-│   ├── stats.ts      ← PlayerStats, TeamStats
+│   ├── player-stats.ts ← PlayerSeasonStats, PlayerTeamStats
 │   └── index.ts      ← barrel
 ├── api/
 │   ├── matches.ts    ← MatchesApi HttpApiGroup
 │   ├── ranking.ts    ← RankingApi HttpApiGroup
-│   ├── stats.ts      ← StatsApi HttpApiGroup
+│   ├── opponent.ts   ← OpponentApi HttpApiGroup
+│   ├── related.ts    ← RelatedApi HttpApiGroup
+│   ├── search.ts     ← SearchApi HttpApiGroup
 │   └── index.ts      ← PsdApi root export
 └── index.ts          ← re-exports everything
 ```

--- a/packages/api-contract/src/api/matches.ts
+++ b/packages/api-contract/src/api/matches.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
 import { Schema as S } from "effect";
-import { Match, MatchDetail, MatchesArray } from "../schemas/match";
+import { MatchDetail, MatchesArray } from "../schemas/match";
 import { PlayerSeasonStats } from "../schemas/player-stats";
 import {
   HttpServiceUnavailable,
@@ -30,14 +30,6 @@ export class MatchesApi extends HttpApiGroup.make("matches")
     // getNextMatches. Powers the matchday-aware /share autocomplete.
     HttpApiEndpoint.get("getMatchesWindow", "/matches/window")
       .addSuccess(MatchesArray)
-      .addError(HttpServiceUnavailable)
-      .addError(HttpBadGateway)
-      .addError(HttpNotFound),
-  )
-  .add(
-    HttpApiEndpoint.get("getMatchById", "/match/:matchId")
-      .setPath(S.Struct({ matchId: S.NumberFromString }))
-      .addSuccess(Match)
       .addError(HttpServiceUnavailable)
       .addError(HttpBadGateway)
       .addError(HttpNotFound),

--- a/packages/api-contract/src/schemas/match.test.ts
+++ b/packages/api-contract/src/schemas/match.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Schema as S } from "effect";
-import {
-  Match,
-  MatchDetail,
-  MatchesArray,
-  MatchStatus,
-  MATCH_STATUS_VALUES,
-} from "./match";
+import { Match, MatchDetail, MatchesArray, MatchStatus } from "./match";
 
 const validMatchTeam = { id: 1, name: "KCVV Elewijt", logo: "/logo.png", score: 2 };
 const validAwayTeam = { id: 2, name: "FC Opponent", score: 1 };
@@ -78,7 +72,14 @@ describe("Match schema", () => {
 });
 
 describe("MatchStatus schema", () => {
-  it.each(MATCH_STATUS_VALUES)("accepts '%s'", (status) => {
+  it.each([
+    "scheduled",
+    "finished",
+    "forfeited",
+    "postponed",
+    "cancelled",
+    "stopped",
+  ] as const)("accepts '%s'", (status) => {
     expect(() => S.decodeUnknownSync(MatchStatus)(status)).not.toThrow();
   });
 

--- a/packages/api-contract/src/schemas/match.ts
+++ b/packages/api-contract/src/schemas/match.ts
@@ -30,12 +30,7 @@ export class MatchTeam extends S.Class<MatchTeam>("MatchTeam")({
  * "cancelled" is distinct from "postponed": cancelled matches will not be played,
  * postponed matches may be rescheduled.
  */
-/**
- * Canonical runtime tuple of all MatchStatus literals — single source of truth.
- * Use this for Storybook argTypes, parameterized tests, or anywhere a runtime
- * iterable is needed. The type is derived from this tuple.
- */
-export const MATCH_STATUS_VALUES = [
+const MATCH_STATUS_VALUES = [
   "scheduled",
   "finished",
   "forfeited",

--- a/packages/api-contract/src/schemas/related.test.ts
+++ b/packages/api-contract/src/schemas/related.test.ts
@@ -1,45 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Schema as S, Effect } from "effect";
-import { RelatedRequest, RelatedItem } from "./related";
-
-describe("RelatedRequest", () => {
-  it("accepts valid request with default limit", async () => {
-    const result = await Effect.runPromise(
-      S.decodeUnknown(RelatedRequest)({ id: "doc-abc123" }),
-    );
-    expect(result.id).toBe("doc-abc123");
-    expect(result.limit).toBe(3);
-  });
-
-  it("accepts request with explicit limit", async () => {
-    const result = await Effect.runPromise(
-      S.decodeUnknown(RelatedRequest)({ id: "doc-abc123", limit: 5 }),
-    );
-    expect(result.limit).toBe(5);
-  });
-
-  it("rejects empty id", async () => {
-    await expect(
-      Effect.runPromise(S.decodeUnknown(RelatedRequest)({ id: "" })),
-    ).rejects.toThrow();
-  });
-
-  it("rejects limit above 5", async () => {
-    await expect(
-      Effect.runPromise(
-        S.decodeUnknown(RelatedRequest)({ id: "doc-abc", limit: 6 }),
-      ),
-    ).rejects.toThrow();
-  });
-
-  it("rejects limit below 1", async () => {
-    await expect(
-      Effect.runPromise(
-        S.decodeUnknown(RelatedRequest)({ id: "doc-abc", limit: 0 }),
-      ),
-    ).rejects.toThrow();
-  });
-});
+import { RelatedItem } from "./related";
 
 describe("RelatedItem", () => {
   it("rejects responsibility type (responsibility paths are excluded from related items)", async () => {

--- a/packages/api-contract/src/schemas/related.ts
+++ b/packages/api-contract/src/schemas/related.ts
@@ -1,12 +1,5 @@
 import { Schema as S } from "effect";
 
-export class RelatedRequest extends S.Class<RelatedRequest>("RelatedRequest")({
-  id: S.String.pipe(S.minLength(1)),
-  limit: S.optional(S.Int.pipe(S.between(1, 5))).pipe(
-    S.withDefaults({ constructor: () => 3, decoding: () => 3 }),
-  ),
-}) {}
-
 export class RelatedItem extends S.Class<RelatedItem>("RelatedItem")({
   /** Sanity document _id */
   id: S.String,

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -14,23 +14,10 @@ export {schemaTypes} from './schema-types'
 // Studio at module load. Import migrations via `@kcvv/sanity-studio/migrations`.
 export {staffStructure} from './structure/staff'
 export {responsibilityStructure} from './structure/responsibility'
-export {
-  organigramNodePreviewSelect,
-  prepareOrganigramNodePreview,
-} from './preview/organigramNode-preview'
-export {
-  responsibilityPreviewSelect,
-  prepareResponsibilityPreview,
-} from './preview/responsibility-preview'
-export {validateOrganigramMember} from './validation/organigram-members'
-export {validateSubjectsCount} from './validation/subjects-count'
-export type {SubjectsCountContext} from './validation/subjects-count'
-export {validateRespondentKey} from './validation/respondent-key'
-export type {RespondentKeyContext} from './validation/respondent-key'
 // Public LauncherTool surface. `useTemplates` and `filterLauncherTemplates`
 // are intentionally NOT re-exported — they would shadow Sanity's own
 // `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.
 // Internal callers reach them via the `./tools/launcher` subpath instead.
 export {launcherTool} from './tools/launcher'
 export {responsibilityTemplates} from './templates'
-export type {LauncherTemplate, LauncherTemplateUi} from './templates'
+export type {LauncherTemplate} from './templates'

--- a/packages/sanity-studio/src/preview/organigramNode-preview.test.ts
+++ b/packages/sanity-studio/src/preview/organigramNode-preview.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {prepareOrganigramNodePreview} from './organigramNode-preview'
+import {prepareOrganigramNodePreview} from '@kcvv/sanity-schemas'
 
 describe('organigramNode preview', () => {
   it('shows member names as subtitle when members exist', () => {

--- a/packages/sanity-studio/src/preview/organigramNode-preview.ts
+++ b/packages/sanity-studio/src/preview/organigramNode-preview.ts
@@ -1,1 +1,0 @@
-export {organigramNodePreviewSelect, prepareOrganigramNodePreview} from '@kcvv/sanity-schemas'

--- a/packages/sanity-studio/src/preview/responsibility-preview.test.ts
+++ b/packages/sanity-studio/src/preview/responsibility-preview.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {prepareResponsibilityPreview} from './responsibility-preview'
+import {prepareResponsibilityPreview} from '@kcvv/sanity-schemas'
 
 describe('responsibility preview', () => {
   it('shows organigramNode title for position type', () => {

--- a/packages/sanity-studio/src/preview/responsibility-preview.ts
+++ b/packages/sanity-studio/src/preview/responsibility-preview.ts
@@ -1,1 +1,0 @@
-export {responsibilityPreviewSelect, prepareResponsibilityPreview} from '@kcvv/sanity-schemas'

--- a/packages/sanity-studio/src/validation/organigram-members.test.ts
+++ b/packages/sanity-studio/src/validation/organigram-members.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest'
-import {validateOrganigramMember} from './organigram-members'
+import {validateOrganigramMember} from '@kcvv/sanity-schemas'
 
 describe('validateOrganigramMember', () => {
   const makeContext = (doc: Record<string, unknown> | null) => ({

--- a/packages/sanity-studio/src/validation/organigram-members.ts
+++ b/packages/sanity-studio/src/validation/organigram-members.ts
@@ -1,1 +1,0 @@
-export {validateOrganigramMember} from '@kcvv/sanity-schemas'

--- a/packages/sanity-studio/src/validation/respondent-key.test.ts
+++ b/packages/sanity-studio/src/validation/respondent-key.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {validateRespondentKey} from './respondent-key'
+import {validateRespondentKey} from '@kcvv/sanity-schemas'
 
 describe('validateRespondentKey', () => {
   const interviewDoc = (subjectKeys: string[]) => ({

--- a/packages/sanity-studio/src/validation/respondent-key.ts
+++ b/packages/sanity-studio/src/validation/respondent-key.ts
@@ -1,2 +1,0 @@
-export {validateRespondentKey} from '@kcvv/sanity-schemas'
-export type {RespondentKeyContext} from '@kcvv/sanity-schemas'

--- a/packages/sanity-studio/src/validation/subjects-count.test.ts
+++ b/packages/sanity-studio/src/validation/subjects-count.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {validateSubjectsCount} from './subjects-count'
+import {validateSubjectsCount} from '@kcvv/sanity-schemas'
 
 describe('validateSubjectsCount', () => {
   const interviewDoc = {articleType: 'interview'} as const

--- a/packages/sanity-studio/src/validation/subjects-count.ts
+++ b/packages/sanity-studio/src/validation/subjects-count.ts
@@ -1,2 +1,0 @@
-export {validateSubjectsCount} from '@kcvv/sanity-schemas'
-export type {SubjectsCountContext} from '@kcvv/sanity-schemas'


### PR DESCRIPTION
Closes #2165

Pure ponytail-audit cleanup — **delete-only** across three workspaces (BFF `apps/api`, shared `packages/api-contract`, `packages/sanity-studio`). Every target re-verified zero-consumer on current `main` (`git grep` + `knip`) before removal, per the spec refinement.

## Changes

- **`getMatchById` endpoint chain** — removed the `/match/:matchId` endpoint def (`api-contract`), the BFF handler + `PsdService.getMatchById`, the `apps/web` `BffService` passthrough, and all referencing tests. The transform `matchDetailToMatch` was its **sole** consumer, so it's removed transitively (otherwise the cleanup would leave new dead code). All match rendering uses the still-present `getMatchDetail` (`/match/:matchId/detail`).
- **`RelatedRequest` schema** — removed the class + its self-test from `related.{ts,test.ts}`. `RelatedItem` and its tests are untouched.
- **`MATCH_STATUS_VALUES`** — dropped the `export` + the "single source of truth" doc; kept a bare `const` feeding `MatchStatus = S.Literal(...)`. The lone consumer (its own test) now inlines the literals.
- **sanity-studio re-export shims** — deleted the 5 one-line `export … from '@kcvv/sanity-schemas'` preview/validation files + their barrel lines in `src/index.ts`; repointed the 5 sibling tests to import directly from `@kcvv/sanity-schemas` (verified those symbols are on the package's public entry).
- **Stray exports narrowed** — `queryForType` (internal to `index-handler.ts`) and `LauncherTemplateUi` (dropped from the public barrel; `LauncherTemplate` kept).
- **Stale-doc fix** — corrected the non-existent `stats.ts`/`StatsApi` references in `apps/api/CLAUDE.md` + `packages/api-contract/CLAUDE.md` to the real groups (matches/ranking/opponent/related/search) and `player-stats.ts`.

**Net −182 lines** (27 files, 26 insertions / 208 deletions).

## Testing

- `pnpm turbo build --filter=@kcvv/api-contract --force` ✓ then `pnpm turbo build --filter=@kcvv/web` ✓ (contract change → **bundler** resolution validated, not just `tsc`)
- `pnpm --filter @kcvv/web check-all` ✓ — 276 files / 3122 tests
- `pnpm --filter @kcvv/api type-check` ✓ + `test` ✓ — 350 tests
- `pnpm --filter @kcvv/api-contract test` ✓ — 80 tests · `pnpm --filter @kcvv/sanity-studio test` ✓ — 169 tests
- `pnpm knip` — no new orphans from this change
- Pre-PR review gate (`/code-review` high + `/simplify`): no findings — delete-only diff, all consumers traced clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed the `/match/:matchId` API endpoint for retrieving individual matches.

* **Refactor**
  * Reorganized API endpoints; removed stats endpoint and added opponent, related, and search endpoints.
  * Consolidated preview and validation utilities into a shared package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->