### PR TITLE
fix(ui): serve hulp 'Helpt met' chips via native anchors (#2312)

### DIFF
--- a/apps/web/src/components/organigram/MemberDetailPanel/MemberDetailPanel.test.tsx
+++ b/apps/web/src/components/organigram/MemberDetailPanel/MemberDetailPanel.test.tsx
@@ -14,12 +14,24 @@
  *    null holder for a vacant position
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { MemberDetailPanel } from "./MemberDetailPanel";
 import type { OrgChartNode } from "@/types/organigram";
 import type { ResponsibilityPath } from "@/types/responsibility";
+
+// Tag anchors that went through next/link so tests can assert the "Helpt met"
+// chip does NOT — Next ≥ 16.2 appends hash fragments instead of replacing them
+// (vercel/next.js#93126), so hash-only navigation must stay a plain <a> (#2312).
+vi.mock("next/link", () => ({
+  default: ({ children, ...rest }: ComponentProps<"a">) => (
+    <a data-next-link="" {...rest}>
+      {children}
+    </a>
+  ),
+}));
 
 const singleNode: OrgChartNode = {
   id: "president",
@@ -83,6 +95,13 @@ const responsibilityPaths: ResponsibilityPath[] = [
 ];
 
 const noop = () => {};
+
+// Chip clicks navigate natively, so the hash leaks across tests in this file
+// (jsdom shares one window.location). Reset unconditionally — inline cleanup
+// after an assertion would be skipped when that assertion fails.
+afterEach(() => {
+  window.history.replaceState(null, "", window.location.pathname);
+});
 
 describe("MemberDetailPanel", () => {
   describe("closed states", () => {
@@ -281,6 +300,45 @@ describe("MemberDetailPanel", () => {
       );
       expect(launcher).not.toHaveFocus();
       document.body.removeChild(launcher);
+    });
+
+    it("renders the chip as a plain <a>, not a next/link (#2312)", () => {
+      render(
+        <MemberDetailPanel
+          node={singleNode}
+          open
+          onClose={noop}
+          responsibilityPaths={responsibilityPaths}
+        />,
+      );
+      expect(
+        screen.getByRole("link", { name: "Lid worden" }),
+      ).not.toHaveAttribute("data-next-link");
+      // Control: the route link still goes through next/link — proves the
+      // tagging mock is active, so the assertion above can't pass vacuously.
+      expect(
+        screen.getByRole("link", { name: /Volledig profiel/ }),
+      ).toHaveAttribute("data-next-link");
+    });
+
+    it("replaces a pre-existing hash with the question slug on chip click (#2312)", async () => {
+      // AC1: from /hulp#structuur the click must land on exactly #lid-worden —
+      // a single hash, not the appended #structuur#lid-worden that routing the
+      // chip through Next ≥ 16.2 produced. Seeding the hash also keeps this
+      // assertion honest: earlier chip-click tests leak #lid-worden into the
+      // shared jsdom location, so without the seed it could pass vacuously.
+      window.location.hash = "#structuur";
+      const user = userEvent.setup();
+      render(
+        <MemberDetailPanel
+          node={singleNode}
+          open
+          onClose={noop}
+          responsibilityPaths={responsibilityPaths}
+        />,
+      );
+      await user.click(screen.getByRole("link", { name: "Lid worden" }));
+      expect(window.location.hash).toBe("#lid-worden");
     });
   });
 

--- a/apps/web/src/components/organigram/MemberDetailPanel/MemberDetailPanel.tsx
+++ b/apps/web/src/components/organigram/MemberDetailPanel/MemberDetailPanel.tsx
@@ -355,8 +355,16 @@ export function MemberDetailPanel({
                               effect skips `returnFocusRef.current.focus()`, which
                               would otherwise pull focus/scroll back to the now-
                               off-screen launcher and fight the hash navigation
-                              (matches normal in-page anchor behaviour). */}
-                          <Link
+                              (matches normal in-page anchor behaviour).
+                              Plain <a>, NOT next/link: Next ≥ 16.2 appends hash
+                              fragments instead of replacing them
+                              (vercel/next.js#93126), turning `#structuur` +
+                              `#lid-worden` into a dead nested hash (#2312). The
+                              nav links' workaround for the same bug
+                              (`handleSamePageAnchorClick`) doesn't fit here:
+                              it pushState's without firing the `hashchange`
+                              that HulpFinder's reveal() needs. */}
+                          <a
                             href={`#${path.id}`}
                             onClick={() => {
                               if (returnFocusRef) returnFocusRef.current = null;
@@ -365,7 +373,7 @@ export function MemberDetailPanel({
                             className="border-jersey-deep text-jersey-deep hover:bg-jersey-deep hover:text-cream inline-block border-[1.5px] px-2 py-1 font-mono text-[10px] tracking-[0.02em] uppercase transition-colors"
                           >
                             {path.question}
-                          </Link>
+                          </a>
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
Closes #2312

## Changes

- `MemberDetailPanel.tsx`: the "Helpt met" chip — the app's only hash-only `next/link` — is now a plain `<a>`. Next ≥ 16.2 appends hash fragments instead of replacing them on client-side navigation (vercel/next.js#93126), producing a dead nested hash (`/hulp#structuur%23contact-bestuur`) that `HulpFinder`'s `hashchange` → `reveal()` could never resolve. Native fragment navigation fires `hashchange`, which is all the finder needs. The existing `onClick` (null the focus-return target, close the panel) is unchanged, as is the className. Comment cross-references the nav links' `handleSamePageAnchorClick` workaround for the same upstream bug and why it doesn't fit here (it `pushState`s without firing `hashchange`).
- `MemberDetailPanel.test.tsx`: a `next/link` tagging mock (`data-next-link`) with a structural test pinning the chip as a plain `<a>` — including a control assertion that "Volledig profiel" still goes through `next/link`, so the assertion can't pass vacuously. A behavioral test seeds `#structuur` and asserts a chip click lands on exactly `#lid-worden` (AC1's replace-not-append, as close as jsdom gets). File-level `afterEach` resets the URL so chip-click tests don't leak hash state across the file.

## Pre-PR review gate

- `/code-review` (Standards + Spec): the Spec axis caught the hash-navigation test being vacuous (earlier chip clicks leak `#lid-worden` into jsdom's shared location) — fixed by seeding `#structuur` and moving cleanup to an unconditional `afterEach`. No standards violations.
- `/simplify` (4 agents): Efficiency + Altitude clean. Reuse flagged the existing `handleSamePageAnchorClick` helper — genuinely doesn't fit (no `hashchange`), cross-referenced in the comment instead. Simplification's suggestion to delete the behavioral hash test was skipped: it's AC1's URL assertion and guards `preventDefault` regressions the structural test can't.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, 3294 tests, build) under Node 24.16.0 (`.nvmrc`)
- MemberDetailPanel suite: 23/23, including red→green on the new structural guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)