### PR TITLE
fix(matches): align web cache layers to the BFF freshness window (#2330)

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -561,6 +561,7 @@ export default async function HomePage() {
 }
 
 /**
- * Enable ISR with 1 hour revalidation
+ * Enable ISR with 15 minute revalidation — the homepage renders live PSD
+ * match data (next match), so its cache is aligned to the BFF freshness window.
  */
-export const revalidate = 3600;
+export const revalidate = 900;

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -633,12 +633,14 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 // 24h ISR — article publishes invalidate on demand via /api/revalidate
 // (revalidatePath '/nieuws/<slug>' + revalidateTag 'articles').
 //
-// Cache-freshness audit (#2330): match articles embed live PSD chrome via
-// getMatchDetail, but this is a webhook-fresh Sanity surface rendered through
-// generateStaticParams. Aligning the embedded match to the BFF window would
-// force the whole news corpus to revalidate every 15 min (route revalidate is
-// static, not per-article) — contradicting "Sanity content is webhook-fresh
-// and unaffected". The chrome is post-hoc enhancement (recap scores are final;
-// any BFF failure degrades to no chrome) and the acute live-match surfaces
-// (homepage, team pages, calendar) are handled separately, so this timer stays.
+// Cache-freshness audit (#2330): this is a webhook-fresh Sanity surface, so the
+// route keeps its 24h ISR window. Match articles (matchPreview/matchRecap) embed
+// live PSD chrome via getMatchDetail, but they are excluded from
+// generateStaticParams (see its filter) and render on demand via ISR. The route
+// `revalidate` is static, not per-article, so aligning the embedded match to the
+// BFF window would force the whole news corpus to revalidate every 15 min —
+// contradicting "Sanity content is webhook-fresh and unaffected". The chrome is
+// post-hoc enhancement (recap scores are final; any BFF failure degrades to no
+// chrome) and the acute live-match surfaces (homepage, team pages, calendar) are
+// handled separately, so this timer stays.
 export const revalidate = 86400;

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -632,4 +632,13 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 
 // 24h ISR — article publishes invalidate on demand via /api/revalidate
 // (revalidatePath '/nieuws/<slug>' + revalidateTag 'articles').
+//
+// Cache-freshness audit (#2330): match articles embed live PSD chrome via
+// getMatchDetail, but this is a webhook-fresh Sanity surface rendered through
+// generateStaticParams. Aligning the embedded match to the BFF window would
+// force the whole news corpus to revalidate every 15 min (route revalidate is
+// static, not per-article) — contradicting "Sanity content is webhook-fresh
+// and unaffected". The chrome is post-hoc enhancement (recap scores are final;
+// any BFF failure degrades to no chrome) and the acute live-match surfaces
+// (homepage, team pages, calendar) are handled separately, so this timer stays.
 export const revalidate = 86400;

--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -332,6 +332,7 @@ export default async function TeamPage({ params }: TeamPageProps) {
   );
 }
 
-// 6h ISR — rosters change rarely; editor publishes invalidate on demand via
-// /api/revalidate (revalidateTag 'teams').
-export const revalidate = 21600;
+// 15 min ISR — the page renders live PSD match data (fixtures + standings), so
+// its cache is aligned to the BFF freshness window. Editor publishes still
+// invalidate rosters on demand via /api/revalidate (revalidateTag 'teams').
+export const revalidate = 900;

--- a/apps/web/src/app/(main)/scheurkalender/page.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/page.tsx
@@ -134,6 +134,7 @@ export default async function ScheurkalenderPageRoute() {
   return <ScheurkalenderPage matches={matches} season={season} />;
 }
 
-// Season fixtures change rarely — cache long (6h ISR). Never generateStaticParams
-// (PSD rate limits); ISR keeps per-request rendering fast without build fan-out.
-export const revalidate = 21600;
+// 15 min ISR — renders live PSD fixtures, so its cache is aligned to the BFF
+// freshness window. Never generateStaticParams (PSD rate limits); ISR keeps
+// per-request rendering fast without build fan-out.
+export const revalidate = 900;

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/page.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/page.tsx
@@ -34,6 +34,11 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// 15 min ISR — renders live PSD opponent-match history. Without an explicit
+// revalidate this on-demand dynamic route would sit in the Full Route Cache
+// indefinitely, so it is aligned to the BFF freshness window.
+export const revalidate = 900;
+
 interface OpponentPageProps {
   params: Promise<{ clubId: string }>;
 }

--- a/apps/web/src/app/api/calendar.ics/route.ts
+++ b/apps/web/src/app/api/calendar.ics/route.ts
@@ -9,7 +9,10 @@ import { generateIcal, normalizeCacheKey } from "@/lib/utils/ical";
 
 export const runtime = "nodejs";
 
