### PR TITLE
fix(api): pace PSD calls without a clock so the gate stops starving

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -110,6 +110,7 @@ pnpm --filter @kcvv/api cache:clear:staging:key "ranking:team:23"
 - Secrets via `wrangler secret put`, never in `wrangler.toml`
 - `Effect.orDie` in HttpApiGroup handlers — errors become 500s; keep errors typed at handler level
 - After changing `@kcvv/api-contract`, run `pnpm turbo build --filter=@kcvv/api-contract` first
+- **Never rate-limit off `Date.now()` inside the `PsdGate` Durable Object.** A DO advances its clock only on I/O, so while every caller is sleeping inside the gate no time passes: a wall-clock token bucket accrues nothing and starves forever (this pinned every fan-out — `matches:window`, `match:detail:*` — at its Jul 30 snapshot until the 7-day hard TTL). Pace with relative sleeps only (`GateLogic.acquireToken`). The failure is silent: a cancelled `waitUntil` sets no negative marker and reports no outcome, so SWR just keeps serving stale.
 
 ## PSD Schema & Transform Rules
 

--- a/apps/api/src/psd/gate-logic.test.ts
+++ b/apps/api/src/psd/gate-logic.test.ts
@@ -3,8 +3,8 @@ import { GateLogic } from "./gate-logic";
 
 /**
  * Deterministic fake scheduler: `now()` reads a mutable clock, `sleep(ms)`
- * advances it and resolves on a microtask. Lets us assert the token bucket's
- * pacing without real timers.
+ * advances it and resolves on a microtask. Lets us assert the gate's pacing
+ * without real timers.
  */
 function fakeScheduler() {
   let clock = 0;
@@ -13,17 +13,14 @@ function fakeScheduler() {
     sleep: async (ms: number) => {
       clock += ms;
     },
-    advance: (ms: number) => {
-      clock += ms;
-    },
     get clock() {
       return clock;
     },
   };
 }
 
