### PR TITLE
perf(api): cut Sanity CDN + PSD request volume (#1921)

### DIFF
--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -63,11 +63,13 @@ describe("TTL constants", () => {
     expect(TTL.RANKING).toBe(60 * 60 * 24);
   });
 
-  it("MATCH_DETAIL_LIVE does not exist", () => {
-    expect("MATCH_DETAIL_LIVE" in TTL).toBe(false);
+  it("match-detail proximity tiers (live / matchday / week)", () => {
+    expect(TTL.MATCH_DETAIL_LIVE).toBe(60);
+    expect(TTL.MATCH_DETAIL_MATCHDAY).toBe(60 * 5);
+    expect(TTL.MATCH_DETAIL_WEEK).toBe(60 * 60);
   });
 
-  it("MATCH_DETAIL_DEFAULT is 24 hours", () => {
+  it("MATCH_DETAIL_DEFAULT is 24 hours (distant)", () => {
     expect(TTL.MATCH_DETAIL_DEFAULT).toBe(60 * 60 * 24);
   });
 

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -7,7 +7,10 @@ export const TTL = {
   NEXT_MATCHES: 60 * 60 * 4, // 4 hours — no live scores, schedule is stable for hours
   MATCHES_WINDOW: 60 * 60 * 4, // 4 hours — matchday picker; in-window matches stay listed regardless of refresh
   MATCH_DETAIL_PAST: 60 * 60 * 24 * 7, // 7 days — historical, never changes
-  MATCH_DETAIL_DEFAULT: 60 * 60 * 24, // 24 hours — upcoming/recent matches
+  MATCH_DETAIL_DEFAULT: 60 * 60 * 24, // 24 hours — distant (kickoff >7d away)
+  MATCH_DETAIL_LIVE: 60, // <3h from kickoff — live, refresh aggressively
+  MATCH_DETAIL_MATCHDAY: 60 * 5, // <24h from kickoff — matchday
+  MATCH_DETAIL_WEEK: 60 * 60, // <7d from kickoff — this week
   RANKING: 60 * 60 * 24, // 24 hours — updates only after a match day
   RELATED: 60 * 60 * 6, // 6 hours — related content changes infrequently
   OPPONENT_HISTORY: 60 * 60 * 24 * 7, // 7 days — historical match data doesn't change

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -315,6 +315,46 @@ describe("matchDetailTtl", () => {
       TTL.MATCH_DETAIL_DEFAULT,
     );
   });
+
+  // Exact tier cutoffs — guard the < vs >= comparisons against off-by-one.
+  it("48h-finished cutoff (>= is PAST)", () => {
+    expect(matchDetailTtl(at(-48 * H), "finished", now)).toBe(
+      TTL.MATCH_DETAIL_PAST, // exactly 48h ago → immutable
+    );
+    expect(matchDetailTtl(at(-48 * H - 1), "finished", now)).toBe(
+      TTL.MATCH_DETAIL_PAST, // just over 48h → immutable
+    );
+    expect(matchDetailTtl(at(-48 * H + 1), "finished", now)).toBe(
+      TTL.MATCH_DETAIL_WEEK, // just under 48h → not yet immutable, ~48h distance
+    );
+  });
+
+  it("3h cutoff (< is LIVE)", () => {
+    expect(matchDetailTtl(at(3 * H - 1), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_LIVE,
+    );
+    expect(matchDetailTtl(at(3 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_MATCHDAY,
+    );
+  });
+
+  it("24h cutoff (< is MATCHDAY)", () => {
+    expect(matchDetailTtl(at(24 * H - 1), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_MATCHDAY,
+    );
+    expect(matchDetailTtl(at(24 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_WEEK,
+    );
+  });
+
+  it("7d cutoff (< is WEEK)", () => {
+    expect(matchDetailTtl(at(7 * 24 * H - 1), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_WEEK,
+    );
+    expect(matchDetailTtl(at(7 * 24 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_DEFAULT,
+    );
+  });
 });
 
 describe("getPlayerStatsHandler", () => {

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -6,8 +6,9 @@ import {
   getMatchesWindowHandler,
   getMatchDetailHandler,
   getPlayerStatsHandler,
+  matchDetailTtl,
 } from "./matches";
-import { HARD_TTL_DEFAULT } from "../cache/kv-cache";
+import { HARD_TTL_DEFAULT, TTL } from "../cache/kv-cache";
 import { PsdService, type PsdServiceInterface } from "../psd/service";
 import type { BffError } from "../psd/errors";
 import { UpstreamUnavailableError, ResourceNotFoundError } from "../psd/errors";
@@ -268,6 +269,51 @@ describe("getMatchDetailHandler", () => {
     if (result._tag === "Left") {
       expect(result.left._tag).toBe("ResourceNotFound");
     }
+  });
+});
+
+describe("matchDetailTtl", () => {
+  const now = new Date("2025-06-01T12:00:00.000Z").getTime();
+  const at = (offsetMs: number) => new Date(now + offsetMs);
+  const H = 60 * 60 * 1000;
+
+  it("settled ≥48h ago → 7 days (immutable)", () => {
+    expect(matchDetailTtl(at(-3 * 24 * H), "finished", now)).toBe(
+      TTL.MATCH_DETAIL_PAST,
+    );
+    expect(matchDetailTtl(at(-3 * 24 * H), "forfeited", now)).toBe(
+      TTL.MATCH_DETAIL_PAST,
+    );
+  });
+
+  it("within 3h of kickoff → live (60s), even when just finished", () => {
+    expect(matchDetailTtl(at(0), "in_progress", now)).toBe(
+      TTL.MATCH_DETAIL_LIVE,
+    );
+    expect(matchDetailTtl(at(-1 * H), "finished", now)).toBe(
+      TTL.MATCH_DETAIL_LIVE,
+    );
+  });
+
+  it("3h–24h from kickoff → matchday (300s)", () => {
+    expect(matchDetailTtl(at(10 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_MATCHDAY,
+    );
+  });
+
+  it("1d–7d from kickoff → this week (3600s)", () => {
+    expect(matchDetailTtl(at(3 * 24 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_WEEK,
+    );
+  });
+
+  it("beyond 7d (past or future) → distant (24h)", () => {
+    expect(matchDetailTtl(at(10 * 24 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_DEFAULT,
+    );
+    expect(matchDetailTtl(at(-10 * 24 * H), "scheduled", now)).toBe(
+      TTL.MATCH_DETAIL_DEFAULT,
+    );
   });
 });
 

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -80,6 +80,36 @@ export const getMatchesWindowHandler = (): Effect.Effect<
   );
 };
 
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Soft cache TTL (seconds) for a match-detail response, derived from kickoff
+ * proximity. The rate-limited PSD hop is then refreshed often only when it
+ * matters (live / matchday) and rarely for distant or settled matches.
+ *
+ *   finished ≥48h ago → 7d   (immutable)
+ *   |kickoff − now| < 3h → 60s   (live)
+ *                   < 24h → 300s  (matchday)
+ *                   < 7d  → 3600s (this week)
+ *   else              → 24h  (distant)
+ */
+export function matchDetailTtl(
+  date: Date,
+  status: string,
+  now: number = Date.now(),
+): number {
+  const kickoff = new Date(date).getTime();
+  const finished = status === "finished" || status === "forfeited";
+
+  if (finished && now - kickoff >= 48 * HOUR_MS) return TTL.MATCH_DETAIL_PAST;
+
+  const distanceMs = Math.abs(kickoff - now);
+  if (distanceMs < 3 * HOUR_MS) return TTL.MATCH_DETAIL_LIVE;
+  if (distanceMs < 24 * HOUR_MS) return TTL.MATCH_DETAIL_MATCHDAY;
+  if (distanceMs < 7 * 24 * HOUR_MS) return TTL.MATCH_DETAIL_WEEK;
+  return TTL.MATCH_DETAIL_DEFAULT;
+}
+
 export const getMatchDetailHandler = (
   matchId: number,
 ): Effect.Effect<
@@ -93,20 +123,10 @@ export const getMatchDetailHandler = (
     return yield* service.getMatchDetail(matchId);
   });
 
-  // Finished ≥48h ago → 7 days (immutable). All other cases → 24h.
-  const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
   return matchDetailCache.getOrFetch(
     cacheKey,
     fetchDetail,
-    (detail) => {
-      const isFinished =
-        detail.status === "finished" || detail.status === "forfeited";
-      const isOldEnough =
-        Date.now() - new Date(detail.date).getTime() >= FORTY_EIGHT_HOURS_MS;
-      return isFinished && isOldEnough
-        ? TTL.MATCH_DETAIL_PAST
-        : TTL.MATCH_DETAIL_DEFAULT;
-    },
+    (detail) => matchDetailTtl(detail.date, detail.status),
     undefined,
     { shouldServeStale },
   );

--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -9,6 +9,9 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=vhb33jaz
 NEXT_PUBLIC_SANITY_DATASET=production
 # SANITY_API_READ_TOKEN: Viewer token from sanity.io/manage → API → Tokens
 SANITY_API_READ_TOKEN=
+# SANITY_REVALIDATE_SECRET: shared secret for the Sanity → /api/revalidate
+# webhook (HMAC). Set the same value in the Sanity console webhook config.
+SANITY_REVALIDATE_SECRET=
 
 # Adobe Typekit (Adobe Fonts) kit ID — required for custom fonts
 # Find at: https://fonts.adobe.com/my_fonts#web_projects-section

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@phosphor-icons/react": "2.1.10",
     "@portabletext/react": "6.2.0",
     "@sanity/client": "7.22.1",
+    "@sanity/webhook": "4.0.4",
     "@tailwindcss/typography": "0.5.20",
     "@touch4it/ical-timezones": "1.9.0",
     "clsx": "2.1.1",

--- a/apps/web/src/app/(landing)/sponsors/page.tsx
+++ b/apps/web/src/app/(landing)/sponsors/page.tsx
@@ -75,4 +75,6 @@ export default async function SponsorsPageRoute() {
   );
 }
 
-export const revalidate = 3600;
+// 24h ISR — sponsor list changes rarely; editor publishes invalidate on
+// demand via /api/revalidate (revalidateTag 'sponsors').
+export const revalidate = 86400;

--- a/apps/web/src/app/(main)/evenementen/page.tsx
+++ b/apps/web/src/app/(main)/evenementen/page.tsx
@@ -47,7 +47,9 @@ export const metadata: Metadata = {
   },
 };
 
-export const revalidate = 300;
+// 1h ISR — events listing; on-demand revalidation via /api/revalidate
+// (revalidatePath '/evenementen') makes new/edited events appear sooner.
+export const revalidate = 3600;
 
 export default async function EvenementenPage() {
   const events = await runPromise(

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -619,4 +619,6 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
   );
 }
 
-export const revalidate = 3600;
+// 24h ISR — article publishes invalidate on demand via /api/revalidate
+// (revalidatePath '/nieuws/<slug>' + revalidateTag 'articles').
+export const revalidate = 86400;

--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -324,4 +324,6 @@ export default async function TeamPage({ params }: TeamPageProps) {
   );
 }
 
-export const revalidate = 3600;
+// 6h ISR — rosters change rarely; editor publishes invalidate on demand via
+// /api/revalidate (revalidateTag 'teams').
+export const revalidate = 21600;

--- a/apps/web/src/app/(main)/spelers/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/spelers/[slug]/page.tsx
@@ -228,4 +228,6 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   );
 }
 
-export const revalidate = 3600;
+// 24h ISR — player data is PSD-synced + editor-published; on-demand
+// revalidation keeps it fresh via /api/revalidate (revalidateTag 'players').
+export const revalidate = 86400;

--- a/apps/web/src/app/(main)/staf/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/staf/[slug]/page.tsx
@@ -205,4 +205,6 @@ export default async function StafPage({ params }: StaffPageProps) {
   );
 }
 
-export const revalidate = 3600;
+// 24h ISR — staff data is PSD-synced + editor-published; on-demand
+// revalidation keeps it fresh via /api/revalidate (revalidateTag 'staff').
+export const revalidate = 86400;

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -428,7 +428,12 @@ export default async function MatchPage({ params }: MatchPageProps) {
 }
 
 /**
- * Enable ISR with 5 minute revalidation for match data
- * (shorter than team pages since match data changes more frequently).
+ * ISR at 5 minutes. Kept modest (not lengthened like the other routes) so the
+ * page picks up fresh BFF match data promptly. Proximity-aware throttling of
+ * the rate-limited PSD hop lives in the BFF's match-detail KV TTL
+ * (`apps/api` `matchDetailTtl`): distant/finished matches are served from KV
+ * for hours/days, so frequent ISR here is cheap. The page's own Sanity reads
+ * (linked articles/galleries) are tag-cached (Scope B), so re-running this
+ * render does not re-hit the Sanity CDN.
  */
 export const revalidate = 300;

--- a/apps/web/src/app/api/revalidate/route.test.ts
+++ b/apps/web/src/app/api/revalidate/route.test.ts
@@ -57,6 +57,26 @@ describe("POST /api/revalidate", () => {
     expect(revalidateTag).not.toHaveBeenCalled();
   });
 
+  it("returns 400 on invalid JSON (signature valid)", async () => {
+    const res = await POST(
+      new Request("http://localhost:3000/api/revalidate", {
+        method: "POST",
+        headers: { "sanity-webhook-signature": "sig" },
+        body: "{not valid json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when _type is missing", async () => {
+    const res = await POST(makeRequest({ slug: "x" }));
+    expect(res.status).toBe(400);
+    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
   it("revalidates article path + tag on a valid payload", async () => {
     const res = await POST(makeRequest({ _type: "article", slug: "hello" }));
     expect(res.status).toBe(200);

--- a/apps/web/src/app/api/revalidate/route.test.ts
+++ b/apps/web/src/app/api/revalidate/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { revalidatePath, revalidateTag, isValidSignature } = vi.hoisted(() => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+  isValidSignature: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath, revalidateTag }));
+vi.mock("@sanity/webhook", () => ({
+  isValidSignature,
+  SIGNATURE_HEADER_NAME: "sanity-webhook-signature",
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown, signature = "sig"): Request {
+  return new Request("http://localhost:3000/api/revalidate", {
+    method: "POST",
+    headers: { "sanity-webhook-signature": signature },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/revalidate", () => {
+  let savedSecret: string | undefined;
+
+  beforeEach(() => {
+    savedSecret = process.env.SANITY_REVALIDATE_SECRET;
+    process.env.SANITY_REVALIDATE_SECRET = "test-secret";
+    revalidatePath.mockReset();
+    revalidateTag.mockReset();
+    isValidSignature.mockReset();
+    isValidSignature.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    if (savedSecret !== undefined) {
+      process.env.SANITY_REVALIDATE_SECRET = savedSecret;
+    } else {
+      delete process.env.SANITY_REVALIDATE_SECRET;
+    }
+  });
+
+  it("returns 503 when the secret is not configured", async () => {
+    delete process.env.SANITY_REVALIDATE_SECRET;
+    const res = await POST(makeRequest({ _type: "article", slug: "x" }));
+    expect(res.status).toBe(503);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid signature with 401", async () => {
+    isValidSignature.mockResolvedValue(false);
+    const res = await POST(makeRequest({ _type: "article", slug: "x" }));
+    expect(res.status).toBe(401);
+    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("revalidates article path + tag on a valid payload", async () => {
+    const res = await POST(makeRequest({ _type: "article", slug: "hello" }));
+    expect(res.status).toBe(200);
+    expect(revalidatePath).toHaveBeenCalledWith("/");
+    expect(revalidatePath).toHaveBeenCalledWith("/nieuws");
+    expect(revalidatePath).toHaveBeenCalledWith("/nieuws/hello");
+    expect(revalidateTag).toHaveBeenCalledWith("articles", "max");
+  });
+
+  it("routes players by psdId, not slug", async () => {
+    const res = await POST(makeRequest({ _type: "player", psdId: 42 }));
+    expect(res.status).toBe(200);
+    expect(revalidatePath).toHaveBeenCalledWith("/spelers/42");
+    expect(revalidateTag).toHaveBeenCalledWith("players", "max");
+  });
+
+  it("routes staff by psdId, not slug", async () => {
+    const res = await POST(makeRequest({ _type: "staffMember", psdId: 900 }));
+    expect(res.status).toBe(200);
+    expect(revalidatePath).toHaveBeenCalledWith("/staf/900");
+    expect(revalidateTag).toHaveBeenCalledWith("staff", "max");
+  });
+
+  it("busts the banners tag + homepage on a homePage/banner change", async () => {
+    await POST(makeRequest({ _type: "homePage" }));
+    expect(revalidatePath).toHaveBeenCalledWith("/");
+    expect(revalidateTag).toHaveBeenCalledWith("banners", "max");
+  });
+
+  it("revalidates both old and new slug on a rename", async () => {
+    await POST(
+      makeRequest({ _type: "team", slug: "new", previousSlug: "old" }),
+    );
+    expect(revalidatePath).toHaveBeenCalledWith("/ploegen/new");
+    expect(revalidatePath).toHaveBeenCalledWith("/ploegen/old");
+    expect(revalidateTag).toHaveBeenCalledWith("teams", "max");
+  });
+
+  it("acks unknown types with 200 and revalidates nothing", async () => {
+    const res = await POST(makeRequest({ _type: "mysteryType" }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ revalidated: false });
+    expect(revalidatePath).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { isValidSignature, SIGNATURE_HEADER_NAME } from "@sanity/webhook";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { SANITY_TAGS } from "@/lib/sanity/cache-tags";
+
+/**
+ * Sanity → Next.js on-demand revalidation (issue #1921, Scope E). A Sanity
+ * webhook POSTs here on publish/delete; we verify its HMAC signature and
+ * revalidate the affected paths + content tags so editor changes appear
+ * immediately despite the long ISR intervals (Scope A) and tagged repo caches
+ * (Scope B).
+ *
+ * The webhook itself is configured by hand in the Sanity console — see the
+ * issue's "Scope E manual step" for the exact URL / projection / secret.
+ */
+
+interface WebhookBody {
+  _type?: string;
+  /** Current `slug.current` from the webhook projection. */
+  slug?: string;
+  /** Previous slug on a rename (`before().slug.current`), if projected. */
+  previousSlug?: string;
+  /** Player/staff detail pages route by PSD id, not a Sanity slug. */
+  psdId?: string | number;
+}
+
+/**
+ * Maps a document `_type` to the paths + content tags to revalidate. `slugs`
+ * holds every slug to bust a detail page for (current + previous, so renames
+ * and deletes clear the stale URL too).
+ */
+function targets(
+  type: string,
+  slugs: string[],
+  psdId: string | undefined,
+): { paths: string[]; tags: string[] } | null {
+  const detail = (prefix: string) => slugs.map((s) => `${prefix}/${s}`);
+  switch (type) {
+    case "article":
+      return {
+        paths: ["/", "/nieuws", ...detail("/nieuws")],
+        tags: [SANITY_TAGS.articles],
+      };
+    case "player":
+      // Player + staff detail pages route by psdId, not a Sanity slug.
+      return {
+        paths: psdId ? [`/spelers/${psdId}`] : [],
+        tags: [SANITY_TAGS.players],
+      };
+    case "team":
+      return {
+        paths: ["/ploegen", ...detail("/ploegen")],
+        tags: [SANITY_TAGS.teams],
+      };
+    case "staffMember":
+      return {
+        paths: psdId ? [`/staf/${psdId}`] : [],
+        tags: [SANITY_TAGS.staff],
+      };
+    case "sponsor":
+      return { paths: ["/sponsors"], tags: [SANITY_TAGS.sponsors] };
+    // The homepage banners read (HOMEPAGE_BANNERS_QUERY) is tagged 'banners'
+    // and lives on '/'; it derefs `banner` docs from the `homePage` document,
+    // so either type changing must bust it.
+    case "homePage":
+    case "banner":
+      return { paths: ["/"], tags: [SANITY_TAGS.banners] };
+    case "page":
+      return { paths: detail("/club"), tags: [] };
+    case "event":
+      return {
+        paths: ["/evenementen", ...detail("/evenementen")],
+        tags: [],
+      };
+    case "photoGallery":
+      return {
+        paths: ["/galerij", ...detail("/galerij")],
+        tags: [SANITY_TAGS.galleries],
+      };
+    default:
+      return null;
+  }
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.SANITY_REVALIDATE_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { ok: false, error: "Revalidation not configured" },
+      { status: 503 },
+    );
+  }
+
+  const rawBody = await request.text();
+  const signature = request.headers.get(SIGNATURE_HEADER_NAME) ?? "";
+  if (!(await isValidSignature(rawBody, signature, secret))) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid signature" },
+      { status: 401 },
+    );
+  }
+
+  let payload: WebhookBody;
+  try {
+    payload = JSON.parse(rawBody) as WebhookBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON" },
+      { status: 400 },
+    );
+  }
+
+  const type = payload._type;
+  if (!type) {
+    return NextResponse.json(
+      { ok: false, error: "Missing _type" },
+      { status: 400 },
+    );
+  }
+
+  const slugs = [
+    ...new Set(
+      [payload.slug, payload.previousSlug].filter(
+        (s): s is string => typeof s === "string" && s.length > 0,
+      ),
+    ),
+  ];
+  const psdId = payload.psdId != null ? String(payload.psdId) : undefined;
+
+  const target = targets(type, slugs, psdId);
+  if (!target) {
+    // Unknown type — ack with 200 so Sanity doesn't retry, but revalidate
+    // nothing.
+    return NextResponse.json({ ok: true, revalidated: false, type });
+  }
+
+  for (const path of target.paths) revalidatePath(path);
+  // Next 16 requires a cache-life profile; "max" is the documented value for
+  // an on-demand purge from a route handler (updateTag is Server-Action only).
+  for (const tag of target.tags) revalidateTag(tag, "max");
+
+  return NextResponse.json({
+    ok: true,
+    revalidated: true,
+    type,
+    paths: target.paths,
+    tags: target.tags,
+  });
+}

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type {
   ARTICLES_QUERY_RESULT,
   ARTICLES_PAGINATED_QUERY_RESULT,
@@ -366,7 +367,11 @@ export class ArticleRepository extends Context.Tag("ArticleRepository")<
 >() {}
 
 export const ArticleRepositoryLive = Layer.succeed(ArticleRepository, {
-  findAll: () => fetchGroq<ARTICLES_QUERY_RESULT>(ARTICLES_QUERY),
+  findAll: () =>
+    fetchGroq<ARTICLES_QUERY_RESULT>(ARTICLES_QUERY, undefined, {
+      revalidate: SANITY_LIST_REVALIDATE,
+      tags: [SANITY_TAGS.articles],
+    }),
   findBySlug: (slug) =>
     fetchGroq<ARTICLE_BY_SLUG_QUERY_RESULT>(ARTICLE_BY_SLUG_QUERY, {
       slug,
@@ -390,9 +395,11 @@ export const ArticleRepositoryLive = Layer.succeed(ArticleRepository, {
     // to `MatchArticleVM` with a type-guard `filter` rather than a bare cast —
     // it drops any anomalous row (e.g. a null `articleType`) instead of
     // mislabeling it, and mirrors the other repository mappers.
-    fetchGroq<MATCH_ARTICLES_QUERY_RESULT>(MATCH_ARTICLES_QUERY, {
-      matchId,
-    }).pipe(
+    fetchGroq<MATCH_ARTICLES_QUERY_RESULT>(
+      MATCH_ARTICLES_QUERY,
+      { matchId },
+      { revalidate: SANITY_LIST_REVALIDATE, tags: [SANITY_TAGS.articles] },
+    ).pipe(
       Effect.map((rows) =>
         rows.filter(
           (row): row is MatchArticleVM =>

--- a/apps/web/src/lib/repositories/homepage.repository.ts
+++ b/apps/web/src/lib/repositories/homepage.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type {
   HOMEPAGE_BANNERS_QUERY_RESULT,
   HOMEPAGE_PLACEHOLDER_QUERY_RESULT,
@@ -132,9 +133,14 @@ export class HomepageRepository extends Context.Tag("HomepageRepository")<
 
 export const HomepageRepositoryLive = Layer.succeed(HomepageRepository, {
   getBanners: () =>
-    fetchGroq<HOMEPAGE_BANNERS_QUERY_RESULT>(HOMEPAGE_BANNERS_QUERY).pipe(
-      Effect.map(toBannersVM),
-    ),
+    fetchGroq<HOMEPAGE_BANNERS_QUERY_RESULT>(
+      HOMEPAGE_BANNERS_QUERY,
+      undefined,
+      {
+        revalidate: SANITY_LIST_REVALIDATE,
+        tags: [SANITY_TAGS.banners],
+      },
+    ).pipe(Effect.map(toBannersVM)),
   getPlaceholder: () =>
     fetchGroq<HOMEPAGE_PLACEHOLDER_QUERY_RESULT>(
       HOMEPAGE_PLACEHOLDER_QUERY,

--- a/apps/web/src/lib/repositories/photoGallery.repository.ts
+++ b/apps/web/src/lib/repositories/photoGallery.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type {
   GALLERIES_QUERY_RESULT,
   GALLERY_BY_SLUG_QUERY_RESULT,
@@ -114,7 +115,11 @@ export class PhotoGalleryRepository extends Context.Tag(
 export const PhotoGalleryRepositoryLive = Layer.succeed(
   PhotoGalleryRepository,
   {
-    findAll: () => fetchGroq<GALLERIES_QUERY_RESULT>(GALLERIES_QUERY),
+    findAll: () =>
+      fetchGroq<GALLERIES_QUERY_RESULT>(GALLERIES_QUERY, undefined, {
+        revalidate: SANITY_LIST_REVALIDATE,
+        tags: [SANITY_TAGS.galleries],
+      }),
     findBySlug: (slug) =>
       fetchGroq<GALLERY_BY_SLUG_QUERY_RESULT>(GALLERY_BY_SLUG_QUERY, {
         slug,
@@ -122,12 +127,16 @@ export const PhotoGalleryRepositoryLive = Layer.succeed(
     findAllSlugs: () =>
       fetchGroq<GALLERY_SLUGS_QUERY_RESULT>(GALLERY_SLUGS_QUERY),
     findByLinkedMatch: (matchId) =>
-      fetchGroq<GALLERIES_BY_MATCH_QUERY_RESULT>(GALLERIES_BY_MATCH_QUERY, {
-        matchId,
-      }),
+      fetchGroq<GALLERIES_BY_MATCH_QUERY_RESULT>(
+        GALLERIES_BY_MATCH_QUERY,
+        { matchId },
+        { revalidate: SANITY_LIST_REVALIDATE, tags: [SANITY_TAGS.galleries] },
+      ),
     findByLinkedEvent: (eventId) =>
-      fetchGroq<GALLERIES_BY_EVENT_QUERY_RESULT>(GALLERIES_BY_EVENT_QUERY, {
-        eventId,
-      }),
+      fetchGroq<GALLERIES_BY_EVENT_QUERY_RESULT>(
+        GALLERIES_BY_EVENT_QUERY,
+        { eventId },
+        { revalidate: SANITY_LIST_REVALIDATE, tags: [SANITY_TAGS.galleries] },
+      ),
   },
 );

--- a/apps/web/src/lib/repositories/player.repository.ts
+++ b/apps/web/src/lib/repositories/player.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type {
   PLAYERS_QUERY_RESULT,
   PLAYER_BY_PSD_ID_QUERY_RESULT,
@@ -136,9 +137,10 @@ export class PlayerRepository extends Context.Tag("PlayerRepository")<
 
 export const PlayerRepositoryLive = Layer.succeed(PlayerRepository, {
   findAll: () =>
-    fetchGroq<PLAYERS_QUERY_RESULT>(PLAYERS_QUERY).pipe(
-      Effect.map((rows) => rows.map(toPlayerVM)),
-    ),
+    fetchGroq<PLAYERS_QUERY_RESULT>(PLAYERS_QUERY, undefined, {
+      revalidate: SANITY_LIST_REVALIDATE,
+      tags: [SANITY_TAGS.players],
+    }).pipe(Effect.map((rows) => rows.map(toPlayerVM))),
   findByPsdId: (psdId) =>
     fetchGroq<PLAYER_BY_PSD_ID_QUERY_RESULT>(PLAYER_BY_PSD_ID_QUERY, {
       psdId,

--- a/apps/web/src/lib/repositories/sponsor.repository.ts
+++ b/apps/web/src/lib/repositories/sponsor.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type { SPONSORS_QUERY_RESULT } from "../sanity/sanity.types";
 
 // ─── GROQ Queries ────────────────────────────────────────────────────────────
@@ -35,5 +36,9 @@ export class SponsorRepository extends Context.Tag("SponsorRepository")<
 >() {}
 
 export const SponsorRepositoryLive = Layer.succeed(SponsorRepository, {
-  findAll: () => fetchGroq<SPONSORS_QUERY_RESULT>(SPONSORS_QUERY),
+  findAll: () =>
+    fetchGroq<SPONSORS_QUERY_RESULT>(SPONSORS_QUERY, undefined, {
+      revalidate: SANITY_LIST_REVALIDATE,
+      tags: [SANITY_TAGS.sponsors],
+    }),
 });

--- a/apps/web/src/lib/repositories/staff.repository.ts
+++ b/apps/web/src/lib/repositories/staff.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type {
   ORGANIGRAM_NODES_QUERY_RESULT,
   STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT,
@@ -208,7 +209,14 @@ export class StaffRepository extends Context.Tag("StaffRepository")<
 
 export const StaffRepositoryLive = Layer.succeed(StaffRepository, {
   findAll: () =>
-    fetchGroq<ORGANIGRAM_NODES_QUERY_RESULT>(ORGANIGRAM_NODES_QUERY).pipe(
+    fetchGroq<ORGANIGRAM_NODES_QUERY_RESULT>(
+      ORGANIGRAM_NODES_QUERY,
+      undefined,
+      {
+        revalidate: SANITY_LIST_REVALIDATE,
+        tags: [SANITY_TAGS.staff],
+      },
+    ).pipe(
       Effect.map((nodes) => [CLUB_ROOT_NODE, ...nodes.map(toOrgChartNode)]),
     ),
   findByPsdId: (psdId) =>

--- a/apps/web/src/lib/repositories/team.repository.ts
+++ b/apps/web/src/lib/repositories/team.repository.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { fetchGroq } from "../sanity/fetch-groq";
+import { SANITY_LIST_REVALIDATE, SANITY_TAGS } from "../sanity/cache-tags";
 import type {
   TEAMS_QUERY_RESULT,
   TEAM_BY_SLUG_QUERY_RESULT,
@@ -272,9 +273,10 @@ export class TeamRepository extends Context.Tag("TeamRepository")<
 
 export const TeamRepositoryLive = Layer.succeed(TeamRepository, {
   findAll: () =>
-    fetchGroq<TEAMS_QUERY_RESULT>(TEAMS_QUERY).pipe(
-      Effect.map((rows) => rows.map(toTeamNavVM)),
-    ),
+    fetchGroq<TEAMS_QUERY_RESULT>(TEAMS_QUERY, undefined, {
+      revalidate: SANITY_LIST_REVALIDATE,
+      tags: [SANITY_TAGS.teams],
+    }).pipe(Effect.map((rows) => rows.map(toTeamNavVM))),
   findBySlug: (slug) =>
     fetchGroq<TEAM_BY_SLUG_QUERY_RESULT>(TEAM_BY_SLUG_QUERY, { slug }).pipe(
       Effect.map((row) => (row ? toTeamDetailVM(row) : null)),

--- a/apps/web/src/lib/sanity/cache-tags.ts
+++ b/apps/web/src/lib/sanity/cache-tags.ts
@@ -1,0 +1,22 @@
+/**
+ * Content-tag names shared by repository list reads (Scope B) and the
+ * `/api/revalidate` Sanity webhook (Scope E). Single source of truth so the
+ * two sides cannot drift — a repo tagging `players` and a webhook revalidating
+ * `player` would silently never invalidate.
+ */
+export const SANITY_TAGS = {
+  players: "players",
+  teams: "teams",
+  sponsors: "sponsors",
+  staff: "staff",
+  articles: "articles",
+  banners: "banners",
+  galleries: "galleries",
+} as const;
+
+/**
+ * Time-based safety net (seconds) for tagged list caches. On-demand
+ * invalidation via `revalidateTag` (Scope E) is the primary freshness
+ * mechanism; this only bounds staleness if a webhook is ever missed.
+ */
+export const SANITY_LIST_REVALIDATE = 60 * 60 * 24; // 24h

--- a/apps/web/src/lib/sanity/fetch-groq.test.ts
+++ b/apps/web/src/lib/sanity/fetch-groq.test.ts
@@ -1,0 +1,35 @@
+import { Effect } from "effect";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("./client", () => ({
+  sanityClient: { fetch: (...args: unknown[]) => fetchMock(...args) },
+}));
+
+import { fetchGroq } from "./fetch-groq";
+
+describe("fetchGroq", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue([]);
+  });
+
+  it("omits the options arg when no cache options are given", async () => {
+    await Effect.runPromise(fetchGroq("*[_type=='x']"));
+    expect(fetchMock).toHaveBeenCalledWith("*[_type=='x']", {});
+  });
+
+  it("forwards revalidate + tags to the client's next options", async () => {
+    await Effect.runPromise(
+      fetchGroq("*[_type=='player']", undefined, {
+        revalidate: 3600,
+        tags: ["players"],
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "*[_type=='player']",
+      {},
+      { next: { revalidate: 3600, tags: ["players"] } },
+    );
+  });
+});

--- a/apps/web/src/lib/sanity/fetch-groq.ts
+++ b/apps/web/src/lib/sanity/fetch-groq.ts
@@ -1,8 +1,27 @@
 import { Effect } from "effect";
 import { sanityClient } from "./client";
 
-export const fetchGroq = <T>(query: string, params?: Record<string, unknown>) =>
+/** Next.js Data Cache directives forwarded to `@sanity/client`'s 3rd arg. */
+export interface GroqCacheOptions {
+  /** Seconds the result is served before the cache revalidates. */
+  revalidate?: number;
+  /** Cache tags for on-demand `revalidateTag` invalidation (Scope E). */
+  tags?: string[];
+}
+
+export const fetchGroq = <T>(
+  query: string,
+  params?: Record<string, unknown>,
+  options?: GroqCacheOptions,
+) =>
   Effect.tryPromise({
-    try: () => sanityClient.fetch<T>(query, params ?? {}),
+    // Only pass the 3rd arg when caching is requested, so untagged callers keep
+    // inheriting the route segment's `revalidate` (current behaviour).
+    try: () =>
+      options
+        ? sanityClient.fetch<T>(query, params ?? {}, {
+            next: { revalidate: options.revalidate, tags: options.tags },
+          })
+        : sanityClient.fetch<T>(query, params ?? {}),
     catch: (cause) => new Error(`Sanity fetch failed: ${String(cause)}`),
   }).pipe(Effect.orDie);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       "@sanity/client":
         specifier: 7.22.1
         version: 7.22.1
+      "@sanity/webhook":
+        specifier: 4.0.4
+        version: 4.0.4
       "@tailwindcss/typography":
         specifier: 0.5.20
         version: 0.5.20(tailwindcss@4.3.0)
@@ -5943,6 +5946,13 @@ packages:
     peerDependenciesMeta:
       "@sanity/types":
         optional: true
+
+  "@sanity/webhook@4.0.4":
+    resolution:
+      {
+        integrity: sha512-c8LmzR5Wx93zJ10ohhp0XlmPrTNSFyvPcLbNY/sN45Wj5VOngz4FbBMbX9j64sSQLt+676U6OhiVfjs1yw3YCw==,
+      }
+    engines: { node: ">=20.0.0" }
 
   "@sanity/worker-channels@2.0.0":
     resolution:
@@ -19534,6 +19544,8 @@ snapshots:
       "@sanity/client": 7.22.1
     optionalDependencies:
       "@sanity/types": 5.30.0(@types/react@19.2.17)
+
+  "@sanity/webhook@4.0.4": {}
 
   "@sanity/worker-channels@2.0.0": {}
 


### PR DESCRIPTION
Closes #1921

## What & why

The site was hitting ~99% of Sanity's 1M-req/month CDN allowance. This tightens the read pattern across three layers, plus a BFF change to protect the lower-limit PSD hop.

## Changes

**Scope A — ISR intervals** (`apps/web`)
- `ploegen/[slug]` 1h→**6h**; `spelers/[slug]`, `staf/[slug]`, `nieuws/[slug]`, `sponsors` 1h→**24h**; `evenementen` listing 5m→**1h**.
- `/wedstrijd/[matchId]` stays at 5m (live BFF data); proximity throttling moved to the BFF (below).

**Scope B — repository read caching** (`apps/web`)
- `fetchGroq` now forwards `{ revalidate, tags }` to `@sanity/client`'s fetch options (v7.22.1 supports it natively — no `next-sanity` swap).
- Stable list reads (`players/teams/sponsors/staff/banners/articles/galleries`) cache across requests, dedupe within a render, and are invalidatable by `revalidateTag`.
- Tag names centralised in `lib/sanity/cache-tags.ts` (single source of truth shared with the webhook, prevents drift).

**Scope E — on-demand revalidation** (`apps/web`)
- New `POST /api/revalidate`: HMAC-verified (`@sanity/webhook`, `SANITY_REVALIDATE_SECRET`), maps `_type` → paths + content tags. Players/staff route by `psdId`; `homePage`/`banner` bust the `banners` tag; rename/delete handled via current+previous slug. Invalid/unsigned → 401; unknown type → 200 no-op.

**BFF — proximity-aware match-detail TTL** (`apps/api`)
- `matchDetailTtl(date, status)` derives the KV soft TTL from kickoff proximity: **live 60s / matchday 300s / this-week 1h / distant 24h / settled 7d**.

## AC deviation (intentional, discussed with owner)

The issue specified kickoff-proximity *tiers on the page-level `revalidate`*. That's circular in App Router — the TTL depends on kickoff, which only the match-detail fetch returns, and Next can't set a fetch's TTL from its own response. The proximity logic instead lives in the **BFF KV soft TTL** (which already supports `(value) => number`), where kickoff *is* known. This protects the rate-limited BFF→PSD hop directly (the real cost) and additionally closes a live-match freshness gap the old flat 24h TTL had.

## 🛑 Manual step required before this is fully live

The Sanity webhook **cannot ship in the PR** — it must be created by hand in the Sanity console (see issue Scope E). Until then, the long Scope-A intervals leave editors with up-to-24h stale content. Values to enter:

- **sanity.io → project → API → Webhooks → Create webhook**
- URL: `https://<deploy-host>/api/revalidate`
- Filter (GROQ): `_type in ["article","player","team","staffMember","sponsor","page","event","photoGallery","homePage","banner"]`
- Projection: `{ _type, "slug": slug.current, "previousSlug": before().slug.current, "psdId": psdId }`
- Trigger on: Create, Update, Delete · HTTP method: POST
- Secret: the value of `SANITY_REVALIDATE_SECRET` (also set this env var on the deploy host)

## Testing

- `apps/api`: type-check, lint, 373 tests ✅
- `apps/web`: lint, type-check, 3126 tests, `next build` ✅
- New tests: `matchDetailTtl` tier matrix, `fetchGroq` option forwarding, `/api/revalidate` route (signature/mapping/psdId/banners/rename/unknown).

## Pre-PR review gate

`/code-review` (high) + `/simplify` ran. Applied: staffMember webhook now routes by `psdId` (was Sanity slug — detail page would never revalidate); added `homePage`/`banner` → `banners` tag case (was tagged but never busted); tagged `findByLinkedEvent` for gallery parity. Skipped: an inline-options helper (lazy/minimal house style — 2-field object, distinct tag per call).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook-based on-demand revalidation to refresh content instantly after updates.

* **Improvements**
  * Enhanced match-detail caching with tiered expiration based on kickoff timing (live/matchday/this week/distant).
  * Updated ISR revalidation intervals across key pages to better balance freshness and performance.
  * Enabled consistent tagged revalidation for Sanity list content (e.g., players, teams, articles, galleries).

* **Tests**
  * Expanded unit tests covering match-detail TTL selection and revalidation webhook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->