### PR TITLE
docs(studio): editor-ux rework conventions + propagation checklist (#1502)

### DIFF
--- a/apps/studio-staging/sanity.config.ts
+++ b/apps/studio-staging/sanity.config.ts
@@ -4,8 +4,7 @@ import {visionTool} from '@sanity/vision'
 import {
   LinkToPsdAction,
   launcherTool,
-  responsibilityTemplates,
-  articleTemplates,
+  launcherTemplates,
   guidedSidebarInspectors,
 } from '@kcvv/sanity-studio'
 import {schemaTypes} from './schemaTypes'
@@ -28,7 +27,7 @@ export default defineConfig({
 
   schema: {
     types: schemaTypes,
-    templates: (prev) => [...prev, ...responsibilityTemplates, ...articleTemplates],
+    templates: (prev) => [...prev, ...launcherTemplates],
   },
 
   document: {

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -4,8 +4,7 @@ import {visionTool} from '@sanity/vision'
 import {
   LinkToPsdAction,
   launcherTool,
-  responsibilityTemplates,
-  articleTemplates,
+  launcherTemplates,
   guidedSidebarInspectors,
 } from '@kcvv/sanity-studio'
 import {schemaTypes} from './schemaTypes'
@@ -24,7 +23,7 @@ export default defineConfig({
 
   schema: {
     types: schemaTypes,
-    templates: (prev) => [...prev, ...responsibilityTemplates, ...articleTemplates],
+    templates: (prev) => [...prev, ...launcherTemplates],
   },
 
   document: {

--- a/packages/sanity-schemas/CLAUDE.md
+++ b/packages/sanity-schemas/CLAUDE.md
@@ -66,6 +66,56 @@ New schemas must adopt the closest semantic match from this list. Never invent a
 - Write `description` for any field whose purpose or constraints aren't obvious from name + type
 - Write descriptions in Dutch when they are editor-facing UI copy; write in English for developer-facing intent
 
+## Editor-UX Convention (Editor-UX Rework)
+
+The editor-UX rework (`docs/prd/sanity-studio-editor-ux-rework.md`) gives every reworked document type three schema-side ingredients. The pattern shipped on `responsibility` (#1499/#1500) and `article` (#1501); copy from `responsibility.ts` when reworking a new type. There are **no** `withPlaceholder` / `sectionIntro` / `*-guidance.ts` abstractions — guidance lives entirely in inline `description` + `.error(...)` copy. (The optional guided inspector is a separate, layered feature — see `packages/sanity-studio` `GuidedSidebar` / #2180 — not a schema concern.)
+
+### 1. Field groups — one `default: true`
+
+Declare `groups` on the document and assign every field a `group`. Exactly one group is `default: true` — make it the tab the editor should land on first (often the one whose value drives `hidden:` conditions, e.g. `responsibility` defaults to `vraag`, `article` to `type`).
+
+```typescript
+groups: [
+  {name: 'vraag', title: 'Vraag', default: true},
+  {name: 'antwoord', title: 'Antwoord'},
+  {name: 'meta', title: 'Meta'},
+],
+```
+
+### 2. Teaching `description` — 1–3 Dutch sentences
+
+Every field whose purpose isn't self-evident gets a Dutch `description` of **1–3 sentences** covering: **what** the field is, a **concrete example**, and the **public-site impact** of the choice. This is editor-facing UI copy, so it is always Dutch (English is for developer-facing intent only — see `Descriptions` above).
+
+### 3. Teaching `.error(...)` on required rules
+
+Every `Rule.required()` carries an `.error('…')` written to teach, not to scold: state that it's required **and why** / what breaks on the site without it. Start with `Verplicht.` and follow with the consequence.
+
+### Good / bad example pair
+
+```typescript
+// GOOD — group, teaching description (what + example + site impact), teaching error
+defineField({
+  name: "question",
+  title: "Question",
+  type: "string",
+  group: "vraag",
+  description:
+    'De vraag in spreektaal, zoals een gebruiker hem zou typen (bijv. "heb een ongeval op training"). Lowercase, geen punt op het einde. Dit is de tekst die getoond wordt in zoekresultaten op de site.',
+  validation: (Rule) =>
+    Rule.required().error(
+      "Verplicht. Zonder vraag verschijnt dit info-pad niet in zoekresultaten — gebruikers kunnen het dan niet vinden.",
+    ),
+});
+
+// BAD — no group, no description, generic non-teaching error
+defineField({
+  name: "question",
+  title: "Question",
+  type: "string",
+  validation: (Rule) => Rule.required(),
+});
+```
+
 ## Documents vs Objects
 
 - `type: "document"` — top-level content a Studio user creates/manages directly (article, player, team, sponsor, event, page…)

--- a/packages/sanity-studio/CLAUDE.md
+++ b/packages/sanity-studio/CLAUDE.md
@@ -51,11 +51,15 @@ Custom Studio Tools live under `src/tools/<name>/`. Each Tool exports:
 
 The `✨ Create` card grid in the top nav. Reads launcher-eligible templates from the workspace via `useTemplates()` and dispatches `router.navigateIntent('create', { type, template })` when an editor picks a card. Sanity routes the intent to a new draft seeded by the template's `value`.
 
+**When a doc type earns a launcher card (IVT):** add one only when there is **shape variation worth seeding** — a field whose value changes which groups/fields the form shows (e.g. `article`'s `articleType` → 4 cards), or a single zero-prefill card that is the teaching on-ramp for a hand-created type (e.g. `responsibility`). **Skip** singletons (`homePage`, `jeugdLandingPage`) and data-driven / rarely-created types (`matchPreview`/`matchRecap` are generated from match data) — those keep working through Sanity's default `+ Create` button.
+
 **Adding a launcher card** for an existing schema type:
 
-1. Create or edit `src/templates/<schemaType>-templates.ts` and export a `<schemaType>Templates: LauncherTemplate[]` constant. Each entry needs `id`, `title`, `schemaType`, `value` (zero-prefill `{}` unless seeding form-shape fields like `articleType`), and a `ui` block (`icon`, Dutch ≤100-char `description`, `group`).
-2. Re-export the manifest from `src/templates/index.ts` and from the package barrel.
-3. Wire it into both studios' `sanity.config.ts` via `schema.templates: (prev) => [...prev, ...<schemaType>Templates]`.
+1. Create or edit `src/templates/<schemaType>-templates.ts` and export a `<schemaType>Templates: LauncherTemplate[]` constant. Each entry needs `id`, `title`, `schemaType`, `value` (zero-prefill `{}` unless seeding form-shape fields like `articleType` — per design decision D6, **never** prefill editorial content), and a `ui` block (`icon`, Dutch ≤100-char `description`, `group`).
+2. Re-export the manifest from `src/templates/index.ts`, **append it to the `launcherTemplates` aggregate** in that same file, and re-export it from the package barrel.
+3. **No `sanity.config.ts` edit.** Both studios register the grid once via `schema.templates: (prev) => [...prev, ...launcherTemplates]`, so appending to the aggregate (step 2) is the only registration step.
+
+The `ui.icon` is a **Lucide icon name string** (kebab-case, e.g. `'mic'`, `'help-circle'`, `'arrow-left-right'`) — the same vocabulary the public site uses. It is currently stored on the template but not yet rendered on the card (the icon slot lands with the icon-name registry); set it correctly now so cards light up when it ships. Do **not** use `@sanity/icons` PascalCase component names here — those are for Tool/Action `icon` slots (e.g. `launcherTool`'s `ComposeSparklesIcon`), not the launcher card `ui.icon`.
 
 **Filtering rules** (enforced by `filterLauncherTemplates`):
 
@@ -67,8 +71,10 @@ The pure filter (`filterLauncherTemplates`) lives in its own file separate from 
 ## Custom Inputs
 
 - One input component per file in `src/inputs/`
-- Pair each component with an `apply-<input>.ts` file that exports the `components` patch used in `defineField` — keeps registration decoupled from the component
+- Pair each component with an `apply-<input>.ts` helper that takes `schemaTypes` and returns a copy with the component grafted onto a specific field's `components.input` — non-mutating, a safe no-op when the target type/field is absent. This keeps `@kcvv/sanity-schemas` React-free: the schema declares a plain field, the graft happens in `src/schema-types.ts` where all `apply-*` helpers compose (`applyRespondentPicker(applyArticleTagsInput(baseSchemaTypes, …), …)`).
 - Export both the component and the apply helper from `src/inputs/index.ts`, then re-export from the package barrel
+
+**Person / contact references:** reuse **`RespondentPicker`** instead of a raw `reference` input. It is grafted onto the target field via `applyRespondentPicker` in `schema-types.ts` (see above) — the schema keeps a plain field, so no React leaks into `@kcvv/sanity-schemas` and no per-studio config edit is needed.
 
 ## Structure Builders
 
@@ -100,6 +106,27 @@ Everything public is exported by name from `src/index.ts`. Rules:
 - Export types with `export type { ... }` to avoid runtime leakage
 - No default exports from the barrel — named only
 - **Migrations are an exception**: they live in the separate `src/migrations/index.ts` sub-barrel (consumed as `@kcvv/sanity-studio/migrations`). See the **Migrations** section below for why mixing them into the root barrel breaks the deployed Studio
+
+## Editor-UX Rework — Adding a New Doc Type (Checklist)
+
+Used verbatim by the Phase 5+ propagation issues (#1503–#1511, #2181). Everything below lands **once** in `@kcvv/sanity-schemas` / `@kcvv/sanity-studio` and applies to **both** studios — there is **no** per-studio `sanity.config.ts` step. Copy the shipped `responsibility` / `article` types as the reference.
+
+**Schema** (`packages/sanity-schemas/src/<type>.ts` — see that package's CLAUDE.md "Editor-UX Convention"):
+
+1. [ ] Declare `groups` with exactly one `default: true`; assign every field a `group`.
+2. [ ] Give every non-obvious field a 1–3 sentence Dutch teaching `description` (what + concrete example + public-site impact).
+3. [ ] Give every `Rule.required()` a teaching `.error('Verplicht. …')` stating what breaks on the site without it.
+4. [ ] For person/contact references, leave the field plain — it gets the `RespondentPicker` graft (step 6), not a raw `reference` input.
+
+**Studio** (`packages/sanity-studio/`):
+
+5. [ ] **Launcher card (only if earned):** if the type has shape variation worth seeding (or is a hand-created singleton-on-ramp), add `src/templates/<type>-templates.ts`, re-export it from `src/templates/index.ts`, **append it to the `launcherTemplates` aggregate**, and re-export from the barrel. `value` seeds only form-shape fields (never editorial content); `ui.icon` is a Lucide name string. Skip for singletons / data-driven types.
+6. [ ] **Custom inputs (if any):** graft via an `apply-<input>.ts` helper composed in `src/schema-types.ts` (reuse `RespondentPicker` for contacts). Schema stays React-free.
+
+**Verify:**
+
+7. [ ] `pnpm --filter @kcvv/sanity-studio check-all` and `pnpm --filter @kcvv/studio check-all` pass.
+8. [ ] Manual smoke against the staging dataset: create the type (via launcher if it has a card), confirm groups/descriptions/errors render, publish.
 
 ## No Duplication With Root CLAUDE.md
 

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -19,7 +19,7 @@ export {responsibilityStructure} from './structure/responsibility'
 // `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.
 // Internal callers reach them via the `./tools/launcher` subpath instead.
 export {launcherTool} from './tools/launcher'
-export {responsibilityTemplates, articleTemplates} from './templates'
+export {launcherTemplates, responsibilityTemplates, articleTemplates} from './templates'
 export type {LauncherTemplate} from './templates'
 export {guidedSidebarInspectors, guidedSidebarInspector} from './inspectors'
 export type {GuideEntry} from './inspectors'

--- a/packages/sanity-studio/src/templates/index.ts
+++ b/packages/sanity-studio/src/templates/index.ts
@@ -1,4 +1,16 @@
+import type {LauncherTemplate} from './types'
+import {responsibilityTemplates} from './responsibility-templates'
+import {articleTemplates} from './article-templates'
+
 export type {LauncherTemplate, LauncherTemplateUi} from './types'
 export {isLauncherTemplate} from './types'
 export {responsibilityTemplates} from './responsibility-templates'
 export {articleTemplates} from './article-templates'
+
+/**
+ * Every launcher manifest, concatenated. Both studios register the launcher
+ * grid with a single `templates: (prev) => [...prev, ...launcherTemplates]`
+ * spread, so adding a new doc type's cards means appending its manifest here —
+ * never touching either `sanity.config.ts`. Keep this in `schemaTypes` order.
+ */
+export const launcherTemplates: LauncherTemplate[] = [...responsibilityTemplates, ...articleTemplates]

--- a/packages/sanity-studio/src/templates/launcher-templates.test.ts
+++ b/packages/sanity-studio/src/templates/launcher-templates.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest'
+import {launcherTemplates, responsibilityTemplates, articleTemplates, isLauncherTemplate} from './index'
+
+describe('launcherTemplates aggregate', () => {
+  it('contains every per-schema manifest so both studios register templates with one spread', () => {
+    expect(launcherTemplates).toEqual([...responsibilityTemplates, ...articleTemplates])
+  })
+
+  it('exposes only launcher-eligible templates', () => {
+    expect(launcherTemplates.length).toBeGreaterThan(0)
+    expect(launcherTemplates.every(isLauncherTemplate)).toBe(true)
+  })
+
+  it('has unique template ids', () => {
+    const ids = launcherTemplates.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})


### PR DESCRIPTION
Closes #1502

Phase 4 of the editor-UX rework. Documents the convention that `responsibility` (#1499/#1500) and `article` (#1501) **actually shipped**, so the Phase 5+ propagation issues (#1503–#1511, #2181) are mechanical instead of re-deriving conventions each time.

## Changes

**Docs**
- `packages/sanity-schemas/CLAUDE.md` — "Editor-UX Convention": field **groups** (one `default: true`), teaching **`description`** copy (1–3 Dutch sentences = what + concrete example + public-site impact), teaching **`.error(...)`** on required rules, with a good/bad example pair. Explicitly notes the dropped abstractions (`withPlaceholder` / `sectionIntro` / `*-guidance.ts`) are **not** convention.
- `packages/sanity-studio/CLAUDE.md` — launcher-IVT convention (when a type earns a card; skip singletons + data-driven types), the `ui.icon` field, `RespondentPicker` graft via `schema-types.ts`, and the verbatim **"add a new doc type to the rework" checklist**.

**Generalization debt retired (the one piece that made the "no per-studio config step" claim untrue)**
- Launcher manifests were spread individually in **both** `sanity.config.ts` (`...responsibilityTemplates, ...articleTemplates`) — adding a new doc type meant editing both configs. Added a `launcherTemplates` aggregate so both studios register the grid once (`...launcherTemplates`); new doc types now only touch `@kcvv/sanity-studio`. Added a regression test for the aggregate.

## Decisions / discrepancies vs the issue text

- **`ui.icon` is a Lucide name string, not `@sanity/icons`.** The issue AC said "`@sanity/icons` `icon` name field", but the shipped `types.ts` JSDoc + actual manifest values (`'mic'`, `'help-circle'`, `'arrow-left-right'`) are kebab-case Lucide names — the same vocabulary the public site uses. `@sanity/icons` PascalCase components are used for Tool/Action icon slots (e.g. `launcherTool`'s `ComposeSparklesIcon`), not card `ui.icon`. Documented the shipped reality, per the re-spec note ("document the pattern `responsibility` actually shipped").
- **`@kcvv/studio` has no `check-all` script** (only `lint`/`build`/`typegen`/`schema:extract`), so the AC's `pnpm --filter @kcvv/studio check-all` can't run as written. Validated the config change with the scripts that exist instead (see Testing). Did not add a `check-all` script — out of scope.

## Testing

- `pnpm --filter @kcvv/sanity-studio check-all` — type-check + lint + 199 tests pass (incl. new aggregate test)
- `pnpm --filter @kcvv/studio --filter @kcvv/studio-staging lint` — pass
- `pnpm --filter @kcvv/studio build` — production studio compiles `sanity.config.ts` + resolves the aggregate (10.6s)
- Pre-PR review gate (`/code-review` high + `/simplify`): clean — no findings (diff is docs + a duplication-removing aggregate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive editor UX conventions for schema authoring with Dutch field descriptions and validation guidance.
  * Updated guidance for adding new document types and custom inputs with step-by-step checklists.

* **Chores**
  * Reorganized template management across studio environments for centralized handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->