### PR TITLE
feat(studio): editor-ux rework — player (#1503)

### DIFF
--- a/packages/sanity-schemas/src/player.ts
+++ b/packages/sanity-schemas/src/player.ts
@@ -4,96 +4,103 @@ export const player = defineType({
   name: 'player',
   title: 'Player',
   type: 'document',
+  // Editor-UX rework groups (#1503). `identiteit` holds the PSD-synced
+  // read-only fields; `redactioneel` is where the editor actually works.
+  groups: [
+    {name: 'identiteit', title: 'Identiteit (PSD)', default: true},
+    {name: 'redactioneel', title: 'Redactioneel'},
+    {name: 'meta', title: 'Meta'},
+  ],
   fields: [
-    // PSD-synced (never edit manually)
+    // ── Identiteit — PSD-synced, read-only ──────────────────────────────────
     defineField({
       name: 'psdId',
       title: 'PSD ID',
       type: 'string',
+      group: 'identiteit',
+      description: 'Unieke identifier uit PSD, gebruikt als publieke slug. Gesynchroniseerd — alleen-lezen, niet bewerken.',
       readOnly: true,
     }),
     defineField({
       name: 'firstName',
       title: 'First name',
       type: 'string',
+      group: 'identiteit',
+      description: 'Voornaam, gesynchroniseerd vanuit PSD. Alleen-lezen — wijzig dit in PSD, niet hier.',
       readOnly: true,
     }),
     defineField({
       name: 'lastName',
       title: 'Last name',
       type: 'string',
+      group: 'identiteit',
+      description: 'Familienaam, gesynchroniseerd vanuit PSD. Alleen-lezen — wijzig dit in PSD, niet hier.',
       readOnly: true,
     }),
     defineField({
       name: 'birthDate',
       title: 'Birth date',
       type: 'date',
+      group: 'identiteit',
+      description: 'Geboortedatum, gesynchroniseerd vanuit PSD. Alleen-lezen.',
       readOnly: true,
     }),
     defineField({
       name: 'keeper',
       title: 'Keeper',
       type: 'boolean',
+      group: 'identiteit',
+      description: 'Geeft aan of de speler een doelman is. Gesynchroniseerd vanuit PSD — alleen-lezen en betrouwbaar voor keepers.',
       readOnly: true,
-      description: 'Synced from PSD — always reliable for keepers',
     }),
     defineField({
       name: 'positionPsd',
       title: 'Position (PSD)',
       type: 'string',
-      readOnly: true,
+      group: 'identiteit',
       description:
-        'Synced from PSD bestPosition — null until the club populates positions in PSD. Use position field as fallback.',
-    }),
-    defineField({
-      name: 'archived',
-      title: 'Archived',
-      type: 'boolean',
-      description: 'Set automatically by sync when member is no longer in PSD. Do not edit manually.',
+        'Positie zoals PSD ze aanlevert (bestPosition). Vaak leeg voor KCVV — gebruik dan het redactionele veld "Position". Alleen-lezen.',
       readOnly: true,
-      hidden: true,
-    }),
-    // Editorial — not available from PSD for KCVV
-    defineField({
-      name: 'jerseyNumber',
-      title: 'Jersey number',
-      type: 'number',
-    }),
-    defineField({
-      name: 'psdImageUrl',
-      title: 'PSD image source URL',
-      type: 'url',
-      readOnly: true,
-      description: 'Raw PSD URL — used to detect when the image needs re-syncing. Not served to the site.',
-      hidden: true,
     }),
     defineField({
       name: 'psdImage',
       title: 'PSD image',
       type: 'image',
+      group: 'identiteit',
+      description:
+        'Spelersfoto gesynchroniseerd vanuit PSD. Alleen-lezen — voeg via "Transparent image" een eigen foto toe om ze op de site te vervangen.',
       readOnly: true,
-      description: 'Player photo synced from PSD and uploaded to Sanity CDN.',
     }),
-    // Editorial enrichment
+    // ── Redactioneel — editor-owned enrichment ──────────────────────────────
+    defineField({
+      name: 'jerseyNumber',
+      title: 'Jersey number',
+      type: 'number',
+      group: 'redactioneel',
+      description: 'Rugnummer van de speler. Redactioneel — PSD levert dit niet aan, vul het zelf in.',
+    }),
     defineField({
       name: 'transparentImage',
       title: 'Transparent image',
       type: 'image',
+      group: 'redactioneel',
       options: {hotspot: true},
-      description: 'PNG with transparent background — replaces PSD image on site',
+      description: 'PNG met transparante achtergrond — vervangt de PSD-foto op de site. Redactioneel, door jou beheerd.',
     }),
     defineField({
       name: 'celebrationImage',
       title: 'Celebration image',
       type: 'image',
+      group: 'redactioneel',
       options: {hotspot: true},
-      description: 'Used for first-team Instagram share cards',
+      description: 'Foto gebruikt op de Instagram-deelkaarten van het eerste elftal. Redactioneel.',
     }),
     defineField({
       name: 'position',
       title: 'Position',
       type: 'string',
-      description: 'PSD does not provide position data for KCVV — set manually.',
+      group: 'redactioneel',
+      description: 'De positie zoals getoond op de site. PSD levert dit niet aan voor KCVV — kies ze hier zelf.',
       options: {
         list: ['Keeper', 'Verdediger', 'Middenvelder', 'Aanvaller', 'Speler'],
       },
@@ -102,6 +109,8 @@ export const player = defineType({
       name: 'bio',
       title: 'Bio',
       type: 'array',
+      group: 'redactioneel',
+      description: 'Korte voorstelling van de speler in vrije tekst. Redactioneel — getoond op het spelersprofiel.',
       of: [
         {
           type: 'block',
@@ -117,6 +126,26 @@ export const player = defineType({
           },
         },
       ],
+    }),
+    // ── Meta — hidden sync plumbing ─────────────────────────────────────────
+    defineField({
+      name: 'psdImageUrl',
+      title: 'PSD image source URL',
+      type: 'url',
+      group: 'meta',
+      description: 'Ruwe PSD-URL — gebruikt om te detecteren wanneer de foto opnieuw gesynchroniseerd moet worden. Niet getoond op de site. Alleen-lezen.',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
+      name: 'archived',
+      title: 'Archived',
+      type: 'boolean',
+      group: 'meta',
+      description: 'Automatisch gezet door de sync wanneer de speler niet meer in PSD voorkomt. Alleen-lezen — niet handmatig bewerken.',
+      initialValue: false,
+      readOnly: true,
+      hidden: true,
     }),
   ],
   preview: {

--- a/packages/sanity-studio/src/inspectors/guide-content.ts
+++ b/packages/sanity-studio/src/inspectors/guide-content.ts
@@ -118,4 +118,15 @@ export const guideContent: Record<string, GuideEntry> = {
       'Gebruik de externe link voor een inschrijvings- of ticketpagina.',
     ],
   },
+  player: {
+    intro:
+      'Een speler is een lid van een ploeg. De identiteit (naam, geboortedatum, foto) komt automatisch uit PSD; jij verrijkt het profiel met bio, foto\'s en de positie.',
+    placement:
+      'Verschijnt in de ploegoverzichten en op het spelersprofiel. De transparante foto vervangt de PSD-foto op de site.',
+    tips: [
+      'De velden onder "Identiteit (PSD)" zijn gesynchroniseerd en alleen-lezen — wijzig ze in PSD, niet hier.',
+      'Vul onder "Redactioneel" de bio, een transparante foto en de positie in — PSD levert die niet aan voor KCVV.',
+      'Het redactionele "Position"-veld is wat op de site verschijnt; "Position (PSD)" is voor KCVV vaak leeg.',
+    ],
+  },
 }


### PR DESCRIPTION
Closes #1503

PR 2 of the 3-PR propagation tail (PSD-synced types). Applies the editor-UX convention to `player`.

## Changes

- **Groups** — `Identiteit (PSD)` (default, all PSD-synced read-only fields) / `Redactioneel` (editor-owned enrichment: bio, transparent + celebration image, jersey number, position label) / `Meta` (hidden sync plumbing: `psdImageUrl`, `archived`).
- **Teaching descriptions** make the **editor-owned vs PSD-synced / read-only** split explicit — the AC's core requirement — so editors don't try to change synced values (e.g. firstName/lastName say "wijzig dit in PSD, niet hier"; the redactioneel `position` notes PSD doesn't supply it for KCVV).
- **`guideContent` entry** (intro + placement + tips), with tips reinforcing the split.
- **`archived` → `initialValue: false`** (sanity-schemas boolean convention, matching the #2197 staffMember fix).
- **No launcher card** — players are PSD-synced and rarely hand-created.

No required fields exist on `player`, so there's no teaching `.error()` (validation semantics unchanged).

## Testing

- `pnpm --filter @kcvv/sanity-schemas type-check` — pass
- `pnpm --filter @kcvv/sanity-studio check-all` — type-check + lint + **214 tests** pass (guide-content shape test covers the new entry)
- `pnpm --filter @kcvv/studio build` — production studio compiles
- No `sanity.config.ts` change — the guide inspector auto-appears for any type with a `guideContent` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)