### PR TITLE
fix(ui): blend homepage banner into news grid, not the matches seam

### DIFF
--- a/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
+++ b/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
@@ -44,28 +44,27 @@ export const BannerSlot = ({
     </div>
   );
 
+  // ponytail: no own background — the banner sits on its SectionStack
+  // wrapper's `gray-100` so it blends into the news grid below rather than
+  // echoing the cream StripedSeam that closes the matches section above.
   if (href) {
     return (
-      <div className="bg-cream">
-        <PageContainer width="index" className="py-8">
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group block transition-all duration-300 motion-safe:hover:translate-x-1 motion-safe:hover:translate-y-1"
-          >
-            {inner}
-          </a>
-        </PageContainer>
-      </div>
+      <PageContainer width="index" className="py-8">
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group block transition-all duration-300 motion-safe:hover:translate-x-1 motion-safe:hover:translate-y-1"
+        >
+          {inner}
+        </a>
+      </PageContainer>
     );
   }
 
   return (
-    <div className="bg-cream">
-      <PageContainer width="index" className="py-8">
-        {inner}
-      </PageContainer>
-    </div>
+    <PageContainer width="index" className="py-8">
+      {inner}
+    </PageContainer>
   );
 };

--- a/apps/web/src/components/search/SearchInterface.stories.tsx
+++ b/apps/web/src/components/search/SearchInterface.stories.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { within } from "storybook/test";
 import { SearchInterface } from "./SearchInterface";
 import type { SearchResponse } from "@/types/search";
 import { fixtureImage } from "@test-fixtures/images";
@@ -21,6 +22,18 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// The semantic augment lane (POST /api/search, `useSemanticAugment`) settles
+// AFTER the lexical GET renders the results, then prepends the "Slim antwoord"
+// card (above results) or appends the "Gerelateerd" list (below). Without
+// waiting, the VR screenshot races that second render and captures a
+// results-only frame — a large top/height diff (flaky, seen on #2282). Wait
+// for the settled semantic surface before the runner screenshots.
+const waitForSemantic =
+  (pattern: RegExp): NonNullable<Story["play"]> =>
+  async ({ canvasElement }) => {
+    await within(canvasElement).findByText(pattern, {}, { timeout: 5000 });
+  };
 
 // ---------------------------------------------------------------------------
 // Mock data
@@ -232,6 +245,7 @@ export const WithSmartAnswer: Story = {
   beforeEach() {
     return mockFetch(mockResponse, { semantic: smartAnswerResponse });
   },
+  play: waitForSemantic(/slim antwoord/i),
 };
 
 /**
@@ -250,6 +264,7 @@ export const WithRelated: Story = {
   beforeEach() {
     return mockFetch(mockResponse, { semantic: relatedResponse });
   },
+  play: waitForSemantic(/gerelateerd/i),
 };
 
 /**


### PR DESCRIPTION
## Problem

On the homepage, the first campaign banner sits directly under the A/B-team
matches section. That matches section **closes with a cream `StripedSeam`**.
`BannerSlot` painted its own full-bleed `bg-cream` band, so the banner echoed
the seam's cream and read as *attached to the matches block*, with a subtle
cream → gray-100 edge between the banner and the news grid below it.

## Change

Drop `BannerSlot`'s `bg-cream` wrapper. The banner now inherits its
`SectionStack` section's `gray-100` — the same background the news grid uses
(the news grid paints no background of its own). Banner + news grid now form
one continuous `gray-100` space, and the matches section stays cleanly closed
by its own seam.

This mirrors the established pattern: home section components (e.g. `NewsGrid`)
stay transparent and let the `SectionStack` wrapper own the background.

Affects all three banner slots (A/B/C) — all three sections already declare
`bg: "gray-100"`, so the component just stops fighting its section.

## Testing

- `pnpm --filter @kcvv/web check-all` — green.
- `BannerSlot.stories.tsx` is `autodocs`-only (no `vr` tag) → no VR baselines
  to update. The autodocs preview now renders on Storybook's default canvas
  instead of a cream band (cosmetic, no test impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
