### PR TITLE
test(studio): guard schema↔renderer + graft seams (#2278)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,6 +61,7 @@
     "yet-another-react-lightbox": "^3.32.0"
   },
   "devDependencies": {
+    "@kcvv/sanity-schemas": "workspace:*",
     "@playwright/test": "1.60.0",
     "@storybook/addon-a11y": "10.4.4",
     "@storybook/addon-docs": "10.4.4",

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.serializer-completeness.test.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.serializer-completeness.test.tsx
@@ -1,0 +1,209 @@
+import { render } from "@testing-library/react";
+import {
+  PortableText,
+  type PortableTextBlock,
+  type PortableTextComponents,
+} from "@portabletext/react";
+import { schemaTypes } from "@kcvv/sanity-schemas";
+import { describe, expect, it, vi } from "vitest";
+import { ArticleBody, buildComponents } from "./ArticleBody";
+
+/**
+ * Guard #1 (#2278) — serializer completeness for the ArticleBody surface.
+ *
+ * `<ArticleBody>` serializes `article.body` + `page.body` (the two fields with
+ * the largest `of:[]` surface). A body block type declared in the schema but
+ * missing from the serializer map renders NOTHING — the exact `qaSectionDivider`
+ * bug that shipped in #2275, which no unit test or type-check caught. This
+ * guard drives the check off the REAL schema `of:[]` (not a hand-maintained key
+ * table): every declared object type, annotation, and custom decorator must
+ * resolve to a handler, and a spy on Portable Text's `unknownType` /
+ * `unknownMark` must never fire. Deleting a serializer entry turns it red.
+ *
+ * Scope boundary (per issue): BioBlock / TeamEditorial (`player.bio`,
+ * `staffMember.bio`, `team.body`) are Normal-locked with a tiny `of:[]` and are
+ * NOT covered here — a deliberate future extension, noted so the gap is on the
+ * record rather than silent.
+ */
+
+// Loose views over the schema so this test needs no `sanity` type import.
+interface OfMember {
+  type?: string;
+  marks?: {
+    annotations?: Array<{ name?: string }>;
+    decorators?: Array<{ value?: string }>;
+  };
+}
+interface FieldLike {
+  name?: string;
+  of?: OfMember[];
+}
+interface SchemaLike {
+  name?: string;
+  fields?: FieldLike[];
+}
+
+const TYPES = schemaTypes as unknown as SchemaLike[];
+
+function bodyOf(typeName: string): OfMember[] {
+  const type = TYPES.find((t) => t.name === typeName);
+  const body = type?.fields?.find((f) => f.name === "body");
+  return Array.isArray(body?.of) ? body.of : [];
+}
+
+const objectTypes = (of: OfMember[]): string[] =>
+  of
+    .map((m) => m.type)
+    .filter((t): t is string => typeof t === "string" && t !== "block");
+
+const blockMember = (of: OfMember[]): OfMember | undefined =>
+  of.find((m) => m.type === "block");
+
+const annotationNames = (of: OfMember[]): string[] =>
+  (blockMember(of)?.marks?.annotations ?? [])
+    .map((a) => a.name)
+    .filter((n): n is string => typeof n === "string");
+
+// Sanity's built-in decorators are handled by @portabletext/react's defaults;
+// only project-custom decorators need an entry in our `marks` map.
+const DEFAULT_DECORATORS = new Set([
+  "strong",
+  "em",
+  "code",
+  "underline",
+  "strike-through",
+]);
+const customDecorators = (of: OfMember[]): string[] =>
+  (blockMember(of)?.marks?.decorators ?? [])
+    .map((d) => d.value)
+    .filter(
+      (v): v is string => typeof v === "string" && !DEFAULT_DECORATORS.has(v),
+    );
+
+// `transferFact` is routed by ArticleBody's adjacency segmenter
+// (`buildSegments` → `<TransferFactGroup>`), NOT the Portable Text `types` map,
+// so it is legitimately absent from the serializer map. Verified to still
+// render via `<ArticleBody>` in its own test below, so the exclusion is not a
+// silent hole.
+const SEGMENTER_HANDLED = new Set(["transferFact"]);
+
+const components = buildComponents({
+  subjects: null,
+  videoBlockPositions: new Map(),
+});
+
+describe.each([["article"], ["page"]])(
+  "ArticleBody serializer completeness — %s.body (#2278)",
+  (typeName) => {
+    const of = bodyOf(typeName);
+
+    it("has a non-empty body of:[] in the real schema", () => {
+      expect(of.length).toBeGreaterThan(0);
+    });
+
+    it("every Portable-Text-routed object type has a serializer", () => {
+      const types = components.types ?? {};
+      const missing = objectTypes(of).filter(
+        (t) => !SEGMENTER_HANDLED.has(t) && !(t in types),
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it("every annotation has a mark serializer", () => {
+      const marks = components.marks ?? {};
+      const missing = annotationNames(of).filter((n) => !(n in marks));
+      expect(missing).toEqual([]);
+    });
+
+    it("every custom decorator has a mark serializer", () => {
+      const marks = components.marks ?? {};
+      const missing = customDecorators(of).filter((n) => !(n in marks));
+      expect(missing).toEqual([]);
+    });
+  },
+);
+
+describe("ArticleBody serializer completeness — render integration (#2278)", () => {
+  it("no article.body type/annotation renders through the unknown fallback", () => {
+    const of = bodyOf("article");
+    const unknownType = vi.fn();
+    const unknownMark = vi.fn();
+    const spied: PortableTextComponents = {
+      ...components,
+      unknownType,
+      unknownMark,
+    };
+
+    const typeBlocks = objectTypes(of)
+      .filter((t) => !SEGMENTER_HANDLED.has(t))
+      .map((t, i) => ({ _type: t, _key: `type-${i}` }) as PortableTextBlock);
+
+    // One text block carrying every annotation (as markDefs) + custom decorator.
+    const annNames = annotationNames(of);
+    const decVals = customDecorators(of);
+    const markDefs = annNames.map((n, i) => ({ _type: n, _key: `md-${i}` }));
+    const textBlock = {
+      _type: "block",
+      _key: "marks",
+      style: "normal",
+      markDefs,
+      children: [
+        ...markDefs.map((md, i) => ({
+          _type: "span",
+          _key: `sa-${i}`,
+          text: "x",
+          marks: [md._key],
+        })),
+        ...decVals.map((v, i) => ({
+          _type: "span",
+          _key: `sd-${i}`,
+          text: "y",
+          marks: [v],
+        })),
+      ],
+    } as unknown as PortableTextBlock;
+
+    render(
+      <PortableText value={[textBlock, ...typeBlocks]} components={spied} />,
+    );
+
+    expect(unknownType).not.toHaveBeenCalled();
+    expect(unknownMark).not.toHaveBeenCalled();
+  });
+
+  it("segmenter-handled transferFact renders via ArticleBody (not dropped)", () => {
+    const { container } = render(
+      <ArticleBody
+        content={[
+          {
+            _type: "transferFact",
+            _key: "tf",
+            playerName: "Test Speler",
+          } as unknown as PortableTextBlock,
+        ]}
+      />,
+    );
+    expect(
+      container.querySelector("[data-transfer-fact-group]"),
+    ).not.toBeNull();
+  });
+
+  it("canary: removing the qaSectionDivider serializer trips unknownType", () => {
+    const types = { ...(components.types ?? {}) } as Record<string, unknown>;
+    delete types.qaSectionDivider;
+    const unknownType = vi.fn();
+    const spied = {
+      ...components,
+      types,
+      unknownType,
+    } as unknown as PortableTextComponents;
+
+    render(
+      <PortableText
+        value={[{ _type: "qaSectionDivider", _key: "q" } as PortableTextBlock]}
+        components={spied}
+      />,
+    );
+    expect(unknownType).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
@@ -564,7 +564,14 @@ interface ComponentsBuildArgs {
   videoBlockPositions: Map<string, number>;
 }
 
-function buildComponents({
+/**
+ * Builds the Portable Text serializer map for the body. Exported so the
+ * serializer-completeness guard (#2278) can assert every `article.body` /
+ * `page.body` `of:[]` type + mark declared in `@kcvv/sanity-schemas` has a
+ * handler here — a missing entry (the shipped `qaSectionDivider` bug) renders
+ * nothing, which no type-check catches.
+ */
+export function buildComponents({
   subjects,
   articleSlug,
   videoBlockPositions,

--- a/packages/sanity-studio/src/inputs/apply-decorator-components.test.ts
+++ b/packages/sanity-studio/src/inputs/apply-decorator-components.test.ts
@@ -8,6 +8,7 @@ import {
 import {schemaTypes as baseSchemaTypes} from '@kcvv/sanity-schemas'
 import {describe, expect, it} from 'vitest'
 import {applyDecoratorComponents} from './apply-decorator-components'
+import {collectBlockDecoratorComponents} from './collect-block-decorator-components'
 
 const Pullquote: ComponentType<BlockDecoratorProps> = () => null
 const Accent: ComponentType<BlockDecoratorProps> = () => null
@@ -118,47 +119,12 @@ describe('applyDecoratorComponents', () => {
   // accent → accent-title fields), not just the hand-rolled fixture above. If a
   // decorator `value` is renamed or dropped, this fails instead of a stale mock.
   describe('against the real @kcvv/sanity-schemas schema', () => {
-    // Collect every block decorator `component` for `value` across each
-    // top-level type's direct `field.of[]` — the reach of the helper.
-    const componentsFor = (
-      types: readonly SchemaTypeDefinition[],
-      value: string,
-    ): unknown[] => {
-      const out: unknown[] = []
-      for (const type of types) {
-        const fields = (type as {fields?: unknown[]}).fields
-        if (!Array.isArray(fields)) continue
-        for (const field of fields) {
-          const of = (field as {of?: unknown}).of
-          if (!Array.isArray(of)) continue
-          for (const member of of) {
-            // Block members only — mirror the helper's own traversal, which
-            // skips non-block members, so the collector's scope matches.
-            if (
-              !member ||
-              typeof member !== 'object' ||
-              (member as {type?: string}).type !== 'block'
-            ) {
-              continue
-            }
-            const decorators = (member as {marks?: {decorators?: unknown}})?.marks
-              ?.decorators
-            if (!Array.isArray(decorators)) continue
-            for (const d of decorators) {
-              if (d && typeof d === 'object' && (d as {value?: string}).value === value) {
-                out.push((d as {component?: unknown}).component)
-              }
-            }
-          }
-        }
-      }
-      return out
-    }
-
     it('grafts the real pullquote + accent decorators', () => {
       const grafted = applyDecoratorComponents(baseSchemaTypes, components)
-      const pullquotes = componentsFor(grafted, 'pullquote')
-      const accents = componentsFor(grafted, 'accent')
+      // Shared collector mirrors this helper's block-only traversal — see
+      // collect-block-decorator-components.ts (kept in one place, #2278).
+      const pullquotes = collectBlockDecoratorComponents(grafted, 'pullquote')
+      const accents = collectBlockDecoratorComponents(grafted, 'accent')
       expect(pullquotes.length).toBeGreaterThan(0)
       expect(accents.length).toBeGreaterThan(0)
       expect(pullquotes.every((c) => c === Pullquote)).toBe(true)

--- a/packages/sanity-studio/src/inputs/apply-decorator-components.test.ts
+++ b/packages/sanity-studio/src/inputs/apply-decorator-components.test.ts
@@ -5,6 +5,7 @@ import {
   defineField,
   defineType,
 } from 'sanity'
+import {schemaTypes as baseSchemaTypes} from '@kcvv/sanity-schemas'
 import {describe, expect, it} from 'vitest'
 import {applyDecoratorComponents} from './apply-decorator-components'
 
@@ -110,5 +111,58 @@ describe('applyDecoratorComponents', () => {
       }),
     ]
     expect(applyDecoratorComponents(input, components)).toEqual(input)
+  })
+
+  // De-drift (#2278): assert the graft lands on the real `pullquote` /`accent`
+  // decorators shipped by `@kcvv/sanity-schemas` (pullquote → bio/body fields,
+  // accent → accent-title fields), not just the hand-rolled fixture above. If a
+  // decorator `value` is renamed or dropped, this fails instead of a stale mock.
+  describe('against the real @kcvv/sanity-schemas schema', () => {
+    // Collect every block decorator `component` for `value` across each
+    // top-level type's direct `field.of[]` — the reach of the helper.
+    const componentsFor = (
+      types: readonly SchemaTypeDefinition[],
+      value: string,
+    ): unknown[] => {
+      const out: unknown[] = []
+      for (const type of types) {
+        const fields = (type as {fields?: unknown[]}).fields
+        if (!Array.isArray(fields)) continue
+        for (const field of fields) {
+          const of = (field as {of?: unknown}).of
+          if (!Array.isArray(of)) continue
+          for (const member of of) {
+            // Block members only — mirror the helper's own traversal, which
+            // skips non-block members, so the collector's scope matches.
+            if (
+              !member ||
+              typeof member !== 'object' ||
+              (member as {type?: string}).type !== 'block'
+            ) {
+              continue
+            }
+            const decorators = (member as {marks?: {decorators?: unknown}})?.marks
+              ?.decorators
+            if (!Array.isArray(decorators)) continue
+            for (const d of decorators) {
+              if (d && typeof d === 'object' && (d as {value?: string}).value === value) {
+                out.push((d as {component?: unknown}).component)
+              }
+            }
+          }
+        }
+      }
+      return out
+    }
+
+    it('grafts the real pullquote + accent decorators', () => {
+      const grafted = applyDecoratorComponents(baseSchemaTypes, components)
+      const pullquotes = componentsFor(grafted, 'pullquote')
+      const accents = componentsFor(grafted, 'accent')
+      expect(pullquotes.length).toBeGreaterThan(0)
+      expect(accents.length).toBeGreaterThan(0)
+      expect(pullquotes.every((c) => c === Pullquote)).toBe(true)
+      expect(accents.every((c) => c === Accent)).toBe(true)
+    })
   })
 })

--- a/packages/sanity-studio/src/inputs/apply-respondent-picker.test.ts
+++ b/packages/sanity-studio/src/inputs/apply-respondent-picker.test.ts
@@ -5,6 +5,7 @@ import {
   type SchemaTypeDefinition,
   type StringInputProps,
 } from 'sanity'
+import {schemaTypes as baseSchemaTypes} from '@kcvv/sanity-schemas'
 import {describe, expect, it} from 'vitest'
 import {applyRespondentPicker} from './apply-respondent-picker'
 
@@ -85,5 +86,22 @@ describe('applyRespondentPicker', () => {
     ]
     const result = applyRespondentPicker(input, StubComponent)
     expect(result).toEqual(input)
+  })
+
+  // De-drift (#2278): the hand-rolled `makeSchemaTypes` fixture above can
+  // diverge from the real schema — which is exactly how the #2275 bug slipped
+  // through (the fixture kept the old `qaPair.respondentKey` shape). Assert the
+  // graft lands on the schema actually shipped by `@kcvv/sanity-schemas`, so a
+  // rename of the type or field fails this test instead of a stale mock.
+  describe('against the real @kcvv/sanity-schemas schema', () => {
+    it('grafts components.input onto the real qaPairRespondent.respondentKey', () => {
+      const result = applyRespondentPicker(baseSchemaTypes, StubComponent)
+      const respondentType = result.find((t) => t.name === 'qaPairRespondent') as unknown as {
+        fields: Array<{name: string; components?: {input?: unknown}}>
+      }
+      expect(respondentType).toBeDefined()
+      const respondent = respondentType.fields.find((f) => f.name === 'respondentKey')
+      expect(respondent?.components?.input).toBe(StubComponent)
+    })
   })
 })

--- a/packages/sanity-studio/src/inputs/collect-block-decorator-components.ts
+++ b/packages/sanity-studio/src/inputs/collect-block-decorator-components.ts
@@ -1,0 +1,52 @@
+import type {SchemaTypeDefinition} from 'sanity'
+
+/**
+ * Shared TEST helper (#2278). Collects the `component` of every block decorator
+ * whose `value` matches, scanning each top-level type's direct `field.of[]`
+ * block members.
+ *
+ * Mirrors `applyDecoratorComponents`' own traversal exactly — it skips
+ * non-block members and does NOT recurse into nested object fields — so the
+ * graft-target guards that assert against it stay aligned with the helper's
+ * real reach in a single place. Keep this in lockstep with
+ * `apply-decorator-components.ts` if that traversal ever changes scope.
+ *
+ * Not re-exported from the package barrel; imported only by the decorator
+ * graft tests.
+ */
+export function collectBlockDecoratorComponents(
+  types: readonly SchemaTypeDefinition[],
+  value: string,
+): unknown[] {
+  const out: unknown[] = []
+  for (const type of types) {
+    const fields = (type as {fields?: unknown[]}).fields
+    if (!Array.isArray(fields)) continue
+    for (const field of fields) {
+      const of = (field as {of?: unknown}).of
+      if (!Array.isArray(of)) continue
+      for (const member of of) {
+        if (
+          !member ||
+          typeof member !== 'object' ||
+          (member as {type?: string}).type !== 'block'
+        ) {
+          continue
+        }
+        const decorators = (member as {marks?: {decorators?: unknown}})?.marks
+          ?.decorators
+        if (!Array.isArray(decorators)) continue
+        for (const d of decorators) {
+          if (
+            d &&
+            typeof d === 'object' &&
+            (d as {value?: string}).value === value
+          ) {
+            out.push((d as {component?: unknown}).component)
+          }
+        }
+      }
+    }
+  }
+  return out
+}

--- a/packages/sanity-studio/src/schema-types.test.ts
+++ b/packages/sanity-studio/src/schema-types.test.ts
@@ -10,6 +10,7 @@ import {describe, expect, it} from 'vitest'
 import {applyArticleTagsInput} from './inputs/apply-article-tags-input'
 import {applyDecoratorComponents} from './inputs/apply-decorator-components'
 import {applyRespondentPicker} from './inputs/apply-respondent-picker'
+import {collectBlockDecoratorComponents} from './inputs/collect-block-decorator-components'
 
 /**
  * Guard #2 (#2278) — graft-target completeness.
@@ -45,52 +46,6 @@ const findField = (
 ): Record<string, unknown> | undefined =>
   type?.fields?.find((f) => (f as {name?: string}).name === fieldName)
 
-/**
- * Collect the `component` of every block decorator whose `value` matches,
- * scanning each top-level type's direct `field.of[]` — the exact reach of
- * `applyDecoratorComponents` (it does not recurse into nested object fields),
- * so the assertion matches what the helper can actually graft.
- */
-function collectDecoratorComponents(
-  types: readonly SchemaTypeDefinition[],
-  value: string,
-): unknown[] {
-  const out: unknown[] = []
-  for (const type of types) {
-    const fields = (type as {fields?: unknown[]}).fields
-    if (!Array.isArray(fields)) continue
-    for (const field of fields) {
-      const of = (field as {of?: unknown}).of
-      if (!Array.isArray(of)) continue
-      for (const member of of) {
-        // Only block members carry decorators the helper grafts — mirror
-        // `applyDecoratorComponents`, which skips non-block members, so the
-        // collector's scope matches the helper's reach exactly.
-        if (
-          !member ||
-          typeof member !== 'object' ||
-          (member as {type?: string}).type !== 'block'
-        ) {
-          continue
-        }
-        const decorators = (member as {marks?: {decorators?: unknown}})?.marks
-          ?.decorators
-        if (!Array.isArray(decorators)) continue
-        for (const d of decorators) {
-          if (
-            d &&
-            typeof d === 'object' &&
-            (d as {value?: string}).value === value
-          ) {
-            out.push((d as {component?: unknown}).component)
-          }
-        }
-      }
-    }
-  }
-  return out
-}
-
 const TagsSentinel: ComponentType<ArrayOfPrimitivesInputProps<string>> = () => null
 const RespondentSentinel: ComponentType<StringInputProps> = () => null
 const PullquoteSentinel: ComponentType<BlockDecoratorProps> = () => null
@@ -125,18 +80,18 @@ describe('schema-types graft targets resolve against the real schema (#2278)', (
     // Both decorators must be declared somewhere reachable in the schema — else
     // the graft is a no-op. pullquote → bio/body fields, accent → title fields.
     expect(
-      collectDecoratorComponents(baseSchemaTypes, 'pullquote').length,
+      collectBlockDecoratorComponents(baseSchemaTypes, 'pullquote').length,
     ).toBeGreaterThan(0)
     expect(
-      collectDecoratorComponents(baseSchemaTypes, 'accent').length,
+      collectBlockDecoratorComponents(baseSchemaTypes, 'accent').length,
     ).toBeGreaterThan(0)
 
     const grafted = applyDecoratorComponents(baseSchemaTypes, {
       pullquote: PullquoteSentinel,
       accent: AccentSentinel,
     })
-    const pullquotes = collectDecoratorComponents(grafted, 'pullquote')
-    const accents = collectDecoratorComponents(grafted, 'accent')
+    const pullquotes = collectBlockDecoratorComponents(grafted, 'pullquote')
+    const accents = collectBlockDecoratorComponents(grafted, 'accent')
     expect(pullquotes.length).toBeGreaterThan(0)
     expect(accents.length).toBeGreaterThan(0)
     expect(pullquotes.every((c) => c === PullquoteSentinel)).toBe(true)

--- a/packages/sanity-studio/src/schema-types.test.ts
+++ b/packages/sanity-studio/src/schema-types.test.ts
@@ -1,0 +1,145 @@
+import type {ComponentType} from 'react'
+import type {
+  ArrayOfPrimitivesInputProps,
+  BlockDecoratorProps,
+  SchemaTypeDefinition,
+  StringInputProps,
+} from 'sanity'
+import {schemaTypes as baseSchemaTypes} from '@kcvv/sanity-schemas'
+import {describe, expect, it} from 'vitest'
+import {applyArticleTagsInput} from './inputs/apply-article-tags-input'
+import {applyDecoratorComponents} from './inputs/apply-decorator-components'
+import {applyRespondentPicker} from './inputs/apply-respondent-picker'
+
+/**
+ * Guard #2 (#2278) — graft-target completeness.
+ *
+ * Every `apply-*` helper grafts a Studio-only concern (an input `component`, a
+ * decorator render `component`) onto a `(type, field)` — or a decorator
+ * `value` — declared in `@kcvv/sanity-schemas`. Each helper is a *silent no-op*
+ * when its target is absent: it returns the input array unchanged. The exact
+ * bug this guards shipped in #2275 — `applyRespondentPicker` kept targeting
+ * `qaPair.respondentKey` after the field moved onto `qaPairRespondent`, so the
+ * picker silently never mounted, yet its unit test passed because the fixture
+ * still used the old shape (stale-mock drift).
+ *
+ * These tests run the real helpers against the REAL base schema with sentinel
+ * components and assert the sentinel actually landed. A rename that orphans a
+ * graft target turns the helper into a no-op → the sentinel never lands → the
+ * suite fails, pointing at the exact target that drifted.
+ *
+ * Mirrors the production graft composition in `schema-types.ts`.
+ */
+
+type Fielded = {name?: string; fields?: Array<Record<string, unknown>>}
+
+const findType = (
+  types: readonly SchemaTypeDefinition[],
+  name: string,
+): Fielded | undefined =>
+  types.find((t) => (t as {name?: string}).name === name) as Fielded | undefined
+
+const findField = (
+  type: Fielded | undefined,
+  fieldName: string,
+): Record<string, unknown> | undefined =>
+  type?.fields?.find((f) => (f as {name?: string}).name === fieldName)
+
+/**
+ * Collect the `component` of every block decorator whose `value` matches,
+ * scanning each top-level type's direct `field.of[]` — the exact reach of
+ * `applyDecoratorComponents` (it does not recurse into nested object fields),
+ * so the assertion matches what the helper can actually graft.
+ */
+function collectDecoratorComponents(
+  types: readonly SchemaTypeDefinition[],
+  value: string,
+): unknown[] {
+  const out: unknown[] = []
+  for (const type of types) {
+    const fields = (type as {fields?: unknown[]}).fields
+    if (!Array.isArray(fields)) continue
+    for (const field of fields) {
+      const of = (field as {of?: unknown}).of
+      if (!Array.isArray(of)) continue
+      for (const member of of) {
+        // Only block members carry decorators the helper grafts — mirror
+        // `applyDecoratorComponents`, which skips non-block members, so the
+        // collector's scope matches the helper's reach exactly.
+        if (
+          !member ||
+          typeof member !== 'object' ||
+          (member as {type?: string}).type !== 'block'
+        ) {
+          continue
+        }
+        const decorators = (member as {marks?: {decorators?: unknown}})?.marks
+          ?.decorators
+        if (!Array.isArray(decorators)) continue
+        for (const d of decorators) {
+          if (
+            d &&
+            typeof d === 'object' &&
+            (d as {value?: string}).value === value
+          ) {
+            out.push((d as {component?: unknown}).component)
+          }
+        }
+      }
+    }
+  }
+  return out
+}
+
+const TagsSentinel: ComponentType<ArrayOfPrimitivesInputProps<string>> = () => null
+const RespondentSentinel: ComponentType<StringInputProps> = () => null
+const PullquoteSentinel: ComponentType<BlockDecoratorProps> = () => null
+const AccentSentinel: ComponentType<BlockDecoratorProps> = () => null
+
+describe('schema-types graft targets resolve against the real schema (#2278)', () => {
+  it('applyArticleTagsInput lands on the real article.tags field', () => {
+    // Pre-check so a rename fails with "target missing" rather than a null deref.
+    expect(findField(findType(baseSchemaTypes, 'article'), 'tags')).toBeDefined()
+
+    const grafted = applyArticleTagsInput(baseSchemaTypes, TagsSentinel)
+    const tags = findField(findType(grafted, 'article'), 'tags') as {
+      components?: {input?: unknown}
+    }
+    expect(tags.components?.input).toBe(TagsSentinel)
+  })
+
+  it('applyRespondentPicker lands on the real qaPairRespondent.respondentKey field', () => {
+    expect(
+      findField(findType(baseSchemaTypes, 'qaPairRespondent'), 'respondentKey'),
+    ).toBeDefined()
+
+    const grafted = applyRespondentPicker(baseSchemaTypes, RespondentSentinel)
+    const key = findField(
+      findType(grafted, 'qaPairRespondent'),
+      'respondentKey',
+    ) as {components?: {input?: unknown}}
+    expect(key.components?.input).toBe(RespondentSentinel)
+  })
+
+  it('applyDecoratorComponents lands on the real pullquote + accent decorators', () => {
+    // Both decorators must be declared somewhere reachable in the schema — else
+    // the graft is a no-op. pullquote → bio/body fields, accent → title fields.
+    expect(
+      collectDecoratorComponents(baseSchemaTypes, 'pullquote').length,
+    ).toBeGreaterThan(0)
+    expect(
+      collectDecoratorComponents(baseSchemaTypes, 'accent').length,
+    ).toBeGreaterThan(0)
+
+    const grafted = applyDecoratorComponents(baseSchemaTypes, {
+      pullquote: PullquoteSentinel,
+      accent: AccentSentinel,
+    })
+    const pullquotes = collectDecoratorComponents(grafted, 'pullquote')
+    const accents = collectDecoratorComponents(grafted, 'accent')
+    expect(pullquotes.length).toBeGreaterThan(0)
+    expect(accents.length).toBeGreaterThan(0)
+    expect(pullquotes.every((c) => c === PullquoteSentinel)).toBe(true)
+    expect(accents.every((c) => c === AccentSentinel)).toBe(true)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
         specifier: ^3.32.0
         version: 3.32.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@kcvv/sanity-schemas':
+        specifier: workspace:*
+        version: link:../../packages/sanity-schemas
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0


### PR DESCRIPTION
Closes #2278

## Why

While fixing the first real interview (#2275) two integration-seam bugs shipped that **no unit test or type-check caught**:

- `qaSectionDivider` was a valid body block with **no frontend serializer** → rendered nothing.
- `applyRespondentPicker` targeted a **renamed field** (`qaPair.respondentKey` → `qaPairRespondent.respondentKey`) → silent no-op; its test passed because the fixture used the **old** shape (stale-mock drift).

This adds the regression net so the next schema rename or new block type can't silently reopen either hole. Post-go-live hardening — not a correctness bug today.

## Guard #2 — graft targets (`packages/sanity-studio`)

New `schema-types.test.ts` runs each `apply-*` helper against the **real** `@kcvv/sanity-schemas` base schema with sentinel components and asserts the sentinel actually landed. Each helper is a silent no-op when its target is absent, so an orphaned `(type, field)` — or decorator `value` — turns the guard red:

- `applyArticleTagsInput` → `article.tags`
- `applyRespondentPicker` → `qaPairRespondent.respondentKey`
- `applyDecoratorComponents` → the `pullquote` + `accent` decorators

`apply-respondent-picker.test.ts` + `apply-decorator-components.test.ts` de-drifted with a real-schema landing assertion each (the decorator collector mirrors the helper's block-only traversal exactly).

## Guard #1 — serializer completeness (`apps/web`)

`@kcvv/sanity-schemas` added as a **devDependency** (the frontend consumes generated TS types, but this guard needs the runtime schema array). New `ArticleBody.serializer-completeness.test.tsx` reads `article.body` + `page.body` `of:[]` from the real schema and asserts every declared object type, annotation, and custom decorator resolves to an `<ArticleBody>` serializer. A spy on `@portabletext/react`'s `unknownType` / `unknownMark` must never fire; **deleting the `qaSectionDivider` serializer turns it red** (verified). `buildComponents` exported for the guard.

`transferFact` is excluded from the Portable Text `types` check — it is routed by ArticleBody's adjacency segmenter, verified separately to still render.

### Scope boundary (recorded, per issue)

BioBlock / TeamEditorial serializer-completeness (`player.bio` / `staffMember.bio` / `team.body`) is deferred — Normal-locked, tiny `of:[]`. Noted in the test, not implemented here.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint + type-check + 3242 tests + build).
- `packages/sanity-studio` suite passes (228 tests) + type-check + lint clean.
- Teeth verified: orphaning a graft target reds Guard #2; deleting the `qaSectionDivider` serializer reds Guard #1.
- New `@kcvv/sanity-schemas` devDep edge is a minimal 3-line `pnpm-lock.yaml` addition (validated with `--frozen-lockfile`).

## Pre-PR review gate

- `/code-review` (high): two adversarial finder agents hunted false-pass holes. Guard #1 sound. Guard #2 found one — the decorator collector scanned all `of[]` members while the helper only grafts `type: "block"` members (a contrived non-block decorator could mask a real graft failure) → **fixed** by mirroring the helper's block-only traversal.
- `/simplify`: test-only diff; the small decorator-collector duplication across two test files is left deliberately (self-contained test code, 2 sites — a shared util would be over-structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared schema package to the web app’s dependencies.
* **Bug Fixes**
  * Improved safety around article Portable Text rendering by ensuring all schema-defined block types and marks/decorators have matching handlers.
  * Strengthened schema-aligned input/decorator grafting to better reflect live content.
* **Tests**
  * Expanded automated checks against the real schema to prevent regressions in article body rendering, decorator components, and schema graft helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->