### PR TITLE
refactor(ui): buildPageMetadata() helper + canonical & BreadcrumbList backfill (#2209)

### DIFF
--- a/apps/web/src/app/(landing)/jeugd/page.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.tsx
@@ -1,5 +1,4 @@
 import { Effect } from "effect";
-import type { Metadata } from "next";
 import { runPromise } from "@/lib/effect/runtime";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import {
@@ -15,9 +14,10 @@ import {
   groupTeamsForLanding,
   type TeamLandingItem,
 } from "@/lib/utils/group-teams";
-import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { PageContainer, StripedSeam } from "@/components/design-system";
 import { PageViewTracker } from "@/components/analytics/PageViewTracker";
 import { JeugdHero } from "@/components/jeugd/JeugdHero/JeugdHero";
@@ -27,18 +27,12 @@ import { EditorialHubAnalytics } from "@/components/editorial/EditorialHubAnalyt
 import { JeugdCtaBand } from "@/components/jeugd/JeugdCtaBand/JeugdCtaBand";
 import { YouthDirectory } from "@/components/team/YouthDirectory";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Jeugdopleiding | KCVV Elewijt",
   description:
     "Ontdek de jeugdopleiding van KCVV Elewijt. Van U6 tot U21: ploegen, nieuws, trainingsinfo en meer.",
-  openGraph: {
-    title: "Jeugdopleiding | KCVV Elewijt",
-    description:
-      "Ontdek de jeugdopleiding van KCVV Elewijt. Van U6 tot U21: ploegen, nieuws, trainingsinfo en meer.",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+  path: "/jeugd",
+});
 
 async function fetchTeams(): Promise<TeamLandingItem[]> {
   try {

--- a/apps/web/src/app/(landing)/sponsors/page.tsx
+++ b/apps/web/src/app/(landing)/sponsors/page.tsx
@@ -7,7 +7,6 @@
  */
 
 import { Effect } from "effect";
-import type { Metadata } from "next";
 import { runPromise } from "@/lib/effect/runtime";
 import {
   SponsorRepository,
@@ -16,14 +15,16 @@ import {
 import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd, buildItemListJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import type { Sponsor } from "@/components/sponsors/Sponsors";
 import { sortByTierThenName } from "@/components/sponsors/sortByTierThenName";
 import { SponsorsPage } from "@/components/sponsors/SponsorsPage/SponsorsPage";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Sponsors | KCVV Elewijt",
   description: "Overzicht van de sponsors die KCVV Elewijt steunen.",
-};
+  path: "/sponsors",
+});
 
 function mapToSponsor(s: SponsorVM): Sponsor {
   return {

--- a/apps/web/src/app/(main)/canonical-urls.test.ts
+++ b/apps/web/src/app/(main)/canonical-urls.test.ts
@@ -136,6 +136,52 @@ describe("Canonical URLs on dynamic routes", () => {
   });
 });
 
+describe("Canonical URLs backfilled via buildPageMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("static page (/privacy) includes canonical URL", async () => {
+    const { metadata } = await import("./privacy/page");
+    expect(metadata).toHaveProperty(
+      "alternates.canonical",
+      `${SITE_CONFIG.siteUrl}/privacy`,
+    );
+  });
+
+  it("/club/[slug] includes canonical URL", async () => {
+    mockRunPromise.mockResolvedValueOnce({
+      title: "Praktische Informatie",
+      metaDescription: null,
+      ogImageUrl: null,
+      heroImageUrl: null,
+      body: [],
+    });
+    const clubSlug = await import("./club/[slug]/page");
+    const metadata = await clubSlug.generateMetadata({
+      params: Promise.resolve({ slug: "inschrijven" }),
+    });
+    expect(metadata).toHaveProperty(
+      "alternates.canonical",
+      `${SITE_CONFIG.siteUrl}/club/inschrijven`,
+    );
+  });
+
+  it("board page (/club/bestuur) includes canonical URL", async () => {
+    mockRunPromise.mockResolvedValueOnce({
+      name: "Bestuur",
+      tagline: null,
+      teamImageUrl: null,
+    });
+    const bestuur = await import("./club/bestuur/page");
+    const metadata = await bestuur.generateMetadata();
+    expect(metadata).toHaveProperty(
+      "alternates.canonical",
+      `${SITE_CONFIG.siteUrl}/club/bestuur`,
+    );
+  });
+});
+
 describe("Noindex routes do NOT have canonical URLs", () => {
   it("/tegenstander/[clubId] has robots noindex and no canonical", async () => {
     const { metadata } = await import("./tegenstander/[clubId]/page");

--- a/apps/web/src/app/(main)/club/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { notFound } from "next/navigation";
 import { Effect } from "effect";
 import type { PortableTextBlock } from "@portabletext/react";
 import { runPromise } from "@/lib/effect/runtime";
 import { PageRepository } from "@/lib/repositories/page.repository";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { PageHero } from "@/components/layout/PageHero";
 import { ArticleBody } from "@/components/article/ArticleBody";
 import {
@@ -45,18 +48,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     ? { url: page.ogImageUrl, alt: page.title }
     : page.heroImageUrl
       ? { url: page.heroImageUrl, alt: page.title }
-      : DEFAULT_OG_IMAGE;
+      : undefined;
 
-  return {
+  return buildPageMetadata({
     title: `${page.title} | KCVV Elewijt`,
     description,
-    openGraph: {
-      title: `${page.title} - KCVV Elewijt`,
-      description,
-      type: "website",
-      images: [ogImage],
-    },
-  };
+    path: `/club/${slug}`,
+    ogTitle: `${page.title} - KCVV Elewijt`,
+    ogImage,
+  });
 }
 
 export const revalidate = 3600;
@@ -71,6 +71,13 @@ export default async function DynamicClubPage({ params }: Props) {
 
   return (
     <div className="bg-cream min-h-screen">
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: SITE_CONFIG.siteUrl },
+          { name: "Club", url: `${SITE_CONFIG.siteUrl}/club` },
+          { name: page.title, url: `${SITE_CONFIG.siteUrl}/club/${slug}` },
+        ])}
+      />
       {/* Hero — kicker "Club", headline = page.title, optional heroImage
           (typographic state when absent). `pb-12` reserves the rhythm before
           the full-bleed seam (StripedSeam carries no margin of its own). */}

--- a/apps/web/src/app/(main)/club/contact/page.tsx
+++ b/apps/web/src/app/(main)/club/contact/page.tsx
@@ -3,19 +3,22 @@
  * Club contact information and categorized email contacts
  */
 
-import type { Metadata } from "next";
 import { Effect } from "effect";
-import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { runPromise } from "@/lib/effect/runtime";
 import { StaffRepository } from "@/lib/repositories/staff.repository";
 import { ContactPage } from "@/components/club/ContactPage/ContactPage";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Contact | KCVV Elewijt",
   description:
     "Contacteer KCVV Elewijt. Adres: Driesstraat 32, 1982 Elewijt. Vind de juiste contactpersoon voor algemene vragen, jeugdwerking, sponsoring en meer.",
+  path: "/club/contact",
+  ogTitle: "Contact - KCVV Elewijt",
+  ogDescription: "Contacteer KCVV Elewijt voor al je vragen",
   keywords: [
     "contact",
     "KCVV Elewijt",
@@ -25,13 +28,7 @@ export const metadata: Metadata = {
     "sponsoring",
     "Elewijt",
   ],
-  openGraph: {
-    title: "Contact - KCVV Elewijt",
-    description: "Contacteer KCVV Elewijt voor al je vragen",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 // ISR — the page fetches key staff contacts at request time; refresh hourly so
 // contact changes in Sanity surface without a redeploy (matches the other

--- a/apps/web/src/app/(main)/club/createBoardPage.tsx
+++ b/apps/web/src/app/(main)/club/createBoardPage.tsx
@@ -7,10 +7,13 @@
 
 import type { Metadata } from "next";
 import type { PortableTextBlock } from "@portabletext/react";
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import { runPromise } from "@/lib/effect/runtime";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { BestuurPage } from "@/components/club/BestuurPage/BestuurPage";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import { PageViewTracker } from "@/components/analytics";
@@ -66,18 +69,15 @@ export function createBoardPage({
         ? `${team.name} — ${team.tagline}`
         : fallbackDescription;
 
-      return {
+      return buildPageMetadata({
         title: `${team.name} | KCVV Elewijt`,
         description,
-        openGraph: {
-          title: team.name,
-          description,
-          type: "website",
-          images: team.teamImageUrl
-            ? [{ url: team.teamImageUrl, alt: `${team.name} foto` }]
-            : [DEFAULT_OG_IMAGE],
-        },
-      };
+        path: `/club/${slug}`,
+        ogTitle: team.name,
+        ogImage: team.teamImageUrl
+          ? { url: team.teamImageUrl, alt: `${team.name} foto` }
+          : undefined,
+      });
     } catch (error) {
       const digest = (error as { digest?: string }).digest;
       if (
@@ -87,10 +87,11 @@ export function createBoardPage({
       ) {
         throw error;
       }
-      return {
+      return buildPageMetadata({
         title: `${fallbackTitle} | KCVV Elewijt`,
         description: fallbackDescription,
-      };
+        path: `/club/${slug}`,
+      });
     }
   }
 
@@ -99,6 +100,13 @@ export function createBoardPage({
 
     return (
       <>
+        <JsonLd
+          data={buildBreadcrumbJsonLd([
+            { name: "Home", url: SITE_CONFIG.siteUrl },
+            { name: "Club", url: `${SITE_CONFIG.siteUrl}/club` },
+            { name: team.name, url: `${SITE_CONFIG.siteUrl}/club/${slug}` },
+          ])}
+        />
         {/* `board` slug is non-PII (bestuur / jeugdbestuur / angels). */}
         <PageViewTracker eventName="board_view" params={{ board: slug }} />
         <BestuurPage

--- a/apps/web/src/app/(main)/club/geschiedenis/page.tsx
+++ b/apps/web/src/app/(main)/club/geschiedenis/page.tsx
@@ -1,13 +1,15 @@
-import type { Metadata } from "next";
-import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { HistoryContent } from "./HistoryContent";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Geschiedenis | KCVV Elewijt",
   description:
     "Tijdslijn van de rijkgevulde geschiedenis van KCVV Elewijt van 1909 tot nu!",
+  path: "/club/geschiedenis",
+  ogTitle: "Geschiedenis - KCVV Elewijt",
   keywords: [
     "geschiedenis",
     "history",
@@ -15,14 +17,7 @@ export const metadata: Metadata = {
     "tijdslijn",
     "Crossing Elewijt",
   ],
-  openGraph: {
-    title: "Geschiedenis - KCVV Elewijt",
-    description:
-      "Tijdslijn van de rijkgevulde geschiedenis van KCVV Elewijt van 1909 tot nu!",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 export default function HistoryPage() {
   return (

--- a/apps/web/src/app/(main)/club/page.tsx
+++ b/apps/web/src/app/(main)/club/page.tsx
@@ -1,7 +1,7 @@
-import type { Metadata } from "next";
 import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import {
   EditorialHeading,
   LinkButton,
@@ -13,11 +13,12 @@ import {
 import { PageHero } from "@/components/layout/PageHero";
 import { ClubEditorialHub } from "@/components/club/ClubEditorialHub/ClubEditorialHub";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Onze club | KCVV Elewijt",
   description:
     "Alles over KCVV Elewijt: geschiedenis, bestuur, organigram en hoe je kan aansluiten.",
-};
+  path: "/club",
+});
 
 /**
  * `/club` index — rebuilt on the retro-terrace-fanzine system (design lock

--- a/apps/web/src/app/(main)/club/ultras/page.tsx
+++ b/apps/web/src/app/(main)/club/ultras/page.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from "next";
 import Image from "next/image";
-import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { getButtonClasses } from "@/components/design-system/Button/button-styles";
 import { TapedFigure } from "@/components/design-system/TapedFigure";
 import { PullQuote } from "@/components/design-system/PullQuote";
@@ -16,18 +16,15 @@ import { RaffleCallout } from "./RaffleCallout";
 const FACEBOOK_URL = "https://www.facebook.com/KCVV.ULTRAS.55/";
 const PHOTO_SIZES = "(min-width: 768px) 640px, 100vw";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "KCVV Ultras | KCVV Elewijt",
   description:
     "Supportersclub van KCVV Elewijt: De Ultra's! Positief aanmoedigen van onze ploeg.",
+  path: "/club/ultras",
+  ogTitle: "KCVV Ultra's 55 - KCVV Elewijt",
+  ogDescription: "Supportersclub van KCVV Elewijt: De Ultra's!",
   keywords: ["ultras", "supporters", "KCVV Elewijt", "sfeeracties"],
-  openGraph: {
-    title: "KCVV Ultra's 55 - KCVV Elewijt",
-    description: "Supportersclub van KCVV Elewijt: De Ultra's!",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 export default function UltrasPage() {
   return (

--- a/apps/web/src/app/(main)/club/word-lid/page.tsx
+++ b/apps/web/src/app/(main)/club/word-lid/page.tsx
@@ -7,18 +7,22 @@
  * practical-info hub. The page is static; the form POSTs to `/api/membership`.
  */
 
-import type { Metadata } from "next";
 import Link from "next/link";
-import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { EditorialHeading, PageContainer } from "@/components/design-system";
 import { MembershipForm } from "@/components/club/MembershipForm/MembershipForm";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Word lid | KCVV Elewijt",
   description:
     "Schrijf je in bij KCVV Elewijt — als speler, jeugdspeler, vrijwilliger, trainer of scheidsrechter. Vul het inschrijfformulier in en we nemen contact met je op.",
+  path: "/club/word-lid",
+  ogTitle: "Word lid van KCVV Elewijt",
+  ogDescription:
+    "Schrijf je in bij KCVV Elewijt — speler, jeugd, vrijwilliger, trainer of scheidsrechter.",
   keywords: [
     "word lid",
     "inschrijven",
@@ -29,15 +33,7 @@ export const metadata: Metadata = {
     "vrijwilliger",
     "Elewijt",
   ],
-  alternates: { canonical: `${SITE_CONFIG.siteUrl}/club/word-lid` },
-  openGraph: {
-    title: "Word lid van KCVV Elewijt",
-    description:
-      "Schrijf je in bij KCVV Elewijt — speler, jeugd, vrijwilliger, trainer of scheidsrechter.",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 export default function WordLidPage() {
   return (

--- a/apps/web/src/app/(main)/evenementen/page.tsx
+++ b/apps/web/src/app/(main)/evenementen/page.tsx
@@ -14,12 +14,14 @@
  * `<EventsBrowser>` client shell; this server page only fetches the feed.
  */
 
-import type { Metadata } from "next";
 import { Effect } from "effect";
 
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { runPromise } from "@/lib/effect/runtime";
 import { EventRepository } from "@/lib/repositories/event.repository";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import {
   EditorialHeading,
   MonoLabel,
@@ -27,10 +29,13 @@ import {
 } from "@/components/design-system";
 import { EventsBrowser } from "@/components/event/EventsBrowser";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Evenementen | KCVV Elewijt",
   description:
     "Alle aankomende evenementen van KCVV Elewijt — clubactiviteiten, jeugdevenementen en supportersuitjes.",
+  path: "/evenementen",
+  ogTitle: "Evenementen - KCVV Elewijt",
+  ogDescription: "Alle aankomende evenementen van KCVV Elewijt",
   keywords: [
     "evenementen",
     "agenda",
@@ -39,13 +44,7 @@ export const metadata: Metadata = {
     "jeugd",
     "KCVV Elewijt",
   ],
-  openGraph: {
-    title: "Evenementen - KCVV Elewijt",
-    description: "Alle aankomende evenementen van KCVV Elewijt",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 // 1h ISR — events listing; on-demand revalidation via /api/revalidate
 // (revalidatePath '/evenementen') makes new/edited events appear sooner.
@@ -61,6 +60,12 @@ export default async function EvenementenPage() {
 
   return (
     <div className="bg-jersey-deep-dark flex min-h-screen flex-col">
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: SITE_CONFIG.siteUrl },
+          { name: "Evenementen", url: `${SITE_CONFIG.siteUrl}/evenementen` },
+        ])}
+      />
       <PageContainer as="header" width="index" className="pt-12 pb-8">
         <MonoLabel tone="cream">KCVV Elewijt · Agenda</MonoLabel>
         <EditorialHeading

--- a/apps/web/src/app/(main)/galerij/page.tsx
+++ b/apps/web/src/app/(main)/galerij/page.tsx
@@ -8,12 +8,14 @@
  * webhook map lands (see PR notes).
  */
 
-import type { Metadata } from "next";
 import { Effect } from "effect";
 
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { runPromise } from "@/lib/effect/runtime";
 import { PhotoGalleryRepository } from "@/lib/repositories/photoGallery.repository";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import {
   EditorialHeading,
   MonoLabel,
@@ -21,18 +23,15 @@ import {
 } from "@/components/design-system";
 import { GalleryCardGrid } from "@/components/gallery/GalleryCardGrid/GalleryCardGrid";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Fotogalerij | KCVV Elewijt",
   description:
     "Foto's van wedstrijden, evenementen en clubmomenten van KCVV Elewijt.",
+  path: "/galerij",
+  ogTitle: "Fotogalerij - KCVV Elewijt",
+  ogDescription: "Foto's van wedstrijden, evenementen en clubmomenten",
   keywords: ["foto's", "galerij", "fotogalerij", "beelden", "KCVV Elewijt"],
-  openGraph: {
-    title: "Fotogalerij - KCVV Elewijt",
-    description: "Foto's van wedstrijden, evenementen en clubmomenten",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 // Galleries change rarely — 24h ISR (align with #1921).
 export const revalidate = 86400;
@@ -47,6 +46,12 @@ export default async function GalerijPage() {
 
   return (
     <div className="bg-cream flex min-h-screen flex-col">
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: SITE_CONFIG.siteUrl },
+          { name: "Galerij", url: `${SITE_CONFIG.siteUrl}/galerij` },
+        ])}
+      />
       <PageContainer as="header" width="index" className="pt-12 pb-8">
         <MonoLabel tone="ink">KCVV Elewijt · Beelden</MonoLabel>
         <EditorialHeading

--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -3,8 +3,6 @@
  * Full-season matches across all KCVV teams + events, with month/week views
  */
 
-import type { Metadata } from "next";
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { Effect } from "effect";
 import { runPromise } from "@/lib/effect/runtime";
 import { BffService } from "@/lib/effect/services/BffService";
@@ -19,6 +17,7 @@ import { PageContainer } from "@/components/design-system";
 import { PageViewTracker } from "@/components/analytics";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildItemListJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { SITE_CONFIG } from "@/lib/constants";
 import { CalendarWidget } from "@/components/calendar/CalendarWidget";
 import {
@@ -32,10 +31,14 @@ import type {
   CalendarTeamInfo,
 } from "./utils";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Kalender | KCVV Elewijt",
   description:
     "Alle wedstrijden én clubactiviteiten van KCVV Elewijt op één kalender — A-ploeg, B-ploeg en jeugd. Bekijk per maand, week of als agenda, of abonneer je op je ploeg.",
+  path: "/kalender",
+  ogTitle: "Kalender — KCVV Elewijt",
+  ogDescription:
+    "Alle wedstrijden én clubactiviteiten van KCVV Elewijt op één kalender.",
   keywords: [
     "wedstrijden",
     "kalender",
@@ -47,14 +50,7 @@ export const metadata: Metadata = {
     "jeugd",
     "KCVV Elewijt",
   ],
-  openGraph: {
-    title: "Kalender — KCVV Elewijt",
-    description:
-      "Alle wedstrijden én clubactiviteiten van KCVV Elewijt op één kalender.",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 interface CalendarData {
   feed: CalendarFeedItem[];

--- a/apps/web/src/app/(main)/ploegen/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/page.tsx
@@ -8,13 +8,13 @@
  */
 
 import { Effect } from "effect";
-import type { Metadata } from "next";
 import { runPromise } from "@/lib/effect/runtime";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import { groupTeamsForLanding } from "@/lib/utils/group-teams";
-import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { PageViewTracker } from "@/components/analytics";
 import { MonoLabel } from "@/components/design-system/MonoLabel";
 import { EditorialHeading } from "@/components/design-system/EditorialHeading";
@@ -26,18 +26,11 @@ const PLOEGEN_TITLE = "Onze ploegen | KCVV Elewijt";
 const PLOEGEN_DESCRIPTION =
   "Alle ploegen van KCVV Elewijt: eerste ploeg, tweede ploeg en jeugd van U6 tot U21.";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: PLOEGEN_TITLE,
   description: PLOEGEN_DESCRIPTION,
-  alternates: { canonical: `${SITE_CONFIG.siteUrl}/ploegen` },
-  openGraph: {
-    title: PLOEGEN_TITLE,
-    description: PLOEGEN_DESCRIPTION,
-    type: "website",
-    url: `${SITE_CONFIG.siteUrl}/ploegen`,
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+  path: "/ploegen",
+});
 
 async function fetchTeams() {
   try {

--- a/apps/web/src/app/(main)/privacy/page.tsx
+++ b/apps/web/src/app/(main)/privacy/page.tsx
@@ -9,9 +9,8 @@
  * typography-plugin prose composition (master design §7 line 587).
  */
 
-import type { Metadata } from "next";
 import Link from "next/link";
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import {
   EditorialHeading,
   DottedDivider,
@@ -24,10 +23,14 @@ import {
  */
 const LAST_UPDATED = "juni 2026";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Privacyverklaring | KCVV Elewijt",
   description:
     "Privacyverklaring en cookiebeleid van KCVV Elewijt. Lees hoe we omgaan met jouw persoonsgegevens conform de GDPR wetgeving.",
+  path: "/privacy",
+  ogTitle: "Privacyverklaring - KCVV Elewijt",
+  ogDescription:
+    "Privacyverklaring en cookiebeleid van KCVV Elewijt conform GDPR",
   keywords: [
     "privacy",
     "privacyverklaring",
@@ -37,14 +40,7 @@ export const metadata: Metadata = {
     "cookies",
     "KCVV Elewijt",
   ],
-  openGraph: {
-    title: "Privacyverklaring - KCVV Elewijt",
-    description:
-      "Privacyverklaring en cookiebeleid van KCVV Elewijt conform GDPR",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 /**
  * Cream/ink prose styling for the legal copy. Replaces the legacy

--- a/apps/web/src/app/(main)/zoeken/page.tsx
+++ b/apps/web/src/app/(main)/zoeken/page.tsx
@@ -8,24 +8,20 @@
  * #2057) unchanged — presentation only.
  */
 
-import type { Metadata } from "next";
 import { Suspense } from "react";
-import { DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { buildPageMetadata } from "@/lib/seo/page-metadata";
 import { SearchInterface } from "@/components/search";
 import { SearchMastheadSkeleton } from "@/components/search/SearchMastheadSkeleton";
 
-export const metadata: Metadata = {
+export const metadata = buildPageMetadata({
   title: "Zoeken | KCVV Elewijt",
   description:
     "Doorzoek nieuws, spelers, teams en meer op de website van KCVV Elewijt",
+  path: "/zoeken",
+  ogTitle: "Zoeken - KCVV Elewijt",
+  ogDescription: "Doorzoek de website van KCVV Elewijt",
   keywords: ["zoeken", "search", "nieuws", "spelers", "teams", "KCVV Elewijt"],
-  openGraph: {
-    title: "Zoeken - KCVV Elewijt",
-    description: "Doorzoek de website van KCVV Elewijt",
-    type: "website",
-    images: [DEFAULT_OG_IMAGE],
-  },
-};
+});
 
 /**
  * Search page with client-side search interface.

--- a/apps/web/src/lib/seo/page-metadata.test.ts
+++ b/apps/web/src/lib/seo/page-metadata.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+import { buildPageMetadata } from "./page-metadata";
+
+describe("buildPageMetadata", () => {
+  it("sets the absolute canonical URL from path", () => {
+    const meta = buildPageMetadata({
+      title: "Contact | KCVV Elewijt",
+      description: "Contacteer KCVV Elewijt.",
+      path: "/club/contact",
+    });
+    expect(meta).toHaveProperty(
+      "alternates.canonical",
+      `${SITE_CONFIG.siteUrl}/club/contact`,
+    );
+  });
+
+  it("falls back to DEFAULT_OG_IMAGE when no ogImage is given", () => {
+    const meta = buildPageMetadata({
+      title: "T",
+      description: "D",
+      path: "/x",
+    });
+    const og = meta.openGraph as { images?: unknown[]; url?: string };
+    expect(og.images).toEqual([DEFAULT_OG_IMAGE]);
+    expect(og.url).toBe(`${SITE_CONFIG.siteUrl}/x`);
+  });
+
+  it("uses the supplied ogImage over the default", () => {
+    const img = { url: "https://cdn.example/og.png", alt: "Foto" };
+    const meta = buildPageMetadata({
+      title: "T",
+      description: "D",
+      path: "/x",
+      ogImage: img,
+    });
+    const og = meta.openGraph as { images?: unknown[] };
+    expect(og.images).toEqual([img]);
+  });
+
+  it("defaults openGraph title/description to the page title/description", () => {
+    const meta = buildPageMetadata({
+      title: "Zoeken | KCVV Elewijt",
+      description: "Doorzoek de website.",
+      path: "/zoeken",
+    });
+    const og = meta.openGraph as { title?: string; description?: string };
+    expect(og.title).toBe("Zoeken | KCVV Elewijt");
+    expect(og.description).toBe("Doorzoek de website.");
+  });
+
+  it("honours tailored ogTitle/ogDescription overrides", () => {
+    const meta = buildPageMetadata({
+      title: "KCVV Ultras | KCVV Elewijt",
+      description: "Supportersclub van KCVV Elewijt: De Ultra's!",
+      path: "/club/ultras",
+      ogTitle: "KCVV Ultra's 55 - KCVV Elewijt",
+      ogDescription: "Supportersclub van KCVV Elewijt: De Ultra's!",
+    });
+    const og = meta.openGraph as { title?: string };
+    expect(og.title).toBe("KCVV Ultra's 55 - KCVV Elewijt");
+  });
+
+  it("omits keywords unless provided", () => {
+    expect(
+      buildPageMetadata({ title: "T", description: "D", path: "/x" }),
+    ).not.toHaveProperty("keywords");
+    expect(
+      buildPageMetadata({
+        title: "T",
+        description: "D",
+        path: "/x",
+        keywords: ["a", "b"],
+      }),
+    ).toHaveProperty("keywords", ["a", "b"]);
+  });
+});

--- a/apps/web/src/lib/seo/page-metadata.test.ts
+++ b/apps/web/src/lib/seo/page-metadata.test.ts
@@ -50,15 +50,19 @@ describe("buildPageMetadata", () => {
   });
 
   it("honours tailored ogTitle/ogDescription overrides", () => {
+    // ogDescription is deliberately distinct from description so the
+    // assertion proves the override is used, not the default fallback.
     const meta = buildPageMetadata({
       title: "KCVV Ultras | KCVV Elewijt",
-      description: "Supportersclub van KCVV Elewijt: De Ultra's!",
+      description:
+        "Supportersclub van KCVV Elewijt: De Ultra's! Positief aanmoedigen van onze ploeg.",
       path: "/club/ultras",
       ogTitle: "KCVV Ultra's 55 - KCVV Elewijt",
       ogDescription: "Supportersclub van KCVV Elewijt: De Ultra's!",
     });
-    const og = meta.openGraph as { title?: string };
+    const og = meta.openGraph as { title?: string; description?: string };
     expect(og.title).toBe("KCVV Ultra's 55 - KCVV Elewijt");
+    expect(og.description).toBe("Supportersclub van KCVV Elewijt: De Ultra's!");
   });
 
   it("omits keywords unless provided", () => {

--- a/apps/web/src/lib/seo/page-metadata.ts
+++ b/apps/web/src/lib/seo/page-metadata.ts
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
+
+/** Open Graph image — subset of Next's OG image object we actually use. */
+export interface OgImage {
+  url: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+}
+
+export interface PageMetadataInput {
+  /** Page `<title>` — passed through verbatim (root layout applies its template). */
+  title: string;
+  description: string;
+  /** Site-relative path, e.g. `/club/contact`. Drives canonical + og:url. */
+  path: string;
+  /** Open Graph title — defaults to {@link PageMetadataInput.title}. */
+  ogTitle?: string;
+  /** Open Graph description — defaults to {@link PageMetadataInput.description}. */
+  ogDescription?: string;
+  /** Open Graph image — defaults to {@link DEFAULT_OG_IMAGE}. */
+  ogImage?: OgImage;
+  keywords?: string[];
+}
+
+/**
+ * Build static-page `Metadata` with the SEO hygiene every indexable page needs:
+ * an absolute `alternates.canonical` from `path`, and an `openGraph` block that
+ * resolves the image to a single `DEFAULT_OG_IMAGE` fallback. Consolidates the
+ * per-page hand-rolled canonical + OG-image boilerplate (#2209).
+ *
+ * Not for noindex routes — they must omit canonical (see `canonical-urls.test`).
+ */
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+  ogTitle,
+  ogDescription,
+  ogImage,
+  keywords,
+}: PageMetadataInput): Metadata {
+  const canonical = `${SITE_CONFIG.siteUrl}${path}`;
+  return {
+    title,
+    description,
+    ...(keywords ? { keywords } : {}),
+    alternates: { canonical },
+    openGraph: {
+      title: ogTitle ?? title,
+      description: ogDescription ?? description,
+      type: "website",
+      url: canonical,
+      images: [ogImage ?? DEFAULT_OG_IMAGE],
+    },
+  };
+}


### PR DESCRIPTION
Closes #2209

## Changes

**New `buildPageMetadata()` helper** (`apps/web/src/lib/seo/page-metadata.ts`)
`buildPageMetadata({ title, description, path, ogImage?, ogTitle?, ogDescription?, keywords? })` returns `Metadata` that:
- always sets an absolute `alternates.canonical` from `path` (matches the existing dynamic-route convention asserted in `canonical-urls.test.ts`),
- emits an `openGraph` block (`type: "website"`, `url` = canonical) and resolves the image to a single `DEFAULT_OG_IMAGE` fallback,
- defaults `og:title`/`og:description` to the page title/description, with optional overrides to preserve the pages' tailored (shorter) OG strings.

**Migrated the 13 indexable static-metadata pages** to the helper — canonical was previously set on only `word-lid` + `ploegen` (2/16). Pages: jeugd, sponsors, club (index), contact, geschiedenis, ultras, word-lid, evenementen, galerij, kalender, ploegen, privacy, zoeken.

**BreadcrumbList JSON-LD backfill** where missing:
- the 3 board pages — one fix in the `createBoardPage` factory,
- `club/[slug]`,
- the `evenementen` + `galerij` index pages.

`club/[slug]` and the board pages also pick up `alternates.canonical` via the helper (the factory sets it in both the success and Sanity-unreachable fallback paths, since canonical is path-derived).

**Deliberately left untouched:** the noindex routes `share`, `tegenstander`, `scheurkalender` — they must omit canonical (guarded by the existing `canonical-urls.test.ts` "Noindex routes do NOT have canonical URLs" block).

## Testing

- `pnpm --filter @kcvv/web check-all` — lint, type-check, **3140 tests**, and `next build` all pass.
- New `page-metadata.test.ts` (6 cases) covers canonical, OG fallback/override, og default-from-title, and keywords omission.
- Extended `canonical-urls.test.ts` (+3 cases) covers canonical on a static page, `club/[slug]`, and the board factory.
- Verified in the built HTML: `<link rel="canonical">`, `og:url`, tailored `og:title`, and `BreadcrumbList` JSON-LD all render; `sponsors` (no canonical before) now has one.

## Pre-PR review gate

`/code-review` (high) + cleanup angles run on the diff — no correctness findings; cleanup findings were style nits (local `OgImage` type vs Next's deep private type; intentional `??` vs spread-conditional) and were refuted.

## Out of scope — pre-existing finding

Discovered (not introduced here): static pages hardcode the full `"X | KCVV Elewijt"` title, which the root layout's `title.template` (`%s | KCVV Elewijt`) then **doubles** → `<title>X | KCVV Elewijt | KCVV Elewijt</title>`. This refactor passes `title` through verbatim, so it is title-neutral. A proper fix (clean page titles + an `og:title` brand-suffix decision) spans the dynamic detail routes too and belongs in its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized SEO metadata generation across many pages using a shared metadata builder for consistent titles, canonical URLs, and social preview data.
* **New Features**
  * Added breadcrumb JSON-LD structured data to selected pages to better communicate site hierarchy to search engines.
* **Tests**
  * Added automated tests to verify canonical URL backfilling and the metadata builder’s behavior (including Open Graph defaults/overrides).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->