-describe("GateLogic — token bucket", () => {
-  it("hands out the initial burst (capacity) without waiting", async () => {
+describe("GateLogic — call pacing", () => {
+  it("throttles sustained demand to rate per second", async () => {
     const s = fakeScheduler();
     const gate = new GateLogic({
       ratePerSecond: 5,
@@ -31,42 +28,29 @@ describe("GateLogic — token bucket", () => {
       sleep: s.sleep,
     });
 
-    for (let i = 0; i < 5; i++) await gate.acquireToken();
-
-    // Full burst granted at t=0 — no simulated sleep needed.
-    expect(s.clock).toBe(0);
-  });
-
-  it("throttles sustained demand to ~rate per second", async () => {
-    const s = fakeScheduler();
-    const gate = new GateLogic({
-      ratePerSecond: 5,
-      now: s.now,
-      sleep: s.sleep,
-    });
-
-    // 20 tokens: 5 free (burst) + 15 paced at 5/s → ≥3s of simulated time.
+    // 20 calls spaced 1/5 s apart — the full index fan-out, exactly at PSD's
+    // ceiling. (No burst allowance: even spacing hits the same 5/s throughput.)
     for (let i = 0; i < 20; i++) await gate.acquireToken();
 
-    expect(s.clock).toBeGreaterThanOrEqual(3000);
-    // And not wildly more than the ideal (15 tokens / 5 per s = 3s).
-    expect(s.clock).toBeLessThan(4000);
+    expect(s.clock).toBe(20 * 200);
   });
 
-  it("refills over wall-clock gaps so a later burst isn't throttled", async () => {
-    const s = fakeScheduler();
+  it("keeps pacing when the clock never advances (Durable Object freezes Date.now)", async () => {
+    // A DO advances `Date.now()` only on I/O; while every caller sleeps in
+    // acquireToken there is none. A clock-driven bucket starves here — this
+    // whole fan-out must still complete off relative sleeps alone.
+    let slept = 0;
     const gate = new GateLogic({
       ratePerSecond: 5,
-      now: s.now,
-      sleep: s.sleep,
+      now: () => 0,
+      sleep: async (ms: number) => {
+        slept += ms;
+      },
     });
 
-    for (let i = 0; i < 5; i++) await gate.acquireToken(); // drain
-    s.advance(2000); // 2s idle → bucket refills to capacity (5)
+    for (let i = 0; i < 20; i++) await gate.acquireToken();
 
-    const before = s.clock;
-    for (let i = 0; i < 5; i++) await gate.acquireToken();
-    expect(s.clock).toBe(before); // served from refilled bucket, no wait
+    expect(slept).toBe(20 * 200);
   });
 });
 

--- a/apps/api/src/psd/gate-logic.test.ts
+++ b/apps/api/src/psd/gate-logic.test.ts
@@ -5,12 +5,18 @@ import { GateLogic } from "./gate-logic";
  * Deterministic fake scheduler: `now()` reads a mutable clock, `sleep(ms)`
  * advances it and resolves on a microtask. Lets us assert the gate's pacing
  * without real timers.
+ *
+ * The yield before advancing matters: time must pass when a sleep COMPLETES,
+ * not when it starts. Advancing at call time would bill each grant for the
+ * cooldown chained behind it, hiding the difference between "granted now" and
+ * "granted one cooldown from now".
  */
 function fakeScheduler() {
   let clock = 0;
   return {
     now: () => clock,
     sleep: async (ms: number) => {
+      await Promise.resolve();
       clock += ms;
     },
     get clock() {
@@ -18,6 +24,23 @@ function fakeScheduler() {
     },
   };
 }
+
+/** Clock reading at the moment each of `n` sequential grants completes. */
+async function grantTimes(
+  gate: GateLogic,
+  clock: () => number,
+  n: number,
+): Promise<number[]> {
+  const at: number[] = [];
+  for (let i = 0; i < n; i++) {
+    await gate.acquireToken();
+    at.push(clock());
+  }
+  return at;
+}
+
+/** 20 grants paced at 5/s: the full index fan-out, first at 0ms, last at 3800ms. */
+const PACED_20 = Array.from({ length: 20 }, (_, i) => i * 200);
 
 describe("GateLogic — call pacing", () => {
   it("throttles sustained demand to rate per second", async () => {
@@ -28,29 +51,26 @@ describe("GateLogic — call pacing", () => {
       sleep: s.sleep,
     });
 
-    // 20 calls spaced 1/5 s apart — the full index fan-out, exactly at PSD's
-    // ceiling. (No burst allowance: even spacing hits the same 5/s throughput.)
-    for (let i = 0; i < 20; i++) await gate.acquireToken();
-
-    expect(s.clock).toBe(20 * 200);
+    // Grant times only. An idle gate owes the first caller nothing, and the
+    // cooldown trailing the last grant is nobody's wait — billing either would
+    // pass a gate that made every call queue behind a cooldown it never needed.
+    // (No burst allowance: even spacing hits the same 5/s throughput.)
+    expect(await grantTimes(gate, () => s.clock, 20)).toEqual(PACED_20);
   });
 
   it("keeps pacing when the clock never advances (Durable Object freezes Date.now)", async () => {
     // A DO advances `Date.now()` only on I/O; while every caller sleeps in
     // acquireToken there is none. A clock-driven bucket starves here — this
-    // whole fan-out must still complete off relative sleeps alone.
-    let slept = 0;
+    // whole fan-out must still complete, and stay evenly paced, off relative
+    // sleeps alone. `now()` is frozen; the scheduler's clock only tracks sleeps.
+    const s = fakeScheduler();
     const gate = new GateLogic({
       ratePerSecond: 5,
       now: () => 0,
-      sleep: async (ms: number) => {
-        slept += ms;
-      },
+      sleep: s.sleep,
     });
 
-    for (let i = 0; i < 20; i++) await gate.acquireToken();
-
-    expect(slept).toBe(20 * 200);
+    expect(await grantTimes(gate, () => s.clock, 20)).toEqual(PACED_20);
   });
 });
 

--- a/apps/api/src/psd/gate-logic.ts
+++ b/apps/api/src/psd/gate-logic.ts
@@ -13,8 +13,8 @@
  * `PsdGate` Durable Object (see gate.ts) hosts ONE instance of this class, which
  * makes both limiters **global across all worker isolates**:
  *
- *  - **Token bucket** — hands out ≤`ratePerSecond` PSD calls/second worldwide,
- *    so a fan-out can't burst past PSD's 5/s ceiling. In-memory per-isolate was
+ *  - **Call pacer** — hands out ≤`ratePerSecond` PSD calls/second worldwide, so
+ *    a fan-out can't burst past PSD's 5/s ceiling. In-memory per-isolate was
  *    ruled out (#2324): 8 isolates × 5/s = 40/s.
  *  - **Single-flight** — the first caller for a cache key becomes the leader and
  *    runs the fan-out; concurrent callers coalesce (N misses → 1 fan-out).
@@ -24,7 +24,7 @@
  */
 
 export interface GateLogicOptions {
-  /** Token-bucket rate & capacity (PSD calls/second). Default 5 (PSD's limit). */
+  /** Pacing rate (PSD calls/second). Default 5 (PSD's limit). */
   readonly ratePerSecond?: number;
   /** Injectable clock (ms). Default `Date.now`. */
   readonly now?: () => number;
@@ -54,8 +54,20 @@ export class GateLogic {
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly leaseMs: number;
 
-  private tokens: number;
-  private lastRefill: number;
+  /**
+   * Resolves when the next call slot opens. Each grant chains a 1/rate-second
+   * sleep onto it, so grants come out at exactly `rate` per second.
+   *
+   * Deliberately clock-FREE. The previous implementation was a wall-clock token
+   * bucket, which deadlocks inside a Durable Object: `Date.now()` only advances
+   * on I/O, and a DO whose callers are all sleeping in `acquireToken` performs
+   * none — so `refill()` accrued nothing, every waiter span until its request's
+   * `waitUntil` budget expired, and no fan-out larger than the burst capacity
+   * ever completed (silently: a cancelled waitUntil sets no negative marker and
+   * reports no outcome, so SWR served the stale value until the 7-day hard TTL).
+   * Relative sleeps still resolve under a frozen clock, so pacing survives.
+   */
+  private slot: Promise<void> = Promise.resolve();
 
   /** key → the in-flight leadership record. */
   private readonly inFlight = new Map<string, Flight>();
@@ -65,9 +77,6 @@ export class GateLogic {
     this.now = opts.now ?? (() => Date.now());
     this.sleep = opts.sleep ?? realSleep;
     this.leaseMs = opts.leaseMs ?? 15_000;
-    // Start full so a single cold fan-out isn't throttled from the first call.
-    this.tokens = this.rate;
-    this.lastRefill = this.now();
   }
 
   /** A flight whose lease has expired is treated as abandoned (dead leader). */
@@ -75,30 +84,15 @@ export class GateLogic {
     return !!flight && this.now() - flight.startedAt < this.leaseMs;
   }
 
-  private refill(): void {
-    const t = this.now();
-    const elapsed = (t - this.lastRefill) / 1000;
-    if (elapsed <= 0) return;
-    this.tokens = Math.min(this.rate, this.tokens + elapsed * this.rate);
-    this.lastRefill = t;
-  }
-
   /**
-   * Resolve when a PSD-call token is available, consuming it. Global ≤rate/s.
-   * Callers `await` this immediately before every PSD fetch.
+   * Resolve when a PSD-call slot is available, consuming it. Global ≤rate/s.
+   * Callers `await` this immediately before every PSD fetch. An idle gate grants
+   * immediately; sustained demand is spaced 1/rate seconds apart.
    */
-  async acquireToken(): Promise<void> {
-    // Loop rather than sleep-once: the injected clock may not advance by the
-    // full deficit in one step (and refill is capped at capacity).
-    for (;;) {
-      this.refill();
-      if (this.tokens >= 1) {
-        this.tokens -= 1;
-        return;
-      }
-      const deficit = 1 - this.tokens;
-      await this.sleep((deficit / this.rate) * 1000);
-    }
+  acquireToken(): Promise<void> {
+    const mine = this.slot;
+    this.slot = mine.then(() => this.sleep(1000 / this.rate));
+    return mine;
   }
 
   /**


### PR DESCRIPTION
## Symptom

A finished match kept rendering its preview (`VOORBESCHOUWING`, kickoff time) on `/wedstrijd/[matchId]` while the calendar list already showed the final score.

## Diagnosis

Not a TTL misconfiguration. Production KV, read on 2026-08-03 17:26 UTC:

| key | `fetchedAt` |
| --- | --- |
| `matches:team:1` (list surface) | 2026-08-03 12:37 ✅ |
| `matches:window` | **2026-07-30 15:19** |
| `match:detail:3416` | **2026-07-30 15:16** (98h) |

Both frozen at the moment the PSD gate Durable Object went live (#2328). `wrangler tail` on a live request:

```text
+0.08s  beginFlight    ok        wall=194ms
+0.98s  acquireToken   ok        wall=11ms     ← 12 granted in the first 2.5s
+1.21s  acquireToken   canceled  wall=28864ms  ← then permanent starvation
+2.47s  acquireToken   canceled  wall=77471ms
FETCH   ok  wall=30064ms  "waitUntil() tasks did not complete within the allowed time"
```

`GateLogic`'s token bucket refilled off `Date.now()`. **A Durable Object advances its clock only on I/O.** Once the bucket drained and every caller was sleeping inside `acquireToken`, no I/O occurred → `refill()` accrued nothing → each waiter spun until its request's `waitUntil` budget expired. At 5/s those 28s should have granted ~140 tokens; they granted zero. The 12 that did land came from unrelated requests arriving and nudging the clock — which is why the failure looked intermittent.

Consequence: no fan-out larger than the burst capacity ever completed.

- `matches:window` (~19 calls) — never refreshed.
- `getMatchDetail` → `buildMatchTeamIndex` (~20 calls) — never refreshed, so `psd:match-team-index:v2` was **absent from KV entirely** and the season-list score backfill could never fire.
- `matches:team:1` is a single call inside the burst — hence a correct list next to a lying detail page.

And it failed silently: a cancelled `waitUntil` sets no negative marker and reports no outcome to the gate, so there was no WARN, no incident ping and no drift nudge. SWR just kept serving the 2026-07-30 value, heading for the 7-day hard-TTL cliff.

## Fix

```ts
acquireToken(): Promise<void> {
  const mine = this.slot;
  this.slot = mine.then(() => this.sleep(1000 / this.rate));
  return mine;
}
```

A promise chain that spaces grants `1/rate` seconds apart using relative sleeps only — no clock reads, so it survives a frozen `Date.now()`. Same global 5/s ceiling. Drops the burst allowance, which costs nothing: even spacing reaches the same throughput.

The lease (`isLive`) still reads the clock, and that stays correct — it is only evaluated at `beginFlight` / `awaitFlight`, i.e. on incoming RPCs, which *are* I/O boundaries.

## Verification

- `pnpm --filter @kcvv/api lint && type-check && test` — 437 tests green.
- New regression test `keeps pacing when the clock never advances (Durable Object freezes Date.now)` **livelocks the test runner** against the old implementation (spins the microtask queue so tightly that vitest's own timeout never fires) — the production bug, reproduced in-process.

## Follow-up

The silent-cancellation gap — a killed `waitUntil` leaves no marker, no outcome, no alert — is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request pacing to prevent concurrent requests from starving.
  * Ensured throttled operations continue progressing even when system time does not advance.
  * Preserved single-flight handling to reduce duplicate work during concurrent requests.

* **Tests**
  * Updated coverage to verify evenly spaced requests and continued progress under sustained demand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->