### PR TITLE
feat(api): slack incident alerting for PSD failures (#2329)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -43,15 +43,16 @@ pnpm --filter @kcvv/api dev                        # wrangler dev on :8787
 
 ## Environment variables
 
-| Variable                   | Where set                            | Notes                                            |
-| -------------------------- | ------------------------------------ | ------------------------------------------------ |
-| `PSD_API_BASE_URL`         | `wrangler.toml [vars]`               | Public, safe to commit                           |
-| `FOOTBALISTO_LOGO_CDN_URL` | `wrangler.toml [vars]`               | Public, safe to commit                           |
-| `PSD_API_KEY`              | `wrangler secret put` / CF dashboard | Never in toml                                    |
-| `PSD_API_AUTH`             | `wrangler secret put` / CF dashboard | Never in toml                                    |
-| `CACHE_LONG_TTL`           | `wrangler.toml [env.staging.vars]`   | Overrides hardTtl to 365d                        |
-| `PSD_API_CLUB`             | `wrangler secret put` / CF dashboard | Never in toml                                    |
-| `RESEND_API_KEY`           | `wrangler secret put` / CF dashboard | Never in toml — see `docs/prd/email-delivery.md` |
+| Variable                   | Where set                            | Notes                                                                                                  |
+| -------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `PSD_API_BASE_URL`         | `wrangler.toml [vars]`               | Public, safe to commit                                                                                 |
+| `FOOTBALISTO_LOGO_CDN_URL` | `wrangler.toml [vars]`               | Public, safe to commit                                                                                 |
+| `PSD_API_KEY`              | `wrangler secret put` / CF dashboard | Never in toml                                                                                          |
+| `PSD_API_AUTH`             | `wrangler secret put` / CF dashboard | Never in toml                                                                                          |
+| `CACHE_LONG_TTL`           | `wrangler.toml [env.staging.vars]`   | Overrides hardTtl to 365d                                                                              |
+| `PSD_API_CLUB`             | `wrangler secret put` / CF dashboard | Never in toml                                                                                          |
+| `RESEND_API_KEY`           | `wrangler secret put` / CF dashboard | Never in toml — see `docs/prd/email-delivery.md`                                                       |
+| `SLACK_ALERT_WEBHOOK_URL`  | `wrangler secret put` / CF dashboard | Never in toml — Slack incoming-webhook for PSD incident/drift alerts (#2329); absent → alerting no-ops |
 
 ## Deployment
 
@@ -65,6 +66,7 @@ wrangler secret put PSD_API_KEY --env staging
 wrangler secret put PSD_API_AUTH --env staging
 wrangler secret put PSD_API_CLUB --env staging
 wrangler secret put RESEND_API_KEY --env staging
+wrangler secret put SLACK_ALERT_WEBHOOK_URL --env staging
 ```
 
 ## Cache

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { Effect, Layer, Schema as S } from "effect";
+import { Effect, Layer, Logger, LogLevel, Schema as S } from "effect";
+import { IncidentTracker } from "../psd/incident";
 import {
   KvCacheService,
   KvCacheLive,
@@ -779,6 +780,108 @@ describe("TypedKvCache — stale-while-revalidate + storm gate (#2328)", () => {
       value: 2,
     });
     expect(mockKv.store.get("neg:test-key")).toBeUndefined();
+  });
+});
+
+describe("TypedKvCache — PSD incident alerting (#2329)", () => {
+  /** Fresh gate with its OWN incident tracker so state can't leak between tests. */
+  const isolatedGate = () =>
+    makePsdGateLayer(
+      new GateLogic({ ratePerSecond: 1e9 }),
+      new IncidentTracker(),
+    );
+
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  it("escalates the serve-stale log WARN→ERROR while an incident is open", async () => {
+    const mockKv = makeMockKv();
+    // 2 h stale (< 24 h drift threshold) — the escalation here is driven purely
+    // by the OPEN incident, not by drift.
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 2 * 60 * 60 * 1000),
+    );
+    const gate = isolatedGate(); // first failure opens the incident
+
+    const entries: { level: string; message: string }[] = [];
+    const capture = Logger.replace(
+      Logger.defaultLogger,
+      Logger.make(({ logLevel, message }) => {
+        entries.push({ level: logLevel.label, message: String(message) });
+      }),
+    );
+
+    // No runner → blocking refresh path (synchronous, easy to assert).
+    const fetchEffect = Effect.fail(new Error("PSD 429") as never);
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(capture),
+          Effect.provide(Logger.minimumLogLevel(LogLevel.All)),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "stale", value: 1 });
+    expect(
+      entries.some(
+        (e) => e.level === "ERROR" && e.message.includes("refresh failed"),
+      ),
+    ).toBe(true);
+    // Under the 24 h threshold → no slow-drift nudge.
+    expect(mockKv.store.get("nudge:test-key")).toBeUndefined();
+  });
+
+  it("slow-drift nudge: >24h stale on a failed refresh sets the once/day marker", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 3 * dayMs), // 3 days stale
+    );
+    const fetchEffect = Effect.fail(new Error("PSD 429") as never);
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(isolatedGate()),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "stale", value: 1 });
+    expect(mockKv.store.get("nudge:test-key")).toBe("1");
+  });
+
+  it("slow-drift nudge is deduped once/day/key (marker already present)", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 3 * dayMs),
+    );
+    mockKv.store.set("nudge:test-key", "1"); // already pinged today
+    const fetchEffect = Effect.fail(new Error("PSD 429") as never);
+
+    await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(isolatedGate()),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    // Marker pre-existed → we must NOT re-write (re-ping) it.
+    expect(mockKv.put).not.toHaveBeenCalledWith(
+      "nudge:test-key",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });
 

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -2,6 +2,7 @@ import { Context, Effect, Either, Layer, Option, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
 import { PsdGateService } from "../psd/gate";
 import { BackgroundRunnerService, type PsdRefreshEnv } from "../psd/background";
+import { buildDriftMessage, postSlack } from "../psd/slack-alert";
 
 /**
  * Per-endpoint soft TTLs in seconds.
@@ -31,6 +32,13 @@ export const TTL = {
  * (KV's minimum expirationTtl is 60 s.) */
 export const NEG_MARKER_TTL = 120; // 2 min
 
+/** Serve-stale age (seconds) past which we escalate logs WARN→ERROR and emit a
+ * slow-drift Slack nudge — the value is creeping toward the hard-expiry cliff. */
+export const DRIFT_NUDGE_THRESHOLD = 60 * 60 * 24; // 24 h (#2329)
+
+/** Dedup window for the slow-drift nudge: at most one Slack ping per day per key. */
+export const NUDGE_MARKER_TTL = 60 * 60 * 24; // 24 h
+
 export interface KvCacheInterface {
   readonly get: (key: string) => Effect.Effect<string | null>;
   readonly set: (
@@ -55,6 +63,13 @@ export const HARD_TTL_DEFAULT = 60 * 60 * 24 * 7;
 export const HARD_TTL_LONG = 60 * 60 * 24 * 365;
 
 const negKey = (key: string): string => `neg:${key}`;
+const nudgeKey = (key: string): string => `nudge:${key}`;
+
+/** Best-effort HTTP status off an upstream error (UpstreamUnavailable carries one). */
+const statusOf = (e: unknown): number | undefined => {
+  const s = (e as { status?: unknown }).status;
+  return typeof s === "number" ? s : undefined;
+};
 
 export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
   const WrapperSchema = S.Struct({
@@ -130,12 +145,71 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
           );
 
         // Keep the stale copy: log why and set the negative marker so subsequent
-        // requests serve stale without re-fanning until it expires.
-        const keepStale = (reason: string) =>
-          Effect.zipRight(
-            Effect.logWarning(`TypedKvCache "${key}": ${reason}`),
-            cache.set(negKey(key), "1", NEG_MARKER_TTL),
-          );
+        // requests serve stale without re-fanning until it expires. Given an
+        // `alert` context, the log escalates WARN→ERROR when an outage is open OR
+        // the value has drifted past the nudge threshold, and a once/day/key
+        // slow-drift Slack nudge fires while drifting (#2329). Called without
+        // `alert` for keeps that carry no stale-age context → plain WARN.
+        const nudge = (staleAgeMs: number, status?: number) =>
+          Effect.gen(function* () {
+            // Once/day/key: skip if we already pinged within the marker window.
+            if ((yield* cache.get(nudgeKey(key))) !== null) return;
+            yield* cache.set(nudgeKey(key), "1", NUDGE_MARKER_TTL);
+            yield* Effect.promise(() =>
+              postSlack(
+                env.SLACK_ALERT_WEBHOOK_URL,
+                buildDriftMessage({
+                  key,
+                  staleAgeMs,
+                  hardTtlMs: effectiveHardTtl * 1000,
+                  status,
+                }),
+              ),
+            );
+          });
+
+        const keepStale = (
+          reason: string,
+          alert?: {
+            readonly staleAgeMs: number;
+            readonly incidentOpen: boolean;
+            readonly status?: number;
+          },
+        ) =>
+          Effect.gen(function* () {
+            const drifting =
+              !!alert && alert.staleAgeMs > DRIFT_NUDGE_THRESHOLD * 1000;
+            const escalate = !!alert && (alert.incidentOpen || drifting);
+            const line = `TypedKvCache "${key}": ${reason}`;
+            yield* escalate ? Effect.logError(line) : Effect.logWarning(line);
+            yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
+            if (alert && drifting) yield* nudge(alert.staleAgeMs, alert.status);
+          });
+
+        // Report a transient-outage refresh failure to the gate (incident
+        // alerting) and keep the stale copy — escalating the log / nudging via
+        // the returned incident state + drift age. Shared by both refresh paths.
+        const failAndKeepStale = (
+          err: unknown,
+          fetchedAt: number,
+          label: string,
+        ) =>
+          Effect.gen(function* () {
+            const status = statusOf(err);
+            const staleAgeMs = Date.now() - fetchedAt;
+            const { incidentOpen } = yield* gate.reportOutcome({
+              ok: false,
+              key,
+              status,
+              error: String(err),
+              staleAgeMs,
+            });
+            yield* keepStale(`${label} (${String(err)})`, {
+              staleAgeMs,
+              incidentOpen,
+              status,
+            });
+          });
 
         // Store a fresh value (schema-validated) and clear any negative marker.
         const storeFresh = (value: A) =>
@@ -148,18 +222,22 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         // serve-stale error (setting the negative marker so we stop re-fanning),
         // propagate otherwise. Used by the correctness guard and, when no
         // background runner is wired, as the stale fallback.
-        const blockingRefresh = (staleValue: A) =>
+        const blockingRefresh = (staleValue: A, fetchedAt: number) =>
           Effect.gen(function* () {
             const result = yield* fetch.pipe(Effect.either);
             if (Either.isRight(result)) {
+              yield* gate.reportOutcome({ ok: true, key });
               yield* storeFresh(result.right);
               return result.right;
             }
             if (!shouldServeStale(result.left)) {
+              // Not a transient PSD outage (404 / decode) → don't touch incident.
               return yield* Effect.fail(result.left);
             }
-            yield* keepStale(
-              `refresh failed, serving stale (${String(result.left)})`,
+            yield* failAndKeepStale(
+              result.left,
+              fetchedAt,
+              "refresh failed, serving stale",
             );
             return staleValue;
           });
@@ -167,22 +245,37 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         // Background (SWR) refresh: single-flight leader fetches and updates KV;
         // any failure (or schema-invalid data) keeps stale + marks. Never throws
         // — it runs detached via the background runner.
-        const backgroundRefresh = Effect.gen(function* () {
-          const leader = yield* gate.beginFlight(key);
-          if (!leader) return; // another isolate/fiber is already refreshing
-          yield* Effect.gen(function* () {
-            const result = yield* fetch.pipe(Effect.either);
-            if (Either.isLeft(result)) {
-              return yield* keepStale(
-                `background refresh failed (${String(result.left)})`,
-              );
-            }
-            const valid = S.decodeUnknownOption(schema)(result.right);
-            yield* Option.isSome(valid)
-              ? persist(result.right)
-              : keepStale("background refresh returned schema-invalid data");
-          }).pipe(Effect.ensuring(gate.endFlight(key)));
-        });
+        const backgroundRefresh = (fetchedAt: number) =>
+          Effect.gen(function* () {
+            const leader = yield* gate.beginFlight(key);
+            if (!leader) return; // another isolate/fiber is already refreshing
+            yield* Effect.gen(function* () {
+              const result = yield* fetch.pipe(Effect.either);
+              if (Either.isLeft(result)) {
+                if (!shouldServeStale(result.left)) {
+                  // Non-outage failure (decode) → keep stale, plain WARN.
+                  return yield* keepStale(
+                    `background refresh failed (${String(result.left)})`,
+                  );
+                }
+                return yield* failAndKeepStale(
+                  result.left,
+                  fetchedAt,
+                  "background refresh failed",
+                );
+              }
+              yield* gate.reportOutcome({ ok: true, key });
+              const valid = S.decodeUnknownOption(schema)(result.right);
+              yield* Option.isSome(valid)
+                ? persist(result.right)
+                : // Not a PSD outage (200 w/ bad shape), but the value still
+                  // drifts toward the cliff — nudge if it's aged past threshold.
+                  keepStale("background refresh returned schema-invalid data", {
+                    staleAgeMs: Date.now() - fetchedAt,
+                    incidentOpen: false,
+                  });
+            }).pipe(Effect.ensuring(gate.endFlight(key)));
+          });
 
         const cached = yield* cache.get(key);
 
@@ -209,7 +302,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             // Correctness guard: a stale value that is now wrong (past-kickoff
             // "next") must not be served — refresh blocking.
             if (options?.mustBlockOnStale?.(value)) {
-              return yield* blockingRefresh(value);
+              return yield* blockingRefresh(value, fetchedAt);
             }
 
             if (Option.isSome(runnerOpt)) {
@@ -217,7 +310,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
               // background (single-flight) via the runner — see background-live.ts.
               // Cast is safe: only PSD handlers provide a runner, and its layer
               // covers this refresh's deps (a non-PSD caller has no runner here).
-              const refresh = backgroundRefresh as Effect.Effect<
+              const refresh = backgroundRefresh(fetchedAt) as Effect.Effect<
                 void,
                 unknown,
                 PsdRefreshEnv
@@ -227,7 +320,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             }
 
             // No background runner wired → fall back to a blocking refresh.
-            return yield* blockingRefresh(value);
+            return yield* blockingRefresh(value, fetchedAt);
           }
         }
 
@@ -245,9 +338,23 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
           const isLeader = yield* gate.beginFlight(key);
           if (isLeader) {
             return yield* Effect.gen(function* () {
-              const value = yield* fetch;
-              yield* storeFresh(value);
-              return value;
+              const result = yield* fetch.pipe(Effect.either);
+              if (Either.isRight(result)) {
+                yield* gate.reportOutcome({ ok: true, key });
+                yield* storeFresh(result.right);
+                return result.right;
+              }
+              // Never-cached miss failure: report a transient PSD outage so the
+              // incident alert still fires on a cold start, then surface it.
+              if (shouldServeStale(result.left)) {
+                yield* gate.reportOutcome({
+                  ok: false,
+                  key,
+                  status: statusOf(result.left),
+                  error: String(result.left),
+                });
+              }
+              return yield* Effect.fail(result.left);
             }).pipe(Effect.ensuring(gate.endFlight(key)));
           }
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -17,6 +17,7 @@ export interface WorkerEnv {
   readonly SANITY_WEBHOOK_SECRET: string; // SVIX signing secret — wrangler secret
   readonly RESEND_API_KEY?: string; // Resend transactional email — wrangler secret (absent locally → email dispatch is a no-op)
   readonly TURNSTILE_SECRET?: string; // Cloudflare Turnstile secret — wrangler secret (absent locally → verification is skipped)
+  readonly SLACK_ALERT_WEBHOOK_URL?: string; // Slack incoming-webhook for PSD incident/drift alerts — wrangler secret (absent locally → alerting is a no-op)
   readonly CACHE_LONG_TTL?: string; // "true" on staging — overrides hardTtl to 365 days
 }
 

--- a/apps/api/src/psd/gate-do.ts
+++ b/apps/api/src/psd/gate-do.ts
@@ -9,16 +9,40 @@
  * imported by the worker entry (index.ts), never by code the Node tests load.
  */
 import { DurableObject } from "cloudflare:workers";
+import type { WorkerEnv } from "../env";
+// Type-only — erases at build, so the DO bundle never pulls in Effect via gate.ts.
+import type { PsdOutcome } from "./gate";
 import { GateLogic } from "./gate-logic";
+import { IncidentTracker } from "./incident";
+import { buildIncidentMessage, postSlack } from "./slack-alert";
 
-export class PsdGate extends DurableObject {
+export class PsdGate extends DurableObject<WorkerEnv> {
   // Instance-lifetime state: survives across requests while the DO stays warm.
   // All coordination logic (including the lease that bounds awaitFlight against
   // a dead leader) lives in GateLogic so it stays unit-testable.
   private readonly logic = new GateLogic();
+  // ONE global incident view across all isolates — debounces 429 storms into a
+  // single outage/recovery Slack ping (see incident.ts, #2329).
+  private readonly incident = new IncidentTracker();
 
   acquireToken(): Promise<void> {
     return this.logic.acquireToken();
+  }
+
+  /**
+   * Record a PSD refresh outcome. Fires a debounced Slack ping on the first 429
+   * of an outage and on recovery, and returns the live incident state so the
+   * read path can escalate its serve-stale log WARN→ERROR while it's open.
+   */
+  async reportOutcome(input: PsdOutcome): Promise<{ incidentOpen: boolean }> {
+    const alert = this.incident.report(input.ok);
+    if (alert) {
+      await postSlack(
+        this.env.SLACK_ALERT_WEBHOOK_URL,
+        buildIncidentMessage(alert, input),
+      );
+    }
+    return { incidentOpen: this.incident.isOpen };
   }
 
   beginFlight(key: string): boolean {

--- a/apps/api/src/psd/gate.ts
+++ b/apps/api/src/psd/gate.ts
@@ -16,6 +16,14 @@
 import { Context, Effect, Layer } from "effect";
 import { WorkerEnvTag } from "../env";
 import { GateLogic } from "./gate-logic";
+import { IncidentTracker } from "./incident";
+import type { IncidentContext } from "./slack-alert";
+
+/** A PSD refresh outcome reported to the gate for incident alerting (#2329).
+ * Extends the message context so the DO can pass it straight to the builder. */
+export interface PsdOutcome extends IncidentContext {
+  readonly ok: boolean;
+}
 
 export interface PsdGate {
   /** Await a global PSD-call token (≤5/s worldwide). Best-effort: proceeds on gate failure. */
@@ -26,6 +34,14 @@ export interface PsdGate {
   readonly endFlight: (key: string) => Effect.Effect<void>;
   /** Resolve when the current leader for `key` finishes (bounded wait). */
   readonly awaitFlight: (key: string) => Effect.Effect<void>;
+  /**
+   * Report a PSD refresh outcome for global incident alerting. Fires a debounced
+   * Slack ping on outage-start/recovery and returns whether an outage is open
+   * (so the serve-stale path can escalate its log WARN→ERROR). Best-effort.
+   */
+  readonly reportOutcome: (
+    outcome: PsdOutcome,
+  ) => Effect.Effect<{ incidentOpen: boolean }>;
 }
 
 export class PsdGateService extends Context.Tag("PsdGateService")<
@@ -39,6 +55,7 @@ interface PsdGateStub {
   beginFlight(key: string): Promise<boolean>;
   endFlight(key: string): Promise<void>;
   awaitFlight(key: string): Promise<void>;
+  reportOutcome(outcome: PsdOutcome): Promise<{ incidentOpen: boolean }>;
 }
 
 /** Fixed name → one global DO instance for the whole worker. */
@@ -72,6 +89,12 @@ export const PsdGateLive = Layer.effect(
         Effect.tryPromise(() => stub().awaitFlight(key)).pipe(
           Effect.orElseSucceed(() => undefined),
         ),
+      reportOutcome: (outcome) =>
+        Effect.tryPromise(() => stub().reportOutcome(outcome)).pipe(
+          // On gate failure, assume no incident — alerting is best-effort and
+          // must never break or escalate the read path on its own.
+          Effect.orElseSucceed(() => ({ incidentOpen: false })),
+        ),
     };
   }),
 );
@@ -83,12 +106,20 @@ export const PsdGateLive = Layer.effect(
  */
 export const makePsdGateLayer = (
   logic: GateLogic,
+  incident: IncidentTracker = new IncidentTracker(),
 ): Layer.Layer<PsdGateService> =>
   Layer.succeed(PsdGateService, {
     acquireToken: Effect.promise(() => logic.acquireToken()),
     beginFlight: (key) => Effect.sync(() => logic.beginFlight(key)),
     endFlight: (key) => Effect.sync(() => logic.endFlight(key)),
     awaitFlight: (key) => Effect.promise(() => logic.awaitFlight(key)),
+    // No Slack post here (no env) — the in-memory layer only tracks state so
+    // tests can observe incident-driven log escalation. The DO does the POST.
+    reportOutcome: (outcome) =>
+      Effect.sync(() => {
+        incident.report(outcome.ok);
+        return { incidentOpen: incident.isOpen };
+      }),
   });
 
 /** A gate with a very high rate — no throttling, real single-flight. Default test layer. */

--- a/apps/api/src/psd/incident.test.ts
+++ b/apps/api/src/psd/incident.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { IncidentTracker, HEALTH_WINDOW_MS } from "./incident";
+
+/** Mutable clock so we can place reports on a timeline deterministically. */
+function clock(start = 1_000_000) {
+  let t = start;
+  return {
+    now: () => t,
+    at: (ms: number) => {
+      t = ms;
+      return ms;
+    },
+  };
+}
+
+describe("IncidentTracker", () => {
+  it("opens an incident on the first failure and returns outage-start once", () => {
+    const c = clock();
+    const tracker = new IncidentTracker({ now: c.now });
+
+    const first = tracker.report(false, c.at(0));
+    expect(first).toEqual({ kind: "outage-start", startedAt: 0 });
+    expect(tracker.isOpen).toBe(true);
+
+    // A second failure inside the incident does NOT re-alert (not per-429).
+    expect(tracker.report(false, c.at(5_000))).toBeNull();
+    expect(tracker.report(false, c.at(30_000))).toBeNull();
+    expect(tracker.isOpen).toBe(true);
+  });
+
+  it("does not alert on success while healthy", () => {
+    const tracker = new IncidentTracker();
+    expect(tracker.report(true, 0)).toBeNull();
+    expect(tracker.report(true, 10_000)).toBeNull();
+    expect(tracker.isOpen).toBe(false);
+  });
+
+  it("recovers on the first success after ≥60s with no failure", () => {
+    const tracker = new IncidentTracker();
+    tracker.report(false, 0); // outage-start
+
+    // A success too soon (<60s after the last failure) does NOT recover.
+    expect(tracker.report(true, 30_000)).toBeNull();
+    expect(tracker.isOpen).toBe(true);
+
+    // First success ≥60s after the last failure → one recovery ping.
+    const rec = tracker.report(true, HEALTH_WINDOW_MS + 1);
+    expect(rec).toMatchObject({
+      kind: "recovery",
+      startedAt: 0,
+      recoveredAt: HEALTH_WINDOW_MS + 1,
+      durationMs: HEALTH_WINDOW_MS + 1,
+    });
+    expect(tracker.isOpen).toBe(false);
+
+    // Further successes after recovery don't re-alert.
+    expect(tracker.report(true, HEALTH_WINDOW_MS + 100)).toBeNull();
+  });
+
+  it("collapses flapping into a single incident (one start, one recovery)", () => {
+    const tracker = new IncidentTracker();
+    const starts: unknown[] = [];
+    const recoveries: unknown[] = [];
+    const record = (a: ReturnType<IncidentTracker["report"]>) => {
+      if (a?.kind === "outage-start") starts.push(a);
+      if (a?.kind === "recovery") recoveries.push(a);
+    };
+
+    record(tracker.report(false, 0)); // start
+    record(tracker.report(true, 10_000)); // too soon → no recovery
+    record(tracker.report(false, 20_000)); // still same incident → no new start
+    record(tracker.report(true, 40_000)); // <60s after last failure → no recovery
+    record(tracker.report(true, 20_000 + HEALTH_WINDOW_MS + 1)); // recovery
+
+    expect(starts).toHaveLength(1);
+    expect(recoveries).toHaveLength(1);
+  });
+
+  it("opens a new incident after a full recovery", () => {
+    const tracker = new IncidentTracker();
+    tracker.report(false, 0);
+    tracker.report(true, HEALTH_WINDOW_MS + 1); // recovery
+    const second = tracker.report(false, HEALTH_WINDOW_MS + 10_000);
+    expect(second).toMatchObject({ kind: "outage-start" });
+  });
+});

--- a/apps/api/src/psd/incident.ts
+++ b/apps/api/src/psd/incident.ts
@@ -1,0 +1,88 @@
+/**
+ * PSD incident tracker — pure, debounced outage state machine.
+ *
+ * PSD failures were silent (WARN-only). This tracks whether PSD is currently in
+ * an outage so the gate can emit exactly ONE Slack "outage started" ping per
+ * incident and ONE "recovered" ping — never one-per-429 (see #2329, #2322).
+ *
+ * Framework-free (like {@link GateLogic}) so it unit-tests in the Node env; a
+ * real Durable Object cannot. The `PsdGate` DO (gate-do.ts) hosts ONE global
+ * instance so the incident view is shared across every worker isolate, and does
+ * the actual Slack POST — this module only decides *when* to alert.
+ *
+ * Debounce: an incident opens on the first failure after ≥`healthWindowMs` of
+ * health, and only closes (recovery) on the first success after ≥`healthWindowMs`
+ * with no failure. That window absorbs flapping into a single incident.
+ */
+
+/** Health window: failures/successes within this of a failure don't flip state. */
+export const HEALTH_WINDOW_MS = 60_000; // 60 s (#2329)
+
+export type IncidentAlert =
+  | { readonly kind: "outage-start"; readonly startedAt: number }
+  | {
+      readonly kind: "recovery";
+      readonly startedAt: number;
+      readonly recoveredAt: number;
+      readonly durationMs: number;
+    };
+
+export interface IncidentTrackerOptions {
+  /** Injectable clock (ms). Default `Date.now`. */
+  readonly now?: () => number;
+  /** Debounce window (ms). Default {@link HEALTH_WINDOW_MS}. */
+  readonly healthWindowMs?: number;
+}
+
+export class IncidentTracker {
+  private readonly now: () => number;
+  private readonly healthWindowMs: number;
+
+  private open = false;
+  private startedAt = 0;
+  // Boot state is "healthy since forever" so the very first failure opens an
+  // incident (it follows ≥healthWindowMs of implied health).
+  private lastFailureAt = Number.NEGATIVE_INFINITY;
+
+  constructor(opts: IncidentTrackerOptions = {}) {
+    this.now = opts.now ?? (() => Date.now());
+    this.healthWindowMs = opts.healthWindowMs ?? HEALTH_WINDOW_MS;
+  }
+
+  /** True while an outage is open (drives WARN→ERROR log escalation). */
+  get isOpen(): boolean {
+    return this.open;
+  }
+
+  /**
+   * Report one PSD refresh outcome. Returns the alert to emit, or null when the
+   * outcome doesn't flip incident state (the common case — most reports are
+   * "still healthy" or "still down").
+   */
+  report(ok: boolean, at: number = this.now()): IncidentAlert | null {
+    const healthyForWindow = at - this.lastFailureAt >= this.healthWindowMs;
+
+    if (ok) {
+      if (this.open && healthyForWindow) {
+        this.open = false;
+        return {
+          kind: "recovery",
+          startedAt: this.startedAt,
+          recoveredAt: at,
+          durationMs: at - this.startedAt,
+        };
+      }
+      return null;
+    }
+
+    // Failure.
+    const wasHealthy = healthyForWindow;
+    this.lastFailureAt = at;
+    if (!this.open && wasHealthy) {
+      this.open = true;
+      this.startedAt = at;
+      return { kind: "outage-start", startedAt: at };
+    }
+    return null;
+  }
+}

--- a/apps/api/src/psd/slack-alert.test.ts
+++ b/apps/api/src/psd/slack-alert.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  buildIncidentMessage,
+  buildDriftMessage,
+  formatDuration,
+  postSlack,
+} from "./slack-alert";
+
+describe("formatDuration", () => {
+  it("formats coarse durations and clamps negatives to 0s", () => {
+    expect(formatDuration(30_000)).toBe("30s");
+    expect(formatDuration(90_000)).toBe("1m");
+    expect(formatDuration(3 * 3600_000 + 12 * 60_000)).toBe("3h 12m");
+    expect(formatDuration(2 * 86400_000 + 5 * 3600_000)).toBe("2d 5h");
+    expect(formatDuration(-1000)).toBe("0s");
+  });
+});
+
+describe("buildIncidentMessage", () => {
+  it("names the key, status, and error on outage-start", () => {
+    const msg = buildIncidentMessage(
+      { kind: "outage-start", startedAt: 0 },
+      { key: "matches:team:42", status: 429, error: "HTTP 429: Too Many" },
+    );
+    expect(msg).toContain("outage started");
+    expect(msg).toContain("matches:team:42");
+    expect(msg).toContain("429");
+    expect(msg).toContain("Too Many");
+  });
+
+  it("reports incident duration on recovery", () => {
+    const msg = buildIncidentMessage(
+      {
+        kind: "recovery",
+        startedAt: 0,
+        recoveredAt: 3_600_000,
+        durationMs: 3_600_000,
+      },
+      { key: "ranking:1" },
+    );
+    expect(msg).toContain("recovered");
+    expect(msg).toContain("ranking:1");
+    expect(msg).toContain("1h 0m");
+  });
+});
+
+describe("buildDriftMessage", () => {
+  it("names the key, stale age, and time to the hard-expiry cliff", () => {
+    const day = 86400_000;
+    const msg = buildDriftMessage({
+      key: "matches:team:42",
+      staleAgeMs: 2 * day, // 2 days stale
+      hardTtlMs: 7 * day, // 7-day cliff
+      status: 429,
+    });
+    expect(msg).toContain("matches:team:42");
+    expect(msg).toContain("2d 0h"); // stale age
+    expect(msg).toContain("5d 0h"); // time to cliff (7 - 2)
+    expect(msg).toContain("429");
+  });
+
+  it("clamps time-to-cliff to 0 when already past the cliff", () => {
+    const day = 86400_000;
+    const msg = buildDriftMessage({
+      key: "k",
+      staleAgeMs: 8 * day,
+      hardTtlMs: 7 * day,
+    });
+    expect(msg).toContain("0s until");
+  });
+});
+
+describe("postSlack", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("no-ops (no fetch) when the webhook URL is absent", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await postSlack(undefined, "hi");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("POSTs a JSON {text} body to the webhook when present", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    await postSlack("https://hooks.slack.test/abc", "hello");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hooks.slack.test/abc",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ text: "hello" }),
+      }),
+    );
+  });
+
+  it("swallows fetch errors (best-effort)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    await expect(
+      postSlack("https://hooks.slack.test/abc", "x"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/psd/slack-alert.ts
+++ b/apps/api/src/psd/slack-alert.ts
@@ -1,0 +1,92 @@
+/**
+ * Slack incident/drift alert payloads for PSD failures (#2329).
+ *
+ * Framework-free so both the `PsdGate` Durable Object (incident pings, plain
+ * async) and the Effect-based KV cache serve-stale path (slow-drift nudge) can
+ * share it. `postSlack` is best-effort and a no-op when the webhook secret is
+ * absent (same pattern as RESEND_API_KEY) — a down Slack must never break the
+ * read path.
+ */
+import type { IncidentAlert } from "./incident";
+
+/** Human duration, coarse: "3d 4h", "5h 12m", "45m", "30s". */
+export function formatDuration(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m`;
+  return `${s}s`;
+}
+
+export interface IncidentContext {
+  /** Cache key / endpoint that triggered the transition. */
+  readonly key: string;
+  /** HTTP status of the failure (e.g. 429), when known. */
+  readonly status?: number;
+  /** Stringified upstream error, when known. */
+  readonly error?: string;
+  /** Age of the stale value being served (ms), when one exists. */
+  readonly staleAgeMs?: number;
+}
+
+/** Message for an incident state change (outage start / recovery). */
+export function buildIncidentMessage(
+  alert: IncidentAlert,
+  ctx: IncidentContext,
+): string {
+  if (alert.kind === "recovery") {
+    return `:large_green_circle: *PSD recovered* — \`${ctx.key}\` after ${formatDuration(
+      alert.durationMs,
+    )} of failures.`;
+  }
+  const status = ctx.status ? ` (HTTP ${ctx.status})` : "";
+  const detail = ctx.error ? `: ${ctx.error}` : "";
+  const stale =
+    ctx.staleAgeMs !== undefined
+      ? ` Serving stale (${formatDuration(ctx.staleAgeMs)} old) until it recovers.`
+      : " Serving stale until it recovers.";
+  return `:red_circle: *PSD outage started* — \`${ctx.key}\`${status} is failing${detail}.${stale}`;
+}
+
+export interface DriftContext {
+  /** Cache key / endpoint serving stale. */
+  readonly key: string;
+  /** How long the served value has been stale. */
+  readonly staleAgeMs: number;
+  /** Hard TTL — the value is evicted (the "cliff") once stale age reaches this. */
+  readonly hardTtlMs: number;
+  /** HTTP status of the failing refresh, when known. */
+  readonly status?: number;
+}
+
+/** Message for the slow-drift nudge: stale data creeping toward the hard cliff. */
+export function buildDriftMessage(ctx: DriftContext): string {
+  const timeToCliff = Math.max(0, ctx.hardTtlMs - ctx.staleAgeMs);
+  const status = ctx.status ? ` (last refresh: HTTP ${ctx.status})` : "";
+  return `:warning: *PSD data drifting stale* — \`${ctx.key}\` is ${formatDuration(
+    ctx.staleAgeMs,
+  )} old${status}; ${formatDuration(timeToCliff)} until it drops off the hard-expiry cliff.`;
+}
+
+/**
+ * Best-effort POST to a Slack incoming webhook. No-op when `webhookUrl` is
+ * absent (local/dev without the secret). Never throws.
+ */
+export async function postSlack(
+  webhookUrl: string | undefined,
+  text: string,
+): Promise<void> {
+  if (!webhookUrl) return;
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+  } catch {
+    // Best-effort: alerting must never break the read path.
+  }
+}


