### PR TITLE
feat(studio): article editor-UX rework — groups, guidance, 4 IVTs (#1501)

### DIFF
--- a/apps/studio-staging/sanity.config.ts
+++ b/apps/studio-staging/sanity.config.ts
@@ -1,7 +1,12 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
-import {LinkToPsdAction, launcherTool, responsibilityTemplates} from '@kcvv/sanity-studio'
+import {
+  LinkToPsdAction,
+  launcherTool,
+  responsibilityTemplates,
+  articleTemplates,
+} from '@kcvv/sanity-studio'
 import {schemaTypes} from './schemaTypes'
 import {structure} from './structure'
 
@@ -22,7 +27,7 @@ export default defineConfig({
 
   schema: {
     types: schemaTypes,
-    templates: (prev) => [...prev, ...responsibilityTemplates],
+    templates: (prev) => [...prev, ...responsibilityTemplates, ...articleTemplates],
   },
 
   document: {

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -1,7 +1,12 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
-import {LinkToPsdAction, launcherTool, responsibilityTemplates} from '@kcvv/sanity-studio'
+import {
+  LinkToPsdAction,
+  launcherTool,
+  responsibilityTemplates,
+  articleTemplates,
+} from '@kcvv/sanity-studio'
 import {schemaTypes} from './schemaTypes'
 import {structure} from './structure'
 
@@ -18,7 +23,7 @@ export default defineConfig({
 
   schema: {
     types: schemaTypes,
-    templates: (prev) => [...prev, ...responsibilityTemplates],
+    templates: (prev) => [...prev, ...responsibilityTemplates, ...articleTemplates],
   },
 
   document: {

--- a/packages/sanity-schemas/src/article.ts
+++ b/packages/sanity-schemas/src/article.ts
@@ -19,11 +19,22 @@ export const article = defineType({
       by: [{ field: "publishedAt", direction: "asc" }],
     },
   ],
+  // Editor-UX rework groups (#1501). `type` is the default tab — the editor
+  // picks the article type first, which drives which conditional fields show.
+  groups: [
+    { name: "type", title: "Type", default: true },
+    { name: "inhoud", title: "Inhoud" },
+    { name: "publicatie", title: "Publicatie" },
+    { name: "gerelateerd", title: "Gerelateerd" },
+  ],
   fields: [
     defineField({
       name: "articleType",
       title: "Article type",
       type: "string",
+      group: "type",
+      description:
+        "Bepaalt de vorm van het artikel: welke velden verschijnen en hoe de pagina rendert. Interview toont portretten + Q&A; Transfer en Event vragen een fact-blok in de inhoud; Match preview/recap koppelt aan een wedstrijd. Kies dit eerst — de rest van het formulier past zich erop aan.",
       options: {
         list: [
           { title: "Interview", value: "interview" },
@@ -36,12 +47,18 @@ export const article = defineType({
         layout: "radio",
       },
       initialValue: "announcement",
-      validation: (r) => r.required(),
+      validation: (r) =>
+        r
+          .required()
+          .error(
+            "Verplicht. Zonder type weet de site niet hoe het artikel gerenderd moet worden en welke velden nodig zijn.",
+          ),
     }),
     defineField({
       name: "linkedMatch",
       title: "Linked match (preview/recap only)",
       type: "string",
+      group: "type",
       description:
         "PSD-wedstrijd-id — kopieer het uit de /wedstrijd/[matchId] URL. Verplicht voor match preview- en match recap-artikels.",
       hidden: ({ parent }) =>
@@ -68,9 +85,10 @@ export const article = defineType({
       name: "subjects",
       title: "Subjects (interview only)",
       type: "array",
+      group: "type",
       of: [{ type: "subject" }],
       description:
-        "Persons the interview is about. For duo/panel interviews, list 2–4. Drives the hero layout (N=1 single portrait / N=2 side-by-side / N=3 trio / N=4 2×2 grid), per-pair attribution on `key` and `quote` pairs, and JSON-LD metadata.",
+        "Personen waarover het interview gaat. Voor duo-/panelinterviews voeg je er 2–4 toe. Bepaalt de hero-lay-out (1 = enkel portret, 2 = naast elkaar, 3 = trio, 4 = 2×2-raster), de attributie per persoon op 'key'- en 'quote'-paren, en de JSON-LD-metadata.",
       hidden: ({ parent }) => parent?.articleType !== "interview",
       validation: (r) =>
         r.custom((subjects, ctx) =>
@@ -83,6 +101,7 @@ export const article = defineType({
       name: "title",
       title: "Title",
       type: "array",
+      group: "inhoud",
       description:
         "Houd de titel kort en krachtig (richtlijn: ~60 tekens). Selecteer één woord en klik op 'Accent' voor de groene cursief. Op de homepagina wordt de titel na 3 regels afgekapt met een ellipsis.",
       // Constrained Portable Text — single block, no styles, no
@@ -104,6 +123,9 @@ export const article = defineType({
       validation: (r) =>
         r
           .required()
+          .error(
+            "Verplicht. Zonder titel heeft het artikel geen kop op de pagina en kan er geen slug gegenereerd worden.",
+          )
           .max(1)
           .custom((blocks) => {
             const arr = blocks as
@@ -118,6 +140,7 @@ export const article = defineType({
       name: "lead",
       title: "Lead",
       type: "string",
+      group: "inhoud",
       description:
         "Korte samenvatting boven het artikel — toont op homepage, news cards, hero, social shares. Laat leeg om de eerste alinea van de body te gebruiken. Richtlijn: ~280 tekens.",
       validation: (r) => r.max(280),
@@ -126,6 +149,7 @@ export const article = defineType({
       name: "author",
       title: "Auteur (Door)",
       type: "string",
+      group: "inhoud",
       description:
         "Naam van de schrijver. Wordt getoond in de byline boven het artikel en in het ArticleCredits-blok onderaan. Optioneel — bij interviews en lange stukken aanbevolen.",
     }),
@@ -133,6 +157,7 @@ export const article = defineType({
       name: "photographer",
       title: "Fotograaf (Beeld)",
       type: "string",
+      group: "inhoud",
       description:
         "Naam van de fotograaf. Wordt getoond in het ArticleCredits-blok onderaan. Optioneel — bij interviews, evenementenverslagen en toekomstige fotogalerijen vermelden.",
     }),
@@ -140,34 +165,64 @@ export const article = defineType({
       name: "slug",
       title: "Slug",
       type: "slug",
+      group: "publicatie",
+      description:
+        "De URL van het artikel (bijv. /nieuws/jouw-titel). Klik 'Generate' om hem uit de titel te maken. Wijzig hem niet meer nadat het artikel gepubliceerd en gedeeld is — bestaande links breken anders.",
       options: { source: "title" },
-      validation: (r) => r.required(),
+      validation: (r) =>
+        r
+          .required()
+          .error(
+            "Verplicht. Zonder slug heeft het artikel geen URL en is het niet bereikbaar op de site.",
+          ),
     }),
-    defineField({ name: "publishedAt", title: "Published at", type: "datetime" }),
+    defineField({
+      name: "publishedAt",
+      title: "Published at",
+      type: "datetime",
+      group: "publicatie",
+      description:
+        "Publicatiedatum en -tijd. Bepaalt de volgorde in nieuwsoverzichten (nieuwste eerst) en de datum in de byline. Laat leeg tot je effectief wil publiceren.",
+    }),
     defineField({
       name: "unpublishAt",
       title: "Unpublish at",
       type: "datetime",
+      group: "publicatie",
+      description:
+        "Optioneel: datum waarop het artikel automatisch van de site verdwijnt. Handig voor tijdelijke aankondigingen. Laat leeg om het artikel online te houden.",
     }),
     defineField({
       name: "featured",
       title: "Featured",
       type: "boolean",
+      group: "publicatie",
+      description:
+        "Zet aan om dit artikel uit te lichten (groter op de homepage / bovenaan overzichten). Gebruik spaarzaam — als alles uitgelicht is, valt niets meer op.",
       initialValue: false,
     }),
     defineField({
       name: "coverImage",
       title: "Cover image",
       type: "image",
+      group: "inhoud",
       description:
         "Verplichte cover-afbeelding (16:9 landschap). Wordt overal gebruikt — homepage, news cards, hero, social shares. Eén upload per artikel.",
       options: { hotspot: true },
-      validation: (r) => r.required(),
+      validation: (r) =>
+        r
+          .required()
+          .error(
+            "Verplicht. De cover-afbeelding wordt overal getoond (homepage, kaarten, hero, social shares) — zonder cover oogt het artikel onaf.",
+          ),
     }),
     defineField({
       name: "tags",
       title: "Tags",
       type: "array",
+      group: "inhoud",
+      description:
+        "Trefwoorden voor filtering en gerelateerde artikels (bijv. 'eerste elftal', 'jeugd'). Typ een woord en druk op Enter. Optioneel, maar helpt lezers verwante artikels te vinden.",
       of: [{ type: "string" }],
       options: { layout: "tags" },
     }),
@@ -175,6 +230,9 @@ export const article = defineType({
       name: "body",
       title: "Body",
       type: "array",
+      group: "inhoud",
+      description:
+        "De volledige inhoud van het artikel. Gebruik het + menu om naast tekst ook beelden, video, Q&A en tabellen toe te voegen. Een event-artikel heeft minstens één Event-fact nodig, een transfer-artikel minstens één Transfer-fact; bij interviews structureer je met Q&A-paren en -secties.",
       // articleType=event requires ≥1 eventFact block, articleType=transfer
       // requires ≥1 transferFact block. Hero has nothing to render without
       // it. Spec: fields.md Ask 6.
@@ -260,12 +318,16 @@ export const article = defineType({
       name: "relatedArticles",
       title: "Related articles",
       type: "array",
+      group: "gerelateerd",
+      description:
+        "Optioneel: artikels die je expliciet onderaan wil tonen als 'lees ook'. Voor een bredere mix (spelers, teams, evenementen) gebruik je 'Related content' hieronder.",
       of: [{ type: "reference", to: [{ type: "article" }] }],
     }),
     defineField({
       name: "metaDescription",
       title: "Meta description",
       type: "string",
+      group: "publicatie",
       description: "Overschrijving voor SEO meta-omschrijving en OG-omschrijving (max. 160 tekens).",
       validation: (r) => r.max(160),
     }),
@@ -273,12 +335,14 @@ export const article = defineType({
       name: "ogImage",
       title: "OG image",
       type: "image",
+      group: "publicatie",
       description: "Optionele overschrijving voor de Open Graph-afbeelding. Valt terug op de omslagafbeelding.",
       options: { hotspot: true },
     }),
     defineField({
       name: "relatedContent",
       title: "Related content",
+      group: "gerelateerd",
       description:
         "Curated mix van gerelateerde items naast het artikel. Pick artikels, spelers, teams, staf of evenementen die je expliciet wil tonen. Curated picks winnen van automatisch afgeleide vermeldingen uit de body (geen dubbele kaarten). Houd het kort — max 8.",
       type: "array",

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -19,5 +19,5 @@ export {responsibilityStructure} from './structure/responsibility'
 // `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.
 // Internal callers reach them via the `./tools/launcher` subpath instead.
 export {launcherTool} from './tools/launcher'
-export {responsibilityTemplates} from './templates'
+export {responsibilityTemplates, articleTemplates} from './templates'
 export type {LauncherTemplate} from './templates'

--- a/packages/sanity-studio/src/schema/article-editor-ux.test.ts
+++ b/packages/sanity-studio/src/schema/article-editor-ux.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from 'vitest'
+
+import {article} from '@kcvv/sanity-schemas'
+
+// Guards the editor-UX rework convention (#1501) on the article doc type:
+// four field groups, every field grouped, every field teaching-described.
+const EXPECTED_GROUPS = ['type', 'inhoud', 'publicatie', 'gerelateerd']
+
+type FieldShape = {name: string; group?: unknown; description?: unknown}
+type GroupShape = {name: string; default?: boolean}
+
+const groups = (article.groups ?? []) as GroupShape[]
+const fields = (article.fields ?? []) as FieldShape[]
+
+describe('article editor-UX rework (#1501)', () => {
+  it('declares the four rework groups in order', () => {
+    expect(groups.map((g) => g.name)).toEqual(EXPECTED_GROUPS)
+  })
+
+  it('marks exactly one group as the default', () => {
+    expect(groups.filter((g) => g.default === true)).toHaveLength(1)
+  })
+
+  it('assigns every field to one of the rework groups', () => {
+    for (const f of fields) {
+      expect(EXPECTED_GROUPS, `field "${f.name}" group`).toContain(f.group)
+    }
+  })
+
+  it('gives every field a non-empty teaching description', () => {
+    for (const f of fields) {
+      expect(typeof f.description, `field "${f.name}" description type`).toBe('string')
+      expect((f.description as string).trim().length, `field "${f.name}" description`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/sanity-studio/src/templates/article-templates.test.ts
+++ b/packages/sanity-studio/src/templates/article-templates.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest'
+
+import {articleTemplates} from './article-templates'
+import {isLauncherTemplate} from './types'
+
+// One launcher card per editorial articleType an editor hand-creates.
+// matchPreview/matchRecap are generated from match data, not launched here.
+const EXPECTED: Record<string, string> = {
+  'article-interview': 'interview',
+  'article-announcement': 'announcement',
+  'article-transfer': 'transfer',
+  'article-event': 'event',
+}
+
+describe('articleTemplates (#1501)', () => {
+  it('exports exactly the four hand-created article types in order', () => {
+    expect(articleTemplates.map((t) => t.id)).toEqual(Object.keys(EXPECTED))
+  })
+
+  it('targets the article schema type', () => {
+    for (const t of articleTemplates) {
+      expect(t.schemaType, t.id).toBe('article')
+    }
+  })
+
+  it('seeds ONLY articleType — no editorial-content prefill (per D6)', () => {
+    for (const t of articleTemplates) {
+      const value = t.value as Record<string, unknown>
+      expect(Object.keys(value), t.id).toEqual(['articleType'])
+      expect(value.articleType, t.id).toBe(EXPECTED[t.id])
+    }
+  })
+
+  it('is launcher-eligible under the Articles group with a ≤100-char description', () => {
+    for (const t of articleTemplates) {
+      expect(isLauncherTemplate(t), t.id).toBe(true)
+      expect(t.ui.group, t.id).toBe('Articles')
+      expect(t.ui.description.trim().length, t.id).toBeGreaterThan(0)
+      expect(t.ui.description.length, t.id).toBeLessThanOrEqual(100)
+    }
+  })
+})

--- a/packages/sanity-studio/src/templates/article-templates.ts
+++ b/packages/sanity-studio/src/templates/article-templates.ts
@@ -1,0 +1,58 @@
+import type {LauncherTemplate} from './types'
+
+/**
+ * Phase 3 launcher manifest for `article` (#1501).
+ *
+ * One card per editorial `articleType` an editor hand-creates. The two
+ * data-driven types (`matchPreview` / `matchRecap`) are generated from match
+ * data, not launched here, so they get no card. Per design decision D6 each
+ * template seeds ONLY `articleType` — the field that changes the form's shape
+ * (which groups/fields show) — and never any editorial-content prefill; the
+ * card copy is the teaching moment.
+ */
+export const articleTemplates: LauncherTemplate[] = [
+  {
+    id: 'article-interview',
+    title: 'Nieuw interview',
+    schemaType: 'article',
+    value: {articleType: 'interview'},
+    ui: {
+      icon: 'mic',
+      description: 'Vraaggesprek met één of meer spelers/staf — toont portretten en Q&A.',
+      group: 'Articles',
+    },
+  },
+  {
+    id: 'article-announcement',
+    title: 'Nieuwe aankondiging',
+    schemaType: 'article',
+    value: {articleType: 'announcement'},
+    ui: {
+      icon: 'megaphone',
+      description: 'Algemeen clubnieuws of mededeling — de standaard artikelvorm.',
+      group: 'Articles',
+    },
+  },
+  {
+    id: 'article-transfer',
+    title: 'Nieuwe transfer',
+    schemaType: 'article',
+    value: {articleType: 'transfer'},
+    ui: {
+      icon: 'arrow-left-right',
+      description: 'Komst, vertrek of verlenging van een speler — vraagt een Transfer-fact.',
+      group: 'Articles',
+    },
+  },
+  {
+    id: 'article-event',
+    title: 'Nieuw event',
+    schemaType: 'article',
+    value: {articleType: 'event'},
+    ui: {
+      icon: 'calendar',
+      description: 'Verslag of aankondiging van een clubevenement — vraagt een Event-fact.',
+      group: 'Articles',
+    },
+  },
+]

--- a/packages/sanity-studio/src/templates/index.ts
+++ b/packages/sanity-studio/src/templates/index.ts
@@ -1,3 +1,4 @@
 export type {LauncherTemplate, LauncherTemplateUi} from './types'
 export {isLauncherTemplate} from './types'
 export {responsibilityTemplates} from './responsibility-templates'
+export {articleTemplates} from './article-templates'


### PR DESCRIPTION
Closes #1501

Phase 3 of the `sanity-studio-editor-ux-rework` milestone: applies the **shipped `responsibility` convention** (inline groups + teaching `description` + `.error()` + launcher IVTs) to the `article` doc type — the most complex consumer, proving the convention generalizes. This is the keystone that unblocks #1502 → the rest of the milestone.

## Changes

**`packages/sanity-schemas/src/article.ts`**
- Declares 4 field groups: `type` (default) / `inhoud` / `publicatie` / `gerelateerd`. Every one of the 18 fields is assigned to a group (3 / 7 / 6 / 2).
- Teaching Dutch `description` on **every** field (8 newly added: `articleType`, `slug`, `publishedAt`, `unpublishAt`, `featured`, `tags`, `body`, `relatedArticles`; `subjects` translated EN→NL).
- Teaching `.error(...)` on every required rule: `articleType`, `title`, `slug`, `coverImage`.
- Existing `articleType`-driven `hidden:` conditions (`linkedMatch`, `subjects`) preserved.

**`packages/sanity-studio/src/templates/article-templates.ts`** (new)
- 4 launcher IVTs — `article-interview` / `article-announcement` / `article-transfer` / `article-event` — each seeding **only** `articleType` (per D6, no editorial-content prefill), grouped under `Articles`. `matchPreview`/`matchRecap` stay data-driven (generated from match data) so they get no card.
- Exported via the `templates` + package barrels; registered in **both** `apps/studio` and `apps/studio-staging` `sanity.config.ts`.

**Tests** (new, in `@kcvv/sanity-studio` — `@kcvv/sanity-schemas` has no test runner)
- `templates/article-templates.test.ts` — ids/order, schemaType, seeds-only-`articleType`, launcher-eligibility + ≤100-char description.
- `schema/article-editor-ux.test.ts` — group order, exactly one default, every field grouped + non-empty description.

## Scope notes

- The 2026-06-19 re-spec dropped the PRD's `GuidedSidebar` / `withPlaceholder` / `*-guidance.ts` / `section-intro` bullets (GuidedSidebar is now #2180). This PR follows the inline `responsibility` pattern only.
- The AC's "new-since-April fields covered" — `linkedMatch`/`subjects` are top-level (grouped + described); the inline body blocks (`eventFact`/`qaSectionDivider`/`qaPair`) already carry teaching descriptions on their own fields, and the `body` field is grouped under `inhoud` with a description naming them. No scope-creep into the 5 block-type files.

## Testing

- `pnpm --filter @kcvv/sanity-studio check-all` — type-check + lint + **191 tests** pass (8 new).
- `pnpm --filter @kcvv/sanity-schemas type-check` — pass.
- `@kcvv/studio` + `@kcvv/studio-staging` lint — pass. (Neither app defines a `check-all` script; the issue's `@kcvv/studio check-all` maps to their available checks.)
- `sanity schema extract` on `apps/studio` — exit 0, the full schema graph (groups + template wiring) loads.
- Pre-PR review gate (`/code-review` + `/simplify` equivalents) ran against the branch diff — **no findings**; the diff faithfully mirrors the `responsibility` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added article creation templates for multiple article types (interview, announcement, transfer, event) accessible via the launcher
  * Reorganized article editor with grouped field sections for improved user experience and easier content management
  * Enhanced validation with clearer, contextual error messages for article fields including title and related content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->