### PR TITLE
ci(config): self-host Renovate to escape the OOM-killed Mend runner

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,46 @@
+# Self-hosted Renovate, replacing the Mend-hosted app.
+#
+# Mend's runner was being OOM-killed by `pnpm install --lockfile-only --recursive`
+# on this workspace — the job died ~60s in, on the first branch that needed a
+# lockfile, so no Renovate config knob could avoid it. See issue #13.
+#
+# Behaviour is unchanged: renovate.json is still the single source of truth and is
+# picked up automatically. This only supplies a runner with enough memory.
+name: Renovate
+
+on:
+  # Daily, even though renovate.json gates normal updates to Monday: vulnerability
+  # alerts bypass that schedule, so a daily tick keeps security fixes at <24h
+  # instead of <7d. Runs with nothing to do finish in about a minute.
+  schedule:
+    - cron: "0 20 * * *" # 21:00 CET / 22:00 CEST — inside the Monday window
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level"
+        type: choice
+        options: [info, debug]
+        default: info
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    # Actions minutes are billed on this repo, so cap a hung run rather than let
+    # it drain the job limit. A full run is normally well under 10 minutes.
+    timeout-minutes: 30
+
+    steps:
+      - uses: renovatebot/github-action@316d7cd859606d6039a2182b7d69199e9b036835 # v46.2.1
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}


### PR DESCRIPTION
## Problem

Mend's hosted runner cannot build a lockfile for this workspace any more. From the job log (2026-08-05), the run ends mid-command, ~60s in, with **no error line at all** — the microvm is killed outright:

```text
Executing command: pnpm install --lockfile-only --recursive --ignore-scripts --ignore-pnpmfile
```

No matching `exec completed` follows. That was the **only** install spawn in the entire run, on the **first** branch that needed a lockfile (`renovate/npm-sharp-vulnerability` — vulnerability branches bypass the schedule, so they go first). The ~30 branches processed before it were metadata-only and cheap.

That rules out every config-level mitigation: since it dies on the *first* install, nothing that reduces the *number* of branches helps — `branchConcurrentLimit`, disabling `lockFileMaintenance`, unticking the queued major boxes on #13. Dropping `pnpmDedupe` in #2344 removed dead weight but could not have fixed this either, because dedupe runs *after* lockfile generation, which never completes.

The workspace didn't grow into the failure: `pnpm-lock.yaml` has been flat at ~20.4k→20.8k lines since June. The runner simply no longer fits it.

## Change

Run Renovate on `ubuntu-latest` instead of Mend's microvm. One new workflow; **`renovate.json` is untouched** and remains the single source of truth.

Daily rather than weekly: `renovate.json` still gates ordinary dependency PRs to `before 11pm on monday`, but `vulnerabilityAlerts` bypass that schedule, so a daily tick cuts security-fix latency from ~7 days to <24h. Runs with nothing to do finish in about a minute.

`timeout-minutes: 30` is deliberate — Actions minutes are billed on this repo (net $5.00 in June), so a hung run gets capped rather than draining the 6h job limit.

## Required before this can work

1. **Create a `RENOVATE_TOKEN` repo secret.** A classic PAT needs **`repo` *and* `workflow`** scopes — `workflow` is not optional here, because `enabledManagers` includes `github-actions`, so Renovate edits files under `.github/workflows/` and pushes without it will be rejected.
2. Merge this PR.
3. Run the workflow manually (**Actions → Renovate → Run workflow**) and confirm it goes green.
4. **Only then, disable the Mend app** for this repo. Until step 4, both would run and could open duplicate PRs.

## Verification

`actionlint` passes clean. The real check is step 3 above — a green manual run that gets past `pnpm install --lockfile-only`, which is precisely where Mend dies.

Watch out on that first successful run: three majors are queued via `unschedule-branch` boxes on #13 (`@cloudflare/workers-types` v5, `@sanity/icons` v5, **TypeScript v7**). TypeScript v7 collides with the deliberate tsgo + tsc dual-install documented in `CLAUDE.md` and must not be automerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
