### PR TITLE
fix(ui): keep the /share auto-fit size after the webfont re-fit

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -392,18 +392,62 @@ pnpm --filter @kcvv/web run vr:check
 # Accept the current rendering as the new baseline (commit the resulting PNGs).
 pnpm --filter @kcvv/web run vr:update
 
-# Surgical baseline update — only stories matching the path pattern.
-# The `--` separator hands the rest to test-storybook, which forwards
-# `--testPathPatterns=<regex>` to Jest. The regex matches the synthetic
-# test file paths the runner generates from story IDs (e.g. `ui-button`,
-# `layout-pagefooter`), NOT the source `.stories.tsx` paths. Use a tight
-# anchor like `ui-button` to scope to one atom (without dragging in
-# `ui-linkbutton`/`ui-downloadbutton`/etc.).
-pnpm --filter @kcvv/web run vr:update:story -- --testPathPatterns=ui-button
+# Surgical run — only stories matching the pattern. Pass the regex as a BARE
+# POSITIONAL argument (see "Scoping a VR run" below); update and compare modes
+# both take it.
+pnpm --filter @kcvv/web run vr:update:story -- ui-button   # update, scoped
+pnpm --filter @kcvv/web run vr:check -- ui-button          # compare, scoped
 
 # Print the diff PNG path(s) for a failed story so the Read tool can inspect them.
 pnpm --filter @kcvv/web run vr:diff layout-pagefooter--standalone
 ```
+
+### Scoping a VR run
+
+A full capture is ~40 min, so always scope. **The pattern is a bare positional
+argument — never a `--testPathPattern(s)=` flag.**
+
+`test-storybook` parses its CLI with commander against a closed option
+allowlist (`--maxWorkers`, `--testTimeout`, `-u`, `--includeTags`,
+`--excludeTags`, `--listTests`, `--ci`, `--shard`, … — see
+`getParsedCliOptions` in `node_modules/@storybook/test-runner/dist/test-storybook.js`).
+Any unrecognised `--flag` prints the help text and exits 1 — including Jest's
+own `--testPathPatterns`, which is **not** passed through. Positional operands
+(`program.args`) _are_ forwarded verbatim to Jest, and Jest treats a bare
+positional as a test-path regex. That is the only scoping channel.
+
+The regex matches the synthetic test files the runner writes to a temp dir, one
+per story **title** (component), named from the story ID:
+`features-share-goalkcvvtemplate.test.js`, `ui-button.test.js`. It does **not**
+match source `.stories.tsx` paths, and it cannot select a single story export
+within a component. Anchor tightly — `ui-button` also matches nothing else, but
+`share` would pull in every `features-share-*` file.
+
+```bash
+# Which files would run? Fast, exits before launching Chromium.
+docker compose -f docker-compose.vr.yml run --rm vr --listTests features-share
+
+# Iterate without the ~2 min Storybook rebuild that the pnpm scripts always do
+# (only valid while apps/web/src is unchanged — otherwise rebuild first).
+docker compose -f docker-compose.vr.yml run --rm vr -u --maxWorkers=1 features-share
+```
+
+Tag-based scoping is the other axis: `--includeTags` / `--excludeTags`, or the
+`STORYBOOK_INCLUDE_TAGS` / `STORYBOOK_EXCLUDE_TAGS` / `STORYBOOK_SKIP_TAGS`
+env vars (comma-separated) for the docker-compose `environment:` block.
+
+### Captures are viewport-clipped, not full-page
+
+The runner screenshots the **viewport**, so anything below the fold of the
+tallest viewport is not in the baseline. This matters for the `Features/Share/*`
+templates: they render a 1080×1920 Instagram Story, and the baselines only cover
+roughly its top third — the crest, kicker, and headline. The crest matchup,
+player name, meta line, and footer are **never captured at any viewport**.
+
+Do not add a `Features/Share/*` story expecting VR to guard something in the
+lower two-thirds of the canvas (a long-name auto-fit, the footer matchup, the
+score meta row) — it cannot. Guard those with a unit test instead; the auto-fit
+regression in #2316 is the worked example.
 
 `vr:check` and `vr:update` rebuild Storybook first, then run the test-runner
 inside Docker. First run pulls the Playwright image (~1.3 GB). Steady-state run
@@ -480,12 +524,12 @@ Phase 2+ atom reskins (Button, Input, Alert, …) intentionally change the visua
 of every story that consumes them. The contract for these PRs:
 
 1. **Update the atom's own baselines surgically.** Run `vr:update:story` with a
-   tight `--testPathPatterns` regex anchored to the atom's story-ID prefix —
-   e.g. `pnpm vr:update:story -- --testPathPatterns=ui-button`. The pattern
-   matches the synthetic test file paths derived from story IDs (e.g.
-   `ui-button.test.js`), not the source `.stories.tsx` paths. The PR's
-   `## VR baselines` section enumerates every changed baseline file with a
-   one-line rationale.
+   tight positional regex anchored to the atom's story-ID prefix — e.g.
+   `pnpm vr:update:story -- ui-button` (see "Scoping a VR run" above; a
+   `--testPathPatterns=` flag is rejected outright). The pattern matches the
+   synthetic test file paths derived from story IDs (e.g. `ui-button.test.js`),
+   not the source `.stories.tsx` paths. The PR's `## VR baselines` section
+   enumerates every changed baseline file with a one-line rationale.
 2. **Defer consumer baselines via `parameters.vr.disable: true`, not `vr-skip`.**
    A consumer story that has the `vr` tag and visually changes because it
    imports the redesigned atom should NOT have its baseline auto-updated in the

--- a/apps/web/src/components/share/shared/ShareElements.tsx
+++ b/apps/web/src/components/share/shared/ShareElements.tsx
@@ -40,7 +40,14 @@ function useAutoFit<T extends HTMLElement>(
               ),
             )
           : fontSize;
-      if (!cancelled) setSize(next);
+      if (cancelled) return;
+      // Write the result back imperatively too: `fit()` just probed the DOM AT
+      // THE BASE SIZE, and when `next` equals the current state React bails out
+      // of the re-render — leaving that probe (= base, overflowing) size on
+      // screen. Hits every warm load, where the first fit already measured
+      // against real Freight metrics so the re-fit computes the same number.
+      el.style.fontSize = `${next}px`;
+      setSize(next);
     };
     fit();
     const refit = () => !cancelled && fit();

--- a/apps/web/src/components/share/shared/ShareFrame.test.tsx
+++ b/apps/web/src/components/share/shared/ShareFrame.test.tsx
@@ -1,14 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { ShareFrame, ShareTop, ShareFoot } from "./ShareFrame";
 import { Headline, Kicker, Scoreline, ShareName } from "./ShareElements";
 
-/** Temporarily fake element width measurement (happy-dom has no layout). */
-function withMeasuredWidths(
-  clientWidth: number,
-  scrollWidth: number,
-  fn: () => void,
-) {
+/** Fake element width measurement (happy-dom has no layout); returns a restore. */
+function fakeMeasuredWidths(clientWidth: number, scrollWidth: number) {
   const proto = HTMLElement.prototype;
   const origClient = Object.getOwnPropertyDescriptor(proto, "clientWidth");
   const origScroll = Object.getOwnPropertyDescriptor(proto, "scrollWidth");
@@ -20,13 +16,25 @@ function withMeasuredWidths(
     configurable: true,
     get: () => scrollWidth,
   });
-  try {
-    fn();
-  } finally {
+  return () => {
     if (origClient) Object.defineProperty(proto, "clientWidth", origClient);
     else delete (proto as unknown as Record<string, unknown>).clientWidth;
     if (origScroll) Object.defineProperty(proto, "scrollWidth", origScroll);
     else delete (proto as unknown as Record<string, unknown>).scrollWidth;
+  };
+}
+
+/** Temporarily fake element width measurement (happy-dom has no layout). */
+function withMeasuredWidths(
+  clientWidth: number,
+  scrollWidth: number,
+  fn: () => void,
+) {
+  const restore = fakeMeasuredWidths(clientWidth, scrollWidth);
+  try {
+    fn();
+  } finally {
+    restore();
   }
 }
 
@@ -54,6 +62,35 @@ describe("ShareName auto-fit", () => {
         fontSize: "85px",
       });
     });
