### PR TITLE
fix(ui): stop nav in-page anchor links from duplicating the hash fragment

### DIFF
--- a/apps/web/src/components/layout/NavDropdown/NavDropdown.tsx
+++ b/apps/web/src/components/layout/NavDropdown/NavDropdown.tsx
@@ -14,6 +14,7 @@ import {
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
+import { handleSamePageAnchorClick } from "@/lib/utils/same-page-anchor";
 
 const OPEN_GRACE_MS = 80;
 const CLOSE_GRACE_MS = 200;
@@ -416,7 +417,10 @@ const NavDropdownRow = ({ item, variant, onClick }: NavDropdownRowProps) => (
       href={item.href}
       role="menuitem"
       aria-current={item.active ? "page" : undefined}
-      onClick={onClick}
+      onClick={(e) => {
+        handleSamePageAnchorClick(e, item.href);
+        onClick();
+      }}
       className={cn(
         "group/row flex items-center gap-2.5 font-mono text-[11px] font-semibold tracking-[0.06em] uppercase no-underline transition-colors",
         variant === "narrow" ? "py-2.5 pr-[18px] pl-[14px]" : "px-1 py-2",

--- a/apps/web/src/components/layout/NavTakeover/NavTakeoverItem.tsx
+++ b/apps/web/src/components/layout/NavTakeover/NavTakeoverItem.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
+import { handleSamePageAnchorClick } from "@/lib/utils/same-page-anchor";
 
 export interface NavTakeoverItemProps {
   label: string;
@@ -116,7 +117,10 @@ export function NavTakeoverItem({
   return (
     <Link
       href={href}
-      onClick={onNavigate}
+      onClick={(e) => {
+        handleSamePageAnchorClick(e, href);
+        onNavigate?.();
+      }}
       className={cn(baseRow, tone, "no-underline")}
     >
       {innerContent}

--- a/apps/web/src/lib/utils/same-page-anchor.test.ts
+++ b/apps/web/src/lib/utils/same-page-anchor.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MouseEvent } from "react";
+import { handleSamePageAnchorClick } from "./same-page-anchor";
+
+/** Minimal stand-in for the fields the handler reads off the click event. */
+function clickEvent(
+  overrides: Partial<MouseEvent<HTMLAnchorElement>> = {},
+): MouseEvent<HTMLAnchorElement> & {
+  preventDefault: ReturnType<typeof vi.fn>;
+} {
+  const preventDefault = vi.fn();
+  return {
+    defaultPrevented: false,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    preventDefault,
+    ...overrides,
+  } as unknown as MouseEvent<HTMLAnchorElement> & {
+    preventDefault: ReturnType<typeof vi.fn>;
+  };
+}
+
+function setUrl(url: string) {
+  window.history.replaceState(null, "", url);
+}
+
+function addSection(id: string): HTMLElement {
+  const el = document.createElement("section");
+  el.id = id;
+  el.scrollIntoView = vi.fn();
+  el.focus = vi.fn();
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  setUrl("/hulp");
+});
+
+describe("handleSamePageAnchorClick", () => {
+  it("intercepts a same-page anchor: scrolls, focuses, keeps a single fragment", () => {
+    const el = addSection("structuur");
+    setUrl("/hulp#structuur");
+    const event = clickEvent();
+
+    handleSamePageAnchorClick(event, "/hulp#structuur");
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(el.scrollIntoView).toHaveBeenCalledOnce();
+    expect(el.focus).toHaveBeenCalledWith({ preventScroll: true });
+    // The bug produced `#structuur#structuur…`; the fragment stays single.
+    expect(window.location.hash).toBe("#structuur");
+  });
+
+  it("self-heals an already-duplicated fragment", () => {
+    addSection("structuur");
+    setUrl("/hulp#structuur#structuur");
+    const event = clickEvent();
+
+    handleSamePageAnchorClick(event, "/hulp#structuur");
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(window.location.hash).toBe("#structuur");
+  });
+
+  it("ignores a cross-page anchor (keeps SPA navigation)", () => {
+    addSection("spelers");
+    setUrl("/hulp");
+    const event = clickEvent();
+
+    handleSamePageAnchorClick(event, "/ploegen/a-ploeg#spelers");
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores modifier clicks (new tab, etc.)", () => {
+    addSection("structuur");
+    setUrl("/hulp#structuur");
+    const event = clickEvent({ metaKey: true });
+
+    handleSamePageAnchorClick(event, "/hulp#structuur");
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores links without a hash", () => {
+    const event = clickEvent();
+    handleSamePageAnchorClick(event, "/hulp");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the target element is absent", () => {
+    setUrl("/hulp#structuur");
+    const event = clickEvent();
+    handleSamePageAnchorClick(event, "/hulp#structuur");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/utils/same-page-anchor.test.ts
+++ b/apps/web/src/lib/utils/same-page-anchor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { MouseEvent } from "react";
 import { handleSamePageAnchorClick } from "./same-page-anchor";
 
@@ -40,6 +40,10 @@ beforeEach(() => {
   setUrl("/hulp");
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("handleSamePageAnchorClick", () => {
   it("intercepts a same-page anchor: scrolls, focuses, keeps a single fragment", () => {
     const el = addSection("structuur");
@@ -55,15 +59,56 @@ describe("handleSamePageAnchorClick", () => {
     expect(window.location.hash).toBe("#structuur");
   });
 
-  it("self-heals an already-duplicated fragment", () => {
+  it("pushes a history entry for an ordinary section change (Back walks sections)", () => {
+    addSection("hulp");
     addSection("structuur");
-    setUrl("/hulp#structuur#structuur");
+    setUrl("/hulp#hulp");
+    const pushState = vi.spyOn(window.history, "pushState");
+    const replaceState = vi.spyOn(window.history, "replaceState");
     const event = clickEvent();
 
     handleSamePageAnchorClick(event, "/hulp#structuur");
 
     expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(pushState).toHaveBeenCalledOnce();
+    expect(replaceState).not.toHaveBeenCalled();
     expect(window.location.hash).toBe("#structuur");
+  });
+
+  it("self-heals an already-duplicated fragment in place (no history entry)", () => {
+    addSection("structuur");
+    setUrl("/hulp#structuur#structuur");
+    const pushState = vi.spyOn(window.history, "pushState");
+    const replaceState = vi.spyOn(window.history, "replaceState");
+    const event = clickEvent();
+
+    handleSamePageAnchorClick(event, "/hulp#structuur");
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(replaceState).toHaveBeenCalledOnce();
+    expect(pushState).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe("#structuur");
+  });
+
+  it("intercepts a same-query anchor", () => {
+    const el = addSection("spelers");
+    setUrl("/hulp?tab=teams");
+    const event = clickEvent();
+
+    handleSamePageAnchorClick(event, "/hulp?tab=teams#spelers");
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(el.scrollIntoView).toHaveBeenCalledOnce();
+  });
+
+  it("ignores an anchor to a different query string (keeps SPA navigation)", () => {
+    addSection("spelers");
+    setUrl("/hulp?tab=matches");
+    const event = clickEvent();
+
+    handleSamePageAnchorClick(event, "/hulp?tab=teams#spelers");
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
   });
 
   it("ignores a cross-page anchor (keeps SPA navigation)", () => {

--- a/apps/web/src/lib/utils/same-page-anchor.ts
+++ b/apps/web/src/lib/utils/same-page-anchor.ts
@@ -1,0 +1,50 @@
+import type { MouseEvent } from "react";
+
+/**
+ * Bypasses Next's App Router for in-page-anchor nav links that target the page
+ * we're already on (e.g. `/hulp#structuur`, `/ploegen/x#spelers`).
+ *
+ * When a page is hard-loaded with a hash already in the URL, Next seeds the
+ * route's `canonicalUrl` *with* that hash. A subsequent same-page `<Link>` click
+ * then computes `route.canonicalUrl + url.hash`, duplicating the fragment
+ * (`/hulp#structuur#structuur…`). Intercepting the click and scrolling natively
+ * sidesteps that path entirely. Cross-page links (different pathname) fall
+ * through to normal SPA `<Link>` navigation.
+ *
+ * Wire it into a `<Link onClick>`: it calls `preventDefault()` only for the
+ * same-page case, which cancels Next's navigation (Link skips navigating when
+ * the click's default was prevented).
+ *
+ * ponytail: only same-page anchors are intercepted; everything else is a no-op.
+ */
+export function handleSamePageAnchorClick(
+  event: MouseEvent<HTMLAnchorElement>,
+  href: string,
+): void {
+  if (event.defaultPrevented) return;
+  // Modifier / middle clicks: let the browser (new tab, etc.) handle it.
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+  const hashIndex = href.indexOf("#");
+  if (hashIndex === -1) return;
+  const path = href.slice(0, hashIndex);
+  const id = href.slice(hashIndex + 1);
+  if (!id) return;
+
+  // Cross-page anchor → keep client-side navigation.
+  if (path && path !== window.location.pathname) return;
+
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  event.preventDefault();
+  // Sync (and self-heal any already-duplicated) fragment without a router round
+  // trip. Passing the current history state keeps Next's internal `__NA` marker,
+  // so its patched `replaceState` treats this as an internal write and doesn't
+  // re-process the URL.
+  if (window.location.hash !== `#${id}`) {
+    window.history.replaceState(window.history.state, "", `#${id}`);
+  }
+  el.scrollIntoView({ behavior: "smooth" });
+  el.focus({ preventScroll: true });
+}

--- a/apps/web/src/lib/utils/same-page-anchor.ts
+++ b/apps/web/src/lib/utils/same-page-anchor.ts
@@ -8,8 +8,8 @@ import type { MouseEvent } from "react";
  * route's `canonicalUrl` *with* that hash. A subsequent same-page `<Link>` click
  * then computes `route.canonicalUrl + url.hash`, duplicating the fragment
  * (`/hulp#structuur#structuur…`). Intercepting the click and scrolling natively
- * sidesteps that path entirely. Cross-page links (different pathname) fall
- * through to normal SPA `<Link>` navigation.
+ * sidesteps that path entirely. Links to a different pathname or query string
+ * fall through to normal SPA `<Link>` navigation.
  *
  * Wire it into a `<Link onClick>`: it calls `preventDefault()` only for the
  * same-page case, which cancels Next's navigation (Link skips navigating when
@@ -25,25 +25,40 @@ export function handleSamePageAnchorClick(
   // Modifier / middle clicks: let the browser (new tab, etc.) handle it.
   if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 
-  const hashIndex = href.indexOf("#");
-  if (hashIndex === -1) return;
-  const path = href.slice(0, hashIndex);
-  const id = href.slice(hashIndex + 1);
-  if (!id) return;
+  const target = new URL(href, window.location.href);
+  if (!target.hash || target.hash === "#") return;
 
-  // Cross-page anchor → keep client-side navigation.
-  if (path && path !== window.location.pathname) return;
+  // Intercept only a genuine in-page scroll: same origin, pathname AND query.
+  // A different pathname or query (e.g. `/hulp?tab=teams#spelers` from
+  // `?tab=matches`) is a real navigation — leave it to Next's `<Link>`.
+  if (
+    target.origin !== window.location.origin ||
+    target.pathname !== window.location.pathname ||
+    target.search !== window.location.search
+  ) {
+    return;
+  }
 
+  const id = decodeURIComponent(target.hash.slice(1));
   const el = document.getElementById(id);
   if (!el) return;
 
   event.preventDefault();
-  // Sync (and self-heal any already-duplicated) fragment without a router round
-  // trip. Passing the current history state keeps Next's internal `__NA` marker,
-  // so its patched `replaceState` treats this as an internal write and doesn't
-  // re-process the URL.
-  if (window.location.hash !== `#${id}`) {
-    window.history.replaceState(window.history.state, "", `#${id}`);
+  // Sync the fragment without a router round trip. Passing the current history
+  // state keeps Next's internal `__NA` marker, so its patched push/replaceState
+  // treats this as an internal write and doesn't re-process the URL.
+  if (window.location.hash !== target.hash) {
+    // A duplicated/garbled fragment (`#structuur#structuur`, possibly
+    // `%23`-encoded) is repaired in place; an ordinary section change gets its
+    // own history entry so Back walks through sections like a native anchor.
+    const isRepair =
+      window.location.hash.startsWith(`${target.hash}#`) ||
+      window.location.hash.startsWith(`${target.hash}%23`);
+    if (isRepair) {
+      window.history.replaceState(window.history.state, "", target.hash);
+    } else {
+      window.history.pushState(window.history.state, "", target.hash);
+    }
   }
   el.scrollIntoView({ behavior: "smooth" });
   el.focus({ preventScroll: true });


### PR DESCRIPTION
## Problem

Clicking a main-navigation link that deep-links to an in-page anchor **on the page you are already on** duplicated the URL fragment. Opening **De club → Organigram** (`/hulp#structuur`) a second time produced `/hulp#structuur%23structuur%23structuur`, which no longer scrolled to the section.

Fixes #2304.

## Root cause

A Next.js 16 App Router quirk. When a page is **hard-loaded with a hash already in the URL** (`/hulp#structuur`), Next seeds the route's `canonicalUrl` *including* that hash. A subsequent same-page `<Link>` click to the same hash then computes `route.canonicalUrl + url.hash` (`segment-cache/navigation.js:156`), concatenating the fragment.

- Hashes added via *client-side* nav don't trigger it (verified).
- The in-page section nav is unaffected because it uses a native `<a href="#structuur">`, not a Next `<Link>`.
- Affects **all** hash-bearing nav links, including team sub-items (`/ploegen/<slug>#spelers`, `#wedstrijden`, `#klassement`).

## Fix

New `handleSamePageAnchorClick` util wired into the nav `<Link>`s. When the link targets an anchor on the **current** page it `preventDefault()`s (which cancels Next's navigation — see `link.js:319`) and scrolls natively instead, also self-healing an already-duplicated fragment. Cross-page links keep normal SPA navigation.

Wired into both render paths:
- `NavDropdown` (desktop dropdown rows)
- `NavTakeoverItem` (mobile takeover items)

## Verification

- Reproduced and root-caused against the live preview with a headless browser (the Chrome extension was unavailable).
- Verified the identical handler on the live `/hulp#structuur`: URL stays clean at `/hulp#structuur` across repeated clicks.
- New unit test `same-page-anchor.test.ts` (6 cases: intercept, self-heal, cross-page passthrough, modifier click, no-hash, missing element).
- `check-all` green: lint, type-check, 3283 unit tests, production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved same-page anchor navigation in dropdown and takeover menus.
  * Clicking an in-page link now smoothly focuses and scrolls to the target section while preserving the URL fragment.

* **Bug Fixes**
  * Prevented duplicated URL hash fragments during same-page navigation.
  * Preserved standard behavior for cross-page links, modifier-clicks, and unavailable targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->