### PR TITLE
chore(config): drop pnpmDedupe to stop Renovate OOM-killing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -195,7 +195,6 @@
   "commitMessageAction": "{{semanticCommitType}}({{semanticCommitScope}}): update",
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-  "postUpdateOptions": ["pnpmDedupe"],
   "prCreation": "immediate",
   "prConcurrentLimit": 3,
   "schedule": ["before 11pm on monday"],


### PR DESCRIPTION
## Problem

Renovate has not run since **2026-07-13** — three scheduled Monday windows missed, and the Dependency Dashboard (#13) frozen with its `manual job` trigger box stuck ticked.

The Mend job page tells the real story: jobs queue fine (`Reason: Scheduled`), then die.

```text
Status: FAILED
Error:  kernel-out-of-memory
```

The container is being OOM-killed. Not a config-validation problem (no open *"Action Required: Fix Renovate Configuration"* issue), not a schedule problem, not a permissions problem. Mend-hosted runner memory is fixed, so the only lever is making the job cheaper.

## Change

Drop `postUpdateOptions: ["pnpmDedupe"]`.

`pnpm dedupe` re-resolves the entire workspace — 18 `package.json` files, a 20.8k-line lockfile — in a child process, on top of Renovate's own heap, once per branch built. It is the most expensive post-update step we run.

It also buys us close to nothing: with `rangeStrategy: "pin"` every direct dependency is already an exact version, so there are no ranges left for dedupe to collapse. Highest cost, lowest value → first thing to cut.

## Why it started failing now, on unchanged config

Same config, more work per job. Three major updates got queued via `unschedule-branch` boxes on #13 (`@cloudflare/workers-types` v5, `@sanity/icons` v5, TypeScript v7) alongside lock-file-maintenance, so a single run now builds several branches, each with its own install + dedupe. That tipped it past the cap.

## If it OOMs again

Escalate one step at a time, cheapest first:

1. Untick those three `[x]` major boxes on #13 — free, no commit, biggest single reduction in per-job work.
2. `"lockFileMaintenance": { "enabled": false }` — the heaviest individual job.
3. `"branchConcurrentLimit": 1` — one branch built per run.

## Verification

`renovate-config-validator` passes:

```text
INFO: Validating renovate.json
INFO: Config validated successfully against 1 file(s)
```

Real verification is the next Mend job reaching `SUCCESS`. Worth watching: **TypeScript v7** is one of the queued majors, and it collides with the deliberate tsgo + tsc dual-install documented in `CLAUDE.md` — that PR should not be automerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation by removing the automatic package deduplication step.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->