### PR TITLE
perf(ui): homepage hero LCP priority + next/image config (#2235)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -132,6 +132,15 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "picsum.photos", pathname: "/**" },
       { protocol: "https", hostname: "cdn.sanity.io", pathname: "/**" },
     ],
+    // PERF-2 (#2235): serve optimizer-transformed heroes as AVIF (best
+    // compression) with WebP fallback, and cache optimized variants for a
+    // day so repeat views skip re-optimization. Most photos already arrive
+    // as pre-transformed Sanity CDN URLs; this only governs the optimizer-
+    // served path. `picsum.photos`/`placehold.co` remotePatterns are used
+    // exclusively by Storybook stories + `*.mocks.ts` — confirmed not
+    // referenced by any production render path.
+    formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 86400,
     // SVG Security Configuration
     // Current analysis (2025-01-05):
     // - Drupal API serves standard image formats: JPEG, PNG, GIF, WebP

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -119,6 +119,9 @@ function toEditorialHeroProps(article: ArticleVM): EditorialHeroProps {
     date: article.publishedAt
       ? formatArticleDate(article.publishedAt)
       : undefined,
+    // PERF-1 (#2235): the homepage hero cover is the LCP element — eager-load
+    // it. Only this call site sets `priority`; below-fold rows stay lazy.
+    priority: true,
   };
 
   const variant = article.articleType ?? "announcement";

--- a/apps/web/src/components/article/EditorialHero/EditorialHero.test.tsx
+++ b/apps/web/src/components/article/EditorialHero/EditorialHero.test.tsx
@@ -64,6 +64,29 @@ describe("EditorialHero — shell + placement", () => {
     ).toBeInTheDocument();
   });
 
+  it("eager-loads the cover image when priority is set (PERF-1), else lazy-loads", () => {
+    const cover = {
+      url: "https://example.com/cover.jpg",
+      alt: "Cover",
+    };
+    const { rerender } = render(
+      <EditorialHero variant="announcement" {...SHARED} coverImage={cover} />,
+    );
+    // Default: below-fold consumers keep next/image's lazy-loading.
+    expect(screen.getByAltText("Cover")).toHaveAttribute("loading", "lazy");
+
+    rerender(
+      <EditorialHero
+        variant="announcement"
+        {...SHARED}
+        coverImage={cover}
+        priority
+      />,
+    );
+    // priority → next/image drops lazy-loading for the LCP hero.
+    expect(screen.getByAltText("Cover")).not.toHaveAttribute("loading", "lazy");
+  });
+
   it("wraps the hero in an <a href='/nieuws/{slug}'> for placement='homepage'", () => {
     const { container } = render(
       <EditorialHero

--- a/apps/web/src/components/article/EditorialHero/EditorialHero.tsx
+++ b/apps/web/src/components/article/EditorialHero/EditorialHero.tsx
@@ -94,6 +94,13 @@ interface EditorialHeroSharedProps {
   /** Cover image artefact rendered in the right column (40fr). */
   coverImage?: EditorialHeroCoverImage;
   /**
+   * Mark the cover image as the LCP element (eager-load + high fetch
+   * priority, no lazy-loading). Set ONLY by the homepage hero call site
+   * — below-fold consumers (detail page, featured rows) leave it off so
+   * they keep lazy-loading. PERF-1 (#2235).
+   */
+  priority?: boolean;
+  /**
    * Optional pre-formatted Dutch date string appended to the kicker
    * (e.g. `"15 mei 2026"`). Per variant the kicker reads:
    * - announcement → `Aankondiging · ${category} · ${date}`
@@ -192,6 +199,8 @@ interface EditorialHeroCoverProps {
    *  reads on the cover figure as the wrapping `<Link>` translates into
    *  it. Only used by the homepage placement (the link carries `group`). */
   pressOnHover?: boolean;
+  /** Forwarded to `next/image` — eager-loads the LCP hero (PERF-1). */
+  priority?: boolean;
 }
 
 function EditorialHeroCover({
@@ -199,6 +208,7 @@ function EditorialHeroCover({
   aspect,
   overlay,
   pressOnHover,
+  priority,
 }: EditorialHeroCoverProps) {
   return (
     <TapedFigure
@@ -219,6 +229,7 @@ function EditorialHeroCover({
         src={coverImage.url}
         alt={coverImage.alt}
         fill
+        priority={priority}
         sizes="(min-width: 1024px) 440px, 100vw"
         className="object-cover"
       />
@@ -397,7 +408,8 @@ function renderMatchEditorial(
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function EditorialHero(props: EditorialHeroProps) {
-  const { title, lead, author, coverImage, placement, slug, date } = props;
+  const { title, lead, author, coverImage, placement, slug, date, priority } =
+    props;
 
   // Variant-specific editorial slot, cover aspect, cover overlay, and
   // below-hero strip. All branches share the placement + link wrapper
@@ -533,6 +545,7 @@ export function EditorialHero(props: EditorialHeroProps) {
             aspect={coverAspect}
             overlay={coverOverlay}
             pressOnHover={pressOnHover}
+            priority={priority}
           />
         ) : undefined
       }


### PR DESCRIPTION
Closes #2235

Core Web Vitals + image-delivery pass on the homepage (pre-go-live §I Performance).

## Changes

- **PERF-1** — Thread a `priority?: boolean` prop through `<EditorialHero>` → cover `next/image`, set `priority: true` **only** at the homepage hero call site (`toEditorialHeroProps`). The homepage hero is the LCP element on the highest-traffic page; it now eager-loads instead of lazy-loading. Detail-page and featured-row consumers leave `priority` off and keep lazy-loading.
- **PERF-2** — `next.config.ts` images: `formats: ["image/avif", "image/webp"]` + `minimumCacheTTL: 86400` so optimizer-served heroes ship AVIF (WebP fallback) and cache for a day. Confirmed `picsum.photos` / `placehold.co` `remotePatterns` are referenced **only** by Storybook stories + `*.mocks.ts`, never by a production render path — left in place (still needed for Storybook rendering).
- **PERF-3** — No code change. Per the owner's investigation on the issue, revalidation is already wired for player/staff edits (`player`/`staff` repos tag `SANITY_TAGS.*`, `/api/revalidate` busts those tags + paths), so the 86400 ISR is correct — no shortening needed.

## Testing

- New unit test: `EditorialHero` eager-loads the cover (`loading` ≠ `lazy`) when `priority` is set, lazy-loads by default.
- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, vitest 3208 passing, `next build`).

## Pre-PR review gate

- **`/code-review` (high)** — clean. Verified: `priority` correctly isolated to the single homepage hero (featured row uses a different component; detail page passes no priority); valid Next image config; type-safe through the discriminated union.
- **`/simplify`** — no findings; the diff is already minimal (one optional prop threaded directly + two declarative config lines).
- Story update intentionally **skipped**: `priority` is a perf-only boolean with zero pixel/visual difference, so a Storybook story / VR baseline would be a no-op. The behavioral contract is covered by the unit test instead.

## VR baselines

None — no visual change (loading-strategy only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved homepage hero image loading for faster display by prioritizing the main cover image.
  * Updated image handling to favor modern optimized formats with a longer cache window for better performance.
* **Tests**
  * Added coverage for hero image loading behavior to verify prioritized images load eagerly and non-prioritized images remain lazy-loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->