### PR TITLE
fix(api): surface a killed waitUntil refresh instead of drifting silently (#2335)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -10,13 +10,20 @@ src/
 ├── index.ts                  ← Worker entry point (HttpApiBuilder.toWebHandler)
 ├── env.ts                    ← WorkerEnv type + WorkerEnvTag (Effect Context)
 ├── cache/
-│   └── kv-cache.ts           ← KvCacheService (get/set with TTL)
+│   └── kv-cache.ts           ← KvCacheService + TypedKvCache (SWR read path, TTLs, drift alerting)
 ├── psd/
 │   ├── errors.ts             ← BffError discriminated union (typed API errors)
 │   ├── schemas.ts            ← Raw PSD API schemas (internal only)
 │   ├── schemas-player-team.ts ← PSD player/team/staff schemas (used by sync)
 │   ├── service.ts            ← PsdService (fetch + transform + business logic)
-│   └── transforms.ts         ← Pure transform functions (PSD → domain types)
+│   ├── transforms.ts         ← Pure transform functions (PSD → domain types)
+│   ├── gate.ts               ← PsdGateService (Effect facade over the gate)
+│   ├── gate-do.ts            ← PsdGate Durable Object (global pacer + single-flight)
+│   ├── gate-logic.ts         ← GateLogic — token bucket + flight leases (DO-free, testable)
+│   ├── incident.ts           ← IncidentTracker (PSD outage open/close state)
+│   ├── slack-alert.ts        ← Incident + slow-drift Slack payloads (framework-free)
+│   ├── background.ts         ← BackgroundRunnerService (detached SWR refresh port)
+│   └── background-live.ts    ← waitUntil-backed runner implementation
 ├── sanity/
 │   ├── config.ts             ← Sanity client config (project ID, dataset, token)
 │   ├── mutation.ts           ← SanityMutation — write ops (upsert, archive, image upload)
@@ -82,12 +89,14 @@ Values are stored as `{ value, fetchedAt }` wrappers. On deploy, existing cache 
 
 A background (SWR) refresh runs in `waitUntil`, which Cloudflare cancels ~30 s after the invocation ends. A **killed** refresh — unlike a **failed** one — runs none of its handlers: no negative marker, no incident report, no drift nudge. The value then drifts toward the 7-day hard-expiry cliff behind a clean `200` and a clean log. Two guards close that gap:
 
-- **`BG_REFRESH_TIMEOUT_MS` (20 s)** bounds the background refresh fetch so a slow one takes the normal failure path (negative marker + escalating log) instead of being killed. Override per call via `getOrFetch`'s `backgroundTimeoutMs` option (tests use a small value). A timed-out refresh deliberately does **not** call `gate.reportOutcome` — a slow fan-out under load is not proof PSD is down, and reporting it would open spurious outage pings. `blockingRefresh` is not bounded: it runs inside the request's own lifetime, and serving stale there would defeat the `mustBlockOnStale` correctness guard.
+- **`BG_REFRESH_TIMEOUT_MS` (12 s)** bounds the background refresh fetch so a slow one takes the normal failure path (negative marker + escalating log) instead of being killed. **The binding ceiling is `GateLogic.leaseMs` (15 s), not the `waitUntil` budget** — a refresh that outruns the lease loses single-flight, so the next reader forks a second full fan-out under exactly the load that made the first one slow, and the original's `endFlight` then releases the new leader's flight. A unit test pins `BG_REFRESH_TIMEOUT_MS < 15 s`; keep them coupled. `getOrFetch`'s `backgroundTimeoutMs` option exists so tests can drive it with a small value — no production caller overrides it. A timed-out refresh deliberately does **not** call `gate.reportOutcome` — a slow fan-out under load is not proof PSD is down, and reporting it would open spurious outage pings. Note the timeout abandons the fan-out but does not cancel it: `fetch` takes no `AbortSignal`, so in-flight PSD calls run to completion.
 - **A read-path drift check** evaluates stale age on every stale serve, before the negative-marker early-return, so a key whose marker keeps being re-set still surfaces. It is the only signal that does not depend on a refresh path executing at all.
+
+`blockingRefresh` is deliberately **not** bounded. It runs inside the request's own lifetime, so nothing kills it out from under its handlers — the failure mode this section exists to fix cannot occur there. (In production it is only reachable via the `mustBlockOnStale` correctness guard, since `index.ts` provides `BackgroundRunnerLive` for the whole API layer.)
 
 **Drift is measured as time past the soft TTL, not absolute age**: `staleForMs = (now − fetchedAt) − softTtl`, compared against `DRIFT_NUDGE_THRESHOLD` (24 h) — "this key has failed to refresh for a day". An absolute rule would fire the instant a healthy 24 h-softTtl key (`matches:team:{id}`, `ranking:team:{id}`) goes stale on a perfectly normal refresh cycle. The same rule governs `keepStale`'s WARN→ERROR escalation. Slack still reports **absolute** age + time-to-cliff.
 
-While drifting: `ERROR` on every stale serve (the `wrangler tail` trace), Slack nudge once per day per key (`nudge:{key}`, `NUDGE_MARKER_TTL`). The dedup KV read only happens on a genuinely drifting key, so the normal stale path costs no extra I/O.
+While drifting: `ERROR` on every stale serve (the `wrangler tail` trace), Slack nudge once per day per key (`nudge:{key}`, `NUDGE_MARKER_TTL`). The drift decision is pure arithmetic, so the normal stale path costs no extra I/O; the nudge's KV dedup read + Slack POST are forked into `waitUntil` rather than run inline, because this is the serve-stale-instantly path. `keepStale` keeps a fallback nudge for the case where the read-path write did not land — it is the only one carrying the failing HTTP status.
 
 | Key pattern                          | softTtl                                                                                                                                                                                                                                                                                                                                                   | hardTtl |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -78,6 +78,17 @@ wrangler secret put SLACK_ALERT_WEBHOOK_URL --env staging
 
 Values are stored as `{ value, fetchedAt }` wrappers. On deploy, existing cache entries without the wrapper trigger a one-time cold start.
 
+### Drift observability (#2335)
+
+A background (SWR) refresh runs in `waitUntil`, which Cloudflare cancels ~30 s after the invocation ends. A **killed** refresh — unlike a **failed** one — runs none of its handlers: no negative marker, no incident report, no drift nudge. The value then drifts toward the 7-day hard-expiry cliff behind a clean `200` and a clean log. Two guards close that gap:
+
+- **`BG_REFRESH_TIMEOUT_MS` (20 s)** bounds the background refresh fetch so a slow one takes the normal failure path (negative marker + escalating log) instead of being killed. Override per call via `getOrFetch`'s `backgroundTimeoutMs` option (tests use a small value). A timed-out refresh deliberately does **not** call `gate.reportOutcome` — a slow fan-out under load is not proof PSD is down, and reporting it would open spurious outage pings. `blockingRefresh` is not bounded: it runs inside the request's own lifetime, and serving stale there would defeat the `mustBlockOnStale` correctness guard.
+- **A read-path drift check** evaluates stale age on every stale serve, before the negative-marker early-return, so a key whose marker keeps being re-set still surfaces. It is the only signal that does not depend on a refresh path executing at all.
+
+**Drift is measured as time past the soft TTL, not absolute age**: `staleForMs = (now − fetchedAt) − softTtl`, compared against `DRIFT_NUDGE_THRESHOLD` (24 h) — "this key has failed to refresh for a day". An absolute rule would fire the instant a healthy 24 h-softTtl key (`matches:team:{id}`, `ranking:team:{id}`) goes stale on a perfectly normal refresh cycle. The same rule governs `keepStale`'s WARN→ERROR escalation. Slack still reports **absolute** age + time-to-cliff.
+
+While drifting: `ERROR` on every stale serve (the `wrangler tail` trace), Slack nudge once per day per key (`nudge:{key}`, `NUDGE_MARKER_TTL`). The dedup KV read only happens on a genuinely drifting key, so the normal stale path costs no extra I/O.
+
 | Key pattern                          | softTtl                                                                                                                                                                                                                                                                                                                                                   | hardTtl |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `psd:current-season-id`              | 24 h                                                                                                                                                                                                                                                                                                                                                      | 7 days  |

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -8,6 +8,7 @@ import {
   TTL,
   HARD_TTL_DEFAULT,
   HARD_TTL_LONG,
+  BG_REFRESH_TIMEOUT_MS,
 } from "./kv-cache";
 import { WorkerEnvTag } from "../env";
 import { PsdGateService, PsdGateTest, makePsdGateLayer } from "../psd/gate";
@@ -66,9 +67,13 @@ function makeWrapper(value: unknown, ageMs: number) {
 function withRunner(
   mockKv: ReturnType<typeof makeMockKv>,
   gateLayer: Layer.Layer<PsdGateService>,
+  /** Extra layers for the DETACHED work. The runner runs it on its own runtime,
+   * so layers provided around `getOrFetch` never reach it — a log capture has
+   * to come in through here. */
+  extra: Layer.Layer<never> = Layer.empty,
 ) {
   const pending: Promise<void>[] = [];
-  const layer = Layer.mergeAll(KvCacheLive, gateLayer).pipe(
+  const layer = Layer.mergeAll(KvCacheLive, gateLayer, extra).pipe(
     Layer.provideMerge(makeEnvLayer(mockKv)),
   );
   const runnerLayer = Layer.succeed(BackgroundRunnerService, {
@@ -84,6 +89,27 @@ function withRunner(
       }),
   });
   return { runnerLayer, settle: () => Promise.all(pending) };
+}
+
+/** Fresh gate with its OWN incident tracker so state can't leak between tests. */
+const isolatedGate = () =>
+  makePsdGateLayer(
+    new GateLogic({ ratePerSecond: 1e9 }),
+    new IncidentTracker(),
+  );
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+/** Collect every log entry emitted while the returned layer is provided. */
+function captureLogs() {
+  const entries: { level: string; message: string }[] = [];
+  const layer = Logger.replace(
+    Logger.defaultLogger,
+    Logger.make(({ logLevel, message }) => {
+      entries.push({ level: logLevel.label, message: String(message) });
+    }),
+  );
+  return { entries, layer };
 }
 
 describe("TTL constants", () => {
@@ -133,6 +159,15 @@ describe("TTL constants", () => {
 
   it("HARD_TTL_DEFAULT is 7 days", () => {
     expect(HARD_TTL_DEFAULT).toBe(60 * 60 * 24 * 7);
+  });
+
+  it("BG_REFRESH_TIMEOUT_MS stays under the gate's flight lease (#2335)", () => {
+    // Outrunning the lease is worse than outrunning the waitUntil budget: at
+    // t=leaseMs the next reader reclaims leadership and forks a SECOND full
+    // fan-out, and the original's endFlight then releases the new leader's
+    // flight. GateLogic's leaseMs default is 15 s (psd/gate-logic.ts); keep
+    // headroom for the failure-path KV write.
+    expect(BG_REFRESH_TIMEOUT_MS).toBeLessThan(15_000);
   });
 });
 
@@ -784,15 +819,6 @@ describe("TypedKvCache — stale-while-revalidate + storm gate (#2328)", () => {
 });
 
 describe("TypedKvCache — PSD incident alerting (#2329)", () => {
-  /** Fresh gate with its OWN incident tracker so state can't leak between tests. */
-  const isolatedGate = () =>
-    makePsdGateLayer(
-      new GateLogic({ ratePerSecond: 1e9 }),
-      new IncidentTracker(),
-    );
-
-  const dayMs = 24 * 60 * 60 * 1000;
-
   it("escalates the serve-stale log WARN→ERROR while an incident is open", async () => {
     const mockKv = makeMockKv();
     // 2 h stale (< 24 h drift threshold) — the escalation here is driven purely
@@ -803,13 +829,7 @@ describe("TypedKvCache — PSD incident alerting (#2329)", () => {
     );
     const gate = isolatedGate(); // first failure opens the incident
 
-    const entries: { level: string; message: string }[] = [];
-    const capture = Logger.replace(
-      Logger.defaultLogger,
-      Logger.make(({ logLevel, message }) => {
-        entries.push({ level: logLevel.label, message: String(message) });
-      }),
-    );
+    const { entries, layer: capture } = captureLogs();
 
     // No runner → blocking refresh path (synchronous, easy to assert).
     const fetchEffect = Effect.fail(new Error("PSD 429") as never);
@@ -842,11 +862,14 @@ describe("TypedKvCache — PSD incident alerting (#2329)", () => {
       makeWrapper({ name: "stale", value: 1 }, 3 * dayMs), // 3 days stale
     );
     const fetchEffect = Effect.fail(new Error("PSD 429") as never);
+    const { entries, layer: capture } = captureLogs();
 
     const result = await Effect.runPromise(
       TypedKvCache(TestSchema)
         .getOrFetch("test-key", fetchEffect, 60)
         .pipe(
+          Effect.provide(capture),
+          Effect.provide(Logger.minimumLogLevel(LogLevel.All)),
           Effect.provide(KvCacheLive),
           Effect.provide(isolatedGate()),
           Effect.provide(makeEnvLayer(mockKv)),
@@ -855,6 +878,14 @@ describe("TypedKvCache — PSD incident alerting (#2329)", () => {
 
     expect(result).toEqual({ name: "stale", value: 1 });
     expect(mockKv.store.get("nudge:test-key")).toBe("1");
+    // #2335: the read-path drift check also claims that marker, so assert
+    // `keepStale`'s own escalated line too — otherwise this no longer proves
+    // anything about the failed-refresh path.
+    expect(
+      entries.some(
+        (e) => e.level === "ERROR" && e.message.includes("refresh failed"),
+      ),
+    ).toBe(true);
   });
 
   it("slow-drift nudge is deduped once/day/key (marker already present)", async () => {
@@ -886,33 +917,17 @@ describe("TypedKvCache — PSD incident alerting (#2329)", () => {
 });
 
 describe("TypedKvCache — silent-drift observability (#2335)", () => {
-  const dayMs = 24 * 60 * 60 * 1000;
-
-  /** Gate whose `reportOutcome` is a spy — a timed-out refresh must not open an
-   * incident, and "not called" is the only way to prove it. */
+  /** The real gate with only `reportOutcome` swapped for a spy — a timed-out
+   * refresh must not open an incident, and "never called" is the only way to
+   * prove it. Wrapping `isolatedGate` keeps single-flight behaviour honest and
+   * survives `PsdGate` gaining methods. */
   function spyGate() {
-    const logic = new GateLogic({ ratePerSecond: 1e9 });
     const reportOutcome = vi.fn(() => Effect.succeed({ incidentOpen: false }));
-    const layer = Layer.succeed(PsdGateService, {
-      acquireToken: Effect.promise(() => logic.acquireToken()),
-      beginFlight: (key: string) => Effect.sync(() => logic.beginFlight(key)),
-      endFlight: (key: string) => Effect.sync(() => logic.endFlight(key)),
-      awaitFlight: (key: string) =>
-        Effect.promise(() => logic.awaitFlight(key)),
-      reportOutcome,
-    });
+    const layer = Layer.effect(
+      PsdGateService,
+      Effect.map(PsdGateService, (real) => ({ ...real, reportOutcome })),
+    ).pipe(Layer.provide(isolatedGate()));
     return { layer, reportOutcome };
-  }
-
-  function captureLogs() {
-    const entries: { level: string; message: string }[] = [];
-    const layer = Logger.replace(
-      Logger.defaultLogger,
-      Logger.make(({ logLevel, message }) => {
-        entries.push({ level: logLevel.label, message: String(message) });
-      }),
-    );
-    return { entries, layer };
   }
 
   /** A fetch that never settles — stands in for the slow fan-out that Cloudflare
@@ -952,6 +967,48 @@ describe("TypedKvCache — silent-drift observability (#2335)", () => {
     // Normal failure path ran: marker set, so we stop re-forking a doomed refresh.
     expect(mockKv.store.get("neg:test-key")).toBe("1");
     // A slow fan-out is not proof PSD is down — no spurious outage ping.
+    expect(reportOutcome).not.toHaveBeenCalled();
+  });
+
+  it("a timed-out refresh on a drifting key escalates its own log to ERROR", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 3 * dayMs),
+    );
+    const { layer: gate, reportOutcome } = spyGate();
+    const { entries, layer: capture } = captureLogs();
+    const { runnerLayer, settle } = withRunner(
+      mockKv,
+      gate,
+      Layer.merge(capture, Logger.minimumLogLevel(LogLevel.All)),
+    );
+
+    await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", hangingFetch, 60, HARD_TTL_DEFAULT, {
+          backgroundTimeoutMs: 20,
+        })
+        .pipe(
+          Effect.provide(capture),
+          Effect.provide(Logger.minimumLogLevel(LogLevel.All)),
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+    await settle();
+
+    // `keepStale`'s OWN line — the read-path check emits a different message, so
+    // this pins the timeout path's escalation rather than being satisfied by it.
+    expect(
+      entries.some(
+        (e) =>
+          e.level === "ERROR" && e.message.includes("timed out after 20ms"),
+      ),
+    ).toBe(true);
+    // Escalation is a log decision, not an incident: still no outage reported.
     expect(reportOutcome).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/cache/kv-cache.test.ts
+++ b/apps/api/src/cache/kv-cache.test.ts
@@ -58,6 +58,34 @@ function makeWrapper(value: unknown, ageMs: number) {
   return JSON.stringify({ value, fetchedAt: Date.now() - ageMs });
 }
 
+/**
+ * A BackgroundRunnerService whose `fork` runs the refresh eagerly on the test
+ * layers and records the promise, so a test can `await settle()` to observe
+ * the background effect's outcome deterministically.
+ */
+function withRunner(
+  mockKv: ReturnType<typeof makeMockKv>,
+  gateLayer: Layer.Layer<PsdGateService>,
+) {
+  const pending: Promise<void>[] = [];
+  const layer = Layer.mergeAll(KvCacheLive, gateLayer).pipe(
+    Layer.provideMerge(makeEnvLayer(mockKv)),
+  );
+  const runnerLayer = Layer.succeed(BackgroundRunnerService, {
+    fork: (_label, effect) =>
+      Effect.sync(() => {
+        // The test fetch is pure, so the refresh never touches PsdService —
+        // `layer` satisfies its real deps (KvCache + gate + env).
+        pending.push(
+          Effect.runPromise(
+            Effect.provide(effect, layer) as unknown as Effect.Effect<void>,
+          ),
+        );
+      }),
+  });
+  return { runnerLayer, settle: () => Promise.all(pending) };
+}
+
 describe("TTL constants", () => {
   it("NEXT_MATCHES is 4 hours", () => {
     expect(TTL.NEXT_MATCHES).toBe(60 * 60 * 4);
@@ -486,34 +514,6 @@ describe("TypedKvCache", () => {
 });
 
 describe("TypedKvCache — stale-while-revalidate + storm gate (#2328)", () => {
-  /**
-   * A BackgroundRunnerService whose `fork` runs the refresh eagerly on the test
-   * layers and records the promise, so a test can `await settle()` to observe
-   * the background effect's outcome deterministically.
-   */
-  function withRunner(
-    mockKv: ReturnType<typeof makeMockKv>,
-    gateLayer: Layer.Layer<PsdGateService>,
-  ) {
-    const pending: Promise<void>[] = [];
-    const layer = Layer.mergeAll(KvCacheLive, gateLayer).pipe(
-      Layer.provideMerge(makeEnvLayer(mockKv)),
-    );
-    const runnerLayer = Layer.succeed(BackgroundRunnerService, {
-      fork: (_label, effect) =>
-        Effect.sync(() => {
-          // The test fetch is pure, so the refresh never touches PsdService —
-          // `layer` satisfies its real deps (KvCache + gate + env).
-          pending.push(
-            Effect.runPromise(
-              Effect.provide(effect, layer) as unknown as Effect.Effect<void>,
-            ),
-          );
-        }),
-    });
-    return { runnerLayer, settle: () => Promise.all(pending) };
-  }
-
   const staleWrapper = (value: unknown) =>
     makeWrapper(value, 2 * 60 * 60 * 1000);
 
@@ -882,6 +882,210 @@ describe("TypedKvCache — PSD incident alerting (#2329)", () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+});
+
+describe("TypedKvCache — silent-drift observability (#2335)", () => {
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  /** Gate whose `reportOutcome` is a spy — a timed-out refresh must not open an
+   * incident, and "not called" is the only way to prove it. */
+  function spyGate() {
+    const logic = new GateLogic({ ratePerSecond: 1e9 });
+    const reportOutcome = vi.fn(() => Effect.succeed({ incidentOpen: false }));
+    const layer = Layer.succeed(PsdGateService, {
+      acquireToken: Effect.promise(() => logic.acquireToken()),
+      beginFlight: (key: string) => Effect.sync(() => logic.beginFlight(key)),
+      endFlight: (key: string) => Effect.sync(() => logic.endFlight(key)),
+      awaitFlight: (key: string) =>
+        Effect.promise(() => logic.awaitFlight(key)),
+      reportOutcome,
+    });
+    return { layer, reportOutcome };
+  }
+
+  function captureLogs() {
+    const entries: { level: string; message: string }[] = [];
+    const layer = Logger.replace(
+      Logger.defaultLogger,
+      Logger.make(({ logLevel, message }) => {
+        entries.push({ level: logLevel.label, message: String(message) });
+      }),
+    );
+    return { entries, layer };
+  }
+
+  /** A fetch that never settles — stands in for the slow fan-out that Cloudflare
+   * would kill ~30 s after the invocation ends. */
+  const hangingFetch = Effect.never as Effect.Effect<{
+    name: string;
+    value: number;
+  }>;
+
+  const nudgePuts = (mockKv: ReturnType<typeof makeMockKv>) =>
+    mockKv.put.mock.calls.filter(([k]) => k === "nudge:test-key");
+
+  it("a timed-out background refresh marks stale and does NOT open an incident", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 2 * 60 * 60 * 1000),
+    );
+    const { layer: gate, reportOutcome } = spyGate();
+    const { runnerLayer, settle } = withRunner(mockKv, gate);
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", hangingFetch, 60, HARD_TTL_DEFAULT, {
+          backgroundTimeoutMs: 20,
+        })
+        .pipe(
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(gate),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+    await settle();
+
+    expect(result).toEqual({ name: "stale", value: 1 });
+    // Normal failure path ran: marker set, so we stop re-forking a doomed refresh.
+    expect(mockKv.store.get("neg:test-key")).toBe("1");
+    // A slow fan-out is not proof PSD is down — no spurious outage ping.
+    expect(reportOutcome).not.toHaveBeenCalled();
+  });
+
+  it("read path nudges a drifting value even when no refresh ever failed", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 3 * dayMs),
+    );
+    const { runnerLayer, settle } = withRunner(mockKv, PsdGateTest);
+    const { entries, layer: capture } = captureLogs();
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch(
+          "test-key",
+          Effect.succeed({ name: "fresh", value: 42 }),
+          60,
+        )
+        .pipe(
+          Effect.provide(capture),
+          Effect.provide(Logger.minimumLogLevel(LogLevel.All)),
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+    await settle();
+
+    expect(result).toEqual({ name: "stale", value: 1 });
+    expect(mockKv.store.get("nudge:test-key")).toBe("1");
+    expect(
+      entries.some(
+        (e) => e.level === "ERROR" && e.message.includes("past its soft TTL"),
+      ),
+    ).toBe(true);
+  });
+
+  it("a drifting key read twice nudges only once (once/day dedup holds)", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 3 * dayMs),
+    );
+    const { layer: gate } = spyGate();
+    const { runnerLayer, settle } = withRunner(mockKv, gate);
+
+    const read = () =>
+      Effect.runPromise(
+        TypedKvCache(TestSchema)
+          .getOrFetch("test-key", hangingFetch, 60, HARD_TTL_DEFAULT, {
+            backgroundTimeoutMs: 20,
+          })
+          .pipe(
+            Effect.provide(runnerLayer),
+            Effect.provide(KvCacheLive),
+            Effect.provide(gate),
+            Effect.provide(makeEnvLayer(mockKv)),
+          ),
+      );
+
+    await read();
+    await settle();
+    await read();
+    await settle();
+
+    expect(nudgePuts(mockKv)).toHaveLength(1);
+  });
+
+  it("a healthy 24h-softTtl key stale by a minute does not nudge or escalate", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, dayMs + 60_000),
+    );
+    const { runnerLayer, settle } = withRunner(mockKv, PsdGateTest);
+    const { entries, layer: capture } = captureLogs();
+
+    // Schema-invalid refresh: the one keepStale path where drift alone decides
+    // escalation (no incident is opened), so it isolates the rule under test.
+    // Absolute age here is >24 h — the old rule would nudge; the soft-TTL-relative
+    // one sees a single minute of drift.
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch(
+          "test-key",
+          Effect.succeed({ name: "bad" } as never),
+          TTL.MATCHES_TEAM,
+        )
+        .pipe(
+          Effect.provide(capture),
+          Effect.provide(Logger.minimumLogLevel(LogLevel.All)),
+          Effect.provide(runnerLayer),
+          Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+    await settle();
+
+    expect(result).toEqual({ name: "stale", value: 1 });
+    expect(mockKv.store.get("nudge:test-key")).toBeUndefined();
+    expect(entries.some((e) => e.level === "ERROR")).toBe(false);
+  });
+
+  it("a drifting key with a negative marker present still nudges", async () => {
+    const mockKv = makeMockKv();
+    mockKv.store.set(
+      "test-key",
+      makeWrapper({ name: "stale", value: 1 }, 3 * dayMs),
+    );
+    mockKv.store.set("neg:test-key", "1");
+
+    let fetchCalled = false;
+    const fetchEffect = Effect.sync(() => {
+      fetchCalled = true;
+      return { name: "fresh", value: 9 };
+    });
+
+    const result = await Effect.runPromise(
+      TypedKvCache(TestSchema)
+        .getOrFetch("test-key", fetchEffect, 60)
+        .pipe(
+          Effect.provide(KvCacheLive),
+          Effect.provide(PsdGateTest),
+          Effect.provide(makeEnvLayer(mockKv)),
+        ),
+    );
+
+    expect(result).toEqual({ name: "stale", value: 1 });
+    expect(fetchCalled).toBe(false);
+    // The marker short-circuits the refresh — the nudge must not depend on it.
+    expect(mockKv.store.get("nudge:test-key")).toBe("1");
   });
 });
 

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -2,7 +2,11 @@ import { Context, Effect, Either, Layer, Option, Schema as S } from "effect";
 import { WorkerEnvTag } from "../env";
 import { PsdGateService } from "../psd/gate";
 import { BackgroundRunnerService, type PsdRefreshEnv } from "../psd/background";
-import { buildDriftMessage, postSlack } from "../psd/slack-alert";
+import {
+  buildDriftMessage,
+  formatDuration,
+  postSlack,
+} from "../psd/slack-alert";
 
 /**
  * Per-endpoint soft TTLs in seconds.
@@ -43,11 +47,20 @@ export const DRIFT_NUDGE_THRESHOLD = 60 * 60 * 24; // 24 h (#2329)
 
 /** Ceiling on a background (SWR) refresh fetch, so a slow one takes the normal
  * failure path (negative marker + escalating log) instead of being silently
- * killed (#2335). Cloudflare cancels `waitUntil` work ~30 s after the invocation
- * ends; 20 s leaves ~10 s of headroom for the failure-path KV write + Slack POST.
- * The gate paces 5 PSD calls/s globally, so a 19-call fan-out is ~3.8 s
- * uncontended — 20 s tolerates roughly 5 concurrent fan-outs. */
-export const BG_REFRESH_TIMEOUT_MS = 20_000;
+ * killed (#2335).
+ *
+ * Two ceilings bound this, and the LOWER one binds: Cloudflare cancels
+ * `waitUntil` work ~30 s after the invocation ends, but `GateLogic.leaseMs`
+ * (15 s, `psd/gate-logic.ts`) reclaims the single-flight lease first. Outrunning
+ * the lease is the worse failure: the next reader becomes leader and forks a
+ * SECOND full fan-out under exactly the load that made the first one slow, and
+ * the original's `endFlight` then releases the new leader's flight. So this must
+ * stay strictly under `leaseMs`, not merely under the `waitUntil` budget.
+ *
+ * 12 s leaves 3 s of lease headroom for the failure-path KV write. The gate
+ * paces 5 PSD calls/s globally, so a 19-call fan-out is ~3.8 s uncontended —
+ * 12 s tolerates roughly 3 concurrent fan-outs before it starts tripping. */
+export const BG_REFRESH_TIMEOUT_MS = 12_000;
 
 /** Dedup window for the slow-drift nudge: at most one Slack ping per day per key. */
 export const NUDGE_MARKER_TTL = 60 * 60 * 24; // 24 h
@@ -155,7 +168,11 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         const backgroundTimeoutMs =
           options?.backgroundTimeoutMs ?? BG_REFRESH_TIMEOUT_MS;
 
-        /** Drift = time spent past the soft TTL. See DRIFT_NUDGE_THRESHOLD. */
+        /** Time (ms) a value has spent PAST its soft TTL — the drift measure.
+         * The single place this arithmetic lives. See DRIFT_NUDGE_THRESHOLD. */
+        const staleFor = (fetchedAt: number, softTtlSec: number) =>
+          Date.now() - fetchedAt - softTtlSec * 1000;
+
         const isDrifting = (staleForMs: number) =>
           staleForMs > DRIFT_NUDGE_THRESHOLD * 1000;
 
@@ -166,14 +183,8 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             cache.delete(negKey(key)),
           );
 
-        // Keep the stale copy: log why and set the negative marker so subsequent
-        // requests serve stale without re-fanning until it expires. Given an
-        // `alert` context, the log escalates WARN→ERROR when an outage is open OR
-        // the value has drifted past the nudge threshold, and a once/day/key
-        // slow-drift Slack nudge fires while drifting (#2329). Called without
-        // `alert` for keeps that carry no stale-age context → plain WARN.
-        // Slack keeps reporting ABSOLUTE age + time-to-cliff; only the drift
-        // decision is soft-TTL-relative (#2335).
+        // Slow-drift Slack ping, once per day per key. Reports ABSOLUTE age +
+        // time-to-cliff — only the decision to call this is soft-TTL-relative.
         const nudge = (staleAgeMs: number, status?: number) =>
           Effect.gen(function* () {
             // Once/day/key: skip if we already pinged within the marker window.
@@ -192,24 +203,34 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             );
           });
 
+        // Keep the stale copy: log why and set the negative marker so subsequent
+        // requests serve stale without re-fanning until it expires. Given an
+        // `alert` context, the log escalates WARN→ERROR when an outage is open OR
+        // the value is drifting (#2329). Called without `alert` for keeps that
+        // carry no stale-age context → plain WARN.
         const keepStale = (
           reason: string,
           alert?: {
-            /** Absolute age of the served value — what Slack reports. */
-            readonly staleAgeMs: number;
-            /** Age past the soft TTL — what decides drift. */
-            readonly staleForMs: number;
+            readonly fetchedAt: number;
+            readonly softTtlSec: number;
             readonly incidentOpen: boolean;
             readonly status?: number;
           },
         ) =>
           Effect.gen(function* () {
-            const drifting = !!alert && isDrifting(alert.staleForMs);
+            const drifting =
+              !!alert &&
+              isDrifting(staleFor(alert.fetchedAt, alert.softTtlSec));
             const escalate = !!alert && (alert.incidentOpen || drifting);
             const line = `TypedKvCache "${key}": ${reason}`;
             yield* escalate ? Effect.logError(line) : Effect.logWarning(line);
             yield* cache.set(negKey(key), "1", NEG_MARKER_TTL);
-            if (alert && drifting) yield* nudge(alert.staleAgeMs, alert.status);
+            // Fallback nudge only: the read-path check fires first on every
+            // stale read and normally claims the once/day marker, so this covers
+            // the case where its KV write did not land. It carries `status`,
+            // which the read path has no access to.
+            if (alert && drifting)
+              yield* nudge(Date.now() - alert.fetchedAt, alert.status);
           });
 
         // Report a transient-outage refresh failure to the gate (incident
@@ -232,8 +253,8 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
               staleAgeMs,
             });
             yield* keepStale(`${label} (${String(err)})`, {
-              staleAgeMs,
-              staleForMs: staleAgeMs - softTtlSec * 1000,
+              fetchedAt,
+              softTtlSec,
               incidentOpen,
               status,
             });
@@ -292,7 +313,6 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
                 Effect.timeoutOption(backgroundTimeoutMs),
               );
               if (Option.isNone(outcome)) {
-                const staleAgeMs = Date.now() - fetchedAt;
                 // Deliberately no `reportOutcome`: a slow fan-out under load is
                 // not proof PSD is down (the global 5/s pacer alone makes ~5
                 // concurrent fan-outs this slow), and reporting it would open
@@ -300,11 +320,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
                 // surface through the drift nudge instead.
                 return yield* keepStale(
                   `background refresh timed out after ${backgroundTimeoutMs}ms`,
-                  {
-                    staleAgeMs,
-                    staleForMs: staleAgeMs - softTtlSec * 1000,
-                    incidentOpen: false,
-                  },
+                  { fetchedAt, softTtlSec, incidentOpen: false },
                 );
               }
               const result = outcome.value;
@@ -324,14 +340,13 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
               }
               yield* gate.reportOutcome({ ok: true, key });
               const valid = S.decodeUnknownOption(schema)(result.right);
-              const staleAgeMs = Date.now() - fetchedAt;
               yield* Option.isSome(valid)
                 ? persist(result.right)
                 : // Not a PSD outage (200 w/ bad shape), but the value still
                   // drifts toward the cliff — nudge if it's aged past threshold.
                   keepStale("background refresh returned schema-invalid data", {
-                    staleAgeMs,
-                    staleForMs: staleAgeMs - softTtlSec * 1000,
+                    fetchedAt,
+                    softTtlSec,
                     incidentOpen: false,
                   });
             }).pipe(Effect.ensuring(gate.endFlight(key)));
@@ -346,9 +361,9 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             const { value, fetchedAt } = decoded.value;
             const resolvedSoftTtl =
               typeof softTtl === "function" ? softTtl(value) : softTtl;
-            const isFresh = (Date.now() - fetchedAt) / 1000 <= resolvedSoftTtl;
+            const staleForMs = staleFor(fetchedAt, resolvedSoftTtl);
 
-            if (isFresh) return value;
+            if (staleForMs <= 0) return value; // fresh
 
             // ── Stale ────────────────────────────────────────────────────────
             // Drift check FIRST (#2335). Every other drift signal hangs off a
@@ -359,13 +374,20 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             // marker keeps being re-set still nudges. Pure arithmetic: the
             // once/day dedup read only happens on a genuinely drifting key, so
             // the normal stale path costs no extra KV I/O.
-            const staleAgeMs = Date.now() - fetchedAt;
-            const staleForMs = staleAgeMs - resolvedSoftTtl * 1000;
             if (isDrifting(staleForMs)) {
               yield* Effect.logError(
-                `TypedKvCache "${key}": serving stale ${Math.round(staleForMs / 1000)}s past its soft TTL — refreshes are not landing`,
+                `TypedKvCache "${key}": serving stale ${formatDuration(staleForMs)} past its soft TTL — refreshes are not landing`,
               );
-              yield* nudge(staleAgeMs);
+              // Detached: the nudge does a KV get + set + an unbounded Slack
+              // POST, and this is the serve-stale-INSTANTLY path. Inline only
+              // when no runner is wired (no `waitUntil` to hand it to).
+              const ping = nudge(Date.now() - fetchedAt);
+              yield* Option.isSome(runnerOpt)
+                ? runnerOpt.value.fork(
+                    `drift:${key}`,
+                    ping as Effect.Effect<void, unknown, PsdRefreshEnv>,
+                  )
+                : ping;
             }
 
             // Negative marker present → a recent refresh failed; serve stale

--- a/apps/api/src/cache/kv-cache.ts
+++ b/apps/api/src/cache/kv-cache.ts
@@ -32,9 +32,22 @@ export const TTL = {
  * (KV's minimum expirationTtl is 60 s.) */
 export const NEG_MARKER_TTL = 120; // 2 min
 
-/** Serve-stale age (seconds) past which we escalate logs WARN→ERROR and emit a
- * slow-drift Slack nudge — the value is creeping toward the hard-expiry cliff. */
+/** Time (seconds) a value may sit PAST ITS SOFT TTL before we escalate logs
+ * WARN→ERROR and emit a slow-drift Slack nudge — refreshes are not landing and
+ * the value is creeping toward the hard-expiry cliff.
+ *
+ * Measured relative to the soft TTL, not as absolute age (#2335): a healthy
+ * 24 h-softTtl key (`MATCHES_TEAM`, `RANKING`) is stale by design between
+ * refreshes, so an absolute rule would nudge on every normal cycle. */
 export const DRIFT_NUDGE_THRESHOLD = 60 * 60 * 24; // 24 h (#2329)
+
+/** Ceiling on a background (SWR) refresh fetch, so a slow one takes the normal
+ * failure path (negative marker + escalating log) instead of being silently
+ * killed (#2335). Cloudflare cancels `waitUntil` work ~30 s after the invocation
+ * ends; 20 s leaves ~10 s of headroom for the failure-path KV write + Slack POST.
+ * The gate paces 5 PSD calls/s globally, so a 19-call fan-out is ~3.8 s
+ * uncontended — 20 s tolerates roughly 5 concurrent fan-outs. */
+export const BG_REFRESH_TIMEOUT_MS = 20_000;
 
 /** Dedup window for the slow-drift nudge: at most one Slack ping per day per key. */
 export const NUDGE_MARKER_TTL = 60 * 60 * 24; // 24 h
@@ -122,6 +135,9 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
          * "next" list whose kickoff has already passed), refresh blocking rather
          * than serving stale. */
         mustBlockOnStale?: (value: A) => boolean;
+        /** Ceiling on the background (SWR) refresh fetch. Defaults to
+         * {@link BG_REFRESH_TIMEOUT_MS}; tests drive it with a small value. */
+        backgroundTimeoutMs?: number;
       },
     ): Effect.Effect<
       A,
@@ -136,6 +152,12 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         const effectiveHardTtl =
           env.CACHE_LONG_TTL === "true" ? HARD_TTL_LONG : hardTtl;
         const shouldServeStale = options?.shouldServeStale ?? (() => true);
+        const backgroundTimeoutMs =
+          options?.backgroundTimeoutMs ?? BG_REFRESH_TIMEOUT_MS;
+
+        /** Drift = time spent past the soft TTL. See DRIFT_NUDGE_THRESHOLD. */
+        const isDrifting = (staleForMs: number) =>
+          staleForMs > DRIFT_NUDGE_THRESHOLD * 1000;
 
         // Persist a fresh value and clear any negative marker.
         const persist = (value: A) =>
@@ -150,6 +172,8 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         // the value has drifted past the nudge threshold, and a once/day/key
         // slow-drift Slack nudge fires while drifting (#2329). Called without
         // `alert` for keeps that carry no stale-age context → plain WARN.
+        // Slack keeps reporting ABSOLUTE age + time-to-cliff; only the drift
+        // decision is soft-TTL-relative (#2335).
         const nudge = (staleAgeMs: number, status?: number) =>
           Effect.gen(function* () {
             // Once/day/key: skip if we already pinged within the marker window.
@@ -171,14 +195,16 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         const keepStale = (
           reason: string,
           alert?: {
+            /** Absolute age of the served value — what Slack reports. */
             readonly staleAgeMs: number;
+            /** Age past the soft TTL — what decides drift. */
+            readonly staleForMs: number;
             readonly incidentOpen: boolean;
             readonly status?: number;
           },
         ) =>
           Effect.gen(function* () {
-            const drifting =
-              !!alert && alert.staleAgeMs > DRIFT_NUDGE_THRESHOLD * 1000;
+            const drifting = !!alert && isDrifting(alert.staleForMs);
             const escalate = !!alert && (alert.incidentOpen || drifting);
             const line = `TypedKvCache "${key}": ${reason}`;
             yield* escalate ? Effect.logError(line) : Effect.logWarning(line);
@@ -192,6 +218,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         const failAndKeepStale = (
           err: unknown,
           fetchedAt: number,
+          softTtlSec: number,
           label: string,
         ) =>
           Effect.gen(function* () {
@@ -206,6 +233,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             });
             yield* keepStale(`${label} (${String(err)})`, {
               staleAgeMs,
+              staleForMs: staleAgeMs - softTtlSec * 1000,
               incidentOpen,
               status,
             });
@@ -222,7 +250,11 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         // serve-stale error (setting the negative marker so we stop re-fanning),
         // propagate otherwise. Used by the correctness guard and, when no
         // background runner is wired, as the stale fallback.
-        const blockingRefresh = (staleValue: A, fetchedAt: number) =>
+        const blockingRefresh = (
+          staleValue: A,
+          fetchedAt: number,
+          softTtlSec: number,
+        ) =>
           Effect.gen(function* () {
             const result = yield* fetch.pipe(Effect.either);
             if (Either.isRight(result)) {
@@ -237,6 +269,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             yield* failAndKeepStale(
               result.left,
               fetchedAt,
+              softTtlSec,
               "refresh failed, serving stale",
             );
             return staleValue;
@@ -245,12 +278,36 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
         // Background (SWR) refresh: single-flight leader fetches and updates KV;
         // any failure (or schema-invalid data) keeps stale + marks. Never throws
         // — it runs detached via the background runner.
-        const backgroundRefresh = (fetchedAt: number) =>
+        const backgroundRefresh = (fetchedAt: number, softTtlSec: number) =>
           Effect.gen(function* () {
             const leader = yield* gate.beginFlight(key);
             if (!leader) return; // another isolate/fiber is already refreshing
             yield* Effect.gen(function* () {
-              const result = yield* fetch.pipe(Effect.either);
+              // Bounded (#2335): a refresh that outruns the `waitUntil` budget
+              // gets killed mid-flight, so NONE of the handlers below run — no
+              // marker, no log, no nudge, and every next request re-forks the
+              // same doomed refresh while the value drifts toward the cliff.
+              const outcome = yield* fetch.pipe(
+                Effect.either,
+                Effect.timeoutOption(backgroundTimeoutMs),
+              );
+              if (Option.isNone(outcome)) {
+                const staleAgeMs = Date.now() - fetchedAt;
+                // Deliberately no `reportOutcome`: a slow fan-out under load is
+                // not proof PSD is down (the global 5/s pacer alone makes ~5
+                // concurrent fan-outs this slow), and reporting it would open
+                // spurious "PSD outage started" pings. Sustained timeouts
+                // surface through the drift nudge instead.
+                return yield* keepStale(
+                  `background refresh timed out after ${backgroundTimeoutMs}ms`,
+                  {
+                    staleAgeMs,
+                    staleForMs: staleAgeMs - softTtlSec * 1000,
+                    incidentOpen: false,
+                  },
+                );
+              }
+              const result = outcome.value;
               if (Either.isLeft(result)) {
                 if (!shouldServeStale(result.left)) {
                   // Non-outage failure (decode) → keep stale, plain WARN.
@@ -261,17 +318,20 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
                 return yield* failAndKeepStale(
                   result.left,
                   fetchedAt,
+                  softTtlSec,
                   "background refresh failed",
                 );
               }
               yield* gate.reportOutcome({ ok: true, key });
               const valid = S.decodeUnknownOption(schema)(result.right);
+              const staleAgeMs = Date.now() - fetchedAt;
               yield* Option.isSome(valid)
                 ? persist(result.right)
                 : // Not a PSD outage (200 w/ bad shape), but the value still
                   // drifts toward the cliff — nudge if it's aged past threshold.
                   keepStale("background refresh returned schema-invalid data", {
-                    staleAgeMs: Date.now() - fetchedAt,
+                    staleAgeMs,
+                    staleForMs: staleAgeMs - softTtlSec * 1000,
                     incidentOpen: false,
                   });
             }).pipe(Effect.ensuring(gate.endFlight(key)));
@@ -291,6 +351,23 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             if (isFresh) return value;
 
             // ── Stale ────────────────────────────────────────────────────────
+            // Drift check FIRST (#2335). Every other drift signal hangs off a
+            // refresh reporting its outcome, and a `waitUntil` refresh that gets
+            // killed reports nothing — so this read-path check is the only one
+            // that fires regardless of whether any refresh ever ran. It also
+            // sits above the negative-marker early-return below, so a key whose
+            // marker keeps being re-set still nudges. Pure arithmetic: the
+            // once/day dedup read only happens on a genuinely drifting key, so
+            // the normal stale path costs no extra KV I/O.
+            const staleAgeMs = Date.now() - fetchedAt;
+            const staleForMs = staleAgeMs - resolvedSoftTtl * 1000;
+            if (isDrifting(staleForMs)) {
+              yield* Effect.logError(
+                `TypedKvCache "${key}": serving stale ${Math.round(staleForMs / 1000)}s past its soft TTL — refreshes are not landing`,
+              );
+              yield* nudge(staleAgeMs);
+            }
+
             // Negative marker present → a recent refresh failed; serve stale
             // instantly and do not re-fan. This wins even over the correctness
             // guard below: during an outage, a bounded ≤2 min of possibly-wrong
@@ -302,7 +379,7 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
             // Correctness guard: a stale value that is now wrong (past-kickoff
             // "next") must not be served — refresh blocking.
             if (options?.mustBlockOnStale?.(value)) {
-              return yield* blockingRefresh(value, fetchedAt);
+              return yield* blockingRefresh(value, fetchedAt, resolvedSoftTtl);
             }
 
             if (Option.isSome(runnerOpt)) {
@@ -310,17 +387,16 @@ export const TypedKvCache = <A, I>(schema: S.Schema<A, I>) => {
               // background (single-flight) via the runner — see background-live.ts.
               // Cast is safe: only PSD handlers provide a runner, and its layer
               // covers this refresh's deps (a non-PSD caller has no runner here).
-              const refresh = backgroundRefresh(fetchedAt) as Effect.Effect<
-                void,
-                unknown,
-                PsdRefreshEnv
-              >;
+              const refresh = backgroundRefresh(
+                fetchedAt,
+                resolvedSoftTtl,
+              ) as Effect.Effect<void, unknown, PsdRefreshEnv>;
               yield* runnerOpt.value.fork(`refresh:${key}`, refresh);
               return value;
             }
 
             // No background runner wired → fall back to a blocking refresh.
-            return yield* blockingRefresh(value, fetchedAt);
+            return yield* blockingRefresh(value, fetchedAt, resolvedSoftTtl);
           }
         }
 


### PR DESCRIPTION
Closes #2335

A background SWR refresh that is **killed** rather than **failed** left no trace anywhere: Cloudflare cancels `waitUntil` work ~30 s after the invocation ends, and none of `backgroundRefresh`'s handlers run — no negative marker, no incident report, no drift nudge. The value drifted toward the 7-day hard-expiry cliff behind a clean `200` and a clean log. That is how #2334 stayed stale for 98 hours until a reader noticed a finished match still showing its preview.

## Changes

**Bound the background refresh.** `BG_REFRESH_TIMEOUT_MS` caps the SWR fetch so a slow one takes the normal failure path instead of being killed. A timed-out refresh sets the negative marker and escalates its log, but deliberately does **not** call `gate.reportOutcome` — the pacer alone makes ~3 concurrent fan-outs this slow, so reporting them would open spurious "PSD outage started" pings. `blockingRefresh` stays unbounded (it runs inside the request's own lifetime, so nothing kills it out from under its handlers).

**Read-path drift check.** Evaluates stale age on every stale serve, placed *before* the negative-marker early-return so a repeatedly-marked key still surfaces. It is the only signal that does not depend on a refresh path executing at all. Drift is now measured as **time past the soft TTL**, not absolute age — the absolute rule fires the instant a healthy 24 h-softTtl key (`matches:team`, `ranking`) goes stale on a perfectly normal cycle. The same rule governs `keepStale`'s WARN→ERROR escalation. Slack still reports absolute age + time-to-cliff.

## Deviation from the spec — please sanity-check

The issue settled `BG_REFRESH_TIMEOUT_MS = 20_000`, derived against the ~30 s `waitUntil` budget. **It shipped as `12_000`.** The spec did not weigh `GateLogic.leaseMs`, which defaults to **15 s** and is what `gate-do.ts` runs with — so 20 s is on the wrong side of the binding ceiling:

- at t=15 s the refresh has lost its flight lease, so the next reader becomes leader and forks a **second** full ~19-call fan-out under exactly the load that made the first one slow — the storm the gate exists to prevent;
- at t=20 s the original times out, and its `Effect.ensuring(gate.endFlight(key))` deletes the flight record by key with no ownership check, releasing the *new* leader's lease and waking its `awaitFlight` waiters early.

12 s keeps 3 s of lease headroom for the failure-path KV write and still tolerates ~3 concurrent fan-outs. A unit test pins `BG_REFRESH_TIMEOUT_MS < 15_000` so the coupling can't silently rot. `GateLogic` itself is untouched (out of scope per the issue).

## Testing

`pnpm --filter @kcvv/api lint && type-check && test` — clean, **444 passing** (`apps/api` has no `check-all`). No `apps/web` or `packages/*` files changed, so `@kcvv/web check-all` was not run.

Five new tests per the spec's checklist, plus one constant guard:

- hanging fetch + small `backgroundTimeoutMs` → negative marker written, `reportOutcome` **not** called
- a timed-out refresh on a drifting key escalates **its own** log line to ERROR
- value stale past threshold with no failed refresh → nudge from the read path
- same key read twice while drifting → **one** nudge (once/day dedup holds)
- 24 h-softTtl key stale by 1 min → no nudge, no ERROR (the false-positive regression guard)
- drifting key **with** a negative marker present → still nudges

Both directions were mutation-checked: reverting `keepStale` to the absolute-age rule fails the 24 h guard, and dropping its WARN→ERROR escalation fails three tests.

## Review gate

`/code-review` (both axes) and `/simplify` (4 agents) ran on the branch.

**Applied:** the timeout-vs-lease finding above · the read-path nudge did a KV get + set + an **unbounded** Slack POST inline on the serve-stale-*instantly* path (`postSlack` has no `AbortSignal`) — now forked through the background runner, inline only when no runner is wired · drift log renders through the existing `formatDuration` (`3d 0h`, not `259200s`) · `isFresh` derives from `staleFor` instead of recomputing it · one `staleFor` helper replaces four copies of the arithmetic, and `keepStale` takes `{ fetchedAt, softTtlSec }` rather than two pre-derived ages · misplaced comment block moved onto `keepStale` · test helpers `isolatedGate`/`dayMs`/`captureLogs` hoisted and reused, `spyGate` wraps the real gate layer · `apps/api/CLAUDE.md` structure block refreshed for the #2328/#2329 files it never listed.

**A reviewer flagged and I did not change:** `keepStale`'s nudge is redundant in practice — the read-path check fires first on every stale read and claims the once/day marker, so `keepStale`'s ping is normally deduped out and its `status` field (the `(last refresh: HTTP 429)` suffix) rarely reaches Slack. Removing it would contradict the issue's decision 4 ("applies to **both** the new read-path check and the existing `keepStale` path"), so it stays as a documented fallback for the case where the read-path KV write did not land. Worth revisiting if the lost status suffix matters.

**Skipped:** `fetch` takes no `AbortSignal`, so the timeout abandons the fan-out without cancelling it — in-flight PSD calls run to completion. Real, but it needs `service.ts` fetch plumbing and is out of scope here; noted in `apps/api/CLAUDE.md`. · Moving `captureLogs` into `src/test-helpers/` would retire two more copies in `service.test.ts` / `sanity-index-sync.test.ts` — repo-wide cleanup, not this branch. · Moving the stale-path closures inside the `Option.isSome(decoded)` block would delete the `softTtlSec` threading, but costs a ~170-line reindent on a hot file for no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
