### PR TITLE
fix(search): respect editorial hotspot on BFF related-card covers

### DIFF
--- a/apps/api/src/search/index-text.ts
+++ b/apps/api/src/search/index-text.ts
@@ -1,3 +1,17 @@
+/**
+ * GROQ projection for an article's related-card cover image. Baked to a
+ * hotspot-aware 16:9 crop (mirrors RELATED_ARTICLES_QUERY in the web app,
+ * #2291) so the related-endpoint NewsCards respect the editorial hotspot
+ * instead of a centre object-cover that chops heads. Resolves to null when the
+ * article has no cover (`null + "…"` is null in GROQ). Shared by the full
+ * reindex (sanity-index-sync) and the per-doc webhook so they can't drift.
+ *
+ * ponytail: 16:9 baked in because handleRelated → NewsCard is the only
+ * consumer of this metadata; store separate hotspot fields if a second aspect
+ * ratio ever needs it.
+ */
+export const ARTICLE_COVER_IMAGE_PROJECTION = `"imageUrl": coverImage.asset->url + "?w=800&h=450&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(coverImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(coverImage.hotspot.y, 0.5))`;
+
 export function buildResponsibilityIndexText(doc: {
   title: string;
   question: string;

--- a/apps/api/src/search/sanity-index-sync.ts
+++ b/apps/api/src/search/sanity-index-sync.ts
@@ -4,6 +4,7 @@ import { WorkerEnvTag } from "../env";
 import { sanityClientConfig } from "../sanity/config";
 import { EmbeddingService } from "./embedding";
 import {
+  ARTICLE_COVER_IMAGE_PROJECTION,
   buildArticleIndexText,
   buildPageIndexText,
   buildResponsibilityIndexText,
@@ -54,7 +55,7 @@ const ARTICLE_QUERY = `*[_type == "article" && publishAt <= now() && (!defined(u
   title,
   "tags": coalesce(tags, []),
   "bodyText": pt::text(body),
-  "imageUrl": coverImage.asset->url
+  ${ARTICLE_COVER_IMAGE_PROJECTION}
 }`;
 
 const PAGE_QUERY = `*[_type == "page"] {

--- a/apps/api/src/webhooks/index-handler.ts
+++ b/apps/api/src/webhooks/index-handler.ts
@@ -5,6 +5,7 @@ import { WorkerEnvTag } from "../env";
 import { sanityClientConfig } from "../sanity/config";
 import { EmbeddingService, EmbeddingServiceLive } from "../search/embedding";
 import {
+  ARTICLE_COVER_IMAGE_PROJECTION,
   buildArticleIndexText,
   buildPageIndexText,
   buildResponsibilityIndexText,
@@ -101,7 +102,7 @@ const typeDescriptors: Record<AllowedType, TypeDescriptor> = {
     },
   },
   article: {
-    query: `*[_id == $id][0]{ _id, "slug": coalesce(slug.current,""), title, "tags": coalesce(tags,[]), "bodyText": pt::text(body), "imageUrl": coverImage.asset->url }`,
+    query: `*[_id == $id][0]{ _id, "slug": coalesce(slug.current,""), title, "tags": coalesce(tags,[]), "bodyText": pt::text(body), ${ARTICLE_COVER_IMAGE_PROJECTION} }`,
     buildIndex: (doc) => {
       const r = S.decodeUnknownSync(ArticleDoc)(doc);
       return {


### PR DESCRIPTION
## Problem

Follow-up to #2291. That PR fixed every **Sanity-side** cover URL (article/event/team/homepage repos, including `relatedArticles` / `relatedContent`), but the "Verder lezen." related cards still centre-crop and chop off heads:

![related cards ignoring hotspot](https://github.com/soniCaH/www.kcvvelewijt.be/assets/placeholder)

The reason: when an article has no editorially-curated `relatedArticles`, `/nieuws/[slug]` falls back to `bff.getRelated()`. Those cover URLs come from **Cloudflare Vectorize metadata**, which the BFF stores as a bare `coverImage.asset->url` — no crop params. `NewsCard`'s 16:9 `object-cover` then centre-crops it.

## Fix

Bake the same hotspot-aware 16:9 crop #2291 used into **both** BFF index paths, via one shared projection constant so they can't drift:

- `apps/api/src/search/index-text.ts` — new `ARTICLE_COVER_IMAGE_PROJECTION`
- `apps/api/src/search/sanity-index-sync.ts` — nightly full reindex
- `apps/api/src/webhooks/index-handler.ts` — per-doc save webhook

Vectorize metadata `imageUrl` is consumed **only** by `handleRelated` → `NewsCard` (search hits Sanity directly), so baking a fixed 16:9 crop is safe. Marked with a `ponytail:` note in case a second aspect ratio ever needs it.

## ⚠️ Requires a reindex

Existing vectors keep the old bare URL until re-indexed. After merge/deploy:
- **Automatic:** nightly cron `30 2 * * *` re-upserts every article; the webhook updates single docs on save.
- **Immediate (optional):** manually fire the scheduled worker (`--remote --test-scheduled`, cron `30 2 * * *`).

## Testing

- `tsgo` type-check clean, `eslint` clean
- 377 BFF tests pass (fetch is mocked, so the GROQ change is wiring-only — no test asserts the query string)

Part of #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved article cover images in search and related content by consistently applying editorial focal points.
  * Standardized cover-image cropping to a 16:9 format for more reliable visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->