### PR TITLE
fix(config): resolve legacy Gatsby URLs to current routes (#2227)

### DIFF
--- a/apps/web/next.config.test.ts
+++ b/apps/web/next.config.test.ts
@@ -6,7 +6,6 @@ describe("next.config redirects", () => {
     const redirects = await nextConfig.redirects!();
 
     const expected = [
-      { source: "/players/:slug", destination: "/spelers/:slug" },
       { source: "/news", destination: "/nieuws" },
       { source: "/news/:slug", destination: "/nieuws/:slug" },
       { source: "/game/:matchId", destination: "/wedstrijd/:matchId" },
@@ -70,13 +69,36 @@ describe("next.config redirects", () => {
     expect(match!.permanent).toBe(true);
   });
 
-  it("redirects /jeugd/:slug to /ploegen/:slug (excluding visie and medisch)", async () => {
+  it("redirects retired Gatsby routes to the nearest page with 308 (#2227 SEO-9)", async () => {
     const redirects = await nextConfig.redirects!();
 
-    const match = redirects.find((r) => r.source.startsWith("/jeugd/"));
-    expect(match).toBeDefined();
-    expect(match!.source).toBe("/jeugd/:slug((?!visie|medisch).*)");
-    expect(match!.destination).toBe("/ploegen/:slug");
-    expect(match!.permanent).toBe(true);
+    const expected = [
+      { source: "/club/cashless", destination: "/club/praktische-informatie" },
+      {
+        source: "/club/cashless/voorwaarden",
+        destination: "/club/praktische-informatie",
+      },
+      { source: "/club/downloads", destination: "/club" },
+      { source: "/kiosk", destination: "/kalender" },
+      { source: "/kiosk/:path*", destination: "/kalender" },
+    ];
+
+    for (const { source, destination } of expected) {
+      const match = redirects.find((r) => r.source === source);
+      expect(match, `Missing redirect for ${source}`).toBeDefined();
+      expect(match!.destination).toBe(destination);
+      expect(match!.permanent).toBe(true);
+    }
+  });
+
+  it("drops the broken static player/staff/youth renames now handled by resolver routes (#2227)", async () => {
+    const redirects = await nextConfig.redirects!();
+    const sources = redirects.map((r) => r.source);
+    // These passed a name-slug / bare age token to psdId-/slug-keyed targets and
+    // 404'd. Resolution now lives in src/app/{player,players,staff}/[slug] and
+    // src/app/(landing)/jeugd/[slug].
+    expect(sources).not.toContain("/players/:slug");
+    expect(sources).not.toContain("/staff/:slug");
+    expect(sources.some((source) => source.startsWith("/jeugd/"))).toBe(false);
   });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,21 +3,14 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
 
-  // Redirects for old /jeugd/* URLs to /ploegen/*
-  // This ensures SEO preservation for any indexed youth team pages
+  // Static SEO redirects for renamed/retired routes. Dynamic legacy resolvers
+  // that need a CMS lookup (player/staff name-slug → psdId, youth age → team
+  // slug) are routes under src/app/{player,players,staff}/[slug] and
+  // src/app/(landing)/jeugd/[slug] instead — a static prefix redirect there
+  // would 404 against the psdId-/slug-keyed targets (#2227).
   async redirects() {
     return [
-      {
-        source: "/jeugd/:slug((?!visie|medisch).*)",
-        destination: "/ploegen/:slug",
-        permanent: true, // 308 redirect for SEO
-      },
       // #819 — Dutch URL renames
-      {
-        source: "/players/:slug",
-        destination: "/spelers/:slug",
-        permanent: true,
-      },
       {
         source: "/news",
         destination: "/nieuws",
@@ -71,12 +64,6 @@ const nextConfig: NextConfig = {
         destination: "/club/praktische-informatie",
         permanent: true,
       },
-      // #1002 — Dutch URL for staff member detail pages
-      {
-        source: "/staff/:slug",
-        destination: "/staf/:slug",
-        permanent: true,
-      },
       // #1964 — Phase 6.E events route rename /events → /evenementen.
       // `permanent: true` emits a 308 (matching every rename above); the
       // issue's "301" is shorthand for a permanent redirect.
@@ -100,6 +87,34 @@ const nextConfig: NextConfig = {
       {
         source: "/club/organigram",
         destination: "/hulp#structuur",
+        permanent: true,
+      },
+      // #2227 (SEO-9) — retired Gatsby routes with no direct equivalent →
+      // nearest live page (owner decision on the issue).
+      {
+        source: "/club/cashless",
+        destination: "/club/praktische-informatie",
+        permanent: true,
+      },
+      {
+        source: "/club/cashless/voorwaarden",
+        destination: "/club/praktische-informatie",
+        permanent: true,
+      },
+      {
+        source: "/club/downloads",
+        destination: "/club",
+        permanent: true,
+      },
+      // Internal kiosk displays (a, b, previous, upcoming, ranking/*) → calendar.
+      {
+        source: "/kiosk",
+        destination: "/kalender",
+        permanent: true,
+      },
+      {
+        source: "/kiosk/:path*",
+        destination: "/kalender",
         permanent: true,
       },
     ];

--- a/apps/web/src/app/(landing)/jeugd/[slug]/page.tsx
+++ b/apps/web/src/app/(landing)/jeugd/[slug]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound, permanentRedirect } from "next/navigation";
+
+import { runPromise } from "@/lib/effect/runtime";
+import {
+  fetchYouthTeamRows,
+  resolveYouthSlug,
+} from "@/lib/seo/legacy-redirect";
+
+interface LegacyYouthProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Legacy Gatsby youth URL `/jeugd/<age-token>` (e.g. `/jeugd/u9`, `/jeugd/u8-wit`).
+ * Youth team slugs drifted to `kcvve-u9-groen` form post-migration, so the old
+ * static `/jeugd/:slug → /ploegen/:slug` pass-through 404'd; it was removed in
+ * favour of this age-based resolver (#2227, SEO-8). 308 to the resolved
+ * `/ploegen/<slug>`; 404 when no youth team of that age exists.
+ */
+export default async function LegacyYouthRedirect({
+  params,
+}: LegacyYouthProps) {
+  const { slug } = await params;
+  const rows = await runPromise(fetchYouthTeamRows());
+  const target = resolveYouthSlug(slug, rows);
+  if (!target) notFound();
+  permanentRedirect(`/ploegen/${target}`);
+}

--- a/apps/web/src/app/legacy-redirects.test.ts
+++ b/apps/web/src/app/legacy-redirects.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Route-level tests for the legacy Gatsby URL resolvers (#2227). The pure
+ * resolution logic is unit-tested in src/lib/seo/legacy-redirect.test.ts; these
+ * assert the route wiring — that each resolver 308s (permanentRedirect) to the
+ * right canonical path and 404s (notFound) when nothing resolves.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  permanentRedirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("@/lib/effect/runtime", () => ({ runPromise: vi.fn() }));
+
+const { runPromise } = await import("@/lib/effect/runtime");
+const mockRun = vi.mocked(runPromise);
+
+const player = await import("./player/[slug]/page");
+const players = await import("./players/[slug]/page");
+const staff = await import("./staff/[slug]/page");
+const youth = await import("./(landing)/jeugd/[slug]/page");
+
+const personRows = [
+  { psdId: "123", firstName: "Jan", lastName: "Janssens" },
+  { psdId: "456", firstName: "Rémi", lastName: "Mendes" },
+];
+const youthRows = [
+  { slug: "kcvve-u9-groen", age: "U9" },
+  { slug: "kcvve-u9-wit", age: "U9" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("legacy redirect routes", () => {
+  it("/player/<name-slug> 308s to /spelers/<psdId>", async () => {
+    mockRun.mockResolvedValueOnce(personRows);
+    await expect(
+      player.default({ params: Promise.resolve({ slug: "jan-janssens" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/spelers/123");
+  });
+
+  it("/players/<name-slug> resolves the same as /player", async () => {
+    mockRun.mockResolvedValueOnce(personRows);
+    await expect(
+      players.default({ params: Promise.resolve({ slug: "remi-mendes" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/spelers/456");
+  });
+
+  it("/staff/<name-slug> 308s to /staf/<psdId>", async () => {
+    mockRun.mockResolvedValueOnce(personRows);
+    await expect(
+      staff.default({ params: Promise.resolve({ slug: "jan-janssens" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/staf/123");
+  });
+
+  it("404s an unresolvable person", async () => {
+    mockRun.mockResolvedValueOnce(personRows);
+    await expect(
+      player.default({ params: Promise.resolve({ slug: "piet-pieters" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  it("/jeugd/<age> 308s to /ploegen/<resolved-slug>", async () => {
+    mockRun.mockResolvedValueOnce(youthRows);
+    await expect(
+      youth.default({ params: Promise.resolve({ slug: "u9" }) }),
+    ).rejects.toThrow("NEXT_REDIRECT:/ploegen/kcvve-u9-groen");
+  });
+
+  it("404s an unknown youth age", async () => {
+    mockRun.mockResolvedValueOnce(youthRows);
+    await expect(
+      youth.default({ params: Promise.resolve({ slug: "u99" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+});

--- a/apps/web/src/app/player/[slug]/page.tsx
+++ b/apps/web/src/app/player/[slug]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound, permanentRedirect } from "next/navigation";
+
+import { runPromise } from "@/lib/effect/runtime";
+import { fetchPlayerRows, resolvePersonPsdId } from "@/lib/seo/legacy-redirect";
+
+interface LegacyPlayerProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Legacy Gatsby player profile URL (`/player/<name-slug>`, also reached via the
+ * old plural `/players/<name-slug>`). Resolve the name-slug to a `psdId` and
+ * 308 to the canonical `/spelers/<psdId>` route; 404 when the person is gone.
+ * `permanentRedirect` emits a 308 — the SEO-equivalent of the AC's "301", and
+ * consistent with every `permanent: true` rename in next.config.
+ */
+export default async function LegacyPlayerRedirect({
+  params,
+}: LegacyPlayerProps) {
+  const { slug } = await params;
+  const rows = await runPromise(fetchPlayerRows());
+  const psdId = resolvePersonPsdId(slug, rows);
+  if (!psdId) notFound();
+  permanentRedirect(`/spelers/${psdId}`);
+}

--- a/apps/web/src/app/players/[slug]/page.tsx
+++ b/apps/web/src/app/players/[slug]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound, permanentRedirect } from "next/navigation";
+
+import { runPromise } from "@/lib/effect/runtime";
+import { fetchPlayerRows, resolvePersonPsdId } from "@/lib/seo/legacy-redirect";
+
+interface LegacyPlayerProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Legacy plural player URL `/players/<name-slug>`. Same resolution as
+ * `/player/<name-slug>` — kept as a sibling shim rather than a cross-segment
+ * re-export (importing through a `[slug]` literal path is bundler-fragile).
+ * The old static `/players/:slug → /spelers/:slug` rename was removed because
+ * it passed a name-slug to the psdId-keyed route and 404'd (#2227, SEO-7).
+ */
+export default async function LegacyPlayersRedirect({
+  params,
+}: LegacyPlayerProps) {
+  const { slug } = await params;
+  const rows = await runPromise(fetchPlayerRows());
+  const psdId = resolvePersonPsdId(slug, rows);
+  if (!psdId) notFound();
+  permanentRedirect(`/spelers/${psdId}`);
+}

--- a/apps/web/src/app/staff/[slug]/page.tsx
+++ b/apps/web/src/app/staff/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound, permanentRedirect } from "next/navigation";
+
+import { runPromise } from "@/lib/effect/runtime";
+import { fetchStaffRows, resolvePersonPsdId } from "@/lib/seo/legacy-redirect";
+
+interface LegacyStaffProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Legacy Gatsby staff profile URL `/staff/<name-slug>`. Resolve the name-slug
+ * to a `psdId` and 308 to the canonical `/staf/<psdId>` route; 404 when gone.
+ * The old static `/staff/:slug → /staf/:slug` rename was removed because it
+ * passed a name-slug to the psdId-keyed route and 404'd (#2227, SEO-7).
+ */
+export default async function LegacyStaffRedirect({
+  params,
+}: LegacyStaffProps) {
+  const { slug } = await params;
+  const rows = await runPromise(fetchStaffRows());
+  const psdId = resolvePersonPsdId(slug, rows);
+  if (!psdId) notFound();
+  permanentRedirect(`/staf/${psdId}`);
+}

--- a/apps/web/src/lib/seo/legacy-redirect.test.ts
+++ b/apps/web/src/lib/seo/legacy-redirect.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  nameToSlug,
+  resolvePersonPsdId,
+  resolveYouthSlug,
+} from "./legacy-redirect";
+
+describe("nameToSlug", () => {
+  it("slugifies firstName + lastName", () => {
+    expect(nameToSlug("Jan", "Janssens")).toBe("jan-janssens");
+  });
+
+  it("strips diacritics and handles multi-word names", () => {
+    expect(nameToSlug("Rémi Eduard", "Mendes Mouro")).toBe(
+      "remi-eduard-mendes-mouro",
+    );
+    expect(nameToSlug("Jannes", "Van Hof")).toBe("jannes-van-hof");
+  });
+
+  it("collapses punctuation and trims hyphens", () => {
+    expect(nameToSlug("Jean-Luc", "O'Connor")).toBe("jean-luc-o-connor");
+  });
+});
+
+describe("resolvePersonPsdId", () => {
+  const rows = [
+    { psdId: "123", firstName: "Jan", lastName: "Janssens" },
+    { psdId: "456", firstName: "Rémi", lastName: "Mendes" },
+    { psdId: null, firstName: "No", lastName: "Id" },
+  ];
+
+  it("resolves a legacy name-slug to its psdId", () => {
+    expect(resolvePersonPsdId("jan-janssens", rows)).toBe("123");
+    expect(resolvePersonPsdId("remi-mendes", rows)).toBe("456");
+  });
+
+  it("is case-insensitive on the incoming slug", () => {
+    expect(resolvePersonPsdId("Jan-Janssens", rows)).toBe("123");
+  });
+
+  it("falls back to a direct psdId match", () => {
+    expect(resolvePersonPsdId("456", rows)).toBe("456");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(resolvePersonPsdId("piet-pieters", rows)).toBeNull();
+  });
+});
+
+describe("resolveYouthSlug", () => {
+  const teams = [
+    { slug: "kcvve-u9p", age: "U9" },
+    { slug: "kcvve-u9-groen", age: "U9" },
+    { slug: "kcvve-u9-wit", age: "U9" },
+    { slug: "kcvve-u8", age: "U8" },
+    // Messy real data: name "KCVVE U16" / slug "kcvve-u16" but age field "U17".
+    { slug: "kcvve-u16", age: "U17" },
+  ];
+
+  it("passes through an already-current slug", () => {
+    expect(resolveYouthSlug("kcvve-u9-groen", teams)).toBe("kcvve-u9-groen");
+  });
+
+  it("resolves a bare age token to the first team of that age by slug order", () => {
+    expect(resolveYouthSlug("u9", teams)).toBe("kcvve-u9-groen");
+    expect(resolveYouthSlug("u8", teams)).toBe("kcvve-u8");
+  });
+
+  it("prefers a colour match when the legacy token carries one", () => {
+    expect(resolveYouthSlug("u9-wit", teams)).toBe("kcvve-u9-wit");
+  });
+
+  it("matches the age token in the slug even when the age field is wrong", () => {
+    expect(resolveYouthSlug("u16", teams)).toBe("kcvve-u16");
+  });
+
+  it("returns null for non-youth or unknown tokens", () => {
+    expect(resolveYouthSlug("u99", teams)).toBeNull();
+    expect(resolveYouthSlug("visie", teams)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/seo/legacy-redirect.ts
+++ b/apps/web/src/lib/seo/legacy-redirect.ts
@@ -1,0 +1,134 @@
+/**
+ * Legacy Gatsby → Next URL resolution (#2227).
+ *
+ * The old Gatsby site keyed player/staff profiles by a name-slug
+ * (`/player/<firstname-lastname>`, `/staff/<…>`) and youth teams by a bare age
+ * token (`/jeugd/u9`). The new routes key players/staff by `psdId`
+ * (`/spelers/<psdId>`, `/staf/<psdId>`) and teams by a CMS slug
+ * (`/ploegen/kcvve-u9-groen`), so a static prefix redirect 404s. These helpers
+ * resolve the legacy form to the current one at request time.
+ *
+ * Queries are plain strings (not `defineQuery`) on purpose: they are
+ * redirect-only and intentionally kept out of the generated `sanity.types`
+ * surface.
+ */
+import { fetchGroq } from "@/lib/sanity/fetch-groq";
+import { SANITY_TAGS, SANITY_LIST_REVALIDATE } from "@/lib/sanity/cache-tags";
+
+// ─── Pure slug logic ─────────────────────────────────────────────────────────
+
+/**
+ * Slugify a person's name the way the legacy site keyed profile URLs:
+ * `"${firstName} ${lastName}"` lowercased, diacritics stripped, `&` → " en ",
+ * non-alphanumerics collapsed to single hyphens. Mirrors the studio's
+ * `slugifyTitle` so behaviour is consistent across the codebase.
+ */
+export function nameToSlug(firstName: string, lastName: string): string {
+  return `${firstName} ${lastName}`
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "")
+    .replace(/&/g, " en ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export interface PersonRow {
+  psdId: string | null;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+/**
+ * Resolve a legacy person name-slug to a `psdId`. Falls back to treating the
+ * slug as a `psdId` directly (covers any `/players/<psdId>` style link).
+ * Returns `null` when nothing matches.
+ */
+export function resolvePersonPsdId(
+  slug: string,
+  rows: readonly PersonRow[],
+): string | null {
+  const target = slug.toLowerCase();
+  for (const row of rows) {
+    if (!row.psdId) continue;
+    if (nameToSlug(row.firstName ?? "", row.lastName ?? "") === target) {
+      return row.psdId;
+    }
+  }
+  return rows.some((row) => row.psdId === slug) ? slug : null;
+}
+
+export interface YouthTeamRow {
+  slug: string | null;
+  age: string | null;
+}
+
+/**
+ * Resolve a legacy youth token (e.g. `"u9"`, `"u8-wit"`) to a current team
+ * slug. Youth slugs drifted to `"kcvve-u9-groen"` form after migration, so the
+ * old `/jeugd/u9` pass-through 404s. Strategy:
+ *   1. pass through a token that is already a current slug;
+ *   2. otherwise match on age (the structured `age` field, or the age token
+ *      appearing as a slug segment) and pick deterministically — a colour
+ *      match (`wit`/`groen`) first, else the first team of that age by slug
+ *      order. Ambiguous one-to-many cases (a single old URL now split into
+ *      colour teams) thus resolve to a stable team rather than 404.
+ * Returns `null` when no youth team of that age exists.
+ */
+export function resolveYouthSlug(
+  token: string,
+  rows: readonly YouthTeamRow[],
+): string | null {
+  const lower = token.toLowerCase();
+  const teams = rows.filter((row): row is YouthTeamRow & { slug: string } =>
+    Boolean(row.slug),
+  );
+
+  if (teams.some((team) => team.slug === lower)) return lower;
+
+  const ageToken = lower.match(/^u\d+/)?.[0];
+  if (!ageToken) return null;
+  const age = ageToken.toUpperCase();
+  const segment = new RegExp(`(^|-)${ageToken}(-|$)`);
+
+  const ofAge = teams
+    .filter(
+      (team) => team.age?.toUpperCase() === age || segment.test(team.slug),
+    )
+    // Deterministic code-unit order (localeCompare may ignore hyphens by locale).
+    .sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+  if (ofAge.length === 0) return null;
+
+  const colour = lower.match(/wit|groen/)?.[0];
+  if (colour) {
+    const match = ofAge.find((team) => team.slug.includes(colour));
+    if (match) return match.slug;
+  }
+  return ofAge[0].slug;
+}
+
+// ─── Cached Sanity reads ─────────────────────────────────────────────────────
+// Mappings change rarely (PSD-synced) → 24h tag-bounded cache, same as the
+// repository list reads.
+
+const PLAYER_ROWS_QUERY = `*[_type == "player" && defined(psdId) && psdId != ""]{ psdId, firstName, lastName }`;
+const STAFF_ROWS_QUERY = `*[_type == "staffMember" && defined(psdId) && psdId != "" && archived != true]{ psdId, firstName, lastName }`;
+const YOUTH_TEAMS_QUERY = `*[_type == "team" && archived != true && defined(slug.current) && age match "U*"]{ "slug": slug.current, age }`;
+
+export const fetchPlayerRows = () =>
+  fetchGroq<PersonRow[]>(PLAYER_ROWS_QUERY, undefined, {
+    revalidate: SANITY_LIST_REVALIDATE,
+    tags: [SANITY_TAGS.players],
+  });
+
+export const fetchStaffRows = () =>
+  fetchGroq<PersonRow[]>(STAFF_ROWS_QUERY, undefined, {
+    revalidate: SANITY_LIST_REVALIDATE,
+    tags: [SANITY_TAGS.staff],
+  });
+
+export const fetchYouthTeamRows = () =>
+  fetchGroq<YouthTeamRow[]>(YOUTH_TEAMS_QUERY, undefined, {
+    revalidate: SANITY_LIST_REVALIDATE,
+    tags: [SANITY_TAGS.teams],
+  });


### PR DESCRIPTION
Closes #2227

~680 of ~870 old Gatsby URLs (player ~553 + staff ~127) would 404 on cutover — the old site keyed profiles by **name-slug** while the new routes key by **psdId**, and a static prefix redirect can't bridge that. Youth and a handful of retired routes were also broken.

## Changes

### SEO-7 — player/staff name-slug → psdId resolver (the 🔴 priority)
- New request-time resolver routes `/player/[slug]`, `/players/[slug]`, `/staff/[slug]`: slugify the Sanity `firstName`+`lastName`, look up the `psdId`, and **308** to `/spelers/<psdId>` / `/staf/<psdId>`. Falls back to a direct psdId match; 404 when the person is gone.
- **Removed** the broken static `/players/:slug → /spelers/:slug` and `/staff/:slug → /staf/:slug` renames — they passed a name-slug straight to the psdId-keyed route and 404'd.

### SEO-8 — youth + news
- Youth team slugs drifted to `kcvve-u9-groen` form, so the static `/jeugd/:slug → /ploegen/:slug` pass-through **404'd** (verified against the dataset). Replaced it with a dynamic `/jeugd/[slug]` resolver that matches on **age** (structured field or slug segment) + optional **colour** (`wit`/`groen`), picking deterministically. Ambiguous one-to-many cases (one old `/jeugd/u9` now split into colour teams) resolve to a stable team instead of 404.
- `/news/:slug → /nieuws/:slug` already exists (kept) and covers the ~145 article URLs given slugs were preserved in migration.

### SEO-9 — retired routes → nearest live page (per your issue comment)
- `/club/cashless` + `/club/cashless/voorwaarden` → `/club/praktische-informatie`
- `/club/downloads` → `/club`
- `/kiosk` + `/kiosk/:path*` (a, b, previous, upcoming, ranking/*) → `/kalender`

Shared slug + cached-fetch logic lives in `src/lib/seo/legacy-redirect.ts` (24h tag-bounded cache, same as the repos). All redirects are 308 (`permanent: true` / `permanentRedirect`) — the AC's "301" is shorthand for a permanent redirect, consistent with every existing rename.

## Testing
- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, test, build). New routes build as dynamic (`ƒ`), no prerender.
- Unit tests for `nameToSlug` / `resolvePersonPsdId` / `resolveYouthSlug` (diacritics, multi-word names, colour/age matching, fallbacks); route-wiring tests asserting 308 targets + 404s; `next.config.test.ts` updated (SEO-9 added, broken static renames asserted absent).
- Pre-PR review gate (correctness + simplification agents on the diff): **no issues, no simplification wins**.

## ⚠️ One assumption to confirm
Name-slug matching assumes the old Gatsby slugged `"firstName lastName"` with standard NFKD/lowercase/hyphenate (`nameToSlug` mirrors the studio's `slugifyTitle`). I couldn't confirm the historic Gatsby slug format (source not in-repo, Drupal host dead). **If the old format differed, `nameToSlug` is a one-line tweak** — and unmatched slugs degrade safely (direct psdId match, else 404). Spot-check a few real old `/player/<slug>` URLs against a preview deploy to confirm coverage.

Youth ambiguity (which colour team an old single `/jeugd/u9` maps to) is deterministic-first-by-slug; tell me if you'd prefer a specific canonical per age.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legacy profile and team URLs now continue to work and redirect visitors to the current site locations.
  * Added support for several retired site routes, including kiosk and club-related paths.

* **Bug Fixes**
  * Removed outdated redirect paths that no longer apply.
  * Unknown or unsupported legacy URLs now correctly return a not-found page instead of misdirecting users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->