### PR TITLE
feat(studio): editor-ux rework — sponsor (#1506)

### DIFF
--- a/packages/sanity-schemas/src/sponsor.ts
+++ b/packages/sanity-schemas/src/sponsor.ts
@@ -4,25 +4,43 @@ export const sponsor = defineType({
   name: 'sponsor',
   title: 'Sponsor',
   type: 'document',
+  // Editor-UX rework groups (#1506). `sponsor` is the default tab — the editor
+  // fills in identity first, then how/where it shows, links, and SEO.
+  groups: [
+    {name: 'sponsor', title: 'Sponsor', default: true},
+    {name: 'weergave', title: 'Tier & weergave'},
+    {name: 'links', title: 'Links'},
+    {name: 'seo', title: 'SEO'},
+  ],
   fields: [
     defineField({
       name: 'name',
       title: 'Name',
       type: 'string',
-      validation: (r) => r.required(),
+      group: 'sponsor',
+      description:
+        'De officiële naam van de sponsor zoals die zelf geschreven wordt (bijv. "Garage Janssens"). Wordt als bijschrift onder het logo en als alt-tekst getoond — zonder naam is de sponsor niet identificeerbaar.',
+      validation: (r) =>
+        r.required().error(
+          'Verplicht. Zonder naam heeft het logo geen bijschrift of alt-tekst en is de sponsor niet identificeerbaar op de site.',
+        ),
     }),
     defineField({
       name: 'logo',
       title: 'Logo',
       type: 'image',
+      group: 'sponsor',
+      description:
+        'Het logo van de sponsor, liefst met transparante achtergrond (PNG of SVG). Wordt in het sponsoroverzicht standaard in grijswaarden getoond en kleurt volledig in bij hover. Zonder logo valt de weergave terug op enkel de naam.',
       options: {hotspot: true},
     }),
-    defineField({name: 'url', title: 'Website', type: 'url'}),
     defineField({
       name: 'tier',
       title: 'Tier',
-      description: 'Selecteer het sponsorniveau. Bestaande sponsors zonder tier moeten bij bewerking een tier krijgen.',
       type: 'string',
+      group: 'weergave',
+      description:
+        'Bepaalt waar en hoe prominent de sponsor verschijnt: "Hoofdsponsor" en "Sponsor" komen op de homepage, "Sympathisant" enkel op de sponsorpagina. Kies het niveau dat overeenkomt met het sponsorcontract.',
       options: {
         list: [
           {title: 'Hoofdsponsor', value: 'hoofdsponsor'},
@@ -30,26 +48,45 @@ export const sponsor = defineType({
           {title: 'Sympathisant', value: 'sympathisant'},
         ],
       },
-      validation: (r) => r.warning('Gelieve een tier te selecteren'),
+      validation: (r) =>
+        r.warning(
+          'Kies een sponsorniveau — zonder tier verschijnt de sponsor niet in de tier-gebaseerde secties (homepage en sponsoroverzicht).',
+        ),
     }),
     defineField({
       name: 'featured',
       title: 'Featured',
-      description: 'Highlight this sponsor in the spotlight section',
       type: 'boolean',
+      group: 'weergave',
+      description:
+        'Zet aan om deze sponsor uit te lichten in de spotlight-sectie op de homepage. Gebruik spaarzaam: meerdere uitgelichte sponsors verdelen de aandacht. Standaard uit.',
       initialValue: false,
+    }),
+    defineField({
+      name: 'active',
+      title: 'Active',
+      type: 'boolean',
+      group: 'weergave',
+      description:
+        'Laat aan om de sponsor zichtbaar te houden op de site. Zet uit om de sponsor tijdelijk te verbergen zonder hem te verwijderen — bijvoorbeeld wanneer een contract afloopt.',
+      initialValue: true,
     }),
     defineField({
       name: 'description',
       title: 'Spotlight description',
-      description: 'Optional tekst die getoond wordt in de spotlight sectie (bv. "Leverde de matchbal voor de wedstrijd van 12 april")',
       type: 'text',
       rows: 3,
+      group: 'weergave',
+      description:
+        'Optionele tekst die in de spotlight-sectie naast het logo verschijnt (bijv. "Leverde de matchbal voor de wedstrijd van 12 april"). Enkel zichtbaar wanneer de sponsor uitgelicht is. Houd het bij één of twee zinnen.',
     }),
     defineField({
       name: 'type',
       title: 'Type (legacy)',
       type: 'string',
+      group: 'weergave',
+      description:
+        'Legacy categorisatie uit de vorige site — verborgen en niet meer gerenderd. Behouden zodat historische data niet breekt; mag weg na een opschoonmigratie.',
       options: {
         list: [
           {title: 'Crossing', value: 'crossing'},
@@ -63,23 +100,29 @@ export const sponsor = defineType({
       hidden: true,
     }),
     defineField({
-      name: 'active',
-      title: 'Active',
-      type: 'boolean',
-      initialValue: true,
+      name: 'url',
+      title: 'Website',
+      type: 'url',
+      group: 'links',
+      description:
+        'Optioneel: de website van de sponsor (bijv. "https://garagejanssens.be"). Maakt het logo klikbaar en opent in een nieuw tabblad. Laat leeg als de sponsor geen website heeft.',
     }),
     defineField({
       name: 'metaDescription',
       title: 'Meta description',
       type: 'string',
-      description: 'Override for SEO meta description and OG description (max 160 characters).',
+      group: 'seo',
+      description:
+        'Optionele SEO-omschrijving voor de sponsordetailpagina (max. 160 tekens). Verschijnt in Google-zoekresultaten en bij het delen op sociale media. Laat leeg om terug te vallen op een automatische omschrijving.',
       validation: (r) => r.max(160),
     }),
     defineField({
       name: 'ogImage',
       title: 'OG image',
       type: 'image',
-      description: 'Optional override for the Open Graph image. Falls back to the logo.',
+      group: 'seo',
+      description:
+        'Optionele afbeelding voor het delen op sociale media (Open Graph). Valt terug op het logo als dit leeg blijft. Gebruik bij voorkeur een liggende afbeelding van 1200×630 pixels.',
       options: {hotspot: true},
     }),
   ],

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -19,7 +19,7 @@ export {responsibilityStructure} from './structure/responsibility'
 // `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.
 // Internal callers reach them via the `./tools/launcher` subpath instead.
 export {launcherTool} from './tools/launcher'
-export {launcherTemplates, responsibilityTemplates, articleTemplates} from './templates'
+export {launcherTemplates, responsibilityTemplates, articleTemplates, sponsorTemplates} from './templates'
 export type {LauncherTemplate} from './templates'
 export {guidedSidebarInspectors, guidedSidebarInspector} from './inspectors'
 export type {GuideEntry} from './inspectors'

--- a/packages/sanity-studio/src/templates/index.ts
+++ b/packages/sanity-studio/src/templates/index.ts
@@ -1,11 +1,13 @@
 import type {LauncherTemplate} from './types'
 import {responsibilityTemplates} from './responsibility-templates'
 import {articleTemplates} from './article-templates'
+import {sponsorTemplates} from './sponsor-templates'
 
 export type {LauncherTemplate, LauncherTemplateUi} from './types'
 export {isLauncherTemplate} from './types'
 export {responsibilityTemplates} from './responsibility-templates'
 export {articleTemplates} from './article-templates'
+export {sponsorTemplates} from './sponsor-templates'
 
 /**
  * Every launcher manifest, concatenated. Both studios register the launcher
@@ -13,4 +15,8 @@ export {articleTemplates} from './article-templates'
  * spread, so adding a new doc type's cards means appending its manifest here —
  * never touching either `sanity.config.ts`. Keep this in `schemaTypes` order.
  */
-export const launcherTemplates: LauncherTemplate[] = [...responsibilityTemplates, ...articleTemplates]
+export const launcherTemplates: LauncherTemplate[] = [
+  ...responsibilityTemplates,
+  ...articleTemplates,
+  ...sponsorTemplates,
+]

--- a/packages/sanity-studio/src/templates/launcher-templates.test.ts
+++ b/packages/sanity-studio/src/templates/launcher-templates.test.ts
@@ -1,9 +1,15 @@
 import {describe, expect, it} from 'vitest'
-import {launcherTemplates, responsibilityTemplates, articleTemplates, isLauncherTemplate} from './index'
+import {
+  launcherTemplates,
+  responsibilityTemplates,
+  articleTemplates,
+  sponsorTemplates,
+  isLauncherTemplate,
+} from './index'
 
 describe('launcherTemplates aggregate', () => {
   it('contains every per-schema manifest so both studios register templates with one spread', () => {
-    expect(launcherTemplates).toEqual([...responsibilityTemplates, ...articleTemplates])
+    expect(launcherTemplates).toEqual([...responsibilityTemplates, ...articleTemplates, ...sponsorTemplates])
   })
 
   it('exposes only launcher-eligible templates', () => {

--- a/packages/sanity-studio/src/templates/sponsor-templates.test.ts
+++ b/packages/sanity-studio/src/templates/sponsor-templates.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, it} from 'vitest'
+
+import {sponsorTemplates} from './sponsor-templates'
+import {isLauncherTemplate} from './types'
+
+describe('sponsorTemplates (#1506)', () => {
+  it('exports a single zero-prefill sponsor-new card', () => {
+    expect(sponsorTemplates.map((t) => t.id)).toEqual(['sponsor-new'])
+    expect(sponsorTemplates[0].value).toEqual({})
+  })
+
+  it('targets the sponsor schema type', () => {
+    expect(sponsorTemplates[0].schemaType).toBe('sponsor')
+  })
+
+  it('is launcher-eligible under the Sponsors group with a ≤100-char description', () => {
+    const t = sponsorTemplates[0]
+    expect(isLauncherTemplate(t)).toBe(true)
+    expect(t.ui.group).toBe('Sponsors')
+    expect(t.ui.description.trim().length).toBeGreaterThan(0)
+    expect(t.ui.description.length).toBeLessThanOrEqual(100)
+  })
+})

--- a/packages/sanity-studio/src/templates/sponsor-templates.ts
+++ b/packages/sanity-studio/src/templates/sponsor-templates.ts
@@ -1,0 +1,23 @@
+import type {LauncherTemplate} from './types'
+
+/**
+ * Phase 5+ launcher manifest for `sponsor` (#1506).
+ *
+ * Sponsors are hand-created one at a time, so a single zero-prefill card is
+ * the teaching on-ramp — there is no form-shape variation to seed (per design
+ * decision D6, templates seed only shape-driving fields, never editorial
+ * content). The card copy is the teaching moment.
+ */
+export const sponsorTemplates: LauncherTemplate[] = [
+  {
+    id: 'sponsor-new',
+    title: 'Nieuwe sponsor',
+    schemaType: 'sponsor',
+    value: {},
+    ui: {
+      icon: 'handshake',
+      description: 'Voeg een sponsor of partner toe — logo, tier en website voor het sponsoroverzicht.',
+      group: 'Sponsors',
+    },
+  },
+]


### PR DESCRIPTION
Closes #1506

Phase 5+ propagation of the editor-UX rework — the **first mechanical use** of the "add a new doc type to the rework" checklist landed in #1502.

## Changes

- **`packages/sanity-schemas/src/sponsor.ts`** — field **groups** (`Sponsor` / `Tier & weergave` / `Links` / `SEO`, with `Sponsor` as `default`), every field assigned; a teaching Dutch `description` on every field (what + concrete example + public-site impact); a teaching `.error()` on the required `name`. `tier` keeps its warning (not required), rewritten to teach the site impact. Field order now follows the groups.
- **`sponsor-new` launcher IVT** (`packages/sanity-studio/src/templates/sponsor-templates.ts`) — sponsors are hand-created, so a single zero-prefill card, appended to the `launcherTemplates` aggregate + regression test.

## Checklist proof

`apps/` is **untouched** — no `sanity.config.ts` edit was needed. Appending the manifest to the `launcherTemplates` aggregate is the only registration step, confirming the #1502 "no per-studio config step" claim works in practice.

## Testing

- `pnpm --filter @kcvv/sanity-studio check-all` — type-check + lint + **202 tests** pass (3 new sponsor-template tests + updated aggregate test)
- `pnpm --filter @kcvv/sanity-schemas type-check` + `build` — pass
- `pnpm --filter @kcvv/studio build` — production studio compiles config + extracts the schema with the new groups (10.6s)
- Pre-PR review gate (`/code-review` + `/simplify`): clean — diff is mechanical pattern-following (schema groups/copy + a template manifest)

> Note: `@kcvv/studio` has no `check-all` script (only `lint`/`build`/`typegen`); validated via `build` as in #2188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sponsor template now available in the content launcher for creating new sponsor entries.

* **Improvements**
  * Reorganized sponsor content schema with grouped field layouts, enhanced validation messaging, and clearer field descriptions for improved editor experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->