### PR TITLE
feat(ui): in-page membership intake form (#1473)

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -18,3 +18,6 @@ SANITY_WEBHOOK_SECRET=
 # Resend — transactional email for member-facing forms.
 # See docs/prd/email-delivery.md for the email-delivery decisions.
 RESEND_API_KEY=
+
+# Cloudflare Turnstile — membership-form spam check (server-side siteverify secret).
+TURNSTILE_SECRET=

--- a/apps/api/src/email/resend.ts
+++ b/apps/api/src/email/resend.ts
@@ -1,0 +1,97 @@
+import { Context, Effect, Layer } from "effect";
+import { WorkerEnvTag } from "../env";
+
+/**
+ * Form-agnostic transactional-email transport over Resend.
+ *
+ * Deliberately knows nothing about membership (or any specific form): it sends
+ * one `{ to, subject, html }` message. Future intake forms (VIP-restaurant,
+ * stage, sponsorship …) reuse this transport and supply their own template
+ * builders — the membership-specific templates live in `forms/membership-emails.ts`.
+ */
+
+/** Verified sender — apex `kcvvelewijt.be` (see docs/prd/email-delivery.md). */
+export const DEFAULT_FROM = "KCVV Elewijt <noreply@kcvvelewijt.be>";
+
+export class EmailDeliveryError extends Error {
+  readonly _tag = "EmailDeliveryError" as const;
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "EmailDeliveryError";
+  }
+}
+
+export interface EmailMessage {
+  readonly to: string | string[];
+  readonly subject: string;
+  readonly html: string;
+  /** Defaults to {@link DEFAULT_FROM}. */
+  readonly from?: string;
+  readonly replyTo?: string;
+}
+
+export interface EmailTransportInterface {
+  readonly dispatchEmail: (
+    msg: EmailMessage,
+  ) => Effect.Effect<void, EmailDeliveryError>;
+}
+
+export class EmailTransport extends Context.Tag("EmailTransport")<
+  EmailTransport,
+  EmailTransportInterface
+>() {}
+
+export const EmailTransportLive = Layer.effect(
+  EmailTransport,
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvTag;
+
+    return {
+      dispatchEmail: (msg) =>
+        Effect.gen(function* () {
+          if (!env.RESEND_API_KEY) {
+            // Local/dev without the secret: no-op so persist-then-send still
+            // completes. The application is already captured in Sanity.
+            yield* Effect.logWarning(
+              "[email] RESEND_API_KEY not set — skipping dispatch",
+            );
+            return;
+          }
+
+          const response = yield* Effect.tryPromise({
+            try: () =>
+              fetch("https://api.resend.com/emails", {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${env.RESEND_API_KEY}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  from: msg.from ?? DEFAULT_FROM,
+                  to: Array.isArray(msg.to) ? msg.to : [msg.to],
+                  subject: msg.subject,
+                  html: msg.html,
+                  ...(msg.replyTo ? { reply_to: msg.replyTo } : {}),
+                }),
+              }),
+            catch: (cause) =>
+              new EmailDeliveryError("Resend request failed", cause),
+          });
+
+          if (!response.ok) {
+            const body = yield* Effect.promise(() =>
+              response.text().catch(() => ""),
+            );
+            return yield* Effect.fail(
+              new EmailDeliveryError(
+                `Resend responded ${response.status}: ${body}`,
+              ),
+            );
+          }
+        }),
+    };
+  }),
+);

--- a/apps/api/src/email/resend.ts
+++ b/apps/api/src/email/resend.ts
@@ -65,6 +65,7 @@ export const EmailTransportLive = Layer.effect(
             try: () =>
               fetch("https://api.resend.com/emails", {
                 method: "POST",
+                signal: AbortSignal.timeout(8000),
                 headers: {
                   Authorization: `Bearer ${env.RESEND_API_KEY}`,
                   "Content-Type": "application/json",

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -14,6 +14,8 @@ export interface WorkerEnv {
   readonly AI: Ai; // Workers AI binding
   readonly SEARCH_INDEX: VectorizeIndex; // Vectorize vector store
   readonly SANITY_WEBHOOK_SECRET: string; // SVIX signing secret — wrangler secret
+  readonly RESEND_API_KEY?: string; // Resend transactional email — wrangler secret (absent locally → email dispatch is a no-op)
+  readonly TURNSTILE_SECRET?: string; // Cloudflare Turnstile secret — wrangler secret (absent locally → verification is skipped)
   readonly CACHE_LONG_TTL?: string; // "true" on staging — overrides hardTtl to 365 days
 }
 

--- a/apps/api/src/forms/membership-emails.ts
+++ b/apps/api/src/forms/membership-emails.ts
@@ -1,0 +1,112 @@
+import type { MembershipRequest, MembershipRole } from "@kcvv/api-contract";
+import type { EmailMessage } from "../email/resend";
+
+const ROLE_LABELS: Record<MembershipRole, string> = {
+  speler: "Speler",
+  jeugdspeler: "Jeugdspeler",
+  vrijwilliger: "Vrijwilliger",
+  trainer: "Trainer",
+  scheidsrechter: "Scheidsrechter",
+};
+
+const GENDER_LABELS: Record<string, string> = {
+  m: "Man",
+  f: "Vrouw",
+  x: "X",
+};
+
+/** Minimal escaping for the user-supplied strings we interpolate into HTML. */
+function esc(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function shell(title: string, body: string): string {
+  return `<div style="font-family:Arial,Helvetica,sans-serif;color:#1a1a1a;max-width:560px;margin:0 auto;line-height:1.5">
+  <h1 style="font-size:18px;color:#005c2e">${title}</h1>
+  ${body}
+  <hr style="border:none;border-top:1px solid #ddd;margin:24px 0" />
+  <p style="font-size:12px;color:#888">KCVV Elewijt · Driesstraat 32, 1982 Elewijt · <a href="https://www.kcvvelewijt.be">kcvvelewijt.be</a></p>
+</div>`;
+}
+
+function applicantHtml(payload: MembershipRequest): string {
+  return shell(
+    "Bedankt voor je inschrijving!",
+    `<p>Beste ${esc(payload.firstName)},</p>
+     <p>We hebben je inschrijving als <strong>${ROLE_LABELS[payload.role]}</strong> goed ontvangen.
+        Iemand van de club neemt binnenkort contact met je op.</p>
+     <p>Er is maar één plezante compagnie. Tot snel!</p>`,
+  );
+}
+
+function parentHtml(payload: MembershipRequest): string {
+  return shell(
+    "Inschrijving ontvangen",
+    `<p>Beste ouder/voogd,</p>
+     <p>We hebben de inschrijving van <strong>${esc(payload.firstName)} ${esc(payload.lastName)}</strong>
+        als <strong>${ROLE_LABELS[payload.role]}</strong> bij KCVV Elewijt ontvangen, met jouw toestemming.
+        Iemand van de club neemt binnenkort contact op.</p>`,
+  );
+}
+
+function adminHtml(payload: MembershipRequest, isMinor: boolean): string {
+  const row = (label: string, value: string) =>
+    `<tr><td style="padding:4px 12px 4px 0;color:#666">${label}</td><td style="padding:4px 0"><strong>${value}</strong></td></tr>`;
+  return shell(
+    "Nieuwe inschrijving via de website",
+    `<table style="border-collapse:collapse;font-size:14px">
+       ${row("Rol", ROLE_LABELS[payload.role])}
+       ${row("Naam", `${esc(payload.firstName)} ${esc(payload.lastName)}`)}
+       ${row("Geboortedatum", `${esc(payload.birthDate)}${isMinor ? " (minderjarig)" : ""}`)}
+       ${row("Geslacht", GENDER_LABELS[payload.gender] ?? esc(payload.gender))}
+       ${row("Gemeente", esc(payload.municipality))}
+       ${row("E-mail", esc(payload.email))}
+       ${payload.priorClub ? row("Vorige club", esc(payload.priorClub)) : ""}
+       ${isMinor && payload.parentEmail ? row("Ouder/voogd e-mail", esc(payload.parentEmail)) : ""}
+     </table>
+     <p style="font-size:13px;color:#888">Beheer deze inschrijving in Sanity Studio (Inschrijvingen).</p>`,
+  );
+}
+
+/**
+ * Membership-specific email templates. Produces the messages the BFF hands to
+ * the form-agnostic {@link EmailMessage} transport: applicant acknowledgment,
+ * parent acknowledgment (minors), and the admin notification.
+ */
+export function buildMembershipEmails(input: {
+  payload: MembershipRequest;
+  isMinor: boolean;
+  adminRecipient: string;
+}): EmailMessage[] {
+  const { payload, isMinor, adminRecipient } = input;
+  const fullName = `${payload.firstName} ${payload.lastName}`;
+
+  const messages: EmailMessage[] = [
+    {
+      to: payload.email,
+      subject: "Bedankt voor je inschrijving bij KCVV Elewijt",
+      html: applicantHtml(payload),
+    },
+  ];
+
+  if (isMinor && payload.parentEmail) {
+    messages.push({
+      to: payload.parentEmail,
+      subject: `Inschrijving ${fullName} bij KCVV Elewijt`,
+      html: parentHtml(payload),
+    });
+  }
+
+  messages.push({
+    to: adminRecipient,
+    subject: `Nieuwe inschrijving: ${fullName} (${ROLE_LABELS[payload.role]})`,
+    html: adminHtml(payload, isMinor),
+    replyTo: payload.email,
+  });
+
+  return messages;
+}

--- a/apps/api/src/forms/membership-rules.test.ts
+++ b/apps/api/src/forms/membership-rules.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { MembershipRequest } from "@kcvv/api-contract";
+import { ageOn, isMinorOn, validateMembershipRules } from "./membership-rules";
+
+const base: MembershipRequest = {
+  role: "vrijwilliger",
+  firstName: "Jan",
+  lastName: "Peeters",
+  birthDate: "1990-06-15",
+  gender: "m",
+  municipality: "Elewijt",
+  email: "jan@example.com",
+  privacyAccepted: true,
+  turnstileToken: "tok",
+} as MembershipRequest;
+
+const SUBMIT = new Date("2026-06-21T10:00:00Z");
+
+describe("ageOn", () => {
+  it("counts a birthday that already passed this year", () => {
+    expect(ageOn("1990-06-15", SUBMIT)).toBe(36);
+  });
+  it("does not count a birthday later this year", () => {
+    expect(ageOn("1990-12-15", SUBMIT)).toBe(35);
+  });
+  it("treats the birthday itself as the new age", () => {
+    expect(ageOn("2008-06-21", SUBMIT)).toBe(18);
+  });
+});
+
+describe("isMinorOn", () => {
+  it("is true the day before the 18th birthday", () => {
+    expect(isMinorOn("2008-06-22", SUBMIT)).toBe(true);
+  });
+  it("is false on the 18th birthday", () => {
+    expect(isMinorOn("2008-06-21", SUBMIT)).toBe(false);
+  });
+});
+
+describe("validateMembershipRules", () => {
+  it("passes a clean adult volunteer", () => {
+    expect(validateMembershipRules(base, SUBMIT)).toEqual({});
+  });
+
+  it("requires parent email + consent for a minor", () => {
+    const errors = validateMembershipRules(
+      { ...base, birthDate: "2012-01-01" },
+      SUBMIT,
+    );
+    expect(errors.parentEmail).toBeDefined();
+    expect(errors.parentalConsent).toBeDefined();
+  });
+
+  it("accepts a minor with parent email + consent", () => {
+    const errors = validateMembershipRules(
+      {
+        ...base,
+        birthDate: "2012-01-01",
+        parentEmail: "ouder@example.com",
+        parentalConsent: true,
+      },
+      SUBMIT,
+    );
+    expect(errors).toEqual({});
+  });
+
+  it("requires medical-cert acknowledgment for speler", () => {
+    const errors = validateMembershipRules({ ...base, role: "speler" }, SUBMIT);
+    expect(errors.medicalCertAcknowledged).toBeDefined();
+  });
+
+  it("requires medical-cert acknowledgment for jeugdspeler (and combines with minor rules)", () => {
+    const errors = validateMembershipRules(
+      { ...base, role: "jeugdspeler", birthDate: "2014-01-01" },
+      SUBMIT,
+    );
+    expect(errors.medicalCertAcknowledged).toBeDefined();
+    expect(errors.parentEmail).toBeDefined();
+  });
+
+  it("does not require medical cert for non-player roles", () => {
+    const errors = validateMembershipRules(
+      { ...base, role: "scheidsrechter" },
+      SUBMIT,
+    );
+    expect(errors.medicalCertAcknowledged).toBeUndefined();
+  });
+});

--- a/apps/api/src/forms/membership-rules.ts
+++ b/apps/api/src/forms/membership-rules.ts
@@ -1,0 +1,57 @@
+import { MEDICAL_CERT_ROLES, type MembershipRequest } from "@kcvv/api-contract";
+
+/**
+ * Age in whole years on `on` for a `YYYY-MM-DD` birth date.
+ *
+ * ponytail: UTC date arithmetic, no tz library. A one-day timezone edge is
+ * immaterial to an 18-year membership threshold.
+ */
+export function ageOn(birthDate: string, on: Date): number {
+  const parts = birthDate.split("-");
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  let age = on.getUTCFullYear() - year;
+  const monthDiff = on.getUTCMonth() + 1 - month;
+  if (monthDiff < 0 || (monthDiff === 0 && on.getUTCDate() < day)) {
+    age -= 1;
+  }
+  return age;
+}
+
+export function isMinorOn(birthDate: string, on: Date): boolean {
+  return ageOn(birthDate, on) < 18;
+}
+
+/**
+ * Cross-field business rules that depend on the submit date (the Effect Schema
+ * only covers shape). Returns a `{ field: message }` map — empty means valid.
+ */
+export function validateMembershipRules(
+  payload: MembershipRequest,
+  now: Date,
+): Record<string, string> {
+  const errors: Record<string, string> = {};
+  const minor = isMinorOn(payload.birthDate, now);
+
+  if (minor) {
+    if (!payload.parentEmail) {
+      errors.parentEmail =
+        "Verplicht voor minderjarigen: vul het e-mailadres van een ouder of voogd in.";
+    }
+    if (payload.parentalConsent !== true) {
+      errors.parentalConsent =
+        "Verplicht voor minderjarigen: de ouder/voogd moet toestemming geven.";
+    }
+  }
+
+  if (
+    MEDICAL_CERT_ROLES.includes(payload.role) &&
+    payload.medicalCertAcknowledged !== true
+  ) {
+    errors.medicalCertAcknowledged =
+      "Bevestig dat je een medisch attest van geneeskundige geschiktheid zal voorleggen.";
+  }
+
+  return errors;
+}

--- a/apps/api/src/forms/turnstile.ts
+++ b/apps/api/src/forms/turnstile.ts
@@ -1,0 +1,53 @@
+import { Effect } from "effect";
+import { WorkerEnvTag } from "../env";
+
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Verify a Cloudflare Turnstile token server-side.
+ *
+ * - No secret configured (local/dev) → skip, treat as passed.
+ * - Explicit `success: false` from Cloudflare → fail (reject the submission).
+ * - Network/parse error → fail-open (log + pass) so a Turnstile outage never
+ *   loses a legit applicant; the honeypot still guards against trivial bots.
+ */
+export const verifyTurnstile = (
+  token: string,
+): Effect.Effect<boolean, never, WorkerEnvTag> =>
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvTag;
+    if (!env.TURNSTILE_SECRET) {
+      yield* Effect.logWarning(
+        "[turnstile] TURNSTILE_SECRET not set — skipping verification",
+      );
+      return true;
+    }
+
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch(SITEVERIFY_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            secret: env.TURNSTILE_SECRET,
+            response: token,
+          }),
+        });
+        const data = (await response.json()) as { success?: boolean };
+        return data.success === true;
+      },
+      catch: (cause) => cause,
+    }).pipe(
+      Effect.catchAll((cause) =>
+        Effect.as(
+          Effect.logWarning(
+            `[turnstile] verification call failed, allowing through: ${String(cause)}`,
+          ),
+          true,
+        ),
+      ),
+    );
+
+    return result;
+  });

