### PR TITLE
feat(api): PSD gate (Durable Object) + stale-while-revalidate read path (#2328)

### DIFF
--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -662,12 +662,50 @@ describe("TypedKvCache — stale-while-revalidate + storm gate (#2328)", () => {
     expect(fanOuts).toBe(1);
   });
 
-  it("sustained outage decouples PSD calls from request volume (~4% collapse)", async () => {
-    // Under a sustained 429, the negative marker suppresses re-fanning: after the
-    // first failed refresh, every subsequent read serves stale WITHOUT fetching
-    // until the marker expires. So PSD load tracks the marker cadence, not the
-    // request rate — the mechanism behind the prototype's 475%→~4% collapse
-    // (#2324). Here: 50 reads during an outage → a single fan-out attempt.
+  it("concurrent misses never run duplicate fan-outs, even when the leader fails", async () => {
+    // AC3 under failure: followers re-enter single-flight instead of all
+    // self-fetching, so at no instant do two fan-outs run for the same key.
+    const mockKv = makeMockKv();
+    const gate = makePsdGateLayer(new GateLogic({ ratePerSecond: 1e9 }));
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const fetchEffect = Effect.gen(function* () {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      yield* Effect.sleep("3 millis");
+      inFlight--;
+      return yield* Effect.fail(new Error("PSD 429") as never);
+    });
+
+    const typedCache = TypedKvCache(TestSchema);
+    const run = () =>
+      Effect.runPromiseExit(
+        typedCache
+          .getOrFetch("test-key", fetchEffect, 60)
+          .pipe(
+            Effect.provide(KvCacheLive),
+            Effect.provide(gate),
+            Effect.provide(makeEnvLayer(mockKv)),
+          ),
+      );
+
+    const exits = await Promise.all(Array.from({ length: 10 }, run));
+    // Nothing was ever cached, so every caller surfaces the error (AC7).
+    for (const e of exits) expect(e._tag).toBe("Failure");
+    // Crucially: fan-outs were serialized, never concurrent.
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("sustained outage decouples PSD calls from request volume", async () => {
+    // The storm collapse (#2324) is this decoupling: today every soft-lapsed read
+    // re-fires the fan-out (the 475%-of-budget storm), whereas the negative
+    // marker makes PSD load track the marker cadence, not the request rate —
+    // after the first failed refresh, every subsequent read serves stale WITHOUT
+    // fetching until the marker expires. Here 50 reads during an outage trigger a
+    // SINGLE fan-out attempt; over a day the fan-out count is bounded by
+    // day/NEG_MARKER_TTL windows rather than by traffic, which is what lands the
+    // steady-state figure in the low-single-digit % the prototype measured (~4%).
     const mockKv = makeMockKv();
     mockKv.store.set("test-key", staleWrapper({ name: "stale", value: 1 }));
     const gate = PsdGateTest;

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -9,6 +9,9 @@ import {
   HARD_TTL_LONG,
 } from "./kv-cache";
 import { WorkerEnvTag } from "../env";
+import { PsdGateService, PsdGateTest, makePsdGateLayer } from "../psd/gate";
+import { GateLogic } from "../psd/gate-logic";
+import { BackgroundRunnerService } from "../psd/background";
 
 function makeMockKv() {
   const store = new Map<string, string>();
@@ -16,6 +19,9 @@ function makeMockKv() {
     get: vi.fn(async (key: string) => store.get(key) ?? null),
     put: vi.fn(async (key: string, value: string) => {
       store.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
     }),
     store,
   };
@@ -33,6 +39,7 @@ function makeEnvLayer(
     PSD_API_CLUB: "test-club",
     PSD_API_AUTH: "test-auth",
     PSD_CACHE: mockKv as unknown as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test-project",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",
@@ -63,10 +70,28 @@ describe("TTL constants", () => {
     expect(TTL.RANKING).toBe(60 * 60 * 24);
   });
 
-  it("match-detail proximity tiers (live / matchday / week)", () => {
-    expect(TTL.MATCH_DETAIL_LIVE).toBe(60);
-    expect(TTL.MATCH_DETAIL_MATCHDAY).toBe(60 * 5);
+  it("match-detail proximity tiers: match TTLs floored at 15 min (#2328)", () => {
+    // SWR serves stale instantly, so the soft TTL only sets refresh cadence —
+    // every PSD-backed tier is ≥15 min. (No live scores → old 60 s tier moot.)
+    expect(TTL.MATCH_DETAIL_LIVE).toBe(60 * 15);
+    expect(TTL.MATCH_DETAIL_MATCHDAY).toBe(60 * 15);
     expect(TTL.MATCH_DETAIL_WEEK).toBe(60 * 60);
+  });
+
+  it("every match soft TTL is ≥15 min (#2328)", () => {
+    const MIN = 15 * 60;
+    for (const ttl of [
+      TTL.MATCHES_TEAM,
+      TTL.NEXT_MATCHES,
+      TTL.MATCHES_WINDOW,
+      TTL.MATCH_DETAIL_LIVE,
+      TTL.MATCH_DETAIL_MATCHDAY,
+      TTL.MATCH_DETAIL_WEEK,
+      TTL.MATCH_DETAIL_DEFAULT,
+      TTL.MATCH_DETAIL_PAST,
+    ]) {
+      expect(ttl).toBeGreaterThanOrEqual(MIN);
+    }
   });
 
   it("MATCH_DETAIL_DEFAULT is 24 hours (distant)", () => {
@@ -101,6 +126,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -122,6 +148,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -156,6 +183,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -182,13 +210,22 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
 
     expect(result).toEqual({ name: "stale", value: 99 });
-    // Should NOT update cache on error
-    expect(mockKv.put).not.toHaveBeenCalled();
+    // The data key must NOT be overwritten on error; only the negative marker
+    // is written (suppresses re-storming for NEG_MARKER_TTL).
+    expect(mockKv.put).not.toHaveBeenCalledWith(
+      "test-key",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mockKv.put).toHaveBeenCalledWith("neg:test-key", "1", {
+      expirationTtl: 120,
+    });
   });
 
   it("cache hit with corrupted JSON: logs warning, falls through to fetch", async () => {
@@ -207,6 +244,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -235,6 +273,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -258,6 +297,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, (v) => v.value * 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -281,6 +321,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60, customHardTtl)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -300,6 +341,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv, { CACHE_LONG_TTL: "true" })),
         ),
     );
@@ -319,6 +361,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv, { CACHE_LONG_TTL: "false" })),
         ),
     );
@@ -351,6 +394,7 @@ describe("TypedKvCache", () => {
         })
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -380,6 +424,7 @@ describe("TypedKvCache", () => {
         })
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -401,6 +446,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -427,6 +473,7 @@ describe("TypedKvCache", () => {
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
           Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
           Effect.provide(makeEnvLayer(mockKv)),
         ),
     );
@@ -434,6 +481,266 @@ describe("TypedKvCache", () => {
     expect(result._tag).toBe("Failure");
     // Should NOT cache invalid data
     expect(mockKv.put).not.toHaveBeenCalled();
+  });
+});
+
+describe("TypedKvCache — stale-while-revalidate + storm gate (#2328)", () => {
+  /**
+   * A BackgroundRunnerService whose `fork` runs the refresh eagerly on the test
+   * layers and records the promise, so a test can `await settle()` to observe
+   * the background effect's outcome deterministically.
+   */
+  function withRunner(
+    mockKv: ReturnType<typeof makeMockKv>,
+    gateLayer: Layer.Layer<PsdGateService>,
+  ) {
+    const pending: Promise<void>[] = [];
+    const layer = Layer.mergeAll(KvCacheLive, gateLayer).pipe(
+      Layer.provideMerge(makeEnvLayer(mockKv)),
+    );
+    const runnerLayer = Layer.succeed(BackgroundRunnerService, {
+      fork: (_label, effect) =>
+        Effect.sync(() => {
+          // The test fetch is pure, so the refresh never touches PsdService —
+          // `layer` satisfies its real deps (KvCache + gate + env).
+          pending.push(
+            Effect.runPromise(
+              Effect.provide(effect, layer) as unknown as Effect.Effect<void>,
+            ),
+          );
+        }),
+    });
+    return { runnerLayer, settle: () => Promise.all(pending) };
+  }
+
+  const staleWrapper = (value: unknown) =>
+    makeWrapper(value, 2 * 60 * 60 * 1000);
+
+  it("serves stale INSTANTLY, then background-refreshes the cache", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", staleWrapper({ name: "old", value: 1 }));
+    const gate = PsdGateTest;
+    const { runnerLayer, settle } = withRunner(mockKv, gate);
+
+    const fetchEffect = Effect.succeed({ name: "fresh", value: 42 });
+    const typedCache = TypedKvCache(TestSchema);
+
+    const result = await Effect.runPromise(
+      typedCache
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    // Foreground result is the STALE value (served without waiting).
+    expect(result).toEqual({ name: "old", value: 1 });
+
+    // Background refresh then overwrites KV with the fresh value.
+    await settle();
+    const stored = JSON.parse(mockKv.store.get("test-key")!);
+    expect(stored.value).toEqual({ name: "fresh", value: 42 });
+  });
+
+  it("negative marker present → serves stale WITHOUT fetching", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", staleWrapper({ name: "stale", value: 7 }));
+    mockKv.store.set("neg:test-key", "1");
+    const gate = PsdGateTest;
+    const { runnerLayer, settle } = withRunner(mockKv, gate);
+
+    let fetchCalled = false;
+    const fetchEffect = Effect.sync(() => {
+      fetchCalled = true;
+      return { name: "fresh", value: 99 };
+    });
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+    await settle();
+
+    expect(result).toEqual({ name: "stale", value: 7 });
+    expect(fetchCalled).toBe(false);
+  });
+
+  it("background refresh failure keeps stale and sets the negative marker", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", staleWrapper({ name: "stale", value: 5 }));
+    const gate = PsdGateTest;
+    const { runnerLayer, settle } = withRunner(mockKv, gate);
+
+    const fetchEffect = Effect.fail(new Error("PSD 429") as never);
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+    await settle();
+
+    expect(result).toEqual({ name: "stale", value: 5 });
+    // Data key unchanged; negative marker set.
+    expect(JSON.parse(mockKv.store.get("test-key")!).value).toEqual({
+      name: "stale",
+      value: 5,
+    });
+    expect(mockKv.store.get("neg:test-key")).toBe("1");
+  });
+
+  it("correctness guard: past-kickoff stale forces a BLOCKING refresh", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", staleWrapper({ name: "old", value: 1 }));
+    const gate = PsdGateTest;
+    const { runnerLayer } = withRunner(mockKv, gate);
+
+    const fetchEffect = Effect.succeed({ name: "fresh", value: 2 });
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60, undefined, {
+          // Treat the stale value as "must not serve" → blocking refresh.
+          mustBlockOnStale: (v) => v.value === 1,
+        })
+        .pipe(
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    // Fresh value returned synchronously (blocking), not the stale one.
+    expect(result).toEqual({ name: "fresh", value: 2 });
+  });
+
+  it("N concurrent misses collapse to ONE fan-out (single-flight)", async () => {
+    const mockKv = makeMockKv();
+    // Fresh shared gate so single-flight state is isolated to this test.
+    const gate = makePsdGateLayer(new GateLogic({ ratePerSecond: 1e9 }));
+
+    let fanOuts = 0;
+    const fetchEffect = Effect.gen(function* () {
+      fanOuts++;
+      // Yield so all concurrent callers pass the miss check before the leader
+      // finishes and writes KV.
+      yield* Effect.sleep("5 millis");
+      return { name: "fetched", value: 1 };
+    });
+
+    const typedCache = TypedKvCache(TestSchema);
+    const run = () =>
+      Effect.runPromise(
+        typedCache
+          .getOrFetch("test-key", fetchEffect, 60)
+          .pipe(
+            Effect.provide(KvCacheLive),
+            Effect.provide(gate),
+            Effect.provide(makeEnvLayer(mockKv)),
+          ),
+      );
+
+    const results = await Promise.all(Array.from({ length: 20 }, run));
+
+    // All callers get the value; only the leader fanned out.
+    for (const r of results) expect(r).toEqual({ name: "fetched", value: 1 });
+    expect(fanOuts).toBe(1);
+  });
+
+  it("sustained outage decouples PSD calls from request volume (~4% collapse)", async () => {
+    // Under a sustained 429, the negative marker suppresses re-fanning: after the
+    // first failed refresh, every subsequent read serves stale WITHOUT fetching
+    // until the marker expires. So PSD load tracks the marker cadence, not the
+    // request rate — the mechanism behind the prototype's 475%→~4% collapse
+    // (#2324). Here: 50 reads during an outage → a single fan-out attempt.
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", staleWrapper({ name: "stale", value: 1 }));
+    const gate = PsdGateTest;
+
+    let fetches = 0;
+    const fetchEffect = Effect.gen(function* () {
+      fetches++;
+      return yield* Effect.fail(new Error("PSD 429") as never);
+    });
+    const typedCache = TypedKvCache(TestSchema);
+
+    for (let i = 0; i < 50; i++) {
+      const { runnerLayer, settle } = withRunner(mockKv, gate);
+      const result = await Effect.runPromise(
+        typedCache
+          .getOrFetch("test-key", fetchEffect, 60)
+          .pipe(
+            Effect.provide(runnerLayer),
+            Effect.provide(KvCacheLive),
+            Effect.provide(gate),
+            Effect.provide(makeEnvLayer(mockKv)),
+          ),
+      );
+      await settle();
+      expect(result).toEqual({ name: "stale", value: 1 }); // always served
+    }
+
+    // 50 requests, but the marker capped PSD calls at the first attempt.
+    expect(fetches).toBe(1);
+  });
+
+  it("self-heals: once PSD recovers, the marker clears and fresh data is served", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set("test-key", staleWrapper({ name: "stale", value: 1 }));
+    mockKv.store.set("neg:test-key", "1"); // outage marker in place
+    const gate = PsdGateTest;
+
+    // Marker present → serve stale, no fetch. Then expire the marker.
+    const typedCache = TypedKvCache(TestSchema);
+    const runOnce = async (
+      fetchEffect: Effect.Effect<{ name: string; value: number }>,
+    ) => {
+      const { runnerLayer, settle } = withRunner(mockKv, gate);
+      const r = await Effect.runPromise(
+        typedCache
+          .getOrFetch("test-key", fetchEffect, 60)
+          .pipe(
+            Effect.provide(runnerLayer),
+            Effect.provide(KvCacheLive),
+            Effect.provide(gate),
+            Effect.provide(makeEnvLayer(mockKv)),
+          ),
+      );
+      await settle();
+      return r;
+    };
+
+    // While marked: stale, no refresh.
+    expect(await runOnce(Effect.succeed({ name: "fresh", value: 2 }))).toEqual({
+      name: "stale",
+      value: 1,
+    });
+
+    // Simulate marker expiry.
+    mockKv.store.delete("neg:test-key");
+
+    // Recovery: serve stale now, background refresh succeeds → KV fresh + marker clear.
+    await runOnce(Effect.succeed({ name: "fresh", value: 2 }));
+    expect(JSON.parse(mockKv.store.get("test-key")!).value).toEqual({
+      name: "fresh",
+      value: 2,
+    });
+    expect(mockKv.store.get("neg:test-key")).toBeUndefined();
   });
 });
 
