### PR TITLE
test(events): make /evenementen e2e resilient to an empty upcoming feed

### DIFF
--- a/apps/web/test/e2e/evenementen.spec.ts
+++ b/apps/web/test/e2e/evenementen.spec.ts
@@ -31,12 +31,23 @@ test.describe("/evenementen", () => {
     page,
   }) => {
     await expect(page.locator("h1").first()).toContainText("Evenementen");
-    await expect(
-      page.getByRole("group", { name: /Filter evenementen op type/i }),
-    ).toBeVisible();
 
-    const tickets = page.locator(TICKET_SELECTOR);
-    expect(await tickets.count()).toBeGreaterThan(0);
+    // The feed is upcoming-only, so an empty dataset (off-season / none seeded)
+    // is a valid state — `<EventsBrowser>` then renders a centred empty message
+    // with NO filter row. Wait for whichever terminal state rendered, then
+    // assert against it (mirrors the `test.skip(allCount === 0)` guard the other
+    // two specs use). `.count()` doesn't auto-wait, so settle on a visible state
+    // first to avoid racing hydration into a false-empty read.
+    const filterBar = page.getByRole("group", {
+      name: /Filter evenementen op type/i,
+    });
+    const emptyState = page.getByText(/Geen evenementen gepland/i);
+    await expect(filterBar.or(emptyState)).toBeVisible();
+
+    if (await emptyState.isVisible()) return;
+
+    await expect(filterBar).toBeVisible();
+    expect(await page.locator(TICKET_SELECTOR).count()).toBeGreaterThan(0);
   });
 
   test("a type filter narrows the feed (or shows the per-type empty state)", async ({


### PR DESCRIPTION
## Problem

`evenementen.spec.ts`'s first test hard-asserted the type-filter group + ≥1 ticket. But `/evenementen` is an **upcoming-only** feed, and `<EventsBrowser>` renders a centred empty state **with no filter row** when there are no upcoming events.

CI builds against the **`production` dataset** — the `NEXT_PUBLIC_SANITY_DATASET` repo variable is unset, so `src/lib/sanity/client.ts` falls back to its `"production"` default — which currently has no upcoming events. So the test failed deterministically on every run.

The page behaviour is correct; the empty state is by design. Only the test was too strict — note the file header already states it's meant to be "resilient to the exact upcoming-event set," and the other two specs already guard with `test.skip(allCount === 0)`.

## Fix

Wait for whichever terminal state renders (`filterBar.or(emptyState)`), then assert against it — return early on the empty state, otherwise assert the filter bar + tickets. `.count()` doesn't auto-wait, so settling on a visible state first avoids racing hydration into a false-empty read.

## Verification

Ran the spec locally against both feed states:

- **Production build (empty feed — reproduces CI):** 1 pass + 2 skip ✅
- **Staging build (events present):** 3 pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing for the events page to properly validate scenarios when no events are scheduled, ensuring the empty state message displays correctly.

* **Bug Fixes**
  * Improved test robustness by handling off-season periods and empty event dataset edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->