### PR TITLE
fix(search): batch Vectorize upserts in the nightly index sync (#2317)

### DIFF
--- a/apps/api/src/search/sanity-index-sync.test.ts
+++ b/apps/api/src/search/sanity-index-sync.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Exit, Layer, Logger } from "effect";
 import { runSanityIndexSync } from "./sanity-index-sync";
-import { EmbeddingService, type EmbeddingServiceInterface } from "./embedding";
 import {
+  EmbeddingError,
+  EmbeddingService,
+  type EmbeddingServiceInterface,
+} from "./embedding";
+import {
+  VectorizeError,
   VectorizeService,
   type VectorizeServiceInterface,
   type VectorRecord,
@@ -58,18 +63,29 @@ function makeEmbeddingMock(): EmbeddingServiceInterface {
   return { embed: () => Effect.succeed(FAKE_VECTOR) };
 }
 
-function makeVectorizeCapture() {
+/**
+ * Records every upsert batch. Each call yields to the macrotask queue so
+ * overlapping calls are observable — `probe.maxInFlight` stays 1 only if the
+ * batches really are upserted one at a time.
+ */
+function makeVectorizeCapture(overrides?: Partial<VectorizeServiceInterface>) {
   const upsertCalls: VectorRecord[][] = [];
+  const probe = { inFlight: 0, maxInFlight: 0 };
   const mock: VectorizeServiceInterface = {
     upsert: (vectors) =>
-      Effect.sync(() => {
+      Effect.promise(async () => {
+        probe.inFlight++;
+        probe.maxInFlight = Math.max(probe.maxInFlight, probe.inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        probe.inFlight--;
         upsertCalls.push(vectors);
       }),
     query: () => Effect.succeed([]),
     getByIds: () => Effect.succeed([]),
     deleteByIds: () => Effect.succeed(undefined as void),
+    ...overrides,
   };
-  return { upsertCalls, mock };
+  return { upsertCalls, probe, mock };
 }
 
 function noopFetch<T>(data: T[]) {
@@ -293,5 +309,120 @@ describe("runSanityIndexSync", () => {
     const upserted = upsertCalls.flat();
     expect(upserted.find((v) => v.id === "sanity-abc-123")).toBeDefined();
     expect(upserted.find((v) => v.id === "article-001")).toBeDefined();
+  });
+
+  it("batches upserts per doc-type instead of once per document", async () => {
+    const { upsertCalls, mock } = makeVectorizeCapture();
+
+    await Effect.runPromise(
+      runSanityIndexSync({
+        fetchResponsibility: noopFetch([
+          mockDoc,
+          { ...mockDoc, _id: "resp-002" },
+          { ...mockDoc, _id: "resp-003" },
+        ]),
+        fetchArticles: noopFetch([
+          mockArticle,
+          { ...mockArticle, _id: "article-002" },
+        ]),
+        fetchPages: noopFetch([mockPage, { ...mockPage, _id: "page-002" }]),
+      }).pipe(
+        Effect.provide(makeEnvLayer()),
+        Effect.provide(Layer.succeed(EmbeddingService, makeEmbeddingMock())),
+        Effect.provide(Layer.succeed(VectorizeService, mock)),
+      ),
+    );
+
+    // 7 documents, one batched upsert per doc-type
+    expect(upsertCalls).toHaveLength(3);
+    expect(upsertCalls.map((batch) => batch.length)).toEqual([3, 2, 2]);
+  });
+
+  it("chunks a batch above the 1000-vector cap and upserts the chunks sequentially", async () => {
+    const { upsertCalls, probe, mock } = makeVectorizeCapture();
+    const manyPages = Array.from({ length: 1001 }, (_, i) => ({
+      ...mockPage,
+      _id: `page-${i}`,
+    }));
+
+    await Effect.runPromise(
+      runSanityIndexSync({
+        fetchResponsibility: noopFetch([]),
+        fetchArticles: noopFetch([]),
+        fetchPages: noopFetch(manyPages),
+      }).pipe(
+        Effect.provide(makeEnvLayer()),
+        Effect.provide(Layer.succeed(EmbeddingService, makeEmbeddingMock())),
+        Effect.provide(Layer.succeed(VectorizeService, mock)),
+      ),
+    );
+
+    expect(upsertCalls.map((batch) => batch.length)).toEqual([1000, 1]);
+    expect(probe.maxInFlight).toBe(1);
+  });
+
+  it("omits a document whose embedding fails and still upserts the rest", async () => {
+    const { upsertCalls, mock } = makeVectorizeCapture();
+    const flakyEmbed: EmbeddingServiceInterface = {
+      embed: (text) =>
+        text.includes("derby")
+          ? Effect.fail(new EmbeddingError("Workers AI unavailable"))
+          : Effect.succeed(FAKE_VECTOR),
+    };
+
+    await Effect.runPromise(
+      runSanityIndexSync({
+        fetchResponsibility: noopFetch([]),
+        fetchArticles: noopFetch([
+          mockArticle,
+          {
+            ...mockArticle,
+            _id: "article-002",
+            title: "Gelijkspel",
+            tags: ["verslag"],
+            bodyText: "KCVV Elewijt speelde 1-1 gelijk.",
+          },
+        ]),
+        fetchPages: noopFetch([]),
+      }).pipe(
+        Effect.provide(makeEnvLayer()),
+        Effect.provide(Layer.succeed(EmbeddingService, flakyEmbed)),
+        Effect.provide(Layer.succeed(VectorizeService, mock)),
+      ),
+    );
+
+    const upserted = upsertCalls.flat();
+    expect(upserted.map((v) => v.id)).toEqual(["article-002"]);
+  });
+
+  it("logs the dropped count and completes the run when a batch keeps failing", async () => {
+    const messages: string[] = [];
+    const TestLogger = Logger.make(({ message }) => {
+      messages.push(String(message));
+    });
+    const { mock: failingVectorize } = makeVectorizeCapture({
+      upsert: () => Effect.fail(new VectorizeError("40041 Too Many Requests")),
+    });
+
+    const exit = await Effect.runPromiseExit(
+      runSanityIndexSync({
+        fetchResponsibility: noopFetch([mockDoc]),
+        fetchArticles: noopFetch([]),
+        fetchPages: noopFetch([]),
+      }).pipe(
+        Effect.provide(makeEnvLayer()),
+        Effect.provide(Layer.succeed(EmbeddingService, makeEmbeddingMock())),
+        Effect.provide(Layer.succeed(VectorizeService, failingVectorize)),
+        Effect.provide(Logger.replace(Logger.defaultLogger, TestLogger)),
+      ),
+    );
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(
+      messages.some((m) => m.includes("dropped 1 of 1") && m.includes("40041")),
+    ).toBe(true);
+    expect(
+      messages.some((m) => m.includes("Indexed 0/1 responsibility paths")),
+    ).toBe(true);
   });
 });

--- a/apps/api/src/search/sanity-index-sync.ts
+++ b/apps/api/src/search/sanity-index-sync.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@sanity/client";
-import { Effect } from "effect";
+import { Array as Arr, Effect, Schedule } from "effect";
 import { WorkerEnvTag } from "../env";
 import { sanityClientConfig } from "../sanity/config";
 import { EmbeddingService } from "./embedding";
@@ -9,7 +9,7 @@ import {
   buildPageIndexText,
   buildResponsibilityIndexText,
 } from "./index-text";
-import { VectorizeService } from "./vectorize";
+import { VectorizeService, type VectorRecord } from "./vectorize";
 
 // ─── Types (only fields needed for indexing) ──────────────────────────────────
 
@@ -65,6 +65,20 @@ const PAGE_QUERY = `*[_type == "page"] {
   "bodyText": pt::text(body)
 }`;
 
+// ─── Batching ────────────────────────────────────────────────────────────────
+
+// Vectorize caps a binding upsert at 1000 vectors/request. Its write-ahead log
+// handles one batch at a time and does not queue concurrent writes, so chunks
+// go out sequentially — parallel upserts contend for that slot and surface as
+// 40041 Too Many Requests.
+const MAX_VECTORS_PER_UPSERT = 1000;
+
+// Belt-and-suspenders for a transient limit; batching is what removes the burst.
+const UPSERT_RETRY = Schedule.exponential("100 millis").pipe(
+  Schedule.jittered,
+  Schedule.intersect(Schedule.recurs(3)),
+);
+
 // ─── Options ─────────────────────────────────────────────────────────────────
 
 interface SyncOptions {
@@ -89,22 +103,45 @@ export const runSanityIndexSync = (options?: SyncOptions) =>
         perspective: "published",
       }));
 
-    const indexDoc = (
+    // A failed embedding drops just its own document from the batch.
+    const embedDoc = (
       id: string,
       text: string,
       metadata: Record<string, string>,
     ) =>
       embedding.embed(text).pipe(
-        Effect.flatMap((vector) =>
-          vectorize.upsert([{ id, values: vector, metadata }]),
-        ),
-        Effect.as(true),
+        Effect.map((values): VectorRecord | null => ({ id, values, metadata })),
         Effect.catchAll((e) =>
           Effect.log(`[search-sync] skipped ${id}: ${String(e)}`).pipe(
-            Effect.as(false),
+            Effect.as(null),
           ),
         ),
       );
+
+    /**
+     * Upserts the embedded documents in ≤1000-sized chunks, skipping the ones
+     * that failed to embed. Returns how many vectors landed.
+     */
+    const upsertBatched = (
+      embedded: (VectorRecord | null)[],
+      label: string,
+    ) => {
+      const vectors = embedded.filter((v) => v !== null);
+      return Effect.forEach(
+        Arr.chunksOf(vectors, MAX_VECTORS_PER_UPSERT),
+        (chunk) =>
+          vectorize.upsert(chunk).pipe(
+            Effect.retry(UPSERT_RETRY),
+            Effect.as(chunk.length),
+            Effect.catchAll((e) =>
+              Effect.logError(
+                `[search-sync] Upsert failed after retries — dropped ${chunk.length} of ${vectors.length} ${label}: ${String(e)}`,
+              ).pipe(Effect.as(0)),
+            ),
+          ),
+        { concurrency: 1 },
+      ).pipe(Effect.map((landed) => landed.reduce((total, n) => total + n, 0)));
+    };
 
     // ── Responsibility paths ──────────────────────────────────────────────
 
@@ -122,24 +159,21 @@ export const runSanityIndexSync = (options?: SyncOptions) =>
       `[search-sync] Indexing ${docs.length} responsibility paths`,
     );
 
-    let successCount = 0;
-
-    yield* Effect.forEach(
+    const responsibilityVectors = yield* Effect.forEach(
       docs,
       (doc) =>
-        indexDoc(doc._id, buildResponsibilityIndexText(doc), {
+        embedDoc(doc._id, buildResponsibilityIndexText(doc), {
           slug: doc.slug,
           type: "responsibility",
           title: doc.title,
           excerpt: doc.summary.slice(0, 200),
-        }).pipe(
-          Effect.tap((ok) =>
-            Effect.sync(() => {
-              if (ok) successCount++;
-            }),
-          ),
-        ),
+        }),
       { concurrency: 5 },
+    );
+
+    const successCount = yield* upsertBatched(
+      responsibilityVectors,
+      "responsibility paths",
     );
 
     yield* Effect.log(
@@ -167,26 +201,23 @@ export const runSanityIndexSync = (options?: SyncOptions) =>
       `[search-sync] Indexing ${articleResult.length} articles`,
     );
 
-    let articleSuccessCount = 0;
-
-    yield* Effect.forEach(
+    const articleVectors = yield* Effect.forEach(
       articleResult,
       (doc) =>
-        indexDoc(doc._id, buildArticleIndexText(doc), {
+        embedDoc(doc._id, buildArticleIndexText(doc), {
           slug: doc.slug,
           type: "article",
           title: doc.title,
           excerpt: (doc.bodyText ?? "").slice(0, 200),
           tags: (doc.tags ?? []).join(","),
           ...(doc.imageUrl ? { imageUrl: doc.imageUrl } : {}),
-        }).pipe(
-          Effect.tap((ok) =>
-            Effect.sync(() => {
-              if (ok) articleSuccessCount++;
-            }),
-          ),
-        ),
+        }),
       { concurrency: 3 },
+    );
+
+    const articleSuccessCount = yield* upsertBatched(
+      articleVectors,
+      "articles",
     );
 
     yield* Effect.log(
@@ -212,25 +243,19 @@ export const runSanityIndexSync = (options?: SyncOptions) =>
 
     yield* Effect.log(`[search-sync] Indexing ${pageResult.length} pages`);
 
-    let pageSuccessCount = 0;
-
-    yield* Effect.forEach(
+    const pageVectors = yield* Effect.forEach(
       pageResult,
       (doc) =>
-        indexDoc(doc._id, buildPageIndexText(doc), {
+        embedDoc(doc._id, buildPageIndexText(doc), {
           slug: doc.slug,
           type: "page",
           title: doc.title,
           excerpt: (doc.bodyText ?? "").slice(0, 200),
-        }).pipe(
-          Effect.tap((ok) =>
-            Effect.sync(() => {
-              if (ok) pageSuccessCount++;
-            }),
-          ),
-        ),
+        }),
       { concurrency: 3 },
     );
+
+    const pageSuccessCount = yield* upsertBatched(pageVectors, "pages");
 
     yield* Effect.log(
       `[search-sync] Indexed ${pageSuccessCount}/${pageResult.length} pages`,


### PR DESCRIPTION
Closes #2317

## Problem

`runSanityIndexSync` fired one `vectorize.upsert([oneVector])` per document at concurrency 5/3/3. Vectorize processes mutations through a write-ahead log that handles **one batch at a time** and does not queue concurrent writes, so those parallel single-vector upserts contended for that one slot and returned `40041 Too Many Requests` — the nightly reconciliation backstop partially failed every night and the `kcvv-search` index drifted.

## Changes

`apps/api/src/search/sanity-index-sync.ts` — caller-side only:

- **Split embed from upsert.** `indexDoc` (embed + upsert + swallow both) became `embedDoc` (embed → `VectorRecord | null`) plus `upsertBatched` (collect → chunk → upsert).
- **One batched upsert per doc-type.** A full run is now **3 requests instead of ~35**. Empty doc-types issue zero requests (`Arr.chunksOf([], 1000)` → `[]`).
- **Growth guard:** batches above Vectorize's 1000-vector binding cap chunk to ≤1000 and go out **sequentially** (`{ concurrency: 1 }`). The corpus is ~35 today.
- **Embedding stays concurrent** at the existing 5 / 3 / 3 — only the upserts serialise.
- **Per-doc embedding failure** drops just that document from its batch and is logged; the remaining documents still upsert.
- **Bounded retry** on the batched upsert: `Schedule.exponential("100 millis")` + `jittered` + `intersect(recurs(3))`. Verified empirically — 4 attempts at t≈1/119/331/693 ms, i.e. 3 retries with exponential+jitter delays preserved. (`intersect` is the correct combinator here: `union` continues while *either* schedule does → unbounded; `compose` would feed `recurs`' zero delay.)
- **Residual failure escalates.** `Effect.logError` with the dropped count (`dropped N of M <label>`), replacing today's silent `Effect.log("[search-sync] skipped …")`.
- **The cron does not hard-fail** on a partial run — a partial backstop beats none, and error-level logs surface the drift in invocation logs.
- **`VectorizeService.upsert` untouched**, so the real-time webhook path (`/webhooks/index`, one doc per request) inherits no sync-only retry semantics.

Side effect: the three mutable `let …SuccessCount` counters are gone — each doc-type's tally is now the `const` return of `upsertBatched`.

> **Note on `Indexed X/Y`:** granularity moves from per-doc to per-chunk, so a chunk failure now zeroes X for that doc-type instead of decrementing by one. That is inherent to batching and matches the batch-level dropped count the issue asked for.

## Testing

`pnpm --filter @kcvv/api lint && type-check && test` — all clean, **401 tests pass** (29 files). Prettier clean.

Four new tests in `sanity-index-sync.test.ts`:

| Test | Guards |
| --- | --- |
| batches upserts per doc-type instead of once per document | 7 docs → `upsertCalls` length 3, sizes `[3, 2, 2]` |
| chunks a batch above the 1000-vector cap and upserts the chunks sequentially | 1001 docs → `[1000, 1]` **and** `maxInFlight === 1` |
| omits a document whose embedding fails and still upserts the rest | only the surviving doc is upserted |
| logs the dropped count and completes the run when a batch keeps failing | `Exit.isSuccess`, plus `dropped 1 of 1` and `40041` in the logs |

**Mutation-checked:** flipping `{ concurrency: 1 }` → `{ concurrency: "unbounded" }` fails the chunking test with `expected 2 to be 1`. This matters — an earlier version of that test asserted only the chunk *sizes*, which stayed `[1000, 1]` under unbounded concurrency, so the "never concurrently" half of the AC was silently unguarded. The mock now yields to the macrotask queue so overlap is observable.

The three existing `VectorizeServiceInterface` mock copies in the new tests were collapsed into one `makeVectorizeCapture(overrides?)` factory, matching the peer form already in `handlers/related.test.ts`.

## Review gate

`/code-review` (both axes) and `/simplify` (4 agents) were run on the branch diff.

**Applied:** the sequencing coverage hole above; folded the repeated `.filter((v) => v !== null)` into `upsertBatched`; native `.reduce` over `Arr.reduce`; deduped the mock factories.

**Refuted (spec-mandated):** switching `Effect.logError` → `logWarning` to match the other `apps/api` degrade paths (the AC names `Effect.logError`); dropping `Schedule.jittered` (the AC names jitter); collapsing `concurrency: 5`/`3` into one constant (the AC says preserve the existing values).

**Skipped as out of scope** — each a pre-existing condition this diff didn't create:

- Moving the 1000 cap / chunking into `vectorize.ts`, where it arguably belongs as a property of the binding — the issue explicitly requires that file stay unchanged. Worth a follow-up if a second bulk caller appears (`deleteByIds` has the same cap).
- Collapsing the three ~95%-identical doc-type blocks into a table-driven loop. Reviewers split on this; the case against won — three doc shapes, three text builders, three metadata projections, two concurrency values, and *asymmetric* fetch-error handling (a responsibility-fetch failure is fatal; articles/pages `catchAll` to `[]`) means a table needs per-entry generics plus an escape hatch.
- The local `makeEnvLayer()` duplicating `test-helpers/env-layer.ts`.

**Two pre-existing issues found while reviewing, neither touched:**

1. A responsibility **fetch** failure still propagates and the cron rethrows inside `waitUntil` — articles and pages have a `catchAll`, responsibilities don't. The asymmetry survives a refactor of exactly that region.
2. The sync's article metadata includes `tags`; the webhook's equivalent builder in `index-handler.ts` omits it. The two indexing paths have drifted on metadata shape.

Say the word and I'll file either as its own issue.

## Not verified here

AC 2 ("a full run indexes 100% with **zero** 40041") can only be ticked by a real nightly run — the code side is 3 sequential requests with no upsert concurrency anywhere. #2323 tracks confirming the Sanity webhook is actually wired to `/webhooks/index` in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
