### PR TITLE
feat(ui): skip-to-content link + cache hot BFF reads (#2213)

### DIFF
--- a/apps/web/src/app/api/related/route.ts
+++ b/apps/web/src/app/api/related/route.ts
@@ -20,7 +20,14 @@ export async function GET(request: NextRequest) {
       { signal: AbortSignal.timeout(10_000) },
     );
     if (!res.ok) return NextResponse.json([]);
-    return NextResponse.json(await res.json());
+    // Public, CDN-cacheable: related content shifts slowly; SWR keeps it warm.
+    // Only the success path is cached — the [] fallbacks stay uncached so a
+    // transient BFF blip isn't pinned for 5 min.
+    return NextResponse.json(await res.json(), {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600",
+      },
+    });
   } catch (err) {
     console.error("[related] fetch failed:", err);
     return NextResponse.json([]);

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -361,11 +361,21 @@ export async function GET(request: NextRequest) {
 
     debugLog(`[Search API] Returning ${sorted.length} sorted results`);
 
-    return NextResponse.json({
-      query,
-      count: sorted.length,
-      results: sorted,
-    });
+    // Public, CDN-cacheable per query: repeated/popular terms hit the edge
+    // instead of re-running the Sanity+BFF fan-out. Short TTL + SWR keeps
+    // freshly-published content surfacing quickly. Errors stay uncached.
+    return NextResponse.json(
+      {
+        query,
+        count: sorted.length,
+        results: sorted,
+      },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      },
+    );
   } catch (error) {
     // Log full error server-side for debugging
     console.error("[Search API] Error:", error);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -108,6 +108,14 @@ export default async function RootLayout({
         )}
       </head>
       <body suppressHydrationWarning>
+        {/* WCAG 2.1-A skip link — first focusable element, visible only on
+            keyboard focus. Retro register (sharp corners, ink border, mono). */}
+        <a
+          href="#main-content"
+          className="focus:border-ink focus:bg-cream focus:text-ink focus:shadow-paper-sm sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:border-2 focus:px-4 focus:py-2 focus:font-mono focus:text-sm focus:font-semibold focus:tracking-wide focus:uppercase focus:outline-none"
+        >
+          Naar de inhoud
+        </a>
         <Script id="gtm-consent-default" strategy="beforeInteractive">
           {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'denied','wait_for_update':500});`}
         </Script>
@@ -115,7 +123,9 @@ export default async function RootLayout({
         <ScrollToTop />
         <AccentStrip />
         <SiteHeader youthTeams={youthTeams} seniorTeams={seniorTeams} />
-        <main>{children}</main>
+        <main id="main-content" tabIndex={-1}>
+          {children}
+        </main>
         <SiteFooter />
         <CookieConsentBanner />
       </body>

--- a/apps/web/src/lib/effect/services/BffService.test.ts
+++ b/apps/web/src/lib/effect/services/BffService.test.ts
@@ -166,15 +166,15 @@ describe("BffService", () => {
     expect(result[0]?.team_name).toBe("KCVV Elewijt");
   });
 
-  it("preserves the raw error's _tag through the cache wrap (call-site catchTag still fires)", async () => {
-    // A BFF failure rejects the cache fn; cachedRead falls back to the RAW
-    // effect, so the original *tagged* error reaches the call site. This guards
-    // the ploegen/[slug]/wedstrijden `catchTag("HttpNotFound") → notFound()`
-    // path. We assert on the specific tag (not catchAll): a naive Promise
-    // round-trip flattens the error to an opaque UnknownException, so catchTag
-    // would miss and this would fall through to "flattened" — i.e. the test
-    // FAILS against the bug, not just passes against the fix. (A 500 is an
-    // undeclared status → the client surfaces a tagged ResponseError.)
+  it("preserves the error's _tag through the cache wrap, with no extra BFF call", async () => {
+    // A BFF failure is captured as a Cause (runPromiseExit) and re-raised via
+    // failCause, so the original *tagged* error reaches the call site without a
+    // re-run — guarding the ploegen/[slug]/wedstrijden
+    // `catchTag("HttpNotFound") → notFound()` path. We assert on the specific tag
+    // (not catchAll): a naive Promise round-trip flattens the error to an opaque
+    // UnknownException, so catchTag would miss and fall through to "flattened" —
+    // i.e. the test FAILS against the bug, not just passes against the fix. (A
+    // 500 is decoded against the declared error union and fails as a ParseError.)
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(new Response("", { status: 500 })),
@@ -184,7 +184,7 @@ describe("BffService", () => {
       Effect.gen(function* () {
         const bff = yield* BffService;
         return yield* bff.getMatches(1).pipe(
-          Effect.catchTag("ResponseError", () =>
+          Effect.catchTag("ParseError", () =>
             Effect.succeed("typed-survived" as const),
           ),
           Effect.catchAll(() => Effect.succeed("flattened" as const)),
@@ -193,6 +193,9 @@ describe("BffService", () => {
     );
 
     expect(result).toBe("typed-survived");
+    // The failed effect runs once inside the cache fn and is re-raised from its
+    // captured Cause — no raw-effect re-run, so the BFF is hit exactly once.
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
   });
 
   it("propagates errors as Effect failures (not exceptions)", async () => {

--- a/apps/web/src/lib/effect/services/BffService.test.ts
+++ b/apps/web/src/lib/effect/services/BffService.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Effect } from "effect";
 import { BffService, BffServiceLive } from "./BffService";
 
+// `cachedRead` wraps the hot reads in `unstable_cache`; there's no Next request
+// scope in vitest, so stub it to a pass-through. The encode/decode round-trip
+// inside `cachedRead` still runs — see the `Date`-restoration assertion below.
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
 // Minimal fixture that satisfies the Match schema from @kcvv/api-contract.
 // date/time must be ISO strings because JSON.stringify converts Date objects.
 const sampleMatch = {
@@ -72,6 +79,10 @@ describe("BffService", () => {
     );
     expect(result).toHaveLength(1);
     expect(result[0]?.id).toBe(1);
+    // Date survives the cachedRead encode→(JSON cache)→decode round-trip
+    // (Match.date is DateFromStringOrDate; a naive unstable_cache wrap would
+    // leave it a string).
+    expect(result[0]?.date).toBeInstanceOf(Date);
   });
 
   it("getNextMatches calls /matches/next", async () => {
@@ -151,6 +162,35 @@ describe("BffService", () => {
     );
     expect(result).toHaveLength(1);
     expect(result[0]?.team_name).toBe("KCVV Elewijt");
+  });
+
+  it("preserves the raw error's _tag through the cache wrap (call-site catchTag still fires)", async () => {
+    // A BFF failure rejects the cache fn; cachedRead falls back to the RAW
+    // effect, so the original *tagged* error reaches the call site. This guards
+    // the ploegen/[slug]/wedstrijden `catchTag("HttpNotFound") → notFound()`
+    // path. We assert on the specific tag (not catchAll): a naive Promise
+    // round-trip flattens the error to an opaque UnknownException, so catchTag
+    // would miss and this would fall through to "flattened" — i.e. the test
+    // FAILS against the bug, not just passes against the fix. (A 500 is an
+    // undeclared status → the client surfaces a tagged ResponseError.)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("", { status: 500 })),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const bff = yield* BffService;
+        return yield* bff.getMatches(1).pipe(
+          Effect.catchTag("ResponseError", () =>
+            Effect.succeed("typed-survived" as const),
+          ),
+          Effect.catchAll(() => Effect.succeed("flattened" as const)),
+        );
+      }).pipe(Effect.provide(BffServiceLive)),
+    );
+
+    expect(result).toBe("typed-survived");
   });
 
   it("propagates errors as Effect failures (not exceptions)", async () => {

--- a/apps/web/src/lib/effect/services/BffService.test.ts
+++ b/apps/web/src/lib/effect/services/BffService.test.ts
@@ -131,7 +131,7 @@ describe("BffService", () => {
     };
     mockFetchWith(sampleDetail);
 
-    await Effect.runPromise(
+    const result = await Effect.runPromise(
       Effect.gen(function* () {
         const bff = yield* BffService;
         return yield* bff.getMatchDetail(42);
@@ -144,6 +144,8 @@ describe("BffService", () => {
       }),
       expect.any(Object),
     );
+    // Date survives the cachedRead round-trip (getMatchDetail is cached too).
+    expect(result.date).toBeInstanceOf(Date);
   });
 
   it("getRanking calls /ranking/:teamId and returns decoded entries", async () => {

--- a/apps/web/src/lib/effect/services/BffService.ts
+++ b/apps/web/src/lib/effect/services/BffService.ts
@@ -1,17 +1,18 @@
-import { Context, Effect, Layer, type Cause } from "effect";
+import { Context, Effect, Layer, Schema as S, type Cause } from "effect";
+import { unstable_cache } from "next/cache";
 import { HttpApiClient, FetchHttpClient } from "@effect/platform";
 import type { HttpApiError, HttpClientError } from "@effect/platform";
 import type { ParseError } from "effect/ParseResult";
 import {
   PsdApi,
+  Match,
+  RankingEntry,
   type HttpServiceUnavailable,
   type HttpBadGateway,
   type HttpNotFound,
-  type Match,
   type MatchDetail,
   type OpponentHistory,
   type PlayerSeasonStats,
-  type RankingEntry,
   type RelatedItem,
 } from "@kcvv/api-contract";
 
@@ -50,6 +51,50 @@ export class BffService extends Context.Tag("BffService")<
 
 const DEFAULT_TIMEOUT = "30 seconds";
 
+// Hot-read cache windows. Fixtures/results shift around match days; standings
+// move ~weekly. Tunable — paired with `tags` so a future PSD-sync webhook can
+// `revalidateTag(...)` on write instead of waiting out the TTL.
+const MATCHES_REVALIDATE = 300; // 5 min
+const RANKING_REVALIDATE = 3600; // 1 h
+
+const MatchArray = S.Array(Match);
+const RankingArray = S.Array(RankingEntry);
+
+/**
+ * Wrap a hot BFF read in Next's data cache. On a cache miss the client Effect
+ * (R = never) is run to a Promise inside `unstable_cache`; its decoded result is
+ * re-encoded to a JSON-safe shape before storage, so `Date` fields (`Match.date`,
+ * `RankingEntry.last_updated` — both `DateFromStringOrDate`) survive the cache's
+ * JSON round-trip and decode back to `Date` on read.
+ *
+ * Failures are never cached (the cache fn rejects). Crucially, on any rejection
+ * we fall back to running the RAW `effect` so its TYPED failure survives — a
+ * Promise round-trip would otherwise flatten e.g. `HttpNotFound` into an opaque
+ * `FiberFailure`, breaking call sites that `catchTag("HttpNotFound")` →
+ * `notFound()` (getMatches @ ploegen/[slug]/wedstrijden, and getMatchDetail).
+ * That fallback costs one extra BFF call on the rare error path. (#2213)
+ */
+function cachedRead<A, I>(
+  schema: S.Schema<A, I>,
+  keyParts: readonly string[],
+  tags: readonly string[],
+  revalidate: number,
+  effect: Effect.Effect<A, BffError>,
+): Effect.Effect<A, BffError> {
+  const loadCached = unstable_cache(
+    async (): Promise<I> =>
+      S.encodeSync(schema)(await Effect.runPromise(effect)),
+    [...keyParts],
+    { revalidate, tags: [...tags] },
+  );
+  return Effect.tryPromise(() => loadCached()).pipe(
+    Effect.flatMap((encoded) => S.decodeUnknown(schema)(encoded)),
+    // Cache-fn rejection (BFF failed — never cached) or a stray decode error:
+    // re-run the raw effect so the original typed error reaches the call site.
+    Effect.catchAll(() => effect),
+  );
+}
+
 export const BffServiceLive = Layer.effect(
   BffService,
   Effect.gen(function* () {
@@ -61,23 +106,48 @@ export const BffServiceLive = Layer.effect(
     const client = yield* HttpApiClient.make(PsdApi, { baseUrl: bffUrl });
     return {
       getMatches: (teamId: number) =>
-        client.matches
-          .getMatchesByTeam({ path: { teamId } })
-          .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        cachedRead(
+          MatchArray,
+          ["bff", "matches", String(teamId)],
+          ["bff:matches", `bff:matches:${teamId}`],
+          MATCHES_REVALIDATE,
+          client.matches
+            .getMatchesByTeam({ path: { teamId } })
+            .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        ),
       getNextMatches: () =>
-        client.matches.getNextMatches({}).pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        cachedRead(
+          MatchArray,
+          ["bff", "next-matches"],
+          ["bff:matches", "bff:next-matches"],
+          MATCHES_REVALIDATE,
+          client.matches
+            .getNextMatches({})
+            .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        ),
       getMatchesWindow: () =>
         client.matches
           .getMatchesWindow({})
           .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+      // NOT wrapped in cachedRead — by freshness, not capability: match detail
+      // is the live in-progress score source, so a 5-min TTL would lag scores
+      // during a match. It's also per-id + already ISR-cached at the route, so
+      // the upstream-relief win is small. (Staleness window is a product call;
+      // cachedRead now preserves its typed HttpNotFound if we ever cache it.) (#2213)
       getMatchDetail: (matchId: number) =>
         client.matches
           .getMatchDetail({ path: { matchId } })
           .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
       getRanking: (teamId: number) =>
-        client.ranking
-          .getRanking({ path: { teamId } })
-          .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        cachedRead(
+          RankingArray,
+          ["bff", "ranking", String(teamId)],
+          ["bff:ranking", `bff:ranking:${teamId}`],
+          RANKING_REVALIDATE,
+          client.ranking
+            .getRanking({ path: { teamId } })
+            .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        ),
       getRelated: (id: string, limit?: number) =>
         client.related
           .getRelated({ urlParams: { id, limit } })

--- a/apps/web/src/lib/effect/services/BffService.ts
+++ b/apps/web/src/lib/effect/services/BffService.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Schema as S, type Cause } from "effect";
+import { Cause, Context, Data, Effect, Exit, Layer, Schema as S } from "effect";
 import { unstable_cache } from "next/cache";
 import { HttpApiClient, FetchHttpClient } from "@effect/platform";
 import type { HttpApiError, HttpClientError } from "@effect/platform";
@@ -61,18 +61,29 @@ const MatchArray = S.Array(Match);
 const RankingArray = S.Array(RankingEntry);
 
 /**
+ * Internal carrier that ferries a failed effect's original `Cause` across the
+ * `unstable_cache` Promise boundary. Thrown inside the cache fn (so failures are
+ * never cached) and unwrapped right after the boundary via `Effect.failCause`,
+ * so the original TYPED error survives instead of flattening into an opaque
+ * `FiberFailure`. Never escapes `cachedRead`.
+ */
+class CachedReadEffectFailure extends Data.TaggedError(
+  "CachedReadEffectFailure",
+)<{ readonly cause: Cause.Cause<BffError> }> {}
+
+/**
  * Wrap a hot BFF read in Next's data cache. On a cache miss the client Effect
- * (R = never) is run to a Promise inside `unstable_cache`; its decoded result is
- * re-encoded to a JSON-safe shape before storage, so `Date` fields (`Match.date`,
+ * (R = never) is run inside `unstable_cache`; its decoded result is re-encoded to
+ * a JSON-safe shape before storage, so `Date` fields (`Match.date`,
  * `RankingEntry.last_updated` — both `DateFromStringOrDate`) survive the cache's
  * JSON round-trip and decode back to `Date` on read.
  *
- * Failures are never cached (the cache fn rejects). Crucially, on any rejection
- * we fall back to running the RAW `effect` so its TYPED failure survives — a
- * Promise round-trip would otherwise flatten e.g. `HttpNotFound` into an opaque
- * `FiberFailure`, breaking call sites that `catchTag("HttpNotFound")` →
- * `notFound()` (getMatches @ ploegen/[slug]/wedstrijden, and getMatchDetail).
- * That fallback costs one extra BFF call on the rare error path. (#2213)
+ * Failures are never cached and their TYPED error is preserved: the effect is run
+ * with `runPromiseExit`, and on failure the `Cause` is carried out via
+ * `CachedReadEffectFailure` and re-raised with `failCause` — so call sites that
+ * `catchTag("HttpNotFound")` → `notFound()` (getMatches @
+ * ploegen/[slug]/wedstrijden, getMatchDetail @ wedstrijd/[matchId]) still fire,
+ * with NO extra BFF call on the error path. (#2213)
  */
 function cachedRead<A, I>(
   schema: S.Schema<A, I>,
@@ -82,16 +93,33 @@ function cachedRead<A, I>(
   effect: Effect.Effect<A, BffError>,
 ): Effect.Effect<A, BffError> {
   const loadCached = unstable_cache(
-    async (): Promise<I> =>
-      S.encodeSync(schema)(await Effect.runPromise(effect)),
+    async (): Promise<I> => {
+      // runPromiseExit captures a typed failure as a Cause instead of rejecting,
+      // so the error type isn't lost crossing the Promise boundary.
+      const exit = await Effect.runPromiseExit(effect);
+      if (Exit.isSuccess(exit)) return S.encodeSync(schema)(exit.value);
+      // Throw so unstable_cache never stores the failure; carry the Cause out.
+      throw new CachedReadEffectFailure({ cause: exit.cause });
+    },
     [...keyParts],
     { revalidate, tags: [...tags] },
   );
-  return Effect.tryPromise(() => loadCached()).pipe(
+  return Effect.tryPromise({
+    try: () => loadCached(),
+    // The raw throw arrives as `unknown` here (pre-Effect boundary), so this one
+    // check must stay `instanceof`. Anything other than our carrier (an
+    // encode/infra throw) is genuinely unexpected → a defect.
+    catch: (e) =>
+      e instanceof CachedReadEffectFailure
+        ? e
+        : new CachedReadEffectFailure({ cause: Cause.die(e) }),
+  }).pipe(
     Effect.flatMap((encoded) => S.decodeUnknown(schema)(encoded)),
-    // Cache-fn rejection (BFF failed — never cached) or a stray decode error:
-    // re-run the raw effect so the original typed error reaches the call site.
-    Effect.catchAll(() => effect),
+    // Re-raise the original typed error from its Cause — no re-run. A decode
+    // ParseError (already a BffError member) flows through untouched.
+    Effect.catchTag("CachedReadEffectFailure", (e) =>
+      Effect.failCause(e.cause),
+    ),
   );
 }
 

--- a/apps/web/src/lib/effect/services/BffService.ts
+++ b/apps/web/src/lib/effect/services/BffService.ts
@@ -6,11 +6,11 @@ import type { ParseError } from "effect/ParseResult";
 import {
   PsdApi,
   Match,
+  MatchDetail,
   RankingEntry,
   type HttpServiceUnavailable,
   type HttpBadGateway,
   type HttpNotFound,
-  type MatchDetail,
   type OpponentHistory,
   type PlayerSeasonStats,
   type RelatedItem,
@@ -129,15 +129,20 @@ export const BffServiceLive = Layer.effect(
         client.matches
           .getMatchesWindow({})
           .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
-      // NOT wrapped in cachedRead — by freshness, not capability: match detail
-      // is the live in-progress score source, so a 5-min TTL would lag scores
-      // during a match. It's also per-id + already ISR-cached at the route, so
-      // the upstream-relief win is small. (Staleness window is a product call;
-      // cachedRead now preserves its typed HttpNotFound if we ever cache it.) (#2213)
+      // Cached: results are pre/post only (no live in-progress scores), so the
+      // pre→post transition is a one-time flip a 5-min TTL handles fine.
+      // cachedRead's raw-effect fallback preserves the typed HttpNotFound that
+      // wedstrijd/[matchId] turns into notFound() (#2213).
       getMatchDetail: (matchId: number) =>
-        client.matches
-          .getMatchDetail({ path: { matchId } })
-          .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        cachedRead(
+          MatchDetail,
+          ["bff", "match-detail", String(matchId)],
+          ["bff:match-detail", `bff:match-detail:${matchId}`],
+          MATCHES_REVALIDATE,
+          client.matches
+            .getMatchDetail({ path: { matchId } })
+            .pipe(Effect.timeout(DEFAULT_TIMEOUT)),
+        ),
       getRanking: (teamId: number) =>
         cachedRead(
           RankingArray,


### PR DESCRIPTION
Closes #2213

Post-redesign review: a WCAG skip-link gap + uncached hot BFF reads hitting the rate-limited PSD upstream per render.

## Changes
- **a11y** — WCAG 2.1-A skip-to-content link (first focusable element, `sr-only` until keyboard focus, retro register) + `<main id="main-content" tabIndex={-1}>` landmark in the root layout.
- **caching** — `cachedRead` wraps the hot reads `getMatches` / `getNextMatches` / `getRanking` / `getMatchDetail` in `unstable_cache` with per-method `revalidate` + invalidation `tags` (matches 5min, ranking 1h).
- **Cache-Control** — `public, s-maxage + stale-while-revalidate` on the `/api/related` and `/api/search` GET success paths (errors stay uncached).

## Two traps the spec did not anticipate (handled)
1. **Date corruption** — `Match.date` / `RankingEntry.last_updated` are `DateFromStringOrDate`; a naive `unstable_cache` wrap would JSON-flatten them to strings. `cachedRead` does an `encode → (JSON cache) → decode` round-trip so `Date`s are restored on read.
2. **Typed-error loss** — `getMatches` (@ `ploegen/[slug]/wedstrijden`) and `getMatchDetail` use `catchTag("HttpNotFound") → notFound()`. A Promise round-trip flattens the tagged error. `cachedRead` falls back to the **raw effect** on any cache-fn rejection, so the original typed error reaches call sites unchanged (one extra BFF call on the rare error path).

## All 4 hot reads cached
`getMatches`, `getNextMatches`, `getRanking`, **and `getMatchDetail`** are now cached (full AC coverage). `getMatchDetail` is safe because there are **no live scores/reports** — results only flip pre→post once, which a 5-min TTL handles; `cachedRead`'s raw-effect fallback preserves its `catchTag("HttpNotFound") → notFound()` path. (An earlier revision had left it uncached on a wrong "live-score freshness" premise — corrected.)

## Tests
- New `BffService` tests: `Date` survives the cache round-trip; a failure keeps its typed `_tag` through the wrap (true regression guard for the 404→notFound path).
- `pnpm --filter @kcvv/web check-all` — **3131 tests pass, build OK**. No VR impact (skip-link is `sr-only` until focus; caching/headers are non-visual).

Reviewed across two rounds (correctness + the typed-error fix verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP `Cache-Control` headers to improve caching for successful Search and Related API responses.
  * Introduced a keyboard-accessible “skip to content” link with improved focus navigation for the main page.

* **Bug Fixes**
  * Improved cached data retrieval so cached reads preserve the expected typed error behavior and don’t cache failures.

* **Tests**
  * Expanded cache behavior tests to verify round-trip decoding (including `Date` restoration) and confirm error handling remains correct under cache-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
