### PR TITLE
fix(schema): organigramNode preview stalls — count members not array-index deref

### DIFF
--- a/packages/sanity-schemas/src/preview/organigramNode-preview.ts
+++ b/packages/sanity-schemas/src/preview/organigramNode-preview.ts
@@ -1,41 +1,33 @@
 /**
  * Sanity preview select + prepare for organigramNode.
- * Selects up to 3 members' names via `members[N]->firstName/lastName`.
+ *
+ * Subtitle shows the member count, not the member names: Sanity's preview store
+ * cannot dereference array elements by numeric index (`members[0]->firstName`),
+ * which stalls the whole preview subscription — leaving blank rows in lists and
+ * a "New Organigram node" fallback title. Reading the raw `members` array (no
+ * deref) resolves cleanly; we count it instead.
  */
 
-const MAX_MEMBERS = 3
-
-export const organigramNodePreviewSelect: Record<string, string> = {
+export const organigramNodePreviewSelect = {
   title: 'title',
   roleCode: 'roleCode',
-  member0FirstName: 'members[0]->firstName',
-  member0LastName: 'members[0]->lastName',
-  member1FirstName: 'members[1]->firstName',
-  member1LastName: 'members[1]->lastName',
-  member2FirstName: 'members[2]->firstName',
-  member2LastName: 'members[2]->lastName',
+  members: 'members',
 }
 
 interface OrganigramNodePreviewSelection {
   title?: string
   roleCode?: string
-  [key: string]: string | undefined
+  members?: unknown[]
 }
 
 export function prepareOrganigramNodePreview(selection: OrganigramNodePreviewSelection) {
-  const {title, roleCode} = selection
+  const {title, roleCode, members} = selection
 
-  const names: string[] = []
-  for (let i = 0; i < MAX_MEMBERS; i++) {
-    const first = selection[`member${i}FirstName`]
-    const last = selection[`member${i}LastName`]
-    const name = [first, last].filter(Boolean).join(' ')
-    if (name) names.push(name)
-  }
-
+  const count = Array.isArray(members) ? members.length : 0
   const badge = roleCode ? `[${roleCode}]` : ''
+
   return {
     title: [badge, title].filter(Boolean).join(' '),
-    subtitle: names.length > 0 ? names.join(', ') : 'Vacant',
+    subtitle: count > 0 ? `${count} ${count === 1 ? 'lid' : 'leden'}` : 'Vacant',
   }
 }

--- a/packages/sanity-studio/src/preview/organigramNode-preview.test.ts
+++ b/packages/sanity-studio/src/preview/organigramNode-preview.test.ts
@@ -1,74 +1,55 @@
 import {describe, expect, it} from 'vitest'
 import {prepareOrganigramNodePreview} from '@kcvv/sanity-schemas'
 
+// `members` items are opaque to the prepare (it only counts them); stub refs suffice.
+const refs = (n: number) => Array.from({length: n}, (_, i) => ({_ref: `m${i}`}))
+
 describe('organigramNode preview', () => {
-  it('shows member names as subtitle when members exist', () => {
+  it('shows member count as subtitle when members exist', () => {
     const result = prepareOrganigramNodePreview({
       title: 'Voorzitter',
       roleCode: 'VP',
-      member0FirstName: 'Kevin',
-      member0LastName: 'Schutijser',
-      member1FirstName: 'David',
-      member1LastName: 'Symkens',
-      member2FirstName: undefined,
-      member2LastName: undefined,
+      members: refs(2),
     })
-    expect(result.subtitle).toBe('Kevin Schutijser, David Symkens')
+    expect(result.subtitle).toBe('2 leden')
   })
 
   it('shows "Vacant" when no members', () => {
     const result = prepareOrganigramNodePreview({
       title: 'ATVJO',
       roleCode: undefined,
-      member0FirstName: undefined,
-      member0LastName: undefined,
-      member1FirstName: undefined,
-      member1LastName: undefined,
-      member2FirstName: undefined,
-      member2LastName: undefined,
+      members: [],
     })
     expect(result.subtitle).toBe('Vacant')
   })
 
-  it('shows single member name', () => {
+  it('shows "Vacant" when members is undefined', () => {
+    const result = prepareOrganigramNodePreview({title: 'ATVJO'})
+    expect(result.subtitle).toBe('Vacant')
+  })
+
+  it('uses singular "lid" for a single member', () => {
     const result = prepareOrganigramNodePreview({
       title: 'Secretaris',
-      roleCode: undefined,
-      member0FirstName: 'Kevin',
-      member0LastName: 'Van Ransbeeck',
-      member1FirstName: undefined,
-      member1LastName: undefined,
-      member2FirstName: undefined,
-      member2LastName: undefined,
+      members: refs(1),
     })
-    expect(result.subtitle).toBe('Kevin Van Ransbeeck')
+    expect(result.subtitle).toBe('1 lid')
   })
 
   it('preserves roleCode in title', () => {
     const result = prepareOrganigramNodePreview({
       title: 'Voorzitter',
       roleCode: 'VP',
-      member0FirstName: 'Rudy',
-      member0LastName: 'Bautmans',
-      member1FirstName: undefined,
-      member1LastName: undefined,
-      member2FirstName: undefined,
-      member2LastName: undefined,
+      members: refs(1),
     })
     expect(result.title).toBe('[VP] Voorzitter')
   })
 
-  it('handles three members', () => {
+  it('counts three members', () => {
     const result = prepareOrganigramNodePreview({
       title: 'Lid',
-      roleCode: undefined,
-      member0FirstName: 'A',
-      member0LastName: 'B',
-      member1FirstName: 'C',
-      member1LastName: 'D',
-      member2FirstName: 'E',
-      member2LastName: 'F',
+      members: refs(3),
     })
-    expect(result.subtitle).toBe('A B, C D, E F')
+    expect(result.subtitle).toBe('3 leden')
   })
 })


### PR DESCRIPTION
## Problem

`organigramNode` previews rendered as **perpetual loading skeletons** everywhere they appear — document lists (Staff → Organigram beheer), the "Rapporteert aan" reference picker, and the editor pane (which fell back to a misleading "New Organigram node" title on real *published* documents). The data was never the issue: all 39 nodes have titles and the equivalent server-side GROQ projection resolves fine.

## Cause

The preview `select` dereferenced array elements **by numeric index**:

```ts
member0FirstName: 'members[0]->firstName',
```

Sanity's preview store tracks array items by `_key`, not position, and cannot resolve a numeric-index path *through a reference*. That stalls the entire preview subscription → blank rows. (The neighbouring `responsibility` preview derefs too — `primaryContact.organigramNode->title` — but without an array index, so it renders fine. The array index is the differentiator.)

## Fix

Read the raw `members` array (no deref — resolves cleanly) and show the **count** in the subtitle instead of the names:

- `3 leden` / `1 lid` / `Vacant`

Trade-off: the picker subtitle no longer lists member *names*. Recovering names would require a custom async preview component (a React component running its own GROQ query) — out of scope for this stall fix.

## Testing

- `packages/sanity-studio/src/preview/organigramNode-preview.test.ts` updated for the count-based subtitle (singular/plural/vacant/undefined/badge). 215 studio tests pass.
- Full-monorepo `type-check` passes.
- Deployed to `kcvv-elewijt-staging` for manual verification — previews resolve in lists and reference pickers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organigram node previews now display member counts with localized formatting ("1 lid", "2 leden") or "Vacant" status instead of individual member names.
  * Role codes are now included in the organigram node preview title.

* **Tests**
  * Updated test suite to validate new member count and vacant status display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->