### PR TITLE
fix(matches): serve finished match reports without stale preview pinning (#2303)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -76,16 +76,16 @@ wrangler secret put RESEND_API_KEY --env staging
 
 Values are stored as `{ value, fetchedAt }` wrappers. On deploy, existing cache entries without the wrapper trigger a one-time cold start.
 
-| Key pattern                          | softTtl                                             | hardTtl |
-| ------------------------------------ | --------------------------------------------------- | ------- |
-| `psd:current-season-id`              | 24 h                                                | 7 days  |
-| `matches:team:{id}`                  | 24 h                                                | 7 days  |
-| `matches:next`                       | 4 h                                                 | 7 days  |
-| `match:detail:{id}`                  | 7 days (finished ≥48h ago) / 24 h (all other cases) | 7 days  |
-| `ranking:team:{id}`                  | 24 h                                                | 7 days  |
-| `stats:team:{id}`                    | 24 h                                                | 7 days  |
-| `stats:player:{memberId}:{seasonId}` | 6 h                                                 | 7 days  |
-| `psd:calls:YYYY-MM-DD`               | 48 h (daily PSD call counter, not via TypedKvCache) | —       |
+| Key pattern                          | softTtl                                                                                                                                                                                                                                                                                                                                                   | hardTtl |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `psd:current-season-id`              | 24 h                                                                                                                                                                                                                                                                                                                                                      | 7 days  |
+| `matches:team:{id}`                  | 24 h                                                                                                                                                                                                                                                                                                                                                      | 7 days  |
+| `matches:next`                       | 4 h                                                                                                                                                                                                                                                                                                                                                       | 7 days  |
+| `match:detail:{id}`                  | proximity-based: 7 days (settled ≥48h ago w/ report) · 60 s (<3h of kickoff) · 5 min (<24h) · 1 h (<7d) · 24 h (distant). Report-pending override: a past match still missing its report (PSD `hasReport` set, or <48h since kickoff) is capped at 5 min so the report self-heals instead of being pinned. See `matchDetailTtl` in `handlers/matches.ts`. | 7 days  |
+| `ranking:team:{id}`                  | 24 h                                                                                                                                                                                                                                                                                                                                                      | 7 days  |
+| `stats:team:{id}`                    | 24 h                                                                                                                                                                                                                                                                                                                                                      | 7 days  |
+| `stats:player:{memberId}:{seasonId}` | 6 h                                                                                                                                                                                                                                                                                                                                                       | 7 days  |
+| `psd:calls:YYYY-MM-DD`               | 48 h (daily PSD call counter, not via TypedKvCache)                                                                                                                                                                                                                                                                                                       | —       |
 
 ## Cache invalidation
 

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -277,83 +277,138 @@ describe("matchDetailTtl", () => {
   const at = (offsetMs: number) => new Date(now + offsetMs);
   const H = 60 * 60 * 1000;
 
+  // A match WITH report data exercises the pure proximity ladder — the
+  // report-pending override never fires, so these assert the base tiers.
+  const settled = { hasReportData: true, hasReport: true };
+  // Preview-shaped: past kickoff, no report data. `hasReport` distinguishes
+  // "PSD says a report exists upstream" from "genuinely reportless".
+  const previewFlagged = { hasReportData: false, hasReport: true };
+  const previewReportless = { hasReportData: false, hasReport: false };
+
   it("settled ≥48h ago → 7 days (immutable)", () => {
-    expect(matchDetailTtl(at(-3 * 24 * H), "finished", now)).toBe(
+    expect(matchDetailTtl(at(-3 * 24 * H), "finished", settled, now)).toBe(
       TTL.MATCH_DETAIL_PAST,
     );
-    expect(matchDetailTtl(at(-3 * 24 * H), "forfeited", now)).toBe(
+    expect(matchDetailTtl(at(-3 * 24 * H), "forfeited", settled, now)).toBe(
       TTL.MATCH_DETAIL_PAST,
     );
   });
 
   it("within 3h of kickoff → live (60s), even when just finished", () => {
-    expect(matchDetailTtl(at(0), "in_progress", now)).toBe(
+    expect(matchDetailTtl(at(0), "in_progress", settled, now)).toBe(
       TTL.MATCH_DETAIL_LIVE,
     );
-    expect(matchDetailTtl(at(-1 * H), "finished", now)).toBe(
+    expect(matchDetailTtl(at(-1 * H), "finished", settled, now)).toBe(
       TTL.MATCH_DETAIL_LIVE,
     );
   });
 
   it("3h–24h from kickoff → matchday (300s)", () => {
-    expect(matchDetailTtl(at(10 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(10 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_MATCHDAY,
     );
   });
 
   it("1d–7d from kickoff → this week (3600s)", () => {
-    expect(matchDetailTtl(at(3 * 24 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(3 * 24 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_WEEK,
     );
   });
 
   it("beyond 7d (past or future) → distant (24h)", () => {
-    expect(matchDetailTtl(at(10 * 24 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(10 * 24 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_DEFAULT,
     );
-    expect(matchDetailTtl(at(-10 * 24 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(-10 * 24 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_DEFAULT,
     );
   });
 
   // Exact tier cutoffs — guard the < vs >= comparisons against off-by-one.
   it("48h-finished cutoff (>= is PAST)", () => {
-    expect(matchDetailTtl(at(-48 * H), "finished", now)).toBe(
+    expect(matchDetailTtl(at(-48 * H), "finished", settled, now)).toBe(
       TTL.MATCH_DETAIL_PAST, // exactly 48h ago → immutable
     );
-    expect(matchDetailTtl(at(-48 * H - 1), "finished", now)).toBe(
+    expect(matchDetailTtl(at(-48 * H - 1), "finished", settled, now)).toBe(
       TTL.MATCH_DETAIL_PAST, // just over 48h → immutable
     );
-    expect(matchDetailTtl(at(-48 * H + 1), "finished", now)).toBe(
+    expect(matchDetailTtl(at(-48 * H + 1), "finished", settled, now)).toBe(
       TTL.MATCH_DETAIL_WEEK, // just under 48h → not yet immutable, ~48h distance
     );
   });
 
   it("3h cutoff (< is LIVE)", () => {
-    expect(matchDetailTtl(at(3 * H - 1), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(3 * H - 1), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_LIVE,
     );
-    expect(matchDetailTtl(at(3 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(3 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_MATCHDAY,
     );
   });
 
   it("24h cutoff (< is MATCHDAY)", () => {
-    expect(matchDetailTtl(at(24 * H - 1), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(24 * H - 1), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_MATCHDAY,
     );
-    expect(matchDetailTtl(at(24 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(24 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_WEEK,
     );
   });
 
   it("7d cutoff (< is WEEK)", () => {
-    expect(matchDetailTtl(at(7 * 24 * H - 1), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(7 * 24 * H - 1), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_WEEK,
     );
-    expect(matchDetailTtl(at(7 * 24 * H), "scheduled", now)).toBe(
+    expect(matchDetailTtl(at(7 * 24 * H), "scheduled", settled, now)).toBe(
       TTL.MATCH_DETAIL_DEFAULT,
     );
+  });
+
+  it("defaults to the proximity ladder when report state is omitted", () => {
+    expect(matchDetailTtl(at(-3 * 24 * H), "finished", undefined, now)).toBe(
+      TTL.MATCH_DETAIL_PAST,
+    );
+  });
+
+  // Report-pending override — a past match still missing its report must not be
+  // pinned behind a long TTL (the "finished match shows preview" bug, #2303).
+  describe("report-pending override", () => {
+    it("caps a just-finished match with no report at matchday cadence", () => {
+      // 30h ago, backfilled to finished but /info still preview-shaped: without
+      // the override this would be WEEK (3600s); the grace window shortens it.
+      expect(
+        matchDetailTtl(at(-30 * H), "finished", previewReportless, now),
+      ).toBe(TTL.MATCH_DETAIL_MATCHDAY);
+    });
+
+    it("keeps re-checking a settled-looking match while PSD flags a report exists", () => {
+      // ≥48h ago (would be PAST=7d) but hasReport=true and no report data yet →
+      // our snapshot missed it; keep polling on a matchday cadence.
+      expect(
+        matchDetailTtl(at(-5 * 24 * H), "finished", previewFlagged, now),
+      ).toBe(TTL.MATCH_DETAIL_MATCHDAY);
+    });
+
+    it("does not over-shorten a live match already under matchday (keeps 60s)", () => {
+      // 1h after kickoff, no report yet → still LIVE (min(60s, 300s) = 60s).
+      expect(
+        matchDetailTtl(at(-1 * H), "finished", previewReportless, now),
+      ).toBe(TTL.MATCH_DETAIL_LIVE);
+    });
+
+    it("backs off for a reportless match beyond 48h with no report flag", () => {
+      // 5 days ago, no report, hasReport=false → genuinely reportless, cache
+      // long (PAST=7d) rather than polling forever.
+      expect(
+        matchDetailTtl(at(-5 * 24 * H), "finished", previewReportless, now),
+      ).toBe(TTL.MATCH_DETAIL_PAST);
+    });
+
+    it("does not fire for a future match without report data", () => {
+      expect(
+        matchDetailTtl(at(10 * H), "scheduled", previewReportless, now),
+      ).toBe(TTL.MATCH_DETAIL_MATCHDAY);
+    });
   });
 });
 

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -9,6 +9,7 @@ import {
   type PlayerSeasonStats as PlayerSeasonStatsType,
 } from "@kcvv/api-contract";
 import { PsdService } from "../psd/service";
+import { isSettledMatchStatus } from "../psd/transforms";
 import { shouldServeStale, type BffError } from "../psd/errors";
 import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
@@ -82,25 +83,17 @@ export const getMatchesWindowHandler = (): Effect.Effect<
 
 const HOUR_MS = 60 * 60 * 1000;
 
-/**
- * Soft cache TTL (seconds) for a match-detail response, derived from kickoff
- * proximity. The rate-limited PSD hop is then refreshed often only when it
- * matters (live / matchday) and rarely for distant or settled matches.
- *
- *   finished ≥48h ago → 7d   (immutable)
- *   |kickoff − now| < 3h → 60s   (live)
- *                   < 24h → 300s  (matchday)
- *                   < 7d  → 3600s (this week)
- *   else              → 24h  (distant)
- */
-export function matchDetailTtl(
-  date: Date,
-  status: string,
-  now: number = Date.now(),
-): number {
-  const kickoff = new Date(date).getTime();
-  const finished = status === "finished" || status === "forfeited";
+/** True when the detail already carries report data (a non-empty lineup or events). */
+export function hasMatchReportData(detail: MatchDetail): boolean {
+  const lineup = detail.lineup;
+  const hasLineup =
+    lineup !== undefined && (lineup.home.length > 0 || lineup.away.length > 0);
+  const hasEvents = detail.events !== undefined && detail.events.length > 0;
+  return hasLineup || hasEvents;
+}
 
+/** Base TTL tier from kickoff proximity (before the report-pending override). */
+function proximityTtl(kickoff: number, finished: boolean, now: number): number {
   if (finished && now - kickoff >= 48 * HOUR_MS) return TTL.MATCH_DETAIL_PAST;
 
   const distanceMs = Math.abs(kickoff - now);
@@ -108,6 +101,53 @@ export function matchDetailTtl(
   if (distanceMs < 24 * HOUR_MS) return TTL.MATCH_DETAIL_MATCHDAY;
   if (distanceMs < 7 * 24 * HOUR_MS) return TTL.MATCH_DETAIL_WEEK;
   return TTL.MATCH_DETAIL_DEFAULT;
+}
+
+/** Report state of a match detail, feeding the report-pending TTL override. */
+interface MatchReportState {
+  /** True when the detail already carries a non-empty lineup or events. */
+  hasReportData: boolean;
+  /** PSD's own `viewGameReport` flag — a report exists upstream. */
+  hasReport: boolean;
+}
+
+/**
+ * Soft cache TTL (seconds) for a match-detail response, derived from kickoff
+ * proximity. The rate-limited PSD hop is then refreshed often only when it
+ * matters (live / matchday) and rarely for distant or settled matches.
+ *
+ *   finished ≥48h ago (with report) → 7d   (immutable)
+ *   |kickoff − now| < 3h → 60s   (live)
+ *                   < 24h → 300s  (matchday)
+ *                   < 7d  → 3600s (this week)
+ *   else              → 24h  (distant)
+ *
+ * Report-pending override: PSD publishes the match report (lineups / events) a
+ * few hours after full-time, so a past match whose `/info` payload is still
+ * preview-shaped (no report data) is a stale snapshot, not settled data. While
+ * a report is still expected — PSD's own `hasReport` flag is set (it exists
+ * upstream, our snapshot just missed it) or we are within 48h of kickoff (grace
+ * window for it to appear) — cap the TTL at a matchday cadence so the report
+ * self-heals within minutes instead of being pinned behind the 7d / weekly TTL.
+ *
+ * `report` defaults to "settled with report" so a caller that only cares about
+ * proximity gets the base ladder.
+ */
+export function matchDetailTtl(
+  date: Date,
+  status: string,
+  report: MatchReportState = { hasReportData: true, hasReport: false },
+  now: number = Date.now(),
+): number {
+  const kickoff = new Date(date).getTime();
+  const natural = proximityTtl(kickoff, isSettledMatchStatus(status), now);
+
+  const reportPending =
+    now > kickoff &&
+    !report.hasReportData &&
+    (report.hasReport || now - kickoff < 48 * HOUR_MS);
+
+  return reportPending ? Math.min(natural, TTL.MATCH_DETAIL_MATCHDAY) : natural;
 }
 
 export const getMatchDetailHandler = (
@@ -126,7 +166,11 @@ export const getMatchDetailHandler = (
   return matchDetailCache.getOrFetch(
     cacheKey,
     fetchDetail,
-    (detail) => matchDetailTtl(detail.date, detail.status),
+    (detail) =>
+      matchDetailTtl(detail.date, detail.status, {
+        hasReportData: hasMatchReportData(detail),
+        hasReport: detail.hasReport,
+      }),
     undefined,
     { shouldServeStale },
   );

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -36,7 +36,7 @@ const cacheMock: KvCacheInterface = {
   // /competitions, /teams and season-games requests.
   get: (key: string) =>
     Effect.succeed(
-      key === "psd:competition-labels" || key === "psd:match-team-index"
+      key === "psd:competition-labels" || key === "psd:match-team-index:v2"
         ? "{}"
         : null,
     ),
@@ -1267,6 +1267,137 @@ describe("PsdService.getMatchDetail", () => {
   });
 });
 
+describe("PsdService.getMatchDetail — status/score backfill from season list", () => {
+  // A preview-shaped `/info` payload: match played, but the report hasn't
+  // populated yet — null goals ⇒ status derived as "scheduled".
+  const previewDetailResponse = {
+    general: {
+      id: 99,
+      date: "2025-01-15 15:00",
+      homeClub: { id: 123, name: "KCVV Elewijt" },
+      awayClub: { id: 456, name: "Opponent FC" },
+      goalsHomeTeam: null,
+      goalsAwayTeam: null,
+      competitionType: { id: 1, name: "3de Nationale", type: "LEAGUE" },
+      viewGameReport: false,
+      status: 0,
+    },
+  };
+
+  // KV mock seeding a populated match-team index (12h cache-hit → no fan-out).
+  const indexKvMock = (entry: Record<string, unknown>): KvCacheInterface => ({
+    get: (key: string) =>
+      Effect.succeed(
+        key === "psd:match-team-index:v2"
+          ? JSON.stringify({ "99": entry })
+          : key === "psd:competition-labels"
+            ? "{}"
+            : null,
+      ),
+    set: () => Effect.succeed(undefined),
+    increment: () => Effect.succeed(undefined),
+  });
+
+  it("backfills finished status + score when /info is still preview-shaped", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => previewDetailResponse,
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(99), {
+      kvMock: indexKvMock({
+        teamId: 1,
+        competitionType: "league",
+        status: "finished",
+        homeScore: 3,
+        awayScore: 1,
+      }),
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.status).toBe("finished");
+      expect(result.right.home_team.score).toBe(3);
+      expect(result.right.away_team.score).toBe(1);
+    }
+  });
+
+  it("does not downgrade a result /info already reports (forward-only)", async () => {
+    // /info reports finished 2-0; a stale index still says "scheduled" — keep
+    // the richer /info result rather than reverting to a preview.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => rawDetailResponse, // finished 2-0
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(99), {
+      kvMock: indexKvMock({
+        teamId: 1,
+        competitionType: "league",
+        status: "scheduled",
+      }),
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.status).toBe("finished");
+      expect(result.right.home_team.score).toBe(2);
+      expect(result.right.away_team.score).toBe(0);
+    }
+  });
+
+  it("keeps /info scores when both are settled but the index score is stale", async () => {
+    // /info reports finished 2-0; the index is settled too but with stale
+    // scores (5-5). The forward-only guard (`!detailSettled`) must keep the
+    // richer /info result and not overwrite it with the index's stale scores.
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => rawDetailResponse, // finished 2-0
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(99), {
+      kvMock: indexKvMock({
+        teamId: 1,
+        competitionType: "league",
+        status: "finished",
+        homeScore: 5,
+        awayScore: 5,
+      }),
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.status).toBe("finished");
+      expect(result.right.home_team.score).toBe(2);
+      expect(result.right.away_team.score).toBe(0);
+    }
+  });
+
+  it("leaves the preview untouched when the list is not yet settled", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => previewDetailResponse,
+    });
+
+    const result = await runService((svc) => svc.getMatchDetail(99), {
+      kvMock: indexKvMock({
+        teamId: 1,
+        competitionType: "league",
+        status: "scheduled",
+      }),
+    });
+
+    expect(result._tag).toBe("Right");
+    if (result._tag === "Right") {
+      expect(result.right.status).toBe("scheduled");
+      expect(result.right.home_team.score).toBeUndefined();
+      // Enrichment still applies (team id + competition type).
+      expect(result.right.kcvv_team_id).toBe(1);
+      expect(result.right.competitionType).toBe("league");
+    }
+  });
+});
+
 const rawDetailWithGoal = {
   general: {
     id: 123,
@@ -1761,7 +1892,7 @@ describe("PsdService.getMatchDetail - competition/team enrichment", () => {
     const kvMock: KvCacheInterface = {
       get: (key: string) =>
         Effect.succeed(
-          key === "psd:match-team-index" ? JSON.stringify(idx) : null,
+          key === "psd:match-team-index:v2" ? JSON.stringify(idx) : null,
         ),
       set: () => Effect.succeed(undefined),
       increment: () => Effect.succeed(undefined),

--- a/apps/api/src/psd/service.ts
+++ b/apps/api/src/psd/service.ts
@@ -36,6 +36,8 @@ import {
   buildCompetitionLabelMap,
   type CompetitionLabelMap,
   resolveCompetitionType,
+  mapGameStatus,
+  isSettledMatchStatus,
   transformFootbalistoMatchDetail,
   transformFootbalistoRankingEntry,
   extractId,
@@ -296,7 +298,10 @@ export const PsdServiceLive = Layer.effect(
     // (new/rescheduled fixtures), and the index is independent of standings
     // freshness (that's `getRanking`'s concern) — so a long TTL costs nothing in
     // live-site accuracy while keeping us far under quota.
-    const MATCH_TEAM_INDEX_CACHE_KEY = "psd:match-team-index";
+    // v2: entries now carry the season-list status + score for the detail
+    // backfill. Bump the key so pre-deployment (v1-shaped) entries are not read
+    // by the new field-shape logic and a clean index is rebuilt on first use.
+    const MATCH_TEAM_INDEX_CACHE_KEY = "psd:match-team-index:v2";
     const MATCH_TEAM_INDEX_TTL = 60 * 60 * 12; // 12h
     // Negative-cache an empty index briefly so a partial upstream outage (e.g.
     // /info ok but the per-team fetches fail) can't trigger a ~20-fetch rebuild
@@ -306,6 +311,12 @@ export const PsdServiceLive = Layer.effect(
     interface MatchTeamIndexEntry {
       teamId: number;
       competitionType: CompetitionType;
+      // Season-list-derived status + score. The list reflects the final result
+      // before the `/info` match report catches up, so `getMatchDetail` can
+      // backfill a settled result while `/info` is still preview-shaped.
+      status: Match["status"];
+      homeScore?: number;
+      awayScore?: number;
     }
     type MatchTeamIndex = Record<string, MatchTeamIndexEntry>;
 
@@ -346,6 +357,14 @@ export const PsdServiceLive = Layer.effect(
             index[key] = {
               teamId: team.id,
               competitionType: resolveCompetitionType(game.competitionType),
+              status: mapGameStatus(
+                game.status,
+                game.goalsHomeTeam,
+                game.goalsAwayTeam,
+                game.cancelled,
+              ),
+              homeScore: game.goalsHomeTeam ?? undefined,
+              awayScore: game.goalsAwayTeam ?? undefined,
             };
           }
         }
@@ -647,10 +666,42 @@ export const PsdServiceLive = Layer.effect(
               Effect.map((index) => {
                 const entry = index[String(matchId)];
                 if (!entry) return detail;
+                // The season-games list is authoritative for status + score and
+                // reflects the final result before `/info` catches up (PSD fills
+                // goals/lineups a while after full-time). When the list already
+                // has a settled result but `/info` is still preview-shaped (null
+                // goals → "scheduled"), backfill status + score forward so the
+                // page shows MATCHVERSLAG with the score instead of the preview.
+                // Forward-only: never downgrade a result `/info` already reports.
+                //
+                // Best-effort: this reads the match-team index, cached up to 12h
+                // (MATCH_TEAM_INDEX_TTL) since team assignments change weekly. So
+                // the backfill fires only once the index has itself refreshed to
+                // the settled result — the immediate post-full-time window is not
+                // guaranteed. The reliable cure for that window is `/info` itself
+                // settling (a few hours later), which the report-pending TTL in
+                // `matchDetailTtl` keeps re-checking rather than pinning stale.
+                const backfill =
+                  isSettledMatchStatus(entry.status) &&
+                  !isSettledMatchStatus(detail.status);
+
                 return {
                   ...detail,
                   kcvv_team_id: entry.teamId,
                   competitionType: entry.competitionType,
+                  ...(backfill
+                    ? {
+                        status: entry.status,
+                        home_team: {
+                          ...detail.home_team,
+                          score: entry.homeScore ?? detail.home_team.score,
+                        },
+                        away_team: {
+                          ...detail.away_team,
+                          score: entry.awayScore ?? detail.away_team.score,
+                        },
+                      }
+                    : {}),
                 };
               }),
             ),

--- a/apps/api/src/psd/transforms.ts
+++ b/apps/api/src/psd/transforms.ts
@@ -197,6 +197,14 @@ export function isUnknownGameStatus(status: number): boolean {
   return status !== 0 && status !== 1 && status !== 2 && status !== 3;
 }
 
+/**
+ * A settled result — the match has a final outcome (played to completion or
+ * forfeited), as opposed to scheduled / postponed / stopped / cancelled.
+ */
+export function isSettledMatchStatus(status: string): boolean {
+  return status === "finished" || status === "forfeited";
+}
+
 // ─── Date parsing ─────────────────────────────────────────────────────────────
 
 function parseDateString(dateStr: string): { date: Date; time: string } {


### PR DESCRIPTION
Closes #2303

## Problem

A finished match could open on its detail page in the **preview** state (VOORBESCHOUWING, no score, empty lineups/events) and only recover after many refreshes. The detail page reads status/score/lineup/events **solely** from `/games/{id}/info`, which returns a preview-shaped payload (null goals → `"scheduled"`, empty report) for a while after full-time — and that snapshot was getting **pinned behind the long "settled match" cache TTL**.

## Approach (BFF-only, owner-approved)

Match reports in PSD only populate a few hours after full-time. The goal: **maximal caching, but surface the report ASAP once it exists** — with the emphasis on night / day-after visitors loading the full report first try, no reloads. Two BFF changes deliver that; the web cache layers (route ISR + `unstable_cache`) are intentionally left unchanged (night/day-after visitors hit cold web caches and render fresh once the report exists).

### A — Report-aware `matchDetailTtl` (`apps/api/src/handlers/matches.ts`)
The proximity ladder is extracted into `proximityTtl`, and a **report-pending override** layers on top: a past match still missing its report data (PSD's `hasReport` flag set, or within 48h of kickoff) is capped at a matchday (≤5 min) re-check cadence and **never** pinned behind the 7d / weekly TTL. A settled match *with* its report still caches for 7 days. → the report self-heals within minutes of appearing upstream; settled matches stay maximally cached.

### B — Status/score backfill (`apps/api/src/psd/service.ts`)
The season-games list is authoritative for the final result and reflects it before `/info` catches up. The existing match-team index now also carries the list's `status` + goals, and `getMatchDetail` backfills status/score **forward-only** (list = settled but `/info` = preview) so the score shows instead of VOORBESCHOUWING.

> **Known bound (documented in code):** the backfill reads the match-team index, cached up to **12h** (sized for weekly team-assignment churn), so it fires only once that index has itself refreshed to the settled result — the immediate post-full-time window is *not* guaranteed. The reliable cure for that window is `/info` itself settling a few hours later, which the report-pending TTL (A) keeps re-checking rather than pinning. Making B reliable in that window would mean a shorter index TTL (PSD-quota-sensitive) or a dedicated short-TTL result lookup — deferred as a follow-up rather than risking quota.

## Changes

- `handlers/matches.ts` — `proximityTtl` helper; `matchDetailTtl` gains a `MatchReportState` options arg + report-pending override; handler passes real report state.
- `psd/service.ts` — `MatchTeamIndexEntry` carries `status`/`homeScore`/`awayScore` (derived via the shared `mapGameStatus`); forward-only backfill in `getMatchDetail`.
- `psd/transforms.ts` — new shared `isSettledMatchStatus` predicate (dedups the finished/forfeited check across 3 sites).
- `apps/api/CLAUDE.md` — `match:detail:{id}` TTL table updated to the current proximity + report-pending policy.

## Testing

- `pnpm --filter @kcvv/api type-check` ✅ · `lint` ✅ · `test` ✅ (386 tests)
- New unit tests: report-pending override (grace window, `hasReport` flag, reportless back-off, live floor, future no-op, default report state) and the status/score backfill (forward-only, not-yet-settled no-op).
- Pre-PR gate: `/code-review` (standards + spec) and `/simplify` (4 agents) run on the branch; all applicable findings applied (shared predicate, doc placement, options object, single-spread backfill, `?? undefined` score idiom, honest best-effort comment).

## Not done (deliberate)

- Web `force-dynamic` / lower route revalidate — owner decision; night/day-after visitors already hit cold web caches, and PSD reports only populate hours later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Match details now more reliably show final statuses and scores when initial data is incomplete.
  - Previously settled matches are preserved without being downgraded by later preview data.
  - Match details refresh more frequently when expected report information is missing, helping updates appear sooner.
  - Live and upcoming matches retain appropriate refresh behavior while report data is pending.

- **Documentation**
  - Updated cache behavior documentation to reflect proximity-based refresh timing and pending-report handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->