@@ -447,6 +754,7 @@ describe("KvCacheService", () => {
     const result = await Effect.runPromise(
       program.pipe(
         Effect.provide(KvCacheLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer(mockKv)),
       ),
     );
@@ -463,6 +771,7 @@ describe("KvCacheService", () => {
     const result = await Effect.runPromise(
       program.pipe(
         Effect.provide(KvCacheLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer(mockKv)),
       ),
     );
@@ -479,6 +788,7 @@ describe("KvCacheService", () => {
         yield* cache.increment(by);
       }).pipe(
         Effect.provide(KvCacheLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer(mockKv)),
       ),
     );

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -1,21 +1,35 @@
-import { Context, Effect, Layer, Option, Schema as S } from "effect";
+import { Context, Effect, Either, Layer, Option, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
+import { PsdGateService } from "../psd/gate";
+import { BackgroundRunnerService, type PsdRefreshEnv } from "../psd/background";
 
-/** Per-endpoint TTLs in seconds */
+/**
+ * Per-endpoint soft TTLs in seconds.
+ *
+ * Every PSD-backed (match) TTL is ≥15 min: with stale-while-revalidate the soft
+ * TTL only sets the background-refresh cadence — stale is always served
+ * instantly — so a tighter window bought nothing but PSD load (#2321). KCVV has
+ * no live scores, so the old 60 s "live" tier was already moot.
+ */
 export const TTL = {
   MATCHES_TEAM: 60 * 60 * 24, // 24 hours — season schedule rarely changes mid-week
   NEXT_MATCHES: 60 * 60 * 4, // 4 hours — no live scores, schedule is stable for hours
   MATCHES_WINDOW: 60 * 60 * 4, // 4 hours — matchday picker; in-window matches stay listed regardless of refresh
   MATCH_DETAIL_PAST: 60 * 60 * 24 * 7, // 7 days — historical, never changes
   MATCH_DETAIL_DEFAULT: 60 * 60 * 24, // 24 hours — distant (kickoff >7d away)
-  MATCH_DETAIL_LIVE: 60, // <3h from kickoff — live, refresh aggressively
-  MATCH_DETAIL_MATCHDAY: 60 * 5, // <24h from kickoff — matchday
-  MATCH_DETAIL_WEEK: 60 * 60, // <7d from kickoff — this week
+  MATCH_DETAIL_LIVE: 60 * 15, // 15 min — floor: no live scores, SWR serves stale instantly
+  MATCH_DETAIL_MATCHDAY: 60 * 15, // 15 min — matchday / result-pending refresh cadence
+  MATCH_DETAIL_WEEK: 60 * 60, // 1 hour — this week
   RANKING: 60 * 60 * 24, // 24 hours — updates only after a match day
   RELATED: 60 * 60 * 6, // 6 hours — related content changes infrequently
   OPPONENT_HISTORY: 60 * 60 * 24 * 7, // 7 days — historical match data doesn't change
   PLAYER_STATS: 60 * 60 * 6, // 6 hours — player stats update after match days
 } as const;
+
+/** Persisted negative marker TTL (seconds). Suppresses re-storming after a failed
+ * refresh: subsequent requests serve stale without re-fanning until it expires.
+ * (KV's minimum expirationTtl is 60 s.) */
+export const NEG_MARKER_TTL = 120; // 2 min
 
 export interface KvCacheInterface {
   readonly get: (key: string) => Effect.Effect<string | null>;
@@ -24,6 +38,7 @@ export interface KvCacheInterface {
     value: string,
     ttl: number,
   ) => Effect.Effect<void>;
+  readonly delete: (key: string) => Effect.Effect<void>;
   /** Increment today's PSD-call counter by n (default 1). Owns the daily key (psd:calls:YYYY-MM-DD). */
   readonly increment: (by?: number) => Effect.Effect<void>;
 }
@@ -39,11 +54,46 @@ export const HARD_TTL_DEFAULT = 60 * 60 * 24 * 7;
 /** Long hard TTL: 365 days — used on staging to minimize PSD API quota usage */
 export const HARD_TTL_LONG = 60 * 60 * 24 * 365;
 
+const negKey = (key: string): string => `neg:${key}`;
+
 export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
   const WrapperSchema = S.Struct({
     value: schema,
     fetchedAt: S.Number,
   });
+
+  /** Decode a raw KV string into {value, fetchedAt}, tolerating the legacy
+   * pre-wrapper format (raw value, fetchedAt: 0). None on any decode failure. */
+  const decodeEntry = (
+    key: string,
+    cached: string,
+  ): Effect.Effect<Option.Option<{ value: A; fetchedAt: number }>> =>
+    Effect.try({
+      try: () => JSON.parse(cached),
+      catch: (e) => new Error(String(e)),
+    }).pipe(
+      Effect.flatMap((parsed) =>
+        S.decodeUnknown(WrapperSchema)(parsed).pipe(
+          Effect.catchAll(() =>
+            S.decodeUnknown(schema)(parsed).pipe(
+              Effect.map((value) => ({ value, fetchedAt: 0 })),
+              Effect.catchAll((legacyErr) =>
+                Effect.zipRight(
+                  Effect.logWarning(
+                    `TypedKvCache: cache decode failed for key "${key}": ${String(legacyErr)}`,
+                  ),
+                  Effect.fail(legacyErr),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      Effect.option,
+    );
+
+  const wrap = (value: A): string =>
+    JSON.stringify({ value, fetchedAt: Date.now() });
 
   return {
     getOrFetch: <E, R>(
@@ -51,45 +101,88 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
       fetch: Effect.Effect<A, E, R>,
       softTtl: number | ((value: A) => number),
       hardTtl: number = HARD_TTL_DEFAULT,
-      options?: { shouldServeStale?: (error: E) => boolean },
-    ): Effect.Effect<A, E, R | KvCacheService | WorkerEnvTag> =>
+      options?: {
+        shouldServeStale?: (error: E) => boolean;
+        /** Correctness guard: when the STALE value fails this predicate (e.g. a
+         * "next" list whose kickoff has already passed), refresh blocking rather
+         * than serving stale. */
+        mustBlockOnStale?: (value: A) => boolean;
+      },
+    ): Effect.Effect<
+      A,
+      E,
+      R | KvCacheService | WorkerEnvTag | PsdGateService
+    > =>
       Effect.gen(function* () {
         const cache = yield* KvCacheService;
         const env = yield* WorkerEnvTag;
+        const gate = yield* PsdGateService;
+        const runnerOpt = yield* Effect.serviceOption(BackgroundRunnerService);
         const effectiveHardTtl =
           env.CACHE_LONG_TTL === "true" ? HARD_TTL_LONG : hardTtl;
+        const shouldServeStale = options?.shouldServeStale ?? (() => true);
+
+        // Store a fresh value (schema-validated) and clear any negative marker.
+        const storeFresh = (value: A) =>
+          Effect.gen(function* () {
+            yield* S.decodeUnknown(schema)(value).pipe(Effect.orDie);
+            yield* cache.set(key, wrap(value), effectiveHardTtl);
+            yield* cache.delete(negKey(key));
+          });
+
+        // Foreground refresh: fetch, store on success, serve stale on a
+        // serve-stale error (setting the negative marker so we stop re-fanning),
+        // propagate otherwise. Used by the correctness guard and, when no
+        // background runner is wired, as the stale fallback.
+        const blockingRefresh = (staleValue: A) =>
+          Effect.gen(function* () {
+            const result = yield* fetch.pipe(Effect.either);
+            if (Either.isRight(result)) {
+              yield* storeFresh(result.right);
+              return result.right;
+            }
+            if (!shouldServeStale(result.left)) {
+              return yield* Effect.fail(result.left);
+            }
+            yield* Effect.logWarning(
+              `TypedKvCache: refresh failed for key "${key}", serving stale (error: ${String(result.left)})`,
+            );
+            yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
+            return staleValue;
+          });
+
+        // Background (SWR) refresh: single-flight leader fetches and updates KV;
+        // any failure keeps stale and sets the negative marker. Never throws —
+        // it runs detached via the background runner.
+        const backgroundRefresh = Effect.gen(function* () {
+          const leader = yield* gate.beginFlight(key);
+          if (!leader) return; // another isolate/fiber is already refreshing
+          yield* Effect.gen(function* () {
+            const result = yield* fetch.pipe(Effect.either);
+            if (Either.isRight(result)) {
+              const valid = S.decodeUnknownOption(schema)(result.right);
+              if (Option.isSome(valid)) {
+                yield* cache.set(key, wrap(result.right), effectiveHardTtl);
+                yield* cache.delete(negKey(key));
+              } else {
+                yield* Effect.logWarning(
+                  `TypedKvCache: background refresh for "${key}" returned schema-invalid data; keeping stale`,
+                );
+                yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
+              }
+            } else {
+              yield* Effect.logWarning(
+                `TypedKvCache: background refresh failed for "${key}", keeping stale (error: ${String(result.left)})`,
+              );
+              yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
+            }
+          }).pipe(Effect.ensuring(gate.endFlight(key)));
+        });
+
         const cached = yield* cache.get(key);
 
         if (cached !== null) {
-          const decoded = yield* Effect.try({
-            try: () => JSON.parse(cached),
-            catch: (e) => new Error(String(e)),
-          }).pipe(
-            Effect.flatMap((parsed) =>
-              S.decodeUnknown(WrapperSchema)(parsed).pipe(
-                Effect.catchAll(() =>
-                  // Legacy pre-wrapper format: try decoding raw value
-                  S.decodeUnknown(schema)(parsed).pipe(
-                    Effect.tap(() =>
-                      Effect.logDebug(
-                        `TypedKvCache: legacy cache entry for key "${key}" — will migrate on next fetch`,
-                      ),
-                    ),
-                    Effect.map((value) => ({ value, fetchedAt: 0 })),
-                    Effect.catchAll((legacyErr) =>
-                      Effect.zipRight(
-                        Effect.logWarning(
-                          `TypedKvCache: cache decode failed for key "${key}": ${String(legacyErr)}`,
-                        ),
-                        Effect.fail(legacyErr),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            Effect.option,
-          );
+          const decoded = yield* decodeEntry(key, cached);
 
           if (Option.isSome(decoded)) {
             const { value, fetchedAt } = decoded.value;
@@ -99,43 +192,63 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
 
             if (isFresh) return value;
 
-            // Stale: attempt refresh, fall back to stale on error
-            const shouldServeStale = options?.shouldServeStale ?? (() => true);
-            const refreshed = yield* fetch.pipe(
-              Effect.map((freshValue) => ({ freshValue, ok: true as const })),
-              Effect.catchAll((err) => {
-                if (!shouldServeStale(err)) {
-                  return Effect.fail(err);
-                }
-                return Effect.gen(function* () {
-                  yield* Effect.logWarning(
-                    `TypedKvCache: refresh failed for key "${key}", serving stale data (age: ${Math.round((Date.now() - fetchedAt) / 1000)}s, error: ${String(err)})`,
-                  );
-                  return { freshValue: value, ok: false as const };
-                });
-              }),
-            );
+            // ── Stale ────────────────────────────────────────────────────────
+            // Negative marker present → a recent refresh failed; serve stale
+            // instantly and do not re-fan. This wins even over the correctness
+            // guard below: during an outage, a bounded ≤2 min of possibly-wrong
+            // "next" beats storming PSD ~19 calls/request while it's down (the
+            // marker self-heals the moment PSD recovers).
+            const marker = yield* cache.get(negKey(key));
+            if (marker !== null) return value;
 
-            if (refreshed.ok) {
-              yield* S.decodeUnknown(schema)(refreshed.freshValue).pipe(
-                Effect.orDie,
-              );
-              const wrapper = JSON.stringify({
-                value: refreshed.freshValue,
-                fetchedAt: Date.now(),
-              });
-              yield* cache.set(key, wrapper, effectiveHardTtl);
+            // Correctness guard: a stale value that is now wrong (past-kickoff
+            // "next") must not be served — refresh blocking.
+            if (options?.mustBlockOnStale?.(value)) {
+              return yield* blockingRefresh(value);
             }
 
-            return refreshed.freshValue;
+            if (Option.isSome(runnerOpt)) {
+              // Stale-while-revalidate: serve stale NOW, refresh in the
+              // background (single-flight, on an env-built layer) — see
+              // background-live.ts. The cast is safe: only PSD read handlers
+              // provide a BackgroundRunnerService, and their layer covers this
+              // refresh's deps (non-PSD callers never reach this branch).
+              const refresh = backgroundRefresh as Effect.Effect<
+                void,
+                unknown,
+                PsdRefreshEnv
+              >;
+              yield* runnerOpt.value.fork(`refresh:${key}`, refresh);
+              return value;
+            }
+
+            // No background runner wired → fall back to a blocking refresh.
+            return yield* blockingRefresh(value);
           }
         }
 
-        // Cache miss: fetch, validate, wrap, store
+        // ── Cache miss (or undecodable) ──────────────────────────────────────
+        // Single-flight: the leader fetches; concurrent callers await it and
+        // re-read KV, so N concurrent misses collapse to one fan-out.
+        const isLeader = yield* gate.beginFlight(key);
+        if (isLeader) {
+          return yield* Effect.gen(function* () {
+            const value = yield* fetch;
+            yield* storeFresh(value);
+            return value;
+          }).pipe(Effect.ensuring(gate.endFlight(key)));
+        }
+
+        yield* gate.awaitFlight(key);
+        const afterWait = yield* cache.get(key);
+        if (afterWait !== null) {
+          const reread = yield* decodeEntry(key, afterWait);
+          if (Option.isSome(reread)) return reread.value.value;
+        }
+        // Leader failed to populate (or timed out) — fetch ourselves. Bounded by
+        // the global token bucket; a true never-cached failure surfaces.
         const value = yield* fetch;
-        yield* S.decodeUnknown(schema)(value).pipe(Effect.orDie);
-        const wrapper = JSON.stringify({ value, fetchedAt: Date.now() });
-        yield* cache.set(key, wrapper, effectiveHardTtl);
+        yield* storeFresh(value);
         return value;
       }),
   };
@@ -154,6 +267,11 @@ export const KvCacheLive = Layer.effect(
       set: (key: string, value: string, ttl: number) =>
         Effect.tryPromise({
           try: () => env.PSD_CACHE.put(key, value, { expirationTtl: ttl }),
+          catch: () => undefined,
+        }).pipe(Effect.orElseSucceed(() => undefined)),
+      delete: (key: string) =>
+        Effect.tryPromise({
+          try: () => env.PSD_CACHE.delete(key),
           catch: () => undefined,
         }).pipe(Effect.orElseSucceed(() => undefined)),
       increment: (by = 1) =>

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -122,13 +122,27 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
           env.CACHE_LONG_TTL === "true" ? HARD_TTL_LONG : hardTtl;
         const shouldServeStale = options?.shouldServeStale ?? (() => true);
 
+        // Persist a fresh value and clear any negative marker.
+        const persist = (value: A) =>
+          Effect.zipRight(
+            cache.set(key, wrap(value), effectiveHardTtl),
+            cache.delete(negKey(key)),
+          );
+
+        // Keep the stale copy: log why and set the negative marker so subsequent
+        // requests serve stale without re-fanning until it expires.
+        const keepStale = (reason: string) =>
+          Effect.zipRight(
+            Effect.logWarning(`TypedKvCache "${key}": ${reason}`),
+            cache.set(negKey(key), "1", NEG_MARKER_TTL),
+          );
+
         // Store a fresh value (schema-validated) and clear any negative marker.
         const storeFresh = (value: A) =>
-          Effect.gen(function* () {
-            yield* S.decodeUnknown(schema)(value).pipe(Effect.orDie);
-            yield* cache.set(key, wrap(value), effectiveHardTtl);
-            yield* cache.delete(negKey(key));
-          });
+          Effect.zipRight(
+            S.decodeUnknown(schema)(value).pipe(Effect.orDie),
+            persist(value),
+          );
 
         // Foreground refresh: fetch, store on success, serve stale on a
         // serve-stale error (setting the negative marker so we stop re-fanning),
@@ -144,38 +158,29 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             if (!shouldServeStale(result.left)) {
               return yield* Effect.fail(result.left);
             }
-            yield* Effect.logWarning(
-              `TypedKvCache: refresh failed for key "${key}", serving stale (error: ${String(result.left)})`,
+            yield* keepStale(
+              `refresh failed, serving stale (${String(result.left)})`,
             );
-            yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
             return staleValue;
           });
 
         // Background (SWR) refresh: single-flight leader fetches and updates KV;
-        // any failure keeps stale and sets the negative marker. Never throws —
-        // it runs detached via the background runner.
+        // any failure (or schema-invalid data) keeps stale + marks. Never throws
+        // — it runs detached via the background runner.
         const backgroundRefresh = Effect.gen(function* () {
           const leader = yield* gate.beginFlight(key);
           if (!leader) return; // another isolate/fiber is already refreshing
           yield* Effect.gen(function* () {
             const result = yield* fetch.pipe(Effect.either);
-            if (Either.isRight(result)) {
-              const valid = S.decodeUnknownOption(schema)(result.right);
-              if (Option.isSome(valid)) {
-                yield* cache.set(key, wrap(result.right), effectiveHardTtl);
-                yield* cache.delete(negKey(key));
-              } else {
-                yield* Effect.logWarning(
-                  `TypedKvCache: background refresh for "${key}" returned schema-invalid data; keeping stale`,
-                );
-                yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
-              }
-            } else {
-              yield* Effect.logWarning(
-                `TypedKvCache: background refresh failed for "${key}", keeping stale (error: ${String(result.left)})`,
+            if (Either.isLeft(result)) {
+              return yield* keepStale(
+                `background refresh failed (${String(result.left)})`,
               );
-              yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
             }
+            const valid = S.decodeUnknownOption(schema)(result.right);
+            yield* Option.isSome(valid)
+              ? persist(result.right)
+              : keepStale("background refresh returned schema-invalid data");
           }).pipe(Effect.ensuring(gate.endFlight(key)));
         });
 
@@ -209,10 +214,9 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
 
             if (Option.isSome(runnerOpt)) {
               // Stale-while-revalidate: serve stale NOW, refresh in the
-              // background (single-flight, on an env-built layer) — see
-              // background-live.ts. The cast is safe: only PSD read handlers
-              // provide a BackgroundRunnerService, and their layer covers this
-              // refresh's deps (non-PSD callers never reach this branch).
+              // background (single-flight) via the runner — see background-live.ts.
+              // Cast is safe: only PSD handlers provide a runner, and its layer
+              // covers this refresh's deps (a non-PSD caller has no runner here).
               const refresh = backgroundRefresh as Effect.Effect<
                 void,
                 unknown,
@@ -228,28 +232,33 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         }
 
         // ── Cache miss (or undecodable) ──────────────────────────────────────
-        // Single-flight: the leader fetches; concurrent callers await it and
-        // re-read KV, so N concurrent misses collapse to one fan-out.
-        const isLeader = yield* gate.beginFlight(key);
-        if (isLeader) {
-          return yield* Effect.gen(function* () {
-            const value = yield* fetch;
-            yield* storeFresh(value);
-            return value;
-          }).pipe(Effect.ensuring(gate.endFlight(key)));
-        }
+        // Single-flight loop: ONLY the leader ever fetches, so at no instant do
+        // two fan-outs run for the same key. Concurrent misses collapse to one
+        // fan-out (followers read the leader's cached result). If the leader
+        // finishes without populating (it failed), followers re-enter — one
+        // becomes the next leader while the rest await it, so failed misses
+        // serialize (never a concurrent duplicate fan-out) and each surfaces a
+        // real never-cached error (AC7). Leadership rotation guarantees every
+        // fiber makes progress; the gate's lease reclaims a dead leader, so this
+        // can't spin forever.
+        for (;;) {
+          const isLeader = yield* gate.beginFlight(key);
+          if (isLeader) {
+            return yield* Effect.gen(function* () {
+              const value = yield* fetch;
+              yield* storeFresh(value);
+              return value;
+            }).pipe(Effect.ensuring(gate.endFlight(key)));
+          }
 
-        yield* gate.awaitFlight(key);
-        const afterWait = yield* cache.get(key);
-        if (afterWait !== null) {
-          const reread = yield* decodeEntry(key, afterWait);
-          if (Option.isSome(reread)) return reread.value.value;
+          yield* gate.awaitFlight(key);
+          const afterWait = yield* cache.get(key);
+          if (afterWait !== null) {
+            const reread = yield* decodeEntry(key, afterWait);
+            if (Option.isSome(reread)) return reread.value.value;
+          }
+          // Empty → the leader failed; loop to re-enter the flight.
         }
-        // Leader failed to populate (or timed out) — fetch ourselves. Bounded by
-        // the global token bucket; a true never-cached failure surfaces.
-        const value = yield* fetch;
-        yield* storeFresh(value);
-        return value;
       }),
   };
 };

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -13,6 +13,7 @@ export interface WorkerEnv {
   readonly SANITY_API_TOKEN: string; // write token — wrangler secret
   readonly AI: Ai; // Workers AI binding
   readonly SEARCH_INDEX: VectorizeIndex; // Vectorize vector store
+  readonly PSD_GATE: DurableObjectNamespace; // global PSD rate-limit + single-flight gate (see psd/gate.ts)
   readonly SANITY_WEBHOOK_SECRET: string; // SVIX signing secret — wrangler secret
   readonly RESEND_API_KEY?: string; // Resend transactional email — wrangler secret (absent locally → email dispatch is a no-op)
   readonly TURNSTILE_SECRET?: string; // Cloudflare Turnstile secret — wrangler secret (absent locally → verification is skipped)

--- a/apps/api/src/handlers/forms.test.ts
+++ b/apps/api/src/handlers/forms.test.ts
@@ -55,6 +55,7 @@ const projectionMock: SanityProjectionInterface = {
 const cacheMock: KvCacheInterface = {
   get: () => Effect.succeed(null),
   set: () => Effect.succeed(undefined),
+  delete: () => Effect.succeed(undefined),
   increment: () => Effect.succeed(undefined),
 };
 

--- a/apps/api/src/handlers/matches.test.ts
+++ b/apps/api/src/handlers/matches.test.ts
@@ -17,6 +17,7 @@ import { UpstreamUnavailableError, ResourceNotFoundError } from "../psd/errors";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
 import { testEnvLayer } from "../test-helpers/env-layer";
+import { PsdGateService, PsdGateTest } from "../psd/gate";
 import {
   MatchesArray,
   MatchDetail,
@@ -83,6 +84,7 @@ function makeCacheMock(): KvCacheInterface {
   return {
     get: () => Effect.succeed(null),
     set: () => Effect.succeed(undefined),
+    delete: () => Effect.succeed(undefined),
     increment: () => Effect.succeed(undefined),
   };
 }
@@ -91,13 +93,14 @@ function provide<A>(
   effect: Effect.Effect<
     A,
     BffError,
-    PsdService | KvCacheService | WorkerEnvTag
+    PsdService | KvCacheService | WorkerEnvTag | PsdGateService
   >,
   overrides: Partial<PsdServiceInterface> = {},
 ) {
   return effect.pipe(
     Effect.provide(Layer.succeed(PsdService, makeServiceMock(overrides))),
     Effect.provide(Layer.succeed(KvCacheService, makeCacheMock())),
+    Effect.provide(PsdGateTest),
     Effect.provide(testEnvLayer),
   );
 }
@@ -214,6 +217,7 @@ describe("getMatchDetailHandler", () => {
         Effect.provide(
           Layer.succeed(KvCacheService, {
             get: () => Effect.succeed(null),
+            delete: () => Effect.succeed(undefined),
             increment: () => Effect.succeed(undefined),
             set: vi.fn((key, value, ttl) => {
               setCalls.push([key, value, ttl]);
@@ -221,6 +225,7 @@ describe("getMatchDetailHandler", () => {
             }),
           }),
         ),
+        Effect.provide(PsdGateTest),
         Effect.provide(testEnvLayer),
         Effect.orDie,
       ),

--- a/apps/api/src/handlers/matches.ts
+++ b/apps/api/src/handlers/matches.ts
@@ -13,6 +13,7 @@ import { isSettledMatchStatus } from "../psd/transforms";
 import { shouldServeStale, type BffError } from "../psd/errors";
 import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
+import { PsdGateService } from "../psd/gate";
 import { withErrorMapping } from "./error-mapping";
 
 const matchesCache = TypedKvCache(MatchesArray);
@@ -24,7 +25,7 @@ export const getMatchesByTeamHandler = (
 ): Effect.Effect<
   readonly Match[],
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = `matches:team:${teamId}`;
   const fetchMatches = Effect.gen(function* () {
@@ -44,7 +45,7 @@ export const getMatchesByTeamHandler = (
 export const getNextMatchesHandler = (): Effect.Effect<
   readonly Match[],
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = "matches:next";
   const fetchMatches = Effect.gen(function* () {
@@ -57,14 +58,21 @@ export const getNextMatchesHandler = (): Effect.Effect<
     fetchMatches,
     (matches) => nextMatchesTtl(matches),
     undefined,
-    { shouldServeStale },
+    {
+      shouldServeStale,
+      // Correctness guard: "next" is computed at fetch time, so a stale copy can
+      // advertise a match that has already kicked off. Never serve that — refresh
+      // blocking so the list recomputes to future-only.
+      mustBlockOnStale: (matches) =>
+        matches.some((m) => new Date(m.date).getTime() < Date.now()),
+    },
   );
 };
 
 export const getMatchesWindowHandler = (): Effect.Effect<
   readonly Match[],
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = "matches:window";
   const fetchMatches = Effect.gen(function* () {
@@ -203,7 +211,7 @@ export const getMatchDetailHandler = (
 ): Effect.Effect<
   MatchDetail,
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = `match:detail:${matchId}`;
   const fetchDetail = Effect.gen(function* () {
@@ -229,7 +237,7 @@ export const getPlayerStatsHandler = (
 ): Effect.Effect<
   PlayerSeasonStatsType,
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > =>
   Effect.gen(function* () {
     const service = yield* PsdService;

--- a/apps/api/src/handlers/opponent.ts
+++ b/apps/api/src/handlers/opponent.ts
@@ -5,6 +5,7 @@ import { PsdService } from "../psd/service";
 import { shouldServeStale, type BffError } from "../psd/errors";
 import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
+import { PsdGateService } from "../psd/gate";
 import { withErrorMapping } from "./error-mapping";
 
 const opponentHistoryCache = TypedKvCache(OpponentHistory);
@@ -15,7 +16,7 @@ export const getOpponentHistoryHandler = (
 ): Effect.Effect<
   OpponentHistory,
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = `opponent:team:${teamId}:club:${clubId}`;
   const fetchHistory = Effect.gen(function* () {

--- a/apps/api/src/handlers/ranking.test.ts
+++ b/apps/api/src/handlers/ranking.test.ts
@@ -4,6 +4,7 @@ import { getRankingHandler } from "./ranking";
 import { PsdService, type PsdServiceInterface } from "../psd/service";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { testEnvLayer } from "../test-helpers/env-layer";
+import { PsdGateTest } from "../psd/gate";
 import { RankingArray, type RankingEntry } from "@kcvv/api-contract";
 import { UpstreamUnavailableError } from "../psd/errors";
 
@@ -44,6 +45,7 @@ function makeServiceMock(
 const cacheMock: KvCacheInterface = {
   get: () => Effect.succeed(null),
   set: () => Effect.succeed(undefined),
+  delete: () => Effect.succeed(undefined),
   increment: () => Effect.succeed(undefined),
 };
 
@@ -53,6 +55,7 @@ describe("getRankingHandler", () => {
       getRankingHandler(1, "https://cdn.example.com").pipe(
         Effect.provide(Layer.succeed(PsdService, makeServiceMock())),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
+        Effect.provide(PsdGateTest),
         Effect.provide(testEnvLayer),
       ),
     );
@@ -75,6 +78,7 @@ describe("getRankingHandler", () => {
             ),
           ),
           Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
+          Effect.provide(PsdGateTest),
           Effect.provide(testEnvLayer),
         ),
       ),
@@ -104,6 +108,7 @@ describe("getRankingHandler", () => {
             ),
           ),
           Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
+          Effect.provide(PsdGateTest),
           Effect.provide(testEnvLayer),
         ),
       ),

--- a/apps/api/src/handlers/ranking.ts
+++ b/apps/api/src/handlers/ranking.ts
@@ -9,6 +9,7 @@ import {
 } from "../psd/errors";
 import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { WorkerEnvTag } from "../env";
+import { PsdGateService } from "../psd/gate";
 import { withErrorMapping } from "./error-mapping";
 
 const rankingCache = TypedKvCache(RankingArray);
@@ -19,7 +20,7 @@ export const getRankingHandler = (
 ): Effect.Effect<
   readonly RankingEntry[],
   BffError,
-  PsdService | KvCacheService | WorkerEnvTag
+  PsdService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = `ranking:team:${teamId}`;
   const fetchRanking = Effect.gen(function* () {

--- a/apps/api/src/handlers/related.test.ts
+++ b/apps/api/src/handlers/related.test.ts
@@ -7,6 +7,7 @@ import {
   type VectorizeServiceInterface,
 } from "../search/vectorize";
 import { testEnvLayer } from "../test-helpers/env-layer";
+import { PsdGateTest } from "../psd/gate";
 
 function makeCacheMock(
   overrides: Partial<KvCacheInterface> = {},
@@ -14,6 +15,7 @@ function makeCacheMock(
   return {
     get: () => Effect.succeed(null),
     set: () => Effect.succeed(undefined),
+    delete: () => Effect.succeed(undefined),
     increment: () => Effect.succeed(undefined),
     ...overrides,
   };
@@ -41,6 +43,7 @@ function runWithProviders(
     effect.pipe(
       Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
       Effect.provide(Layer.succeed(VectorizeService, vectorizeMock)),
+      Effect.provide(PsdGateTest),
       Effect.provide(testEnvLayer),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as Effect.Effect<any, never, never>,

--- a/apps/api/src/handlers/related.ts
+++ b/apps/api/src/handlers/related.ts
@@ -6,6 +6,7 @@ import { handleRelated } from "../search/related-handler";
 import { KvCacheService, TTL, TypedKvCache } from "../cache/kv-cache";
 import { VectorizeService } from "../search/vectorize";
 import { WorkerEnvTag } from "../env";
+import { PsdGateService } from "../psd/gate";
 
 const DEFAULT_LIMIT = 3;
 const MAX_LIMIT = 5; // upper bound from S.between(1, 5) in api-contract
@@ -18,7 +19,7 @@ export const getRelatedHandler = (request: {
 }): Effect.Effect<
   readonly (typeof RelatedItem.Type)[],
   never,
-  VectorizeService | KvCacheService | WorkerEnvTag
+  VectorizeService | KvCacheService | WorkerEnvTag | PsdGateService
 > => {
   const cacheKey = `related:${request.id}:max`;
   return relatedCache

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,8 @@ import { PsdApi } from "@kcvv/api-contract";
 import { WorkerEnvTag, type WorkerEnv } from "./env";
 import { PsdTeamClientLive } from "./sync/psd-team-client";
 import { PsdServiceLive } from "./psd/service";
+import { PsdGateLive } from "./psd/gate";
+import { BackgroundRunnerLive } from "./psd/background-live";
 import { KvCacheLive } from "./cache/kv-cache";
 import { MatchesApiLive } from "./handlers/matches";
 import { OpponentApiLive } from "./handlers/opponent";
@@ -36,6 +38,10 @@ import { SanityMutationLive } from "./sanity/mutation";
 import { SanityProjectionLive } from "./sanity/projection";
 import { runSync } from "./sync/psd-sanity-sync";
 import { handleIndexWebhook } from "./webhooks/index-handler";
+
+// The PSD gate Durable Object must be exported from the worker entry (the
+// `main` module) for Cloudflare to bind it — see wrangler.toml [[durable_objects]].
+export { PsdGate } from "./psd/gate-do";
 
 /**
  * Provides DefaultServices (HttpPlatform | Etag.Generator | FileSystem | Path)
@@ -55,7 +61,7 @@ const WorkerPlatformLayer = Layer.mergeAll(
  * @param env - The Worker environment (bindings such as KV namespaces and secrets) to supply to the runtime
  * @returns A Layer supplying the PsdApi implementation composed with live services (matches, ranking, search, embedding, vectorization, HTTP client, KV cache) and required platform services
  */
-function buildAppLayer(env: WorkerEnv) {
+function buildAppLayer(env: WorkerEnv, ctx: ExecutionContext) {
   return HttpApiBuilder.api(PsdApi).pipe(
     Layer.provide(MatchesApiLive),
     Layer.provide(OpponentApiLive),
@@ -68,6 +74,10 @@ function buildAppLayer(env: WorkerEnv) {
     Layer.provide(VectorizeServiceLive),
     Layer.provide(AiAnswerServiceLive),
     Layer.provide(PsdServiceLive),
+    // Global PSD gate (token bucket + single-flight) and the SWR background
+    // runner that keeps the read path fresh without storming PSD (#2328).
+    Layer.provide(PsdGateLive),
+    Layer.provide(BackgroundRunnerLive(env, ctx)),
     Layer.provide(SanityProjectionLive),
     Layer.provide(SanityMutationLive),
     Layer.provide(KvCacheLive),
@@ -77,7 +87,11 @@ function buildAppLayer(env: WorkerEnv) {
 }
 
 export default {
-  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: WorkerEnv,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
     // Webhook routes use Effect internally but keep raw Request/Response entry point
     if (
       request.method === "POST" &&
@@ -96,7 +110,7 @@ export default {
     }
 
     const { handler, dispose } = HttpApiBuilder.toWebHandler(
-      buildAppLayer(env),
+      buildAppLayer(env, ctx),
       { middleware: HttpMiddleware.cors() },
     );
     try {

--- a/apps/api/src/psd/background-live.ts
+++ b/apps/api/src/psd/background-live.ts
@@ -1,0 +1,49 @@
+/**
+ * Live background-refresh runner (see background.ts for the seam + rationale).
+ *
+ * Runs each SWR refresh on a layer built straight from `env` — independent of
+ * the per-request Effect runtime, which `index.ts` disposes in a `finally` — and
+ * keeps the isolate alive with `ctx.waitUntil`. Imported only by the worker
+ * entry, so pulling in the full PSD read stack here can't create an import cycle
+ * with `cache/kv-cache.ts`.
+ */
+import { Effect, Layer } from "effect";
+import { WorkerEnvTag, type WorkerEnv } from "../env";
+import { KvCacheLive } from "../cache/kv-cache";
+import { SanityProjectionLive } from "../sanity/projection";
+import { PsdServiceLive } from "./service";
+import { PsdGateLive } from "./gate";
+import { BackgroundRunnerService, type BackgroundRunner } from "./background";
+
+/** The PSD read stack a background refresh needs, exposing every PsdRefreshEnv service. */
+const backgroundStackLayer = (env: WorkerEnv) =>
+  PsdServiceLive.pipe(
+    Layer.provideMerge(
+      Layer.mergeAll(KvCacheLive, PsdGateLive, SanityProjectionLive),
+    ),
+    Layer.provideMerge(Layer.succeed(WorkerEnvTag, env)),
+  );
+
+export const makeBackgroundRunner = (
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): BackgroundRunner => {
+  const layer = backgroundStackLayer(env);
+  return {
+    fork: (label, effect) =>
+      Effect.sync(() => {
+        ctx.waitUntil(
+          Effect.runPromise(Effect.scoped(Effect.provide(effect, layer))).catch(
+            (e: unknown) =>
+              console.error(
+                `[bg:${label}]`,
+                e instanceof Error ? (e.stack ?? e.message) : String(e),
+              ),
+          ),
+        );
+      }),
+  };
+};
+
+export const BackgroundRunnerLive = (env: WorkerEnv, ctx: ExecutionContext) =>
+  Layer.succeed(BackgroundRunnerService, makeBackgroundRunner(env, ctx));

--- a/apps/api/src/psd/background.ts
+++ b/apps/api/src/psd/background.ts
@@ -1,0 +1,37 @@
+/**
+ * Background refresh runner — the stale-while-revalidate execution seam.
+ *
+ * When a soft-lapsed key is read, the cache serves stale INSTANTLY and schedules
+ * the refresh here. The refresh must survive the response returning: the
+ * per-request Effect runtime is `dispose()`d in a `finally`, so a fiber forked on
+ * it would be interrupted. The live runner (see background-live.ts) therefore
+ * runs the refresh on a fresh layer built from `env` and extends the isolate's
+ * life with `ctx.waitUntil` — both independent of the request runtime.
+ *
+ * This module is a leaf (type-only imports) so `cache/kv-cache.ts` can depend on
+ * the tag without a `kv-cache → background → service → kv-cache` runtime cycle.
+ */
+import { Context, Effect } from "effect";
+import type { WorkerEnvTag } from "../env";
+import type { KvCacheService } from "../cache/kv-cache";
+import type { PsdService } from "./service";
+import type { PsdGateService } from "./gate";
+
+/** Everything a PSD background refresh needs; the live runner's layer provides it. */
+export type PsdRefreshEnv =
+  | PsdService
+  | KvCacheService
+  | PsdGateService
+  | WorkerEnvTag;
+
+export interface BackgroundRunner {
+  /** Fire-and-forget a refresh on an env-built layer via `ctx.waitUntil`. */
+  readonly fork: (
+    label: string,
+    effect: Effect.Effect<void, unknown, PsdRefreshEnv>,
+  ) => Effect.Effect<void>;
+}
+
+export class BackgroundRunnerService extends Context.Tag(
+  "BackgroundRunnerService",
+)<BackgroundRunnerService, BackgroundRunner>() {}

--- a/apps/api/src/psd/fetch-json.test.ts
+++ b/apps/api/src/psd/fetch-json.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Effect, Layer } from "effect";
 import { PsdService, PsdServiceLive } from "./service";
+import { PsdGateTest } from "./gate";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService, type KvCacheInterface } from "../cache/kv-cache";
 import { UpstreamUnavailableError } from "./errors";
@@ -20,6 +21,7 @@ function makeEnvLayer() {
     PSD_API_CLUB: "test-club",
     PSD_API_AUTH: "test-auth",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test-project",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",
@@ -32,6 +34,7 @@ function makeEnvLayer() {
 const cacheMock: KvCacheInterface = {
   get: () => Effect.succeed(null),
   set: () => Effect.succeed(undefined),
+  delete: () => Effect.succeed(undefined),
   increment: () => Effect.succeed(undefined),
 };
 
@@ -68,6 +71,7 @@ function runGetTeamMatches(teamId: number) {
     Effect.either(
       program.pipe(
         Effect.provide(PsdServiceLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
         Effect.provide(Layer.succeed(SanityProjection, sanityMock)),

--- a/apps/api/src/psd/gate-do.ts
+++ b/apps/api/src/psd/gate-do.ts
@@ -1,0 +1,46 @@
+/**
+ * PsdGate Durable Object — hosts ONE global {@link GateLogic} instance so the
+ * PSD token bucket and single-flight registry are shared across every worker
+ * isolate (the whole point: in-memory per-isolate limiters would multiply the
+ * rate by the isolate count — see #2324).
+ *
+ * Thin RPC wrapper: all real logic is in the framework-free, unit-tested
+ * GateLogic. This module imports `cloudflare:workers`, so it must only ever be
+ * imported by the worker entry (index.ts), never by code the Node tests load.
+ */
+import { DurableObject } from "cloudflare:workers";
+import { GateLogic } from "./gate-logic";
+
+/** Max time a cross-isolate waiter blocks on a leader before giving up (dead-leader guard). */
+const AWAIT_FLIGHT_TIMEOUT_MS = 10_000;
+
+export class PsdGate extends DurableObject {
+  // Instance-lifetime state: survives across requests while the DO stays warm.
+  private readonly logic = new GateLogic();
+
+  acquireToken(): Promise<void> {
+    return this.logic.acquireToken();
+  }
+
+  beginFlight(key: string): boolean {
+    return this.logic.beginFlight(key);
+  }
+
+  endFlight(key: string): void {
+    this.logic.endFlight(key);
+  }
+
+  async awaitFlight(key: string): Promise<void> {
+    // Bound the wait: if the leader isolate died without endFlight, waiters must
+    // not hang. On timeout the caller falls back to serving stale / its own fetch.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, AWAIT_FLIGHT_TIMEOUT_MS);
+    });
+    try {
+      await Promise.race([this.logic.awaitFlight(key), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/apps/api/src/psd/gate-do.ts
+++ b/apps/api/src/psd/gate-do.ts
@@ -11,11 +11,10 @@
 import { DurableObject } from "cloudflare:workers";
 import { GateLogic } from "./gate-logic";
 
-/** Max time a cross-isolate waiter blocks on a leader before giving up (dead-leader guard). */
-const AWAIT_FLIGHT_TIMEOUT_MS = 10_000;
-
 export class PsdGate extends DurableObject {
   // Instance-lifetime state: survives across requests while the DO stays warm.
+  // All coordination logic (including the lease that bounds awaitFlight against
+  // a dead leader) lives in GateLogic so it stays unit-testable.
   private readonly logic = new GateLogic();
 
   acquireToken(): Promise<void> {
@@ -30,17 +29,7 @@ export class PsdGate extends DurableObject {
     this.logic.endFlight(key);
   }
 
-  async awaitFlight(key: string): Promise<void> {
-    // Bound the wait: if the leader isolate died without endFlight, waiters must
-    // not hang. On timeout the caller falls back to serving stale / its own fetch.
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<void>((resolve) => {
-      timer = setTimeout(resolve, AWAIT_FLIGHT_TIMEOUT_MS);
-    });
-    try {
-      await Promise.race([this.logic.awaitFlight(key), timeout]);
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
+  awaitFlight(key: string): Promise<void> {
+    return this.logic.awaitFlight(key);
   }
 }

--- a/apps/api/src/psd/gate-logic.test.ts
+++ b/apps/api/src/psd/gate-logic.test.ts
@@ -116,6 +116,45 @@ describe("GateLogic — single-flight", () => {
     await expect(gate.awaitFlight("idle")).resolves.toBeUndefined();
   });
 
+  it("awaitFlight gives up after the lease if the leader never ends", async () => {
+    // Dead-leader guard: a leader killed before endFlight must not hang waiters.
+    const gate = new GateLogic({ leaseMs: 20 });
+    gate.beginFlight("k"); // leader never calls endFlight
+    await expect(gate.awaitFlight("k")).resolves.toBeUndefined();
+  });
+
+  it("reclaims leadership after the lease expires (dead-leader guard)", () => {
+    let clock = 0;
+    const gate = new GateLogic({ now: () => clock, leaseMs: 1000 });
+
+    expect(gate.beginFlight("k")).toBe(true);
+    expect(gate.beginFlight("k")).toBe(false); // live leader holds it
+    expect(gate.isInFlight("k")).toBe(true);
+
+    clock += 1500; // leader died without endFlight; lease lapses
+
+    expect(gate.isInFlight("k")).toBe(false);
+    expect(gate.beginFlight("k")).toBe(true); // reclaimed by the next caller
+  });
+
+  it("reclaiming a lapsed flight wakes anyone still awaiting it", async () => {
+    let clock = 0;
+    const gate = new GateLogic({ now: () => clock, leaseMs: 1000 });
+    gate.beginFlight("k");
+
+    let woken = false;
+    const waiter = gate.awaitFlight("k").then(() => {
+      woken = true;
+    });
+    await Promise.resolve();
+    expect(woken).toBe(false);
+
+    clock += 1500;
+    gate.beginFlight("k"); // reclaim → resolves the abandoned flight's promise
+    await waiter;
+    expect(woken).toBe(true);
+  });
+
   it("N concurrent misses coalesce onto ONE fan-out", async () => {
     const gate = new GateLogic();
     let fanOuts = 0;

--- a/apps/api/src/psd/gate-logic.test.ts
+++ b/apps/api/src/psd/gate-logic.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { GateLogic } from "./gate-logic";
+
+/**
+ * Deterministic fake scheduler: `now()` reads a mutable clock, `sleep(ms)`
+ * advances it and resolves on a microtask. Lets us assert the token bucket's
+ * pacing without real timers.
+ */
+function fakeScheduler() {
+  let clock = 0;
+  return {
+    now: () => clock,
+    sleep: async (ms: number) => {
+      clock += ms;
+    },
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    get clock() {
+      return clock;
+    },
+  };
+}
+
+describe("GateLogic — token bucket", () => {
+  it("hands out the initial burst (capacity) without waiting", async () => {
+    const s = fakeScheduler();
+    const gate = new GateLogic({
+      ratePerSecond: 5,
+      now: s.now,
+      sleep: s.sleep,
+    });
+
+    for (let i = 0; i < 5; i++) await gate.acquireToken();
+
+    // Full burst granted at t=0 — no simulated sleep needed.
+    expect(s.clock).toBe(0);
+  });
+
+  it("throttles sustained demand to ~rate per second", async () => {
+    const s = fakeScheduler();
+    const gate = new GateLogic({
+      ratePerSecond: 5,
+      now: s.now,
+      sleep: s.sleep,
+    });
+
+    // 20 tokens: 5 free (burst) + 15 paced at 5/s → ≥3s of simulated time.
+    for (let i = 0; i < 20; i++) await gate.acquireToken();
+
+    expect(s.clock).toBeGreaterThanOrEqual(3000);
+    // And not wildly more than the ideal (15 tokens / 5 per s = 3s).
+    expect(s.clock).toBeLessThan(4000);
+  });
+
+  it("refills over wall-clock gaps so a later burst isn't throttled", async () => {
+    const s = fakeScheduler();
+    const gate = new GateLogic({
+      ratePerSecond: 5,
+      now: s.now,
+      sleep: s.sleep,
+    });
+
+    for (let i = 0; i < 5; i++) await gate.acquireToken(); // drain
+    s.advance(2000); // 2s idle → bucket refills to capacity (5)
+
+    const before = s.clock;
+    for (let i = 0; i < 5; i++) await gate.acquireToken();
+    expect(s.clock).toBe(before); // served from refilled bucket, no wait
+  });
+});
+
+describe("GateLogic — single-flight", () => {
+  it("elects exactly one leader among concurrent callers for a key", () => {
+    const gate = new GateLogic();
+    const results = Array.from({ length: 50 }, () =>
+      gate.beginFlight("matches:next"),
+    );
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+
+  it("a different key gets its own leader", () => {
+    const gate = new GateLogic();
+    expect(gate.beginFlight("a")).toBe(true);
+    expect(gate.beginFlight("b")).toBe(true);
+    expect(gate.beginFlight("a")).toBe(false);
+  });
+
+  it("endFlight releases the key so a later caller can lead again", () => {
+    const gate = new GateLogic();
+    expect(gate.beginFlight("k")).toBe(true);
+    expect(gate.beginFlight("k")).toBe(false);
+    gate.endFlight("k");
+    expect(gate.beginFlight("k")).toBe(true);
+  });
+
+  it("awaitFlight resolves when the leader ends its flight", async () => {
+    const gate = new GateLogic();
+    gate.beginFlight("k");
+
+    let resolved = false;
+    const waiter = gate.awaitFlight("k").then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false); // still in flight
+
+    gate.endFlight("k");
+    await waiter;
+    expect(resolved).toBe(true);
+  });
+
+  it("awaitFlight for an idle key resolves immediately", async () => {
+    const gate = new GateLogic();
+    await expect(gate.awaitFlight("idle")).resolves.toBeUndefined();
+  });
+
+  it("N concurrent misses coalesce onto ONE fan-out", async () => {
+    const gate = new GateLogic();
+    let fanOuts = 0;
+
+    // Each caller: if leader → run the (single) fan-out; else await + reuse.
+    const caller = async () => {
+      if (gate.beginFlight("matches:next")) {
+        fanOuts++;
+        await Promise.resolve(); // simulate async fan-out
+        gate.endFlight("matches:next");
+      } else {
+        await gate.awaitFlight("matches:next");
+      }
+    };
+
+    await Promise.all(Array.from({ length: 30 }, caller));
+    expect(fanOuts).toBe(1);
+  });
+});

--- a/apps/api/src/psd/gate-logic.ts
+++ b/apps/api/src/psd/gate-logic.ts
@@ -30,6 +30,19 @@ export interface GateLogicOptions {
   readonly now?: () => number;
   /** Injectable sleep. Default a real `setTimeout` promise. */
   readonly sleep?: (ms: number) => Promise<void>;
+  /**
+   * Max lifetime of a single-flight leadership (ms). If a leader isolate is
+   * killed before `endFlight` (waitUntil budget exceeded, eviction), its entry
+   * would otherwise pin the key forever and defeat single-flight. After the
+   * lease the next `beginFlight` reclaims leadership. Default 15 s — well above a
+   * throttled ~19-call fan-out (~4 s at 5/s), well below permanent. */
+  readonly leaseMs?: number;
+}
+
+interface Flight {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+  readonly startedAt: number;
 }
 
 const realSleep = (ms: number): Promise<void> =>
@@ -39,21 +52,27 @@ export class GateLogic {
   private readonly rate: number;
   private readonly now: () => number;
   private readonly sleep: (ms: number) => Promise<void>;
+  private readonly leaseMs: number;
 
   private tokens: number;
   private lastRefill: number;
 
-  /** key → promise that resolves when the current leader ends its flight. */
-  private readonly inFlight = new Map<string, Promise<void>>();
-  private readonly resolvers = new Map<string, () => void>();
+  /** key → the in-flight leadership record. */
+  private readonly inFlight = new Map<string, Flight>();
 
   constructor(opts: GateLogicOptions = {}) {
     this.rate = opts.ratePerSecond ?? 5;
     this.now = opts.now ?? (() => Date.now());
     this.sleep = opts.sleep ?? realSleep;
+    this.leaseMs = opts.leaseMs ?? 15_000;
     // Start full so a single cold fan-out isn't throttled from the first call.
     this.tokens = this.rate;
     this.lastRefill = this.now();
+  }
+
+  /** A flight whose lease has expired is treated as abandoned (dead leader). */
+  private isLive(flight: Flight | undefined): boolean {
+    return !!flight && this.now() - flight.startedAt < this.leaseMs;
   }
 
   private refill(): void {
@@ -86,30 +105,54 @@ export class GateLogic {
    * Single-flight leadership. Returns `true` to the first caller for `key`
    * (the leader — it must run the work, then call `endFlight(key)`), `false`
    * to every concurrent caller (they should `awaitFlight(key)` or serve stale).
+   * A caller also becomes leader if the previous leader's lease has expired
+   * (dead-leader reclaim), waking anyone waiting on the abandoned flight.
    */
   beginFlight(key: string): boolean {
-    if (this.inFlight.has(key)) return false;
-    this.inFlight.set(
-      key,
-      new Promise<void>((resolve) => this.resolvers.set(key, resolve)),
-    );
+    const existing = this.inFlight.get(key);
+    if (this.isLive(existing)) return false;
+    // No live leader (never claimed, or the previous lease expired) → take it.
+    existing?.resolve(); // wake waiters stuck on the abandoned flight
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    this.inFlight.set(key, { promise, resolve, startedAt: this.now() });
     return true;
   }
 
   /** Release the flight for `key`, waking every `awaitFlight` waiter. */
   endFlight(key: string): void {
-    this.resolvers.get(key)?.();
-    this.resolvers.delete(key);
-    this.inFlight.delete(key);
+    const flight = this.inFlight.get(key);
+    if (flight) {
+      flight.resolve();
+      this.inFlight.delete(key);
+    }
   }
 
-  /** Resolve when the current leader for `key` calls `endFlight`. No-op if idle. */
+  /**
+   * Resolve when the current leader for `key` calls `endFlight`, or after the
+   * lease elapses — a leader isolate killed before `endFlight` must not hang
+   * cross-isolate waiters forever. No-op if idle.
+   */
   async awaitFlight(key: string): Promise<void> {
-    await this.inFlight.get(key);
+    const flight = this.inFlight.get(key);
+    if (!flight) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        flight.promise,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, this.leaseMs);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
-  /** True while a leader holds the flight for `key`. */
+  /** True while a live (unexpired) leader holds the flight for `key`. */
   isInFlight(key: string): boolean {
-    return this.inFlight.has(key);
+    return this.isLive(this.inFlight.get(key));
   }
 }

--- a/apps/api/src/psd/gate-logic.ts
+++ b/apps/api/src/psd/gate-logic.ts
@@ -1,0 +1,115 @@
+/**
+ * PSD gate — pure coordination logic.
+ *
+ * The PSD read path storms its own quota: without coordination, N concurrent
+ * cache-misses each fire the ~19-call `getNextMatches` fan-out, and a failed
+ * refresh never advances `fetchedAt`, so every subsequent request re-fans out
+ * until PSD recovers (see #2320). PSD's published limits are 5 req/s + 2 000/day
+ * (#2319), shared across every read endpoint — one fan-out already saturates the
+ * per-second budget, so the 2nd concurrent miss 429s instantly.
+ *
+ * This module is the storm fix, expressed as framework-free logic so it can be
+ * unit-tested in the Node test env (a real Durable Object cannot). The
+ * `PsdGate` Durable Object (see gate.ts) hosts ONE instance of this class, which
+ * makes both limiters **global across all worker isolates**:
+ *
+ *  - **Token bucket** — hands out ≤`ratePerSecond` PSD calls/second worldwide,
+ *    so a fan-out can't burst past PSD's 5/s ceiling. In-memory per-isolate was
+ *    ruled out (#2324): 8 isolates × 5/s = 40/s.
+ *  - **Single-flight** — the first caller for a cache key becomes the leader and
+ *    runs the fan-out; concurrent callers coalesce (N misses → 1 fan-out).
+ *
+ * The persisted negative marker that suppresses re-storming lives in KV (it must
+ * outlive a single DO instance), not here — see cache/kv-cache.ts.
+ */
+
+export interface GateLogicOptions {
+  /** Token-bucket rate & capacity (PSD calls/second). Default 5 (PSD's limit). */
+  readonly ratePerSecond?: number;
+  /** Injectable clock (ms). Default `Date.now`. */
+  readonly now?: () => number;
+  /** Injectable sleep. Default a real `setTimeout` promise. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export class GateLogic {
+  private readonly rate: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  private tokens: number;
+  private lastRefill: number;
+
+  /** key → promise that resolves when the current leader ends its flight. */
+  private readonly inFlight = new Map<string, Promise<void>>();
+  private readonly resolvers = new Map<string, () => void>();
+
+  constructor(opts: GateLogicOptions = {}) {
+    this.rate = opts.ratePerSecond ?? 5;
+    this.now = opts.now ?? (() => Date.now());
+    this.sleep = opts.sleep ?? realSleep;
+    // Start full so a single cold fan-out isn't throttled from the first call.
+    this.tokens = this.rate;
+    this.lastRefill = this.now();
+  }
+
+  private refill(): void {
+    const t = this.now();
+    const elapsed = (t - this.lastRefill) / 1000;
+    if (elapsed <= 0) return;
+    this.tokens = Math.min(this.rate, this.tokens + elapsed * this.rate);
+    this.lastRefill = t;
+  }
+
+  /**
+   * Resolve when a PSD-call token is available, consuming it. Global ≤rate/s.
+   * Callers `await` this immediately before every PSD fetch.
+   */
+  async acquireToken(): Promise<void> {
+    // Loop rather than sleep-once: the injected clock may not advance by the
+    // full deficit in one step (and refill is capped at capacity).
+    for (;;) {
+      this.refill();
+      if (this.tokens >= 1) {
+        this.tokens -= 1;
+        return;
+      }
+      const deficit = 1 - this.tokens;
+      await this.sleep((deficit / this.rate) * 1000);
+    }
+  }
+
+  /**
+   * Single-flight leadership. Returns `true` to the first caller for `key`
+   * (the leader — it must run the work, then call `endFlight(key)`), `false`
+   * to every concurrent caller (they should `awaitFlight(key)` or serve stale).
+   */
+  beginFlight(key: string): boolean {
+    if (this.inFlight.has(key)) return false;
+    this.inFlight.set(
+      key,
+      new Promise<void>((resolve) => this.resolvers.set(key, resolve)),
+    );
+    return true;
+  }
+
+  /** Release the flight for `key`, waking every `awaitFlight` waiter. */
+  endFlight(key: string): void {
+    this.resolvers.get(key)?.();
+    this.resolvers.delete(key);
+    this.inFlight.delete(key);
+  }
+
+  /** Resolve when the current leader for `key` calls `endFlight`. No-op if idle. */
+  async awaitFlight(key: string): Promise<void> {
+    await this.inFlight.get(key);
+  }
+
+  /** True while a leader holds the flight for `key`. */
+  isInFlight(key: string): boolean {
+    return this.inFlight.has(key);
+  }
+}

--- a/apps/api/src/psd/gate.ts
+++ b/apps/api/src/psd/gate.ts
@@ -1,0 +1,97 @@
+/**
+ * PSD gate — Effect service over the global {@link GateLogic}.
+ *
+ * The live layer talks to the `PsdGate` Durable Object (one global instance, see
+ * gate-do.ts) so the token bucket and single-flight registry are shared across
+ * every worker isolate. The DO class itself lives in a separate module because
+ * it imports `cloudflare:workers`, which the Node test env can't resolve — this
+ * file must stay importable by the unit tests, so it only references the stub
+ * structurally.
+ *
+ * The gate is **best-effort**: if the DO is unreachable, every operation
+ * degrades to "no coordination" (proceed without a token, act as leader) so a
+ * gate hiccup never breaks the read path — the KV negative marker + SWR still
+ * bound the storm.
+ */
+import { Context, Effect, Layer } from "effect";
+import { WorkerEnvTag } from "../env";
+import { GateLogic } from "./gate-logic";
+
+export interface PsdGate {
+  /** Await a global PSD-call token (≤5/s worldwide). Best-effort: proceeds on gate failure. */
+  readonly acquireToken: Effect.Effect<void>;
+  /** Become the single-flight leader for `key`? `true` = you run the work. */
+  readonly beginFlight: (key: string) => Effect.Effect<boolean>;
+  /** Release the flight for `key` (leader only). */
+  readonly endFlight: (key: string) => Effect.Effect<void>;
+  /** Resolve when the current leader for `key` finishes (bounded wait). */
+  readonly awaitFlight: (key: string) => Effect.Effect<void>;
+}
+
+export class PsdGateService extends Context.Tag("PsdGateService")<
+  PsdGateService,
+  PsdGate
+>() {}
+
+/** Structural view of the DO stub's RPC surface (see PsdGate in gate-do.ts). */
+interface PsdGateStub {
+  acquireToken(): Promise<void>;
+  beginFlight(key: string): Promise<boolean>;
+  endFlight(key: string): Promise<void>;
+  awaitFlight(key: string): Promise<void>;
+}
+
+/** Fixed name → one global DO instance for the whole worker. */
+const GATE_DO_NAME = "global";
+
+/** DO-backed gate. Every op degrades safely if the Durable Object is unreachable. */
+export const PsdGateLive = Layer.effect(
+  PsdGateService,
+  Effect.gen(function* () {
+    const env = yield* WorkerEnvTag;
+    const stub = (): PsdGateStub =>
+      env.PSD_GATE.get(
+        env.PSD_GATE.idFromName(GATE_DO_NAME),
+      ) as unknown as PsdGateStub;
+
+    return {
+      acquireToken: Effect.tryPromise(() => stub().acquireToken()).pipe(
+        Effect.orElseSucceed(() => undefined),
+      ),
+      beginFlight: (key) =>
+        Effect.tryPromise(() => stub().beginFlight(key)).pipe(
+          // On gate failure, act as leader: the caller does the work rather than
+          // waiting on coordination that isn't available.
+          Effect.orElseSucceed(() => true),
+        ),
+      endFlight: (key) =>
+        Effect.tryPromise(() => stub().endFlight(key)).pipe(
+          Effect.orElseSucceed(() => undefined),
+        ),
+      awaitFlight: (key) =>
+        Effect.tryPromise(() => stub().awaitFlight(key)).pipe(
+          Effect.orElseSucceed(() => undefined),
+        ),
+    };
+  }),
+);
+
+/**
+ * In-memory gate backed by a caller-supplied {@link GateLogic}. For tests and as
+ * a graceful fallback — NOT for production multi-isolate use (each isolate would
+ * get its own limiter). Pass a shared `GateLogic` to exercise coalescing.
+ */
+export const makePsdGateLayer = (
+  logic: GateLogic,
+): Layer.Layer<PsdGateService> =>
+  Layer.succeed(PsdGateService, {
+    acquireToken: Effect.promise(() => logic.acquireToken()),
+    beginFlight: (key) => Effect.sync(() => logic.beginFlight(key)),
+    endFlight: (key) => Effect.sync(() => logic.endFlight(key)),
+    awaitFlight: (key) => Effect.promise(() => logic.awaitFlight(key)),
+  });
+
+/** A gate with a very high rate — no throttling, real single-flight. Default test layer. */
+export const PsdGateTest = makePsdGateLayer(
+  new GateLogic({ ratePerSecond: 1e9 }),
+);

--- a/apps/api/src/psd/opponent.test.ts
+++ b/apps/api/src/psd/opponent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Effect, Layer, Schema as S } from "effect";
 import { PsdService, PsdServiceLive } from "./service";
+import { PsdGateTest } from "./gate";
 import { OpponentHistory } from "@kcvv/api-contract";
 import { UpstreamUnavailableError, type BffError } from "./errors";
 import { WorkerEnvTag } from "../env";
@@ -21,6 +22,7 @@ function makeEnvLayer() {
     PSD_API_CLUB: "test-club",
     PSD_API_AUTH: "test-auth",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test-project",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",
@@ -36,6 +38,7 @@ const cacheMock: KvCacheInterface = {
   get: (key: string) =>
     Effect.succeed(key === "psd:competition-labels" ? "{}" : null),
   set: () => Effect.succeed(undefined),
+  delete: () => Effect.succeed(undefined),
   increment: () => Effect.succeed(undefined),
 };
 
@@ -60,6 +63,7 @@ function runService<A>(
     Effect.either(
       program.pipe(
         Effect.provide(PsdServiceLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
         Effect.provide(Layer.succeed(SanityProjection, sanityProjectionMock)),

--- a/apps/api/src/psd/service.test.ts
+++ b/apps/api/src/psd/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Effect, Layer, Logger, Schema as S } from "effect";
 import { PsdService, PsdServiceLive } from "./service";
+import { PsdGateTest } from "./gate";
 import { Match, MatchDetail, RankingEntry } from "@kcvv/api-contract";
 import { UpstreamUnavailableError, type BffError } from "./errors";
 import { WorkerEnvTag } from "../env";
@@ -21,6 +22,7 @@ function makeEnvLayer() {
     PSD_API_CLUB: "test-club",
     PSD_API_AUTH: "test-auth",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test-project",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",
@@ -41,6 +43,7 @@ const cacheMock: KvCacheInterface = {
         : null,
     ),
   set: () => Effect.succeed(undefined),
+  delete: () => Effect.succeed(undefined),
   increment: () => Effect.succeed(undefined),
 };
 
@@ -152,6 +155,7 @@ function runService<A>(
     Effect.either(
       program.pipe(
         Effect.provide(PsdServiceLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, kv)),
         Effect.provide(Layer.succeed(SanityProjection, sanity)),
@@ -625,6 +629,7 @@ describe("PsdService.getNextMatches", () => {
         }
         return Effect.succeed(undefined);
       },
+      delete: () => Effect.succeed(undefined),
       increment: () => Effect.succeed(undefined),
     };
 
@@ -662,6 +667,7 @@ describe("PsdService.getNextMatches", () => {
           ? Effect.succeed(cachedIds)
           : Effect.succeed(null),
       set: () => Effect.succeed(undefined),
+      delete: () => Effect.succeed(undefined),
       increment: () => Effect.succeed(undefined),
     };
 
@@ -1168,6 +1174,7 @@ describe("PsdService.getRanking", () => {
         return yield* svc.getRanking(1, "https://cdn.example.com");
       }).pipe(
         Effect.provide(PsdServiceLive),
+        Effect.provide(PsdGateTest),
         Effect.provide(makeEnvLayer()),
         Effect.provide(Layer.succeed(KvCacheService, cacheMock)),
         Effect.provide(Layer.succeed(SanityProjection, makeSanityMock())),
@@ -1295,6 +1302,7 @@ describe("PsdService.getMatchDetail — status/score backfill from season list",
             : null,
       ),
     set: () => Effect.succeed(undefined),
+    delete: () => Effect.succeed(undefined),
     increment: () => Effect.succeed(undefined),
   });
 
@@ -1895,6 +1903,7 @@ describe("PsdService.getMatchDetail - competition/team enrichment", () => {
           key === "psd:match-team-index:v2" ? JSON.stringify(idx) : null,
         ),
       set: () => Effect.succeed(undefined),
+      delete: () => Effect.succeed(undefined),
       increment: () => Effect.succeed(undefined),
     };
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
@@ -1954,6 +1963,7 @@ describe("PsdService.getMatchDetail - competition/team enrichment", () => {
               : null, // psd:match-team-index → null → force a build
         ),
       set: () => Effect.succeed(undefined),
+      delete: () => Effect.succeed(undefined),
       increment: () => Effect.succeed(undefined),
     };
     (global.fetch as ReturnType<typeof vi.fn>)

--- a/apps/api/src/psd/service.ts
+++ b/apps/api/src/psd/service.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer, Option, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
 import { KvCacheService } from "../cache/kv-cache";
+import { PsdGateService } from "./gate";
 import { SanityProjection } from "../sanity/projection";
 import {
   UpstreamUnavailableError,
@@ -144,6 +145,7 @@ export const PsdServiceLive = Layer.effect(
   Effect.gen(function* () {
     const env = yield* WorkerEnvTag;
     const cache = yield* KvCacheService;
+    const gate = yield* PsdGateService;
     const projection = yield* SanityProjection;
     const base = env.PSD_API_BASE_URL;
 
@@ -155,8 +157,12 @@ export const PsdServiceLive = Layer.effect(
       "Content-Type": "application/json",
     };
 
+    // Every PSD call passes the global gate first: `acquireToken` blocks until a
+    // ≤5/s worldwide token is free (best-effort — proceeds if the gate is down),
+    // capping the fan-out below PSD's rate limit. `increment` records the call.
     const countedFetch = <A, I>(url: string, schema: S.Schema<A, I>) =>
-      fetchJson(url, schema, psdHeaders).pipe(
+      gate.acquireToken.pipe(
+        Effect.zipRight(fetchJson(url, schema, psdHeaders)),
         Effect.ensuring(cache.increment()),
       );
 

--- a/apps/api/src/sanity/mutation.test.ts
+++ b/apps/api/src/sanity/mutation.test.ts
@@ -64,6 +64,7 @@ function makeTestLayer() {
       get: vi.fn().mockResolvedValue(null),
       put: vi.fn().mockResolvedValue(undefined),
     } as unknown as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test-project",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",

--- a/apps/api/src/sanity/projection.test.ts
+++ b/apps/api/src/sanity/projection.test.ts
@@ -26,6 +26,7 @@ function makeTestLayer() {
         PSD_API_CLUB: "test-club",
         PSD_API_AUTH: "test-auth",
         PSD_CACHE: {} as KVNamespace,
+        PSD_GATE: {} as DurableObjectNamespace,
         SANITY_PROJECT_ID: "test-project",
         SANITY_DATASET: "test",
         SANITY_API_TOKEN: "test-token",

--- a/apps/api/src/search/embedding.test.ts
+++ b/apps/api/src/search/embedding.test.ts
@@ -20,6 +20,7 @@ function makeEnvLayer(ai: Ai) {
     PSD_API_CLUB: "",
     PSD_API_AUTH: "",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "",
     SANITY_DATASET: "",
     SANITY_API_TOKEN: "",

--- a/apps/api/src/search/sanity-index-sync.test.ts
+++ b/apps/api/src/search/sanity-index-sync.test.ts
@@ -52,6 +52,7 @@ function makeEnvLayer() {
     PSD_API_CLUB: "",
     PSD_API_AUTH: "",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "",
     SANITY_DATASET: "",
     SANITY_API_TOKEN: "",

--- a/apps/api/src/search/vectorize.test.ts
+++ b/apps/api/src/search/vectorize.test.ts
@@ -41,6 +41,7 @@ function makeEnvLayer(index: VectorizeIndex) {
     PSD_API_CLUB: "",
     PSD_API_AUTH: "",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "",
     SANITY_DATASET: "",
     SANITY_API_TOKEN: "",

--- a/apps/api/src/sync/run-sync.test.ts
+++ b/apps/api/src/sync/run-sync.test.ts
@@ -148,6 +148,7 @@ function makeEnvLayer(kvStub: KVNamespace) {
     PSD_API_CLUB: "test-club",
     PSD_API_AUTH: "test-auth",
     PSD_CACHE: kvStub,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",

--- a/apps/api/src/test-helpers/env-layer.ts
+++ b/apps/api/src/test-helpers/env-layer.ts
@@ -9,6 +9,7 @@ const defaultTestEnv: WorkerEnv = {
   PSD_API_CLUB: "test-club",
   PSD_API_AUTH: "test-auth",
   PSD_CACHE: {} as KVNamespace,
+  PSD_GATE: {} as DurableObjectNamespace,
   SANITY_PROJECT_ID: "test",
   SANITY_DATASET: "test",
   SANITY_API_TOKEN: "test-token",

--- a/apps/api/src/webhooks/index-handler.test.ts
+++ b/apps/api/src/webhooks/index-handler.test.ts
@@ -63,6 +63,7 @@ function makeEnv(overrides: Partial<WorkerEnv> = {}): WorkerEnv {
     PSD_API_CLUB: "",
     PSD_API_AUTH: "",
     PSD_CACHE: {} as KVNamespace,
+    PSD_GATE: {} as DurableObjectNamespace,
     SANITY_PROJECT_ID: "test",
     SANITY_DATASET: "test",
     SANITY_API_TOKEN: "test-token",

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -31,6 +31,16 @@ binding = "PSD_CACHE"
 id = "82533c23954d4ed98871dd53465c5c0e"
 preview_id = "4ee68193dd574f7fa01fba9d53d5d475"
 
+# Global PSD gate — one instance hosts the token bucket + single-flight registry
+# shared across all isolates (see src/psd/gate-do.ts, #2328).
+[[durable_objects.bindings]]
+name = "PSD_GATE"
+class_name = "PsdGate"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["PsdGate"]
+
 [ai]
 binding = "AI"
 
@@ -59,6 +69,12 @@ CACHE_LONG_TTL = "true"
 [[env.staging.kv_namespaces]]
 binding = "PSD_CACHE"
 id = "4ee68193dd574f7fa01fba9d53d5d475"
+
+# Named envs don't inherit top-level DO bindings — redeclare for staging.
+# Migrations ([[migrations]]) are defined once at the top level and apply here too.
+[[env.staging.durable_objects.bindings]]
+name = "PSD_GATE"
+class_name = "PsdGate"
 
 [env.staging.ai]
 binding = "AI"

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -37,9 +37,11 @@ preview_id = "4ee68193dd574f7fa01fba9d53d5d475"
 name = "PSD_GATE"
 class_name = "PsdGate"
 
+# SQLite-backed: the only supported DO storage class for new namespaces. PsdGate
+# keeps no durable storage (pure in-memory GateLogic), so the backing is moot.
 [[migrations]]
 tag = "v1"
-new_classes = ["PsdGate"]
+new_sqlite_classes = ["PsdGate"]
 
 [ai]
 binding = "AI"

--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,8 @@
       "ignoreDependencies": ["prettier-plugin-tailwindcss", "playwright"]
     },
     "apps/api": {
-      "ignoreBinaries": ["jq"]
+      "ignoreBinaries": ["jq"],
+      "ignoreDependencies": ["cloudflare"]
     },
     "apps/studio": {
       "entry": ["structure.ts"],


### PR DESCRIPTION
Closes #2328

Part A+B of the [reliable PSD match delivery spec (#2327)](https://github.com/soniCaH/www.kcvvelewijt.be/issues/2327) — the core storm fix. The PSD read path stormed its own quota (5 req/s + 2 000/day, **global** across all PSD calls): concurrent cache-misses each fired the ~19-call fan-out, and a failed refresh never advanced `fetchedAt`, so every request re-fanned until PSD recovered — serving up to 48 h-stale data silently (#2320).

## Changes

- **`PsdGate` Durable Object** (one global instance) hosts a framework-free `GateLogic`: a **≤5/s token bucket** + **single-flight registry**, shared across all worker isolates. `countedFetch` awaits a token before every PSD call (best-effort — degrades to a no-op if the DO is unreachable). Binding + `[[migrations]]` in `wrangler.toml` (prod + staging), typed in `env.ts`.
- **`TypedKvCache` → stale-while-revalidate**: serve stale instantly, refresh in the background via `ctx.waitUntil` on a layer built from `env` (independent of the disposed per-request runtime). N concurrent misses collapse to **one** fan-out.
- **Persisted negative marker** (~2 min) suppresses re-storming after a failed refresh and self-heals on recovery.
- **Correctness guard**: a stale "next" list whose kickoff has passed refreshes blocking instead of serving stale — but the negative marker wins during an active outage (bounded ≤2 min of possibly-stale over storming PSD while it's down).
- **Stale is the floor**: any refresh failure serves stale; only a never-cached key can error.
- **All match soft TTLs floored at 15 min** (SWR makes tighter windows pointless; KCVV has no live scores).

## Pre-PR review gate

Ran `/code-review` (Standards + Spec) and `/simplify`. Findings applied:

- **Dead-leader single-flight poison** (Standards): a leader isolate killed before `endFlight` would pin a key forever → added a **lease** that reclaims abandoned flights; the `awaitFlight` timeout moved into `GateLogic` so one module owns the whole invariant and it's unit-tested (the DO is now pure pass-through).
- **AC3 miss-path failure** (Spec): followers used to self-fetch when the leader failed → up to N concurrent fan-outs. Now followers only ever **re-enter single-flight** (serialize; each still surfaces a real error), verified by a `maxInFlight === 1` test.
- Folded duplicated refresh logic into `persist()` / `keepStale()`; tightened comments.

Skipped (noted in review): folding the negative marker into the wrapper (sound but a larger refactor — follow-up), caching the invariant schedule to derive "next" at read (out of #2328 scope), the `runDetached` extraction (would touch unrelated `scheduled` handlers).

## Testing

- `apps/api` has no `check-all`; ran the equivalent — **lint + type-check + `vitest` (422 tests)** all pass.
- New tests: `gate-logic` token bucket + single-flight + lease reclaim + `awaitFlight` timeout; `kv-cache` SWR (serve-stale-then-refresh, negative marker, correctness guard, one-fan-out coalescing, no-concurrent-fan-out-on-failure, sustained-outage decoupling, self-heal).
- `wrangler deploy --dry-run` (prod + staging) bundles with the `PsdGate` Durable Object binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated request limiting to improve reliability during high-demand periods.
  * Added stale-while-revalidate caching, allowing users to receive cached results while updates run in the background.
  * Added protection against repeated failed refreshes and request storms.
  * Added single-flight handling so concurrent requests share one refresh operation.

* **Bug Fixes**
  * Match data now refreshes when cached results include outdated upcoming matches.
  * Failed refreshes preserve usable stale data instead of overwriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->