### PR TITLE
fix(ui): wrapped-link hover underline + social links + misc page bugs (#2242)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -702,54 +702,39 @@
 /* ===== Canonical inline body-text link (#2154) =====
    The single treatment for inline links inside long-form body copy — article
    bodies, CMS pages, hulp answers, legal copy. jersey-deep text with a
-   hand-pulled, match-score-tint highlighter that sweeps in left→right on hover
-   (revealed via clip-path so the slab is fixed-size and its ends never drift),
-   overshooting the text ~4px each side so it reads like a hand-drawn marker.
-   `isolation: isolate` keeps the `::after` marker behind the text but above the
-   page surface. UI / affordance links (nav, CTA, mono "→" links) keep their own
-   styling — this is body copy only. Unlayered so it beats the typography plugin
-   and the `main a` colour fallback. */
+   hand-pulled, match-score-tint highlighter that sweeps in left→right on hover.
+   The marker is a per-fragment `background-image` (not an absolutely-positioned
+   `::after`) so it covers EVERY line of a wrapped link: `box-decoration-break:
+   clone` repaints the background on each line fragment, and `background-size`
+   width animates the reveal (an absolute `::after` only ever covers one line
+   box — the CMS-1 wrapped-link bug). UI / affordance links (nav, CTA, mono "→"
+   links) keep their own styling — this is body copy only. Unlayered so it beats
+   the typography plugin and the `main a` colour fallback. */
 .prose-link {
-  position: relative;
-  isolation: isolate;
   color: var(--color-jersey-link);
   text-decoration: none;
   font-weight: 500;
-  transition: color 0.3s ease;
-}
-
-.prose-link::after {
-  content: "";
-  position: absolute;
-  z-index: -1;
-  left: -4px;
-  right: -4px;
-  bottom: 0.02em;
-  height: 0.42em;
-  background-color: color-mix(in srgb, var(--color-jersey-deep) 40%, transparent);
-  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='black'/></svg>");
-  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='black'/></svg>");
-  -webkit-mask-size: 100% 100%;
-  mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-clip-path: inset(0 100% 0 0);
-  clip-path: inset(0 100% 0 0);
+  /* #008755 (--color-jersey-deep) @ 40% baked into the fill — a CSS var can't
+     be referenced inside a data-URI SVG. */
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='%23008755' fill-opacity='0.4'/></svg>");
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 0% 0.42em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
   transition:
-    -webkit-clip-path 320ms ease-out,
-    clip-path 320ms ease-out;
-  pointer-events: none;
+    color 0.3s ease,
+    background-size 320ms ease-out;
 }
 
-.prose-link:hover::after,
-.prose-link:focus-visible::after {
-  -webkit-clip-path: inset(0 0 0 0);
-  clip-path: inset(0 0 0 0);
+.prose-link:hover,
+.prose-link:focus-visible {
+  background-size: 100% 0.42em;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .prose-link::after {
-    transition: none;
+  .prose-link {
+    transition: color 0.3s ease;
   }
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -714,9 +714,19 @@
   color: var(--color-jersey-link);
   text-decoration: none;
   font-weight: 500;
+  /* 4px breathing room each side so the marker overshoots the text like the
+     hand-drawn original (the old `::after` used left/right: -4px); the matching
+     negative margin cancels it from inline layout so surrounding copy never
+     shifts. With box-decoration-break: clone the overshoot is restored on every
+     fragment of a wrapped link. */
+  padding-inline: 4px;
+  margin-inline: -4px;
   /* #008755 (--color-jersey-deep) @ 40% baked into the fill — a CSS var can't
-     be referenced inside a data-URI SVG. */
-  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 1 4.7 L 50 4.3 L 99 4.0 L 99 10.8 L 50 11.1 L 1 11.0 Z' fill='%23008755' fill-opacity='0.4'/></svg>");
+     be referenced inside a data-URI SVG. The marker's left/right ink edges sit
+     at x=0/100 (not 1/99); left-anchored at background-position-x:0 the start
+     stays pinned ~4px before the word and never creeps right as background-size
+     animates the reveal. */
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 14' preserveAspectRatio='none'><path d='M 0 4.7 L 50 4.3 L 100 4.0 L 100 10.8 L 50 11.1 L 0 11.0 Z' fill='%23008755' fill-opacity='0.4'/></svg>");
   background-repeat: no-repeat;
   background-position: 0 100%;
   background-size: 0% 0.42em;

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.test.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.test.tsx
@@ -167,6 +167,29 @@ describe("<ArticleBody>", () => {
       expect(link?.textContent).toContain("Volg ons");
     });
 
+    it("recognises social subdomains (m.facebook.com) but not look-alikes", () => {
+      const content = [
+        paragraph("First paragraph, plain (DropCap target)."),
+        paragraphWithLink("Mobiel", "https://m.facebook.com/KCVVElewijt"),
+      ];
+      const { container } = render(<ArticleBody content={content} />);
+      expect(
+        container.querySelector('a[data-article-link="social"]'),
+      ).toBeTruthy();
+
+      const lookalike = render(
+        <ArticleBody
+          content={[
+            paragraph("First paragraph, plain (DropCap target)."),
+            paragraphWithLink("Nep", "https://notfacebook.com/x"),
+          ]}
+        />,
+      );
+      expect(
+        lookalike.container.querySelector('a[data-article-link="social"]'),
+      ).toBeNull();
+    });
+
     it("keeps the .prose-link marker for non-social external links", () => {
       const content = [
         paragraph("First paragraph, plain (DropCap target)."),

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.test.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.test.tsx
@@ -60,6 +60,16 @@ function paragraphWithAccent(
   } as PortableTextBlock;
 }
 
+function paragraphWithLink(text: string, href: string): PortableTextBlock {
+  return {
+    _type: "block",
+    _key: "link-block",
+    style: "normal",
+    children: [{ _type: "span", _key: "lc", text, marks: ["lk"] }],
+    markDefs: [{ _type: "link", _key: "lk", href }],
+  } as PortableTextBlock;
+}
+
 describe("<ArticleBody>", () => {
   describe("DropCap injection", () => {
     it("wraps the first normal paragraph in <DropCapParagraph>", () => {
@@ -136,6 +146,37 @@ describe("<ArticleBody>", () => {
       ).toBeNull();
       const dropcap = container.querySelector('[data-tone="ink"]');
       expect(dropcap?.textContent).toBe("Een groene cursief");
+    });
+  });
+
+  describe("social link affordance (CMS-2)", () => {
+    it("renders a Facebook link as a bordered icon affordance, not .prose-link", () => {
+      const content = [
+        paragraph("First paragraph, plain (DropCap target)."),
+        paragraphWithLink("Volg ons", "https://facebook.com/KCVVElewijt/"),
+      ];
+      const { container } = render(<ArticleBody content={content} />);
+      const link = container.querySelector('a[data-article-link="social"]');
+      expect(link).toBeTruthy();
+      expect(link?.getAttribute("href")).toBe(
+        "https://facebook.com/KCVVElewijt/",
+      );
+      expect(link?.getAttribute("target")).toBe("_blank");
+      expect(link?.className).not.toContain("prose-link");
+      expect(link?.querySelector("svg")).toBeTruthy(); // brand icon present
+      expect(link?.textContent).toContain("Volg ons");
+    });
+
+    it("keeps the .prose-link marker for non-social external links", () => {
+      const content = [
+        paragraph("First paragraph, plain (DropCap target)."),
+        paragraphWithLink("Bekijk", "https://www.voetbalvlaanderen.be"),
+      ];
+      const { container } = render(<ArticleBody content={content} />);
+      expect(
+        container.querySelector('a[data-article-link="social"]'),
+      ).toBeNull();
+      expect(container.querySelector("a.prose-link")).toBeTruthy();
     });
   });
 

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
@@ -5,7 +5,11 @@ import type {
 } from "@portabletext/react";
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowSquareOut as ExternalLinkIcon } from "@/lib/icons.redesign";
+import {
+  ArrowSquareOut as ExternalLinkIcon,
+  FacebookLogo,
+  InstagramLogo,
+} from "@/lib/icons.redesign";
 import type { ReactNode } from "react";
 import { BodyQuote } from "@/components/design-system/BodyQuote";
 import { DropCapParagraph } from "@/components/design-system/DropCapParagraph";
@@ -242,6 +246,27 @@ function resolveInternalLinkHref(ref?: InternalLinkReference): string {
     default:
       return "#";
   }
+}
+
+/**
+ * Known social hosts → the brand icon that turns a plain body link into a
+ * recognisable affordance (CMS-2). Returns null for everything else, so
+ * ordinary external links keep the canonical `.prose-link` highlighter marker.
+ */
+function socialBrandFor(
+  href: string,
+): { Icon: typeof FacebookLogo; label: string } | null {
+  let host: string;
+  try {
+    host = new URL(href).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return null; // relative / malformed href → not a social affordance
+  }
+  if (host === "facebook.com" || host === "fb.com" || host === "fb.me")
+    return { Icon: FacebookLogo, label: "Facebook" };
+  if (host === "instagram.com")
+    return { Icon: InstagramLogo, label: "Instagram" };
+  return null;
 }
 
 /**
@@ -609,6 +634,28 @@ function buildComponents({
       }) => {
         const href = value?.href ?? "#";
         const isExternal = href.startsWith("http");
+        const social = isExternal ? socialBrandFor(href) : null;
+        if (social) {
+          const { Icon, label } = social;
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-article-link="social"
+              // Social links read as a bordered icon affordance (CMS-2), reusing
+              // the footer's square brand-button idiom on the cream body surface.
+              className="border-jersey-deep/40 text-jersey-deep hover:border-jersey-deep hover:bg-jersey-deep/5 inline-flex items-center gap-1.5 border px-2 py-0.5 align-baseline font-medium no-underline transition-colors"
+            >
+              <Icon
+                aria-hidden="true"
+                className="inline-block size-[1em] shrink-0"
+              />
+              {children}
+              <span className="sr-only"> ({label}, opens in new tab)</span>
+            </a>
+          );
+        }
         return (
           <a
             href={href}

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
@@ -258,13 +258,18 @@ function socialBrandFor(
 ): { Icon: typeof FacebookLogo; label: string } | null {
   let host: string;
   try {
-    host = new URL(href).hostname.replace(/^www\./, "").toLowerCase();
+    host = new URL(href).hostname.toLowerCase();
   } catch {
     return null; // relative / malformed href → not a social affordance
   }
-  if (host === "facebook.com" || host === "fb.com" || host === "fb.me")
+  // Match a registrable domain OR any of its subdomains (www., m., web.,
+  // business., l. …) — the `.` prefix on the suffix check rejects look-alikes
+  // like notfacebook.com.
+  const isHost = (domains: string[]) =>
+    domains.some((d) => host === d || host.endsWith(`.${d}`));
+  if (isHost(["facebook.com", "fb.com", "fb.me", "fb.watch"]))
     return { Icon: FacebookLogo, label: "Facebook" };
-  if (host === "instagram.com")
+  if (isHost(["instagram.com", "instagr.am"]))
     return { Icon: InstagramLogo, label: "Instagram" };
   return null;
 }

--- a/apps/web/src/components/player/BioBlock/BioBlock.tsx
+++ b/apps/web/src/components/player/BioBlock/BioBlock.tsx
@@ -87,7 +87,7 @@ export function BioBlock({ bio, playerName, className }: BioBlockProps) {
         {hasPullquote ? (
           <aside
             data-testid="bioblock-pullquote"
-            className="self-start lg:sticky lg:top-8"
+            className="self-start lg:sticky lg:top-24"
           >
             <PullQuote
               tone="jersey"

--- a/apps/web/src/components/share/shared/ShareElements.tsx
+++ b/apps/web/src/components/share/shared/ShareElements.tsx
@@ -43,9 +43,29 @@ function useAutoFit<T extends HTMLElement>(
       if (!cancelled) setSize(next);
     };
     fit();
+    const refit = () => !cancelled && fit();
     const fonts = typeof document !== "undefined" ? document.fonts : undefined;
-    if (fonts?.ready) {
-      fonts.ready.then(() => !cancelled && fit()).catch(() => {});
+    if (fonts) {
+      // Re-measure once webfonts settle. Adobe Typekit injects its @font-face
+      // ASYNCHRONOUSLY, so `fonts.ready` can resolve BEFORE Freight is even
+      // pending — the first measure then uses the narrower fallback metrics, a
+      // long name "fits", and it overflows when the wider Freight swaps in
+      // (SHARE-1). `fonts.load()` for the element's own computed font forces and
+      // awaits that specific face, so the re-fit runs against real metrics.
+      const el = ref.current;
+      if (el && typeof fonts.load === "function") {
+        const cs = getComputedStyle(el);
+        const font = `${cs.fontStyle} ${cs.fontWeight} ${fontSize}px ${cs.fontFamily}`;
+        try {
+          fonts
+            .load(font, el.textContent ?? "")
+            .then(refit)
+            .catch(() => {});
+        } catch {
+          // happy-dom / malformed shorthand → skip the targeted reload
+        }
+      }
+      fonts.ready?.then(refit).catch(() => {});
     }
     return () => {
       cancelled = true;


### PR DESCRIPTION
Closes #2242

Fixes the global wrapped-link hover bug plus three small page bugs from
`docs/pre-go-live-remarks.md` §C (milestone: go-live-ux-polish).

## Changes

- **CMS-1** — `.prose-link` highlighter marker (article/CMS/hulp/legal body
  copy) was an absolutely-positioned `::after`, which can only cover one line
  box, so a wrapped/multi-line link only got the marker on a tiny segment. It's
  now a per-fragment `background-image` with `box-decoration-break: clone`
  (paints on every line fragment) and a `background-size` width sweep. Same
  hand-pulled torn-marker shape and left→right hover reveal; the jersey-deep
  @40% colour is baked into the SVG fill (a CSS var can't live in a data-URI).
- **CMS-2** — Facebook/Instagram links inside body copy now render as a bordered
  brand-icon affordance (reusing the footer's square brand-button idiom, sharp
  corners) instead of a plain text marker link. Non-social external links keep
  `.prose-link`.
- **SHARE-1** — `/share` long player names (e.g. "Jonas Aelbrecht") overflowed
  the canvas. Root cause: `useAutoFit` measured with the fallback font (Adobe
  Typekit injects Freight's `@font-face` async, so `fonts.ready` can resolve
  before Freight is even pending), the name "fit", and overflowed once the wider
  Freight swapped in. Now it also `document.fonts.load()`s the element's actual
  computed font and re-measures against real metrics.
- **PLAYER-6** — BioBlock sticky pull-quote `lg:top-8` (32px) scrolled under the
  64px (`h-16`) sticky header → `lg:top-24` (96px) clears it with the original
  32px gap.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, 54+ tests,
  build).
- Added 2 ArticleBody tests for the social-link affordance (Facebook → icon
  affordance; non-social external → `.prose-link`).
- Existing ShareName auto-fit tests unchanged and green (the font-load re-fit is
  skipped in happy-dom, which has no `document.fonts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social links in article content are now rendered with branded Facebook/Instagram labeling, including an icon, and open in a new tab.

* **Bug Fixes**
  * Improved article link highlighting with smoother “marker” animation for hover/focus, better wrapped-line behavior, and reduced-motion support.
  * Improved text-fitting behavior after fonts load for share elements.
  * Adjusted pull-quote vertical positioning on large screens.

* **Tests**
  * Added tests covering social-link rendering and non-social external URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->