### PR DESCRIPTION
Closes #2329 — Part C of the reliable PSD match delivery spec (#2327).

PSD failures were silent (`WARN`-only). This wires **debounced Slack alerting** into the PSD gate (Durable Object) and the serve-stale cache path.

## Changes

- **`psd/incident.ts`** — pure, unit-tested `IncidentTracker` state machine (mirrors `gate-logic.ts`): opens one incident on the first failure after ≥60s of health, closes on the first success after ≥60s healthy. One outage-start + one recovery per incident — **never per-429**.
- **`psd/slack-alert.ts`** — framework-free message builders (`buildIncidentMessage`, `buildDriftMessage`, `formatDuration`) + best-effort `postSlack` (no-op when the secret is absent, same pattern as `RESEND_API_KEY`).
- **`psd/gate-do.ts`** — the `PsdGate` DO hosts one global `IncidentTracker` and posts the outage/recovery ping to `SLACK_ALERT_WEBHOOK_URL`; `reportOutcome` returns `{ incidentOpen }`.
- **`psd/gate.ts`** — `reportOutcome` added to the Effect `PsdGate` service (live + test layers).
- **`cache/kv-cache.ts`** — serve-stale path reports outcomes; log escalates **WARN→ERROR** while an incident is open or the value has drifted past 24h; **once/day/key** slow-drift Slack nudge (via a `nudge:<key>` KV marker, 24h TTL) naming stale age + time-to-hard-cliff.
- **`env.ts` + `apps/api/CLAUDE.md`** — new `SLACK_ALERT_WEBHOOK_URL` wrangler secret (never in `wrangler.toml`; absent → alerting no-ops), documented in the env table + staging secrets.

