### PR TITLE
fix(config): stop devDependency majors from automerging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,11 +82,6 @@
       "automerge": true
     },
     {
-      "description": "Automerge devDependencies",
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    },
-    {
       "description": "Batch all remaining non-major devDependencies into one weekly PR to cut CI runs. Placed before the specific groups below so those (eslint, storybook, typescript, playwright, react types) still win for their packages; everything else (wrangler, prettier, workers-types, etc.) collapses here.",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Problem

```json
{
  "description": "Automerge devDependencies",
  "matchDepTypes": ["devDependencies"],
  "automerge": true
}
```

No `matchUpdateTypes` filter, and it sits *after* `"Automerge non-major updates"`. Later rules win, so this granted `automerge: true` to devDependency updates of **any** size — majors included.

Nothing downstream reset it. Only the Next.js and nvm rules set `automerge: false` for majors, and neither covers the general case.

`typescript` is a devDependency in every workspace here, so `renovate/major-typescript-packages` (**TypeScript v7**, currently sitting on the dashboard) would have merged itself — straight into the deliberate tsgo + tsc dual-install that `CLAUDE.md` explicitly says to keep until TS 7.0 GA.

## Change

Delete the rule rather than add `matchUpdateTypes` to it. Restricted to `minor`/`patch`/`pin`/`digest` it would be a strict subset of `"Automerge non-major updates"` immediately above, which already matches every `depType`. Redundant either way — so it goes.

## Result

Every remaining automerge rule is update-type gated, and none grants automerge to a major:

```text
true  | minor, patch, pin, digest |          | Automerge non-major updates
false | major                     | next     | Separate major Next.js updates
true  | minor, patch              | nvm      | Auto-update .nvmrc minor/patch
false | major                     | nvm      | Major Node.js updates need manual review
```

Non-major updates still automerge exactly as before — devDependencies included. The only behaviour that changes is that **majors now wait for a human**, which was already the intent everywhere else in this config.

## Verification

`renovate-config-validator` passes:

```text
INFO: Validating renovate.json
INFO: Config validated successfully against 1 file(s)
```

Rule table above generated from the parsed config, not read by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
