### PR TITLE
chore(studio): interview seed + Drupal migration scripts

### DIFF
--- a/apps/studio/scripts/migrate-drupal-node.ts
+++ b/apps/studio/scripts/migrate-drupal-node.ts
@@ -41,7 +41,17 @@ const decode = (s: string) =>
     .replace(/&gt;/g, '>')
     .replace(/ /g, ' ')
 
-const stripTags = (s: string) => s.replace(/<[^>]+>/g, '')
+// Strip tags to a fixpoint: a single pass can be circumvented by nesting
+// (`<scr<script>ipt>` → one pass leaves `<script>`), so repeat until stable.
+const stripTags = (s: string): string => {
+  let prev: string
+  let out = s
+  do {
+    prev = out
+    out = out.replace(/<[^>]*>/g, '')
+  } while (out !== prev)
+  return out
+}
 
 // Assumes the regular Drupal interview shape: each <p> is a single logical unit
 // — question (wholly <strong>), answer (wholly <em>), or plain prose. Marks are

--- a/apps/studio/scripts/migrate-drupal-node.ts
+++ b/apps/studio/scripts/migrate-drupal-node.ts
@@ -1,0 +1,251 @@
+import {randomBytes, randomUUID} from 'node:crypto'
+import {getCliClient} from 'sanity/cli'
+
+/**
+ * Migrate a legacy Drupal article node into a Sanity `article` DRAFT.
+ *
+ * Fetches the node over JSON:API, converts its `<p>/<strong>/<em>/<br>` body
+ * to Portable Text, uploads the cover image, resolves the interview subject
+ * (leading "Firstname Lastname:" in the title → Sanity player/staff), and
+ * runs the same strong-Q / em-A → `qaBlock` transform used for the in-place
+ * seed conversions. Creates a `drafts.` document so it can be reviewed and
+ * published in Studio rather than going live unreviewed.
+ *
+ * Dry-run by default. Set APPLY=1 to upload the image and create the draft.
+ *
+ *   cd apps/studio
+ *   NID=1125 npx sanity exec scripts/migrate-drupal-node.ts --with-user-token
+ *   APPLY=1 NID=1125 npx sanity exec scripts/migrate-drupal-node.ts --with-user-token
+ */
+
+const NID = process.env.NID ?? '1125'
+const apply = process.env.APPLY === '1'
+const DRUPAL = 'https://api.kcvvelewijt.be'
+const client = getCliClient()
+const key = () => randomBytes(6).toString('hex')
+
+// ── HTML → Portable Text (regular Drupal body only) ────────────────────────
+type Span = {_type: string; _key: string; text: string; marks: string[]}
+type Block = {_type: string; _key: string; style: string; markDefs: unknown[]; children: Span[]}
+
+const decode = (s: string) =>
+  s
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&hellip;/g, '…')
+    .replace(/&mdash;/g, '—')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/ /g, ' ')
+
+const stripTags = (s: string) => s.replace(/<[^>]+>/g, '')
+
+function htmlToBlocks(html: string): Block[] {
+  const blocks: Block[] = []
+  for (const seg of html.split(/<\/p>/i)) {
+    const m = seg.match(/<p[^>]*>([\s\S]*)$/i)
+    if (!m) continue
+    const inner = m[1]
+    const hasEm = /<em\b/i.test(inner)
+    const hasStrong = /<strong\b/i.test(inner)
+    const text = decode(stripTags(inner)).replace(/\r/g, '').trim()
+    if (!text) continue
+    const marks = hasEm ? ['em'] : hasStrong ? ['strong'] : []
+    blocks.push({
+      _type: 'block',
+      _key: key(),
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: key(), text, marks}],
+    })
+  }
+  return blocks
+}
+
+// ── strong-Q / em-A → qaBlock (mirror of seed-interview-qa-pairs) ───────────
+const textOf = (b: Block) => b.children.map((c) => c.text).join('')
+const hasMark = (b: Block, m: string) => b.children.some((c) => c.marks.includes(m))
+const isQuestion = (b: Block) => hasMark(b, 'strong') && !hasMark(b, 'em') && textOf(b).trim().endsWith('?')
+const isAnswer = (b: Block) => hasMark(b, 'em')
+const isSeparator = (b: Block) => {
+  const t = textOf(b).trim()
+  return t === '' || /^[—–-]{1,3}$/.test(t)
+}
+
+function cleanAnswer(blocks: Block[]): Block[] {
+  const out = blocks.map((b) => ({
+    _type: 'block',
+    _key: key(),
+    style: 'normal',
+    markDefs: [] as unknown[],
+    children: b.children.map((c) => ({
+      _type: 'span',
+      _key: key(),
+      text: c.text,
+      marks: c.marks.filter((m) => m !== 'em' && m !== 'strong'),
+    })),
+  }))
+  if (out.length > 0) {
+    const first = out[0].children[0]
+    if (first) first.text = first.text.replace(/^\s*[—–-]\s*[“"«‘']?\s*/, '')
+    const lastCh = out[out.length - 1].children
+    const last = lastCh[lastCh.length - 1]
+    if (last) {
+      last.text = last.text.replace(/[”"»’]\s*(\([^)]*\))\s*$/, ' $1')
+      last.text = last.text.replace(/\s*[”"»’]\s*$/, '')
+    }
+  }
+  return out
+}
+
+function toQaBody(body: Block[], subjectKey: string) {
+  const firstQ = body.findIndex(isQuestion)
+  if (firstQ < 0) return {body, pairs: 0}
+  const intro = body.slice(0, firstQ).filter((b) => !isSeparator(b))
+  const pairs: unknown[] = []
+  let i = firstQ
+  let lastEnd = firstQ
+  while (i < body.length) {
+    if (!isQuestion(body[i])) {
+      i++
+      continue
+    }
+    const q = body[i]
+    let j = i + 1
+    const ans: Block[] = []
+    while (j < body.length && isAnswer(body[j])) {
+      ans.push(body[j])
+      j++
+    }
+    if (ans.length > 0) {
+      pairs.push({
+        _type: 'qaPair',
+        _key: key(),
+        question: textOf(q).trim(),
+        tag: 'standard',
+        respondents: [
+          {_type: 'qaPairRespondent', _key: key(), respondentKey: subjectKey, answer: cleanAnswer(ans)},
+        ],
+      })
+      lastEnd = j
+    }
+    i = j
+  }
+  const outro = body.slice(lastEnd).filter((b) => !isSeparator(b))
+  return {body: [...intro, {_type: 'qaBlock', _key: key(), pairs, groupAtTail: false}, ...outro], pairs: pairs.length}
+}
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+async function main() {
+  const url = `${DRUPAL}/jsonapi/node/article?filter%5Bdrupal_internal__nid%5D=${NID}&include=field_media_article_image.field_media_image,field_tags`
+  const res = await fetch(url, {headers: {Accept: 'application/vnd.api+json'}})
+  const json = (await res.json()) as any
+  const node = json.data?.[0]
+  if (!node) throw new Error(`Drupal node ${NID} not found`)
+  const a = node.attributes
+
+  const title: string = a.title
+  const lead: string = a.body?.summary ?? ''
+  const publishedAt: string = a.created
+  const featured = Boolean(a.field_featured ?? a.promote)
+  const slug = slugify(title.replace(/[:"“”].*$/, '') + ' ' + title.replace(/^[^:]*:/, ''))
+  const coverFile = (json.included ?? []).find((x: any) => x.type === 'file--file')
+  const coverUrl = coverFile ? DRUPAL + coverFile.attributes.uri.url : null
+  const tagTerms = (json.included ?? [])
+    .filter((x: any) => x.type?.startsWith('taxonomy_term'))
+    .map((x: any) => x.attributes?.name)
+    .filter(Boolean)
+
+  // Subject: "Firstname Lastname: …" → Sanity player/staff.
+  const leadName = title.split(':')[0].trim()
+  const [firstName, ...rest] = leadName.split(/\s+/)
+  const lastName = rest.join(' ')
+  const person = await client.fetch<{_id: string; _type: string; firstName?: string; lastName?: string} | null>(
+    `*[_type in ["player","staffMember"] && firstName == $f && lastName == $l][0]{_id,_type,firstName,lastName}`,
+    {f: firstName, l: lastName},
+  )
+
+  const rawBlocks = htmlToBlocks(a.body?.value ?? '')
+  const subjectKey = key()
+  const {body, pairs} = toQaBody(rawBlocks, subjectKey)
+
+  console.log('\n========== MIGRATE DRUPAL NODE ' + NID + ' ==========')
+  console.log('title      :', title)
+  console.log('slug       : /nieuws/' + slug)
+  console.log('lead       :', lead)
+  console.log('publishedAt:', publishedAt, '| featured:', featured)
+  console.log('cover      :', coverUrl)
+  console.log('tags       :', tagTerms.join(', ') || '(none)')
+  console.log(
+    'subject    :',
+    person ? `${person.firstName} ${person.lastName} (${person._type} ${person._id})` : `NOT FOUND for "${leadName}"`,
+  )
+  console.log('body       :', pairs, 'Q&A pairs +', body.length - 1, 'prose block(s)')
+
+  if (!person) {
+    console.warn('\n! Subject not resolved — set it manually in Studio (interview requires a subject).')
+  }
+
+  if (!apply) {
+    const qa = body.find((b: any) => b._type === 'qaBlock') as any
+    ;(qa?.pairs ?? []).forEach((p: any, n: number) => {
+      const ans = p.respondents[0].answer.map((bl: any) => bl.children.map((c: any) => c.text).join('')).join(' ⏎ ')
+      console.log(`\n  [${n + 1}] Q: ${p.question}`)
+      console.log(`      A: ${ans.length > 200 ? ans.slice(0, 140) + ' …→ ' + ans.slice(-55) : ans}`)
+    })
+    console.log('\nDry run — set APPLY=1 to upload the cover + create the DRAFT.')
+    return
+  }
+
+  let coverImage: unknown
+  if (coverUrl) {
+    const buf = Buffer.from(await (await fetch(coverUrl)).arrayBuffer())
+    const asset = await client.assets.upload('image', buf, {filename: coverUrl.split('/').pop()})
+    coverImage = {_type: 'image', asset: {_type: 'reference', _ref: asset._id}}
+    console.log('uploaded cover asset:', asset._id)
+  }
+
+  const doc: Record<string, unknown> = {
+    _id: `drafts.${randomUUID()}`,
+    _type: 'article',
+    articleType: 'interview',
+    title: [{_type: 'block', _key: key(), style: 'normal', markDefs: [], children: [{_type: 'span', _key: key(), text: title, marks: []}]}],
+    slug: {_type: 'slug', current: slug},
+    lead,
+    publishedAt,
+    featured,
+    ...(tagTerms.length ? {tags: tagTerms} : {}),
+    ...(person
+      ? {
+          subjects: [
+            person._type === 'player'
+              ? {_type: 'subject', _key: subjectKey, kind: 'player', playerRef: {_type: 'reference', _ref: person._id}}
+              : {_type: 'subject', _key: subjectKey, kind: 'staff', staffRef: {_type: 'reference', _ref: person._id}},
+          ],
+        }
+      : {}),
+    ...(coverImage ? {coverImage} : {}),
+    body,
+  }
+
+  const created = await client.create(doc as any)
+  console.log('\n✓ Created draft:', created._id)
+  console.log('  Review & publish in Studio.')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/apps/studio/scripts/migrate-drupal-node.ts
+++ b/apps/studio/scripts/migrate-drupal-node.ts
@@ -36,9 +36,12 @@ const decode = (s: string) =>
     .replace(/&quot;/g, '"')
     .replace(/&hellip;/g, '…')
     .replace(/&mdash;/g, '—')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    // `&amp;` MUST be unescaped after the other entities: doing it earlier lets
+    // the produced `&` re-form a following entity (`&amp;lt;` → `&lt;` → `<`),
+    // a double-unescape. Placing it here means its output can't be re-consumed.
+    .replace(/&amp;/g, '&')
     .replace(/ /g, ' ')
 
 // Strip tags to a fixpoint: a single pass can be circumvented by nesting

--- a/apps/studio/scripts/migrate-drupal-node.ts
+++ b/apps/studio/scripts/migrate-drupal-node.ts
@@ -43,6 +43,13 @@ const decode = (s: string) =>
 
 const stripTags = (s: string) => s.replace(/<[^>]+>/g, '')
 
+// Assumes the regular Drupal interview shape: each <p> is a single logical unit
+// — question (wholly <strong>), answer (wholly <em>), or plain prose. Marks are
+// applied per paragraph, not per inline run; `em` wins over `strong` so an
+// em+strong answer-continuation is still classified as an answer. Genuinely
+// mixed inline content (bold + italic in one paragraph) is out of scope for
+// these bodies and would be flattened — check the dry-run before trusting a new
+// source.
 function htmlToBlocks(html: string): Block[] {
   const blocks: Block[] = []
   for (const seg of html.split(/<\/p>/i)) {
@@ -101,7 +108,7 @@ function cleanAnswer(blocks: Block[]): Block[] {
   return out
 }
 
-function toQaBody(body: Block[], subjectKey: string) {
+function toQaBody(body: Block[], subjectKey: string | undefined) {
   const firstQ = body.findIndex(isQuestion)
   if (firstQ < 0) return {body, pairs: 0}
   const intro = body.slice(0, firstQ).filter((b) => !isSeparator(b))
@@ -116,18 +123,31 @@ function toQaBody(body: Block[], subjectKey: string) {
     const q = body[i]
     let j = i + 1
     const ans: Block[] = []
-    while (j < body.length && isAnswer(body[j])) {
-      ans.push(body[j])
+    // Skip separators between question and answer while collecting; stop at the
+    // next question or at plain prose (outro).
+    while (j < body.length && (isAnswer(body[j]) || isSeparator(body[j]))) {
+      if (isAnswer(body[j])) ans.push(body[j])
       j++
     }
     if (ans.length > 0) {
+      const question = textOf(q).trim()
+      if (question.length > 240) {
+        console.warn(`  ! question exceeds 240-char schema limit (${question.length}) — will fail validation: ${question.slice(0, 60)}…`)
+      }
       pairs.push({
         _type: 'qaPair',
         _key: key(),
-        question: textOf(q).trim(),
+        question,
         tag: 'standard',
         respondents: [
-          {_type: 'qaPairRespondent', _key: key(), respondentKey: subjectKey, answer: cleanAnswer(ans)},
+          {
+            _type: 'qaPairRespondent',
+            _key: key(),
+            // Only attribute when a subject was resolved; otherwise leave the
+            // key unset so it can never dangle against a missing subjects[].
+            ...(subjectKey ? {respondentKey: subjectKey} : {}),
+            answer: cleanAnswer(ans),
+          },
         ],
       })
       lastEnd = j
@@ -135,7 +155,9 @@ function toQaBody(body: Block[], subjectKey: string) {
     i = j
   }
   const outro = body.slice(lastEnd).filter((b) => !isSeparator(b))
-  return {body: [...intro, {_type: 'qaBlock', _key: key(), pairs, groupAtTail: false}, ...outro], pairs: pairs.length}
+  // Never emit an empty qaBlock — if no pairs were built, return the prose as-is.
+  const qaBlocks = pairs.length > 0 ? [{_type: 'qaBlock', _key: key(), pairs, groupAtTail: false}] : []
+  return {body: [...intro, ...qaBlocks, ...outro], pairs: pairs.length}
 }
 
 const slugify = (s: string) =>
@@ -149,6 +171,7 @@ const slugify = (s: string) =>
 async function main() {
   const url = `${DRUPAL}/jsonapi/node/article?filter%5Bdrupal_internal__nid%5D=${NID}&include=field_media_article_image.field_media_image,field_tags`
   const res = await fetch(url, {headers: {Accept: 'application/vnd.api+json'}})
+  if (!res.ok) throw new Error(`Drupal JSON:API returned HTTP ${res.status} for node ${NID}`)
   const json = (await res.json()) as any
   const node = json.data?.[0]
   if (!node) throw new Error(`Drupal node ${NID} not found`)
@@ -176,7 +199,9 @@ async function main() {
   )
 
   const rawBlocks = htmlToBlocks(a.body?.value ?? '')
-  const subjectKey = key()
+  // Only mint a subject key (and thus a respondentKey) when the subject was
+  // resolved — keeps subjects[]._key and respondentKey aligned.
+  const subjectKey = person ? key() : undefined
   const {body, pairs} = toQaBody(rawBlocks, subjectKey)
 
   console.log('\n========== MIGRATE DRUPAL NODE ' + NID + ' ==========')
@@ -209,7 +234,9 @@ async function main() {
 
   let coverImage: unknown
   if (coverUrl) {
-    const buf = Buffer.from(await (await fetch(coverUrl)).arrayBuffer())
+    const imgRes = await fetch(coverUrl)
+    if (!imgRes.ok) throw new Error(`Cover image fetch returned HTTP ${imgRes.status} for ${coverUrl}`)
+    const buf = Buffer.from(await imgRes.arrayBuffer())
     const asset = await client.assets.upload('image', buf, {filename: coverUrl.split('/').pop()})
     coverImage = {_type: 'image', asset: {_type: 'reference', _ref: asset._id}}
     console.log('uploaded cover asset:', asset._id)

--- a/apps/studio/scripts/seed-interview-qa-pairs.ts
+++ b/apps/studio/scripts/seed-interview-qa-pairs.ts
@@ -111,23 +111,29 @@ function transform(body: Block[], subjectKey: string) {
       ans.push(body[j])
       j++
     }
+    // A question with no contiguous answer is an unsupported shape — abort
+    // rather than silently dropping content or emitting a partial qaBlock.
     if (ans.length === 0) {
-      console.warn(`  ! question with no answer, skipped: ${textOf(q).slice(0, 60)}`)
-      i = j
-      continue
+      throw new Error(`Question with no answer (unsupported shape) — aborting: ${textOf(q).slice(0, 60)}`)
+    }
+    const question = textOf(q).trim()
+    if (question.length > 240) {
+      throw new Error(
+        `Question exceeds the 240-char schema limit (${question.length}) — aborting: ${question.slice(0, 60)}…`,
+      )
     }
     const cleaned = cleanAnswer(ans)
     pairs.push({
       _type: 'qaPair',
       _key: key(),
-      question: textOf(q).trim(),
+      question,
       tag: 'standard',
       respondents: [
         {_type: 'qaPairRespondent', _key: key(), respondentKey: subjectKey, answer: cleaned},
       ],
     })
     preview.push({
-      q: textOf(q).trim(),
+      q: question,
       a: cleaned.map((b) => b.children.map((c) => c.text).join('')).join(' ⏎ '),
       blocks: ans.length,
     })
@@ -153,9 +159,19 @@ async function main() {
       console.warn(`\n${id}: NOT FOUND`)
       continue
     }
-    const subjectKey = doc.subjects?.[0]?._key
+    // This transform attributes every answer to one subject, so it only makes
+    // sense for single-subject interviews — a duo/panel needs per-answer
+    // attribution the source prose doesn't carry.
+    const subjects = doc.subjects ?? []
+    if (subjects.length !== 1) {
+      console.warn(
+        `\n${doc.title} (${id}): expected exactly 1 subject, found ${subjects.length} — skipped (multi-subject needs manual attribution)`,
+      )
+      continue
+    }
+    const subjectKey = subjects[0]?._key
     if (!subjectKey) {
-      console.warn(`\n${doc.title} (${id}): no subject set — skipped`)
+      console.warn(`\n${doc.title} (${id}): subject has no _key — skipped`)
       continue
     }
     const result = transform(doc.body ?? [], subjectKey)

--- a/apps/studio/scripts/seed-interview-qa-pairs.ts
+++ b/apps/studio/scripts/seed-interview-qa-pairs.ts
@@ -1,0 +1,189 @@
+import {randomBytes} from 'node:crypto'
+import {getCliClient} from 'sanity/cli'
+
+/**
+ * One-off: convert legacy interview articles (seeded before interview types
+ * existed) whose Q&A lives as loose Portable Text — question = `strong`
+ * block ending in "?", answer = following `em` block(s) prefixed `— "…"` —
+ * into a single structured `qaBlock` (pairs → respondents → answer).
+ *
+ * Intro paragraphs (before the first question) and outro paragraphs (after
+ * the last answer) are kept as body prose; standalone separators (—, ---)
+ * are dropped. Answers are cleaned: leading `— "` / trailing `"` stripped,
+ * em/strong styling removed (link annotations preserved), multi-paragraph
+ * answers kept as multiple blocks.
+ *
+ * Single-subject interviews → each answer attributed to the sole subject's
+ * `_key`. Idempotent: after conversion there are no `strong`-question blocks,
+ * so a re-run detects no Q&A and skips.
+ *
+ * Dry-run by default. Set APPLY=1 to write.
+ *
+ *   cd apps/studio
+ *   npx sanity exec scripts/seed-interview-qa-pairs.ts --with-user-token
+ *   APPLY=1 npx sanity exec scripts/seed-interview-qa-pairs.ts --with-user-token
+ */
+
+const IDS = [
+  '4029e7ec-dc31-47bf-87f1-4caddbc988e4', // Dieter Van Dionant
+  'febb5ced-44ce-4858-a5cb-2e2d07708667', // Max Breugelmans
+]
+
+const apply = process.env.APPLY === '1'
+const client = getCliClient()
+const key = () => randomBytes(6).toString('hex')
+
+type Span = {_type?: string; _key?: string; text?: string; marks?: string[]}
+type Block = {
+  _type: string
+  _key?: string
+  style?: string
+  markDefs?: unknown[]
+  children?: Span[]
+}
+
+const textOf = (b: Block) => (b.children ?? []).map((c) => c.text ?? '').join('')
+const hasMark = (b: Block, m: string) =>
+  (b.children ?? []).some((c) => (c.marks ?? []).includes(m))
+
+const isQuestion = (b: Block) =>
+  b._type === 'block' &&
+  hasMark(b, 'strong') &&
+  !hasMark(b, 'em') &&
+  textOf(b).trim().endsWith('?')
+
+const isAnswer = (b: Block) => b._type === 'block' && hasMark(b, 'em')
+
+const isSeparator = (b: Block) => {
+  if (b._type !== 'block') return false
+  const t = textOf(b).trim()
+  return t === '' || /^[—–-]{1,3}$/.test(t)
+}
+
+/** Strip em/strong (keep link-annotation marks), trim leading `— "` and trailing `"`. */
+function cleanAnswer(blocks: Block[]): Block[] {
+  const out = blocks.map((b) => ({
+    _type: 'block',
+    _key: key(),
+    style: 'normal',
+    markDefs: b.markDefs ?? [],
+    children: (b.children ?? []).map((c) => ({
+      _type: 'span',
+      _key: key(),
+      text: c.text ?? '',
+      marks: (c.marks ?? []).filter((m) => m !== 'em' && m !== 'strong'),
+    })),
+  }))
+  if (out.length > 0) {
+    const first = out[0].children[0]
+    if (first) first.text = first.text.replace(/^\s*[—–-]\s*[“"«‘']?\s*/, '')
+    const lastChildren = out[out.length - 1].children
+    const last = lastChildren[lastChildren.length - 1]
+    if (last) {
+      // closing quote right before a trailing stage-direction: `…!” (lacht)` → `…! (lacht)`
+      last.text = last.text.replace(/[”"»’]\s*(\([^)]*\))\s*$/, ' $1')
+      // plain trailing closing quote
+      last.text = last.text.replace(/\s*[”"»’]\s*$/, '')
+    }
+  }
+  return out
+}
+
+function transform(body: Block[], subjectKey: string) {
+  const firstQ = body.findIndex(isQuestion)
+  if (firstQ < 0) return null
+
+  const intro = body.slice(0, firstQ).filter((b) => !isSeparator(b))
+
+  const pairs: unknown[] = []
+  const preview: {q: string; a: string; blocks: number}[] = []
+  let i = firstQ
+  let lastAnswerEnd = firstQ
+  while (i < body.length) {
+    if (!isQuestion(body[i])) {
+      i++
+      continue
+    }
+    const q = body[i]
+    let j = i + 1
+    const ans: Block[] = []
+    while (j < body.length && isAnswer(body[j])) {
+      ans.push(body[j])
+      j++
+    }
+    if (ans.length === 0) {
+      console.warn(`  ! question with no answer, skipped: ${textOf(q).slice(0, 60)}`)
+      i = j
+      continue
+    }
+    const cleaned = cleanAnswer(ans)
+    pairs.push({
+      _type: 'qaPair',
+      _key: key(),
+      question: textOf(q).trim(),
+      tag: 'standard',
+      respondents: [
+        {_type: 'qaPairRespondent', _key: key(), respondentKey: subjectKey, answer: cleaned},
+      ],
+    })
+    preview.push({
+      q: textOf(q).trim(),
+      a: cleaned.map((b) => b.children.map((c) => c.text).join('')).join(' ⏎ '),
+      blocks: ans.length,
+    })
+    lastAnswerEnd = j
+    i = j
+  }
+
+  const outro = body.slice(lastAnswerEnd).filter((b) => !isSeparator(b))
+  const qaBlock = {_type: 'qaBlock', _key: key(), pairs, groupAtTail: false}
+  const newBody = [...intro, qaBlock, ...outro]
+  return {newBody, preview, introCount: intro.length, outroCount: outro.length}
+}
+
+async function main() {
+  for (const id of IDS) {
+    const doc = await client.fetch<{
+      _id: string
+      title: unknown
+      body?: Block[]
+      subjects?: {_key?: string}[]
+    }>(`*[_id == $id][0]{_id, "title": pt::text(title), body, subjects[]{_key}}`, {id})
+    if (!doc) {
+      console.warn(`\n${id}: NOT FOUND`)
+      continue
+    }
+    const subjectKey = doc.subjects?.[0]?._key
+    if (!subjectKey) {
+      console.warn(`\n${doc.title} (${id}): no subject set — skipped`)
+      continue
+    }
+    const result = transform(doc.body ?? [], subjectKey)
+    if (!result) {
+      console.log(`\n${doc.title} (${id}): no Q&A detected (already converted?) — skipped`)
+      continue
+    }
+    console.log(`\n########## ${doc.title} ##########`)
+    console.log(
+      `intro paragraphs: ${result.introCount} | Q&A pairs: ${result.preview.length} | outro paragraphs: ${result.outroCount}`,
+    )
+    result.preview.forEach((p, n) => {
+      const body =
+        p.a.length > 260 ? `${p.a.slice(0, 170)}  …[tail]→  ${p.a.slice(-80)}` : p.a
+      console.log(`\n  [${n + 1}] Q: ${p.q}`)
+      console.log(`      A${p.blocks > 1 ? ` (${p.blocks} paragraphs)` : ''}: ${body}`)
+    })
+    if (apply) {
+      await client.patch(id).set({body: result.newBody}).commit()
+      console.log(`\n  ✓ WRITTEN`)
+    }
+  }
+  console.log(apply ? '\nApplied.' : '\nDry run — set APPLY=1 to write.')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })


### PR DESCRIPTION
Two one-off `sanity exec` scripts, **already run against production**, committed for traceability (same rationale as the earlier `remap-qa-respondent-keys.ts`).

- **`seed-interview-qa-pairs.ts`** — converts legacy interview bodies (`strong`-question / `em`-answer prose) into structured `qaBlock`s. Ran on the Dieter Van Dionant + Max Breugelmans interviews.
- **`migrate-drupal-node.ts`** — migrates a Drupal article node (via JSON:API) into a Sanity article **draft**: HTML→Portable Text, cover-image upload, subject resolution (title name → player/staff), and the same Q&A transform. Parameterized by `NID`; ran for node 1125 (Vincent Haegeman).

Both dry-run by default (`APPLY=1` to write) and idempotent. No app/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to convert legacy interview content into a structured Q&A format for Sanity.
  * Added support for migrating Drupal article content into draft Sanity interview documents, including images, tags, and subject matching.
  * Dry-run mode is available by default, with an apply option for writing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->