-const CACHE_MAX_AGE = 43200; // 12 hours
+// 15 min — this feed is built from live PSD match data (bff.getMatches), so its
+// cache (unstable_cache revalidate + Cache-Control) is aligned to the BFF
+// freshness window rather than holding fixtures for 12h.
+const CACHE_MAX_AGE = 900;
 const MAX_TEAM_IDS = 20;
 const FETCH_CONCURRENCY = 5;
 


### PR DESCRIPTION
Closes #2330

Part D of the reliable PSD match delivery spec (#2327). The BFF is the single source of truth for PSD freshness (~15 min window), but Next.js ISR/route caches sat in front and could hold PSD match data far longer — the homepage cached next-match for 1h. This aligns every PSD-data-bearing web surface to a 15 min (900s) cache. Sanity-only pages keep their long, webhook-fresh timers.

## Audit conclusion

I grepped every route segment under `apps/web/src/app` for `revalidate` / `dynamic` / `Cache-Control` / `headers()` and traced each candidate's data source (PSD = via BFF/`BffService`; Sanity = repositories/GROQ).

**PSD-data-bearing → aligned to ≤15 min:**

| Surface | Before | After | PSD data |
| --- | --- | --- | --- |
| `(landing)/page.tsx` | `revalidate = 3600` | `900` | next-match widget |
| `ploegen/[slug]/page.tsx` | `revalidate = 21600` | `900` | `bff.getMatches` fixtures + standings |
| `scheurkalender/page.tsx` | `revalidate = 21600` | `900` | `bff.getMatches` fixtures |
| `tegenstander/[clubId]/page.tsx` | _(none)_ | `revalidate = 900` | `bff.getOpponentHistory` |
| `api/calendar.ics/route.ts` | `CACHE_MAX_AGE = 43200` | `900` | `bff.getMatches` |

Two of these were beyond the issue's "known" list but fall squarely under *"audit every PSD-data-bearing page"*:

- **`tegenstander/[clubId]`** — an on-demand dynamic route (no `generateStaticParams`) with **no cache config at all**, so its Full Route Cache would sit indefinitely. Now capped at 900.
- **`api/calendar.ics`** — this is exactly AC4's target: a manual `Cache-Control: max-age/s-maxage=43200` (12h) override on a PSD surface. Both the `unstable_cache` revalidate and the header now sit at 900 in lockstep.

**Left unchanged (Sanity-only, webhook-fresh):** `ploegen` index, `spelers/[slug]`, `staf/[slug]`, `nieuws` index, all `club/*`, `evenementen/*`, `galerij/*`, `jeugd`, `sponsors`, `hulp`. The `players`/`player`/`staff` dirs are legacy SEO redirects (no render). `wedstrijd/[matchId]` (300) and the `force-dynamic` routes (`kalender`, `ploegen/[slug]/wedstrijden`, `share`, `api/search`) were already fine.

**One documented exception — `nieuws/[slug]` (kept at 24h):** match articles embed live PSD chrome via `getMatchDetail`, but this is a webhook-fresh Sanity surface rendered through `generateStaticParams`. A route `revalidate` is static (can't target only match articles), so aligning it would force the entire news corpus to revalidate every 15 min — contradicting *"Sanity content is webhook-fresh and unaffected"*. The embedded match is post-hoc enhancement (recap scores are final; any BFF failure degrades to no chrome), and the acute live-match surfaces are handled above. Recorded as an audit note in the file for the owner to revisit if desired.

## Changes

- Homepage, `ploegen/[slug]`, `scheurkalender`: `revalidate` → `900`.
- `tegenstander/[clubId]`: add `revalidate = 900`.
- `api/calendar.ics`: `CACHE_MAX_AGE` → `900`.
- `nieuws/[slug]`: audit-note comment only (no timer change).

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint + type-check + test + build). Build-time BFF transport errors on `localhost:8787` are expected (no local BFF; the pages degrade gracefully via `catchAll`).
- Build output confirms the effective `Revalidate` on `/` and `/scheurkalender` is `5m` (Next takes the minimum of the route ceiling and an inner 300s PSD cache) — well within the 15 min window.

## Review

Ran `/code-review` (Standards + Spec) and `/simplify`:
- **Applied:** the Spec axis flagged `nieuws/[slug]` as an audit gap — addressed with the documented exception above.
- **Refuted:** Standards flagged the repeated `900` literal as centralizable into a shared constant. Next.js requires `revalidate` to be a statically-analyzable **literal** export, so an imported constant is fragile/unsupported for the page exports and would split the pattern; four self-documenting literals is the Next-native form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Homepage, team pages, opponent histories, and the tear-off calendar now refresh approximately every 15 minutes, helping display more current match information.
  * Calendar feed updates are reflected sooner in connected calendar applications.
  * Match-related data is better aligned with the latest available live information.
* **Documentation**
  * Added clarification about freshness expectations for match-related news content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->