### PR TITLE
fix(news): render body lists + h3-h6 headings, drop selectable h1

### DIFF
--- a/apps/web/src/components/article/ArticleBody/ArticleBody.serializer-completeness.test.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.serializer-completeness.test.tsx
@@ -29,6 +29,8 @@ import { ArticleBody, buildComponents } from "./ArticleBody";
 // Loose views over the schema so this test needs no `sanity` type import.
 interface OfMember {
   type?: string;
+  styles?: Array<{ value?: string }>;
+  lists?: Array<{ value?: string }>;
   marks?: {
     annotations?: Array<{ name?: string }>;
     decorators?: Array<{ value?: string }>;
@@ -80,6 +82,41 @@ const customDecorators = (of: OfMember[]): string[] =>
       (v): v is string => typeof v === "string" && !DEFAULT_DECORATORS.has(v),
     );
 
+// A `block` member that omits `lists` inherits Sanity's implicit bullet+number
+// defaults — the exact state of `article.body`, which is why an editor can add a
+// list the renderer must serialize. `lists: []` (bio/title blocks) opts out.
+const DEFAULT_LISTS = ["bullet", "number"];
+const listValues = (of: OfMember[]): string[] => {
+  const block = blockMember(of);
+  if (!block) return [];
+  if (block.lists === undefined) return DEFAULT_LISTS;
+  return block.lists
+    .map((l) => l.value)
+    .filter((v): v is string => typeof v === "string");
+};
+
+// A `block` member that omits `styles` inherits Sanity's default set. `normal`
+// renders through Portable Text's default <p>; every other style needs a `block`
+// serializer or it falls through as a bare, Preflight-stripped tag (flat text).
+const DEFAULT_STYLES = [
+  "normal",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "blockquote",
+];
+const styleValues = (of: OfMember[]): string[] => {
+  const block = blockMember(of);
+  if (!block) return [];
+  if (block.styles === undefined) return DEFAULT_STYLES;
+  return block.styles
+    .map((s) => s.value)
+    .filter((v): v is string => typeof v === "string");
+};
+
 // `transferFact` is routed by ArticleBody's adjacency segmenter
 // (`buildSegments` → `<TransferFactGroup>`), NOT the Portable Text `types` map,
 // so it is legitimately absent from the serializer map. Verified to still
@@ -118,6 +155,34 @@ describe.each([["article"], ["page"]])(
     it("every custom decorator has a mark serializer", () => {
       const marks = components.marks ?? {};
       const missing = customDecorators(of).filter((n) => !(n in marks));
+      expect(missing).toEqual([]);
+    });
+
+    // Lists live on the block's `lists` config, NOT the `of:[]` object surface —
+    // so the type/annotation/decorator guards above are blind to them. Without a
+    // `list`/`listItem` serializer, Tailwind Preflight strips the default ul/ol
+    // markers and lists render as flat text (the #shipped bug).
+    it("every list style has a list + listItem serializer", () => {
+      const values = listValues(of);
+      const list = (components.list ?? {}) as Record<string, unknown>;
+      const missing = values.filter((v) => !(v in list));
+      expect(missing).toEqual([]);
+      if (values.length > 0) expect(components.listItem).toBeDefined();
+    });
+
+    // Block styles (h1–h6, blockquote) live on the block's `styles` config, also
+    // outside the type/annotation/decorator surface. h1 must NOT be offered (the
+    // article title is the page's only <h1>); every other offered style must have
+    // a block serializer or it renders as flat text.
+    it("does not offer h1 (title is the only page <h1>)", () => {
+      expect(styleValues(of)).not.toContain("h1");
+    });
+
+    it("every non-normal block style has a block serializer", () => {
+      const block = (components.block ?? {}) as Record<string, unknown>;
+      const missing = styleValues(of).filter(
+        (v) => v !== "normal" && !(v in block),
+      );
       expect(missing).toEqual([]);
     });
   },
@@ -186,6 +251,42 @@ describe("ArticleBody serializer completeness — render integration (#2278)", (
     expect(
       container.querySelector("[data-transfer-fact-group]"),
     ).not.toBeNull();
+  });
+
+  it("bullet + numbered lists render with visible markers (Preflight-safe)", () => {
+    const { container } = render(
+      <ArticleBody
+        content={
+          [
+            {
+              _type: "block",
+              _key: "b1",
+              style: "normal",
+              listItem: "bullet",
+              level: 1,
+              markDefs: [],
+              children: [{ _type: "span", _key: "s1", text: "een", marks: [] }],
+            },
+            {
+              _type: "block",
+              _key: "b2",
+              style: "normal",
+              listItem: "number",
+              level: 1,
+              markDefs: [],
+              children: [
+                { _type: "span", _key: "s2", text: "twee", marks: [] },
+              ],
+            },
+          ] as unknown as PortableTextBlock[]
+        }
+      />,
+    );
+    // Bare <ul>/<ol> would render (Preflight kills their markers) — assert the
+    // explicit marker classes are present, which is what makes bullets visible.
+    expect(container.querySelector("ul")?.className).toContain("list-disc");
+    expect(container.querySelector("ol")?.className).toContain("list-decimal");
+    expect(container.querySelectorAll("li")).toHaveLength(2);
   });
 
   it("canary: removing the qaSectionDivider serializer trips unknownType", () => {

--- a/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
+++ b/apps/web/src/components/article/ArticleBody/ArticleBody.tsx
@@ -182,12 +182,17 @@ type PortableTextSpanLike = {
 type PortableTextBlockLike = {
   _type?: string;
   style?: string;
+  listItem?: string;
   children?: PortableTextSpanLike[];
 };
 
 function isNormalParagraph(block: PortableTextBlock): boolean {
   if (block._type !== "block") return false;
-  const style = (block as PortableTextBlockLike).style;
+  const b = block as PortableTextBlockLike;
+  // A list item carries style "normal" too — but it must render as a bullet,
+  // not get lifted into the drop-cap lead paragraph.
+  if (b.listItem !== undefined) return false;
+  const style = b.style;
   return style === undefined || style === "normal";
 }
 
@@ -578,8 +583,44 @@ export function buildComponents({
         if (!value) return null;
         return <QASectionDivider title={[value]} />;
       },
+      // h3–h6 are plain in-body subheadings. Preflight zeroes heading size,
+      // weight and margins, so each level restates its own scale — without
+      // this they'd render as flat body text (same failure mode as lists).
+      // h1 is not selectable in the schema: the article title is the only <h1>.
+      h3: ({ children }) => (
+        <h3 className="font-display text-ink mt-10 mb-3 text-2xl font-black">
+          {children}
+        </h3>
+      ),
+      h4: ({ children }) => (
+        <h4 className="font-display text-ink mt-8 mb-2 text-xl font-black">
+          {children}
+        </h4>
+      ),
+      h5: ({ children }) => (
+        <h5 className="font-display text-ink mt-6 mb-2 text-lg font-bold">
+          {children}
+        </h5>
+      ),
+      h6: ({ children }) => (
+        <h6 className="text-ink mt-6 mb-2 font-mono text-sm font-semibold tracking-[0.14em] uppercase">
+          {children}
+        </h6>
+      ),
       blockquote: ({ children }) => <BodyQuote>{children}</BodyQuote>,
     },
+    // Tailwind v4 Preflight strips list-style + padding from ul/ol; the body is
+    // not wrapped in `prose`, so lists need explicit markers/indent here or they
+    // render as flat text.
+    list: {
+      bullet: ({ children }) => (
+        <ul className="my-4 list-disc space-y-1 pl-6">{children}</ul>
+      ),
+      number: ({ children }) => (
+        <ol className="my-4 list-decimal space-y-1 pl-6">{children}</ol>
+      ),
+    },
+    listItem: ({ children }) => <li className="pl-1">{children}</li>,
     types: {
       pullQuote: ({ value }: { value: PullQuoteBlock }) =>
         renderPullQuote(value, subjects),

--- a/packages/sanity-schemas/src/article.ts
+++ b/packages/sanity-schemas/src/article.ts
@@ -268,6 +268,19 @@ export const article = defineType({
       of: [
         {
           type: "block",
+          // H1 is dropped so the article title stays the page's only <h1>.
+          // H2 renders as the section divider; H3–H6 as plain subheadings
+          // (all serialized in <ArticleBody>). Lists keep their bullet+number
+          // defaults (now serialized).
+          styles: [
+            { title: "Normaal", value: "normal" },
+            { title: "Tussentitel (groene divider)", value: "h2" },
+            { title: "Kop 3", value: "h3" },
+            { title: "Kop 4", value: "h4" },
+            { title: "Kop 5", value: "h5" },
+            { title: "Kop 6", value: "h6" },
+            { title: "Citaat", value: "blockquote" },
+          ],
           marks: {
             annotations: [
               {

--- a/packages/sanity-schemas/src/page.ts
+++ b/packages/sanity-schemas/src/page.ts
@@ -47,17 +47,20 @@ export const page = defineType({
       title: 'Body',
       type: 'array',
       group: 'inhoud',
-      // Styles locked to what <ArticleBody> intentionally styles (STUDIO-2):
-      // Normal, H2 (the green "act divider") and Blockquote. H1/H3–H6 are
-      // dropped from the dropdown because <ArticleBody> only overrides h2 +
-      // blockquote — the rest fall through to the default serializer as bare,
-      // unstyled heading tags. Lists keep their defaults.
+      // Styles match article.body: H1 is dropped so the page title stays the
+      // only <h1>. H2 renders as the section divider; H3–H6 as plain
+      // subheadings (all serialized in <ArticleBody>). Lists keep their
+      // bullet+number defaults (now serialized).
       of: [
         {
           type: 'block',
           styles: [
             {title: 'Normaal', value: 'normal'},
             {title: 'Tussentitel (groene divider)', value: 'h2'},
+            {title: 'Kop 3', value: 'h3'},
+            {title: 'Kop 4', value: 'h4'},
+            {title: 'Kop 5', value: 'h5'},
+            {title: 'Kop 6', value: 'h6'},
             {title: 'Citaat', value: 'blockquote'},
           ],
         },


### PR DESCRIPTION
## Problem

Article body content rendered `<ul>`/`<ol>` as **flat text — no bullets, no numbers**. Same root cause affected in-body headings.

`<ArticleBody>` renders Portable Text with **no `prose` wrapper**, and its `buildComponents()` config had **no `list`/`listItem` serializer** and no `h3`–`h6` block serializers. So `<ul>`/`<ol>`/`<li>` and `<h3>`–`<h6>` fell back to `@portabletext/react`'s bare, unclassed defaults — which Tailwind v4 Preflight strips (`list-style: none`, `padding: 0`, headings inherit font-size/weight). Result: flat text.

### Why the #2278 serializer-completeness guard missed it

The guard only walked the `of:[]` **object types** + block **annotations** + **decorators**. It was blind to the block's own **`styles`** and **`lists`** config — two whole rendering surfaces. `article.body` also declared no `styles`, so it inherited *all* Sanity defaults, making **h1** and unstyled **h3–h6** selectable in the editor.

## Changes

- **`ArticleBody.tsx`**
  - Add `list.bullet` / `list.number` + `listItem` serializers (the fix — markers now visible under Preflight).
  - Add `h3`–`h6` block serializers so in-body subheadings render with real size/weight/margins.
  - Guard `isNormalParagraph` so a list item that is the article's first block is no longer swallowed into the drop-cap lead paragraph.
- **`article.ts` / `page.ts`** — lock `body` styles to **Normaal / H2 (divider) / Kop 3–6 / Citaat**. **h1 is dropped** so the title stays the page's only `<h1>`; h2–h6 are all selectable and serialized. (`page.body` is rendered exclusively by `<ArticleBody>`, so headings/lists are styled everywhere it appears.)
- **Serializer-completeness guard** — extended to the two blind surfaces: every offered **list style** needs a `list`+`listItem` serializer, every non-`normal` **block style** needs a serializer, **h1 must not be offered**, plus a render test asserting bullets/numbers actually show. Would have caught all three defects.

## Scope note

`bio` / `team.body` surfaces (`/staf/[slug]`, player/team bodies) use separate **Normal-locked** renderers (`BioBlock` / `TeamEditorial` / `BestuurPage`) and are intentionally left unchanged (STUDIO-7).

## Testing

- `apps/web` ArticleBody suite: **57 passed** (incl. new list + style guards).
- `@kcvv/web` + `@kcvv/sanity-schemas` type-check clean; `@kcvv/web` lint clean.
- No VR baseline changes — no existing story renders lists or h3–h6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Article content now supports richer heading levels and clearer list rendering.
  * Bullet and numbered lists display with visible markers.
  * Additional subheading styles are available in article/page content editing.

* **Bug Fixes**
  * List items are no longer treated like normal paragraphs, so they won’t appear as part of the lead drop-cap paragraph.
  * Heading styles are handled more consistently, with the top-level page heading kept separate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->