### PR TITLE
fix(matches): render per-team fixtures page on every request

### DIFF
--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
@@ -20,10 +20,6 @@ interface WedstrijdenPageProps {
   params: Promise<{ slug: string }>;
 }
 
-export async function generateStaticParams() {
-  return [];
-}
-
 export async function generateMetadata({
   params,
 }: WedstrijdenPageProps): Promise<Metadata> {
@@ -217,4 +213,9 @@ export default async function WedstrijdenPage({
   );
 }
 
-export const revalidate = 3600;
+// Render on every request so the "next match" highlight and live scores
+// reflect the current time instead of a stale 1-hour ISR snapshot (this
+// low-traffic route rarely regenerated). PSD rate limits stay protected by
+// the BffService `getMatches` cache + TeamRepository caches underneath.
+// Mirrors `/kalender`, which is force-dynamic for the same reason.
+export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Summary

The per-team fixtures page (`/ploegen/[slug]/wedstrijden`) baked `now` (`const now = new Date()`) and match scores into a **1-hour ISR snapshot** (`export const revalidate = 3600`). Because this is a low-traffic route, that snapshot rarely regenerated — so the page served a **stale "next match" highlight** and **missing/outdated scores** long after kickoff.

## Fix

- Replace `export const revalidate = 3600` with `export const dynamic = "force-dynamic"`, so `now` and scores reflect **each request**. This mirrors the club-wide calendar (`/kalender`), which is already `force-dynamic` for exactly this reason (`apps/web/src/app/(main)/kalender/page.tsx`).
- Remove the now-inert `generateStaticParams` (it returned `[]` and is ignored under `force-dynamic`).

PSD rate limits stay protected by the existing caches underneath — `BffService.getMatches` (300s `unstable_cache`) and the `TeamRepository` caches — which are untouched. The longer-term `revalidateTag` idea mentioned in the issue is intentionally **not** implemented here; this is the minimal `force-dynamic` swap.

## How verified

A route-segment config flag isn't meaningfully unit-testable, so verification is by build output + reasoning:

- `pnpm --filter @kcvv/web run check-all` (lint + type-check + test + build) passes.
- The production build now reports the route as **`ƒ /ploegen/[slug]/wedstrijden`** — `ƒ (Dynamic) server-rendered on demand` — instead of an ISR entry, confirming per-request rendering.
- The existing e2e smoke coverage (`apps/web/test/e2e/wedstrijden.spec.ts`) asserts only structural rendering (HTTP 200, `<h1>` "Wedstrijden", next-match anchor count) — none of which depends on ISR vs `force-dynamic` — so it remains valid.

Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Match pages now refresh on every visit, keeping next-match highlights and live-score information up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->