+  });
+
+  it("keeps the fitted size after the webfont re-fit re-measures", async () => {
+    const restoreWidths = fakeMeasuredWidths(920, 2000);
+    const origFonts = Object.getOwnPropertyDescriptor(document, "fonts");
+    Object.defineProperty(document, "fonts", {
+      configurable: true,
+      value: { ready: Promise.resolve(), load: () => Promise.resolve([]) },
+    });
+    try {
+      render(
+        <ShareFrame width={1080} height={1920} register="cream">
+          <ShareName fontSize={185}>Amirgan Bouakhouf</ShareName>
+        </ShareFrame>,
+      );
+      // The re-fit probes the DOM at the base size and computes the SAME 85px,
+      // so React bails out of re-rendering — the probe must not survive.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByText("Amirgan Bouakhouf")).toHaveStyle({
+        fontSize: "85px",
+      });
+    } finally {
+      if (origFonts) Object.defineProperty(document, "fonts", origFonts);
+      else delete (document as unknown as Record<string, unknown>).fonts;
+      restoreWidths();
+    }
   });
 
   it("does not scale a name that already fits", () => {

--- a/docs/prd/redesign-phase-2.md
+++ b/docs/prd/redesign-phase-2.md
@@ -84,13 +84,13 @@ Phase 2.0 — Tracer bullet (tokens + vr:update:story + Button.primary + Phospho
 
 ### 5.0 Tracer bullet (Phase 2.0)
 
-- [ ] `apps/web/package.json` contains `vr:update:story` script that invokes `test-storybook -u` and forwards trailing arguments to the test-runner. Invoke as `pnpm vr:update:story -- --testPathPatterns=<regex>` so the explicit Jest flag (plural — `--testPathPattern` was deprecated) reaches Jest via test-storybook's pass-through. The regex matches synthetic test file paths derived from story IDs (e.g. `ui-button`), not source `.stories.tsx` paths.
+- [ ] `apps/web/package.json` contains `vr:update:story` script that invokes `test-storybook -u` and forwards trailing arguments to the test-runner. Invoke as `pnpm vr:update:story -- <regex>` — the pattern must be a BARE POSITIONAL argument; `test-storybook` rejects unknown `--flags` (including Jest's `--testPathPatterns`) and only forwards positional operands to Jest. The regex matches synthetic test file paths derived from story IDs (e.g. `ui-button`), not source `.stories.tsx` paths.
 - [ ] `apps/web/src/styles/globals.css` `@theme` block contains `--color-alert: #B84A3A`, `--color-warning: #C68B2C`, `--color-alert-soft: #E8D5CF`, `--color-warning-soft: #ECDDB8`
 - [ ] `@phosphor-icons/react` installed in `apps/web/package.json`
 - [ ] `apps/web/src/lib/icons.redesign.ts` exists and exports at least `ArrowRight` as a `weight="fill"` wrapper component
 - [ ] `<Button variant="primary">` renders `bg-jersey-deep text-cream` with the documented hover/focus treatment
 - [ ] `Button.stories.tsx` `PrimaryRedesigned` story exists with `tags: ["autodocs", "vr"]` and a captured VR baseline
-- [ ] `pnpm vr:update:story -- --testPathPatterns=ui-button` (or any `testPathPatterns` regex anchored to the Button atom's story-ID prefix) updates only Button-story baselines (verified by counting changed PNG files)
+- [ ] `pnpm vr:update:story -- ui-button` (or any positional regex anchored to the Button atom's story-ID prefix) updates only Button-story baselines (verified by counting changed PNG files)
 - [ ] `pnpm --filter @kcvv/web check-all` passes
 
 ### 5.A Track A acceptance (per child issue, summarised here)
@@ -457,7 +457,7 @@ Legacy `--color-kcvv-warning` and `--color-kcvv-alert` stay defined; legacy comp
 "vr:update:story": "pnpm run vr:build-storybook && docker compose -f docker-compose.vr.yml run --rm vr -u"
 ```
 
-Invocation: `pnpm vr:update:story -- --testPathPatterns=ui-button` — only updates baselines for stories whose synthetic test path matches the regex. The `--` separator hands the trailing arguments to test-storybook, which forwards `--testPathPatterns=<regex>` to Jest (the flag is plural in current Jest; the singular `--testPathPattern` is deprecated). The regex matches the synthetic test file paths derived from story IDs (e.g. `ui-button`, `layout-pagefooter`), not the source `.stories.tsx` file paths. Use a tight anchor like `ui-button` to scope to a single atom without dragging in `ui-linkbutton`/`ui-downloadbutton`/etc. Pattern is a Jest-compatible regex string.
+Invocation: `pnpm vr:update:story -- ui-button` — only updates baselines for stories whose synthetic test path matches the regex. The `--` separator hands the trailing arguments to test-storybook, which forwards positional operands (and only those — unknown `--flags` are rejected) to Jest, where a bare positional is read as a test-path regex. The regex matches the synthetic test file paths derived from story IDs (e.g. `ui-button`, `layout-pagefooter`), not the source `.stories.tsx` file paths. Use a tight anchor like `ui-button` to scope to a single atom without dragging in `ui-linkbutton`/`ui-downloadbutton`/etc. Pattern is a Jest-compatible regex string.
 
 ### 6.9 Composition primitives — `<ClippedCard>` + `<StampBadge>`
 
@@ -529,7 +529,7 @@ Submit button uses `<Button variant="secondary">` (cream-soft body + ink border 
 
 VR baselines are committed in the same PR as the atom that invalidates them. For each atom PR:
 
-1. Run `pnpm vr:update:story -- --testPathPatterns=<regex>` locally (e.g. `pnpm vr:update:story -- --testPathPatterns=ui-button`) to capture only the changed atom's baselines. The regex is a Jest-compatible `testPathPatterns` value; anchor it tightly to the atom's story-ID prefix (which is what the synthetic test paths use, not source paths). First-degree consumer stories whose visuals change because they import the redesigned atom should be opted out via `parameters.vr.disable: true` per `apps/web/CLAUDE.md` → _Atom reskin PRs_, with the consumer's redesign issue as the re-evaluate date — not auto-baselined here.
+1. Run `pnpm vr:update:story -- <regex>` locally (e.g. `pnpm vr:update:story -- ui-button`) to capture only the changed atom's baselines. The regex is a Jest-compatible test-path pattern passed positionally; anchor it tightly to the atom's story-ID prefix (which is what the synthetic test paths use, not source paths). First-degree consumer stories whose visuals change because they import the redesigned atom should be opted out via `parameters.vr.disable: true` per `apps/web/CLAUDE.md` → _Atom reskin PRs_, with the consumer's redesign issue as the re-evaluate date — not auto-baselined here.
 2. Inspect the produced baselines manually — the atom should look correct in light + dark, sm + md + lg, default + hover/focus/disabled per its story matrix.
 3. Stage and commit the new/updated baseline PNGs in the same commit as the component change.
 4. PR description includes a "## VR baselines" section listing every story file whose baseline changed (justifies the update per the VR contract).


### PR DESCRIPTION
## Problem

Long player names on the `/share` graphics overflow the 1080px frame and get
clipped in the exported PNG — the auto-fit added in #2159 stopped taking effect
(reported against `kcvv-nextjs.vercel.app`: a Goal KCVV story rendered
"Bixente Ceus…" running straight off the right edge).

## Root cause

`useAutoFit` (`apps/web/src/components/share/shared/ShareElements.tsx`) probes by
writing the **base** font size onto the element imperatively, measuring
`scrollWidth`, then calling `setSize(next)`.

The webfont re-fit (`fonts.load` / `fonts.ready`) re-runs `fit()`. It computes the
**same** number the first fit already produced, so React bails out of the
re-render — and the base-size probe stays on the DOM. The name then overflows the
frame and `html-to-image` captures it clipped.

That's why it read as intermittent:

- **Cold load** — the first fit measures fallback metrics, the re-fit computes a
  *different* number, React re-renders, everything works.
- **Warm load** — Freight is already loaded by the rest of the page (normal since
  #2174 moved the body font to Freight Sans Pro too), both fits agree, and the
  element is left at base size.

Every consumer of the hook was affected: `ShareName`, `Headline`, `Scoreline`.

## Fix

Write the computed size back imperatively alongside `setSize`, so the probe value
can never survive a React bail-out.

```typescript
if (cancelled) return;
el.style.fontSize = `${next}px`;
setSize(next);
```

## Testing

- New regression test in `ShareFrame.test.tsx` stubs `document.fonts` so the
  re-fit actually runs (the existing auto-fit tests only ever exercised the first
  fit, which is why this slipped through). Verified it **fails** on the old code
  and passes on the new.
- `vitest src/components/share` — 120/120 green.
- `lint` + `type-check` clean.

## VR baselines

**None changed.** Docker-local scoped run over all 8 `features-share-*` suites:
72 snapshots, 72 passed, 0 written. Two independent reasons the fix is invisible
to VR — both verified, neither a reason to skip the run:

1. The story fixtures use short names (`Mertens`, `Janssen`, `Jan Peeters`), so
   auto-fit is a no-op at base size.
2. Captures are viewport-clipped, not full-page. These templates are a
   1080×1920 Story canvas, so the baselines only cover the top third — crest,
   kicker, headline. The player-name band sits ~1150px down and is **never**
   captured at any viewport.

I did try adding a `LongName` story as a guard, captured its baselines, and then
dropped it: the name isn't in the screenshot at any viewport, so it would have
been a guard that can never fail. The unit test is the real guard. Limitation (2)
is now written down in `apps/web/CLAUDE.md`.

## Drive-by: VR scoping was broken

While checking baselines I found that `apps/web/CLAUDE.md`'s surgical-capture
command has never worked. `test-storybook` parses its CLI with commander against
a closed option allowlist and exits 1 with the help text on any unrecognised
`--flag` — including Jest's `--testPathPatterns`, which the docs have recommended
since Phase 2. Every documented scoped capture failed before running anything,
leaving the full ~40-minute suite as the only option.

Positional operands _are_ forwarded verbatim to Jest, which reads a bare
positional as a test-path regex:

```bash
pnpm --filter @kcvv/web run vr:update:story -- features-share   # works
docker compose -f docker-compose.vr.yml run --rm vr --listTests features-share
# → 8 files, e.g. features-share-goalkcvvtemplate.test.js
```

Second commit fixes that in `apps/web/CLAUDE.md` and `docs/prd/redesign-phase-2.md`,
and documents `--includeTags` / `STORYBOOK_*_TAGS` as the other scoping axis plus
the bare `docker compose run` form that skips the ~2 min Storybook rebuild.
No new markdownlint violations (violation counts identical before/after; neither
file was lint-clean to begin with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ShareName auto-fitting so font sizes are applied reliably and remain consistent after webfont loading and re-measurement.

* **Documentation**
  * Updated visual regression guidance with the correct syntax for running targeted story updates and checks.
  * Clarified how positional patterns are matched and documented the targeted baseline workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->