### PR TITLE
chore(config): widen Renovate schedule to full Monday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -181,7 +181,7 @@
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on Monday"],
+    "schedule": ["before 11pm on monday"],
     "commitMessagePrefix": "🔧 ",
     "commitMessageAction": "chore(deps): update",
     "commitMessageTopic": "lock files"
@@ -198,6 +198,6 @@
   "postUpdateOptions": ["pnpmDedupe"],
   "prCreation": "immediate",
   "prConcurrentLimit": 3,
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 11pm on monday"],
   "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
## Problem

Renovate stopped opening PRs — "not even weekly" (dashboard #13). Diagnosis from GitHub-side evidence:

- Renovate **is** still running (dashboard #13 last edited `2026-07-09 06:41 UTC`; it rebased the open PR today). Config is valid (0 warnings).
- All ~17 update groups sit under **"Awaiting Schedule"** on the dashboard — that bucket means *outside the schedule window* (not rate-limited, not errored).
- Last batch created: `2026-06-28` UTC = the **Mon Jun 29** Brussels window. **Mon Jul 6 produced nothing.** Only 1 PR open (`#2273`), well under the limit of 3.

### Root cause

```json
"schedule": ["before 6am on monday"]
```

With `:timezone(Europe/Brussels)` that's a **~6h window once a week** (Sun 22:00 → Mon 04:00 UTC in summer); `lockFileMaintenance` was even tighter (~3h). Mend's hosted bot runs a few times a day with drifting timing, so many weeks no run lands inside the window and the whole batch is skipped.

## Change

Widen both windows to `before 11pm on monday` (~23h) so any Monday run catches it. Weekly-on-Monday cadence is preserved.

**Deliberately unchanged:**
- `prConcurrentLimit: 3` — the shared `pnpm-lock.yaml` means merging one dep PR conflicts/rebases the others → re-runs their CI. The low cap is what bounds that weekly churn. Not raised.
- `rebaseWhen: "conflicted"` — already the least-churny setting.

Validated with `renovate-config-validator` (passes).

## After merge

The backlog drains 3-at-a-time on Mondays (by design). To flush it once now, tick **"🔐 Create all awaiting schedule PRs at once"** on issue #13 — still respects the concurrency limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated update schedule to run later in the day on Mondays, reducing early-morning activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->