### PR TITLE
docs: pre-go-live accuracy pass on READMEs + SECURITY.md (#2245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ PSD_API_KEY=...
 - **[ProSoccerData API](https://prosoccerdata.com/)** — match results and rankings via BFF
 - **[Cloudflare Workers](https://workers.cloudflare.com/)** — BFF proxy with caching (Wrangler)
 
-### UI Components
-
-- **[d3-org-chart](https://github.com/bumbeishvili/org-chart)** — organization chart visualization
-
 ### Development Tools
 
 - **[Turborepo](https://turbo.build/)** — monorepo build orchestration
@@ -154,7 +150,7 @@ pnpm --filter @kcvv/web build-storybook
 
 ```bash
 pnpm --filter @kcvv/api dev         # wrangler dev
-pnpm --filter @kcvv/api deploy      # wrangler deploy
+pnpm --filter @kcvv/api run deploy  # wrangler deploy (bare `deploy` hits pnpm's built-in)
 ```
 
 ---
@@ -168,9 +164,9 @@ Interactive help system — visitors describe their role and question to find th
 **Status:** Active — data managed via Sanity CMS
 **Docs:** `RESPONSIBILITY.md`
 
-### Organigram (`/club/organigram`)
+### Organigram (part of `/hulp`)
 
-Interactive organizational chart of the club structure.
+Interactive organizational chart of the club structure, rendered within the Responsibility Finder page.
 
 **Status:** Implemented — fully migrated to Sanity (`organigramNode` + `staffMember`)
 
@@ -189,7 +185,7 @@ Content for articles, teams, players, organigram, sponsors, and events.
 ## Design System
 
 - **Primary Color:** `#4acf52` (KCVV green)
-- **Fonts:** Quasimoda (headings), Montserrat (body) via Adobe Typekit
+- **Fonts:** Freight Display/Big Pro (headings) + Freight Sans Pro (body) via Adobe Typekit; IBM Plex Mono (mono) self-hosted via `next/font`
 - **Spacing:** Tailwind v4 scale
 - **Breakpoints:** standard Tailwind (`sm`, `md`, `lg`, `xl`, `2xl`)
 
@@ -201,7 +197,7 @@ See Storybook Foundation stories (`pnpm --filter @kcvv/web storybook`) and `apps
 
 - **Unit tests:** Vitest — target 80%+ coverage. Run: `pnpm test`
 - **Component stories:** Storybook 10 with interaction tests. Run: `pnpm --filter @kcvv/web storybook`
-- **E2E:** Playwright configured, no specs yet
+- **E2E:** Playwright — specs for homepage, article detail, events, matches + route smoke-tests (`apps/web/test/e2e/`)
 
 ---
 
@@ -221,7 +217,7 @@ pnpm --filter @kcvv/web check-all
 git push -u origin feat/feature-name
 ```
 
-**Commit scopes:** `news`, `matches`, `teams`, `players`, `sponsors`, `calendar`, `ranking`, `api`, `ui`, `schema`, `migration`, `config`, `deps`
+**Commit scopes:** `news`, `matches`, `events`, `teams`, `players`, `sponsors`, `calendar`, `ranking`, `search`, `sync`, `analytics`, `studio`, `api`, `ui`, `schema`, `config`, `deps`, `deps-dev` (enforced by `commitlint.config.js`)
 
 Pre-commit hooks run automatically: lint-staged, type-check, commitlint.
 
@@ -230,9 +226,9 @@ Pre-commit hooks run automatically: lint-staged, type-check, commitlint.
 ## Deployment
 
 - **Web (apps/web):** Vercel — auto-deploys from `main`
-- **BFF (apps/api):** Cloudflare Workers — `pnpm --filter @kcvv/api deploy`
-- **Studio production:** sanity.io — `pnpm --filter @kcvv/studio deploy`
-- **Studio staging:** sanity.io — `pnpm --filter @kcvv/studio-staging deploy`
+- **BFF (apps/api):** Cloudflare Workers — `pnpm --filter @kcvv/api run deploy` (or `wrangler deploy`)
+- **Studio production:** sanity.io — `cd apps/studio && npx sanity deploy` (manual; no CI auto-deploy)
+- **Studio staging:** sanity.io — `cd apps/studio-staging && SANITY_STUDIO_DATASET=staging npx sanity deploy`
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,9 +14,9 @@
 **Security Measures:**
 
 1. ✅ `contentDispositionType: 'attachment'` — Forces download instead of inline display
-2. ✅ Limited to specific remote patterns (placehold.co, cdn.sanity.io, Cloudflare CDN)
+2. ✅ Limited to the image hosts allowlisted in `next.config.ts` `remotePatterns`
 3. ✅ No user uploads — all images are author-controlled via Sanity; the public site has no upload endpoint
-4. ✅ Static asset delivery — Sanity/Cloudflare serve uploaded media as static files (no execution)
+4. ✅ Static asset delivery — Sanity serves uploaded media as static files via `cdn.sanity.io` (no execution)
 
 ### File Upload Security
 
@@ -29,14 +29,14 @@ MIME validation and the SVG hardening below before shipping it.
 #### Sanity CMS server-side validation (primary control)
 
 1. **Field-level restrictions** — Sanity processes and restricts uploaded assets server-side
-2. **CDN delivery** — assets are served as static files from `cdn.sanity.io` / Cloudflare CDN
+2. **CDN delivery** — assets are served as static files from `cdn.sanity.io`
 3. **No arbitrary file execution** — assets are static, never executed
 
 #### Next.js Image remote allowlist
 
 - **Location:** `next.config.ts` `remotePatterns`
 - **Purpose:** restrict which domains can serve images
-- **Allowed domains:** placehold.co, cdn.sanity.io, Cloudflare CDN — images from other domains are rejected
+- **Allowed hosts:** the `remotePatterns` allowlist in `next.config.ts` — images from any other host are rejected
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 ### SVG Handling
 
-**Current Status (2026-04-26):**
+**Current Status (2026-06-26):**
 
 - `dangerouslyAllowSVG: true` is enabled in `next.config.ts`
 - **Current Risk: LOW** — No user-uploaded SVGs are accepted
@@ -15,43 +15,28 @@
 
 1. ✅ `contentDispositionType: 'attachment'` — Forces download instead of inline display
 2. ✅ Limited to specific remote patterns (placehold.co, cdn.sanity.io, Cloudflare CDN)
-3. ✅ Runtime MIME type validation — Schema enforces image MIME types (JPEG/PNG/GIF/WebP only, no SVG)
-4. ✅ Automated test coverage — Tests verify PDF/SVG files are rejected at schema level
+3. ✅ No user uploads — all images are author-controlled via Sanity; the public site has no upload endpoint
+4. ✅ Static asset delivery — Sanity/Cloudflare serve uploaded media as static files (no execution)
 
-### File Upload Security — Defense in Depth
+### File Upload Security
 
-**⚠️ CRITICAL: MIME Type Validation Alone is INSUFFICIENT!**
+**The public site accepts no user file uploads** — all images are author-controlled in
+Sanity and served as static assets, so there is no client-facing upload surface to guard.
+There is intentionally **no app-level MIME schema** in the web app; the controls below apply
+to author-uploaded media. If a user-facing upload surface is ever added, implement runtime
+MIME validation and the SVG hardening below before shipping it.
 
-Our file validation uses a **defense-in-depth approach** with multiple security layers. MIME types can be easily spoofed by attackers, so we implement validation at multiple levels:
+#### Sanity CMS server-side validation (primary control)
 
-#### Layer 1: Schema Validation (Frontend/Runtime)
+1. **Field-level restrictions** — Sanity processes and restricts uploaded assets server-side
+2. **CDN delivery** — assets are served as static files from `cdn.sanity.io` / Cloudflare CDN
+3. **No arbitrary file execution** — assets are static, never executed
 
-- **Location:** `apps/web/src/lib/effect/schemas/file.schema.ts`
-- **Purpose:** Type safety and basic MIME type filtering
-- **Validates:** Accepts only `image/jpeg`, `image/png`, `image/gif`, `image/webp`
-- **⚠️ Limitation:** This is NOT a security control — it's defense-in-depth and type safety
-
-#### Layer 2: Sanity CMS Server-Side Validation (PRIMARY SECURITY CONTROL)
-
-Sanity performs server-side validation on all file uploads:
-
-1. **MIME type enforcement** — Sanity restricts accepted file types at the field level
-2. **CDN delivery** — Images are served via Cloudflare CDN from `cdn.sanity.io`
-3. **No arbitrary file execution** — Assets are served as static files, not executed
-
-#### Layer 3: Next.js Image Optimization
+#### Next.js Image remote allowlist
 
 - **Location:** `next.config.ts` `remotePatterns`
-- **Purpose:** Restrict which domains can serve images
-- **Current allowed domains:** placehold.co, cdn.sanity.io, Cloudflare CDN
-- Any image from unapproved domains will be rejected
-
-#### Testing File Validation
-
-```bash
-# Run schema validation tests
-pnpm --filter @kcvv/web test file.schema.test.ts
-```
+- **Purpose:** restrict which domains can serve images
+- **Allowed domains:** placehold.co, cdn.sanity.io, Cloudflare CDN — images from other domains are rejected
 
 ---
 
@@ -146,6 +131,6 @@ If you discover a security vulnerability, please email: kevin@kcvvelewijt.be
 
 ## Last Security Review
 
-- **Date:** 2026-04-26
+- **Date:** 2026-06-26
 - **Reviewer:** Kevin Van Ransbeeck
 - **Status:** ✅ Safe — No user-uploaded SVGs; fully migrated to Sanity + Cloudflare CDN

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -27,7 +27,7 @@ pnpm --filter @kcvv/api dev                        # wrangler dev on :8787
 
 ```bash
 pnpm --filter @kcvv/api dev              # wrangler dev (local)
-pnpm --filter @kcvv/api deploy           # deploy to production
+pnpm --filter @kcvv/api run deploy       # deploy to production (bare `deploy` hits pnpm's built-in)
 pnpm --filter @kcvv/api deploy:staging   # deploy to staging
 pnpm --filter @kcvv/api test
 pnpm --filter @kcvv/api cache:clear:staging                    # clear all staging KV keys

--- a/apps/studio-staging/README.md
+++ b/apps/studio-staging/README.md
@@ -18,8 +18,8 @@ cd apps/studio-staging && SANITY_STUDIO_DATASET=staging npx sanity deploy
 
 Deploys to [kcvv-elewijt-staging.sanity.studio](https://kcvv-elewijt-staging.sanity.studio).
 
-> `SANITY_STUDIO_DATASET=staging` is **required** — the staging config derives its dataset
-> from this env var; without it the build succeeds but the deploy stalls on a hidden prompt.
+> `SANITY_STUDIO_DATASET=staging` is **required**. The staging `sanity.config.ts` derives its
+> dataset from this env var and throws if it is unset, so the deploy fails fast at config-eval.
 > Use `npx sanity deploy` (or `pnpm --filter @kcvv/studio-staging run deploy`) — **not** bare
 > `pnpm --filter @kcvv/studio-staging deploy` (pnpm's built-in `deploy`, which errors). There
 > is no CI auto-deploy; schema changes only go live after a manual redeploy.

--- a/apps/studio-staging/README.md
+++ b/apps/studio-staging/README.md
@@ -13,8 +13,16 @@ pnpm --filter @kcvv/studio-staging dev   # starts Studio at http://localhost:333
 ## Deploy
 
 ```bash
-pnpm --filter @kcvv/studio-staging deploy
+cd apps/studio-staging && SANITY_STUDIO_DATASET=staging npx sanity deploy
 ```
+
+Deploys to [kcvv-elewijt-staging.sanity.studio](https://kcvv-elewijt-staging.sanity.studio).
+
+> `SANITY_STUDIO_DATASET=staging` is **required** — the staging config derives its dataset
+> from this env var; without it the build succeeds but the deploy stalls on a hidden prompt.
+> Use `npx sanity deploy` (or `pnpm --filter @kcvv/studio-staging run deploy`) — **not** bare
+> `pnpm --filter @kcvv/studio-staging deploy` (pnpm's built-in `deploy`, which errors). There
+> is no CI auto-deploy; schema changes only go live after a manual redeploy.
 
 ## Editing schemas
 

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -13,10 +13,14 @@ pnpm --filter @kcvv/studio dev   # starts Studio at http://localhost:3333
 ## Deploy
 
 ```bash
-pnpm --filter @kcvv/studio deploy
+cd apps/studio && npx sanity deploy
 ```
 
 Deploys to [kcvvelewijt.sanity.studio](https://kcvvelewijt.sanity.studio).
+
+> Use `npx sanity deploy` (or `pnpm --filter @kcvv/studio run deploy`) — **not** bare
+> `pnpm --filter @kcvv/studio deploy`, which invokes pnpm's built-in `deploy` and errors.
+> There is no CI auto-deploy; schema changes only go live after a manual redeploy.
 
 ## Editing schemas
 

--- a/apps/web/test/fixtures/images/README.md
+++ b/apps/web/test/fixtures/images/README.md
@@ -6,7 +6,7 @@ services (placehold.co, picsum, unsplash) that produced flaky baselines.
 
 ## Why local fixtures
 
-- **Determinism.** A single 503 from `placehold.co` during `pnpm vr:update`
+- **Determinism.** A single 503 from `placehold.co` during `pnpm --filter @kcvv/web vr:update`
   was enough to ship a corrupted baseline as truth — the test runner
   captured a broken-image render and committed it as the new ground
   truth. Local files eliminate that flake class.
@@ -107,9 +107,9 @@ off before merge.
 - After changing a shape's GROQ query, run with `--refresh` to clear
   prior picks.
 - To replace one fixture, delete its `manifest.json` entry and its
-  WebP file, then run `pnpm fixtures:sync` — the script tops up to
+  WebP file, then run `pnpm --filter @kcvv/web fixtures:sync` — the script tops up to
   pool size with the next available candidate.
-- After refreshing the pool, re-baseline VR (`pnpm vr:update`) in the
+- After refreshing the pool, re-baseline VR (`pnpm --filter @kcvv/web vr:update`) in the
   same PR — see memory `feedback_vr_baseline_in_same_pr.md`.
 
 ## Imgbot

--- a/packages/api-contract/README.md
+++ b/packages/api-contract/README.md
@@ -1,0 +1,26 @@
+# @kcvv/api-contract
+
+Shared **API contract** for the KCVV Elewijt BFF: [Effect Schema](https://effect.website)
+definitions for the _normalized_ response shapes the Cloudflare Workers BFF (`apps/api`)
+returns and the Next.js web app (`apps/web`) consumes.
+
+Post-transformation types only — `Match`, `MatchDetail`, `RankingEntry`, the `PsdApi`
+HttpApi group, etc. Raw upstream (Footbalisto/PSD) shapes stay in `apps/api`/`apps/web`
+as an implementation detail and never belong here.
+
+## Usage
+
+```typescript
+import { Match, PsdApi } from "@kcvv/api-contract";
+```
+
+Source-only package (no emitted JS) — both consumers bundle the `src/` TypeScript
+directly (Turbopack for web, esbuild/Wrangler for the BFF). `tsc --noEmit` type-check
+can pass while a barrel re-export is unresolvable by the bundler, so after changing
+anything here, rebuild the web app to validate resolution:
+
+```bash
+pnpm turbo build --filter=@kcvv/web
+```
+
+Conventions for adding schemas live in [`CLAUDE.md`](./CLAUDE.md).

--- a/packages/sanity-schemas/README.md
+++ b/packages/sanity-schemas/README.md
@@ -1,0 +1,17 @@
+# @kcvv/sanity-schemas
+
+Shared Sanity schema definitions (documents + objects) for the KCVV Elewijt content model.
+
+**Single source of truth.** Both Studios — `apps/studio` (production) and
+`apps/studio-staging` (staging) — import these identical definitions. There are no
+per-studio schema copies; editing a file in `src/` applies to both Studios automatically.
+
+## Usage
+
+```typescript
+import { schemaTypes } from "@kcvv/sanity-schemas";
+```
+
+Source-only package, consumed directly by both Studio configs. All schema files live
+in `src/`. Schemas here stay React-free; presentation grafts (custom input/preview
+components, decorator icons) live in [`@kcvv/sanity-studio`](../sanity-studio/).

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -1,0 +1,17 @@
+# @kcvv/sanity-studio
+
+Shared Sanity Studio UI for KCVV Elewijt — the custom Studio building blocks both
+`apps/studio` (production) and `apps/studio-staging` (staging) compose: custom
+input/preview components, desk structure, and content migrations.
+
+## Usage
+
+```typescript
+import { ... } from "@kcvv/sanity-studio";
+import { ... } from "@kcvv/sanity-studio/migrations";
+```
+
+Source-only package. Schema _definitions_ live in
+[`@kcvv/sanity-schemas`](../sanity-schemas/), not here — this package is presentation
+and tooling (e.g. the `applyDecoratorComponents` graft that adds React decorator icons
+to the React-free schema marks).


### PR DESCRIPTION
Closes #2245

Pre-go-live accuracy pass on every README + SECURITY.md (DOC-1).

## Changes

- **SECURITY.md** — the real find: it documented a file-upload *"Layer 1 schema validation"* (`apps/web/src/lib/effect/schemas/file.schema.ts`) and a rejection-test suite that **don't exist** — there is no app-level image-MIME schema anywhere in `apps/web/src`. Rewrote the File Upload section to the actual posture (no user-upload surface; Sanity server-side validation + Next.js `remotePatterns` are the real controls) and bumped the review date to 2026-06-26.
- **`apps/studio/README.md` + `apps/studio-staging/README.md`** — both documented `pnpm --filter <studio> deploy`, which invokes pnpm's built-in `deploy` and errors. Corrected to `npx sanity deploy`, added the staging deploy URL, and documented the required `SANITY_STUDIO_DATASET=staging` env var.
- **`apps/web/test/fixtures/images/README.md`** — bare `pnpm fixtures:sync` / `pnpm vr:update` are web-only scripts that fail from repo root; qualified with `--filter @kcvv/web` to match the already-correct line 40.
- **New READMEs** for the three previously-undocumented workspace packages: `@kcvv/api-contract`, `@kcvv/sanity-schemas`, `@kcvv/sanity-studio`.

### Deliberately skipped

- `scripts/team-image-backfill/README.md` npm→pnpm — standalone historical Drupal-migration script; accurate as written.
- Expanding `docs/prd/README.md` — accurate placeholder, not broken.

## Testing

- Pre-commit gate passed (turbo type-check across all 7 packages; docs-only diff, no code touched).
- All 7 files prettier-clean; MD040 verified (no bare fenced blocks).
- Multi-agent `/code-review` + `/simplify` gate skipped: pure-docs diff, verified line-by-line against the real file tree (those gates target code correctness).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deployment steps for production and staging Studio environments, including the required command and manual redeploy guidance.
  * Updated security guidance to reflect the current review date and the handling of image sources and uploads.
  * Added or expanded package documentation for shared API contracts, Sanity schemas, and Studio UI usage.
  * Updated fixture and visual-regression instructions to use the correct project-scoped commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->