### PR TITLE
docs(config): record the design system, and fix the drift writing it down exposed

### DIFF
--- a/apps/web/.impeccable/design.json
+++ b/apps/web/.impeccable/design.json
@@ -523,7 +523,7 @@
       },
       {
         "name": "The No-Grey-UI Rule",
-        "body": "There is no neutral grey chrome layer. A surface is cream, a step of cream, or ink. One exception survives: `gray-100` (#f3f4f6) is the `<SectionStack>` surface behind five homepage sections — the news grid and the three banner strips. The components on it are fully redesigned; only the surface underneath is pre-redesign. It is the single cool grey in a warm system and must not spread — new section surfaces use a cream step.",
+        "body": "There is no neutral grey chrome layer. A surface is cream, a step of cream, or ink. One exception survives: `gray-100` (#f3f4f6) is the `<SectionStack>` surface behind four homepage sections — the news grid and the three banner strips. The components on it are fully redesigned; only the surface underneath is pre-redesign. It is the single cool grey in a warm system and must not spread — new section surfaces use a cream step.",
         "section": "colors"
       },
       {
@@ -603,7 +603,7 @@
       "Don't pin a Display-size heading's italic accent to a heavy weight — Freight Big Pro has no 900 italic.",
       "Don't add a new typeface. Freight Sans Pro, Freight Display Pro, Freight Big Pro and IBM Plex Mono are the whole set.",
       "Don't build a 16px semibold sans \"section label\" register between display serif and 11px mono.",
-      "Don't spread gray-100 beyond the five homepage sections that already use it; new section surfaces step through cream. (foundation-gray-light and the four table-* tokens have been removed — they had no consumers.)",
+      "Don't spread gray-100 beyond the four homepage sections that already use it; new section surfaces step through cream. (foundation-gray-light and the four table-* tokens have been removed — they had no consumers.)",
       "Don't rely on hover to reveal anything necessary — the primary usage scene is a phone, outdoors.",
       "Don't use emoji as icons."
     ]