--- a/apps/api/src/forms/turnstile.ts
+++ b/apps/api/src/forms/turnstile.ts
@@ -28,6 +28,7 @@ export const verifyTurnstile = (
       try: async () => {
         const response = await fetch(SITEVERIFY_URL, {
           method: "POST",
+          signal: AbortSignal.timeout(5000),
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             secret: env.TURNSTILE_SECRET,

--- a/apps/api/src/handlers/feedback.test.ts
+++ b/apps/api/src/handlers/feedback.test.ts
@@ -19,6 +19,7 @@ function makeSanityMock(
     archiveStaff: () => Effect.succeed(undefined),
     archiveTeams: () => Effect.succeed(undefined),
     writeFeedback: writeFeedbackImpl ?? (() => Effect.succeed(undefined)),
+    writeMembershipApplication: () => Effect.succeed(undefined),
   };
 }
 

--- a/apps/api/src/handlers/forms.test.ts
+++ b/apps/api/src/handlers/forms.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { Effect, Layer, Exit } from "effect";
+import type { MembershipRequest } from "@kcvv/api-contract";
+import {
+  SanityMutation,
+  type SanityMutationInterface,
+} from "../sanity/mutation";
+import {
+  SanityProjection,
+  type SanityProjectionInterface,
+} from "../sanity/projection";
+import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
+import { EmailTransport, type EmailTransportInterface } from "../email/resend";
+import { makeTestEnvLayer } from "../test-helpers/env-layer";
+import { handleMembership } from "./forms";
+
+const validPayload: MembershipRequest = {
+  role: "vrijwilliger",
+  firstName: "Jan",
+  lastName: "Peeters",
+  birthDate: "1990-06-15",
+  gender: "m",
+  municipality: "Elewijt",
+  email: "jan@example.com",
+  privacyAccepted: true,
+  turnstileToken: "tok",
+} as MembershipRequest;
+
+function makeMutationMock(
+  writeImpl?: SanityMutationInterface["writeMembershipApplication"],
+): SanityMutationInterface {
+  return {
+    upsertPlayer: () => Effect.succeed(undefined),
+    upsertTeam: () => Effect.succeed(undefined),
+    upsertStaff: () => Effect.succeed(undefined),
+    uploadPlayerImage: () => Effect.succeed(undefined),
+    archivePlayers: () => Effect.succeed(undefined),
+    archiveStaff: () => Effect.succeed(undefined),
+    archiveTeams: () => Effect.succeed(undefined),
+    writeFeedback: () => Effect.succeed(undefined),
+    writeMembershipApplication: writeImpl ?? (() => Effect.succeed(undefined)),
+  };
+}
+
+const projectionMock: SanityProjectionInterface = {
+  getPlayersImageState: () => Effect.succeed(new Map()),
+  getActivePlayerPsdIds: () => Effect.succeed([]),
+  getActiveStaffPsdIds: () => Effect.succeed([]),
+  getActiveTeamPsdIds: () => Effect.succeed([]),
+  getVisibleTeamPsdIds: () => Effect.succeed([]),
+  getProtectedStaffPsdIds: () => Effect.succeed([]),
+  getFormRoutingConfig: () => Effect.succeed(null),
+};
+
+const cacheMock: KvCacheInterface = {
+  get: () => Effect.succeed(null),
+  set: () => Effect.succeed(undefined),
+  increment: () => Effect.succeed(undefined),
+};
+
+function run(
+  payload: MembershipRequest,
+  opts: {
+    write?: SanityMutationInterface["writeMembershipApplication"];
+    dispatch?: EmailTransportInterface["dispatchEmail"];
+  } = {},
+) {
+  const emailMock: EmailTransportInterface = {
+    dispatchEmail: opts.dispatch ?? (() => Effect.succeed(undefined)),
+  };
+  const layer = Layer.mergeAll(
+    Layer.succeed(SanityMutation, makeMutationMock(opts.write)),
+    Layer.succeed(SanityProjection, projectionMock),
+    Layer.succeed(KvCacheService, cacheMock),
+    Layer.succeed(EmailTransport, emailMock),
+    makeTestEnvLayer(), // no TURNSTILE_SECRET → verification skipped
+  );
+  return Effect.runPromiseExit(
+    Effect.provide(handleMembership(payload), layer),
+  );
+}
+
+describe("handleMembership", () => {
+  it("persists and returns ok for a valid adult submission", async () => {
+    const write = vi.fn(() => Effect.succeed(undefined as void));
+    const dispatch = vi.fn(() => Effect.succeed(undefined as void));
+    const exit = await run(validPayload, { write, dispatch });
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    // applicant ack + admin notification (no parent for an adult)
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a honeypot submission without persisting", async () => {
+    const write = vi.fn(() => Effect.succeed(undefined as void));
+    const exit = await run(
+      { ...validPayload, company: "spam-bot" } as MembershipRequest,
+      { write },
+    );
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("rejects a minor without parent fields (400 with field errors)", async () => {
+    const write = vi.fn(() => Effect.succeed(undefined as void));
+    const exit = await run(
+      { ...validPayload, birthDate: "2012-01-01" } as MembershipRequest,
+      { write },
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(write).not.toHaveBeenCalled();
+    if (Exit.isFailure(exit)) {
+      const error = JSON.stringify(exit.cause);
+      expect(error).toContain("parentEmail");
+    }
+  });
+
+  it("sends a parent acknowledgment for a consenting minor", async () => {
+    const dispatch = vi.fn(() => Effect.succeed(undefined as void));
+    const exit = await run(
+      {
+        ...validPayload,
+        birthDate: "2012-01-01",
+        parentEmail: "ouder@example.com",
+        parentalConsent: true,
+      } as MembershipRequest,
+      { dispatch },
+    );
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    // applicant + parent + admin
+    expect(dispatch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api/src/handlers/forms.ts
+++ b/apps/api/src/handlers/forms.ts
@@ -1,0 +1,150 @@
+import { Effect } from "effect";
+import { HttpApiBuilder } from "@effect/platform";
+import {
+  PsdApi,
+  HttpBadRequest,
+  HttpServiceUnavailable,
+  type MembershipRequest,
+  type MembershipRole,
+} from "@kcvv/api-contract";
+import { SanityMutation } from "../sanity/mutation";
+import { SanityProjection, type FormRoutingConfig } from "../sanity/projection";
+import { KvCacheService } from "../cache/kv-cache";
+import { EmailTransport } from "../email/resend";
+import { verifyTurnstile } from "../forms/turnstile";
+import { isMinorOn, validateMembershipRules } from "../forms/membership-rules";
+import { buildMembershipEmails } from "../forms/membership-emails";
+
+const DEFAULT_ADMIN_RECIPIENT = "info@kcvvelewijt.be";
+const ROUTING_CACHE_KEY = "forms:routing-config";
+const ROUTING_CACHE_TTL = 60 * 60; // 1h — config changes rarely; submissions are sparse
+
+/** Cached per-role admin recipient; falls back to info@ on any miss/error. */
+const resolveAdminRecipient = (role: MembershipRole) =>
+  Effect.gen(function* () {
+    const cache = yield* KvCacheService;
+    const projection = yield* SanityProjection;
+
+    const cached = yield* cache.get(ROUTING_CACHE_KEY);
+    let config: FormRoutingConfig | null = cached
+      ? yield* Effect.try({
+          try: () => JSON.parse(cached) as FormRoutingConfig,
+          catch: () => new Error("parse"),
+        }).pipe(Effect.orElseSucceed(() => null))
+      : null;
+
+    if (!config) {
+      config = yield* projection
+        .getFormRoutingConfig()
+        .pipe(Effect.orElseSucceed(() => null));
+      if (config) {
+        yield* cache.set(
+          ROUTING_CACHE_KEY,
+          JSON.stringify(config),
+          ROUTING_CACHE_TTL,
+        );
+      }
+    }
+
+    return config?.[role] ?? DEFAULT_ADMIN_RECIPIENT;
+  });
+
+/**
+ * Handle a public membership-intake submission.
+ *
+ * Order: honeypot → Turnstile → business rules → persist (Sanity) → send
+ * (Resend, best-effort). Persist-then-send means a captured application is
+ * never lost to an email failure.
+ */
+export const handleMembership = (payload: MembershipRequest) =>
+  Effect.gen(function* () {
+    // 1. Honeypot — bots fill `company`. Pretend success, persist nothing.
+    if (payload.company && payload.company.trim() !== "") {
+      yield* Effect.logInfo(
+        "[membership] honeypot tripped — dropping submission",
+      );
+      return { ok: true as const };
+    }
+
+    // 2. Turnstile spam check.
+    const human = yield* verifyTurnstile(payload.turnstileToken);
+    if (!human) {
+      return yield* Effect.fail(
+        new HttpBadRequest({
+          error: "Verificatie mislukt. Vernieuw de pagina en probeer opnieuw.",
+        }),
+      );
+    }
+
+    // 3. Cross-field business rules (minor flow, medical cert).
+    const now = new Date();
+    const fieldErrors = validateMembershipRules(payload, now);
+    if (Object.keys(fieldErrors).length > 0) {
+      return yield* Effect.fail(
+        new HttpBadRequest({
+          error: "Sommige velden ontbreken of zijn ongeldig.",
+          fields: fieldErrors,
+        }),
+      );
+    }
+
+    const isMinor = isMinorOn(payload.birthDate, now);
+
+    // 4. Persist first — failure here is the only one that fails the request.
+    const sanity = yield* SanityMutation;
+    yield* sanity
+      .writeMembershipApplication({
+        role: payload.role,
+        firstName: payload.firstName,
+        lastName: payload.lastName,
+        birthDate: payload.birthDate,
+        gender: payload.gender,
+        municipality: payload.municipality,
+        email: payload.email,
+        priorClub: payload.priorClub,
+        isMinor,
+        parentEmail: payload.parentEmail,
+        parentalConsent: payload.parentalConsent ?? false,
+        medicalCertAcknowledged: payload.medicalCertAcknowledged ?? false,
+        privacyAccepted: payload.privacyAccepted,
+        submittedAt: now.toISOString(),
+      })
+      .pipe(
+        Effect.mapError(
+          () =>
+            new HttpServiceUnavailable({
+              error:
+                "Inschrijving kon niet worden opgeslagen. Probeer later opnieuw.",
+            }),
+        ),
+      );
+
+    // 5. Send acknowledgments + admin notification — best-effort.
+    const adminRecipient = yield* resolveAdminRecipient(payload.role);
+    const transport = yield* EmailTransport;
+    const messages = buildMembershipEmails({
+      payload,
+      isMinor,
+      adminRecipient,
+    });
+    yield* Effect.forEach(
+      messages,
+      (message) =>
+        transport
+          .dispatchEmail(message)
+          .pipe(
+            Effect.catchAll((err) =>
+              Effect.logWarning(
+                `[membership] email dispatch failed: ${String(err)}`,
+              ),
+            ),
+          ),
+      { discard: true },
+    );
+
+    return { ok: true as const };
+  });
+
+export const FormsApiLive = HttpApiBuilder.group(PsdApi, "forms", (handlers) =>
+  handlers.handle("membershipForm", ({ payload }) => handleMembership(payload)),
+);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,6 +26,8 @@ import { OpponentApiLive } from "./handlers/opponent";
 import { RankingApiLive } from "./handlers/ranking";
 import { RelatedApiLive } from "./handlers/related";
 import { SearchApiLive } from "./handlers/search";
+import { FormsApiLive } from "./handlers/forms";
+import { EmailTransportLive } from "./email/resend";
 import { EmbeddingServiceLive } from "./search/embedding";
 import { VectorizeServiceLive } from "./search/vectorize";
 import { AiAnswerServiceLive } from "./search/ai-answer";
@@ -60,6 +62,8 @@ function buildAppLayer(env: WorkerEnv) {
     Layer.provide(RankingApiLive),
     Layer.provide(RelatedApiLive),
     Layer.provide(SearchApiLive),
+    Layer.provide(FormsApiLive),
+    Layer.provide(EmailTransportLive),
     Layer.provide(EmbeddingServiceLive),
     Layer.provide(VectorizeServiceLive),
     Layer.provide(AiAnswerServiceLive),

--- a/apps/api/src/psd/fetch-json.test.ts
+++ b/apps/api/src/psd/fetch-json.test.ts
@@ -42,6 +42,7 @@ const sanityMock: SanityProjectionInterface = {
   getActiveTeamPsdIds: () => Effect.succeed([]),
   getVisibleTeamPsdIds: () => Effect.succeed([]),
   getProtectedStaffPsdIds: () => Effect.succeed([]),
+  getFormRoutingConfig: () => Effect.succeed(null),
 };
 
 const seasons = [

--- a/apps/api/src/psd/opponent.test.ts
+++ b/apps/api/src/psd/opponent.test.ts
@@ -46,6 +46,7 @@ const sanityProjectionMock: SanityProjectionInterface = {
   getActiveTeamPsdIds: () => Effect.succeed([]),
   getVisibleTeamPsdIds: () => Effect.succeed([]),
   getProtectedStaffPsdIds: () => Effect.succeed([]),
+  getFormRoutingConfig: () => Effect.succeed(null),
 };
 
 function runService<A>(

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -54,6 +54,7 @@ function makeSanityMock(
     getActiveTeamPsdIds: () => Effect.succeed([]),
     getVisibleTeamPsdIds: () => Effect.succeed(visiblePsdIds),
     getProtectedStaffPsdIds: () => Effect.succeed([]),
+    getFormRoutingConfig: () => Effect.succeed(null),
   };
 }
 

--- a/apps/api/src/sanity/mutation.ts
+++ b/apps/api/src/sanity/mutation.ts
@@ -48,6 +48,24 @@ export interface SanityStaffDoc {
   functionTitle: string | null; // from PSD functionTitle; null clears the stored value
 }
 
+/** Public membership-intake submission, persisted before email dispatch. */
+export interface SanityMembershipApplicationDoc {
+  role: string;
+  firstName: string;
+  lastName: string;
+  birthDate: string; // "YYYY-MM-DD"
+  gender: string;
+  municipality: string;
+  email: string;
+  priorClub?: string;
+  isMinor: boolean;
+  parentEmail?: string;
+  parentalConsent: boolean;
+  medicalCertAcknowledged: boolean;
+  privacyAccepted: boolean;
+  submittedAt: string; // ISO timestamp set by the BFF
+}
+
 // ─── Error ────────────────────────────────────────────────────────────────────
 
 export class SanityMutationError extends Error {
@@ -101,6 +119,10 @@ export interface SanityMutationInterface {
     pathTitle: string;
     vote: "up" | "down";
   }) => Effect.Effect<void, SanityMutationError>;
+  /** Create a membershipApplication document (status defaults to "new"). */
+  readonly writeMembershipApplication: (
+    doc: SanityMembershipApplicationDoc,
+  ) => Effect.Effect<void, SanityMutationError>;
 }
 
 export class SanityMutation extends Context.Tag("SanityMutation")<
@@ -463,6 +485,34 @@ export const SanityMutationLive = Layer.effect(
             }),
           catch: (cause) =>
             new SanityMutationError("Failed to write search feedback", cause),
+        }).pipe(Effect.asVoid),
+
+      writeMembershipApplication: (doc) =>
+        Effect.tryPromise({
+          try: () =>
+            client.create({
+              _type: "membershipApplication",
+              status: "new",
+              role: doc.role,
+              firstName: doc.firstName,
+              lastName: doc.lastName,
+              birthDate: doc.birthDate,
+              gender: doc.gender,
+              municipality: doc.municipality,
+              email: doc.email,
+              ...(doc.priorClub ? { priorClub: doc.priorClub } : {}),
+              isMinor: doc.isMinor,
+              ...(doc.parentEmail ? { parentEmail: doc.parentEmail } : {}),
+              parentalConsent: doc.parentalConsent,
+              medicalCertAcknowledged: doc.medicalCertAcknowledged,
+              privacyAccepted: doc.privacyAccepted,
+              submittedAt: doc.submittedAt,
+            }),
+          catch: (cause) =>
+            new SanityMutationError(
+              "Failed to write membership application",
+              cause,
+            ),
         }).pipe(Effect.asVoid),
     };
   }),

--- a/apps/api/src/sanity/projection.ts
+++ b/apps/api/src/sanity/projection.ts
@@ -17,6 +17,15 @@ export class SanityQueryError extends Error {
   }
 }
 
+/** Per-role admin-notification recipients from the formRoutingConfig singleton. */
+export interface FormRoutingConfig {
+  speler: string | null;
+  jeugdspeler: string | null;
+  vrijwilliger: string | null;
+  trainer: string | null;
+  scheidsrechter: string | null;
+}
+
 // ─── Service ──────────────────────────────────────────────────────────────────
 
 export interface SanityProjectionInterface {
@@ -45,6 +54,11 @@ export interface SanityProjectionInterface {
   /** Fetch PSD IDs of staff members referenced by active organigramNode or responsibility documents. */
   readonly getProtectedStaffPsdIds: () => Effect.Effect<
     string[],
+    SanityQueryError
+  >;
+  /** Fetch the formRoutingConfig singleton (null per-role field → no override). */
+  readonly getFormRoutingConfig: () => Effect.Effect<
+    FormRoutingConfig | null,
     SanityQueryError
   >;
 }
@@ -163,6 +177,16 @@ export const SanityProjectionLive = Layer.effect(
               "Failed to fetch protected staff PSD IDs",
               cause,
             ),
+        }),
+
+      getFormRoutingConfig: () =>
+        Effect.tryPromise({
+          try: () =>
+            client.fetch<FormRoutingConfig | null>(
+              `*[_type == "formRoutingConfig"][0]{ speler, jeugdspeler, vrijwilliger, trainer, scheidsrechter }`,
+            ),
+          catch: (cause) =>
+            new SanityQueryError("Failed to fetch form routing config", cause),
         }),
     };
   }),

--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -47,6 +47,9 @@ function makeSanityMocks() {
   const archiveStaff = vi.fn(() => Effect.succeed(undefined as void));
   const archiveTeams = vi.fn(() => Effect.succeed(undefined as void));
   const writeFeedback = vi.fn(() => Effect.succeed(undefined as void));
+  const writeMembershipApplication = vi.fn(() =>
+    Effect.succeed(undefined as void),
+  );
 
   // Read methods (SanityProjection)
   const getPlayersImageState = vi.fn(() =>
@@ -59,6 +62,7 @@ function makeSanityMocks() {
   const getActiveTeamPsdIds = vi.fn(() => Effect.succeed([] as string[]));
   const getVisibleTeamPsdIds = vi.fn(() => Effect.succeed([] as string[]));
   const getProtectedStaffPsdIds = vi.fn(() => Effect.succeed([] as string[]));
+  const getFormRoutingConfig = vi.fn(() => Effect.succeed(null));
 
   const writerMock: SanityMutationInterface = {
     upsertPlayer,
@@ -69,6 +73,7 @@ function makeSanityMocks() {
     archiveStaff,
     archiveTeams,
     writeFeedback,
+    writeMembershipApplication,
   };
 
   const readerMock: SanityProjectionInterface = {
@@ -78,6 +83,7 @@ function makeSanityMocks() {
     getActiveTeamPsdIds,
     getVisibleTeamPsdIds,
     getProtectedStaffPsdIds,
+    getFormRoutingConfig,
   };
 
   return {
@@ -367,6 +373,9 @@ describe("runSync", () => {
       archiveStaff: vi.fn(() => Effect.succeed(undefined as void)),
       archiveTeams: vi.fn(() => Effect.succeed(undefined as void)),
       writeFeedback: vi.fn(() => Effect.succeed(undefined as void)),
+      writeMembershipApplication: vi.fn(() =>
+        Effect.succeed(undefined as void),
+      ),
     };
     const readerMock: SanityProjectionInterface = {
       getPlayersImageState: vi.fn(() =>
@@ -382,6 +391,7 @@ describe("runSync", () => {
       getActiveTeamPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       getVisibleTeamPsdIds: vi.fn(() => Effect.succeed([] as string[])),
       getProtectedStaffPsdIds: vi.fn(() => Effect.succeed([] as string[])),
+      getFormRoutingConfig: vi.fn(() => Effect.succeed(null)),
     };
     const psdMock = makePsdTeamClientMock(
       [ONE_TEAM],

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -14,6 +14,7 @@ SANITY_DATASET = "production"
 # SANITY_API_TOKEN is a secret — set via: wrangler secret put SANITY_API_TOKEN
 # SANITY_WEBHOOK_SECRET is a secret — set via: wrangler secret put SANITY_WEBHOOK_SECRET
 # RESEND_API_KEY is a secret — set via: wrangler secret put RESEND_API_KEY (see docs/prd/email-delivery.md)
+# TURNSTILE_SECRET is a secret — set via: wrangler secret put TURNSTILE_SECRET (membership form spam check)
 
 [observability.logs]
 enabled = true
@@ -53,6 +54,7 @@ CACHE_LONG_TTL = "true"
 # SANITY_API_TOKEN is a secret — set via: wrangler secret put SANITY_API_TOKEN --env staging
 # SANITY_WEBHOOK_SECRET is a secret — set via: wrangler secret put SANITY_WEBHOOK_SECRET --env staging
 # RESEND_API_KEY is a secret — set via: wrangler secret put RESEND_API_KEY --env staging (see docs/prd/email-delivery.md)
+# TURNSTILE_SECRET is a secret — set via: wrangler secret put TURNSTILE_SECRET --env staging (membership form spam check)
 
 [[env.staging.kv_namespaces]]
 binding = "PSD_CACHE"

--- a/apps/studio-staging/structure.ts
+++ b/apps/studio-staging/structure.ts
@@ -1,5 +1,9 @@
 import type {StructureResolver} from 'sanity/structure'
-import {staffStructure, responsibilityStructure} from '@kcvv/sanity-studio'
+import {
+  staffStructure,
+  responsibilityStructure,
+  membershipApplicationStructure,
+} from '@kcvv/sanity-studio'
 
 export const structure: StructureResolver = (S) =>
   S.list()
@@ -65,9 +69,18 @@ export const structure: StructureResolver = (S) =>
             .documentId('jeugdLandingPage')
             .title('Jeugd landing page configuratie'),
         ),
+      S.listItem()
+        .title('Form routing config')
+        .child(
+          S.document()
+            .schemaType('formRoutingConfig')
+            .documentId('formRoutingConfig')
+            .title('Form routing config'),
+        ),
       S.divider(),
       responsibilityStructure(S),
       S.divider(),
+      membershipApplicationStructure(S),
       S.listItem()
         .title('📊 Feedback')
         .child(

--- a/apps/studio/structure.ts
+++ b/apps/studio/structure.ts
@@ -1,5 +1,9 @@
 import type {StructureResolver} from 'sanity/structure'
-import {staffStructure, responsibilityStructure} from '@kcvv/sanity-studio'
+import {
+  staffStructure,
+  responsibilityStructure,
+  membershipApplicationStructure,
+} from '@kcvv/sanity-studio'
 
 export const structure: StructureResolver = (S) =>
   S.list()
@@ -65,9 +69,18 @@ export const structure: StructureResolver = (S) =>
             .documentId('jeugdLandingPage')
             .title('Jeugd landing page configuratie'),
         ),
+      S.listItem()
+        .title('Form routing config')
+        .child(
+          S.document()
+            .schemaType('formRoutingConfig')
+            .documentId('formRoutingConfig')
+            .title('Form routing config'),
+        ),
       S.divider(),
       responsibilityStructure(S),
       S.divider(),
+      membershipApplicationStructure(S),
       S.listItem()
         .title('📊 Feedback')
         .child(

--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -29,7 +29,7 @@ describe("next.config redirects", () => {
       { source: "/teams", destination: "/ploegen" },
       { source: "/team/:slug", destination: "/ploegen/:slug" },
       { source: "/club/history", destination: "/club/geschiedenis" },
-      { source: "/club/register", destination: "/club/word-lid" },
+      { source: "/club/register", destination: "/club/inschrijven" },
     ];
 
     for (const { source, destination } of expected) {

--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -29,7 +29,7 @@ describe("next.config redirects", () => {
       { source: "/teams", destination: "/ploegen" },
       { source: "/team/:slug", destination: "/ploegen/:slug" },
       { source: "/club/history", destination: "/club/geschiedenis" },
-      { source: "/club/register", destination: "/club/inschrijven" },
+      { source: "/club/register", destination: "/club/word-lid" },
     ];
 
     for (const { source, destination } of expected) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -61,7 +61,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/club/register",
-        destination: "/club/word-lid",
+        destination: "/club/inschrijven",
         permanent: true,
       },
       // #1002 — Dutch URL for staff member detail pages

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -61,7 +61,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/club/register",
-        destination: "/club/inschrijven",
+        destination: "/club/word-lid",
         permanent: true,
       },
       // #1002 — Dutch URL for staff member detail pages

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -26,7 +26,8 @@ De officiële website van KCVV Elewijt: https://www.kcvvelewijt.be
 - /club/geschiedenis — Clubgeschiedenis
 - /club/organigram — Bestuursstructuur
 - /club/contact — Contactgegevens
-- /club/inschrijven — Lid worden / Inschrijven
+- /club/word-lid — Lid worden (online inschrijvingsformulier)
+- /club/inschrijven — Praktische info (lidgeld, terugbetalingen, ProSoccerData)
 - /zoeken — Zoeken op de website
 - /privacy — Privacybeleid
 

--- a/apps/web/src/app/(landing)/jeugd/page.test.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.test.tsx
@@ -80,7 +80,7 @@ describe("/jeugd page — cream tracer composition", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders the closing JeugdCtaBand linking to /hulp", async () => {
+  it("renders the closing JeugdCtaBand linking to /club/word-lid", async () => {
     const JeugdPage = (await import("./page")).default;
     render(await JeugdPage());
 
@@ -93,7 +93,7 @@ describe("/jeugd page — cream tracer composition", () => {
     ).toBeInTheDocument();
     expect(
       within(cta).getByRole("link", { name: /schrijf je in/i }),
-    ).toHaveAttribute("href", "/hulp");
+    ).toHaveAttribute("href", "/club/word-lid");
   });
 
   it("fires jeugd_view on page view", async () => {

--- a/apps/web/src/app/(main)/club/[slug]/page.test.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.test.tsx
@@ -165,6 +165,38 @@ describe("/club/[slug] page", () => {
     ).toBeInTheDocument();
   });
 
+  it("adds a 'Schrijf je in' CTA to /club/word-lid on the inschrijven (Praktische Informatie) page", async () => {
+    mockFindBySlug.mockReturnValue(
+      Effect.succeed(
+        makePage({ slug: "inschrijven", title: "Praktische Informatie" }),
+      ),
+    );
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "inschrijven" }),
+    });
+    render(page);
+
+    expect(
+      screen.getByRole("link", { name: /schrijf je in/i }),
+    ).toHaveAttribute("href", "/club/word-lid");
+  });
+
+  it("does not add the membership CTA on other club pages", async () => {
+    mockFindBySlug.mockReturnValue(
+      Effect.succeed(makePage({ slug: "downloads" })),
+    );
+
+    const page = await DynamicClubPage({
+      params: Promise.resolve({ slug: "downloads" }),
+    });
+    render(page);
+
+    expect(
+      screen.queryByRole("link", { name: /schrijf je in/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not render SanityArticleBody / InteriorPageHero artefacts", async () => {
     mockFindBySlug.mockReturnValue(Effect.succeed(makePage()));
 

--- a/apps/web/src/app/(main)/club/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.tsx
@@ -7,7 +7,19 @@ import { runPromise } from "@/lib/effect/runtime";
 import { PageRepository } from "@/lib/repositories/page.repository";
 import { PageHero } from "@/components/layout/PageHero";
 import { ArticleBody } from "@/components/article/ArticleBody";
-import { PageContainer, StripedSeam } from "@/components/design-system";
+import {
+  CtaBand,
+  PageContainer,
+  StripedSeam,
+} from "@/components/design-system";
+
+/**
+ * Slug of the CMS "Praktische Informatie" page — gets a closing CTA to the
+ * membership form. ponytail: a single stable, load-bearing slug (also driving
+ * the nav link + /club/register redirect); promote to a CMS field if a second
+ * page ever needs a form CTA.
+ */
+const MEMBERSHIP_INFO_SLUG = "inschrijven";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -79,6 +91,21 @@ export default async function DynamicClubPage({ params }: Props) {
           renders bare here (no max-w wrapper would box the cream into a band). */}
       {body.length > 0 ? (
         <ArticleBody className="article-body" content={body} />
+      ) : null}
+
+      {slug === MEMBERSHIP_INFO_SLUG ? (
+        <CtaBand
+          ariaLabel="Schrijf je in"
+          heading="Klaar om lid te worden?"
+          emphasis={{ text: "lid te worden", tone: "warm" }}
+          lead="Schrijf je online in via ons inschrijvingsformulier — we nemen daarna contact met je op."
+          buttonLabel={
+            <>
+              Schrijf je in <span aria-hidden="true">+</span>
+            </>
+          }
+          href="/club/word-lid"
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/app/(main)/club/word-lid/page.tsx
+++ b/apps/web/src/app/(main)/club/word-lid/page.tsx
@@ -2,11 +2,13 @@
  * Word lid — membership intake
  *
  * Static sibling under `club/` that beats the `club/[slug]` CMS catch-all.
- * Replaces the external Google Forms / placeholder `/club/inschrijven` links.
- * The page is static; the form POSTs client-side to `/api/membership`.
+ * The structured membership-signup entry point, reached from the "Word lid"
+ * CTAs. The CMS "Praktische Informatie" page (`/club/inschrijven`) stays as the
+ * practical-info hub. The page is static; the form POSTs to `/api/membership`.
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
@@ -27,6 +29,7 @@ export const metadata: Metadata = {
     "vrijwilliger",
     "Elewijt",
   ],
+  alternates: { canonical: `${SITE_CONFIG.siteUrl}/club/word-lid` },
   openGraph: {
     title: "Word lid van KCVV Elewijt",
     description:
@@ -63,6 +66,11 @@ export default function WordLidPage() {
             Speler, jeugdspeler, vrijwilliger, trainer of scheidsrechter — vul
             het formulier in en we nemen binnenkort contact met je op. Het
             lidgeld regelen we samen nadat we je gecontacteerd hebben.
+          </p>
+          <p className="mt-4 text-[length:var(--text-body-md)]">
+            <Link href="/club/inschrijven" className="prose-link">
+              Praktische info — lidgeld, terugbetalingen &amp; ProSoccerData →
+            </Link>
           </p>
         </header>
 

--- a/apps/web/src/app/(main)/club/word-lid/page.tsx
+++ b/apps/web/src/app/(main)/club/word-lid/page.tsx
@@ -1,0 +1,73 @@
+/**
+ * Word lid — membership intake
+ *
+ * Static sibling under `club/` that beats the `club/[slug]` CMS catch-all.
+ * Replaces the external Google Forms / placeholder `/club/inschrijven` links.
+ * The page is static; the form POSTs client-side to `/api/membership`.
+ */
+
+import type { Metadata } from "next";
+import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { EditorialHeading, PageContainer } from "@/components/design-system";
+import { MembershipForm } from "@/components/club/MembershipForm/MembershipForm";
+
+export const metadata: Metadata = {
+  title: "Word lid | KCVV Elewijt",
+  description:
+    "Schrijf je in bij KCVV Elewijt — als speler, jeugdspeler, vrijwilliger, trainer of scheidsrechter. Vul het inschrijfformulier in en we nemen contact met je op.",
+  keywords: [
+    "word lid",
+    "inschrijven",
+    "lid worden",
+    "KCVV Elewijt",
+    "speler",
+    "jeugd",
+    "vrijwilliger",
+    "Elewijt",
+  ],
+  openGraph: {
+    title: "Word lid van KCVV Elewijt",
+    description:
+      "Schrijf je in bij KCVV Elewijt — speler, jeugd, vrijwilliger, trainer of scheidsrechter.",
+    type: "website",
+    images: [DEFAULT_OG_IMAGE],
+  },
+};
+
+export default function WordLidPage() {
+  return (
+    <div className="bg-cream py-16 md:py-20">
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: SITE_CONFIG.siteUrl },
+          { name: "Club", url: `${SITE_CONFIG.siteUrl}/club` },
+          { name: "Word lid", url: `${SITE_CONFIG.siteUrl}/club/word-lid` },
+        ])}
+      />
+      <PageContainer width="prose">
+        <header className="mb-10 flex flex-col">
+          <span className="text-jersey-deep font-mono text-[length:var(--text-label)] font-semibold tracking-[var(--text-label--tracking)] uppercase">
+            Sluit je aan
+          </span>
+          <EditorialHeading
+            level={1}
+            size="display-xl"
+            emphasis={{ text: "compagnie." }}
+            className="mt-3 mb-0 break-words hyphens-auto"
+          >
+            Er is maar één plezante
+          </EditorialHeading>
+          <p className="text-ink-soft font-display mt-5 max-w-[60ch] text-[length:var(--text-body-lg)] leading-[var(--text-body-lg--lh)]">
+            Speler, jeugdspeler, vrijwilliger, trainer of scheidsrechter — vul
+            het formulier in en we nemen binnenkort contact met je op. Het
+            lidgeld regelen we samen nadat we je gecontacteerd hebben.
+          </p>
+        </header>
+
+        <MembershipForm />
+      </PageContainer>
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/privacy/page.test.tsx
+++ b/apps/web/src/app/(main)/privacy/page.test.tsx
@@ -17,7 +17,7 @@ describe("PrivacyPage (Phase 8 cream-minimal reskin)", () => {
   it("renders the mono last-updated line in the header", () => {
     render(<PrivacyPage />);
     expect(
-      screen.getByText(/laatst bijgewerkt · februari 2026/i),
+      screen.getByText(/laatst bijgewerkt · juni 2026/i),
     ).toBeInTheDocument();
   });
 
@@ -118,7 +118,7 @@ describe("PrivacyPage (Phase 8 cream-minimal reskin)", () => {
   it("displays the last updated date in the Wijzigingen section", () => {
     render(<PrivacyPage />);
     expect(
-      screen.getByText(/laatst bijgewerkt:\s*februari 2026/i),
+      screen.getByText(/laatst bijgewerkt:\s*juni 2026/i),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -22,7 +22,7 @@ import {
  * Last updated date for the privacy policy.
  * NOTE: Maintainers must update this constant whenever the privacy policy content changes.
  */
-const LAST_UPDATED = "februari 2026";
+const LAST_UPDATED = "juni 2026";
 
 export const metadata: Metadata = {
   title: "Privacyverklaring | KCVV Elewijt",

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -141,6 +141,36 @@ export default function PrivacyPage() {
           </ul>
 
           <DottedDivider color="paper-edge" />
+          <h2>Inschrijvingsformulier (Word lid)</h2>
+          <p>
+            Wanneer je je inschrijft via{" "}
+            <Link href="/club/word-lid" className="prose-link">
+              /club/word-lid
+            </Link>
+            , verwerken we enkel de gegevens die nodig zijn om je inschrijving
+            op te volgen:
+          </p>
+          <ul>
+            <li>Voornaam en achternaam</li>
+            <li>Geboortedatum (om te bepalen of je minderjarig bent)</li>
+            <li>Geslacht</li>
+            <li>Gemeente</li>
+            <li>E-mailadres</li>
+            <li>Vorige club (optioneel)</li>
+            <li>
+              E-mailadres van een ouder/voogd (enkel bij minderjarigen, samen
+              met hun toestemming)
+            </li>
+          </ul>
+          <p>
+            We vragen géén telefoonnummer, volledig adres, rijksregisternummer,
+            nationaliteit of school via dit formulier. De ingediende
+            inschrijvingen worden bewaard tot maximaal 1 jaar na de laatste
+            opvolging, tenzij ze leiden tot een effectief lidmaatschap — dan
+            geldt de bewaartermijn voor leden hieronder.
+          </p>
+
+          <DottedDivider color="paper-edge" />
           <h2>Waarvoor gebruiken we je gegevens?</h2>
           <ul>
             <li>

--- a/apps/web/src/app/api/membership/route.ts
+++ b/apps/web/src/app/api/membership/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const bffUrl = process.env.KCVV_API_URL;
+  if (!bffUrl) {
+    return NextResponse.json(
+      { ok: false, error: "Inschrijvingen zijn momenteel niet beschikbaar." },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Ongeldige aanvraag." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const res = await fetch(`${bffUrl}/forms/membership`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    // Pass the BFF response through (incl. 400 field errors) so the form can
+    // render per-field messages.
+    const data = await res.json().catch(() => ({ ok: res.ok }));
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error("[Membership API] Proxy error:", error);
+    return NextResponse.json(
+      { ok: false, error: "Inschrijving kon niet worden verzonden." },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/components/club/MembershipForm/MembershipForm.test.tsx
+++ b/apps/web/src/components/club/MembershipForm/MembershipForm.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MembershipForm } from "./MembershipForm";
+
+describe("MembershipForm", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the base fields", () => {
+    render(<MembershipForm />);
+    expect(screen.getByLabelText(/Voornaam/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Achternaam/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/E-mail/)).toBeInTheDocument();
+  });
+
+  it("reveals the medical-certificate checkbox only for player roles", () => {
+    render(<MembershipForm />);
+    expect(screen.queryByText(/medisch attest/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/inschrijven als/i), {
+      target: { value: "speler" },
+    });
+    expect(screen.getByText(/medisch attest/i)).toBeInTheDocument();
+  });
+
+  it("reveals the parent-consent block for a minor birth date", () => {
+    render(<MembershipForm />);
+    expect(screen.queryByText(/Minderjarig/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Geboortedatum/), {
+      target: { value: "2014-05-01" },
+    });
+    expect(screen.getByLabelText(/E-mail ouder\/voogd/i)).toBeInTheDocument();
+    expect(screen.getByText(/geef toestemming/i)).toBeInTheDocument();
+  });
+
+  it("posts to /api/membership and shows a success message", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ ok: true }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<MembershipForm defaultRole="vrijwilliger" />);
+    fireEvent.change(screen.getByLabelText(/Voornaam/), {
+      target: { value: "Jan" },
+    });
+    fireEvent.change(screen.getByLabelText(/Achternaam/), {
+      target: { value: "Peeters" },
+    });
+    fireEvent.change(screen.getByLabelText(/Geboortedatum/), {
+      target: { value: "1990-06-15" },
+    });
+    fireEvent.change(screen.getByLabelText(/Geslacht/), {
+      target: { value: "m" },
+    });
+    fireEvent.change(screen.getByLabelText(/Gemeente/), {
+      target: { value: "Elewijt" },
+    });
+    fireEvent.change(screen.getByLabelText(/^E-mail/), {
+      target: { value: "jan@example.com" },
+    });
+    fireEvent.click(screen.getByLabelText(/privacyverklaring/i));
+    fireEvent.submit(screen.getByText(/Inschrijven/).closest("form")!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Bedankt voor je inschrijving/i),
+      ).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/membership",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/web/src/components/club/MembershipForm/MembershipForm.test.tsx
+++ b/apps/web/src/components/club/MembershipForm/MembershipForm.test.tsx
@@ -31,8 +31,10 @@ describe("MembershipForm", () => {
     render(<MembershipForm />);
     expect(screen.queryByText(/Minderjarig/i)).not.toBeInTheDocument();
 
+    // Born ~10 years ago — always a minor regardless of when the test runs.
+    const minorYear = new Date().getFullYear() - 10;
     fireEvent.change(screen.getByLabelText(/Geboortedatum/), {
-      target: { value: "2014-05-01" },
+      target: { value: `${minorYear}-05-01` },
     });
     expect(screen.getByLabelText(/E-mail ouder\/voogd/i)).toBeInTheDocument();
     expect(screen.getByText(/geef toestemming/i)).toBeInTheDocument();

--- a/apps/web/src/components/club/MembershipForm/MembershipForm.tsx
+++ b/apps/web/src/components/club/MembershipForm/MembershipForm.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useId, useMemo, useState, type ReactNode } from "react";
+import {
+  EMAIL_PATTERN,
+  MEDICAL_CERT_ROLES,
+  type MembershipRole,
+} from "@kcvv/api-contract";
+import {
+  Button,
+  ClippedCard,
+  Input,
+  Label,
+  Select,
+  StampBadge,
+} from "@/components/design-system";
+import { trackEvent } from "@/lib/analytics/track-event";
+import { TurnstileWidget } from "./TurnstileWidget";
+
+const ROLE_OPTIONS: { value: MembershipRole; label: string }[] = [
+  { value: "speler", label: "Speler" },
+  { value: "jeugdspeler", label: "Jeugdspeler" },
+  { value: "vrijwilliger", label: "Vrijwilliger" },
+  { value: "trainer", label: "Trainer" },
+  { value: "scheidsrechter", label: "Scheidsrechter" },
+];
+
+const REQUIRED_MSG = "Verplicht.";
+
+/** Minor preview for conditional fields — the BFF recomputes authoritatively. */
+function isMinor(birthDate: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) return false;
+  const today = new Date();
+  const [y, m, d] = birthDate.split("-").map(Number);
+  let age = today.getFullYear() - y;
+  const monthDiff = today.getMonth() + 1 - m;
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < d)) age -= 1;
+  return age < 18;
+}
+
+const SUBMIT_URL = "/api/membership";
+
+interface MembershipFormProps {
+  /** Storybook/testing: seed the role to render role-specific fields. */
+  defaultRole?: MembershipRole | "";
+  /** Storybook/testing: seed the birth date to render the minor flow. */
+  defaultBirthDate?: string;
+}
+
+type SubmitState = "idle" | "submitting" | "success" | "error";
+
+function CheckboxField({
+  id,
+  checked,
+  onChange,
+  error,
+  children,
+}: {
+  id: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="flex cursor-pointer items-start gap-3">
+        <input
+          id={id}
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          className="accent-jersey-deep mt-0.5 size-4 shrink-0 rounded-none"
+        />
+        <span className="text-ink text-[length:var(--text-body-sm)] leading-snug">
+          {children}
+        </span>
+      </label>
+      {error ? (
+        <p className="text-alert mt-1 text-[length:var(--text-body-sm)]">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function MembershipForm({
+  defaultRole = "",
+  defaultBirthDate = "",
+}: MembershipFormProps) {
+  const uid = useId();
+  const fieldId = (name: string) => `${uid}-${name}`;
+
+  const [role, setRole] = useState<MembershipRole | "">(defaultRole);
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [birthDate, setBirthDate] = useState(defaultBirthDate);
+  const [gender, setGender] = useState("");
+  const [municipality, setMunicipality] = useState("");
+  const [email, setEmail] = useState("");
+  const [priorClub, setPriorClub] = useState("");
+  const [parentEmail, setParentEmail] = useState("");
+  const [parentalConsent, setParentalConsent] = useState(false);
+  const [medicalCertAcknowledged, setMedicalCertAcknowledged] = useState(false);
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [honeypot, setHoneypot] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState("");
+
+  const [state, setState] = useState<SubmitState>("idle");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [generalError, setGeneralError] = useState("");
+
+  const minor = useMemo(() => isMinor(birthDate), [birthDate]);
+  const isPlayer = role !== "" && MEDICAL_CERT_ROLES.includes(role);
+
+  const validate = (): Record<string, string> => {
+    const errors: Record<string, string> = {};
+    if (!role) errors.role = REQUIRED_MSG;
+    if (!firstName.trim()) errors.firstName = REQUIRED_MSG;
+    if (!lastName.trim()) errors.lastName = REQUIRED_MSG;
+    if (!birthDate) errors.birthDate = REQUIRED_MSG;
+    if (!gender) errors.gender = REQUIRED_MSG;
+    if (!municipality.trim()) errors.municipality = REQUIRED_MSG;
+    if (!EMAIL_PATTERN.test(email))
+      errors.email = "Vul een geldig e-mailadres in.";
+    if (isPlayer && !medicalCertAcknowledged) {
+      errors.medicalCertAcknowledged = "Bevestig dit om verder te gaan.";
+    }
+    if (minor) {
+      if (!EMAIL_PATTERN.test(parentEmail)) {
+        errors.parentEmail =
+          "Vul een geldig e-mailadres in van een ouder/voogd.";
+      }
+      if (!parentalConsent) {
+        errors.parentalConsent = "Toestemming van een ouder/voogd is vereist.";
+      }
+    }
+    if (!privacyAccepted) {
+      errors.privacyAccepted =
+        "Aanvaard de privacyverklaring om verder te gaan.";
+    }
+    return errors;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (state === "submitting") return;
+
+    const clientErrors = validate();
+    if (Object.keys(clientErrors).length > 0) {
+      setFieldErrors(clientErrors);
+      setGeneralError("Controleer de gemarkeerde velden.");
+      setState("error");
+      return;
+    }
+
+    setState("submitting");
+    setFieldErrors({});
+    setGeneralError("");
+
+    try {
+      const response = await fetch(SUBMIT_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          role,
+          firstName,
+          lastName,
+          birthDate,
+          gender,
+          municipality,
+          email,
+          priorClub: priorClub || undefined,
+          parentEmail: minor ? parentEmail : undefined,
+          parentalConsent: minor ? parentalConsent : undefined,
+          medicalCertAcknowledged: isPlayer
+            ? medicalCertAcknowledged
+            : undefined,
+          privacyAccepted,
+          turnstileToken,
+          company: honeypot,
+        }),
+      });
+
+      const data = (await response.json().catch(() => ({}))) as {
+        ok?: boolean;
+        fields?: Record<string, string>;
+        error?: string;
+      };
+
+      if (response.ok && data.ok) {
+        trackEvent("membership_form_submit", {
+          role,
+          is_minor: minor,
+          has_prior_club: priorClub.trim() !== "",
+        });
+        setState("success");
+        return;
+      }
+
+      if (response.status === 400 && data.fields) {
+        setFieldErrors(data.fields);
+      }
+      setGeneralError(
+        data.error ??
+          "Er ging iets mis. Controleer je gegevens en probeer opnieuw.",
+      );
+      setState("error");
+    } catch {
+      setGeneralError(
+        "Verzenden mislukt. Controleer je internetverbinding en probeer opnieuw.",
+      );
+      setState("error");
+    }
+  };
+
+  if (state === "success") {
+    return (
+      <ClippedCard as="section">
+        <StampBadge tone="jersey" rotation={-2} position="top-right">
+          ✓ ONTVANGEN
+        </StampBadge>
+        <h2 className="font-display mb-3 text-[32px] leading-[1.05] font-black">
+          Bedankt voor je inschrijving!
+        </h2>
+        <p className="text-ink-soft text-[length:var(--text-body-md)]">
+          We hebben je inschrijving goed ontvangen en sturen je een
+          bevestigingsmail. Iemand van de club neemt binnenkort contact op.
+        </p>
+      </ClippedCard>
+    );
+  }
+
+  return (
+    <ClippedCard as="section">
+      <StampBadge tone="jersey" rotation={2} position="top-right">
+        ★ WORD LID
+      </StampBadge>
+
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="text-ink-muted border-paper-edge mb-6 flex items-center justify-between border-b pb-2 font-mono text-[11px] tracking-[0.08em] uppercase">
+          <span>Inschrijfformulier · KCVV Elewijt</span>
+        </div>
+
+        <h2 className="font-display mb-6 text-[40px] leading-[1.05] font-black">
+          Welkom bij de club.
+        </h2>
+
+        {/* Honeypot — visually hidden, off-screen; bots fill it, humans don't. */}
+        <div
+          aria-hidden
+          className="absolute left-[-9999px] h-0 w-0 overflow-hidden"
+        >
+          <label htmlFor={fieldId("company")}>Bedrijf (niet invullen)</label>
+          <input
+            id={fieldId("company")}
+            name="company"
+            tabIndex={-1}
+            autoComplete="off"
+            value={honeypot}
+            onChange={(e) => setHoneypot(e.target.value)}
+          />
+        </div>
+
+        <div className="mb-5">
+          <Label htmlFor={fieldId("role")} required>
+            Ik wil me inschrijven als
+          </Label>
+          <Select
+            id={fieldId("role")}
+            name="role"
+            value={role}
+            placeholder="Maak een keuze…"
+            error={fieldErrors.role}
+            onChange={(e) => setRole(e.target.value as MembershipRole)}
+          >
+            {ROLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div className="grid grid-cols-1 gap-x-5 gap-y-[18px] md:grid-cols-2">
+          <div>
+            <Label htmlFor={fieldId("firstName")} required>
+              Voornaam
+            </Label>
+            <Input
+              id={fieldId("firstName")}
+              name="firstName"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              error={fieldErrors.firstName}
+              autoComplete="given-name"
+            />
+          </div>
+          <div>
+            <Label htmlFor={fieldId("lastName")} required>
+              Achternaam
+            </Label>
+            <Input
+              id={fieldId("lastName")}
+              name="lastName"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              error={fieldErrors.lastName}
+              autoComplete="family-name"
+            />
+          </div>
+          <div>
+            <Label htmlFor={fieldId("birthDate")} required>
+              Geboortedatum
+            </Label>
+            <Input
+              id={fieldId("birthDate")}
+              name="birthDate"
+              type="date"
+              value={birthDate}
+              onChange={(e) => setBirthDate(e.target.value)}
+              error={fieldErrors.birthDate}
+            />
+          </div>
+          <div>
+            <Label htmlFor={fieldId("gender")} required>
+              Geslacht
+            </Label>
+            <Select
+              id={fieldId("gender")}
+              name="gender"
+              value={gender}
+              placeholder="Maak een keuze…"
+              error={fieldErrors.gender}
+              onChange={(e) => setGender(e.target.value)}
+            >
+              <option value="m">Man</option>
+              <option value="f">Vrouw</option>
+              <option value="x">X</option>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor={fieldId("municipality")} required>
+              Gemeente
+            </Label>
+            <Input
+              id={fieldId("municipality")}
+              name="municipality"
+              value={municipality}
+              onChange={(e) => setMunicipality(e.target.value)}
+              error={fieldErrors.municipality}
+              autoComplete="address-level2"
+            />
+          </div>
+          <div>
+            <Label htmlFor={fieldId("email")} required>
+              E-mail
+            </Label>
+            <Input
+              id={fieldId("email")}
+              name="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              error={fieldErrors.email}
+              autoComplete="email"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <Label htmlFor={fieldId("priorClub")} optional>
+              Vorige club
+            </Label>
+            <Input
+              id={fieldId("priorClub")}
+              name="priorClub"
+              value={priorClub}
+              onChange={(e) => setPriorClub(e.target.value)}
+              error={fieldErrors.priorClub}
+            />
+          </div>
+        </div>
+
+        {isPlayer ? (
+          <div className="mt-6">
+            <CheckboxField
+              id={fieldId("medical")}
+              checked={medicalCertAcknowledged}
+              onChange={setMedicalCertAcknowledged}
+              error={fieldErrors.medicalCertAcknowledged}
+            >
+              Ik begrijp dat ik bij de eerste training een medisch attest van
+              geneeskundige geschiktheid moet voorleggen.
+            </CheckboxField>
+          </div>
+        ) : null}
+
+        {minor ? (
+          <div className="border-paper-edge mt-6 space-y-4 border-l-2 pl-4">
+            <p className="text-ink-muted font-mono text-[11px] tracking-[0.08em] uppercase">
+              Minderjarig — ouder/voogd vereist
+            </p>
+            <div>
+              <Label htmlFor={fieldId("parentEmail")} required>
+                E-mail ouder/voogd
+              </Label>
+              <Input
+                id={fieldId("parentEmail")}
+                name="parentEmail"
+                type="email"
+                value={parentEmail}
+                onChange={(e) => setParentEmail(e.target.value)}
+                error={fieldErrors.parentEmail}
+                autoComplete="email"
+              />
+            </div>
+            <CheckboxField
+              id={fieldId("parentalConsent")}
+              checked={parentalConsent}
+              onChange={setParentalConsent}
+              error={fieldErrors.parentalConsent}
+            >
+              Ik ben de ouder/voogd en geef toestemming voor deze inschrijving.
+            </CheckboxField>
+          </div>
+        ) : null}
+
+        <div className="mt-6">
+          <CheckboxField
+            id={fieldId("privacy")}
+            checked={privacyAccepted}
+            onChange={setPrivacyAccepted}
+            error={fieldErrors.privacyAccepted}
+          >
+            Ik aanvaard de{" "}
+            <a href="/privacy" className="prose-link underline" target="_blank">
+              privacyverklaring
+            </a>
+            .
+          </CheckboxField>
+        </div>
+
+        <TurnstileWidget onToken={setTurnstileToken} />
+
+        {generalError ? (
+          <p className="text-alert mt-5 text-[length:var(--text-body-md)]">
+            {generalError}
+          </p>
+        ) : null}
+
+        <div className="border-paper-edge mt-7 flex items-center justify-between border-t border-dashed pt-4">
+          <span className="text-ink-muted font-mono text-[11px] tracking-[0.08em] uppercase">
+            {state === "submitting" ? "Versturen…" : "Word lid van KCVV"}
+          </span>
+          <Button
+            variant="secondary"
+            withArrow
+            type="submit"
+            disabled={state === "submitting"}
+          >
+            Inschrijven
+          </Button>
+        </div>
+      </form>
+    </ClippedCard>
+  );
+}

--- a/apps/web/src/components/club/MembershipForm/MembershipForm.tsx
+++ b/apps/web/src/components/club/MembershipForm/MembershipForm.tsx
@@ -433,7 +433,12 @@ export function MembershipForm({
             error={fieldErrors.privacyAccepted}
           >
             Ik aanvaard de{" "}
-            <a href="/privacy" className="prose-link underline" target="_blank">
+            <a
+              href="/privacy"
+              className="prose-link underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               privacyverklaring
             </a>
             .

--- a/apps/web/src/components/club/MembershipForm/TurnstileWidget.tsx
+++ b/apps/web/src/components/club/MembershipForm/TurnstileWidget.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+interface TurnstileApi {
+  render: (
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      callback: (token: string) => void;
+      "expired-callback"?: () => void;
+      "error-callback"?: () => void;
+    },
+  ) => string;
+  remove: (id: string) => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+/**
+ * Cloudflare Turnstile widget. With no site key configured (local/dev) it
+ * renders nothing and reports an empty token — the BFF skips verification when
+ * its secret is likewise absent. ponytail: global `window.turnstile` lock; the
+ * widget is the only consumer.
+ */
+export function TurnstileWidget({
+  onToken,
+}: {
+  onToken: (token: string) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!SITE_KEY) {
+      onToken("");
+      return;
+    }
+
+    let cancelled = false;
+    let widgetId: string | null = null;
+
+    const render = () => {
+      if (cancelled || !ref.current || !window.turnstile) return;
+      widgetId = window.turnstile.render(ref.current, {
+        sitekey: SITE_KEY,
+        callback: (token) => onToken(token),
+        "expired-callback": () => onToken(""),
+        "error-callback": () => onToken(""),
+      });
+    };
+
+    if (window.turnstile) {
+      render();
+    } else {
+      const existing = document.querySelector<HTMLScriptElement>(
+        `script[src="${SCRIPT_SRC}"]`,
+      );
+      const script = existing ?? document.createElement("script");
+      if (!existing) {
+        script.src = SCRIPT_SRC;
+        script.async = true;
+        script.defer = true;
+        document.head.appendChild(script);
+      }
+      script.addEventListener("load", render);
+    }
+
+    return () => {
+      cancelled = true;
+      if (widgetId && window.turnstile) window.turnstile.remove(widgetId);
+    };
+  }, [onToken]);
+
+  if (!SITE_KEY) return null;
+  return <div ref={ref} className="mt-2" />;
+}

--- a/apps/web/src/components/club/MembershipForm/TurnstileWidget.tsx
+++ b/apps/web/src/components/club/MembershipForm/TurnstileWidget.tsx
@@ -45,6 +45,7 @@ export function TurnstileWidget({
 
     let cancelled = false;
     let widgetId: string | null = null;
+    let scriptEl: HTMLScriptElement | null = null;
 
     const render = () => {
       if (cancelled || !ref.current || !window.turnstile) return;
@@ -62,18 +63,19 @@ export function TurnstileWidget({
       const existing = document.querySelector<HTMLScriptElement>(
         `script[src="${SCRIPT_SRC}"]`,
       );
-      const script = existing ?? document.createElement("script");
+      scriptEl = existing ?? document.createElement("script");
       if (!existing) {
-        script.src = SCRIPT_SRC;
-        script.async = true;
-        script.defer = true;
-        document.head.appendChild(script);
+        scriptEl.src = SCRIPT_SRC;
+        scriptEl.async = true;
+        scriptEl.defer = true;
+        document.head.appendChild(scriptEl);
       }
-      script.addEventListener("load", render);
+      scriptEl.addEventListener("load", render);
     }
 
     return () => {
       cancelled = true;
+      if (scriptEl) scriptEl.removeEventListener("load", render);
       if (widgetId && window.turnstile) window.turnstile.remove(widgetId);
     };
   }, [onToken]);

--- a/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Homepage Jeugd block. Phase 4.5 R5.B adds a top stripe band (cream-jersey-deep StripedSeam, xl height — cream paper-tape on the dark green field), shifts the editorial accent from "De toekomst" to "Elewijt", and introduces a dual CTA row ("Ontdek onze jeugd" → /jeugd, "Schrijf je in" → /club/inschrijven). Background stays the composed jersey-deep gradient + halftone photo overlay from Phase 4.B.4.',
+          'Homepage Jeugd block. Phase 4.5 R5.B adds a top stripe band (cream-jersey-deep StripedSeam, xl height — cream paper-tape on the dark green field), shifts the editorial accent from "De toekomst" to "Elewijt", and introduces a dual CTA row ("Ontdek onze jeugd" → /jeugd, "Schrijf je in" → /club/word-lid). Background stays the composed jersey-deep gradient + halftone photo overlay from Phase 4.B.4.',
       },
     },
   },

--- a/apps/web/src/components/home/YouthSection/YouthSection.test.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.test.tsx
@@ -41,10 +41,10 @@ describe("YouthSection", () => {
     expect(link).toHaveAttribute("href", "/jeugd");
   });
 
-  it("renders the secondary CTA 'Schrijf je in' → /club/inschrijven (R5.B)", () => {
+  it("renders the secondary CTA 'Schrijf je in' → /club/word-lid (R5.B)", () => {
     render(<YouthSection />);
     const link = screen.getByRole("link", { name: /schrijf je in/i });
-    expect(link).toHaveAttribute("href", "/club/inschrijven");
+    expect(link).toHaveAttribute("href", "/club/word-lid");
   });
 
   it("shifts heading emphasis to 'Elewijt' (R5.B brief §8)", () => {

--- a/apps/web/src/components/home/YouthSection/YouthSection.tsx
+++ b/apps/web/src/components/home/YouthSection/YouthSection.tsx
@@ -59,14 +59,14 @@ export const YouthSection = ({ className }: YouthSectionProps) => (
       </div>
 
       {/* Dual-CTA row — primary "Ontdek onze jeugd" → /jeugd, secondary
-          "Schrijf je in" → the existing /club/inschrijven route
+          "Schrijf je in" → the existing /club/word-lid route
           (mirrors the SiteHeader "Word lid" link target). Wraps to a
           vertical stack on narrow viewports via `flex-wrap`. */}
       <div className="flex flex-wrap items-center gap-3.5">
         <LinkButton href="/jeugd" variant="primary" withArrow>
           Ontdek onze jeugd
         </LinkButton>
-        <LinkButton href="/club/inschrijven" variant="inverted" withArrow>
+        <LinkButton href="/club/word-lid" variant="inverted" withArrow>
           Schrijf je in
         </LinkButton>
       </div>

--- a/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.stories.tsx
+++ b/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'The `/jeugd` closing CTA band (Phase 7). The shared `<CtaBand>` with youth copy: "Interesse in onze jeugd?" + a warm paper-stamp "Schrijf je in +" → /hulp (until the membership form #1473 ships).',
+          'The `/jeugd` closing CTA band (Phase 7). The shared `<CtaBand>` with youth copy: "Interesse in onze jeugd?" + a warm paper-stamp "Schrijf je in +" → /club/word-lid (the #1473 membership form).',
       },
     },
   },

--- a/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.test.tsx
+++ b/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.test.tsx
@@ -23,10 +23,10 @@ describe("JeugdCtaBand", () => {
     expect(heading.textContent).not.toContain("?.");
   });
 
-  it('renders the "Schrijf je in" CTA linking to /hulp by default', () => {
+  it('renders the "Schrijf je in" CTA linking to /club/word-lid by default', () => {
     render(<JeugdCtaBand />);
     const link = screen.getByRole("link", { name: /schrijf je in/i });
-    expect(link).toHaveAttribute("href", "/hulp");
+    expect(link).toHaveAttribute("href", "/club/word-lid");
   });
 
   it("honours a custom href", () => {

--- a/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.tsx
+++ b/apps/web/src/components/jeugd/JeugdCtaBand/JeugdCtaBand.tsx
@@ -2,9 +2,9 @@ import { CtaBand } from "@/components/design-system";
 
 export interface JeugdCtaBandProps {
   /**
-   * Where "Schrijf je in +" links. Defaults to `/hulp` until the membership
-   * intake form (#1473) ships (PRD redesign-phase-7-jeugd §7). A `mailto:` or
-   * external href renders a plain styled `<a>`.
+   * Where "Schrijf je in +" links. Defaults to the membership intake form
+   * `/club/word-lid` (#1473). A `mailto:` or external href renders a plain
+   * styled `<a>`.
    */
   href?: string;
 }
@@ -14,7 +14,7 @@ export interface JeugdCtaBandProps {
  * `<CtaBand>` with youth copy: "Interesse in onze jeugd?" + a `warm` paper-stamp
  * "Schrijf je in +". Render full-bleed as the page's last element.
  */
-export function JeugdCtaBand({ href = "/hulp" }: JeugdCtaBandProps) {
+export function JeugdCtaBand({ href = "/club/word-lid" }: JeugdCtaBandProps) {
   return (
     <CtaBand
       ariaLabel="Schrijf je in"

--- a/apps/web/src/components/layout/NavDropdown/NavDropdown.stories.tsx
+++ b/apps/web/src/components/layout/NavDropdown/NavDropdown.stories.tsx
@@ -63,7 +63,7 @@ const deClubGroups: NavDropdownGroup[] = [
   {
     label: "Praktisch",
     items: [
-      { label: "Praktische Info", href: "/club/word-lid" },
+      { label: "Praktische Info", href: "/club/inschrijven" },
       { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
       { label: "Cashless clubkaart", href: "/club/cashless" },
       { label: "Contact", href: "/club/contact" },

--- a/apps/web/src/components/layout/NavDropdown/NavDropdown.stories.tsx
+++ b/apps/web/src/components/layout/NavDropdown/NavDropdown.stories.tsx
@@ -63,7 +63,7 @@ const deClubGroups: NavDropdownGroup[] = [
   {
     label: "Praktisch",
     items: [
-      { label: "Praktische Info", href: "/club/inschrijven" },
+      { label: "Praktische Info", href: "/club/word-lid" },
       { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
       { label: "Cashless clubkaart", href: "/club/cashless" },
       { label: "Contact", href: "/club/contact" },

--- a/apps/web/src/components/layout/SiteFooter/SiteFooter.test.tsx
+++ b/apps/web/src/components/layout/SiteFooter/SiteFooter.test.tsx
@@ -63,7 +63,7 @@ describe("SiteFooter", () => {
     render(<SiteFooter />);
     expect(screen.getByRole("link", { name: "Als speler" })).toHaveAttribute(
       "href",
-      "/club/inschrijven",
+      "/club/word-lid",
     );
     expect(
       screen.getByRole("link", { name: "Als vrijwilliger" }),

--- a/apps/web/src/components/layout/SiteFooter/footerLinks.ts
+++ b/apps/web/src/components/layout/SiteFooter/footerLinks.ts
@@ -22,7 +22,7 @@ export const FOOTER_COLUMNS: ReadonlyArray<FooterColumn> = [
   {
     heading: "Aansluiten",
     links: [
-      { label: "Als speler", href: "/club/inschrijven" },
+      { label: "Als speler", href: "/club/word-lid" },
       { label: "Als vrijwilliger", href: "/club/vrijwilliger" },
       { label: "Als sponsor", href: "/sponsors" },
     ],

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
@@ -64,11 +64,11 @@ describe("SiteHeader", () => {
     });
   });
 
-  it("renders Word lid link to /club/inschrijven on desktop", () => {
+  it("renders Word lid link to /club/word-lid on desktop", () => {
     render(<SiteHeader />);
     const wordLid = screen.getAllByRole("link", { name: /word lid/i });
     expect(wordLid.length).toBeGreaterThan(0);
-    expect(wordLid[0]).toHaveAttribute("href", "/club/inschrijven");
+    expect(wordLid[0]).toHaveAttribute("href", "/club/word-lid");
   });
 
   it("opens the drawer when the hamburger is clicked", async () => {

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
@@ -177,7 +177,7 @@ function SiteHeaderInner({
               <MagnifyingGlass size={18} aria-hidden="true" />
             </Link>
             <Link
-              href="/club/inschrijven"
+              href="/club/word-lid"
               className="border-ink text-ink hover:border-jersey-deep hover:text-jersey-deep inline-flex items-center border px-2.5 py-1.5 font-mono text-[11px] font-semibold tracking-[0.04em] whitespace-nowrap uppercase no-underline transition-colors duration-150 xl:px-3.5 xl:py-2 xl:text-[13px] 2xl:text-[14px]"
             >
               Word lid
@@ -226,7 +226,7 @@ function SiteHeaderInner({
         })}
         <div className="mt-6">
           <Link
-            href="/club/inschrijven"
+            href="/club/word-lid"
             onClick={handleClose}
             className={getButtonClasses({
               variant: "primary",

--- a/apps/web/src/components/layout/menuItems.ts
+++ b/apps/web/src/components/layout/menuItems.ts
@@ -38,7 +38,7 @@ export const staticMenuItems: MenuItem[] = [
       {
         label: "Praktisch",
         items: [
-          { label: "Praktische Info", href: "/club/inschrijven" },
+          { label: "Praktische Info", href: "/club/word-lid" },
           { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
           { label: "Cashless clubkaart", href: "/club/cashless" },
           { label: "Contact", href: "/club/contact" },

--- a/apps/web/src/components/layout/menuItems.ts
+++ b/apps/web/src/components/layout/menuItems.ts
@@ -38,7 +38,7 @@ export const staticMenuItems: MenuItem[] = [
       {
         label: "Praktisch",
         items: [
-          { label: "Praktische Info", href: "/club/word-lid" },
+          { label: "Praktische Info", href: "/club/inschrijven" },
           { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
           { label: "Cashless clubkaart", href: "/club/cashless" },
           { label: "Contact", href: "/club/contact" },

--- a/apps/web/src/components/team/TeamEnrolmentCta/TeamEnrolmentCta.test.tsx
+++ b/apps/web/src/components/team/TeamEnrolmentCta/TeamEnrolmentCta.test.tsx
@@ -2,7 +2,7 @@
  * TeamEnrolmentCta unit tests.
  *
  * Covers:
- *  - Youth → renders, heading + CTA link to /club/inschrijven
+ *  - Youth → renders, heading + CTA link to /club/word-lid
  *  - Senior → renders null
  *  - Youth without an age group → still renders (jersey just has no letter)
  *  - Click → fires team_enrolment_cta_click with the team_slug param
@@ -40,7 +40,7 @@ describe("TeamEnrolmentCta", () => {
     vi.mocked(trackEvent).mockClear();
   });
 
-  it("renders the youth CTA linking to the static /club/inschrijven route", () => {
+  it("renders the youth CTA linking to the static /club/word-lid route", () => {
     render(
       <TeamEnrolmentCta
         teamType="youth"
@@ -52,7 +52,7 @@ describe("TeamEnrolmentCta", () => {
       /sluit je aan bij de jeugd van elewijt/i,
     );
     const link = screen.getByRole("link", { name: "Word lid" });
-    expect(link).toHaveAttribute("href", "/club/inschrijven");
+    expect(link).toHaveAttribute("href", "/club/word-lid");
   });
 
   it("returns null for a senior team", () => {
@@ -66,7 +66,7 @@ describe("TeamEnrolmentCta", () => {
     render(<TeamEnrolmentCta teamType="youth" teamSlug="kcvv-elewijt-jeugd" />);
     expect(screen.getByRole("link", { name: "Word lid" })).toHaveAttribute(
       "href",
-      "/club/inschrijven",
+      "/club/word-lid",
     );
   });
 

--- a/apps/web/src/components/team/TeamEnrolmentCta/TeamEnrolmentCta.tsx
+++ b/apps/web/src/components/team/TeamEnrolmentCta/TeamEnrolmentCta.tsx
@@ -15,11 +15,11 @@ import { cn } from "@/lib/utils/cn";
  *
  * A standalone fanzine section that sits between <SquadGrid> and <TeamStaff>
  * (no section-nav anchor — it's a CTA, not navigable content) and links to the
- * static `/club/inschrijven` route. Out-of-PRD addition on top of the shipped
+ * static `/club/word-lid` route. Out-of-PRD addition on top of the shipped
  * Phase 6.C page; design locked in `enrolment-cta-locked.md` (#1949).
  *
  * Youth-only: returns `null` for senior teams. Senior recruitment runs via
- * trials/contact, and `/club/inschrijven` is in practice the youth enrolment
+ * trials/contact, and `/club/word-lid` is in practice the youth enrolment
  * route (target of `/jeugd`, the homepage `YouthSection`, `JeugdEditorialGrid`,
  * `ResponsibilityBlock`).
  *
@@ -28,7 +28,7 @@ import { cn } from "@/lib/utils/cn";
  * and a corner `<JerseyShirt>` carrying the team's age group as chest letter.
  */
 
-const ENROLMENT_HREF = "/club/inschrijven";
+const ENROLMENT_HREF = "/club/word-lid";
 
 export interface TeamEnrolmentCtaProps {
   /** Render only for youth teams; senior returns `null`. */

--- a/apps/web/src/stories/features/forms/MembershipForm.stories.tsx
+++ b/apps/web/src/stories/features/forms/MembershipForm.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { MembershipForm } from "@/components/club/MembershipForm/MembershipForm";
+
+/**
+ * Membership-intake form for `/club/word-lid`, built from the locked Phase 2.A.4
+ * form atoms inside a <ClippedCard> + <StampBadge> shell. Role selector reveals
+ * role-specific fields; a minor birth date reveals the parent-consent block.
+ *
+ * `defaultRole` / `defaultBirthDate` exist only to render the conditional
+ * branches statically for docs + visual regression — the live form starts empty.
+ */
+const meta: Meta<typeof MembershipForm> = {
+  title: "Features/Forms/MembershipForm",
+  component: MembershipForm,
+  tags: ["autodocs", "vr"],
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div className="bg-cream w-[760px] max-w-full p-12">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Empty form — base fields, no role selected yet. */
+export const Default: Story = {};
+
+/** Senior player — reveals the medical-certificate acknowledgment. */
+export const Speler: Story = {
+  args: { defaultRole: "speler" },
+};
+
+/** Volunteer — base fields only, no medical cert. */
+export const Vrijwilliger: Story = {
+  args: { defaultRole: "vrijwilliger" },
+};
+
+/** Minor youth player — medical cert + parent-consent block both visible. */
+export const MinderjarigeJeugdspeler: Story = {
+  args: { defaultRole: "jeugdspeler", defaultBirthDate: "2014-05-01" },
+};

--- a/apps/web/test/e2e/routes.spec.ts
+++ b/apps/web/test/e2e/routes.spec.ts
@@ -56,6 +56,10 @@ test.describe("static routes", () => {
     await smokeTest(page, { path: "/club/bestuur" });
   });
 
+  test("/club/word-lid", async ({ page }) => {
+    await smokeTest(page, { path: "/club/word-lid" });
+  });
+
   test("/club/jeugdbestuur", async ({ page }) => {
     await smokeTest(page, { path: "/club/jeugdbestuur" });
   });

--- a/packages/api-contract/src/api/forms.ts
+++ b/packages/api-contract/src/api/forms.ts
@@ -1,0 +1,11 @@
+import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
+import { MembershipRequest, MembershipResponse } from "../schemas/forms";
+import { HttpBadRequest, HttpServiceUnavailable } from "../schemas/http-errors";
+
+export class FormsApi extends HttpApiGroup.make("forms").add(
+  HttpApiEndpoint.post("membershipForm", "/forms/membership")
+    .setPayload(MembershipRequest)
+    .addSuccess(MembershipResponse)
+    .addError(HttpBadRequest)
+    .addError(HttpServiceUnavailable),
+) {}

--- a/packages/api-contract/src/api/index.ts
+++ b/packages/api-contract/src/api/index.ts
@@ -4,8 +4,9 @@ import { OpponentApi } from "./opponent";
 import { RankingApi } from "./ranking";
 import { RelatedApi } from "./related";
 import { SearchApi } from "./search";
+import { FormsApi } from "./forms";
 
-export { MatchesApi, OpponentApi, RankingApi, RelatedApi, SearchApi };
+export { MatchesApi, OpponentApi, RankingApi, RelatedApi, SearchApi, FormsApi };
 
 /** Root API definition — implemented by apps/api (Cloudflare Worker), consumed by apps/web */
 export class PsdApi extends HttpApi.make("psd")
@@ -13,4 +14,5 @@ export class PsdApi extends HttpApi.make("psd")
   .add(OpponentApi)
   .add(RankingApi)
   .add(RelatedApi)
-  .add(SearchApi) {}
+  .add(SearchApi)
+  .add(FormsApi) {}

--- a/packages/api-contract/src/schemas/forms.ts
+++ b/packages/api-contract/src/schemas/forms.ts
@@ -1,0 +1,63 @@
+import { Schema as S } from "effect";
+
+/** The five membership roles a public applicant can pick. */
+export const MembershipRole = S.Literal(
+  "speler",
+  "jeugdspeler",
+  "vrijwilliger",
+  "trainer",
+  "scheidsrechter",
+);
+export type MembershipRole = S.Schema.Type<typeof MembershipRole>;
+
+/** Roles that must acknowledge the medical-certificate requirement. */
+export const MEDICAL_CERT_ROLES: ReadonlyArray<MembershipRole> = [
+  "speler",
+  "jeugdspeler",
+];
+
+export const MembershipGender = S.Literal("m", "f", "x");
+export type MembershipGender = S.Schema.Type<typeof MembershipGender>;
+
+/** Permissive single-line email check — full RFC validation is not worth it. */
+export const EMAIL_PATTERN = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+const Email = S.Trim.pipe(S.minLength(1), S.pattern(EMAIL_PATTERN));
+
+/**
+ * Public membership-intake payload. Shape/type rules live here (a decode
+ * failure → automatic 400). Cross-field rules that depend on `birthDate`
+ * (minor → parent fields, player → medical cert) are enforced server-side in
+ * the BFF handler, which recomputes the minor flag on the submit date.
+ */
+export class MembershipRequest extends S.Class<MembershipRequest>(
+  "MembershipRequest",
+)({
+  role: MembershipRole,
+  firstName: S.Trim.pipe(S.minLength(1), S.maxLength(100)),
+  lastName: S.Trim.pipe(S.minLength(1), S.maxLength(100)),
+  /** Full date `YYYY-MM-DD` — needed to compute the minor flag. */
+  birthDate: S.String.pipe(S.pattern(/^\d{4}-\d{2}-\d{2}$/)),
+  gender: MembershipGender,
+  /** City only — no street, no postal code. */
+  municipality: S.Trim.pipe(S.minLength(1), S.maxLength(100)),
+  email: Email,
+  priorClub: S.optional(S.Trim.pipe(S.maxLength(200))),
+  /** Parent/guardian email — required server-side only when the applicant is a minor. */
+  parentEmail: S.optional(Email),
+  parentalConsent: S.optional(S.Boolean),
+  /** Medical-cert acknowledgment — required server-side only for player roles. */
+  medicalCertAcknowledged: S.optional(S.Boolean),
+  /** Privacy statement must be accepted — a literal `true` rejects anything else at decode. */
+  privacyAccepted: S.Literal(true),
+  /** Cloudflare Turnstile token, verified server-side. */
+  turnstileToken: S.String,
+  /** Honeypot — bots fill it, humans never see it. Non-empty → silently dropped. */
+  company: S.optional(S.String),
+}) {}
+
+export class MembershipResponse extends S.Class<MembershipResponse>(
+  "MembershipResponse",
+)({
+  ok: S.Boolean,
+}) {}

--- a/packages/api-contract/src/schemas/http-errors.ts
+++ b/packages/api-contract/src/schemas/http-errors.ts
@@ -17,3 +17,13 @@ export class HttpNotFound extends S.TaggedError<HttpNotFound>()(
   { error: S.String },
   { status: 404 },
 ) {}
+
+export class HttpBadRequest extends S.TaggedError<HttpBadRequest>()(
+  "HttpBadRequest",
+  {
+    error: S.String,
+    /** Optional per-field validation messages, keyed by field name. */
+    fields: S.optional(S.Record({ key: S.String, value: S.String })),
+  },
+  { status: 400 },
+) {}

--- a/packages/api-contract/src/schemas/index.ts
+++ b/packages/api-contract/src/schemas/index.ts
@@ -6,3 +6,4 @@ export * from "./ranking";
 export * from "./related";
 export * from "./player-stats";
 export * from "./search";
+export * from "./forms";

--- a/packages/sanity-schemas/src/formRoutingConfig.ts
+++ b/packages/sanity-schemas/src/formRoutingConfig.ts
@@ -1,0 +1,41 @@
+import {defineField, defineType} from 'sanity'
+
+const DEFAULT_RECIPIENT = 'info@kcvvelewijt.be'
+
+const roleRecipient = (name: string, title: string, helper: string) =>
+  defineField({
+    name,
+    title,
+    type: 'string',
+    initialValue: DEFAULT_RECIPIENT,
+    description: helper,
+    validation: (Rule) =>
+      Rule.required()
+        .email()
+        .error('Vul een geldig e-mailadres in — hierheen gaan de meldingen van nieuwe inschrijvingen.'),
+  })
+
+/**
+ * Singleton: per-role recipient for membership-form admin notifications. The
+ * BFF reads this (cached) when an application comes in and routes the notice to
+ * the matching role address — all default to info@kcvvelewijt.be.
+ */
+export const formRoutingConfig = defineType({
+  name: 'formRoutingConfig',
+  title: 'Form routing config',
+  type: 'document',
+  // @ts-expect-error __experimental_actions is not in the public type yet
+  __experimental_actions: ['update', 'publish'],
+  fields: [
+    roleRecipient('speler', 'Speler', 'Ontvanger van inschrijvingen als senior speler.'),
+    roleRecipient('jeugdspeler', 'Jeugdspeler', 'Ontvanger van jeugd-inschrijvingen.'),
+    roleRecipient('vrijwilliger', 'Vrijwilliger', 'Ontvanger van vrijwilligers-inschrijvingen.'),
+    roleRecipient('trainer', 'Trainer', 'Ontvanger van trainer-inschrijvingen.'),
+    roleRecipient('scheidsrechter', 'Scheidsrechter', 'Ontvanger van scheidsrechter-inschrijvingen.'),
+  ],
+  preview: {
+    prepare() {
+      return {title: 'Form routing config'}
+    },
+  },
+})

--- a/packages/sanity-schemas/src/formRoutingConfig.ts
+++ b/packages/sanity-schemas/src/formRoutingConfig.ts
@@ -7,12 +7,15 @@ const roleRecipient = (name: string, title: string, helper: string) =>
     name,
     title,
     type: 'string',
+    group: 'ontvangers',
     initialValue: DEFAULT_RECIPIENT,
     description: helper,
     validation: (Rule) =>
       Rule.required()
         .email()
-        .error('Vul een geldig e-mailadres in — hierheen gaan de meldingen van nieuwe inschrijvingen.'),
+        .error(
+          'Verplicht. Naar dit adres sturen we de melding van elke nieuwe inschrijving voor deze rol — een leeg of ongeldig adres betekent dat niemand de aanvraag te zien krijgt.',
+        ),
   })
 
 /**
@@ -26,6 +29,7 @@ export const formRoutingConfig = defineType({
   type: 'document',
   // @ts-expect-error __experimental_actions is not in the public type yet
   __experimental_actions: ['update', 'publish'],
+  groups: [{name: 'ontvangers', title: 'Ontvangers', default: true}],
   fields: [
     roleRecipient('speler', 'Speler', 'Ontvanger van inschrijvingen als senior speler.'),
     roleRecipient('jeugdspeler', 'Jeugdspeler', 'Ontvanger van jeugd-inschrijvingen.'),

--- a/packages/sanity-schemas/src/index.ts
+++ b/packages/sanity-schemas/src/index.ts
@@ -30,6 +30,8 @@ export {banner} from './banner'
 export {homePage} from './homePage'
 export {jeugdLandingPage} from './jeugdLandingPage'
 export {matchesSliderPlaceholder} from './matchesSliderPlaceholder'
+export {membershipApplication} from './membershipApplication'
+export {formRoutingConfig} from './formRoutingConfig'
 
 import {player} from './player'
 import {team, trainingDay} from './team'
@@ -54,6 +56,8 @@ import {banner} from './banner'
 import {homePage} from './homePage'
 import {jeugdLandingPage} from './jeugdLandingPage'
 import {matchesSliderPlaceholder} from './matchesSliderPlaceholder'
+import {membershipApplication} from './membershipApplication'
+import {formRoutingConfig} from './formRoutingConfig'
 
 export const schemaTypes = [
   player,
@@ -82,4 +86,6 @@ export const schemaTypes = [
   homePage,
   jeugdLandingPage,
   matchesSliderPlaceholder,
+  membershipApplication,
+  formRoutingConfig,
 ]

--- a/packages/sanity-schemas/src/membershipApplication.ts
+++ b/packages/sanity-schemas/src/membershipApplication.ts
@@ -1,0 +1,204 @@
+import {defineField, defineType} from 'sanity'
+
+const ROLE_OPTIONS = [
+  {title: 'Speler', value: 'speler'},
+  {title: 'Jeugdspeler', value: 'jeugdspeler'},
+  {title: 'Vrijwilliger', value: 'vrijwilliger'},
+  {title: 'Trainer', value: 'trainer'},
+  {title: 'Scheidsrechter', value: 'scheidsrechter'},
+]
+
+const STATUS_OPTIONS = [
+  {title: 'Nieuw', value: 'new'},
+  {title: 'Gecontacteerd', value: 'contacted'},
+  {title: 'Goedgekeurd', value: 'approved'},
+  {title: 'Afgewezen', value: 'rejected'},
+]
+
+/**
+ * Membership-intake submission, created by the public `/club/word-lid` form via
+ * the BFF (never by an editor). Submitted fields are read-only; editors manage
+ * the `status` workflow and add internal `notes`.
+ */
+export const membershipApplication = defineType({
+  name: 'membershipApplication',
+  title: 'Inschrijving',
+  type: 'document',
+  groups: [
+    {name: 'aanvraag', title: 'Aanvraag', default: true},
+    {name: 'toestemming', title: 'Toestemming'},
+    {name: 'beheer', title: 'Beheer'},
+  ],
+  fields: [
+    defineField({
+      name: 'role',
+      title: 'Rol',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      description:
+        'De rol waarvoor deze persoon zich inschreef. Bepaalt naar welk e-mailadres de melding ging (zie Form routing config).',
+      options: {list: ROLE_OPTIONS},
+      validation: (Rule) =>
+        Rule.required().error('Verplicht — wordt automatisch ingevuld door het formulier.'),
+    }),
+    defineField({
+      name: 'firstName',
+      title: 'Voornaam',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      validation: (Rule) => Rule.required().error('Verplicht.'),
+    }),
+    defineField({
+      name: 'lastName',
+      title: 'Achternaam',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      validation: (Rule) => Rule.required().error('Verplicht.'),
+    }),
+    defineField({
+      name: 'birthDate',
+      title: 'Geboortedatum',
+      type: 'date',
+      group: 'aanvraag',
+      readOnly: true,
+      options: {dateFormat: 'DD-MM-YYYY'},
+      description: 'Volledige geboortedatum. Bepaalt of de aanvrager minderjarig is.',
+      validation: (Rule) => Rule.required().error('Verplicht.'),
+    }),
+    defineField({
+      name: 'isMinor',
+      title: 'Minderjarig',
+      type: 'boolean',
+      group: 'aanvraag',
+      readOnly: true,
+      description:
+        'Automatisch berekend uit de geboortedatum op het moment van inschrijven. Bij minderjarigen is een ouder/voogd-e-mail + toestemming vereist.',
+    }),
+    defineField({
+      name: 'gender',
+      title: 'Geslacht',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      options: {
+        list: [
+          {title: 'Man', value: 'm'},
+          {title: 'Vrouw', value: 'f'},
+          {title: 'X', value: 'x'},
+        ],
+      },
+      validation: (Rule) => Rule.required().error('Verplicht.'),
+    }),
+    defineField({
+      name: 'municipality',
+      title: 'Gemeente',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      validation: (Rule) => Rule.required().error('Verplicht.'),
+    }),
+    defineField({
+      name: 'email',
+      title: 'E-mail',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      description: 'Het e-mailadres van de aanvrager — gebruik dit om contact op te nemen.',
+      validation: (Rule) => Rule.required().error('Verplicht.'),
+    }),
+    defineField({
+      name: 'priorClub',
+      title: 'Vorige club',
+      type: 'string',
+      group: 'aanvraag',
+      readOnly: true,
+      description: 'Optioneel opgegeven door de aanvrager.',
+    }),
+    defineField({
+      name: 'parentEmail',
+      title: 'Ouder/voogd e-mail',
+      type: 'string',
+      group: 'toestemming',
+      readOnly: true,
+      description: 'Enkel ingevuld bij minderjarigen. Kreeg ook een bevestigingsmail.',
+    }),
+    defineField({
+      name: 'parentalConsent',
+      title: 'Ouderlijke toestemming',
+      type: 'boolean',
+      group: 'toestemming',
+      readOnly: true,
+      description: 'De ouder/voogd bevestigde toestemming te geven voor deze inschrijving (minderjarigen).',
+    }),
+    defineField({
+      name: 'medicalCertAcknowledged',
+      title: 'Medisch attest erkend',
+      type: 'boolean',
+      group: 'toestemming',
+      readOnly: true,
+      description:
+        'Speler/jeugdspeler bevestigde een medisch attest van geneeskundige geschiktheid te zullen voorleggen bij de eerste training.',
+    }),
+    defineField({
+      name: 'privacyAccepted',
+      title: 'Privacyverklaring aanvaard',
+      type: 'boolean',
+      group: 'toestemming',
+      readOnly: true,
+      description: 'De aanvrager aanvaardde de privacyverklaring bij het inschrijven.',
+    }),
+    defineField({
+      name: 'submittedAt',
+      title: 'Ingediend op',
+      type: 'datetime',
+      group: 'beheer',
+      readOnly: true,
+      description: 'Tijdstip waarop het formulier werd ingediend.',
+    }),
+    defineField({
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+      group: 'beheer',
+      initialValue: 'new',
+      options: {list: STATUS_OPTIONS, layout: 'radio'},
+      description:
+        'Beheer de opvolging: Nieuw → Gecontacteerd → Goedgekeurd/Afgewezen. Bepaalt onder welke filter deze inschrijving in de lijst verschijnt.',
+      validation: (Rule) => Rule.required().error('Verplicht — kies een status zodat de inschrijving correct gefilterd wordt.'),
+    }),
+    defineField({
+      name: 'notes',
+      title: 'Notities',
+      type: 'text',
+      rows: 3,
+      group: 'beheer',
+      description: 'Interne notities voor de opvolging. Niet zichtbaar voor de aanvrager.',
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Nieuwste eerst',
+      name: 'submittedAtDesc',
+      by: [{field: 'submittedAt', direction: 'desc'}],
+    },
+  ],
+  preview: {
+    select: {
+      firstName: 'firstName',
+      lastName: 'lastName',
+      role: 'role',
+      status: 'status',
+    },
+    prepare({firstName, lastName, role, status}) {
+      const roleLabel = ROLE_OPTIONS.find((r) => r.value === role)?.title ?? role
+      const statusLabel = STATUS_OPTIONS.find((s) => s.value === status)?.title ?? status
+      return {
+        title: `${firstName ?? ''} ${lastName ?? ''}`.trim() || '(naamloos)',
+        subtitle: [roleLabel, statusLabel].filter(Boolean).join(' · '),
+      }
+    },
+  },
+})

--- a/packages/sanity-studio/src/index.ts
+++ b/packages/sanity-studio/src/index.ts
@@ -14,6 +14,7 @@ export {schemaTypes} from './schema-types'
 // Studio at module load. Import migrations via `@kcvv/sanity-studio/migrations`.
 export {staffStructure} from './structure/staff'
 export {responsibilityStructure} from './structure/responsibility'
+export {membershipApplicationStructure} from './structure/membershipApplication'
 // Public LauncherTool surface. `useTemplates` and `filterLauncherTemplates`
 // are intentionally NOT re-exported — they would shadow Sanity's own
 // `useTemplates` hook for any consumer importing from `@kcvv/sanity-studio`.

--- a/packages/sanity-studio/src/structure/membershipApplication.ts
+++ b/packages/sanity-studio/src/structure/membershipApplication.ts
@@ -1,0 +1,45 @@
+import type {StructureBuilder} from 'sanity/structure'
+
+const STATUSES = [
+  {title: '🆕 Nieuw', value: 'new'},
+  {title: '📞 Gecontacteerd', value: 'contacted'},
+  {title: '✅ Goedgekeurd', value: 'approved'},
+  {title: '❌ Afgewezen', value: 'rejected'},
+] as const
+
+const NEWEST_FIRST = [{field: 'submittedAt', direction: 'desc'}] as const
+
+/**
+ * Inschrijvingen desk structure: all applications plus one filter view per
+ * status. Mirrors the feedback section's filter-chip pattern. Labels in Dutch.
+ */
+export function membershipApplicationStructure(S: StructureBuilder) {
+  return S.listItem()
+    .title('📨 Inschrijvingen')
+    .child(
+      S.list()
+        .title('Inschrijvingen')
+        .items([
+          S.listItem()
+            .title('Alle inschrijvingen')
+            .child(
+              S.documentList()
+                .title('Alle inschrijvingen')
+                .filter('_type == "membershipApplication"')
+                .defaultOrdering([...NEWEST_FIRST]),
+            ),
+          S.divider(),
+          ...STATUSES.map(({title, value}) =>
+            S.listItem()
+              .title(title)
+              .child(
+                S.documentList()
+                  .title(title)
+                  .filter('_type == "membershipApplication" && status == $status')
+                  .params({status: value})
+                  .defaultOrdering([...NEWEST_FIRST]),
+              ),
+          ),
+        ]),
+    )
+}


### PR DESCRIPTION
Closes #1473

## What

In-page Dutch membership-intake form at **`/club/word-lid`** replacing the dead external/placeholder links. Captures submissions in Sanity (persist-then-send) and dispatches acknowledgment + admin-notification emails via Resend, built in the BFF.

## Changes

**`packages/api-contract`** *(in scope by necessity — the endpoint contract lives here, mirroring `feedback`)*
- `FormsApi` group + `POST /forms/membership`, `MembershipRequest`/`MembershipResponse`, shared `EMAIL_PATTERN`/`MEDICAL_CERT_ROLES`, and a new `HttpBadRequest` (400 + field errors).

**`apps/api` (BFF)**
- `POST /forms/membership`: honeypot → Turnstile verify → Effect-Schema + business-rule validation → **persist** (`membershipApplication`) → **send** (best-effort).
- **Form-agnostic `dispatchEmail()` Resend transport** (`email/resend.ts`) + membership-specific templates (`forms/membership-emails.ts`). Future forms reuse the transport.
- `writeMembershipApplication` mutation + cached `getFormRoutingConfig` read for per-role admin routing.
- Env: `RESEND_API_KEY` (already scaffolded) + new `TURNSTILE_SECRET`.

**`packages/sanity-schemas` + `packages/sanity-studio`**
- `membershipApplication` doc + `formRoutingConfig` singleton (#1502 convention: groups + teaching `description` + `.error()`).
- Studio **Inschrijvingen** list view with status filter chips + singleton wiring (both studios, kept in sync).

**`apps/web`**
- `/club/word-lid` static page (beats the `club/[slug]` catch-all) + `MembershipForm` (5 roles, minor flow, medical-cert ack, privacy + Turnstile + honeypot, client + server validation), `/api/membership` proxy, `membership_form_submit` analytics.
- `/privacy` extended with the membership-form data + retention section.
- Storybook story (`Features/Forms/MembershipForm`, autodocs + vr) with per-role + minor variants.

**Cutover** — there were **no Google Forms links**; every entry point pointed at the never-built `/club/inschrijven`. Repointed all of them to `/club/word-lid`: header, footer, menu, YouthSection, TeamEnrolmentCta, **JeugdCtaBand** (was deferred to this issue), and the `/club/register` redirect. The jeugd dead-route remap files intentionally keep `/club/inschrijven` (CMS input remapped to `/hulp`).

## Extensibility note
The email transport is deliberately form-agnostic so the planned VIP-restaurant / stage / sponsorship forms reuse it. The broader shared spine (FormShell, BaseSubmissionFields, parameterized Studio view) is **deferred to form #2** — drawn from two real shapes rather than guessed from membership alone.

## Out of scope (per spec)
Payment (PSD handles it after contact), GTM/GA4 tag wiring (→ #1974), VR baseline capture (→ #1376; stories are vr-tagged).

## Review gate (Step 5.5)
Ran correctness + reuse/simplify reviews on the diff. **Applied:** missed `/club/register` redirect (was 308→404) + `JeugdCtaBand` repoint (both with tests); deduped `PLAYER_ROLES`→`MEDICAL_CERT_ROLES` and the email regex→shared `EMAIL_PATTERN`; hoisted in-render constants. **Skipped (intentional):** client/worker `isMinor` duplication (different runtimes, cheap preview); per-surface role-label maps (no natural shared home).

## Testing
- `pnpm --filter @kcvv/web check-all` ✅ (lint + type-check + 3107 tests + build)
- `@kcvv/api` 368 tests ✅, `api-contract`/`sanity-schemas`/`sanity-studio` type-check ✅
- New tests: `membership-rules` (age/minor boundaries), `handleMembership` (honeypot/minor/persist/email), `MembershipForm` (conditional fields + submit).

## Deploy notes
Set BFF secrets before go-live: `wrangler secret put RESEND_API_KEY` and `wrangler secret put TURNSTILE_SECRET` (+ `--env staging`). Set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` on Vercel. Add the 5 `formRoutingConfig` recipients in Studio (default `info@kcvvelewijt.be`). Without the secrets, Turnstile verification is skipped and email dispatch is a no-op (submissions still persist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added online membership enrollment form ("Word lid") with role selection, personal details, conditional parent consent for minors, and medical-certificate acknowledgment for specific roles.
  * Integrated bot-protection verification for form submissions.
  * Implemented transactional email notifications for membership submissions (applicant and admin acknowledgments).

* **Documentation**
  * Updated privacy policy with membership form data handling and retention details.
  * Refreshed "last updated" date.

* **Chores**
  * Updated website navigation and CTAs to direct users to the new membership form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->