### PR TITLE
feat(ui): rebuild /scheurkalender for the season poster block

### DIFF
--- a/apps/web/src/app/(main)/scheurkalender/loading.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/loading.tsx
@@ -1,9 +1,27 @@
 /**
  * Scheurkalender Page — Loading Skeleton
- * Mirrors the Treatment A sheet: masthead bar + weekend fixture rows.
+ * Mirrors the poster sheet: masthead bar + two calendar-year columns, each a
+ * month heading followed by fixture rows opening on the date tab.
  */
 
 import { PageContainer } from "@/components/design-system";
+
+/** One column: a month heading, then rows of date-tab + match. */
+function ColumnSkeleton({ rows }: { rows: number }) {
+  return (
+    <>
+      <div className="bg-ink/10 mt-5 mb-[7px] h-7 w-40 animate-pulse rounded first:mt-0.5" />
+      {Array.from({ length: rows }).map((_, row) => (
+        <div key={row} className="flex items-center gap-3 py-[5px]">
+          <div className="bg-ink/10 h-2.5 w-[17px] animate-pulse rounded" />
+          <div className="bg-ink/10 h-3.5 w-5 animate-pulse rounded" />
+          <div className="bg-ink/10 h-2.5 w-10 animate-pulse rounded" />
+          <div className="bg-ink/10 h-3 flex-1 animate-pulse rounded" />
+        </div>
+      ))}
+    </>
+  );
+}
 
 export default function ScheurkalenderLoading() {
   return (
@@ -15,16 +33,14 @@ export default function ScheurkalenderLoading() {
             <div className="bg-ink/10 h-4 w-56 animate-pulse rounded" />
             <div className="bg-ink/10 h-3 w-32 animate-pulse rounded" />
           </div>
-          {/* Fixture rows */}
-          <div className="divide-ink/10 divide-y">
-            {Array.from({ length: 8 }).map((_, row) => (
-              <div key={row} className="flex items-center gap-4 px-2.5 py-2">
-                <div className="bg-ink/10 h-3 w-16 animate-pulse rounded" />
-                <div className="bg-ink/10 h-3 w-10 animate-pulse rounded" />
-                <div className="bg-ink/10 h-3 flex-1 animate-pulse rounded" />
-                <div className="bg-ink/10 h-3 flex-1 animate-pulse rounded" />
-              </div>
-            ))}
+          {/* Two calendar-year columns */}
+          <div className="grid grid-cols-2 px-5 pt-1.5 pb-[18px]">
+            <div className="border-ink/15 border-r pr-[17px]">
+              <ColumnSkeleton rows={7} />
+            </div>
+            <div className="pl-[17px]">
+              <ColumnSkeleton rows={5} />
+            </div>
           </div>
         </div>
       </PageContainer>

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
@@ -1,10 +1,13 @@
 /**
  * ScheurkalenderPage Stories
  *
- * Private (noindex, unlinked) full-season A + B league fixture table — the data
- * source the club screenshots into the A2 InDesign season poster. Treatment A:
- * a print-clean white sheet (body font — Freight Sans Pro as of #2174), date·time·home·away with the KCVV side
- * bolded and the squad label inline, grouped per weekend. See #2137.
+ * Private (noindex, unlinked) full-season A + B league fixture list — the data
+ * source the club screenshots into the InDesign season poster. Poster layout:
+ * two columns split on the calendar year, Freight Big month headings with an
+ * italic jersey-deep year, and a fixed weekday · day · kickoff date tab.
+ *
+ * The poster block is 340 × 567 mm; screenshot at roughly 860 px browser width,
+ * which prints the club names at ~5.5 mm.
  *
  * Pages/* stories are design references and are not VR-tested (page composition
  * is the e2e suite's concern).
@@ -18,66 +21,139 @@ import {
 import ScheurkalenderLoading from "@/app/(main)/scheurkalender/loading";
 
 // ---------------------------------------------------------------------------
-// Mock data — real fixtures (subset of the locked mock), A + B league across
-// several weekends, mixing home/away for each squad.
+// Mock data — real 26/27 fixtures spanning both calendar years, so the column
+// split, the month headings and the weekend seams are all exercised. Opponent
+// names are left in raw PSD casing ("Ksc Blankenberge") to show the re-casing.
 // ---------------------------------------------------------------------------
 
 const seasonFixtures: ScheurkalenderMatch[] = [
   {
     id: 1,
-    date: "2025-08-30",
+    date: "2026-08-29",
     time: "20:00",
-    opponent: "Fc Zemst Sportief",
+    opponent: "Fenixx Beigem Humbeek",
     kcvvLabel: "B",
     kcvvIsHome: true,
   },
   {
     id: 2,
-    date: "2025-08-31",
+    date: "2026-08-30",
     time: "15:00",
-    opponent: "Sc City Pirates Antwerpen",
+    opponent: "Ksc Blankenberge",
     kcvvLabel: "A",
     kcvvIsHome: true,
   },
   {
     id: 3,
-    date: "2025-09-07",
-    time: "20:00",
-    opponent: "As Verbroedering Geel",
+    date: "2026-09-05",
+    time: "19:30",
+    opponent: "Ksv Rumbeke",
     kcvvLabel: "A",
     kcvvIsHome: false,
   },
   {
     id: 4,
-    date: "2025-09-13",
-    time: "14:30",
-    opponent: "Peutie Fc",
+    date: "2026-09-06",
+    time: "17:00",
+    opponent: "Kcs Machelen",
     kcvvLabel: "B",
-    kcvvIsHome: true,
+    kcvvIsHome: false,
   },
   {
     id: 5,
-    date: "2025-09-14",
-    time: "15:00",
-    opponent: "Herleving Red Star Haasdonk",
-    kcvvLabel: "A",
+    date: "2026-09-12",
+    time: "20:00",
+    opponent: "Perk Steenokkerzeel Verenigd 1820",
+    kcvvLabel: "B",
     kcvvIsHome: true,
   },
   {
     id: 6,
-    date: "2025-09-20",
-    time: "19:30",
-    opponent: "Ksc Keerbergen",
+    date: "2026-09-13",
+    time: "15:00",
+    opponent: "Kvv St-denijs Sport",
+    kcvvLabel: "A",
+    kcvvIsHome: true,
+  },
+  {
+    id: 7,
+    date: "2026-10-04",
+    time: "15:00",
+    opponent: "Kvk Ieper",
+    kcvvLabel: "A",
+    kcvvIsHome: false,
+  },
+  {
+    id: 8,
+    date: "2026-10-10",
+    time: "20:00",
+    opponent: "Fc Inkad Diegem",
+    kcvvLabel: "B",
+    kcvvIsHome: true,
+  },
+  {
+    id: 9,
+    date: "2026-11-01",
+    time: "14:30",
+    opponent: "Eendr Elene-grotenberge",
+    kcvvLabel: "A",
+    kcvvIsHome: false,
+  },
+  {
+    id: 10,
+    date: "2026-12-13",
+    time: "17:00",
+    opponent: "Fenixx Beigem Humbeek",
     kcvvLabel: "B",
     kcvvIsHome: false,
   },
   {
-    id: 7,
-    date: "2025-09-21",
-    time: "15:00",
-    opponent: "Fc Turkse Rangers Waterschei",
+    id: 11,
+    date: "2027-01-09",
+    time: "20:00",
+    opponent: "Kcs Machelen",
+    kcvvLabel: "B",
+    kcvvIsHome: true,
+  },
+  {
+    id: 12,
+    date: "2027-01-10",
+    time: "14:30",
+    opponent: "Ksv Rumbeke",
     kcvvLabel: "A",
+    kcvvIsHome: true,
+  },
+  {
+    id: 13,
+    date: "2027-01-16",
+    time: "19:30",
+    opponent: "K Sp Amicii Tange",
+    kcvvLabel: "B",
     kcvvIsHome: false,
+  },
+  {
+    id: 14,
+    date: "2027-02-14",
+    time: "15:00",
+    opponent: "Erpe-mere United",
+    kcvvLabel: "A",
+    kcvvIsHome: true,
+  },
+  {
+    id: 15,
+    date: "2027-03-06",
+    time: "18:00",
+    opponent: "Fc Inkad Diegem",
+    kcvvLabel: "B",
+    kcvvIsHome: false,
+  },
+  {
+    id: 16,
+    date: "2027-03-14",
+    time: "15:00",
+    opponent: "Zwevegem Sport",
+    kcvvLabel: "A",
+    kcvvIsHome: true,
   },
 ];
 
@@ -93,11 +169,11 @@ const meta = {
     docs: {
       description: {
         component:
-          "Private InDesign-poster data source for /scheurkalender. Full-season A + B league fixtures grouped per weekend; KCVV side bolded with the squad label inline. The screen toolbar (print button) is hidden on print; the white sheet composites cleanly into the poster screenshot.",
+          "Private InDesign-poster data source for /scheurkalender. Full-season A + B league fixtures split across two columns on the calendar year, with Freight Big month headings and a fixed weekday · day · kickoff date tab. The screen toolbar (print button) is hidden on print; the white sheet composites cleanly into the poster screenshot.",
       },
     },
   },
-  args: { season: "25/26" },
+  args: { season: "26/27" },
   tags: ["autodocs"],
 } satisfies Meta<typeof ScheurkalenderPage>;
 
@@ -108,12 +184,26 @@ type Story = StoryObj<typeof meta>;
 // Stories
 // ---------------------------------------------------------------------------
 
-/** Full-season A + B league table across several weekends. */
+/** Full season — both calendar years, so the two-column split is visible. */
 export const Default: Story = {
   args: { matches: seasonFixtures },
 };
 
-/** A single weekend (two fixtures). */
+/**
+ * Poster width — the ~860 px render the owner screenshots at, which prints the
+ * club names at roughly 5.5 mm inside the 340 × 567 mm block.
+ */
+export const PosterWidth: Story = {
+  args: { matches: seasonFixtures },
+  parameters: { viewport: { defaultViewport: "kcvvTablet" } },
+};
+
+/** First half of the season only — falls back to a single full-width column. */
+export const SingleYear: Story = {
+  args: { matches: seasonFixtures.filter((m) => m.date.startsWith("2026")) },
+};
+
+/** One weekend, both squads. */
 export const SingleWeekend: Story = {
   args: { matches: seasonFixtures.slice(0, 2) },
 };
@@ -123,7 +213,7 @@ export const NoMatches: Story = {
   args: { matches: [] },
 };
 
-/** Mobile viewport. */
+/** Mobile viewport. The sheet keeps its two columns — it is a poster source, not a responsive page. */
 export const MobileViewport: Story = {
   args: { matches: seasonFixtures },
   globals: { viewport: { value: "kcvvMobile" } },

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
@@ -21,141 +21,89 @@ import {
 import ScheurkalenderLoading from "@/app/(main)/scheurkalender/loading";
 
 // ---------------------------------------------------------------------------
-// Mock data — real 26/27 fixtures spanning both calendar years, so the column
-// split, the month headings and the weekend seams are all exercised. Opponent
-// names are left in raw PSD casing ("Ksc Blankenberge") to show the re-casing.
+// Mock data
 // ---------------------------------------------------------------------------
 
-const seasonFixtures: ScheurkalenderMatch[] = [
-  {
-    id: 1,
-    date: "2026-08-29",
-    time: "20:00",
-    opponent: "Fenixx Beigem Humbeek",
-    kcvvLabel: "B",
-    kcvvIsHome: true,
-  },
-  {
-    id: 2,
-    date: "2026-08-30",
-    time: "15:00",
-    opponent: "Ksc Blankenberge",
-    kcvvLabel: "A",
-    kcvvIsHome: true,
-  },
-  {
-    id: 3,
-    date: "2026-09-05",
-    time: "19:30",
-    opponent: "Ksv Rumbeke",
-    kcvvLabel: "A",
-    kcvvIsHome: false,
-  },
-  {
-    id: 4,
-    date: "2026-09-06",
-    time: "17:00",
-    opponent: "Kcs Machelen",
-    kcvvLabel: "B",
-    kcvvIsHome: false,
-  },
-  {
-    id: 5,
-    date: "2026-09-12",
-    time: "20:00",
-    opponent: "Perk Steenokkerzeel Verenigd 1820",
-    kcvvLabel: "B",
-    kcvvIsHome: true,
-  },
-  {
-    id: 6,
-    date: "2026-09-13",
-    time: "15:00",
-    opponent: "Kvv St-denijs Sport",
-    kcvvLabel: "A",
-    kcvvIsHome: true,
-  },
-  {
-    id: 7,
-    date: "2026-10-04",
-    time: "15:00",
-    opponent: "Kvk Ieper",
-    kcvvLabel: "A",
-    kcvvIsHome: false,
-  },
-  {
-    id: 8,
-    date: "2026-10-10",
-    time: "20:00",
-    opponent: "Fc Inkad Diegem",
-    kcvvLabel: "B",
-    kcvvIsHome: true,
-  },
-  {
-    id: 9,
-    date: "2026-11-01",
-    time: "14:30",
-    opponent: "Eendr Elene-grotenberge",
-    kcvvLabel: "A",
-    kcvvIsHome: false,
-  },
-  {
-    id: 10,
-    date: "2026-12-13",
-    time: "17:00",
-    opponent: "Fenixx Beigem Humbeek",
-    kcvvLabel: "B",
-    kcvvIsHome: false,
-  },
-  {
-    id: 11,
-    date: "2027-01-09",
-    time: "20:00",
-    opponent: "Kcs Machelen",
-    kcvvLabel: "B",
-    kcvvIsHome: true,
-  },
-  {
-    id: 12,
-    date: "2027-01-10",
-    time: "14:30",
-    opponent: "Ksv Rumbeke",
-    kcvvLabel: "A",
-    kcvvIsHome: true,
-  },
-  {
-    id: 13,
-    date: "2027-01-16",
-    time: "19:30",
-    opponent: "K Sp Amicii Tange",
-    kcvvLabel: "B",
-    kcvvIsHome: false,
-  },
-  {
-    id: 14,
-    date: "2027-02-14",
-    time: "15:00",
-    opponent: "Erpe-mere United",
-    kcvvLabel: "A",
-    kcvvIsHome: true,
-  },
-  {
-    id: 15,
-    date: "2027-03-06",
-    time: "18:00",
-    opponent: "Fc Inkad Diegem",
-    kcvvLabel: "B",
-    kcvvIsHome: false,
-  },
-  {
-    id: 16,
-    date: "2027-03-14",
-    time: "15:00",
-    opponent: "Zwevegem Sport",
-    kcvvLabel: "A",
-    kcvvIsHome: true,
-  },
+/**
+ * The complete 26/27 league season — all 56 A + B fixtures, verbatim from the
+ * BFF. Kept as a compact tuple table rather than 56 object literals so the data
+ * stays readable; `seasonFixtures` below expands it to `ScheurkalenderMatch[]`.
+ * Opponent names keep their raw PSD casing ("Ksc Blankenberge") so the stories
+ * exercise the re-casing.
+ *
+ * Tuple order: [date, kickoff, squad, kcvvIsHome, opponent]
+ */
+type FixtureTuple = [string, string, "A" | "B", boolean, string];
+
+const SEASON_26_27: FixtureTuple[] = [
+  ["2026-08-29", "20:00", "B", true, "Fenixx Beigem Humbeek"],
+  ["2026-08-30", "15:00", "A", true, "Ksc Blankenberge"],
+  ["2026-09-05", "19:30", "A", false, "Ksv Rumbeke"],
+  ["2026-09-06", "17:00", "B", false, "Kcs Machelen"],
+  ["2026-09-12", "20:00", "B", true, "Perk Steenokkerzeel Verenigd 1820"],
+  ["2026-09-13", "15:00", "A", true, "Kvv St-denijs Sport"],
+  ["2026-09-19", "20:00", "B", false, "Peutie Fc"],
+  ["2026-09-20", "15:00", "A", false, "Kfc Wambeek Ternat"],
+  ["2026-09-26", "20:00", "B", true, "K Sp Amicii Tange"],
+  ["2026-09-27", "15:00", "A", true, "Kve Drongen"],
+  ["2026-10-04", "15:00", "A", false, "Kvk Ieper"],
+  ["2026-10-10", "20:00", "B", true, "Fc Inkad Diegem"],
+  ["2026-10-11", "15:00", "A", true, "K Berchem Sport 2004"],
+  ["2026-10-18", "15:00", "A", false, "Erpe-mere United"],
+  ["2026-10-24", "20:00", "B", true, "Kfc Eppegem"],
+  ["2026-10-25", "14:30", "A", true, "Football Club Gullegem"],
+  ["2026-10-31", "18:00", "B", false, "Fc Zemst Sportief"],
+  ["2026-11-01", "14:30", "A", false, "Eendr Elene-grotenberge"],
+  ["2026-11-08", "14:30", "A", false, "Avanti Stekene"],
+  ["2026-11-08", "15:00", "B", false, "Ac Bormstraat Kapelle"],
+  ["2026-11-14", "20:00", "B", true, "Kv Woluwe-zaventem"],
+  ["2026-11-15", "14:30", "A", true, "Kws Club Lauwe"],
+  ["2026-11-21", "20:00", "A", false, "Sc City Pirates Antwerpen"],
+  ["2026-11-22", "14:30", "B", false, "Infinity Fc Vilvoorde"],
+  ["2026-11-28", "20:00", "B", true, "Sk Laar"],
+  ["2026-11-29", "14:30", "A", true, "Olsa Brakel"],
+  ["2026-12-05", "17:30", "B", false, "Vv Groot Kapelle"],
+  ["2026-12-05", "18:00", "A", false, "Zwevegem Sport"],
+  ["2026-12-13", "15:00", "A", false, "Ksc Blankenberge"],
+  ["2026-12-13", "17:00", "B", false, "Fenixx Beigem Humbeek"],
+  ["2027-01-09", "20:00", "B", true, "Kcs Machelen"],
+  ["2027-01-10", "14:30", "A", true, "Ksv Rumbeke"],
+  ["2027-01-16", "19:30", "B", false, "K Sp Amicii Tange"],
+  ["2027-01-17", "15:00", "A", false, "Kve Drongen"],
+  ["2027-01-23", "20:00", "B", true, "Peutie Fc"],
+  ["2027-01-24", "14:30", "A", true, "Kfc Wambeek Ternat"],
+  ["2027-01-31", "14:30", "A", false, "Kws Club Lauwe"],
+  ["2027-01-31", "14:30", "B", false, "Kv Woluwe-zaventem"],
+  ["2027-02-14", "15:00", "A", true, "Erpe-mere United"],
+  ["2027-02-20", "19:30", "B", false, "Perk Steenokkerzeel Verenigd 1820"],
+  ["2027-02-21", "15:00", "A", false, "Kvv St-denijs Sport"],
+  ["2027-02-28", "15:00", "A", true, "Kvk Ieper"],
+  ["2027-03-06", "18:00", "B", false, "Fc Inkad Diegem"],
+  ["2027-03-06", "20:00", "A", false, "K Berchem Sport 2004"],
+  ["2027-03-13", "20:00", "B", true, "Vv Groot Kapelle"],
+  ["2027-03-14", "15:00", "A", true, "Zwevegem Sport"],
+  ["2027-03-21", "15:00", "A", false, "Olsa Brakel"],
+  ["2027-03-21", "15:00", "B", false, "Sk Laar"],
+  ["2027-04-03", "20:00", "B", true, "Infinity Fc Vilvoorde"],
+  ["2027-04-04", "15:00", "A", true, "Sc City Pirates Antwerpen"],
+  ["2027-04-10", "20:00", "B", true, "Ac Bormstraat Kapelle"],
+  ["2027-04-11", "15:00", "A", true, "Avanti Stekene"],
+  ["2027-04-17", "19:30", "B", false, "Kfc Eppegem"],
+  ["2027-04-18", "15:00", "A", false, "Football Club Gullegem"],
+  ["2027-04-25", "15:00", "A", true, "Eendr Elene-grotenberge"],
+  ["2027-04-25", "15:00", "B", true, "Fc Zemst Sportief"],
 ];
+
+const seasonFixtures: ScheurkalenderMatch[] = SEASON_26_27.map(
+  ([date, time, kcvvLabel, kcvvIsHome, opponent], index) => ({
+    id: index + 1,
+    date,
+    time,
+    opponent,
+    kcvvLabel,
+    kcvvIsHome,
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Meta

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
@@ -1,176 +1,257 @@
 /**
  * ScheurkalenderPage Component Tests
  *
- * Treatment A (#2137): weekend grouping, inline A/B + bold KCVV side,
- * no-year date, single weekend rule (no boundary doubling), empty state.
+ * Poster layout: calendar-year column split, Freight Big month headings with an
+ * italic jersey-deep year, fixed date tab (weekday · day · kickoff), dotted
+ * weekend seams, club-name re-casing, empty state.
  */
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import {
   ScheurkalenderPage,
+  formatClubName,
   type ScheurkalenderMatch,
 } from "./ScheurkalenderPage";
 
-// Real fixtures (subset of the locked mock). Three weekends (ISO weeks):
-//   wk 35: za 30/08 + zo 31/08   wk 36: zo 07/09   wk 37: za 13/09
+// Fixtures spanning both calendar years of a season, so the column split is
+// exercised. Weekends: 29–30/08, 05–06/09 (2026) | 09–10/01, 16/01 (2027).
 const fixtures: ScheurkalenderMatch[] = [
   {
     id: 1,
-    date: "2025-08-30",
+    date: "2026-08-29",
     time: "20:00",
-    opponent: "Fc Zemst Sportief",
+    opponent: "Fenixx Beigem Humbeek",
     kcvvLabel: "B",
     kcvvIsHome: true,
   },
   {
     id: 2,
-    date: "2025-08-31",
+    date: "2026-08-30",
     time: "15:00",
-    opponent: "Sc City Pirates Antwerpen",
+    opponent: "Ksc Blankenberge",
     kcvvLabel: "A",
     kcvvIsHome: true,
   },
   {
     id: 3,
-    date: "2025-09-07",
-    time: "20:00",
-    opponent: "As Verbroedering Geel",
+    date: "2026-09-05",
+    time: "19:30",
+    opponent: "Ksv Rumbeke",
     kcvvLabel: "A",
     kcvvIsHome: false,
   },
   {
     id: 4,
-    date: "2025-09-13",
-    time: "14:30",
-    opponent: "Peutie Fc",
+    date: "2027-01-09",
+    time: "20:00",
+    opponent: "Kcs Machelen",
+    kcvvLabel: "B",
+    kcvvIsHome: true,
+  },
+  {
+    id: 5,
+    date: "2027-01-16",
+    time: "19:30",
+    opponent: "Erpe-mere United",
     kcvvLabel: "B",
     kcvvIsHome: false,
   },
 ];
 
+const renderPage = (matches = fixtures, season = "26/27") =>
+  render(<ScheurkalenderPage matches={matches} season={season} />);
+
+describe("formatClubName", () => {
+  it("uppercases federation prefixes", () => {
+    expect(formatClubName("Ksc Blankenberge")).toBe("KSC Blankenberge");
+    expect(formatClubName("Kvv St-denijs Sport")).toBe("KVV St-Denijs Sport");
+    expect(formatClubName("Fc Inkad Diegem")).toBe("FC Inkad Diegem");
+    expect(formatClubName("K Sp Amicii Tange")).toBe("K SP Amicii Tange");
+  });
+
+  it("capitalises after a hyphen", () => {
+    expect(formatClubName("Erpe-mere United")).toBe("Erpe-Mere United");
+  });
+
+  it("leaves ordinary words alone", () => {
+    expect(formatClubName("Yellow Red Mechelen")).toBe("Yellow Red Mechelen");
+  });
+});
+
 describe("ScheurkalenderPage", () => {
   describe("masthead", () => {
     it("renders the season + A & B subtitle", () => {
-      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
+      renderPage();
       expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-        "KCVV Elewijt — Competitie 25/26",
+        "KCVV Elewijt — Competitie 26/27",
       );
       expect(screen.getByText("A & B · Wedstrijdkalender")).toBeInTheDocument();
     });
   });
 
   describe("empty state", () => {
-    it("renders the empty message and no table when there are no fixtures", () => {
-      render(<ScheurkalenderPage matches={[]} season="25/26" />);
+    it("renders the empty message and no month headings", () => {
+      renderPage([]);
       expect(
         screen.getByText("Geen competitiewedstrijden gevonden."),
       ).toBeInTheDocument();
-      expect(screen.queryByRole("table")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { level: 2 }),
+      ).not.toBeInTheDocument();
     });
   });
 
-  describe("weekend grouping", () => {
-    it("buckets fixtures per weekend (ISO week) into separate <tbody>s", () => {
-      const { container } = render(
-        <ScheurkalenderPage matches={fixtures} season="25/26" />,
-      );
-      const tbodies = container.querySelectorAll("tbody");
-      expect(tbodies).toHaveLength(3);
-      expect(tbodies[0].querySelectorAll("tr")).toHaveLength(2); // 30+31 Aug
-      expect(tbodies[1].querySelectorAll("tr")).toHaveLength(1); // 7 Sep
-      expect(tbodies[2].querySelectorAll("tr")).toHaveLength(1); // 13 Sep
+  describe("calendar-year column split", () => {
+    it("puts the first year left and the second right", () => {
+      const { container } = renderPage();
+      const columns = container.querySelectorAll(".grid-cols-2 > div");
+      expect(columns).toHaveLength(2);
+
+      const left = within(columns[0] as HTMLElement)
+        .getAllByRole("heading", { level: 2 })
+        .map((h) => h.textContent);
+      const right = within(columns[1] as HTMLElement)
+        .getAllByRole("heading", { level: 2 })
+        .map((h) => h.textContent);
+
+      expect(left).toEqual(["Augustus ’26.", "September ’26."]);
+      expect(right).toEqual(["Januari ’27."]);
     });
 
-    it("renders a single 2px rule between weekends with no hairline doubling", () => {
-      const { container } = render(
-        <ScheurkalenderPage matches={fixtures} season="25/26" />,
-      );
-      const tbodies = container.querySelectorAll("tbody");
+    it("renders a single full-width column when the fixtures span one year", () => {
+      const { container } = renderPage(fixtures.slice(0, 3));
+      expect(container.querySelector(".grid-cols-2")).not.toBeInTheDocument();
+      expect(container.querySelector(".grid-cols-1")).toBeInTheDocument();
+    });
 
-      // First weekend's first row has no top rule (no doubling at the very top).
-      const firstWeekendRows = tbodies[0].querySelectorAll("tr");
-      firstWeekendRows[0]
-        .querySelectorAll("td")
-        .forEach((td) => expect(td.className).not.toContain("border-t-2"));
-
-      // Last row of a weekend drops its bottom hairline (no doubling at the seam).
-      firstWeekendRows[firstWeekendRows.length - 1]
-        .querySelectorAll("td")
-        .forEach((td) => expect(td.className).not.toContain("border-b"));
-
-      // Each subsequent weekend opens with the single 2px ink rule.
-      tbodies[1]
-        .querySelectorAll("tr")[0]
-        .querySelectorAll("td")
-        .forEach((td) => expect(td.className).toContain("border-t-2"));
+    it("keeps a Sat/Sun pair in the month of its Saturday", () => {
+      // 31/01/2027 (Sun) belongs to the weekend whose Saturday is 30/01 → Januari.
+      const { container } = renderPage([
+        {
+          id: 9,
+          date: "2027-01-31",
+          time: "15:00",
+          opponent: "Kvk Ieper",
+          kcvvLabel: "A",
+          kcvvIsHome: true,
+        },
+      ]);
+      const headings = container.querySelectorAll("h2");
+      expect(headings).toHaveLength(1);
+      expect(headings[0]).toHaveTextContent("Januari ’27.");
     });
   });
 
-  describe("rows", () => {
-    it("formats dates as Dutch weekday + DD/MM with no year", () => {
-      const { container } = render(
-        <ScheurkalenderPage matches={fixtures} season="25/26" />,
-      );
-      expect(screen.getByText("za 30/08")).toBeInTheDocument();
-      expect(screen.getByText("zo 31/08")).toBeInTheDocument();
-      expect(screen.getByText("zo 07/09")).toBeInTheDocument();
-      expect(screen.getByText("za 13/09")).toBeInTheDocument();
-      // No 4-digit year anywhere in the fixture table.
-      const table = container.querySelector("table");
-      expect(table?.textContent).not.toMatch(/20\d{2}/);
+  describe("month heading", () => {
+    it("renders the year as an italic jersey-deep <em> with a trailing period", () => {
+      renderPage();
+      const heading = screen.getByRole("heading", {
+        level: 2,
+        name: /Augustus/,
+      });
+      expect(heading).toHaveTextContent("Augustus ’26.");
+      const em = heading.querySelector("em");
+      expect(em).toHaveTextContent("’26");
+      expect(em?.className).toContain("text-jersey-deep");
+      expect(em?.className).toContain("italic");
     });
 
-    it("renders kickoff times", () => {
-      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
-      expect(screen.getAllByText("20:00")).toHaveLength(2); // ids 1 & 3
-      expect(screen.getByText("14:30")).toBeInTheDocument();
+    it("carries no rule beneath it", () => {
+      renderPage();
+      const heading = screen.getByRole("heading", {
+        level: 2,
+        name: /Augustus/,
+      });
+      expect(heading.className).not.toContain("border-b");
+    });
+  });
+
+  describe("fixture rows", () => {
+    it("renders weekday, day-of-month and kickoff in one date tab", () => {
+      renderPage();
+      const tab = screen.getAllByText("za")[0]!.parentElement;
+      expect(tab).toHaveTextContent("za2920:00");
+      // Day-of-month only — the month lives in the heading, so no DD/MM here.
+      expect(tab?.textContent).not.toMatch(/\d{2}\/\d{2}/);
     });
 
-    it("renders the KCVV squad inline (A/B) from the queried team", () => {
-      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
-      expect(screen.getAllByText("KCVV Elewijt A")).toHaveLength(2);
-      expect(screen.getAllByText("KCVV Elewijt B")).toHaveLength(2);
+    it("renders no year anywhere in a fixture row", () => {
+      const { container } = renderPage();
+      container
+        .querySelectorAll(".grid-cols-2 section > div")
+        .forEach((row) => {
+          expect(row.textContent).not.toMatch(/20\d{2}/);
+        });
+    });
+
+    it("re-cases opponent names", () => {
+      renderPage();
+      expect(screen.getByText(/KSC Blankenberge/)).toBeInTheDocument();
+      expect(screen.getByText(/Erpe-Mere United/)).toBeInTheDocument();
+      expect(screen.queryByText(/Ksc Blankenberge/)).not.toBeInTheDocument();
     });
 
     it("bolds the KCVV side and leaves the opponent unbolded", () => {
-      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
-      screen
-        .getAllByText(/^KCVV Elewijt [AB]$/)
-        .forEach((cell) => expect(cell.className).toContain("font-extrabold"));
-      expect(screen.getByText("Fc Zemst Sportief").className).not.toContain(
-        "font-extrabold",
-      );
-      expect(screen.getByText("As Verbroedering Geel").className).not.toContain(
+      renderPage();
+      // Row markup is [KCVV span][dash span][opponent span] when KCVV is home.
+      const kcvvHome =
+        screen.getByText(/KSC Blankenberge/).previousElementSibling
+          ?.previousElementSibling;
+      expect(kcvvHome).toHaveTextContent("KCVV Elewijt A");
+      expect(kcvvHome?.className).toContain("font-extrabold");
+      expect(screen.getByText(/KSC Blankenberge/).className).not.toContain(
         "font-extrabold",
       );
     });
 
-    it("places KCVV in the home column when home, away column when away", () => {
-      const { container } = render(
-        <ScheurkalenderPage matches={fixtures} season="25/26" />,
-      );
-      const rows = container.querySelectorAll("tbody tr");
-      // Match 1: KCVV B home → home cell (3rd <td>) is the KCVV cell.
-      expect(rows[0].querySelectorAll("td")[2]).toHaveTextContent(
-        "KCVV Elewijt B",
-      );
-      // Match 3 (weekend 2, first row): KCVV A away → away cell (4th <td>).
-      expect(rows[2].querySelectorAll("td")[3]).toHaveTextContent(
+    it("places KCVV on the away side when playing away", () => {
+      renderPage();
+      // Match 3: KCVV A away at KSV Rumbeke → opponent first, KCVV second.
+      const opponent = screen.getByText(/KSV Rumbeke/);
+      expect(opponent.className).toContain("text-ink-soft");
+      expect(opponent.nextElementSibling?.nextElementSibling).toHaveTextContent(
         "KCVV Elewijt A",
       );
     });
 
-    it("renders no logos, squad pills, or scores", () => {
-      const { container } = render(
-        <ScheurkalenderPage matches={fixtures} season="25/26" />,
-      );
+    it("renders the squad letter in jersey-deep", () => {
+      const { container } = renderPage();
+      const squad = container.querySelector(".text-jersey-deep:not(em)");
+      expect(squad).toHaveTextContent(/^[AB]$/);
+    });
+
+    it("renders no logos or images", () => {
+      const { container } = renderPage();
       expect(container.querySelectorAll("img")).toHaveLength(0);
+    });
+  });
+
+  describe("weekend seams", () => {
+    it("separates weekends within a month with a dotted seam, not the first one", () => {
+      const { container } = renderPage();
+      // Augustus has one weekend, September one → check January's two-weekend month
+      // via a month with two weekends: build one explicitly.
+      const augustus = container.querySelector("section");
+      const weekendBlocks = augustus?.querySelectorAll(":scope > div");
+      expect(weekendBlocks?.[0]?.className).not.toContain("border-t");
+    });
+
+    it("opens each subsequent weekend in a month with a dotted top border", () => {
+      const { container } = renderPage([
+        fixtures[3]!, // 09/01/2027
+        fixtures[4]!, // 16/01/2027 — same month, next weekend
+      ]);
+      const blocks = container.querySelectorAll("section > div");
+      expect(blocks).toHaveLength(2);
+      expect(blocks[0]!.className).not.toContain("border-t");
+      expect(blocks[1]!.className).toContain("border-t");
+      expect(blocks[1]!.className).toContain("border-dotted");
     });
   });
 
   describe("chrome", () => {
     it("renders the print button", () => {
-      render(<ScheurkalenderPage matches={fixtures} season="25/26" />);
+      renderPage();
       expect(
         screen.getByRole("button", { name: "Afdrukken" }),
       ).toBeInTheDocument();

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
@@ -125,20 +125,33 @@ describe("ScheurkalenderPage", () => {
     });
 
     it("keeps a Sat/Sun pair in the month of its Saturday", () => {
-      // 31/01/2027 (Sun) belongs to the weekend whose Saturday is 30/01 → Januari.
+      // 31/01/2026 (Sat) and 01/02/2026 (Sun) are the same ISO week but different
+      // months — the pair must stay together under the Saturday's heading rather
+      // than splitting across Januari and Februari.
       const { container } = renderPage([
         {
           id: 9,
-          date: "2027-01-31",
-          time: "15:00",
+          date: "2026-01-31",
+          time: "20:00",
           opponent: "Kvk Ieper",
+          kcvvLabel: "B",
+          kcvvIsHome: true,
+        },
+        {
+          id: 10,
+          date: "2026-02-01",
+          time: "15:00",
+          opponent: "Sk Laar",
           kcvvLabel: "A",
           kcvvIsHome: true,
         },
       ]);
       const headings = container.querySelectorAll("h2");
       expect(headings).toHaveLength(1);
-      expect(headings[0]).toHaveTextContent("Januari ’27.");
+      expect(headings[0]).toHaveTextContent("Januari ’26.");
+      // Both fixtures sit under that single heading.
+      expect(screen.getByText(/KVK Ieper/)).toBeInTheDocument();
+      expect(screen.getByText(/SK Laar/)).toBeInTheDocument();
     });
   });
 
@@ -173,6 +186,24 @@ describe("ScheurkalenderPage", () => {
       expect(tab).toHaveTextContent("za2920:00");
       // Day-of-month only — the month lives in the heading, so no DD/MM here.
       expect(tab?.textContent).not.toMatch(/\d{2}\/\d{2}/);
+    });
+
+    it("keeps the date tab a fixed width when a fixture has no kickoff time", () => {
+      renderPage([
+        {
+          id: 11,
+          date: "2026-08-29",
+          opponent: "Sk Laar",
+          kcvvLabel: "A",
+          kcvvIsHome: true,
+        },
+      ]);
+      const tab = screen.getByText("za").parentElement!;
+      // Third track must stay a fixed width — an `auto` track would collapse
+      // here and shift the club names left, out of line with timed rows.
+      expect(tab.className).toContain("grid-cols-[17px_20px_46px]");
+      expect(tab.children).toHaveLength(3);
+      expect(tab.children[2]).toBeEmptyDOMElement();
     });
 
     it("renders no year anywhere in a fixture row", () => {

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -198,8 +198,11 @@ function FixtureRow({ match }: { match: ScheurkalenderMatch }) {
   return (
     <div className="flex items-baseline gap-3 py-[5px]">
       {/* Fixed tab stops: weekday · day · kickoff. The hairline keeps the display
-          numeral and the mono time from reading as one run of digits. */}
-      <div className="grid shrink-0 grid-cols-[17px_20px_auto] items-baseline gap-x-2">
+          numeral and the mono time from reading as one run of digits. The third
+          track is a fixed width, not `auto` — `time` is optional, and an auto
+          track collapses on a timeless fixture and shunts its club names left
+          out of line with every other row. */}
+      <div className="grid shrink-0 grid-cols-[17px_20px_46px] items-baseline gap-x-2">
         <span className="text-ink-muted font-mono text-[9px] tracking-[0.08em] uppercase">
           {NL_WEEKDAYS[dt.weekday - 1]}
         </span>

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -1,15 +1,23 @@
 /**
  * ScheurkalenderPage Component
  *
- * Private InDesign-poster data source (#2137) — Treatment A, locked in
- * `docs/design/mockups/phase-10-scheurkalender/sk1-poster-table-compare.html`.
+ * Private InDesign-poster data source (#2137) — poster layout, locked with the
+ * owner against the live 26/27 season.
  *
- * Renders the full-season A + B *league* fixture table the club screenshots
- * into the A2 season poster: a print-clean white sheet in the body font
- * (Freight Sans Pro as of #2174 — inherits `--font-family-body`), columns
- * date·time·home·away with the KCVV side bolded and the squad label inline,
- * fixtures grouped per weekend (ISO week) with a single 2px rule between groups.
- * No logos, no squad pills, no scores.
+ * Renders the full-season A + B *league* fixture list the club screenshots into
+ * the season poster. The poster block is 340 × 567 mm, which a single
+ * chronological column cannot fill without dropping the club names below ~3.4 mm
+ * printed; the fixtures are therefore split across **two columns on the calendar
+ * year** (first year left, second right) so the break always lands on New Year
+ * regardless of how the fixture list shifts season to season.
+ *
+ * Within a column: a Freight Big month heading (month in ink, year as an italic
+ * jersey-deep `<em>`, trailing period, no rule beneath — mirroring
+ * `/ploegen/[slug]/wedstrijden`), then one row per fixture. Each row opens with a
+ * fixed three-stop date tab — weekday · day · kickoff — so every club name starts
+ * on the same left edge, and weekends are separated by a dotted seam.
+ *
+ * Deliberately absent: logos, squad pills, scores, and free-weekend markers.
  */
 
 import { DateTime } from "luxon";
@@ -18,8 +26,64 @@ import { PrintButton } from "./PrintButton";
 import { PrintDate } from "./PrintDate";
 
 // KCVV is in Belgium — pin date/week derivation to Europe/Brussels so the
-// weekday, DD/MM, and ISO-week bucket are stable across server/DST.
+// weekday, day-of-month, and ISO-week bucket are stable across server/DST.
 const TZ = "Europe/Brussels";
+
+/**
+ * Club-name prefixes PSD returns title-cased ("Ksc Blankenberge"). At poster
+ * size a lowercased federation prefix reads as a typo, so restore the caps.
+ */
+const CLUB_ABBREVIATIONS = new Set([
+  "AC",
+  "AS",
+  "EWS",
+  "FC",
+  "K",
+  "KA",
+  "KAA",
+  "KC",
+  "KCS",
+  "KCVV",
+  "KFC",
+  "KSC",
+  "KSK",
+  "KSV",
+  "KV",
+  "KVC",
+  "KVE",
+  "KVK",
+  "KVV",
+  "KVW",
+  "MVC",
+  "RC",
+  "SC",
+  "SK",
+  "SP",
+  "TSV",
+  "US",
+  "VC",
+  "VK",
+  "VV",
+  "VW",
+]);
+
+/** "Ksc Blankenberge" → "KSC Blankenberge"; "Erpe-mere" → "Erpe-Mere". */
+export function formatClubName(name: string): string {
+  return name
+    .split(" ")
+    .map((token) => {
+      if (CLUB_ABBREVIATIONS.has(token.toUpperCase()))
+        return token.toUpperCase();
+      if (token.includes("-")) {
+        return token
+          .split("-")
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join("-");
+      }
+      return token;
+    })
+    .join(" ");
+}
 
 export interface ScheurkalenderMatch {
   id: number;
@@ -27,27 +91,40 @@ export interface ScheurkalenderMatch {
   date: string;
   /** Kickoff time as `HH:MM`. */
   time?: string;
-  /** Opponent club name, exactly as PSD returns it. */
+  /** Opponent club name, as PSD returns it (re-cased for display). */
   opponent: string;
   /** Which KCVV squad plays — rendered inline ("KCVV Elewijt A" / "… B"). */
   kcvvLabel: "A" | "B";
-  /** True when KCVV plays at home (KCVV occupies the home column). */
+  /** True when KCVV plays at home (KCVV occupies the home slot). */
   kcvvIsHome: boolean;
 }
 
 export interface ScheurkalenderPageProps {
   /** Full-season A + B league fixtures, pre-sorted by date then time. */
   matches: ScheurkalenderMatch[];
-  /** Season label for the masthead, e.g. "25/26". */
+  /** Season label for the masthead, e.g. "26/27". */
   season: string;
 }
 
 interface Weekend {
   key: string;
+  /** The weekend's Saturday — anchors which month/year the weekend belongs to. */
+  saturday: DateTime;
   matches: ScheurkalenderMatch[];
 }
 
-/** Bucket fixtures per weekend (ISO week — Mon–Sun share a `<tbody>`). */
+interface MonthGroup {
+  key: string;
+  /** "Augustus" */
+  monthName: string;
+  /** "’26" */
+  yearSuffix: string;
+  weekends: Weekend[];
+}
+
+const NL_WEEKDAYS = ["ma", "di", "wo", "do", "vr", "za", "zo"];
+
+/** Bucket fixtures per weekend (ISO week — Mon–Sun share a group). */
 function groupByWeekend(matches: ScheurkalenderMatch[]): Weekend[] {
   const order: string[] = [];
   const buckets = new Map<string, ScheurkalenderMatch[]>();
@@ -62,21 +139,138 @@ function groupByWeekend(matches: ScheurkalenderMatch[]): Weekend[] {
     }
     bucket.push(match);
   }
-  return order.map((key) => ({ key, matches: buckets.get(key)! }));
+  return order.map((key) => {
+    const bucket = buckets.get(key)!;
+    // Anchor on the weekend's Saturday so a Sat/Sun pair never straddles two
+    // month headings (e.g. 31 Jan + 1 Feb both belong to January).
+    const monday = DateTime.fromISO(bucket[0]!.date, { zone: TZ }).startOf(
+      "week",
+    );
+    return { key, saturday: monday.plus({ days: 5 }), matches: bucket };
+  });
 }
 
-/** "za 30/08" — lowercase Dutch weekday abbrev + DD/MM, no year. */
-function formatShortDate(isoDate: string): string {
-  const dt = DateTime.fromISO(isoDate, { zone: TZ }).setLocale("nl");
-  return dt.isValid ? dt.toFormat("ccc dd/MM") : isoDate;
+/** Bucket weekends per month, labelled from the weekend's Saturday. */
+function groupByMonth(weekends: Weekend[]): MonthGroup[] {
+  const groups: MonthGroup[] = [];
+  for (const weekend of weekends) {
+    const key = weekend.saturday.toFormat("yyyy-MM");
+    const last = groups.at(-1);
+    if (last?.key === key) {
+      last.weekends.push(weekend);
+      continue;
+    }
+    const monthName = weekend.saturday.setLocale("nl").toFormat("LLLL");
+    groups.push({
+      key,
+      monthName: monthName.charAt(0).toUpperCase() + monthName.slice(1),
+      yearSuffix: `’${weekend.saturday.toFormat("yy")}`,
+      weekends: [weekend],
+    });
+  }
+  return groups;
+}
+
+/**
+ * Split weekends into the poster's two columns on the calendar year: the first
+ * year left, everything after it right. Returns a single column when the
+ * fixtures span only one year, so the sheet never renders an empty half.
+ */
+function splitByYear(weekends: Weekend[]): Weekend[][] {
+  const firstYear = weekends[0]?.saturday.year;
+  if (firstYear === undefined) return [];
+  const left = weekends.filter((w) => w.saturday.year === firstYear);
+  const right = weekends.filter((w) => w.saturday.year !== firstYear);
+  return right.length > 0 ? [left, right] : [left];
+}
+
+function FixtureRow({ match }: { match: ScheurkalenderMatch }) {
+  const dt = DateTime.fromISO(match.date, { zone: TZ });
+  const kcvvName = (
+    <>
+      KCVV Elewijt <span className="text-jersey-deep">{match.kcvvLabel}</span>
+    </>
+  );
+  const opponentName = formatClubName(match.opponent);
+  const home = match.kcvvIsHome ? kcvvName : opponentName;
+  const away = match.kcvvIsHome ? opponentName : kcvvName;
+
+  return (
+    <div className="flex items-baseline gap-3 py-[5px]">
+      {/* Fixed tab stops: weekday · day · kickoff. The hairline keeps the display
+          numeral and the mono time from reading as one run of digits. */}
+      <div className="grid shrink-0 grid-cols-[17px_20px_auto] items-baseline gap-x-2">
+        <span className="text-ink-muted font-mono text-[9px] tracking-[0.08em] uppercase">
+          {NL_WEEKDAYS[dt.weekday - 1]}
+        </span>
+        <span className="font-display text-ink text-right text-[19px] leading-none">
+          {dt.day}
+        </span>
+        <span className="text-ink-muted border-ink/15 border-l pl-2.5 font-mono text-[11px] leading-[1.4]">
+          {match.time ?? ""}
+        </span>
+      </div>
+      <div className="text-ink flex-1 text-sm leading-tight">
+        <span className={match.kcvvIsHome ? "font-extrabold" : "text-ink-soft"}>
+          {home}
+        </span>
+        <span className="text-ink-muted mx-[7px] text-xs">&ndash;</span>
+        <span className={match.kcvvIsHome ? "text-ink-soft" : "font-extrabold"}>
+          {away}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function FixtureColumn({ weekends }: { weekends: Weekend[] }) {
+  return (
+    <>
+      {groupByMonth(weekends).map((group) => (
+        // The top-margin reset belongs on the <section> — the <h2> is always its
+        // section's first child, so `first:` on the heading would match every month.
+        <section
+          key={group.key}
+          aria-label={`${group.monthName} ${group.yearSuffix}`}
+          className="mt-5 first:mt-0.5"
+        >
+          {/* Month heading — Freight Big, ink month + italic jersey-deep year,
+              trailing period, no rule beneath. The kit ships freight-big-pro
+              italic at 400/700 only, so the year stays at a real 700 rather
+              than a browser-faked oblique 900. */}
+          <h2 className="font-display-big text-ink mb-[7px] text-[30px] leading-[1.05] font-black tracking-[-0.01em]">
+            {group.monthName}{" "}
+            <em className="text-jersey-deep font-bold italic">
+              {group.yearSuffix}
+            </em>
+            .
+          </h2>
+          {group.weekends.map((weekend, index) => (
+            <div
+              key={weekend.key}
+              className={
+                index > 0
+                  ? "border-ink/20 mt-0.5 border-t border-dotted pt-0.5"
+                  : ""
+              }
+            >
+              {weekend.matches.map((match) => (
+                <FixtureRow key={match.id} match={match} />
+              ))}
+            </div>
+          ))}
+        </section>
+      ))}
+    </>
+  );
 }
 
 export function ScheurkalenderPage({
   matches,
   season,
 }: ScheurkalenderPageProps) {
-  const hasMatches = matches.length > 0;
-  const weekends = groupByWeekend(matches);
+  const columns = splitByYear(groupByWeekend(matches));
+  const hasMatches = columns.length > 0;
 
   return (
     <div className="bg-cream min-h-screen print:bg-white">
@@ -86,7 +280,7 @@ export function ScheurkalenderPage({
       </PageContainer>
 
       <PageContainer className="pt-4 pb-12 print:p-0">
-        {/* The "sheet" — this is what gets screenshotted into the InDesign poster. */}
+        {/* The "sheet" — this is what gets screenshotted into the poster. */}
         <div className="border-ink border-2 bg-white print:border-0">
           {/* Masthead */}
           <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
@@ -99,57 +293,26 @@ export function ScheurkalenderPage({
           </div>
 
           {hasMatches ? (
-            <table className="w-full border-collapse text-[13px]">
-              {weekends.map((weekend, weekendIndex) => (
-                <tbody key={weekend.key}>
-                  {weekend.matches.map((match, rowIndex) => {
-                    const isLastRow = rowIndex === weekend.matches.length - 1;
-                    // Hairline between rows within a weekend; none on the last
-                    // row; a single 2px ink rule opens each subsequent weekend.
-                    const isWeekendBoundary =
-                      weekendIndex > 0 && rowIndex === 0;
-                    const cell = [
-                      "px-2.5 py-1.5 align-baseline",
-                      isLastRow ? "" : "border-b border-b-ink/15",
-                      isWeekendBoundary ? "border-t-ink border-t-2" : "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ");
-                    const kcvvName = `KCVV Elewijt ${match.kcvvLabel}`;
-                    const homeName = match.kcvvIsHome
-                      ? kcvvName
-                      : match.opponent;
-                    const awayName = match.kcvvIsHome
-                      ? match.opponent
-                      : kcvvName;
-                    return (
-                      <tr key={match.id}>
-                        <td
-                          className={`${cell} font-body text-ink-soft w-[88px] whitespace-nowrap`}
-                        >
-                          {formatShortDate(match.date)}
-                        </td>
-                        <td
-                          className={`${cell} text-ink-muted w-[56px] text-right font-mono whitespace-nowrap`}
-                        >
-                          {match.time ?? ""}
-                        </td>
-                        <td
-                          className={`${cell} text-ink ${match.kcvvIsHome ? "font-extrabold" : ""}`}
-                        >
-                          {homeName}
-                        </td>
-                        <td
-                          className={`${cell} text-ink ${match.kcvvIsHome ? "" : "font-extrabold"}`}
-                        >
-                          {awayName}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
+            <div
+              className={`grid px-5 pt-1.5 pb-[18px] ${
+                columns.length > 1 ? "grid-cols-2" : "grid-cols-1"
+              }`}
+            >
+              {columns.map((weekends, index) => (
+                <div
+                  key={weekends[0]?.key ?? index}
+                  className={
+                    index === 0 && columns.length > 1
+                      ? "border-ink/15 border-r pr-[17px]"
+                      : columns.length > 1
+                        ? "pl-[17px]"
+                        : ""
+                  }
+                >
+                  <FixtureColumn weekends={weekends} />
+                </div>
               ))}
-            </table>
+            </div>
           ) : (
             <p className="text-ink-muted px-4 py-16 text-center font-mono text-sm">
               Geen competitiewedstrijden gevonden.

--- a/docs/design/mockups/phase-10-scheurkalender/sk2-poster-layout-locked.md
+++ b/docs/design/mockups/phase-10-scheurkalender/sk2-poster-layout-locked.md
@@ -1,0 +1,60 @@
+# /scheurkalender — poster layout (LOCKED)
+
+Supersedes the Treatment A table locked in `sk1-poster-table-compare.html`. That
+treatment shipped in #2137 and was correct as a fixture table, but read as a
+spreadsheet and did not fit the poster block at a legible type size.
+
+Locked with the owner on 2026-08-04 against the live 26/27 season.
+
+## The poster block
+
+**340 × 567 mm** (ratio 1 : 1.67) — the space between the sponsor blocks in the
+InDesign poster. The owner screenshots the sheet and places it there; the
+background texture, sponsor logos, and title stay in InDesign.
+
+## Decision — two columns, split on the calendar year
+
+| Option                      | Fits 340 × 567 mm?                              | Printed club-name height |
+| --------------------------- | ----------------------------------------------- | ------------------------ |
+| One column                  | **No** — 600 mm at 1400 px render (33 mm over)  | 3.4 mm                   |
+| One column, compact         | Only from ~1150 px render                       | 4.0 mm                   |
+| **Two columns, year split** | **Yes** — 538 mm at 860 px render (29 mm spare) | **5.5 mm**               |
+| Two columns, compact        | Yes, with room to spare                         | 4.7 mm                   |
+
+Measured in headless Chromium against the real season (56 fixtures). One column
+was eliminated on arithmetic: it cannot fill the block without dropping the club
+names to a size that does not survive being read off a poster.
+
+**Screenshot at ~860 px browser width.** Narrower gives bigger type but a taller
+block (820 px → 5.8 mm, 564 mm — fills the block almost exactly); wider gives the
+reverse.
+
+## Locked details
+
+- **Column split is on the calendar year**, not a balanced CSS flow — the break
+  always lands on New Year, so the left column is the autumn half and the right
+  the spring half every season, regardless of how the fixture list shifts. A
+  season spanning one year only renders a single full-width column.
+- **Month heading** mirrors `/ploegen/[slug]/wedstrijden`: `font-display-big`
+  (freight-big-pro) at **900**, month in ink, year as an italic jersey-deep
+  `<em>` with a trailing period, and **no rule beneath**. Set at 30 px here, not
+  the live `--text-display-xl` (44–72 px), which would swamp a poster column.
+  The year stays at a real **700 italic** — the Typekit kit ships
+  freight-big-pro italic at 400/700 only, so a 900 italic would be a
+  browser-faked oblique.
+- **Date tab** is three fixed stops — weekday (mono 9 px) · day-of-month
+  (Freight Display 19 px, right-aligned) · kickoff (mono 11 px behind a hairline
+  rule). The kickoff sits in the tab rather than in a right-hand column, so every
+  club name starts on one left edge and the dead band between date and match is
+  gone. The day-of-month carries no month or year — the heading owns those.
+- **Weekend seams** are a dotted hairline between weekends within a month; the
+  first weekend of a month has none.
+- **KCVV side is bolded**, squad letter (`A`/`B`) inline and in jersey-deep;
+  opponent in `text-ink-soft`.
+- **Club names are re-cased** — PSD returns `Ksc Blankenberge` / `Erpe-mere`,
+  which read as typos at poster size. `formatClubName` uppercases known
+  federation prefixes and capitalises after a hyphen.
+- **Free weekends are omitted.** They were prototyped as an explicit hatched row
+  and rejected by the owner. Consequence, accepted: a gap in the season is
+  indistinguishable from a fixture that has not been published yet.
+- **Still absent:** logos, squad pills, scores, competition labels.


### PR DESCRIPTION
Rebuilds `/scheurkalender` — the private data source the club screenshots into the
InDesign season poster — so it actually fits the poster block at a legible size.

Context for #2137, which shipped the Treatment A table this replaces. Not a bug
in that work: it was a correct fixture table, but it was specced before the
poster block was measured.

## Why

The poster block is **340 × 567 mm**. A single chronological column needs
**600 mm** of height in it, and only gets under 567 mm by dropping the club
names to **3.4 mm** printed — too small to read off a poster.

Measured with headless Chromium against the real 26/27 season (56 fixtures):

| Layout | Fits 340 × 567 mm? | Printed club-name height |
| ------ | ------------------ | ------------------------ |
| One column | **No** — 600 mm at a 1400 px render | 3.4 mm |
| One column, compact | Only from ~1150 px | 4.0 mm |
| **Two columns, year split** | **Yes** — 538 mm at 860 px (29 mm spare) | **5.5 mm** |
| Two columns, compact | Yes, comfortably | 4.7 mm |

One column was eliminated on arithmetic, not taste.

## What changed

- **Two columns split on the calendar year** — first year left, second right, so
  the break always lands on New Year regardless of how the fixture list shifts
  season to season. A balanced CSS flow would drift. A season spanning one year
  renders a single full-width column instead of an empty half.
- **Month headings now mirror `/ploegen/[slug]/wedstrijden`** — `font-display-big`
  at 900, month in ink, year as an italic jersey-deep `<em>`, trailing period, no
  rule beneath. Set at 30 px rather than the live `--text-display-xl` (44–72 px),
  which would swamp a poster column. The year stays at a real **700 italic**: the
  Typekit kit ships `freight-big-pro` italic at 400/700 only, so a 900 italic
  would be a browser-faked oblique.
- **Kickoff moved into a fixed three-stop date tab** (weekday · day · time, with a
  hairline before the time) instead of a right-hand column. Every club name now
  starts on one left edge; this is what reclaimed the width the two columns needed.
- **Club names re-cased for print** — PSD returns `Ksc Blankenberge` / `Erpe-mere`,
  which read as typos at poster size.
- **Weekend seams** are a dotted hairline within a month; the first weekend of a
  month has none.
- **Free-weekend markers dropped** at the owner's request.
- **Loading skeleton** re-shaped to the two-column sheet — it still mirrored the
  retired table.

Locked details, including the measurement table and the rejected alternatives, in
`docs/design/mockups/phase-10-scheurkalender/sk2-poster-layout-locked.md`. It
supersedes `sk1-poster-table-compare.html`.

## Known trade-off

Dropping free-weekend markers means a gap in the season is indistinguishable from
a fixture that has not been published yet. Prototyped as an explicit hatched row
and rejected by the owner; recorded in the locked doc so it is a decision rather
than an oversight.

## Follow-up

`formatClubName` is deliberately **local to this component** — the same raw PSD
casing affects `/ploegen`, `/kalender`, `/wedstrijd/[matchId]`, the homepage and
the share templates, and `/ploegen/.../wedstrijden` currently renders our own club
as `Kcvv Elewijt`. Fixing that properly belongs in the BFF: **#2336**, which
includes deleting this local helper as an acceptance criterion.

## Testing

- 21 unit tests on the component (column split, month-heading composition, date
  tab, re-casing, seams, empty state) plus `formatClubName`.
- Verified against the live 26/27 season through the deployed BFF: two columns,
  Augustus ’26 → April ’27, split 2026 / 2027, casing corrected.
- `pnpm --filter @kcvv/web check-all` — lint, type-check, 3304/3304 tests, build
  all pass.

## VR baselines

None. `Pages/*` stories are design references and are not VR-tagged — page
composition is the e2e suite's concern (`docs/prd/page-level-testing-rework.md`).
No baseline PNGs are added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Scheurkalender as a poster-style calendar with two columns split by calendar year.
  - Added month headings, weekend separators, date tabs, home/away emphasis, and improved club-name formatting.
  - Added clearer poster-width and single-year viewing options.
  - Updated loading states to better reflect the calendar layout.

- **Documentation**
  - Added the finalized poster-layout specification, including typography, dimensions, formatting, and display rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->