### PR TITLE
feat(sync): sync club-wide staff (team-less club functions) from PSD (#2311)

### DIFF
--- a/apps/api/src/psd/schemas-player-team.ts
+++ b/apps/api/src/psd/schemas-player-team.ts
@@ -98,3 +98,36 @@ export const PsdMembersPageSchema = S.Struct({
   totalElements: S.Number,
   totalPages: S.Number,
 });
+
+// ─── Club-wide staff (quicksearch) ───────────────────────────────────────────
+//
+// GET /members/quicksearch/status/{status} is a club-wide member search — the
+// only endpoint that returns staff with a general club function (board members,
+// club-level roles) who are attached to no team, which /teams/{id}/staff never
+// surfaces. Its response is PII-heavy (address, medical, bank) and shaped
+// differently from the team endpoints: the pageable wrapper is nested under
+// `playerList`, and records carry `positions` instead of `bestPosition`.
+//
+// Only the fields the staff sync reads are declared — S.Struct strips all
+// unknown keys, so the PII never enters the pipeline. PsdMember can't be reused
+// (it requires keeper/bestPosition/nationality/active, absent or unverified
+// here), so this minimal shape stands alone.
+
+export class PsdClubStaffMember extends S.Class<PsdClubStaffMember>(
+  "PsdClubStaffMember",
+)({
+  id: S.Number,
+  firstName: S.String,
+  lastName: S.String,
+  birthDate: S.NullOr(S.String),
+  functionTitle: S.NullOr(S.String),
+  status: S.String,
+}) {}
+
+export const PsdQuicksearchStaffPageSchema = S.Struct({
+  playerList: S.Struct({
+    content: S.Array(PsdClubStaffMember),
+    totalElements: S.Number,
+    totalPages: S.Number,
+  }),
+});

--- a/apps/api/src/sync/psd-sanity-sync.ts
+++ b/apps/api/src/sync/psd-sanity-sync.ts
@@ -1,5 +1,9 @@
-import { Effect } from "effect";
-import type { PsdMember, PsdTeam } from "../psd/schemas-player-team";
+import { Effect, Either } from "effect";
+import type {
+  PsdClubStaffMember,
+  PsdMember,
+  PsdTeam,
+} from "../psd/schemas-player-team";
 import type {
   SanityPlayerDoc,
   SanityTeamDoc,
@@ -82,8 +86,16 @@ export function transformTeam(
  * Convert a PSD staff member record into a Sanity staffMember document.
  * Only PSD-sourced fields are written — editorial fields (role, department,
  * parentMember, inOrganigram, roleLabel, responsibilities, photo) are never touched.
+ *
+ * Accepts both team-scoped `PsdMember` and club-wide `PsdClubStaffMember` — only
+ * the shared fields below are read.
  */
-export function transformStaff(psd: PsdMember): SanityStaffDoc {
+export function transformStaff(
+  psd: Pick<
+    PsdMember,
+    "id" | "firstName" | "lastName" | "birthDate" | "functionTitle"
+  >,
+): SanityStaffDoc {
   return {
     psdId: String(psd.id),
     firstName: psd.firstName,
@@ -397,20 +409,61 @@ export const runSync = Effect.gen(function* () {
       sanityWriter.archivePlayers(ids),
     );
 
-    const activeStaffInSanity = yield* sanityReader.getActiveStaffPsdIds();
-    const protectedStaffIds = yield* sanityReader.getProtectedStaffPsdIds();
-    for (const id of protectedStaffIds) accumulatedStaffIds.add(id);
-    if (protectedStaffIds.length > 0) {
+    // Club-wide staff (team-less club functions: board members, general roles)
+    // are never returned by /teams/{id}/staff, so without this fetch their IDs
+    // are absent from accumulatedStaffIds and reconciliation would archive them.
+    // Fetched once per cycle, here at cycle end, so their IDs are fresh for the
+    // orphan check. On fetch failure we SKIP staff reconciliation entirely
+    // rather than risk archiving team-less staff on a partial ID set.
+    const reconcileStaffWithClubWide = (
+      clubRaw: readonly PsdClubStaffMember[],
+    ) =>
+      Effect.gen(function* () {
+        // The endpoint returns a system "Admin" account (id 1) with a blank
+        // firstName — skip nameless/non-person rows so no junk staffMember doc
+        // is created. status is always "staff" here but filter defensively.
+        const clubStaff = clubRaw.filter(
+          (m) => m.status === "staff" && m.firstName.trim() !== "",
+        );
+        // Team-attached staff were already upserted during their team's run;
+        // only the genuinely team-less members still need writing.
+        const toUpsert = clubStaff.filter(
+          (m) => !accumulatedStaffIds.has(String(m.id)),
+        );
+        yield* Effect.forEach(
+          toUpsert,
+          (m) => sanityWriter.upsertStaff(transformStaff(m)),
+          { concurrency: 3 },
+        );
+        for (const m of clubStaff) accumulatedStaffIds.add(String(m.id));
+        yield* Effect.log(
+          `reconciliation: club-wide staff fetched — ${toUpsert.length} upserted, ${clubStaff.length} protected from archival`,
+        );
+
+        const activeStaffInSanity = yield* sanityReader.getActiveStaffPsdIds();
+        const protectedStaffIds = yield* sanityReader.getProtectedStaffPsdIds();
+        for (const id of protectedStaffIds) accumulatedStaffIds.add(id);
+        if (protectedStaffIds.length > 0) {
+          yield* Effect.log(
+            `reconciliation: ${protectedStaffIds.length} staff protected by organigram/responsibility refs: ${protectedStaffIds.join(", ")}`,
+          );
+        }
+        yield* reconcileEntity(
+          "staff",
+          activeStaffInSanity,
+          accumulatedStaffIds,
+          (ids) => sanityWriter.archiveStaff(ids),
+        );
+      });
+
+    const clubStaffResult = yield* Effect.either(psd.getRawClubStaff());
+    if (Either.isLeft(clubStaffResult)) {
       yield* Effect.log(
-        `reconciliation: ${protectedStaffIds.length} staff protected by organigram/responsibility refs: ${protectedStaffIds.join(", ")}`,
+        `reconciliation: SKIPPED staff archival — club-wide staff fetch failed: ${String(clubStaffResult.left)}`,
       );
+    } else {
+      yield* reconcileStaffWithClubWide(clubStaffResult.right);
     }
-    yield* reconcileEntity(
-      "staff",
-      activeStaffInSanity,
-      accumulatedStaffIds,
-      (ids) => sanityWriter.archiveStaff(ids),
-    );
 
     const activeTeamsInSanity = yield* sanityReader.getActiveTeamPsdIds();
     yield* reconcileEntity(

--- a/apps/api/src/sync/psd-team-client.ts
+++ b/apps/api/src/sync/psd-team-client.ts
@@ -2,8 +2,10 @@ import { Context, Effect, Layer, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService } from "../cache/kv-cache";
 import {
+  PsdClubStaffMember,
   PsdMember,
   PsdMembersPageSchema,
+  PsdQuicksearchStaffPageSchema,
   PsdTeam,
   PsdTeamsSchema,
 } from "../psd/schemas-player-team";
@@ -46,6 +48,10 @@ export interface PsdTeamClientInterface {
   readonly getRawStaff: (
     teamId: number,
   ) => Effect.Effect<readonly PsdMember[], PsdTeamClientErrors>;
+  readonly getRawClubStaff: () => Effect.Effect<
+    readonly PsdClubStaffMember[],
+    PsdTeamClientErrors
+  >;
 }
 
 export class PsdTeamClient extends Context.Tag("PsdTeamClient")<
@@ -109,23 +115,24 @@ export const PsdTeamClientLive = Layer.effect(
         Effect.ensuring(cache.increment()),
       );
 
-    const fetchPaginatedTeamPeople = (
-      kind: "members" | "staff",
-      teamId: number,
+    // Fetch every page of a Spring-pageable endpoint: read page 0 to learn
+    // totalPages, then fetch the rest at bounded concurrency. `fetchPage` owns
+    // the URL, schema, and any envelope-unwrapping (e.g. `.playerList`).
+    const paginateAll = <T>(
+      fetchPage: (
+        page: number,
+      ) => Effect.Effect<
+        { readonly totalPages: number; readonly content: readonly T[] },
+        PsdTeamClientErrors
+      >,
     ) =>
       Effect.gen(function* () {
-        const firstPage = yield* countedFetch(
-          `${base}/teams/${teamId}/${kind}`,
-          PsdMembersPageSchema,
-        );
+        const firstPage = yield* fetchPage(0);
         if (firstPage.totalPages <= 1) return firstPage.content;
 
         const remainingPages = yield* Effect.all(
           Array.from({ length: firstPage.totalPages - 1 }, (_, i) =>
-            countedFetch(
-              `${base}/teams/${teamId}/${kind}?page=${i + 1}`,
-              PsdMembersPageSchema,
-            ).pipe(Effect.map((page) => page.content)),
+            fetchPage(i + 1).pipe(Effect.map((page) => page.content)),
           ),
           { concurrency: 3 },
         );
@@ -136,9 +143,28 @@ export const PsdTeamClientLive = Layer.effect(
     return {
       getRawTeams: () => countedFetch(`${base}/teams`, PsdTeamsSchema),
       getRawMembers: (teamId: number) =>
-        fetchPaginatedTeamPeople("members", teamId),
+        paginateAll((page) =>
+          countedFetch(
+            `${base}/teams/${teamId}/members?page=${page}`,
+            PsdMembersPageSchema,
+          ),
+        ),
       getRawStaff: (teamId: number) =>
-        fetchPaginatedTeamPeople("staff", teamId),
+        paginateAll((page) =>
+          countedFetch(
+            `${base}/teams/${teamId}/staff?page=${page}`,
+            PsdMembersPageSchema,
+          ),
+        ),
+      // Club-wide staff search — nested `playerList` wrapper. Adds ~2 PSD calls;
+      // called once per sync cycle only.
+      getRawClubStaff: () =>
+        paginateAll((page) =>
+          countedFetch(
+            `${base}/members/quicksearch/status/staff?page=${page}&size=100`,
+            PsdQuicksearchStaffPageSchema,
+          ).pipe(Effect.map((r) => r.playerList)),
+        ),
     };
   }),
 );

--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -6,9 +6,13 @@ import { SanityMutation, SanityMutationError } from "../sanity/mutation";
 import type { SanityProjectionInterface } from "../sanity/projection";
 import { SanityProjection } from "../sanity/projection";
 import type { PsdTeamClientInterface } from "./psd-team-client";
-import { PsdTeamClient } from "./psd-team-client";
+import { PsdTeamClient, PsdTeamClientError } from "./psd-team-client";
 import { WorkerEnvTag } from "../env";
-import type { PsdMember, PsdTeam } from "../psd/schemas-player-team";
+import type {
+  PsdClubStaffMember,
+  PsdMember,
+  PsdTeam,
+} from "../psd/schemas-player-team";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -108,11 +112,13 @@ function makePsdTeamClientMock(
   teams: readonly PsdTeam[],
   members: readonly PsdMember[],
   staff: readonly PsdMember[] = [],
+  clubStaff: readonly PsdClubStaffMember[] = [],
 ) {
   const mock: PsdTeamClientInterface = {
     getRawTeams: () => Effect.succeed(teams),
     getRawMembers: () => Effect.succeed(members),
     getRawStaff: () => Effect.succeed(staff),
+    getRawClubStaff: () => Effect.succeed(clubStaff),
   };
   return mock;
 }
@@ -593,6 +599,7 @@ describe("runSync", () => {
               ],
         ),
       getRawStaff: () => Effect.succeed([]),
+      getRawClubStaff: () => Effect.succeed([]),
     };
 
     // Run 1: processes Team A (cursor 0 → 1)
@@ -660,6 +667,104 @@ describe("runSync", () => {
     // With 1 team, cursor wraps to 0 immediately → reconciliation runs
     expect(archiveStaff).toHaveBeenCalledOnce();
     expect(archiveStaff).toHaveBeenCalledWith(["900"]);
+  });
+
+  it("upserts club-wide (team-less) staff at cycle end and protects them from archival", async () => {
+    const kvStub = makeKvStub();
+
+    // PSD team endpoint returns 1 staff for the single team.
+    const teamStaff: PsdMember[] = [{ ...ONE_STAFF, id: 500 }];
+
+    // Club-wide endpoint returns the team staff PLUS two team-less club
+    // functions (board member 9391) — and a nameless system account (id 1).
+    const clubStaff: PsdClubStaffMember[] = [
+      {
+        id: 500,
+        firstName: "Piet",
+        lastName: "Trainer",
+        birthDate: null,
+        functionTitle: "Coach",
+        status: "staff",
+      },
+      {
+        id: 9391,
+        firstName: "Kim",
+        lastName: "Bautmans",
+        birthDate: null,
+        functionTitle: "Club-API",
+        status: "staff",
+      },
+      {
+        id: 1,
+        firstName: "",
+        lastName: "Admin",
+        birthDate: null,
+        functionTitle: "",
+        status: "staff",
+      },
+    ];
+
+    const {
+      getActiveStaffPsdIds,
+      upsertStaff,
+      archiveStaff,
+      writerMock,
+      readerMock,
+    } = makeSanityMocks();
+
+    // Sanity already has the team-less board member 9391 as active. Without the
+    // club-wide fetch it would be an orphan (never in any team) and archived.
+    getActiveStaffPsdIds.mockReturnValue(Effect.succeed(["500", "9391"]));
+
+    const psdMock = makePsdTeamClientMock(
+      [ONE_TEAM],
+      [ONE_PLAYER],
+      teamStaff,
+      clubStaff,
+    );
+
+    await Effect.runPromise(
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, writerMock, readerMock, psdMock)),
+      ),
+    );
+
+    // 9391 upserted from the club-wide fetch (resurrects archived board members).
+    expect(upsertStaff).toHaveBeenCalledWith(
+      expect.objectContaining({ psdId: "9391" }),
+    );
+    // Nameless system account (id 1) is skipped — no junk staffMember doc.
+    expect(upsertStaff).not.toHaveBeenCalledWith(
+      expect.objectContaining({ psdId: "1" }),
+    );
+    // Nothing archived: 9391 is now accumulated, so it is not an orphan.
+    expect(archiveStaff).not.toHaveBeenCalled();
+  });
+
+  it("skips staff archival when the club-wide staff fetch fails", async () => {
+    const kvStub = makeKvStub();
+
+    const { getActiveStaffPsdIds, archiveStaff, writerMock, readerMock } =
+      makeSanityMocks();
+    // 9391 would look like an orphan, but the failed club-wide fetch means we
+    // cannot safely tell — so archival is skipped rather than risking deletion.
+    getActiveStaffPsdIds.mockReturnValue(Effect.succeed(["500", "9391"]));
+
+    const psdMock: PsdTeamClientInterface = {
+      getRawTeams: () => Effect.succeed([ONE_TEAM]),
+      getRawMembers: () => Effect.succeed([ONE_PLAYER]),
+      getRawStaff: () => Effect.succeed([{ ...ONE_STAFF, id: 500 }]),
+      getRawClubStaff: () =>
+        Effect.fail(new PsdTeamClientError("club-wide fetch boom")),
+    };
+
+    await Effect.runPromise(
+      runSync.pipe(
+        Effect.provide(buildTestLayer(kvStub, writerMock, readerMock, psdMock)),
+      ),
+    );
+
+    expect(archiveStaff).not.toHaveBeenCalled();
   });
 
   it("archives orphan team when cycle completes (team disappears from PSD)", async () => {
@@ -733,6 +838,7 @@ describe("runSync", () => {
                 { ...ONE_STAFF, id: 700 },
               ],
         ),
+      getRawClubStaff: () => Effect.succeed([]),
     };
 
     // Run 1: processes Team A (cursor 0 → 1)

--- a/apps/studio/migrations/stringify-psd-id/index.ts
+++ b/apps/studio/migrations/stringify-psd-id/index.ts
@@ -1,0 +1,34 @@
+import {defineMigration, at, set} from 'sanity/migrate'
+
+/**
+ * Coerce numeric `psdId` → string on player / staffMember / team documents.
+ * Part of #2311.
+ *
+ * Background: `psdId` is authored as a string everywhere in the sync pipeline
+ * (`transformStaff`/`transformMember`/`transformTeam` all do `String(psd.id)`),
+ * but a handful of older docs had a numeric `psdId`. That broke the
+ * `typeof id === "string"` filter in `getProtectedStaffPsdIds`, letting
+ * reconciliation archive organigram-referenced staff.
+ *
+ * The data fix was already applied directly to both datasets on 2026-07-29
+ * (staging: 11 docs, production: 10 docs), so this migration is a documented,
+ * idempotent no-op safety net — it only touches docs whose `psdId` is still a
+ * number, and re-running it changes nothing once all are strings.
+ *
+ * Run with:
+ *   npx sanity@latest migration run stringify-psd-id --project vhb33jaz --dataset production
+ *   npx sanity@latest migration run stringify-psd-id --project vhb33jaz --dataset staging
+ */
+export default defineMigration({
+  title: 'Coerce numeric psdId → string on player/staffMember/team',
+  documentTypes: ['player', 'staffMember', 'team'],
+
+  migrate: {
+    document(doc) {
+      if (typeof doc.psdId === 'number') {
+        return at('psdId', set(String(doc.psdId)))
+      }
+      return undefined
+    },
+  },
+})

--- a/apps/studio/migrations/stringify-psd-id/index.ts
+++ b/apps/studio/migrations/stringify-psd-id/index.ts
@@ -15,9 +15,9 @@ import {defineMigration, at, set} from 'sanity/migrate'
  * idempotent no-op safety net — it only touches docs whose `psdId` is still a
  * number, and re-running it changes nothing once all are strings.
  *
- * Run with:
- *   npx sanity@latest migration run stringify-psd-id --project vhb33jaz --dataset production
- *   npx sanity@latest migration run stringify-psd-id --project vhb33jaz --dataset staging
+ * Run with (`sanity migration run` dry-runs by default — `--no-dry-run` applies):
+ *   npx sanity@latest migration run stringify-psd-id --project vhb33jaz --dataset production --no-dry-run
+ *   npx sanity@latest migration run stringify-psd-id --project vhb33jaz --dataset staging --no-dry-run
  */
 export default defineMigration({
   title: 'Coerce numeric psdId → string on player/staffMember/team',

--- a/docs/psd-api-reference.md
+++ b/docs/psd-api-reference.md
@@ -256,6 +256,45 @@ Squad/members for a team.
 
 ---
 
+### Members (club-wide)
+
+#### `GET /members/quicksearch/status/{status}`
+
+Club-wide member search by status — **not team-scoped**. This is the only endpoint that
+returns staff with a general club function who are not attached to any team (e.g. board
+members), which `GET /teams/{id}/staff` never surfaces. Verified live on 2026-07-29:
+141 staff total for KCVV, including team-less members (`team: null`).
+
+**Path param:** `status` — `speler` or `staff` (same values as the `status` field used by
+`partitionMembers` in the sync).
+
+**Query params:** `page` (zero-based), `size`, `q`, `teamid`, `since` (ddMMyyyy), and more —
+see the full spec.
+
+**Response shape differs from the team endpoints.** The paginated wrapper is nested under
+`playerList` instead of top-level:
+
+```typescript
+{
+  id: null,
+  actions: [...],
+  customFieldValues: [...],
+  playerList: {          // ← Spring pageable wrapper
+    content: Member[],   // full Member records (superset of team-endpoint fields,
+                         //   incl. PII: address, medical, bank — project only what's needed)
+    totalElements: number,
+    totalPages: number,
+    number: number,      // current page, zero-based
+    ...
+  }
+}
+```
+
+`PsdMembersPageSchema` (top-level `content`/`totalPages`) does **not** decode this response —
+a nested wrapper schema is required. Member records include `id`, `firstName`, `lastName`,
+`status`, `functionTitle`, `birthDate`, `profilePictureURL`, but **no** `bestPosition`
+(the quicksearch shape has `positions` instead).
+
 ## Key schema: `Game` object
 
 Returned by `/games/team/{teamId}` and `/games/{id}`:


### PR DESCRIPTION
Closes #2311

## Problem

The nightly PSD→Sanity sync only fetched staff per team (`GET /teams/{id}/staff`), so staff with a **general club function** (board members, club-level roles) attached to no team in PSD — e.g. Kim Bautmans (PSD ID 9391) — were never synced, and existing club-level staff docs were archived as orphans by cycle-end reconciliation.

## Changes

- **`schemas-player-team.ts`** — `PsdClubStaffMember` + `PsdQuicksearchStaffPageSchema` (nested `playerList` wrapper). Minimal fields only, so `S.Struct` strips the endpoint's PII (address, medical, bank) on decode. A dedicated schema rather than reusing `PsdMember` because the quicksearch response has no `bestPosition`.
- **`psd-team-client.ts`** — `getRawClubStaff()` fetching `/members/quicksearch/status/staff` with zero-based pagination. Extracted a shared `paginateAll` helper so team and club-wide fetches no longer duplicate the pagination skeleton.
- **`psd-sanity-sync.ts`** — once per cycle (at cycle-end reconciliation) fetch club-wide staff, upsert the genuinely team-less members, and accumulate **all** their IDs into the staff protection set before the orphan check — so team-less staff are protected and previously-archived docs are resurrected via `upsertStaff`'s `archived: false`. On fetch failure, staff archival is **skipped** rather than risking deletion on a partial ID set. A blank-`firstName` guard drops the PSD system "Admin" account (id 1). `transformStaff` now takes a structural `Pick<PsdMember>` so both sources share it.
- **`stringify-psd-id` migration** — idempotent no-op safety net (numeric `psdId` → string; data already fixed in both datasets on 2026-07-29).
- **docs** — new "Members (club-wide)" section in `psd-api-reference.md`.

## Testing

- `pnpm --filter @kcvv/api lint` / `type-check` / `test` — all green (389 tests).
- New tests: team-less staff (9391) upserted + protected from archival; nameless system account (id 1) skipped; staff archival skipped when the club-wide fetch fails.
- **Validated against the live PSD endpoint**: 141 staff, 2 pages, nested `playerList` wrapper, no `bestPosition`, only 1 nameless system row. Confirmed `?page=0` is identical to no page param on the team endpoints (the pagination refactor).

## Review gate

- `/code-review` — 0 standards violations, 0 spec defects. Point 7 (harden `getProtectedStaffPsdIds`) intentionally skipped: it's optional ("Consider"), and the migration + applied data fix mean no `psdId` stays numeric, so the silent filter no longer drops anything.
- `/simplify` — **applied**: shared `paginateAll` helper, dedup of already-upserted staff, flattened staff-reconciliation into a named closure. **Skipped**: generalizing the nameless-filter into `partitionMembers` (would change unrelated player/team sync paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Club-wide staff records are now retrieved and included during end-of-cycle synchronization, including team-less staff.
  * Staff reconciliation now recognizes club-wide staff so they’re protected from unintended archival.
* **Bug Fixes**
  * Staff archival is skipped if club-wide staff data can’t be retrieved, reducing risk of unsafe deletions.
* **Documentation**
  * Added API documentation for the club-wide staff quicksearch endpoint, including pagination and response shape.
* **Chores**
  * Added a Studio migration to convert numeric PSD IDs to strings for player, staffMember, and team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->