--- a/apps/web/.impeccable/design.json
+++ b/apps/web/.impeccable/design.json
@@ -1,0 +1,611 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-04T00:00:00Z",
+  "title": "Design System: KCVV Elewijt",
+  "extensions": {
+    "colorMeta": {
+      "cream": {
+        "role": "neutral",
+        "displayName": "Paper Cream",
+        "canonical": "oklch(95.5% 0.018 92)",
+        "tonalRamp": [
+          "oklch(15% 0.018 92)",
+          "oklch(26% 0.018 92)",
+          "oklch(37% 0.018 92)",
+          "oklch(49% 0.018 92)",
+          "oklch(60% 0.018 92)",
+          "oklch(72% 0.018 92)",
+          "oklch(83% 0.018 92)",
+          "oklch(95% 0.018 92)"
+        ]
+      },
+      "cream-soft": {
+        "role": "neutral",
+        "displayName": "Soft Cream",
+        "canonical": "oklch(92.5% 0.021 92)",
+        "tonalRamp": [
+          "oklch(15% 0.021 92)",
+          "oklch(26% 0.021 92)",
+          "oklch(37% 0.021 92)",
+          "oklch(49% 0.021 92)",
+          "oklch(60% 0.021 92)",
+          "oklch(72% 0.021 92)",
+          "oklch(83% 0.021 92)",
+          "oklch(95% 0.021 92)"
+        ]
+      },
+      "cream-deep": {
+        "role": "neutral",
+        "displayName": "Deep Cream",
+        "canonical": "oklch(87.4% 0.037 90)",
+        "tonalRamp": [
+          "oklch(15% 0.037 90)",
+          "oklch(26% 0.037 90)",
+          "oklch(37% 0.037 90)",
+          "oklch(49% 0.037 90)",
+          "oklch(60% 0.037 90)",
+          "oklch(72% 0.037 90)",
+          "oklch(83% 0.037 90)",
+          "oklch(95% 0.037 90)"
+        ]
+      },
+      "paper-edge": {
+        "role": "neutral",
+        "displayName": "Paper Edge",
+        "canonical": "oklch(84.8% 0.031 92)",
+        "tonalRamp": [
+          "oklch(15% 0.031 92)",
+          "oklch(26% 0.031 92)",
+          "oklch(37% 0.031 92)",
+          "oklch(49% 0.031 92)",
+          "oklch(60% 0.031 92)",
+          "oklch(72% 0.031 92)",
+          "oklch(83% 0.031 92)",
+          "oklch(95% 0.031 92)"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Press Ink",
+        "canonical": "oklch(14.5% 0 0)",
+        "tonalRamp": [
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(37% 0 0)",
+          "oklch(49% 0 0)",
+          "oklch(60% 0 0)",
+          "oklch(72% 0 0)",
+          "oklch(83% 0 0)",
+          "oklch(95% 0 0)"
+        ]
+      },
+      "ink-soft": {
+        "role": "neutral",
+        "displayName": "Soft Ink",
+        "canonical": "oklch(23.8% 0 0)",
+        "tonalRamp": [
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(37% 0 0)",
+          "oklch(49% 0 0)",
+          "oklch(60% 0 0)",
+          "oklch(72% 0 0)",
+          "oklch(83% 0 0)",
+          "oklch(95% 0 0)"
+        ]
+      },
+      "ink-muted": {
+        "role": "neutral",
+        "displayName": "Muted Ink",
+        "canonical": "oklch(51.6% 0 0)",
+        "tonalRamp": [
+          "oklch(15% 0 0)",
+          "oklch(26% 0 0)",
+          "oklch(37% 0 0)",
+          "oklch(49% 0 0)",
+          "oklch(60% 0 0)",
+          "oklch(72% 0 0)",
+          "oklch(83% 0 0)",
+          "oklch(95% 0 0)"
+        ]
+      },
+      "jersey-deep": {
+        "role": "primary",
+        "displayName": "Jersey Deep",
+        "canonical": "oklch(52.3% 0.128 158)",
+        "tonalRamp": [
+          "oklch(15% 0.128 158)",
+          "oklch(26% 0.128 158)",
+          "oklch(37% 0.128 158)",
+          "oklch(49% 0.128 158)",
+          "oklch(60% 0.128 158)",
+          "oklch(72% 0.128 158)",
+          "oklch(83% 0.128 158)",
+          "oklch(95% 0.128 158)"
+        ]
+      },
+      "jersey-link": {
+        "role": "primary",
+        "displayName": "Jersey Link",
+        "canonical": "oklch(48.7% 0.126 158)",
+        "tonalRamp": [
+          "oklch(15% 0.126 158)",
+          "oklch(26% 0.126 158)",
+          "oklch(37% 0.126 158)",
+          "oklch(49% 0.126 158)",
+          "oklch(60% 0.126 158)",
+          "oklch(72% 0.126 158)",
+          "oklch(83% 0.126 158)",
+          "oklch(95% 0.126 158)"
+        ]
+      },
+      "jersey": {
+        "role": "primary",
+        "displayName": "Terrace Green",
+        "canonical": "oklch(75.5% 0.198 146)",
+        "tonalRamp": [
+          "oklch(15% 0.198 146)",
+          "oklch(26% 0.198 146)",
+          "oklch(37% 0.198 146)",
+          "oklch(49% 0.198 146)",
+          "oklch(60% 0.198 146)",
+          "oklch(72% 0.198 146)",
+          "oklch(83% 0.198 146)",
+          "oklch(95% 0.198 146)"
+        ]
+      },
+      "jersey-bright": {
+        "role": "primary",
+        "displayName": "Bright Jersey",
+        "canonical": "oklch(72.3% 0.192 150)",
+        "tonalRamp": [
+          "oklch(15% 0.192 150)",
+          "oklch(26% 0.192 150)",
+          "oklch(37% 0.192 150)",
+          "oklch(49% 0.192 150)",
+          "oklch(60% 0.192 150)",
+          "oklch(72% 0.192 150)",
+          "oklch(83% 0.192 150)",
+          "oklch(95% 0.192 150)"
+        ]
+      },
+      "jersey-deep-dark": {
+        "role": "primary",
+        "displayName": "Retro Forest",
+        "canonical": "oklch(31.3% 0.061 156)",
+        "tonalRamp": [
+          "oklch(15% 0.061 156)",
+          "oklch(26% 0.061 156)",
+          "oklch(37% 0.061 156)",
+          "oklch(49% 0.061 156)",
+          "oklch(60% 0.061 156)",
+          "oklch(72% 0.061 156)",
+          "oklch(83% 0.061 156)",
+          "oklch(95% 0.061 156)"
+        ]
+      },
+      "warm": {
+        "role": "secondary",
+        "displayName": "Poster Yellow",
+        "canonical": "oklch(82.7% 0.113 82)",
+        "tonalRamp": [
+          "oklch(15% 0.113 82)",
+          "oklch(26% 0.113 82)",
+          "oklch(37% 0.113 82)",
+          "oklch(49% 0.113 82)",
+          "oklch(60% 0.113 82)",
+          "oklch(72% 0.113 82)",
+          "oklch(83% 0.113 82)",
+          "oklch(95% 0.113 82)"
+        ]
+      },
+      "tape-cream": {
+        "role": "secondary",
+        "displayName": "Ghost Tape",
+        "canonical": "rgb(232 224 200 / 0.85)",
+        "tonalRamp": [
+          "oklch(15% 0.028 92)",
+          "oklch(26% 0.028 92)",
+          "oklch(37% 0.028 92)",
+          "oklch(49% 0.028 92)",
+          "oklch(60% 0.028 92)",
+          "oklch(72% 0.028 92)",
+          "oklch(83% 0.028 92)",
+          "oklch(95% 0.028 92)"
+        ]
+      },
+      "alert": {
+        "role": "tertiary",
+        "displayName": "Dusty Brick",
+        "canonical": "oklch(53.5% 0.135 32)",
+        "tonalRamp": [
+          "oklch(15% 0.135 32)",
+          "oklch(26% 0.135 32)",
+          "oklch(37% 0.135 32)",
+          "oklch(49% 0.135 32)",
+          "oklch(60% 0.135 32)",
+          "oklch(72% 0.135 32)",
+          "oklch(83% 0.135 32)",
+          "oklch(95% 0.135 32)"
+        ]
+      },
+      "alert-soft": {
+        "role": "tertiary",
+        "displayName": "Dusty Brick Tint",
+        "canonical": "oklch(87.4% 0.028 32)",
+        "tonalRamp": [
+          "oklch(15% 0.028 32)",
+          "oklch(26% 0.028 32)",
+          "oklch(37% 0.028 32)",
+          "oklch(49% 0.028 32)",
+          "oklch(60% 0.028 32)",
+          "oklch(72% 0.028 32)",
+          "oklch(83% 0.028 32)",
+          "oklch(95% 0.028 32)"
+        ]
+      },
+      "warning": {
+        "role": "tertiary",
+        "displayName": "Aged Mustard",
+        "canonical": "oklch(67.3% 0.126 74)",
+        "tonalRamp": [
+          "oklch(15% 0.126 74)",
+          "oklch(26% 0.126 74)",
+          "oklch(37% 0.126 74)",
+          "oklch(49% 0.126 74)",
+          "oklch(60% 0.126 74)",
+          "oklch(72% 0.126 74)",
+          "oklch(83% 0.126 74)",
+          "oklch(95% 0.126 74)"
+        ]
+      },
+      "warning-soft": {
+        "role": "tertiary",
+        "displayName": "Aged Mustard Tint",
+        "canonical": "oklch(89.1% 0.049 88)",
+        "tonalRamp": [
+          "oklch(15% 0.049 88)",
+          "oklch(26% 0.049 88)",
+          "oklch(37% 0.049 88)",
+          "oklch(49% 0.049 88)",
+          "oklch(60% 0.049 88)",
+          "oklch(72% 0.049 88)",
+          "oklch(83% 0.049 88)",
+          "oklch(95% 0.049 88)"
+        ]
+      },
+      "success-soft": {
+        "role": "tertiary",
+        "displayName": "Sage Tint",
+        "canonical": "oklch(90.2% 0.041 140)",
+        "tonalRamp": [
+          "oklch(15% 0.041 140)",
+          "oklch(26% 0.041 140)",
+          "oklch(37% 0.041 140)",
+          "oklch(49% 0.041 140)",
+          "oklch(60% 0.041 140)",
+          "oklch(72% 0.041 140)",
+          "oklch(83% 0.041 140)",
+          "oklch(95% 0.041 140)"
+        ]
+      },
+      "card-red": {
+        "role": "tertiary",
+        "displayName": "Card Red",
+        "canonical": "oklch(55.6% 0.174 38)",
+        "tonalRamp": [
+          "oklch(15% 0.174 38)",
+          "oklch(26% 0.174 38)",
+          "oklch(37% 0.174 38)",
+          "oklch(49% 0.174 38)",
+          "oklch(60% 0.174 38)",
+          "oklch(72% 0.174 38)",
+          "oklch(83% 0.174 38)",
+          "oklch(95% 0.174 38)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "Freight Big Pro at 900. Page-defining hero headings, at most one per page. Has no 900 italic — accent emphasis drops to Freight Display Pro italic."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Freight Display Pro at 700. Section-opening editorial headings."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Freight Display Pro at 700. The default editorial heading size."
+      },
+      "subtitle": {
+        "displayName": "Subtitle",
+        "purpose": "Card headings and sub-sections. A smaller 600-weight step exists below it."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Freight Sans Pro. All prose, capped at a 680px reading column."
+      },
+      "body-lg": {
+        "displayName": "Body Large",
+        "purpose": "Article leads and intro paragraphs."
+      },
+      "body-sm": {
+        "displayName": "Body Small",
+        "purpose": "Captions, hints and secondary copy."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "IBM Plex Mono. Scores, dates, stat values and inline data."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Uppercase mono at 11px / 0.08em. Kickers, badges, pills, statuses and navigation. The most-used non-body style in the system."
+      }
+    },
+    "shadows": [
+      {
+        "name": "paper-sm",
+        "value": "4px 4px 0 0 #0a0a0a",
+        "purpose": "The default hard offset. Buttons, badges, stamps, chrome."
+      },
+      {
+        "name": "paper-md",
+        "value": "6px 6px 0 0 #0a0a0a",
+        "purpose": "Cards at rest — the most common card weight."
+      },
+      {
+        "name": "paper-lift",
+        "value": "8px 8px 0 0 #0a0a0a",
+        "purpose": "Hover target of a tilt-mode card, and emphasis cards."
+      },
+      {
+        "name": "paper-sm-soft",
+        "value": "4px 4px 0 0 #6b6b6b",
+        "purpose": "Same offset in ink-muted, for surfaces on ink or dark-green fields where pure ink loses its silhouette. Also the resting shadow of every form field."
+      },
+      {
+        "name": "paper-sm-soft-hover",
+        "value": "3px 3px 0 0 #6b6b6b",
+        "purpose": "The 1px compression a form field makes on hover."
+      },
+      {
+        "name": "paper-sm-alert",
+        "value": "4px 4px 0 0 #e8d5cf",
+        "purpose": "Error-state field shadow, tinted so the offset reads as part of the alert moment."
+      },
+      {
+        "name": "paper-sm-alert-hover",
+        "value": "3px 3px 0 0 #e8d5cf",
+        "purpose": "Hover compression of the error-state field shadow."
+      }
+    ],
+    "motion": [
+      {
+        "name": "motion-fast",
+        "value": "150ms ease-out",
+        "purpose": "Colour-only transitions: nav links, dropdown open, field chrome."
+      },
+      {
+        "name": "motion-base",
+        "value": "240ms cubic-bezier(0.2, 0.8, 0.2, 1)",
+        "purpose": "Default easing for state transitions and content reveals."
+      },
+      {
+        "name": "motion-tape",
+        "value": "300ms ease-out",
+        "purpose": "Tape and paper movement."
+      },
+      {
+        "name": "press-down",
+        "value": "300ms cubic-bezier(0.4, 0, 0.2, 1)",
+        "purpose": "The canonical press-down on buttons and cards: translate(1px, 1px) with the shadow collapsing to none. Translate is gated behind motion-safe; the shadow collapse is not."
+      },
+      {
+        "name": "reveal",
+        "value": "500ms cubic-bezier(0.22, 1, 0.36, 1)",
+        "purpose": "Scroll-triggered fade-up for article bodies and timeline items. Fully disabled under prefers-reduced-motion."
+      }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "desk", "value": "960px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "2xl", "value": "1536px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The default call to action. Jersey-deep paper stamp that presses into its own shadow on hover.",
+      "html": "<button class=\"ds-btn ds-btn-primary\">Word lid <span class=\"ds-btn-arrow\" aria-hidden=\"true\">→</span></button>",
+      "css": ".ds-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 1rem; font-weight: 500; padding: 12px 32px; border: 2px solid var(--color-ink, #0a0a0a); border-radius: 0; cursor: pointer; transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-btn-primary { background: var(--color-jersey-deep, #008755); color: var(--color-cream, #f5f1e6); box-shadow: 4px 4px 0 0 var(--color-ink, #0a0a0a); } .ds-btn-primary:hover { filter: brightness(1.1); transform: translate(1px, 1px); box-shadow: none; } .ds-btn-primary:focus-visible { outline: 2px solid var(--color-jersey-deep, #008755); outline-offset: 2px; } .ds-btn-arrow { transition: transform 300ms ease-out; } .ds-btn-primary:hover .ds-btn-arrow { transform: translateX(4px); }"
+    },
+    {
+      "name": "Inverted Button",
+      "kind": "button",
+      "refersTo": "button-inverted",
+      "description": "Cream button for placement on ink or jersey-deep surfaces. Uses the muted-ink shadow so the offset stays visible against a dark field.",
+      "html": "<div class=\"ds-btn-inverted-stage\"><button class=\"ds-btn ds-btn-inverted\">Bekijk kalender</button></div>",
+      "css": ".ds-btn-inverted-stage { background: var(--color-ink, #0a0a0a); padding: 28px; } .ds-btn-inverted { display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 1rem; font-weight: 500; padding: 12px 32px; border: 2px solid var(--color-ink, #0a0a0a); border-radius: 0; cursor: pointer; background: var(--color-cream, #f5f1e6); color: var(--color-ink, #0a0a0a); box-shadow: 4px 4px 0 0 var(--color-ink-muted, #6b6b6b); transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-btn-inverted:hover { background: var(--color-cream-soft, #ede8da); transform: translate(1px, 1px); box-shadow: none; } .ds-btn-inverted:focus-visible { outline: 2px solid var(--color-jersey-deep, #008755); outline-offset: 2px; }"
+    },
+    {
+      "name": "Taped Card",
+      "kind": "card",
+      "refersTo": "card-paper",
+      "description": "The signature surface: cream paper, 2px ink border, hard offset shadow, a tape strip half-over the top edge, and a sub-degree resting rotation.",
+      "html": "<article class=\"ds-card\"><span class=\"ds-card-tape\" aria-hidden=\"true\"></span><p class=\"ds-card-kicker\">Wedstrijdverslag</p><h3 class=\"ds-card-title\">Drie punten in de <em>slotfase</em>.</h3><p class=\"ds-card-body\">Een late kopbal van de tweede paal beslist een taaie namiddag op de Driesstraat.</p></article>",
+      "css": ".ds-card { position: relative; display: block; max-width: 340px; background: var(--color-cream, #f5f1e6); color: var(--color-ink, #0a0a0a); border: 2px solid var(--color-ink, #0a0a0a); border-radius: 0; padding: 20px; box-shadow: 6px 6px 0 0 var(--color-ink, #0a0a0a); transform: rotate(-0.25deg); transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-card:hover { transform: rotate(-0.25deg) translate(1px, 1px); box-shadow: none; } .ds-card-tape { position: absolute; top: 0; left: 12%; width: 96px; height: 20px; background: var(--color-jersey, #4acf52); opacity: 0.9; transform: translateY(-50%) rotate(-0.5deg); pointer-events: none; } .ds-card-kicker { margin: 0 0 10px; font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.08em; line-height: 1; text-transform: uppercase; color: var(--color-ink, #0a0a0a); } .ds-card-title { margin: 0 0 10px; font-family: var(--font-display, \"freight-display-pro\", Georgia, serif); font-size: 1.6rem; font-weight: 700; line-height: 1.1; letter-spacing: -0.025em; } .ds-card-title em { font-style: italic; color: var(--color-jersey-deep, #008755); } .ds-card-body { margin: 0; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 1rem; line-height: 1.6; }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "One state of the eight-state field machine. Border weight encodes progress (idle / hover / filled / focus); shadow encodes pressure. Focus is the deepest press in the system.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">E-mailadres</span><input class=\"ds-input\" type=\"email\" placeholder=\"jij@voorbeeld.be\" /><span class=\"ds-field-hint\">We gebruiken dit enkel voor je inschrijving.</span></label>",
+      "css": ".ds-field { display: block; max-width: 320px; } .ds-field-label { display: block; margin-bottom: 8px; font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-ink, #0a0a0a); } .ds-input { width: 100%; height: 40px; padding: 0 16px; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 1rem; color: var(--color-ink, #0a0a0a); background: #ffffff; border: 2px solid rgba(10, 10, 10, 0.3); border-radius: 0; box-shadow: 4px 4px 0 0 var(--color-ink-muted, #6b6b6b); transition: all 150ms ease-out; } .ds-input::placeholder { color: rgba(10, 10, 10, 0.4); } .ds-input:hover { border-color: rgba(10, 10, 10, 0.4); box-shadow: 3px 3px 0 0 var(--color-ink-muted, #6b6b6b); transform: translate(1px, 1px); } .ds-input:focus { outline: none; border-color: var(--color-ink, #0a0a0a); box-shadow: none; transform: translate(2px, 2px); } .ds-field-hint { display: block; margin-top: 8px; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 0.875rem; font-style: italic; color: rgba(10, 10, 10, 0.6); }"
+    },
+    {
+      "name": "Field — Error State",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "The alert branch of the field machine: border and offset shadow both switch to the dusty-brick pair, and the error survives focus.",
+      "html": "<label class=\"ds-field\"><span class=\"ds-field-label\">E-mailadres</span><input class=\"ds-input-error\" type=\"email\" value=\"jij@\" /><span class=\"ds-field-error\">Vul een geldig e-mailadres in.</span></label>",
+      "css": ".ds-input-error { width: 100%; height: 40px; padding: 0 16px; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 1rem; color: var(--color-ink, #0a0a0a); background: #ffffff; border: 2px solid var(--color-alert, #b84a3a); border-radius: 0; box-shadow: 4px 4px 0 0 var(--color-alert-soft, #e8d5cf); transition: all 150ms ease-out; } .ds-input-error:hover { box-shadow: 3px 3px 0 0 var(--color-alert-soft, #e8d5cf); transform: translate(1px, 1px); } .ds-input-error:focus { outline: none; border-color: var(--color-alert, #b84a3a); box-shadow: none; transform: translate(2px, 2px); } .ds-field-error { display: inline-block; margin-top: 8px; padding: 4px 8px; background: var(--color-alert-soft, #e8d5cf); border: 2px solid var(--color-alert, #b84a3a); font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-alert, #b84a3a); }"
+    },
+    {
+      "name": "Mono Label Pill",
+      "kind": "chip",
+      "refersTo": "pill-jersey-deep",
+      "description": "The system's workhorse label. Uppercase mono at 11px / 0.08em, sharp corners. The jersey-deep pill uses pure white text — cream on jersey-deep fails AA.",
+      "html": "<span class=\"ds-pill ds-pill-jersey\">Competitie</span> <span class=\"ds-pill ds-pill-ink\">Uitwedstrijd</span> <span class=\"ds-pill ds-pill-cream\">Jeugd</span>",
+      "css": ".ds-pill { display: inline-block; padding: 4px 8px; font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 11px; font-weight: 500; line-height: 1; letter-spacing: 0.08em; text-transform: uppercase; border-radius: 0; } .ds-pill-jersey { background: var(--color-jersey-deep, #008755); color: #ffffff; } .ds-pill-ink { background: var(--color-ink, #0a0a0a); color: var(--color-cream, #f5f1e6); } .ds-pill-cream { background: var(--color-cream-soft, #ede8da); color: var(--color-ink, #0a0a0a); border: 1px solid var(--color-paper-edge, #d9d2bd); }"
+    },
+    {
+      "name": "Stamp Badge",
+      "kind": "custom",
+      "refersTo": "stamp-badge",
+      "description": "A rotated, content-bearing rubber stamp pinned over a card edge. Distinct from a tape strip: the stamp carries text, the tape is purely graphic.",
+      "html": "<div class=\"ds-stamp-host\"><span class=\"ds-stamp\">★ Uitverkocht</span><p class=\"ds-stamp-body\">Seizoensafsluiter — kantine, zaterdag 20u.</p></div>",
+      "css": ".ds-stamp-host { position: relative; max-width: 300px; margin-top: 18px; padding: 20px; background: var(--color-cream, #f5f1e6); border: 2px solid var(--color-ink, #0a0a0a); border-radius: 0; box-shadow: 6px 6px 0 0 var(--color-ink, #0a0a0a); } .ds-stamp { position: absolute; top: -14px; right: 36px; display: inline-block; padding: 6px 14px; background: var(--color-jersey-deep, #008755); color: var(--color-cream, #f5f1e6); border: 1.5px solid var(--color-ink, #0a0a0a); border-radius: 0; box-shadow: 4px 4px 0 0 var(--color-ink, #0a0a0a); font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; transform: rotate(2deg); } .ds-stamp-body { margin: 0; font-family: var(--font-family-body, \"freight-sans-pro\", Arial, sans-serif); font-size: 1rem; line-height: 1.6; color: var(--color-ink, #0a0a0a); }"
+    },
+    {
+      "name": "Navigation",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "Uppercase mono nav on cream. Colour-only state change over 150ms; the utility action carries a 1px ink border that recolours on hover.",
+      "html": "<nav class=\"ds-nav\" aria-label=\"Hoofdnavigatie\"><a class=\"ds-nav-link ds-nav-link-active\" href=\"#\">Nieuws</a><a class=\"ds-nav-link\" href=\"#\">Ploegen</a><a class=\"ds-nav-link\" href=\"#\">Jeugd</a><a class=\"ds-nav-link\" href=\"#\">Kalender</a><a class=\"ds-nav-action\" href=\"#\">Word lid</a></nav>",
+      "css": ".ds-nav { display: flex; align-items: center; gap: 22px; padding: 16px 20px; background: var(--color-cream, #f5f1e6); } .ds-nav-link { font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 13px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; text-decoration: none; white-space: nowrap; color: var(--color-ink, #0a0a0a); transition: color 150ms ease-out; } .ds-nav-link:hover, .ds-nav-link:focus-visible { color: var(--color-jersey-deep, #008755); } .ds-nav-link-active { color: var(--color-jersey-deep, #008755); } .ds-nav-action { margin-left: auto; padding: 8px 14px; font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 13px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; text-decoration: none; white-space: nowrap; color: var(--color-ink, #0a0a0a); border: 1px solid var(--color-ink, #0a0a0a); border-radius: 0; transition: color 150ms ease-out, border-color 150ms ease-out; } .ds-nav-action:hover, .ds-nav-action:focus-visible { color: var(--color-jersey-deep, #008755); border-color: var(--color-jersey-deep, #008755); }"
+    },
+    {
+      "name": "Editorial Heading",
+      "kind": "custom",
+      "refersTo": "headline",
+      "description": "Serif display type set tight with exactly one emphasis moment — an accent italic word — and an auto-terminated period. The accent em drops to Freight Display Pro because Freight Big Pro has no 900 italic.",
+      "html": "<h2 class=\"ds-heading\">Er is maar één <em>plezante</em> compagnie.</h2>",
+      "css": ".ds-heading { margin: 0; max-width: 12ch; font-family: var(--font-display-big, \"freight-big-pro\", Georgia, serif); font-size: clamp(2.5rem, 1.5rem + 5vw, 4rem); font-weight: 900; line-height: 1; letter-spacing: -0.025em; color: var(--color-ink, #0a0a0a); } .ds-heading em { font-family: var(--font-display, \"freight-display-pro\", Georgia, serif); font-weight: 700; font-style: italic; color: var(--color-jersey-deep, #008755); }"
+    },
+    {
+      "name": "Striped Seam",
+      "kind": "custom",
+      "refersTo": "card-ink",
+      "description": "A full-bleed 45° two-tone stripe band used as a section rule. Four colour pairs; the angle can flip so a top and bottom seam lean toward each other and tape a section shut.",
+      "html": "<div class=\"ds-seam-stack\"><svg class=\"ds-seam\" role=\"presentation\" aria-hidden=\"true\" width=\"100%\" height=\"18\"><defs><pattern id=\"ds-seam-p\" patternUnits=\"userSpaceOnUse\" width=\"16\" height=\"16\" patternTransform=\"rotate(-45)\"><rect x=\"0\" y=\"0\" width=\"8\" height=\"16\" fill=\"#0a0a0a\"/><rect x=\"8\" y=\"0\" width=\"8\" height=\"16\" fill=\"#f5f1e6\"/></pattern></defs><rect width=\"100%\" height=\"100%\" fill=\"url(#ds-seam-p)\"/></svg><p class=\"ds-seam-caption\">Volgende wedstrijd</p></div>",
+      "css": ".ds-seam-stack { background: var(--color-cream, #f5f1e6); } .ds-seam { display: block; } .ds-seam-caption { margin: 16px 0 0; font-family: var(--font-family-mono, \"IBM Plex Mono\", monospace); font-size: 11px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-ink, #0a0a0a); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Retro-Terrace Fanzine",
+    "overview": "This is a self-published supporter zine that happens to be a website. Everything is printed on cream paper stock, everything is drawn in hard black ink, and everything that matters is stuck down with tape or hit with a rubber stamp. Nothing glows, nothing blurs, nothing floats. The page has a physical thickness: cards cast a hard offset shadow with no blur, as if a rectangle of paper were laid on the page and lit from a single fixed point. Press one and it slides into its own shadow.\n\nThe register is confident and slightly rough. Headlines are enormous serif display type set tight, with a single italic word pulled out in green or a hand-drawn highlighter stroke swiped across it. Structural labels — kickers, statuses, timestamps, scores — are set in uppercase monospace at 11px, tracked wide, the typeface of a photocopied team sheet. Photographs are warm-tinted like aged newsprint and laid on the page under a barely-visible paper grain. Tape strips sit at sub-degree angles, enough to break the perfect grid without looking seasick.\n\nWhat this deliberately is not: the Sportlink/Twizzit amateur-club house style (stock hero, rounded cards, generic sans, logo on a blue gradient); modern SaaS product UI (soft blurred shadows, gradient fills, glassmorphism, Inter); and big-club broadcast slick (dark glossy panels, neon data viz, motion-heavy hero video). Those three are the anti-references. When a decision could go either way, go toward print and away from all three.",
+    "keyCharacteristics": [
+      "Cream paper surface with near-black ink — never white-on-grey product chrome",
+      "Zero border radius on every rectangle; circles are the only curve",
+      "Hard offset shadows (4px 4px 0 0 ink), never blur",
+      "Press-down interaction: surfaces slide into their shadow instead of lifting",
+      "Serif display type at extreme scale against 11px uppercase mono labels — no middle register",
+      "Tape, stamps, perforations and hand-drawn strokes as the ornament vocabulary",
+      "Green is rare and load-bearing, never a wash"
+    ],
+    "rules": [
+      {
+        "name": "The Rare Green Rule",
+        "body": "Green is an event, not a surface treatment. On any given screen it appears on the primary CTA, the accent word in one heading, and active state — and effectively nowhere else. If a screen reads as green, it is wrong.",
+        "section": "colors"
+      },
+      {
+        "name": "The Two-Greens Rule",
+        "body": "`jersey` is decorative and never touches text; `jersey-deep` carries meaning and text. Inline body links use `jersey-link` and nothing else. Picking the wrong green is the single most common colour error in this system.",
+        "section": "colors"
+      },
+      {
+        "name": "The No-Grey-UI Rule",
+        "body": "There is no neutral grey chrome layer. A surface is cream, a step of cream, or ink. One exception survives: `gray-100` (#f3f4f6) is the `<SectionStack>` surface behind five homepage sections — the news grid and the three banner strips. The components on it are fully redesigned; only the surface underneath is pre-redesign. It is the single cool grey in a warm system and must not spread — new section surfaces use a cream step.",
+        "section": "colors"
+      },
+      {
+        "name": "The Missing Italic Rule",
+        "body": "Freight Big Pro ships italic at 400 and 700 only — there is no 900 italic. So a Display-size heading with an accent word switches the `<em>` down to Freight Display Pro italic rather than faking a heavy italic. Never pin an accent `<em>` to `font-black`.",
+        "section": "typography"
+      },
+      {
+        "name": "The One Emphasis Rule",
+        "body": "An editorial heading gets exactly one emphasis moment: an accent-coloured italic word or a highlighter stroke, never both, and never two accented words. Emphasis is authored as a Portable Text `accent` decorator, never as a separate \"accent word\" string field.",
+        "section": "typography"
+      },
+      {
+        "name": "The Terminal Period Rule",
+        "body": "Editorial headings are auto-terminated with a period unless they already end in `.`, `?` or `!`. The period is part of the voice — declarative, printed, finished.",
+        "section": "typography"
+      },
+      {
+        "name": "The No Middle Register Rule",
+        "body": "There is display serif and there is 11px mono. Resist inventing a 16px semibold sans \"section label\" — that is product-UI language and it flattens the contrast the system runs on.",
+        "section": "typography"
+      },
+      {
+        "name": "The Three Widths Rule",
+        "body": "A content container may use 680, 1040 or 1280 and no other value. If a layout seems to need 900px, it needs one of the three.",
+        "section": "layout"
+      },
+      {
+        "name": "The Full-Bleed Never Wraps Rule",
+        "body": "Striped seams and coloured bands are viewport-wide by definition. Wrapping one in a max-width container is always a bug.",
+        "section": "layout"
+      },
+      {
+        "name": "The No Blur Rule",
+        "body": "Every shadow in this system has a blur radius of `0`. A blurred shadow is from a different design language and does not belong here — no exceptions, including \"just a subtle one\".",
+        "section": "elevation"
+      },
+      {
+        "name": "The Press-Down Rule",
+        "body": "Interactive paper does not rise on hover; it presses. The surface translates +1px, +1px (buttons and cards) or +1px/+2px (fields) and its shadow collapses to none, so it appears pushed flat against the page. The translate is gated behind `motion-safe:`; the shadow collapse is not, so reduced-motion users keep the affordance.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Complete Vocabulary Rule",
+        "body": "The six documented weights are the entire shadow system — there is no ninth option to reach for. The pre-redesign blurred family (--shadow-sm, --shadow-DEFAULT, --shadow-md, --shadow-lg, --shadow-card-hover, --shadow-input, --shadow-input-focus, --shadow-soft) and the orphaned asymmetric pair (--shadow-photo-tape, --shadow-photo-tape-lift) were removed from globals.css; all ten had zero consumers. Adding a blurred token back is a change to the design language, not a convenience.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Sharp Corner Rule",
+        "body": "If it is a rectangle, its radius is `0`. Circles are circles. There is nothing in between.",
+        "section": "shapes"
+      },
+      {
+        "name": "The Sub-Degree Rule",
+        "body": "Grid card and tape rotations live in a −0.5° to +0.5° pool. Individual tilt should be barely perceptible; the effect is only that the grid stops being perfect. Steeper angles are reserved for explicitly named polaroid compositions.",
+        "section": "shapes"
+      }
+    ],
+    "dos": [
+      "Do set every rectangle's border radius to 0 and reserve curves for true circles.",
+      "Do use hard offset shadows with 0 blur, in exactly the six documented weights.",
+      "Do press interactive surfaces into their shadow on hover (translate(1px, 1px) + shadow-none), gating only the translate behind motion-safe:.",
+      "Do pick the right green: jersey decorative only, jersey-deep for meaning and large text, jersey-link for inline prose links, jersey-bright for green text on ink.",
+      "Do reach for an existing primitive — taped card, ticket stub, mono label, editorial heading, tape strip, stamp badge, striped seam — before writing new markup.",
+      "Do route every page through the three container widths (680 / 1040 / 1280).",
+      "Do keep photographs in colour with the newsprint warm-tint; greyscale-to-colour-on-hover belongs to sponsor logos alone.",
+      "Do author heading emphasis as a Portable Text accent decorator, one emphasis per heading.",
+      "Do use Phosphor Fill icons from the single icon source."
+    ],
+    "donts": [
+      "Don't introduce a blurred shadow, a gradient fill, or a glassmorphic surface — those are the SaaS anti-reference.",
+      "Don't reintroduce a blurred shadow token. The pre-redesign family and the orphaned --shadow-photo-tape* pair were deleted from globals.css; re-adding one changes the design language.",
+      "Don't put a radius on a loading skeleton. A skeleton must match the sharp shape of what it stands in for — 44 stray rounded / rounded-sm classes were removed from ten skeleton files for exactly this reason.",
+      "Don't set jersey (#4acf52) as a text colour, and don't put it on cream.",
+      "Don't wrap a striped seam or a coloured band in a max-width container.",
+      "Don't invent a container width outside 680 / 1040 / 1280 (chrome's 1440 is header and footer only).",
+      "Don't pin a Display-size heading's italic accent to a heavy weight — Freight Big Pro has no 900 italic.",
+      "Don't add a new typeface. Freight Sans Pro, Freight Display Pro, Freight Big Pro and IBM Plex Mono are the whole set.",
+      "Don't build a 16px semibold sans \"section label\" register between display serif and 11px mono.",
+      "Don't spread gray-100 beyond the five homepage sections that already use it; new section surfaces step through cream. (foundation-gray-light and the four table-* tokens have been removed — they had no consumers.)",
+      "Don't rely on hover to reveal anything necessary — the primary usage scene is a phone, outdoors.",
+      "Don't use emoji as icons."
+    ]
+  }
+}

--- a/apps/web/.impeccable/design.json
+++ b/apps/web/.impeccable/design.json
@@ -568,7 +568,7 @@
       },
       {
         "name": "The Complete Vocabulary Rule",
-        "body": "The six documented weights are the entire shadow system — there is no ninth option to reach for. The pre-redesign blurred family (--shadow-sm, --shadow-DEFAULT, --shadow-md, --shadow-lg, --shadow-card-hover, --shadow-input, --shadow-input-focus, --shadow-soft) and the orphaned asymmetric pair (--shadow-photo-tape, --shadow-photo-tape-lift) were removed from globals.css; all ten had zero consumers. Adding a blurred token back is a change to the design language, not a convenience.",
+        "body": "The seven documented tokens are the entire shadow system — there is nothing else to reach for. The pre-redesign blurred family (--shadow-sm, --shadow-DEFAULT, --shadow-md, --shadow-lg, --shadow-card-hover, --shadow-input, --shadow-input-focus, --shadow-soft) and the orphaned asymmetric pair (--shadow-photo-tape, --shadow-photo-tape-lift) were removed from globals.css; all ten had zero consumers. Adding a blurred token back is a change to the design language, not a convenience.",
         "section": "elevation"
       },
       {
@@ -584,7 +584,7 @@
     ],
     "dos": [
       "Do set every rectangle's border radius to 0 and reserve curves for true circles.",
-      "Do use hard offset shadows with 0 blur, in exactly the six documented weights.",
+      "Do use hard offset shadows with 0 blur, in exactly the seven documented tokens.",
       "Do press interactive surfaces into their shadow on hover (translate(1px, 1px) + shadow-none), gating only the translate behind motion-safe:.",
       "Do pick the right green: jersey decorative only, jersey-deep for meaning and large text, jersey-link for inline prose links, jersey-bright for green text on ink.",
       "Do reach for an existing primitive — taped card, ticket stub, mono label, editorial heading, tape strip, stamp badge, striped seam — before writing new markup.",
@@ -596,7 +596,7 @@
     "donts": [
       "Don't introduce a blurred shadow, a gradient fill, or a glassmorphic surface — those are the SaaS anti-reference.",
       "Don't reintroduce a blurred shadow token. The pre-redesign family and the orphaned --shadow-photo-tape* pair were deleted from globals.css; re-adding one changes the design language.",
-      "Don't put a radius on a loading skeleton. A skeleton must match the sharp shape of what it stands in for — 44 stray rounded / rounded-sm classes were removed from ten skeleton files for exactly this reason.",
+      "Don't put a radius on a loading skeleton. A skeleton must match the sharp shape of what it stands in for — 44 stray rounded / rounded-sm classes were removed from eight skeleton files for exactly this reason.",
       "Don't set jersey (#4acf52) as a text colour, and don't put it on cream.",
       "Don't wrap a striped seam or a coloured band in a max-width container.",
       "Don't invent a container width outside 680 / 1040 / 1280 (chrome's 1440 is header and footer only).",

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -163,7 +163,15 @@ The legacy tabbed `<TeamDetail>` and its children `<TeamStandings>` / `<TeamSche
 
 ## Design Conventions
 
-**Storybook is the authoritative design system reference.** Check `Foundation/Colors`, `Foundation/Typography`, and `Foundation/Spacing & Icons` stories for all design tokens (colors, spacing, border-radius, typography). Do not hardcode values not defined there.
+Two references, different jobs — read the one that answers your question:
+
+| Source                             | Owns                                                                                                                                                                                                        | Read it when                                                                                         |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `apps/web/DESIGN.md`               | The **rules**: why corners are sharp, which of the four greens carries meaning, why shadows never blur, one emphasis per heading, the three container widths. Thirteen named rules plus a Do's/Don'ts list. | Designing or reviewing anything new. Start here — the rules are not derivable from the token values. |
+| Storybook (`Foundation/*`, `UI/*`) | The **values and components**: every live token, every primitive's variant API, rendered states.                                                                                                            | You need an exact value, or the current shape of a component.                                        |
+| `apps/web/PRODUCT.md`              | Durable product truth: audiences, success criteria, constraints, and the hard list of what this site does **not** do (no tickets, shop, streaming, live scores, accounts, newsletter).                      | Scoping a feature, or tempted to add a surface the product doesn't have.                             |
+
+Storybook stays authoritative for **values** — do not hardcode a colour, spacing, radius or type value that isn't defined there. DESIGN.md is authoritative for **intent**; where a token could be used two ways, its rule decides. `.impeccable/design.json` is the machine-readable sidecar for DESIGN.md — regenerate both together via `/impeccable document`, never by hand.
 
 ### Page layout — `<PageContainer>` and the three body widths
 

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,0 +1,385 @@
+---
+name: KCVV Elewijt
+description: A retro-terrace fanzine for a Belgian amateur football club — cream paper, hard ink, tape and stamps.
+colors:
+  cream: "#f5f1e6"
+  cream-soft: "#ede8da"
+  cream-deep: "#e1d7bf"
+  paper-edge: "#d9d2bd"
+  ink: "#0a0a0a"
+  ink-soft: "#1f1f1f"
+  ink-muted: "#6b6b6b"
+  jersey: "#4acf52"
+  jersey-deep: "#008755"
+  jersey-link: "#007c46"
+  jersey-bright: "#22c55e"
+  jersey-deep-dark: "#133d28"
+  warm: "#f0c264"
+  tape-cream: "rgb(232 224 200 / 0.85)"
+  alert: "#b84a3a"
+  alert-soft: "#e8d5cf"
+  warning: "#c68b2c"
+  warning-soft: "#ecddb8"
+  success-soft: "#d8e7d0"
+  card-red: "#c93f1c"
+typography:
+  display:
+    fontFamily: "freight-big-pro, Freight Display Fallback, georgia, Times New Roman, serif"
+    fontSize: "clamp(3.5rem, 1.5rem + 8vw, 6rem)"
+    fontWeight: 900
+    lineHeight: 1
+    letterSpacing: "-0.025em"
+  headline:
+    fontFamily: "freight-display-pro, Freight Display Fallback, georgia, Times New Roman, serif"
+    fontSize: "clamp(2.75rem, 1.5rem + 5vw, 4.5rem)"
+    fontWeight: 700
+    lineHeight: 1.05
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "freight-display-pro, Freight Display Fallback, georgia, Times New Roman, serif"
+    fontSize: "clamp(2rem, 1.25rem + 3vw, 3rem)"
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: "-0.025em"
+  subtitle:
+    fontFamily: "freight-display-pro, Freight Display Fallback, georgia, Times New Roman, serif"
+    fontSize: "clamp(1.5rem, 1rem + 1.5vw, 2rem)"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.025em"
+  body:
+    fontFamily: "freight-sans-pro, Freight Sans Fallback, -apple-system, system-ui, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+  body-lg:
+    fontFamily: "freight-sans-pro, Freight Sans Fallback, -apple-system, system-ui, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 400
+    lineHeight: 1.55
+  body-sm:
+    fontFamily: "freight-sans-pro, Freight Sans Fallback, -apple-system, system-ui, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.55
+  mono:
+    fontFamily: "IBM Plex Mono, Consolas, Liberation Mono, Courier, monospace"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.4
+  label:
+    fontFamily: "IBM Plex Mono, Consolas, Liberation Mono, Courier, monospace"
+    fontSize: "0.6875rem"
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: "0.08em"
+rounded:
+  none: "0"
+  full: "9999px"
+spacing:
+  card-sm: "0.75rem"
+  card-md: "1.25rem"
+  card-lg: "2rem"
+  prose: "680px"
+  wide: "1040px"
+  index: "1280px"
+components:
+  button-primary:
+    backgroundColor: "{colors.jersey-deep}"
+    textColor: "{colors.cream}"
+    rounded: "{rounded.none}"
+    padding: "0.75rem 2rem"
+  button-primary-hover:
+    backgroundColor: "{colors.jersey-deep}"
+    textColor: "{colors.cream}"
+  button-inverted:
+    backgroundColor: "{colors.cream}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "0.75rem 2rem"
+  button-secondary:
+    backgroundColor: "{colors.cream-soft}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "0.75rem 2rem"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "0.75rem 2rem"
+  card-paper:
+    backgroundColor: "{colors.cream}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.card-md}"
+  card-ink:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.cream}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.card-md}"
+  input:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "0 1rem"
+    height: "2.5rem"
+  input-focus:
+    backgroundColor: "#ffffff"
+    textColor: "{colors.ink}"
+  pill-jersey-deep:
+    backgroundColor: "{colors.jersey-deep}"
+    textColor: "#ffffff"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "0.25rem 0.5rem"
+  stamp-badge:
+    backgroundColor: "{colors.jersey-deep}"
+    textColor: "{colors.cream}"
+    rounded: "{rounded.none}"
+    padding: "0.375rem 0.875rem"
+  nav-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+---
+
+# Design System: KCVV Elewijt
+
+## Overview
+
+**Creative North Star: "The Retro-Terrace Fanzine"**
+
+This is a self-published supporter zine that happens to be a website. Everything is printed on cream paper stock, everything is drawn in hard black ink, and everything that matters is stuck down with tape or hit with a rubber stamp. Nothing glows, nothing blurs, nothing floats. The page has a physical thickness: cards cast a hard offset shadow with no blur, as if a rectangle of paper were laid on the page and lit from a single fixed point. Press one and it slides into its own shadow.
+
+The register is confident and slightly rough. Headlines are enormous serif display type set tight, with a single italic word pulled out in green or a hand-drawn highlighter stroke swiped across it. Structural labels — kickers, statuses, timestamps, scores — are set in uppercase monospace at 11px, tracked wide, the typeface of a photocopied team sheet. Photographs are warm-tinted like aged newsprint and laid on the page under a barely-visible paper grain. Tape strips sit at sub-degree angles, enough to break the perfect grid without looking seasick.
+
+What this deliberately is not: the Sportlink/Twizzit amateur-club house style (stock hero, rounded cards, generic sans, logo on a blue gradient); modern SaaS product UI (soft blurred shadows, gradient fills, glassmorphism, Inter); and big-club broadcast slick (dark glossy panels, neon data viz, motion-heavy hero video). Those three are the anti-references. When a decision could go either way, go toward print and away from all three.
+
+**Key Characteristics:**
+
+- Cream paper surface with near-black ink — never white-on-grey product chrome
+- Zero border radius on every rectangle; circles are the only curve
+- Hard offset shadows (`4px 4px 0 0` ink), never blur
+- Press-down interaction: surfaces slide into their shadow instead of lifting
+- Serif display type at extreme scale against 11px uppercase mono labels — no middle register
+- Tape, stamps, perforations and hand-drawn strokes as the ornament vocabulary
+- Green is rare and load-bearing, never a wash
+
+## Colors
+
+A print palette: one paper, one ink, one green, one warm accent, and a small set of aged status tones. There is no grey UI layer — depth comes from stepping the cream down or flipping the whole surface to ink.
+
+### Primary
+
+- **Jersey Deep** (`#008755`): the club green, and the only green allowed to carry meaning. Primary buttons, large display headings, italic accent words in headlines, active states, and dark section fills. It is a text-safe green on cream at large sizes.
+- **Jersey Link** (`#007c46`): a fractionally darker green that exists for one reason — inline links in body copy. Jersey Deep is only ~4.05:1 on cream, below AA for normal text; this is ~4.6:1 while staying ≥3:1 against surrounding ink. Never use it for anything but inline prose links.
+- **Jersey** (`#4acf52`): the bright terrace green. Decorative only — stripe patterns, tape strips, spinner bars. **Never text, never on cream.**
+- **Jersey Bright** (`#22c55e`): green text on ink surfaces only, where the deep green disappears.
+- **Jersey Deep Dark** (`#133d28`): desaturated retro forest. The far stop of the photo-overlay gradient and the darkest green field.
+
+### Secondary
+
+- **Warm** (`#f0c264`): aged-poster yellow. Warm tape strips, accent words on dark green surfaces, button stripe details. It is the only accent that survives on a jersey-deep field, where green tape has no contrast.
+
+### Neutral
+
+- **Cream** (`#f5f1e6`): the page. Every surface starts here.
+- **Cream Soft** (`#ede8da`): a card sitting on the page — the first step down.
+- **Cream Deep** (`#e1d7bf`): the deepest paper tone; section bands that need to recede.
+- **Paper Edge** (`#d9d2bd`): card outlines and dividers on cream, where a full ink border would be too loud.
+- **Ink** (`#0a0a0a`): primary text, every border, every hard shadow, and the fill for dark interlude panels.
+- **Ink Soft** (`#1f1f1f`): a dark surface layered on a dark surface.
+- **Ink Muted** (`#6b6b6b`): bylines, timestamps, metadata, and the soft shadow offset used where pure ink would vanish.
+- **Tape Cream** (`rgb(232 224 200 / 0.85)`): the tape colour that nearly disappears into the paper — read by edge and shadow only.
+
+### Tertiary
+
+Status tones, tuned for print rather than for a dashboard. Each pairs a saturated stroke colour with a desaturated body tint.
+
+- **Alert / Alert Soft** (`#b84a3a` / `#e8d5cf`): dusty brick red. Error field chrome, error alerts, alert-tone stamps.
+- **Warning / Warning Soft** (`#c68b2c` / `#ecddb8`): aged mustard ochre.
+- **Success Soft** (`#d8e7d0`): desaturated sage. Body tint only — success has no stroke colour of its own; it borrows jersey-deep.
+- **Card Red** (`#c93f1c`): reserved severity tone for a cancelled/dead match state. Pairs with cream foreground text.
+
+### Named Rules
+
+**The Rare Green Rule.** Green is an event, not a surface treatment. On any given screen it appears on the primary CTA, the accent word in one heading, and active state — and effectively nowhere else. If a screen reads as green, it is wrong.
+
+**The Two-Greens Rule.** `jersey` is decorative and never touches text; `jersey-deep` carries meaning and text. Inline body links use `jersey-link` and nothing else. Picking the wrong green is the single most common colour error in this system.
+
+**The No-Grey-UI Rule.** There is no neutral grey chrome layer. A surface is cream, a step of cream, or ink. One exception survives: `gray-100` (`#f3f4f6`) is the `<SectionStack>` surface behind five homepage sections — the news grid and the three banner strips. The components on it are fully redesigned; only the surface underneath is pre-redesign. It is the single cool grey in a warm system and must not spread — new section surfaces use a cream step.
+
+## Typography
+
+**Display Font:** Freight Big Pro (`freight-big-pro`, with metric-matched Georgia fallback) — the heaviest headline register only
+**Secondary Display:** Freight Display Pro (`freight-display-pro`, same fallback) — every other heading, and all italic accents
+**Body Font:** Freight Sans Pro (`freight-sans-pro`, with metric-matched Arial fallback)
+**Label/Mono Font:** IBM Plex Mono (self-hosted)
+
+**Character:** A newspaper masthead bolted to a photocopied team sheet. The serif display faces carry all the drama — set at up to 96px with line-height 1 and negative tracking, they stack into dense blocks rather than sitting on a line. Freight Sans below them is quiet and highly legible at 1.6 line-height. The mono is the system's connective tissue: it labels, times, numbers and categorises everything, always uppercase, always tracked open.
+
+### Hierarchy
+
+- **Display** (900, `clamp(3.5rem, 1.5rem + 8vw, 6rem)`, lh 1): Freight Big Pro. Page-defining hero headings, one per page at most.
+- **Headline** (700, `clamp(2.75rem, 1.5rem + 5vw, 4.5rem)`, lh 1.05): Freight Display Pro. Section-opening editorial headings.
+- **Title** (700, `clamp(2rem, 1.25rem + 3vw, 3rem)`, lh 1.1): the default editorial heading size.
+- **Subtitle** (700, `clamp(1.5rem, 1rem + 1.5vw, 2rem)`, lh 1.2) and a **small** step (600, `clamp(1.25rem, 1rem + 1vw, 1.5rem)`, lh 1.3): card headings and sub-sections.
+- **Body** (400, 1rem, lh 1.6): all prose. Reading column capped at 680px.
+- **Body Large / Small** (400, 1.125rem lh 1.55 / 0.875rem lh 1.55): leads and captions.
+- **Mono** (500, 0.875rem, lh 1.4): scores, dates, stat values, inline data.
+- **Label** (500, 0.6875rem / 11px, lh 1, tracking 0.08em, uppercase): kickers, badges, pills, statuses, nav. The most-used non-body style in the system.
+
+Navigation sits just outside the label token — uppercase mono, 600 weight, tracking 0.04em, scaling 11px → 13px → 14px across `xl` / `2xl`.
+
+### Named Rules
+
+**The Missing Italic Rule.** Freight Big Pro ships italic at 400 and 700 only — there is no 900 italic. So a Display-size heading with an accent word switches the `<em>` down to Freight Display Pro italic rather than faking a heavy italic. Never pin an accent `<em>` to `font-black`.
+
+**The One Emphasis Rule.** An editorial heading gets exactly one emphasis moment: an accent-coloured italic word _or_ a highlighter stroke, never both, and never two accented words. Emphasis is authored as a Portable Text `accent` decorator, never as a separate "accent word" string field.
+
+**The Terminal Period Rule.** Editorial headings are auto-terminated with a period unless they already end in `.`, `?` or `!`. The period is part of the voice — declarative, printed, finished.
+
+**The No Middle Register Rule.** There is display serif and there is 11px mono. Resist inventing a 16px semibold sans "section label" — that is product-UI language and it flattens the contrast the system runs on.
+
+## Layout
+
+The body is a single centred column at one of exactly three widths, chosen by the page's role: **680px** for reading (articles, forms, legal), **1040px** for detail pages (the default), and **1280px** for card-grid indexes and landing pages. Every page routes through one container primitive; hand-rolled `mx-auto max-w-*` wrappers are drift.
+
+Three things sit outside those widths and only three: global chrome (header and footer span 1440px, the only value above 1280); element sizing (a photo, a quote measure, a scaled diagram keeps its own max-width); and full-bleed bands (striped seams, hero backgrounds, coloured CTA bands) which span the viewport and are never wrapped in a container.
+
+Horizontal gutters are 1rem on mobile, 2rem from `md` up. Vertical rhythm belongs to the consuming section, not the container. Card padding steps 0.75rem / 1.25rem / 2rem.
+
+Breakpoints: 640 (`sm`), 768 (`md`), 960 (`desk`), 1024 (`lg`), 1280 (`xl`), 1536 (`2xl`). The 960 step is inherited and used sparingly.
+
+The real usage scene is a phone held outdoors on the sideline. Layouts collapse to a single column early, tap targets stay generous, and nothing important hides behind hover.
+
+### Named Rules
+
+**The Three Widths Rule.** A content container may use 680, 1040 or 1280 and no other value. If a layout seems to need 900px, it needs one of the three.
+
+**The Full-Bleed Never Wraps Rule.** Striped seams and coloured bands are viewport-wide by definition. Wrapping one in a max-width container is always a bug.
+
+## Elevation & Depth
+
+The system is **flat-graphic, not lifted**. Depth is drawn, not simulated: a hard offset rectangle of pure ink with zero blur radius, exactly as a print designer would fake a drop shadow with a second black box. There is no ambient light, no spread, no colour bleed.
+
+Only three weights exist, plus a muted sibling for surfaces where black-on-black would vanish and an alert-tinted sibling for error fields.
+
+### Shadow Vocabulary
+
+- **Paper Small** (`box-shadow: 4px 4px 0 0 #0a0a0a`): the default. Buttons, badges, stamps, chrome.
+- **Paper Medium** (`box-shadow: 6px 6px 0 0 #0a0a0a`): cards at rest — the most common card weight.
+- **Paper Lift** (`box-shadow: 8px 8px 0 0 #0a0a0a`): the hover target of a tilt-mode card, and emphasis cards.
+- **Paper Small Soft** (`box-shadow: 4px 4px 0 0 #6b6b6b`): the same offset in ink-muted, for anything sitting on an ink or dark-green surface where pure ink loses its silhouette. Also the resting shadow of every form field.
+- **Paper Small Soft Hover** (`box-shadow: 3px 3px 0 0 #6b6b6b`): the 1px compression a form field makes on hover.
+- **Paper Small Alert** / **Alert Hover** (`4px 4px 0 0 #e8d5cf` / `3px 3px 0 0 #e8d5cf`): error-state fields only, so the offset reads as part of the alert moment.
+
+### Named Rules
+
+**The No Blur Rule.** Every shadow in this system has a blur radius of `0`. A blurred shadow is from a different design language and does not belong here — no exceptions, including "just a subtle one".
+
+**The Press-Down Rule.** Interactive paper does not rise on hover; it presses. The surface translates `+1px, +1px` (buttons and cards) or `+1px/+2px` (fields) and its shadow collapses to `none`, so it appears pushed flat against the page. The translate is gated behind `motion-safe:`; the shadow collapse is not, so reduced-motion users keep the affordance.
+
+**The Complete Vocabulary Rule.** The six weights above are the entire shadow system — there is no ninth option to reach for. The pre-redesign blurred family (`--shadow-sm`, `--shadow-DEFAULT`, `--shadow-md`, `--shadow-lg`, `--shadow-card-hover`, `--shadow-input`, `--shadow-input-focus`, `--shadow-soft`) and the orphaned asymmetric pair (`--shadow-photo-tape`, `--shadow-photo-tape-lift`) were removed from `globals.css`; all ten had zero consumers. Adding a blurred token back is a change to the design language, not a convenience.
+
+## Shapes
+
+**Everything rectangular is sharp.** Border radius is `0` on cards, buttons, inputs, selects, textareas, pills, badges, modals, images and bands. The only curve in the system is a true circle (`rounded-full`) for avatars, timeline bullets, spinner dots and score circles. There is no small-radius softening step, and there is no "just 2px" exception.
+
+Borders are the primary structural device: a solid `2px` ink border defines nearly every surface, dropping to `1.5px` on stamps and `2px` at reduced opacity (`ink/30` → `ink/40` → `ink/60` → `ink`) to encode form-field state. Dividers on cream use paper-edge rather than ink.
+
+The ornament vocabulary is physical: **tape strips** (small solid rectangles anchored half-over a card edge at −0.5° to +0.5°, or −5°/+4° for polaroid compositions), **stamps** (rotated ~2°, mono uppercase, bordered and shadowed), **perforations** (a masked half-disc column with a dashed tear guide, on ticket-stub alerts), **striped seams** (45° two-tone SVG bands used as full-bleed section rules), and **highlighter strokes** (a hand-drawn SVG marker that sweeps left-to-right on hover behind inline links and heading accents).
+
+Photographs get a newsprint treatment: a warm-tint filter (`sepia(0.06) saturate(0.94) hue-rotate(-4deg) contrast(1.02) brightness(1.01)`) plus a 4%-opacity SVG turbulence grain in multiply. They stay in colour.
+
+### Named Rules
+
+**The Sharp Corner Rule.** If it is a rectangle, its radius is `0`. Circles are circles. There is nothing in between.
+
+**The Sub-Degree Rule.** Grid card and tape rotations live in a −0.5° to +0.5° pool. Individual tilt should be barely perceptible; the effect is only that the grid stops being perfect. Steeper angles are reserved for explicitly named polaroid compositions.
+
+## Components
+
+### Buttons
+
+- **Shape:** sharp (`0` radius), solid `2px` ink border, hard offset shadow at all times.
+- **Primary:** jersey-deep fill, cream text, `4px 4px 0 0` ink shadow. Padding 0.75rem / 2rem at the default size (0.5/1.5 small, 1/2.5 large).
+- **Inverted:** cream fill, ink text, muted-ink shadow — for placement on dark surfaces.
+- **Secondary:** cream-soft fill, ink text. **Ghost:** transparent, ink text, `ink/5` hover wash.
+- **Hover:** the canonical press-down — `translate(1px, 1px)` with the shadow collapsing to none over 300ms. Primary additionally brightens 110%.
+- **Focus:** a 2px jersey-deep ring at 2px offset.
+- **Disabled:** 50% opacity, `not-allowed` cursor, and every hover effect neutralised back to the resting surface so the button visibly does not react.
+- An optional trailing `→` glyph translates 4px right on group hover.
+
+### Cards / Containers
+
+- **Corner Style:** sharp (`0`).
+- **Background:** cream, cream-soft, ink, jersey or jersey-deep — the text colour flips with the surface.
+- **Border:** solid `2px` ink on every variant. On an ink card the border merges into the fill and the shadow alone defines the silhouette — which is why ink cards must use the muted shadow.
+- **Shadow Strategy:** Paper Medium at rest by default; see Elevation.
+- **Internal Padding:** 0.75rem / 1.25rem / 2rem, or none for flush-edge media cards.
+- **Rotation:** optional, from the sub-degree pool, applied as a CSS-variable transform so it composes with the press or tilt hover rather than fighting it.
+- **Tape:** zero or more tape strips as children, so they translate with the card frame on press.
+
+### Inputs / Fields
+
+An eight-state machine shared identically by text input, select and textarea — the border weight encodes progress through the state, and the shadow encodes pressure.
+
+- **Style:** white surface (the one white in the system — a field is a form you write on, not paper you print), sharp corners, `2px` border at `ink/30`, resting muted-ink offset shadow.
+- **Hover:** border to `ink/40`, shadow compresses to `3px 3px`, surface nudges 1px.
+- **Filled** (text present, not focused): border anchors at `ink/60`, resting shadow returns.
+- **Focus:** border goes full ink, shadow snaps to none, surface presses 2px — the deepest press in the system.
+- **Error:** border and shadow both switch to the alert pair; an `AlertBadge` renders below. Error survives focus.
+- **Disabled:** `ink/15` border, cream-soft fill, 50% opacity, all motion frozen — deliberately still inside the paper vocabulary rather than shadowless.
+- **Sizes:** 2rem / 2.5rem / 3rem tall with 0.75 / 1 / 1.25rem inline padding. Hints render in italic `ink/60` beneath.
+
+### Chips / Labels
+
+- **Mono Label:** the workhorse. Uppercase mono, 11px, tracking 0.08em, weight 500. Plain (inline, ink or cream) or as a solid pill in jersey, jersey-deep, ink or cream-soft.
+- Pills are sharp-cornered with 0.5rem / 0.25rem padding. The jersey-deep pill uses pure white text, not cream — cream at 85% on jersey-deep fails AA.
+
+### Navigation
+
+- Uppercase mono, weight 600, tracking 0.04em, 11px scaling to 14px on wide viewports, no underline.
+- Default ink; hover and active shift to jersey-deep, colour only, 150ms.
+- The utility action carries a 1px ink border that recolours to jersey-deep on hover.
+- Dropdowns fade and drop 4px over 150ms; reduced motion collapses to instant. Mobile uses a full takeover drawer, not a squeezed menu.
+
+### Stamp Badge
+
+A rotated, content-bearing paper stamp that pins over the edge of a card — 14px above the parent, 36px in from its anchoring side, rotated ~2°. Uppercase mono 11px bold at 0.1em tracking, `1.5px` ink border, Paper Small shadow, in jersey-deep, ink or alert tone. Distinct from a tape strip: the stamp carries text, the tape is purely graphic.
+
+### Striped Seam
+
+A full-bleed 45° two-tone stripe band (12 / 18 / 24 / 28px tall) rendered as an SVG pattern, used as a section rule. Four pairs: ink-cream (default, high contrast), jersey-cream, jersey-tonal-dark, and cream-jersey-deep. The angle can flip so a top and bottom seam lean toward each other and "tape" a section shut.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** set every rectangle's border radius to `0` and reserve curves for true circles.
+- **Do** use hard offset shadows with `0` blur, in exactly the six documented weights.
+- **Do** press interactive surfaces into their shadow on hover (`translate(1px, 1px)` + `shadow-none`), gating only the translate behind `motion-safe:`.
+- **Do** pick the right green: `jersey` decorative only, `jersey-deep` for meaning and large text, `jersey-link` for inline prose links, `jersey-bright` for green text on ink.
+- **Do** reach for an existing primitive — taped card, ticket stub, mono label, editorial heading, tape strip, stamp badge, striped seam — before writing new markup.
+- **Do** route every page through the three container widths (680 / 1040 / 1280).
+- **Do** keep photographs in colour with the newsprint warm-tint; greyscale-to-colour-on-hover belongs to sponsor logos alone.
+- **Do** author heading emphasis as a Portable Text `accent` decorator, one emphasis per heading.
+- **Do** use Phosphor Fill icons from the single icon source.
+
+### Don't:
+
+- **Don't** introduce a blurred shadow, a gradient fill, or a glassmorphic surface — those are the SaaS anti-reference.
+- **Don't** reintroduce a blurred shadow token. The pre-redesign family and the orphaned `--shadow-photo-tape*` pair were deleted from `globals.css`; re-adding one changes the design language.
+- **Don't** put a radius on a loading skeleton. A skeleton must match the sharp shape of what it stands in for — 44 stray `rounded` / `rounded-sm` classes were removed from ten skeleton files for exactly this reason.
+- **Don't** set `jersey` (`#4acf52`) as a text colour, and don't put it on cream.
+- **Don't** wrap a striped seam or a coloured band in a max-width container.
+- **Don't** invent a container width outside 680 / 1040 / 1280 (chrome's 1440 is header and footer only).
+- **Don't** pin a Display-size heading's italic accent to a heavy weight — Freight Big Pro has no 900 italic.
+- **Don't** add a new typeface. Freight Sans Pro, Freight Display Pro, Freight Big Pro and IBM Plex Mono are the whole set.
+- **Don't** build a 16px semibold sans "section label" register between display serif and 11px mono.
+- **Don't** spread `gray-100` beyond the five homepage sections that already use it; new section surfaces step through cream. (`foundation-gray-light` and the four `table-*` tokens have been removed — they had no consumers.)
+- **Don't** rely on hover to reveal anything necessary — the primary usage scene is a phone, outdoors.
+- **Don't** use emoji as icons.

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -282,7 +282,7 @@ Only three weights exist, plus a muted sibling for surfaces where black-on-black
 
 **The Press-Down Rule.** Interactive paper does not rise on hover; it presses. The surface translates `+1px, +1px` (buttons and cards) or `+1px/+2px` (fields) and its shadow collapses to `none`, so it appears pushed flat against the page. The translate is gated behind `motion-safe:`; the shadow collapse is not, so reduced-motion users keep the affordance.
 
-**The Complete Vocabulary Rule.** The six weights above are the entire shadow system — there is no ninth option to reach for. The pre-redesign blurred family (`--shadow-sm`, `--shadow-DEFAULT`, `--shadow-md`, `--shadow-lg`, `--shadow-card-hover`, `--shadow-input`, `--shadow-input-focus`, `--shadow-soft`) and the orphaned asymmetric pair (`--shadow-photo-tape`, `--shadow-photo-tape-lift`) were removed from `globals.css`; all ten had zero consumers. Adding a blurred token back is a change to the design language, not a convenience.
+**The Complete Vocabulary Rule.** The seven tokens above are the entire shadow system — there is nothing else to reach for. The pre-redesign blurred family (`--shadow-sm`, `--shadow-DEFAULT`, `--shadow-md`, `--shadow-lg`, `--shadow-card-hover`, `--shadow-input`, `--shadow-input-focus`, `--shadow-soft`) and the orphaned asymmetric pair (`--shadow-photo-tape`, `--shadow-photo-tape-lift`) were removed from `globals.css`; all ten had zero consumers. Adding a blurred token back is a change to the design language, not a convenience.
 
 ## Shapes
 
@@ -360,7 +360,7 @@ A full-bleed 45° two-tone stripe band (12 / 18 / 24 / 28px tall) rendered as an
 ### Do:
 
 - **Do** set every rectangle's border radius to `0` and reserve curves for true circles.
-- **Do** use hard offset shadows with `0` blur, in exactly the six documented weights.
+- **Do** use hard offset shadows with `0` blur, in exactly the seven documented tokens.
 - **Do** press interactive surfaces into their shadow on hover (`translate(1px, 1px)` + `shadow-none`), gating only the translate behind `motion-safe:`.
 - **Do** pick the right green: `jersey` decorative only, `jersey-deep` for meaning and large text, `jersey-link` for inline prose links, `jersey-bright` for green text on ink.
 - **Do** reach for an existing primitive — taped card, ticket stub, mono label, editorial heading, tape strip, stamp badge, striped seam — before writing new markup.
@@ -373,7 +373,7 @@ A full-bleed 45° two-tone stripe band (12 / 18 / 24 / 28px tall) rendered as an
 
 - **Don't** introduce a blurred shadow, a gradient fill, or a glassmorphic surface — those are the SaaS anti-reference.
 - **Don't** reintroduce a blurred shadow token. The pre-redesign family and the orphaned `--shadow-photo-tape*` pair were deleted from `globals.css`; re-adding one changes the design language.
-- **Don't** put a radius on a loading skeleton. A skeleton must match the sharp shape of what it stands in for — 44 stray `rounded` / `rounded-sm` classes were removed from ten skeleton files for exactly this reason.
+- **Don't** put a radius on a loading skeleton. A skeleton must match the sharp shape of what it stands in for — 44 stray `rounded` / `rounded-sm` classes were removed from eight skeleton files for exactly this reason.
 - **Don't** set `jersey` (`#4acf52`) as a text colour, and don't put it on cream.
 - **Don't** wrap a striped seam or a coloured band in a max-width container.
 - **Don't** invent a container width outside 680 / 1040 / 1280 (chrome's 1440 is header and footer only).

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -209,7 +209,7 @@ Status tones, tuned for print rather than for a dashboard. Each pairs a saturate
 
 **The Two-Greens Rule.** `jersey` is decorative and never touches text; `jersey-deep` carries meaning and text. Inline body links use `jersey-link` and nothing else. Picking the wrong green is the single most common colour error in this system.
 
-**The No-Grey-UI Rule.** There is no neutral grey chrome layer. A surface is cream, a step of cream, or ink. One exception survives: `gray-100` (`#f3f4f6`) is the `<SectionStack>` surface behind five homepage sections — the news grid and the three banner strips. The components on it are fully redesigned; only the surface underneath is pre-redesign. It is the single cool grey in a warm system and must not spread — new section surfaces use a cream step.
+**The No-Grey-UI Rule.** There is no neutral grey chrome layer. A surface is cream, a step of cream, or ink. One exception survives: `gray-100` (`#f3f4f6`) is the `<SectionStack>` surface behind four homepage sections — the news grid and the three banner strips. The components on it are fully redesigned; only the surface underneath is pre-redesign. It is the single cool grey in a warm system and must not spread — new section surfaces use a cream step.
 
 ## Typography
 
@@ -380,6 +380,6 @@ A full-bleed 45° two-tone stripe band (12 / 18 / 24 / 28px tall) rendered as an
 - **Don't** pin a Display-size heading's italic accent to a heavy weight — Freight Big Pro has no 900 italic.
 - **Don't** add a new typeface. Freight Sans Pro, Freight Display Pro, Freight Big Pro and IBM Plex Mono are the whole set.
 - **Don't** build a 16px semibold sans "section label" register between display serif and 11px mono.
-- **Don't** spread `gray-100` beyond the five homepage sections that already use it; new section surfaces step through cream. (`foundation-gray-light` and the four `table-*` tokens have been removed — they had no consumers.)
+- **Don't** spread `gray-100` beyond the four homepage sections that already use it; new section surfaces step through cream. (`foundation-gray-light` and the four `table-*` tokens have been removed — they had no consumers.)
 - **Don't** rely on hover to reveal anything necessary — the primary usage scene is a phone, outdoors.
 - **Don't** use emoji as icons.

--- a/apps/web/PRODUCT.md
+++ b/apps/web/PRODUCT.md
@@ -1,0 +1,95 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Two primary audiences, weighted equally — when they conflict, neither one automatically wins:
+
+1. **Supporters on matchday.** Fans and Elewijt locals checking results, standings, lineups, goalscorers and the calendar. Mostly on a phone, frequently outdoors at or near the pitch.
+2. **Youth parents.** Parents of U6–U21 players following their kid's team: schedule, squad, practical info, photos.
+
+Secondary, confirmed but not decision-driving: prospective members and volunteers, sponsors and partners, and the club's own board/staff/volunteers.
+
+All visitors are anonymous — there is no registration or login anywhere on the site, and all content is free.
+
+## Product Purpose
+
+The official website of KCVV Elewijt, a Belgian amateur football club (stamnummer 55) in Elewijt, a sub-municipality of Zemst in Vlaams-Brabant. It publishes the club's competitive record and editorial life: news, match results and details, league tables, team squads, player and staff profiles, the club calendar, events, photo galleries, sponsors, and club information.
+
+Success means three things, in the club's own terms:
+
+- **Recruit players and volunteers.** Membership signups, volunteer roles, and youth intake.
+- **Deliver sponsor value.** Visible, credible return for sponsors — a reason to renew, and a reason for new partners to join.
+- **Show the club is serious.** A small amateur club whose site punches well above its division.
+
+Being the club's canonical publishing channel over social media was explicitly _not_ selected as a success criterion. Do not design as if displacing Facebook/Instagram is a goal.
+
+## Positioning
+
+Amateur clubs at this level either run a template site or live entirely on Facebook. KCVV Elewijt runs neither. Two things a neighbouring club could not truthfully copy:
+
+- **Real, synced competitive data across the whole club** — not just the first team. Match results, lineups, goal events, cards, standings and per-player season statistics are synced from ProSoccerData for senior A/B _and_ every youth team U6–U21, and rendered as first-class pages (`/wedstrijd/[matchId]`, `/spelers/[slug]`, `/ploegen/[slug]`).
+- **An authored visual identity, not a theme.** A committed design world with its own typography, primitives and photography rules, maintained as a documented design system in Storybook.
+
+## Operating Context
+
+- **Language:** Dutch throughout the UI (labels, slugs, display values); English in code. The canonical glossary is `docs/ubiquitous-language.md`.
+- **Matchday rhythm.** Traffic and relevance peak around fixtures: before (lineup, opponent, kickoff, location) and immediately after (score, goalscorers, standings movement, report).
+- **Season rhythm.** Squads, teams and standings turn over per season; youth teams are organised as Bovenbouw / Middenbouw / Onderbouw.
+- **Home ground:** Driesstraat 32, 1982 Elewijt, Belgium.
+- **Editorial workflow.** Club editors — volunteers, not professionals — author news, events, pages, galleries and Q&A content in Sanity Studio. Authoring friction is a real product constraint, not a nicety.
+- **Data workflow.** Competitive data flows ProSoccerData → BFF (Cloudflare Workers) → site. The club does not hand-enter results.
+
+## Capabilities and Constraints
+
+**Has:** news and article detail; match calendar and match detail with lineups, events and a match-day standings snapshot; team pages with squad, fixtures and league table; senior and youth team overviews; player and staff profiles with season statistics; opponent pages; club information pages (history, board, youth board, Angels, Ultras, contact, membership); help / who-is-who; events; photo galleries; sponsor overview; site search; membership application form; iCal calendar export; share cards.
+
+**Does not have, and must not be designed as if it did:** ticket sales, an online shop, live match streaming, live in-play scores, betting or odds, paid or gated content, user accounts or login, and a newsletter or email-signup of any kind.
+
+**Technical constraints that shape design:**
+
+- Competitive data comes from a rate-limited upstream (ProSoccerData) via the BFF. Pages that depend on it use ISR or dynamic rendering, never build-time prerendering of every match or player. Match data can legitimately be stale; designs must survive missing or partial data.
+- Fields the upstream does not reliably provide — venue on a match, some competition metadata, `is_home` on match detail — must never be designed into a layout as guaranteed. Audit real data before rendering a field.
+- Editorial content is Portable Text from Sanity; rich-text emphasis is expressed as decorator marks, not as separate accent fields.
+
+**Undecided / open:** none recorded at product level.
+
+## Brand Commitments
+
+- **Name:** KCVV Elewijt. Founded **1909**. Stamnummer **55**.
+- **Motto:** "Er is maar één plezante compagnie" — the club's only tagline. Never "meer dan een club" or any invented variant.
+- **Club colours:** green and white.
+- **Voice:** Dutch, plain, club-insider warmth without corporate polish. Never fabricate club history, honours, quotes, testimonials or magazine/edition chrome.
+- **Typography is fixed:** Freight Sans Pro (body), Freight Display / Freight Big Pro (headings), IBM Plex Mono. No new typefaces.
+- **Icons:** Phosphor Fill, via the single icon source. No emoji in UI.
+- **Sponsor treatment:** three tiers — main, second, regular. Sponsor logos are the only imagery rendered greyscale-to-colour-on-hover; every other photograph stays in colour.
+
+## Evidence on Hand
+
+- **Real competitive data:** live ProSoccerData sync for all senior and youth teams — results, lineups, goal events, cards, standings, per-player statistics.
+- **Real editorial archive:** club news and match reports, an authored club history, events, and photo galleries in Sanity.
+- **Real people:** player, staff and organigram records with photos; a who-is-who of club contacts.
+- **Real sponsors:** a live sponsor roster with tiered logos.
+- **Real photography:** club and matchday photography, plus a panorama of the ground (`docs/design/Untitled_Panorama-1.jpg`).
+- **Socials:** facebook.com/KCVVElewijt, instagram.com/kcvve.
+- **Absent — never fabricate:** testimonials, attendance or engagement figures, honours or trophy claims, press coverage, and any club statistic the ProSoccerData sync does not actually provide.
+
+## Product Principles
+
+1. **The result is the headline.** Whatever the page, a supporter should be able to answer "what happened / what's next" in a single glance on a phone.
+2. **Youth is first-class, not a sub-section.** Every affordance built for the first team — squad, fixtures, profiles, statistics — must hold up for a U9 team and a nine-year-old's profile page, including its privacy constraints.
+3. **Render only what the data actually provides.** Design against real ProSoccerData and Sanity shapes; a layout that needs a field the source may omit is a broken layout.
+4. **Sponsors get real estate, not decoration.** Sponsor presence is a product obligation with commercial consequences, and is designed deliberately rather than tucked into a footer strip.
+5. **Punch above the division.** The bar is not "good for an amateur club" — visible craft is itself one of the three success criteria.
+
+## Accessibility & Inclusion
+
+Two confirmed, product-specific requirements. No formal WCAG conformance level has been adopted as a target.
+
+- **Phone-first, outdoors.** The realistic usage scene is a phone held in daylight on the sideline, possibly on a weak connection. Legibility, contrast in sunlight, and page weight are functional requirements, not polish.
+- **Less-digital visitors.** Older supporters and volunteers are a real part of the audience: plain Dutch, generous tap targets, no jargon, and no interaction that must be discovered (hover-only affordances, hidden gestures, unlabelled icons).

--- a/apps/web/src/app/(landing)/jeugd/loading.tsx
+++ b/apps/web/src/app/(landing)/jeugd/loading.tsx
@@ -57,9 +57,9 @@ export default function JeugdLoading() {
       {/* CTA band (full-bleed) */}
       <div className="bg-jersey-deep-dark border-ink animate-pulse border-y-2">
         <div className="mx-auto flex max-w-[var(--container-index)] flex-col items-center gap-4 px-4 py-12 sm:py-16 md:px-8">
-          <div className="bg-cream/15 h-8 w-72 max-w-full rounded" />
-          <div className="bg-cream/15 h-4 w-96 max-w-full rounded" />
-          <div className="bg-cream/15 h-11 w-40 rounded" />
+          <div className="bg-cream/15 h-8 w-72 max-w-full" />
+          <div className="bg-cream/15 h-4 w-96 max-w-full" />
+          <div className="bg-cream/15 h-11 w-40" />
         </div>
       </div>
     </>

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -12,8 +12,8 @@
  *
  * Per-section components own their own backgrounds and editorial
  * chrome, so `<SectionStack>` uses `bg: "transparent"` for those
- * sections. The five `bg: "gray-100"` sections (news grid + the three
- * banner strips) are the exception: `<BannerSlot>` and `<NewsGrid>` are
+ * sections. The four grey sections (news grid + the three banner
+ * strips) are the exception: `<BannerSlot>` and `<NewsGrid>` are
  * both fully redesigned, but the surface they sit on is still the
  * pre-redesign cool grey rather than a cream step. Retiring `gray-100`
  * here is an open homepage design decision, not leftover migration.

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -12,7 +12,11 @@
  *
  * Per-section components own their own backgrounds and editorial
  * chrome, so `<SectionStack>` uses `bg: "transparent"` for those
- * sections and `bg: "gray-100"` for the legacy `<BannerSlot>` strips.
+ * sections. The five `bg: "gray-100"` sections (news grid + the three
+ * banner strips) are the exception: `<BannerSlot>` and `<NewsGrid>` are
+ * both fully redesigned, but the surface they sit on is still the
+ * pre-redesign cool grey rather than a cream step. Retiring `gray-100`
+ * here is an open homepage design decision, not leftover migration.
  */
 
 import { Effect } from "effect";

--- a/apps/web/src/app/(main)/club/[slug]/loading.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/loading.tsx
@@ -23,13 +23,13 @@ export default function ClubPageLoading() {
           className="mx-auto w-full animate-pulse space-y-4"
           style={{ maxWidth: "var(--container-prose)" }}
         >
-          <div className="bg-cream-soft h-5 w-full rounded" />
-          <div className="bg-cream-soft h-5 w-full rounded" />
-          <div className="bg-cream-soft h-5 w-4/5 rounded" />
-          <div className="bg-cream-soft mt-6 h-48 w-full rounded-sm" />
-          <div className="bg-cream-soft mt-6 h-5 w-full rounded" />
-          <div className="bg-cream-soft h-5 w-full rounded" />
-          <div className="bg-cream-soft h-5 w-2/3 rounded" />
+          <div className="bg-cream-soft h-5 w-full" />
+          <div className="bg-cream-soft h-5 w-full" />
+          <div className="bg-cream-soft h-5 w-4/5" />
+          <div className="bg-cream-soft mt-6 h-48 w-full" />
+          <div className="bg-cream-soft mt-6 h-5 w-full" />
+          <div className="bg-cream-soft h-5 w-full" />
+          <div className="bg-cream-soft h-5 w-2/3" />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/(main)/club/loading.tsx
+++ b/apps/web/src/app/(main)/club/loading.tsx
@@ -25,7 +25,7 @@ export default function ClubLoading() {
 
       {/* Editorial nav hub — header + uniform 3-up grid. */}
       <PageContainer width="index" className="py-12">
-        <div className="bg-ink/10 mb-8 h-10 w-72 max-w-full animate-pulse rounded" />
+        <div className="bg-ink/10 mb-8 h-10 w-72 max-w-full animate-pulse" />
         <div
           data-testid="club-hub-skeleton"
           className="grid animate-pulse grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3"
@@ -37,8 +37,8 @@ export default function ClubLoading() {
             >
               <div className="bg-ink/10 border-ink aspect-[16/9] border-b-2" />
               <div className="flex flex-col gap-2 p-3.5">
-                <div className="bg-ink/10 h-5 w-3/4 rounded" />
-                <div className="bg-ink/10 h-3 w-1/3 rounded" />
+                <div className="bg-ink/10 h-5 w-3/4" />
+                <div className="bg-ink/10 h-3 w-1/3" />
               </div>
             </div>
           ))}

--- a/apps/web/src/app/(main)/kalender/loading.tsx
+++ b/apps/web/src/app/(main)/kalender/loading.tsx
@@ -80,7 +80,7 @@ export default function CalendarLoading() {
               <div className="border-paper-edge mb-1 grid grid-cols-7 border-b border-dashed">
                 {Array.from({ length: 7 }).map((_, i) => (
                   <div key={i} className="flex justify-center py-2">
-                    <div className="bg-cream-soft h-3 w-6 rounded" />
+                    <div className="bg-cream-soft h-3 w-6" />
                   </div>
                 ))}
               </div>
@@ -90,7 +90,7 @@ export default function CalendarLoading() {
                     key={i}
                     className="border-paper-edge min-h-[108px] border-r border-b border-dashed p-1.5 [&:nth-child(7n)]:border-r-0"
                   >
-                    <div className="bg-cream-soft h-3 w-4 rounded" />
+                    <div className="bg-cream-soft h-3 w-4" />
                   </div>
                 ))}
               </div>

--- a/apps/web/src/app/(main)/ploegen/loading.tsx
+++ b/apps/web/src/app/(main)/ploegen/loading.tsx
@@ -9,10 +9,10 @@ function FlagshipSkeleton() {
   return (
     <div className="border-ink grid animate-pulse grid-cols-1 border-2 sm:grid-cols-[1.25fr_1fr]">
       <div className="flex flex-col gap-4 p-6 sm:p-10">
-        <div className="bg-paper-edge h-3 w-24 rounded" />
-        <div className="bg-paper-edge h-10 w-48 rounded" />
-        <div className="bg-paper-edge h-3 w-32 rounded" />
-        <div className="bg-paper-edge mt-2 h-9 w-36 rounded" />
+        <div className="bg-paper-edge h-3 w-24" />
+        <div className="bg-paper-edge h-10 w-48" />
+        <div className="bg-paper-edge h-3 w-32" />
+        <div className="bg-paper-edge mt-2 h-9 w-36" />
       </div>
       <div className="bg-cream-soft min-h-[220px] sm:min-h-[300px]" />
     </div>
@@ -23,9 +23,9 @@ export default function TeamsLoading() {
   return (
     <PageContainer width="index" className="py-10 sm:py-14">
       <div className="mb-10 flex animate-pulse flex-col gap-3">
-        <div className="bg-paper-edge h-3 w-24 rounded" />
-        <div className="bg-paper-edge h-12 w-72 rounded" />
-        <div className="bg-paper-edge h-4 w-96 max-w-full rounded" />
+        <div className="bg-paper-edge h-3 w-24" />
+        <div className="bg-paper-edge h-12 w-72" />
+        <div className="bg-paper-edge h-4 w-96 max-w-full" />
       </div>
 
       <div className="flex flex-col gap-10 sm:gap-16">
@@ -34,16 +34,13 @@ export default function TeamsLoading() {
       </div>
 
       <div className="mt-16 animate-pulse space-y-8">
-        <div className="bg-paper-edge h-8 w-48 rounded" />
+        <div className="bg-paper-edge h-8 w-48" />
         {Array.from({ length: 3 }).map((_, div) => (
           <div key={div} className="space-y-4">
-            <div className="bg-paper-edge h-3 w-40 rounded" />
+            <div className="bg-paper-edge h-3 w-40" />
             <div className="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="border-paper-edge h-20 rounded-sm border-2"
-                />
+                <div key={i} className="border-paper-edge h-20 border-2" />
               ))}
             </div>
           </div>

--- a/apps/web/src/app/(main)/scheurkalender/loading.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/loading.tsx
@@ -10,13 +10,13 @@ import { PageContainer } from "@/components/design-system";
 function ColumnSkeleton({ rows }: { rows: number }) {
   return (
     <>
-      <div className="bg-ink/10 mt-5 mb-[7px] h-7 w-40 animate-pulse rounded first:mt-0.5" />
+      <div className="bg-ink/10 mt-5 mb-[7px] h-7 w-40 animate-pulse first:mt-0.5" />
       {Array.from({ length: rows }).map((_, row) => (
         <div key={row} className="flex items-center gap-3 py-[5px]">
-          <div className="bg-ink/10 h-2.5 w-[17px] animate-pulse rounded" />
-          <div className="bg-ink/10 h-3.5 w-5 animate-pulse rounded" />
-          <div className="bg-ink/10 h-2.5 w-10 animate-pulse rounded" />
-          <div className="bg-ink/10 h-3 flex-1 animate-pulse rounded" />
+          <div className="bg-ink/10 h-2.5 w-[17px] animate-pulse" />
+          <div className="bg-ink/10 h-3.5 w-5 animate-pulse" />
+          <div className="bg-ink/10 h-2.5 w-10 animate-pulse" />
+          <div className="bg-ink/10 h-3 flex-1 animate-pulse" />
         </div>
       ))}
     </>
@@ -30,8 +30,8 @@ export default function ScheurkalenderLoading() {
         <div className="border-ink border-2 bg-white">
           {/* Masthead */}
           <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
-            <div className="bg-ink/10 h-4 w-56 animate-pulse rounded" />
-            <div className="bg-ink/10 h-3 w-32 animate-pulse rounded" />
+            <div className="bg-ink/10 h-4 w-56 animate-pulse" />
+            <div className="bg-ink/10 h-3 w-32 animate-pulse" />
           </div>
           {/* Two calendar-year columns */}
           <div className="grid grid-cols-2 px-5 pt-1.5 pb-[18px]">

--- a/apps/web/src/app/(main)/spelers/[slug]/loading.tsx
+++ b/apps/web/src/app/(main)/spelers/[slug]/loading.tsx
@@ -16,16 +16,16 @@ export default function PlayerDetailLoading() {
       <PageContainer as="section" className="animate-pulse py-12 lg:py-16">
         <div className="grid grid-cols-1 items-start gap-x-10 gap-y-8 sm:grid-cols-[1fr_minmax(220px,320px)]">
           <div className="flex flex-col gap-5">
-            <div className="bg-paper-edge h-4 w-24 rounded" />
-            <div className="bg-paper-edge h-24 w-32 rounded" />
+            <div className="bg-paper-edge h-4 w-24" />
+            <div className="bg-paper-edge h-24 w-32" />
             <div className="space-y-2">
-              <div className="bg-paper-edge h-12 w-3/4 rounded" />
-              <div className="bg-paper-edge h-10 w-2/3 rounded" />
+              <div className="bg-paper-edge h-12 w-3/4" />
+              <div className="bg-paper-edge h-10 w-2/3" />
             </div>
-            <div className="bg-paper-edge h-3 w-48 rounded" />
-            <div className="bg-paper-edge h-7 w-40 rounded" />
+            <div className="bg-paper-edge h-3 w-48" />
+            <div className="bg-paper-edge h-7 w-40" />
           </div>
-          <div className="bg-paper-edge aspect-[3/4] w-full max-w-[320px] justify-self-start rounded sm:justify-self-end" />
+          <div className="bg-paper-edge aspect-[3/4] w-full max-w-[320px] justify-self-start sm:justify-self-end" />
         </div>
       </PageContainer>
       <div className="bg-paper-edge h-[18px] w-full" />
@@ -34,9 +34,9 @@ export default function PlayerDetailLoading() {
         className="bg-cream animate-pulse py-12 lg:py-16"
       >
         <div className="space-y-3">
-          <div className="bg-paper-edge h-4 w-full rounded" />
-          <div className="bg-paper-edge h-4 w-11/12 rounded" />
-          <div className="bg-paper-edge h-4 w-10/12 rounded" />
+          <div className="bg-paper-edge h-4 w-full" />
+          <div className="bg-paper-edge h-4 w-11/12" />
+          <div className="bg-paper-edge h-4 w-10/12" />
         </div>
       </PageContainer>
     </div>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -25,11 +25,6 @@
   size-adjust: 90%;
 }
 
-:root {
-  /* Foundation Grays */
-  --color-foundation-gray-light: #edeff4;
-}
-
 /* ===== Spinner — scarf barber-pole + compact dot pulse (Phase 2.B.1) =====
 
    Visual contract locked at the Track B design checkpoint (2026-04-30).
@@ -272,15 +267,13 @@
 @theme {
   /* ===== Color Palette ===== */
 
-  /* Foundation Grays */
+  /* Foundation Gray — the last pre-redesign neutral still in service, as the
+     `<SectionStack bg="gray-100">` surface behind the homepage news grid and
+     banner strips. It is the one cool grey in a warm cream system; retiring it
+     is a homepage design decision, not a cleanup. `--color-foundation-gray-light`
+     and the four `--color-table-*` tokens were removed here — they had no
+     consumers anywhere in the app. */
   --color-gray-100: #f3f4f6;
-  --color-foundation-gray-light: #edeff4;
-
-  /* Table Colors */
-  --color-table-header-bg: #f3f4f6;
-  --color-table-border: #e5e7eb;
-  --color-table-border-header: #d1d5db;
-  --color-table-row-even: #f9fafb;
 
   /* ===== Typography ===== */
 
@@ -350,20 +343,18 @@
 
   /* ===== Border Radius ===== */
 
-  --radius-DEFAULT: 0.25rem;
-  --radius-card: 4px;
+  /* Intentionally empty. Every rectangle in this system is sharp — the
+     `--radius-DEFAULT` / `--radius-card` tokens were removed because nothing
+     consumed them once the loading skeletons were squared off. Circles use
+     Tailwind's built-in `rounded-full`. */
 
   /* ===== Box Shadows ===== */
 
+  /* Depth is drawn, never blurred — the `--shadow-paper-*` family below is the
+     whole vocabulary. The pre-redesign blurred set (`sm`, `DEFAULT`, `md`,
+     `lg`, `card-hover`, `input`, `input-focus`) was removed here: zero
+     consumers, and reintroducing a blur would break the paper idiom. */
   --shadow-none: none;
-  --shadow-sm: 0 2px 5px 0 rgba(0, 0, 0, 0.16);
-  --shadow-DEFAULT:
-    0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
-  --shadow-md: 0 2px 10px 0 rgba(0, 0, 0, 0.12);
-  --shadow-lg: 0 0 10px rgba(0, 0, 0, 0.7);
-  --shadow-card-hover: 0 12px 32px rgba(0, 0, 0, 0.15); /* soft elevated card hover */
-  --shadow-input: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-  --shadow-input-focus: 0 0 5px #cacaca;
 
   /* ===== Redesign / Cream Surface (Phase 0) ===== */
 
@@ -496,15 +487,11 @@
   --shadow-paper-sm: 4px 4px 0 0 var(--color-ink);
   --shadow-paper-md: 6px 6px 0 0 var(--color-ink);
   --shadow-paper-lift: 8px 8px 0 0 var(--color-ink);
-  --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.08);
 
-  /* Asymmetric photo shadow — Phase 4.5 (R9). Different cadence from
-     `--shadow-paper-{sm,md,lg}` (symmetric, for cards): tape-shadow offsets
-     2px right + 4px down ("leans forward" feel). Hover-lift moves to
-     `tape-lift` to suggest the photo rising off the page. Used by
-     <TapedFigure>. */
-  --shadow-photo-tape: 2px 4px 0 0 var(--color-ink);
-  --shadow-photo-tape-lift: 4px 8px 0 0 var(--color-ink);
+  /* `--shadow-soft` (blurred) and the asymmetric `--shadow-photo-tape` /
+     `-lift` pair were removed here. The photo-tape pair dates from the Phase
+     4.5 R9 photo treatment, but <TapedFigure> declares no shadow of its own —
+     it delegates to <TapedCard>, so both tokens had been orphaned since. */
 
   --motion-fast: 150ms ease-out;
   --motion-base: 240ms cubic-bezier(0.2, 0.8, 0.2, 1);

--- a/apps/web/src/components/layout/MatchStrip/MatchStripSkeleton.tsx
+++ b/apps/web/src/components/layout/MatchStrip/MatchStripSkeleton.tsx
@@ -9,8 +9,8 @@ export function MatchStripSkeleton() {
       className="bg-cream border-ink/15 min-h-[40px] border-t border-b motion-safe:animate-pulse lg:min-h-[48px]"
     >
       <div className="flex min-h-[40px] items-center justify-center gap-3 px-4 py-2 lg:min-h-[48px]">
-        <div className="bg-ink/10 h-4 w-32 rounded-sm" />
-        <div className="bg-ink/10 hidden h-3 w-48 rounded-sm lg:block" />
+        <div className="bg-ink/10 h-4 w-32" />
+        <div className="bg-ink/10 hidden h-3 w-48 lg:block" />
       </div>
     </div>
   );

--- a/apps/web/src/stories/foundation/Colors.mdx
+++ b/apps/web/src/stories/foundation/Colors.mdx
@@ -94,26 +94,17 @@ in dark gradients.
 
 ---
 
-## Foundation Grays
+## Foundation Gray
 
-Structural grays for cards, dividers, and input backgrounds.
+The last pre-redesign neutral still in service: the `<SectionStack bg="gray-100">`
+surface behind the homepage news grid and banner strips. It is the one cool grey
+in a warm cream system — prefer `cream-soft` for any new section surface.
 
-<SwatchRow items={[
-  { name: 'gray-100', variable: '--color-gray-100', hex: '#f3f4f6' },
-  { name: 'foundation-gray-light', variable: '--color-foundation-gray-light', hex: '#edeff4' },
-]} />
-
----
-
-## Table Colors
-
-Semantic colors for HTML table rendering (used in article body table blocks).
+`foundation-gray-light` and the four `table-*` tokens were removed alongside the
+blurred shadow family; none of them had a consumer anywhere in the app.
 
 <SwatchRow items={[
-  { name: 'table-header-bg', variable: '--color-table-header-bg', hex: '#f3f4f6' },
-  { name: 'table-border', variable: '--color-table-border', hex: '#e5e7eb' },
-  { name: 'table-border-header', variable: '--color-table-border-header', hex: '#d1d5db' },
-  { name: 'table-row-even', variable: '--color-table-row-even', hex: '#f9fafb' },
+  { name: 'gray-100 (homepage news / banner sections)', variable: '--color-gray-100', hex: '#f3f4f6' },
 ]} />
 
 ---
@@ -314,20 +305,16 @@ trio so hover/focus presses stay in lockstep — never inline these values.
       <td><div style={{ background: '#fff', height: '2.5rem', width: '5rem', border: '2px solid var(--color-alert)', boxShadow: 'var(--shadow-paper-sm-alert-hover)', transform: 'translate(1px, 1px)' }} /></td>
       <td>Form-field error hover — same press idiom, alert-soft tint.</td>
     </tr>
-    <tr>
-      <td><code>--shadow-photo-tape</code></td>
-      <td><code>2px 4px 0 0 ink</code></td>
-      <td><div style={{ background: 'var(--color-cream)', height: '2.5rem', width: '5rem', border: '2px solid var(--color-ink)', boxShadow: 'var(--shadow-photo-tape)' }} /></td>
-      <td>Phase 4.5 (R9) — asymmetric photo shadow ("leans forward" feel) used by `&lt;TapedFigure&gt;`.</td>
-    </tr>
-    <tr>
-      <td><code>--shadow-photo-tape-lift</code></td>
-      <td><code>4px 8px 0 0 ink</code></td>
-      <td><div style={{ background: 'var(--color-cream)', height: '2.5rem', width: '5rem', border: '2px solid var(--color-ink)', boxShadow: 'var(--shadow-photo-tape-lift)' }} /></td>
-      <td>Phase 4.5 (R9) — hover-lift companion to `--shadow-photo-tape`.</td>
-    </tr>
   </tbody>
 </table>
+
+The table above is the complete shadow vocabulary. Every entry has a `0` blur
+radius — depth in this system is drawn, not simulated. The pre-redesign blurred
+family (`--shadow-sm`, `--shadow-DEFAULT`, `--shadow-md`, `--shadow-lg`,
+`--shadow-card-hover`, `--shadow-input`, `--shadow-input-focus`, `--shadow-soft`)
+and the asymmetric `--shadow-photo-tape` / `-lift` pair were all removed: none of
+them had a consumer. `<TapedFigure>` declares no shadow of its own — it delegates
+to `<TapedCard>`.
 
 ## Tape colour tokens
 

--- a/apps/web/src/stories/foundation/Colors.mdx
+++ b/apps/web/src/stories/foundation/Colors.mdx
@@ -282,6 +282,18 @@ trio so hover/focus presses stay in lockstep — never inline these values.
       <td>Default paper-card chrome (TapedCard, Alert outer, BrandedTab inactive).</td>
     </tr>
     <tr>
+      <td><code>--shadow-paper-md</code></td>
+      <td><code>6px 6px 0 0 ink</code></td>
+      <td><div style={{ background: 'var(--color-cream)', height: '2.5rem', width: '5rem', border: '2px solid var(--color-ink)', boxShadow: 'var(--shadow-paper-md)' }} /></td>
+      <td>Cards at rest — the most common card weight (TapedCard default).</td>
+    </tr>
+    <tr>
+      <td><code>--shadow-paper-lift</code></td>
+      <td><code>8px 8px 0 0 ink</code></td>
+      <td><div style={{ background: 'var(--color-cream)', height: '2.5rem', width: '5rem', border: '2px solid var(--color-ink)', boxShadow: 'var(--shadow-paper-lift)' }} /></td>
+      <td>Hover target of a tilt-mode card, and emphasis cards.</td>
+    </tr>
+    <tr>
       <td><code>--shadow-paper-sm-soft</code></td>
       <td><code>4px 4px 0 0 ink-muted</code></td>
       <td><div style={{ background: 'var(--color-cream)', height: '2.5rem', width: '5rem', border: '2px solid var(--color-ink)', boxShadow: 'var(--shadow-paper-sm-soft)' }} /></td>

--- a/apps/web/src/stories/foundation/SpacingAndIcons.mdx
+++ b/apps/web/src/stories/foundation/SpacingAndIcons.mdx
@@ -87,18 +87,12 @@ container convergence (#2155).
 
 ## Shadows
 
-<table>
-  <thead><tr><th>Token</th><th>Usage</th></tr></thead>
-  <tbody>
-    <tr><td><code>shadow-sm</code></td><td>Cards, subtle elevation</td></tr>
-    <tr><td><code>shadow</code></td><td>Default card shadow</td></tr>
-    <tr><td><code>shadow-md</code></td><td>Raised elements</td></tr>
-    <tr><td><code>shadow-lg</code></td><td>Modals, overlays</td></tr>
-    <tr><td><code>shadow-card-hover</code></td><td>Legacy — pre-redesign card hover. Redesign cards use the press-down model (see the Paper shadows section below); not used by current cards.</td></tr>
-    <tr><td><code>shadow-input</code></td><td>Form input inset</td></tr>
-    <tr><td><code>shadow-input-focus</code></td><td>Form input focus state</td></tr>
-  </tbody>
-</table>
+There is one shadow vocabulary: the hard, zero-blur paper offsets documented in
+the Paper shadows section below. The pre-redesign blurred tokens (`shadow-sm`,
+`shadow`, `shadow-md`, `shadow-lg`, `shadow-card-hover`, `shadow-input`,
+`shadow-input-focus`) were removed — none of them had a consumer, and a blurred
+shadow breaks the paper idiom. `shadow-none` remains, as the collapsed half of
+the press-down.
 
 ---
 
@@ -257,24 +251,9 @@ soft shadow stays available for chrome that should sit subtly above content
     <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2', marginTop: '12px' }}>--shadow-paper-lift</div>
     <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2' }}>8px offset (hover lift)</div>
   </div>
-  <div style={{ textAlign: 'center' }}>
-    <div style={{ width: '120px', height: '120px', background: 'var(--color-cream-soft)', border: '1px solid var(--color-paper-edge)', boxShadow: 'var(--shadow-soft)' }} />
-    <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2', marginTop: '12px' }}>--shadow-soft</div>
-    <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2' }}>diffuse, for chrome</div>
-  </div>
-  <div style={{ textAlign: 'center' }}>
-    <div style={{ width: '120px', height: '120px', background: 'var(--color-cream-soft)', border: '1px solid var(--color-ink)', boxShadow: 'var(--shadow-photo-tape)' }} />
-    <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2', marginTop: '12px' }}>--shadow-photo-tape</div>
-    <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2' }}>2px / 4px asymmetric (R9)</div>
-  </div>
-  <div style={{ textAlign: 'center' }}>
-    <div style={{ width: '120px', height: '120px', background: 'var(--color-cream-soft)', border: '1px solid var(--color-ink)', boxShadow: 'var(--shadow-photo-tape-lift)' }} />
-    <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2', marginTop: '12px' }}>--shadow-photo-tape-lift</div>
-    <div style={{ fontSize: '11px', fontFamily: 'monospace', color: '#9a9da2' }}>4px / 8px asymmetric hover (R9)</div>
-  </div>
 </div>
 
-The two `--shadow-photo-tape*` tokens use an asymmetric offset (2 / 4 and 4 / 8) different from the symmetric paper shadows. Photos lean forward; cards rest flat. Both vocabularies coexist — see `<TapedFigure>` for the photo idiom.
+Every shadow here has a `0` blur radius: depth is drawn, not simulated. `--shadow-soft` and the asymmetric `--shadow-photo-tape*` pair were removed — both were orphaned (`<TapedFigure>` declares no shadow of its own and delegates to `<TapedCard>`), and a blurred shadow does not belong in the paper idiom.
 
 ### Motion
 

--- a/apps/web/src/stories/foundation/SpacingAndIcons.mdx
+++ b/apps/web/src/stories/foundation/SpacingAndIcons.mdx
@@ -90,8 +90,8 @@ container convergence (#2155).
 There is one shadow vocabulary: the hard, zero-blur paper offsets documented in
 the Paper shadows section below. The pre-redesign blurred tokens (`shadow-sm`,
 `shadow`, `shadow-md`, `shadow-lg`, `shadow-card-hover`, `shadow-input`,
-`shadow-input-focus`) were removed — none of them had a consumer, and a blurred
-shadow breaks the paper idiom. `shadow-none` remains, as the collapsed half of
+`shadow-input-focus`, `shadow-soft`) were removed — none of them had a consumer,
+and a blurred shadow breaks the paper idiom. `shadow-none` remains, as the collapsed half of
 the press-down.
 
 ---
@@ -231,9 +231,10 @@ grid. The pool is intentionally narrow so the page never tips into chaos.
 ### Paper shadows
 
 The redesign uses hard-edged offset shadows ("paper shadows") for cards on the
-cream surface — they read like risograph print rather than soft web glows. The
-soft shadow stays available for chrome that should sit subtly above content
-(dropdowns, sticky bars).
+cream surface — they read like risograph print rather than soft web glows. There
+is no soft alternative for chrome that should sit subtly above content: use the
+ink-muted `--shadow-paper-sm-soft` sibling, which keeps the hard offset but
+softens its colour.
 
 <div style={{ display: 'flex', gap: '32px', flexWrap: 'wrap', alignItems: 'flex-start', marginBottom: '24px', padding: '32px 24px', background: 'var(--color-cream)', borderRadius: '8px', border: '1px solid var(--color-paper-edge)' }}>
   <div style={{ textAlign: 'center' }}>


### PR DESCRIPTION
Records the design system as documentation, and fixes the drift that writing it down exposed.

Storybook has been the authoritative reference for what each token and component *is*. Nothing stated what the **rules** are — why corners are sharp, which of the four greens carries meaning, that a blurred shadow is out of bounds — so every new surface rediscovered the system by reading its neighbours.

## What's here

### 1. `fix(ui)` — square off loading skeletons

Every non-circular border radius left in the app lived in a loading skeleton: **44 stray `rounded` / `rounded-sm` classes across eight files**. A skeleton stands in for the real component's shape, and every real surface is sharp — so the placeholders were previewing a rounder page than the one that loads.

`rounded-full` untouched: circles (avatars, timeline bullets, score badges) are the one legitimate curve.

### 2. `chore(config)` — drop tokens with no consumers

Fifteen tokens that nothing references. They survived the redesign because they are defined in `@theme {}` and documented in Storybook, which makes them look alive — a standing invitation to reintroduce a blurred shadow or a rounded corner into a system built on neither.

| Removed | Why |
| --- | --- |
| `--shadow-sm`, `--shadow-DEFAULT`, `--shadow-md`, `--shadow-lg`, `--shadow-card-hover`, `--shadow-input`, `--shadow-input-focus`, `--shadow-soft` | Pre-redesign blurred family. Zero consumers. |
| `--shadow-photo-tape`, `--shadow-photo-tape-lift` | The R9 comment attributes them to `<TapedFigure>`, which declares no shadow of its own and delegates to `<TapedCard>`. Orphaned since. |
| `--radius-DEFAULT`, `--radius-card` | Unreferenced once the skeletons were squared. |
| `--color-foundation-gray-light`, `--color-table-header-bg`, `--color-table-border`, `--color-table-border-header`, `--color-table-row-even` | Appear nowhere outside their own Storybook swatches. |

Kept: `--shadow-none` (the collapsed half of the press-down) and `--color-gray-100` (the `<SectionStack>` surface behind four homepage sections — see the open question below). Both Foundation MDX docs updated so Storybook stops rendering swatches for tokens that no longer exist.

### 3. `docs(config)` — `PRODUCT.md`, `DESIGN.md`, `.impeccable/design.json`

- **`PRODUCT.md`** — durable product truth: two co-primary audiences (matchday supporters, youth parents), the three success criteria the club named, the phone-first-outdoors and less-digital constraints, and the hard boundary on what the site does not do (no tickets, shop, streaming, live scores, accounts, newsletter).
- **`DESIGN.md`** — the visual system in the [DESIGN.md spec](https://github.com/google-labs-code/design.md) format: token frontmatter plus the eight canonical sections, extracted from the live theme and primitives rather than from intentions. Thirteen named rules, including what was previously tribal knowledge — the two-greens distinction, the missing 900 italic in Freight Big Pro, one emphasis per heading, three container widths, no blur, sharp corners.
- **`.impeccable/design.json`** — machine-readable sidecar: tonal ramps, shadow/motion/breakpoint tokens, ten self-contained component snippets.

### 4. `docs(config)` — point `CLAUDE.md` at both

Without this, nothing loads the two files above and the thirteen rules never reach the agent that needs them. Splits the references by job rather than ranking them:

- **`DESIGN.md`** owns intent — why corners are sharp, which green carries meaning, why shadows never blur.
- **Storybook** stays authoritative for values and component shapes.
- **`PRODUCT.md`** owns product truth and the list of surfaces this site deliberately does not have.

Also records that `.impeccable/design.json` is regenerated with `DESIGN.md`, never hand-edited.

## Correction worth flagging

A doc comment on the homepage described `<BannerSlot>` as legacy. **It isn't** — it is fully redesigned (sharp corners, ink border, paper shadow, canonical press-down; last touched in #2282). What is actually pre-redesign is the `gray-100` **surface** under it, which is shared with the news grid across four sections. The comment is corrected.

## Open question — not addressed here

`gray-100` (`#f3f4f6`) is the one cool grey in a warm cream system. Swapping those four homepage sections to a cream step is a visible homepage change and a design decision, so it is deliberately left out of this PR. Filed as #2342 — it needs an owner decision (cream-soft / cream-deep / transparent) before it can be implemented.

## Verification

`lint`, `type-check`, **3305 tests across 290 files**, and `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
