### PR TITLE
fix(ui): post-redesign consistency quick-fixes

### DIFF
--- a/apps/web/src/app/(main)/club/contact/page.tsx
+++ b/apps/web/src/app/(main)/club/contact/page.tsx
@@ -33,6 +33,11 @@ export const metadata: Metadata = {
   },
 };
 
+// ISR — the page fetches key staff contacts at request time; refresh hourly so
+// contact changes in Sanity surface without a redeploy (matches the other
+// club/* fetching pages' cadence).
+export const revalidate = 3600;
+
 export default async function ContactPageRoute() {
   const keyContacts = await runPromise(
     Effect.gen(function* () {

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -57,7 +57,7 @@ import {
   MatchArticleLinkCard,
   selectMatchArticle,
 } from "@/components/match/MatchArticleLinkCard";
-import { StripedSeam } from "@/components/design-system";
+import { PageContainer, StripedSeam } from "@/components/design-system";
 import { GallerySection } from "@/components/gallery/GallerySection/GallerySection";
 import { MatchStripSlot } from "@/components/layout/MatchStrip/MatchStripSlot";
 import { PageViewTracker, TrackInView } from "@/components/analytics";
@@ -310,16 +310,18 @@ export default async function MatchPage({ params }: MatchPageProps) {
 
       <MatchStripSlot />
 
-      <MatchHero
-        homeTeam={homeTeam}
-        awayTeam={awayTeam}
-        date={match.date}
-        time={time}
-        venue={match.venue}
-        status={match.status}
-        competition={match.competition}
-        kcvvTeamLabel={match.kcvv_team_label}
-      />
+      <PageContainer className="py-12 lg:py-16">
+        <MatchHero
+          homeTeam={homeTeam}
+          awayTeam={awayTeam}
+          date={match.date}
+          time={time}
+          venue={match.venue}
+          status={match.status}
+          competition={match.competition}
+          kcvvTeamLabel={match.kcvv_team_label}
+        />
+      </PageContainer>
 
       {(hasLineup || hasEvents || hasStandings || hasArticle || hasGallery) && (
         <StripedSeam colorPair="ink-cream" height="md" />

--- a/apps/web/src/components/club/ClubEditorialHub/ClubEditorialHub.test.tsx
+++ b/apps/web/src/components/club/ClubEditorialHub/ClubEditorialHub.test.tsx
@@ -64,7 +64,7 @@ describe("ClubEditorialHub", () => {
     );
     expect(screen.getByRole("link", { name: /word lid/i })).toHaveAttribute(
       "href",
-      "/club/aansluiten",
+      "/club/word-lid",
     );
   });
 

--- a/apps/web/src/components/club/ClubEditorialHub/ClubEditorialHub.tsx
+++ b/apps/web/src/components/club/ClubEditorialHub/ClubEditorialHub.tsx
@@ -78,7 +78,7 @@ export const CLUB_HUB_CARDS: ClubHubCard[] = [
   {
     variant: "news",
     tag: "Aansluiten",
-    href: "/club/aansluiten",
+    href: "/club/word-lid",
     title: "Word lid",
     arrowText: "Schrijf je in",
     imageUrl: "/images/youth-trainers.jpg",

--- a/apps/web/src/components/layout/menuItems.test.ts
+++ b/apps/web/src/components/layout/menuItems.test.ts
@@ -46,7 +46,7 @@ describe("staticMenuItems", () => {
     const praktisch = deClub.childGroups!.find((g) => g.label === "Praktisch")!;
     const labels = praktisch.items.map((i) => i.label);
     expect(labels).toEqual([
-      "Praktische Info",
+      "Praktische info",
       "Word vrijwilliger",
       "Cashless clubkaart",
       "Contact",
@@ -157,9 +157,9 @@ describe("buildSeniorMenuItem", () => {
     );
     expect(hrefs).toEqual({
       Info: "/ploegen/a-ploeg",
-      "Spelers & Staff": "/ploegen/a-ploeg#spelers",
+      "Spelers & staf": "/ploegen/a-ploeg#spelers",
       Wedstrijden: "/ploegen/a-ploeg#wedstrijden",
-      Stand: "/ploegen/a-ploeg#klassement",
+      Klassement: "/ploegen/a-ploeg#klassement",
     });
     // No legacy tab query params survive.
     for (const child of item!.children ?? []) {

--- a/apps/web/src/components/layout/menuItems.ts
+++ b/apps/web/src/components/layout/menuItems.ts
@@ -38,7 +38,7 @@ export const staticMenuItems: MenuItem[] = [
       {
         label: "Praktisch",
         items: [
-          { label: "Praktische Info", href: "/club/inschrijven" },
+          { label: "Praktische info", href: "/club/inschrijven" },
           { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
           { label: "Cashless clubkaart", href: "/club/cashless" },
           { label: "Contact", href: "/club/contact" },
@@ -100,16 +100,16 @@ export const buildSeniorMenuItem = (
     href,
     children: [
       { label: "Info", href },
-      { label: "Spelers & Staff", href: `${href}#spelers` },
+      { label: "Spelers & staf", href: `${href}#spelers` },
       { label: "Wedstrijden", href: `${href}#wedstrijden` },
-      { label: "Stand", href: `${href}#klassement` },
+      { label: "Klassement", href: `${href}#klassement` },
     ],
   };
 };
 
 export const seniorNavLabel = (name: string): string => {
   const lastWord = name.trim().split(/\s+/).at(-1) ?? name;
-  return /^[A-Z]$/.test(lastWord) ? `${lastWord}-Ploeg` : name;
+  return /^[A-Z]$/.test(lastWord) ? `${lastWord}-ploeg` : name;
 };
 
 export const buildJeugdItem = (youthTeams?: TeamNavVM[]): MenuItem => {


### PR DESCRIPTION
Confirmed quick-fixes from the 2026-06-22 post-redesign consistency review. The remaining review items are spec'd as ready issues **#2206–#2213**.

## Changes
- **Dead membership CTA** — the `/club` hub "Word lid" card pointed at `/club/aansluiten` (no route, no CMS page → 404). Repointed to `/club/word-lid`.
- **Nav Dutch corrections** — `A-Ploeg`→`A-ploeg`, `Praktische Info`→`Praktische info`, `Spelers & Staff`→`Spelers & staf`, `Stand`→`Klassement` (`menuItems.ts`).
- **`club/contact` ISR** — added `revalidate = 3600`; it fetches key staff at request time but had no ISR, so the contact list was frozen at build until a redeploy.
- **Match hero layout bug** — `MatchHero` on `/wedstrijd/[matchId]` rendered bare (no container), so it spanned full-bleed and butted against the header. Wrapped in `<PageContainer>` (default width, matching the body sections + sibling detail heroes).

## Testing
- `pnpm --filter @kcvv/web check-all` passes (lint + type-check + test + build).
- Updated `menuItems.test.ts` + `ClubEditorialHub.test.tsx` for the renamed labels/href.
- **No VR baseline impact**: nav stories use their own fixtures (not live `menuItems`); the hero wrap is page-level (Pages/* aren't VR-tested); the href change is non-visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact page now refreshes hourly for fresh staff data via incremental static regeneration.
  * Updated club navigation routing.

* **Style**
  * Improved menu label text consistency and capitalization across navigation items.
  * Enhanced layout spacing on match detail page.

* **Tests**
  * Updated test expectations to reflect routing and label changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->