## Acceptance criteria

- [x] `SLACK_ALERT_WEBHOOK_URL` secret, documented in the env table
- [x] Debounced outage-start / recovery pings from the DO — one/two per incident, not per-429
- [x] Slow-drift nudge on serve-stale (>24h), once/day/key, with age + time-to-cliff
- [x] Serve-stale log WARN→ERROR while an incident is open or past the nudge threshold
- [x] Message payloads name endpoint/key, error, stale age
- [x] Quality gate passes

## Testing

- `type-check` (tsgo) clean · `lint` (eslint) clean · **438 tests pass** (16 new: incident state machine, message builders, `postSlack`, WARN→ERROR escalation, drift-nudge marker + dedup)
- `pnpm --filter @kcvv/api check-all` — note: `apps/api` has no `check-all` script; ran `lint` + `type-check` + `test` individually (all pass).

## Pre-PR review gate

Ran `/code-review` (high) + `/simplify`. Applied: `PsdOutcome` type dedup (DO imports type from gate; `PsdOutcome extends IncidentContext`), incident payloads now carry stale age (AC5), drift nudge fires on persistently-schema-invalid drift too, extracted the shared `failAndKeepStale` helper, tightened a doc comment.
Skipped (with rationale): folding `reportOutcome({ok:true})` into `endFlight` (rare cold paths only, would double-report on failure); moving the drift nudge into the DO (KV is the correct store for once/day dedup — a DO in-memory map resets on eviction within a day — and it would sacrifice the nudge logic's Node-testability). In-memory DO incident state can re-ping after eviction — accepted, matches the existing `GateLogic` in-memory design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
