### PR TITLE
refactor(ui): rename /club/inschrijven → /club/praktische-informatie + reword word-lid (#2207)

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -29,7 +29,12 @@ describe("next.config redirects", () => {
       { source: "/teams", destination: "/ploegen" },
       { source: "/team/:slug", destination: "/ploegen/:slug" },
       { source: "/club/history", destination: "/club/geschiedenis" },
-      { source: "/club/register", destination: "/club/inschrijven" },
+      { source: "/club/register", destination: "/club/praktische-informatie" },
+      // #2207 — practical-info hub re-slugged inschrijven → praktische-informatie
+      {
+        source: "/club/inschrijven",
+        destination: "/club/praktische-informatie",
+      },
     ];
 
     for (const { source, destination } of expected) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -61,7 +61,14 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/club/register",
-        destination: "/club/inschrijven",
+        destination: "/club/praktische-informatie",
+        permanent: true,
+      },
+      // #2207 — CMS practical-info hub re-slugged (was wrongly "inschrijven",
+      // which reads as "sign up"; the signup is /club/word-lid).
+      {
+        source: "/club/inschrijven",
+        destination: "/club/praktische-informatie",
         permanent: true,
       },
       // #1002 — Dutch URL for staff member detail pages

--- a/apps/web/src/app/(main)/club/word-lid/page.tsx
+++ b/apps/web/src/app/(main)/club/word-lid/page.tsx
@@ -3,7 +3,7 @@
  *
  * Static sibling under `club/` that beats the `club/[slug]` CMS catch-all.
  * The structured membership-signup entry point, reached from the "Word lid"
- * CTAs. The CMS "Praktische Informatie" page (`/club/inschrijven`) stays as the
+ * CTAs. The CMS "Praktische Informatie" page (`/club/praktische-informatie`) stays as the
  * practical-info hub. The page is static; the form POSTs to `/api/membership`.
  */
 
@@ -64,12 +64,13 @@ export default function WordLidPage() {
           </EditorialHeading>
           <p className="text-ink-soft font-display mt-5 max-w-[60ch] text-[length:var(--text-body-lg)] leading-[var(--text-body-lg--lh)]">
             Speler, jeugdspeler, vrijwilliger, trainer of scheidsrechter — vul
-            het formulier in en we nemen binnenkort contact met je op. Het
-            lidgeld regelen we samen nadat we je gecontacteerd hebben.
+            het formulier in en we nemen binnenkort contact met je op. Dit is
+            een aanvraag: sommige ploegen zitten vol, dus een plekje is niet
+            altijd gegarandeerd.
           </p>
           <p className="mt-4 text-[length:var(--text-body-md)]">
-            <Link href="/club/inschrijven" className="prose-link">
-              Praktische info — lidgeld, terugbetalingen &amp; ProSoccerData →
+            <Link href="/club/praktische-informatie" className="prose-link">
+              Praktische info →
             </Link>
           </p>
         </header>

--- a/apps/web/src/components/layout/NavDropdown/NavDropdown.stories.tsx
+++ b/apps/web/src/components/layout/NavDropdown/NavDropdown.stories.tsx
@@ -63,7 +63,7 @@ const deClubGroups: NavDropdownGroup[] = [
   {
     label: "Praktisch",
     items: [
-      { label: "Praktische Info", href: "/club/inschrijven" },
+      { label: "Praktische Info", href: "/club/praktische-informatie" },
       { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
       { label: "Cashless clubkaart", href: "/club/cashless" },
       { label: "Contact", href: "/club/contact" },

--- a/apps/web/src/components/layout/SiteFooter/SiteFooter.test.tsx
+++ b/apps/web/src/components/layout/SiteFooter/SiteFooter.test.tsx
@@ -94,7 +94,7 @@ describe("SiteFooter", () => {
     );
     expect(
       screen.getByRole("link", { name: "Praktische info" }),
-    ).toHaveAttribute("href", "/club");
+    ).toHaveAttribute("href", "/club/praktische-informatie");
   });
 
   it("renders copyright with founding year 1909 and current year", () => {

--- a/apps/web/src/components/layout/SiteFooter/footerLinks.ts
+++ b/apps/web/src/components/layout/SiteFooter/footerLinks.ts
@@ -34,7 +34,7 @@ export const FOOTER_COLUMNS: ReadonlyArray<FooterColumn> = [
       { label: "Geschiedenis", href: "/club/geschiedenis" },
       { label: "Bestuur", href: "/club/bestuur" },
       { label: "Contact", href: "/club/contact" },
-      { label: "Praktische info", href: "/club" },
+      { label: "Praktische info", href: "/club/praktische-informatie" },
     ],
   },
 ];

--- a/apps/web/src/components/layout/menuItems.ts
+++ b/apps/web/src/components/layout/menuItems.ts
@@ -38,7 +38,7 @@ export const staticMenuItems: MenuItem[] = [
       {
         label: "Praktisch",
         items: [
-          { label: "Praktische info", href: "/club/inschrijven" },
+          { label: "Praktische info", href: "/club/praktische-informatie" },
           { label: "Word vrijwilliger", href: "/club/vrijwilliger" },
           { label: "Cashless clubkaart", href: "/club/cashless" },
           { label: "Contact", href: "/club/contact" },


### PR DESCRIPTION
Closes #2207

## Changes

- **Slug rename** `/club/inschrijven` → `/club/praktische-informatie`
  - `next.config.ts`: new 308 `/club/inschrijven` → `/club/praktische-informatie`; re-pointed the existing `/club/register` redirect at the new slug
  - Re-pointed in-code links: nav `menuItems.ts`, footer `footerLinks.ts` ("Praktische info" was wrongly → `/club`), `word-lid/page.tsx` link, and the `NavDropdown` story mirror
- **word-lid reword** → enquiry framing: lead now reads as an *aanvraag* (we contact you; some ploegen may be full, no guaranteed spot). Dropped the `lidgeld` line and trimmed the link to plain `Praktische info →` — no cost mention.

## Left intentionally
- `JeugdEditorialGrid.test.tsx` negative guard ("old dead route gone") and the `jeugd-landing-page` CMS-passthrough fixture still reference `/club/inschrijven` — neither is a live link; the redirect covers them.

## Owner action required (manual, non-blocking)
- **Sanity:** rename the `page` doc slug `inschrijven` → `praktische-informatie` on **prod + staging**. Until then the redirect keeps `/club/inschrijven` resolving.
- Verify the praktische-informatie CMS page has a clear lidgeld + terugbetaling section (owner supplies content).

## Testing
- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, 3131 tests, build)
- Updated tests: redirect destination + footer href assertions
- Pre-PR review gate: `/code-review` (low) — no findings; `/simplify` skipped (pure rename/copy diff, no simplification surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated club section redirects to consolidate navigation to a unified practical information page.
  * Fixed footer and menu navigation links to reference the correct club information resource.
  * Updated membership signup page content and internal links for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->