### PR TITLE
fix(matches): stop match-detail loading skeleton from overflowing on mobile

### DIFF
--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.test.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Match Detail Loading Skeleton — Mobile Overflow Guard
+ *
+ * Regression guard for #2299: the scoreboard row hard-coded fixed-width
+ * placeholders (`w-10` crest + `w-32` name) with no `min-w-0` / `shrink-0`, so
+ * each `1fr` grid track's min-content (~180px) floored the row near 456px and
+ * forced horizontal scroll at 320/375/414. The real `MatchHero` `TeamSlot`
+ * shrinks below its content via `min-w-0` rows, `shrink-0` crests, and a
+ * `min-w-0 flex-1` truncating name — the skeleton must mirror that.
+ *
+ * jsdom cannot measure layout, so this asserts the shrink-enabling classes are
+ * present rather than pixel widths. The overflow itself was verified in a
+ * headless Chromium (`document.scrollingElement.scrollWidth === innerWidth` at
+ * 320/375/414) — see the PR description.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import WedstrijdLoading from "./loading";
+
+/** The two `flex` team-slot rows inside the `1fr_auto_1fr` scoreboard grid. */
+function getTeamRows(container: HTMLElement): HTMLElement[] {
+  const scoreboard = container.querySelector<HTMLElement>(
+    '[class*="1fr_auto_1fr"]',
+  );
+  expect(scoreboard).not.toBeNull();
+  return Array.from(
+    scoreboard!.querySelectorAll<HTMLElement>(":scope > div"),
+  ).filter((el) => el.className.split(/\s+/).includes("flex"));
+}
+
+describe("Match detail loading skeleton — scoreboard overflow guard", () => {
+  it("renders two team-slot rows that can shrink below content width (min-w-0)", () => {
+    const { container } = render(<WedstrijdLoading />);
+    const rows = getTeamRows(container);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.className.split(/\s+/)).toContain("min-w-0");
+    }
+  });
+
+  it("keeps team crest placeholders at a fixed size (shrink-0)", () => {
+    const { container } = render(<WedstrijdLoading />);
+    for (const row of getTeamRows(container)) {
+      const crest = row.querySelector<HTMLElement>(".rounded-full");
+      expect(crest).not.toBeNull();
+      expect(crest!.className.split(/\s+/)).toContain("shrink-0");
+    }
+  });
+
+  it("lets team-name placeholders flex instead of a fixed w-32", () => {
+    const { container } = render(<WedstrijdLoading />);
+    for (const row of getTeamRows(container)) {
+      const name = Array.from(
+        row.querySelectorAll<HTMLElement>(":scope > div"),
+      ).find((el) => !el.className.includes("rounded-full"));
+      expect(name).not.toBeUndefined();
+      const tokens = name!.className.split(/\s+/);
+      expect(tokens).toContain("flex-1");
+      expect(tokens).toContain("min-w-0");
+      // The fixed width that caused the overflow must be gone (max-w-32 is fine).
+      expect(tokens).not.toContain("w-32");
+    }
+  });
+});

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/loading.tsx
@@ -58,14 +58,14 @@ export default function MatchDetailLoading() {
           <div className="flex flex-col gap-6 p-5 md:p-6">
             <div className="bg-cream-soft h-3 w-32" />
             <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4">
-              <div className="flex items-center gap-3">
-                <div className="bg-cream-deep h-10 w-10 rounded-full" />
-                <div className="bg-cream-deep h-5 w-32" />
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="bg-cream-deep h-10 w-10 shrink-0 rounded-full" />
+                <div className="bg-cream-deep h-5 max-w-32 min-w-0 flex-1" />
               </div>
               <div className="bg-cream-deep h-8 w-16" />
-              <div className="flex flex-row-reverse items-center gap-3">
-                <div className="bg-cream-deep h-10 w-10 rounded-full" />
-                <div className="bg-cream-deep h-5 w-32" />
+              <div className="flex min-w-0 flex-row-reverse items-center gap-3">
+                <div className="bg-cream-deep h-10 w-10 shrink-0 rounded-full" />
+                <div className="bg-cream-deep h-5 max-w-32 min-w-0 flex-1" />
               </div>
             </div>
             <div className="border-ink border-t pt-3">


### PR DESCRIPTION
## Problem

On mobile, the `/wedstrijd/[matchId]` **loading skeleton** was wider than the viewport and caused horizontal scroll. The loaded page rendered fine — only the skeleton overflowed.

Root cause (verified against `main`): the skeleton's scoreboard row uses `grid-cols-[1fr_auto_1fr]` with fixed-width placeholders (`w-10` crest + `w-32` name) and **no** `min-w-0` / `shrink-0`. Each side track's min-content (~180px) floored the row near 456px, overflowing at 320 / 375 / 414. The real `MatchHero` `TeamSlot` doesn't overflow because it already uses `min-w-0` rows, `shrink-0` crests, and a `min-w-0 flex-1 truncate` name.

## Fix

Mirror `MatchHero`'s `TeamSlot` in the skeleton's scoreboard row:

- `min-w-0` on each of the two team-slot flex rows.
- `shrink-0` on the two crest placeholders (`h-10 w-10 rounded-full`).
- name placeholders `h-5 w-32` → `h-5 min-w-0 max-w-32 flex-1` (fluid, capped, collapsible).

## Verification

- `check-all` (lint + type-check + build) green. Full vitest green apart from two unrelated cold-import timeout flakes (`not-found.test.ts`, `jeugd/page.test.tsx`) that pass in isolation with an adequate `--testTimeout` — neither touches this route.
- Added a colocated regression test (`loading.test.tsx`) asserting the shrink-enabling classes are present. jsdom/happy-dom can't measure layout, so the overflow itself was verified in headless Chromium: `document.scrollingElement.scrollWidth === window.innerWidth` at 320 / 375 / 414.

## VR baselines

None. Loading skeletons are not visual-regression tracked, so no baselines change. The existing `loading-envelope.test.tsx` root-className contract (`min-h-screen`) is untouched.

Closes #2299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
