### PR TITLE
feat(studio): editor-ux rework — banner, homePage, page (#1509, #1510, #1508)

### DIFF
--- a/packages/sanity-schemas/src/banner.ts
+++ b/packages/sanity-schemas/src/banner.ts
@@ -4,26 +4,44 @@ export const banner = defineType({
   name: 'banner',
   title: 'Banner',
   type: 'document',
+  // Editor-UX rework groups (#1509). `inhoud` is the default tab.
+  groups: [
+    {name: 'inhoud', title: 'Inhoud', default: true},
+    {name: 'link', title: 'Link'},
+  ],
   fields: [
     defineField({
       name: 'image',
       title: 'Banner image',
       type: 'image',
+      group: 'inhoud',
       options: {hotspot: true},
-      validation: (r) => r.required(),
+      description:
+        'De bannerafbeelding (bijv. een webshop- of sponsoractie). Wordt op de homepage volledig in kleur getoond in een breed, liggend kader (verhouding ~6:1). Gebruik een brede afbeelding zodat ze niet ongelukkig bijgesneden wordt.',
+      validation: (r) =>
+        r.required().error(
+          'Verplicht. Zonder afbeelding is er geen banner om te tonen en blijft de bannerslot op de homepage leeg.',
+        ),
     }),
     defineField({
       name: 'alt',
       title: 'Alt text',
       type: 'string',
-      validation: (r) => r.required(),
-      description: 'Required for accessibility. Describe the banner content.',
+      group: 'inhoud',
+      description:
+        'Beschrijf wat er op de banner staat (bijv. "Bestel je nieuwe thuistruitje in de webshop"). Wordt voorgelezen door schermlezers en getoond wanneer de afbeelding niet laadt.',
+      validation: (r) =>
+        r.required().error(
+          'Verplicht voor toegankelijkheid. Zonder alt-tekst is de banner onbruikbaar voor schermlezergebruikers en onleesbaar voor zoekmachines.',
+        ),
     }),
     defineField({
       name: 'href',
       title: 'Click-through URL',
       type: 'url',
-      description: 'Optional. Wraps the banner in a link.',
+      group: 'link',
+      description:
+        'Optioneel: de bestemming wanneer een bezoeker op de banner klikt (bijv. "https://shop.kcvvelewijt.be"). Maakt de hele banner klikbaar en opent in een nieuw tabblad. Laat leeg voor een niet-klikbare banner.',
     }),
   ],
   preview: {

--- a/packages/sanity-schemas/src/homePage.ts
+++ b/packages/sanity-schemas/src/homePage.ts
@@ -6,30 +6,46 @@ export const homePage = defineType({
   type: 'document',
   // @ts-expect-error __experimental_actions is not in the public type yet
   __experimental_actions: ['update', 'publish'],
+  // Editor-UX rework groups (#1510). Singleton — `bannerslots` is the default tab.
+  groups: [
+    {name: 'bannerslots', title: 'Bannerslots', default: true},
+    {name: 'widgets', title: 'Widgets'},
+  ],
   fields: [
     defineField({
       name: 'bannerSlotA',
       title: 'Banner slot A (below Match Widget)',
       type: 'reference',
       to: [{type: 'banner'}],
+      group: 'bannerslots',
+      description:
+        'Optionele banner die op de homepage onder het wedstrijdenblok verschijnt. Verwijst naar een Banner-document (bijv. een webshopactie). Laat leeg om deze slot over te slaan.',
     }),
     defineField({
       name: 'bannerSlotB',
       title: 'Banner slot B (below News section)',
       type: 'reference',
       to: [{type: 'banner'}],
+      group: 'bannerslots',
+      description:
+        'Optionele banner die onder de nieuwssectie verschijnt. Verwijst naar een Banner-document. Laat leeg om deze slot over te slaan.',
     }),
     defineField({
       name: 'bannerSlotC',
       title: 'Banner slot C (below Youth section)',
       type: 'reference',
       to: [{type: 'banner'}],
+      group: 'bannerslots',
+      description:
+        'Optionele banner die onder de jeugdsectie verschijnt. Verwijst naar een Banner-document. Laat leeg om deze slot over te slaan.',
     }),
     defineField({
       name: 'matchesSliderPlaceholder',
       title: 'Placeholder wedstrijdenblok',
       type: 'matchesSliderPlaceholder',
-      description: 'Optioneel. Getoond wanneer er geen aankomende wedstrijden zijn.',
+      group: 'widgets',
+      description:
+        'Optioneel tekstblok dat het wedstrijdenblok vervangt wanneer er geen aankomende wedstrijden zijn (bijv. tijdens de winterstop). Laat leeg om het blok dan gewoon te verbergen.',
     }),
   ],
   preview: {

--- a/packages/sanity-schemas/src/page.ts
+++ b/packages/sanity-schemas/src/page.ts
@@ -4,44 +4,69 @@ export const page = defineType({
   name: 'page',
   title: 'Page',
   type: 'document',
+  // Editor-UX rework groups (#1508). `inhoud` is the default tab.
+  groups: [
+    {name: 'inhoud', title: 'Inhoud', default: true},
+    {name: 'seo', title: 'SEO'},
+  ],
   fields: [
     defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-      validation: (r) => r.required(),
+      group: 'inhoud',
+      description:
+        'De titel van de pagina (bijv. "Praktische info" of "Geschiedenis"). Wordt als hoofdtitel bovenaan de pagina getoond en in de browsertab.',
+      validation: (r) =>
+        r.required().error('Verplicht. Zonder titel heeft de pagina geen kop en geen bruikbare browsertitel.'),
     }),
     defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
+      group: 'inhoud',
       options: {source: 'title'},
-      validation: (r) => r.required(),
+      description:
+        'Het URL-pad van de pagina (`/{slug}`). Eens gepubliceerd: niet meer wijzigen — externe links breken anders. Klik "Generate" om hem uit de titel af te leiden.',
+      validation: (r) =>
+        r.required().error(
+          'Verplicht. De slug bepaalt de URL waarop de pagina bereikbaar is — zonder slug verschijnt ze niet op de site.',
+        ),
     }),
     defineField({
       name: 'heroImage',
       title: 'Hero image',
       type: 'image',
+      group: 'inhoud',
       options: {hotspot: true},
+      description:
+        'Optionele bannerafbeelding bovenaan de pagina. Wordt in kleur en volle breedte getoond. Zonder afbeelding start de pagina meteen met de titel en de tekst.',
     }),
     defineField({
       name: 'body',
       title: 'Body',
       type: 'array',
+      group: 'inhoud',
       of: [{type: 'block'}, {type: 'articleImage'}, {type: 'fileAttachment'}],
+      description:
+        'De inhoud van de pagina: opgemaakte tekst, afbeeldingen en bijlagen (bijv. een PDF met reglement). Dit is wat bezoekers als hoofdtekst lezen.',
     }),
     defineField({
       name: 'metaDescription',
       title: 'Meta description',
       type: 'string',
-      description: 'Overschrijving voor SEO meta-omschrijving en OG-omschrijving (max. 160 tekens).',
+      group: 'seo',
+      description:
+        'Optionele SEO-omschrijving (max. 160 tekens). Verschijnt in Google-zoekresultaten en bij het delen op sociale media. Laat leeg om automatisch terug te vallen op het begin van de tekst.',
       validation: (r) => r.max(160),
     }),
     defineField({
       name: 'ogImage',
       title: 'OG image',
       type: 'image',
-      description: 'Optionele overschrijving voor de Open Graph-afbeelding. Valt terug op de hero-afbeelding.',
+      group: 'seo',
+      description:
+        'Optionele afbeelding voor het delen op sociale media (Open Graph). Valt terug op de hero-afbeelding als dit leeg blijft. Gebruik bij voorkeur een liggende afbeelding van 1200×630 pixels.',
       options: {hotspot: true},
     }),
   ],

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -19,7 +19,7 @@ export {responsibilityStructure} from './structure/responsibility'
 // `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.
 // Internal callers reach them via the `./tools/launcher` subpath instead.
 export {launcherTool, curatedNewDocumentOptions} from './tools/launcher'
-export {launcherTemplates, responsibilityTemplates, articleTemplates, sponsorTemplates} from './templates'
+export {launcherTemplates, responsibilityTemplates, articleTemplates, sponsorTemplates, pageTemplates} from './templates'
 export type {LauncherTemplate} from './templates'
 export {guidedSidebarInspectors, guidedSidebarInspector} from './inspectors'
 export type {GuideEntry} from './inspectors'

--- a/packages/sanity-studio/src/templates/index.ts
+++ b/packages/sanity-studio/src/templates/index.ts
@@ -2,12 +2,14 @@ import type {LauncherTemplate} from './types'
 import {responsibilityTemplates} from './responsibility-templates'
 import {articleTemplates} from './article-templates'
 import {sponsorTemplates} from './sponsor-templates'
+import {pageTemplates} from './page-templates'
 
 export type {LauncherTemplate, LauncherTemplateUi} from './types'
 export {isLauncherTemplate} from './types'
 export {responsibilityTemplates} from './responsibility-templates'
 export {articleTemplates} from './article-templates'
 export {sponsorTemplates} from './sponsor-templates'
+export {pageTemplates} from './page-templates'
 
 /**
  * Every launcher manifest, concatenated. Both studios register the launcher
@@ -19,4 +21,5 @@ export const launcherTemplates: LauncherTemplate[] = [
   ...responsibilityTemplates,
   ...articleTemplates,
   ...sponsorTemplates,
+  ...pageTemplates,
 ]

--- a/packages/sanity-studio/src/templates/launcher-templates.test.ts
+++ b/packages/sanity-studio/src/templates/launcher-templates.test.ts
@@ -4,12 +4,18 @@ import {
   responsibilityTemplates,
   articleTemplates,
   sponsorTemplates,
+  pageTemplates,
   isLauncherTemplate,
 } from './index'
 
 describe('launcherTemplates aggregate', () => {
   it('contains every per-schema manifest so both studios register templates with one spread', () => {
-    expect(launcherTemplates).toEqual([...responsibilityTemplates, ...articleTemplates, ...sponsorTemplates])
+    expect(launcherTemplates).toEqual([
+      ...responsibilityTemplates,
+      ...articleTemplates,
+      ...sponsorTemplates,
+      ...pageTemplates,
+    ])
   })
 
   it('exposes only launcher-eligible templates', () => {

--- a/packages/sanity-studio/src/templates/page-templates.test.ts
+++ b/packages/sanity-studio/src/templates/page-templates.test.ts
@@ -1,0 +1,23 @@
+import {describe, expect, it} from 'vitest'
+
+import {pageTemplates} from './page-templates'
+import {isLauncherTemplate} from './types'
+
+describe('pageTemplates (#1508)', () => {
+  it('exports a single zero-prefill page-new card', () => {
+    expect(pageTemplates.map((t) => t.id)).toEqual(['page-new'])
+    expect(pageTemplates[0].value).toEqual({})
+  })
+
+  it('targets the page schema type', () => {
+    expect(pageTemplates[0].schemaType).toBe('page')
+  })
+
+  it('is launcher-eligible under the Pages group with a ≤100-char description', () => {
+    const t = pageTemplates[0]
+    expect(isLauncherTemplate(t)).toBe(true)
+    expect(t.ui.group).toBe('Pages')
+    expect(t.ui.description.trim().length).toBeGreaterThan(0)
+    expect(t.ui.description.length).toBeLessThanOrEqual(100)
+  })
+})

--- a/packages/sanity-studio/src/templates/page-templates.ts
+++ b/packages/sanity-studio/src/templates/page-templates.ts
@@ -1,0 +1,23 @@
+import type {LauncherTemplate} from './types'
+
+/**
+ * Phase 5+ launcher manifest for `page` (#1508).
+ *
+ * Static info pages are hand-created one at a time, so a single zero-prefill
+ * card is the teaching on-ramp — no form-shape variation to seed (per design
+ * decision D6, templates seed only shape-driving fields, never editorial
+ * content). The card copy is the teaching moment.
+ */
+export const pageTemplates: LauncherTemplate[] = [
+  {
+    id: 'page-new',
+    title: 'Nieuwe pagina',
+    schemaType: 'page',
+    value: {},
+    ui: {
+      icon: 'file-text',
+      description: 'Een statische infopagina (bijv. praktische info, geschiedenis) — vrije tekst met titel en URL.',
+      group: 'Pages',
+    },
+  },
+]


### PR DESCRIPTION
Batches the three smallest editor-UX propagations (per the #1502 "add a new doc type" checklist). One PR, three doc types.

Closes #1509
Closes #1510
Closes #1508

## Changes

| Type | Groups | Required `.error()` | Launcher card |
| --- | --- | --- | --- |
| **banner** (#1509) | Inhoud / Link | image, alt | — (rarely created) |
| **homePage** (#1510) | Bannerslots / Widgets | none | — (singleton) |
| **page** (#1508) | Inhoud / SEO | title, slug | `page-new` |

Every field gets a teaching Dutch `description` (what + concrete example + public-site impact). `homePage` keeps its `__experimental_actions` singleton restriction.

## Checklist proof

`apps/` is **untouched** — `page-new` is appended to the `launcherTemplates` aggregate (no `sanity.config.ts` edit). Its auto-default is automatically hidden by the curated `+ Create` menu (#2190), so `+ Page` is replaced by `+ Nieuwe pagina`. banner/homePage have no card and keep their defaults (homePage's create is suppressed by the singleton actions anyway).

## Testing

- `pnpm --filter @kcvv/sanity-studio check-all` — type-check + lint + **210 tests** pass (3 new page-template tests + updated aggregate test)
- `pnpm --filter @kcvv/sanity-schemas type-check` — pass
- `pnpm --filter @kcvv/studio --filter @kcvv/studio-staging lint` + `@kcvv/studio build` — pass

> `@kcvv/studio` has no `check-all` script (only `lint`/`build`/`typegen`); validated via `build` as in prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new page template for creating static information pages.
  * Introduced organized editor tabs for banner, homepage, and page content schemas to improve content management workflow.

* **Documentation**
  * Enhanced field descriptions and validation messages in Dutch across schemas for clearer editor guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->