### PR TITLE
feat(schema): flatten photoGallery images for native bulk upload (#2363)

### DIFF
--- a/apps/web/scripts/seed-1471-photo-galleries-staging.mjs
+++ b/apps/web/scripts/seed-1471-photo-galleries-staging.mjs
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 import {
   assertProductionGuard,
   makeClient,
+  imageRef,
   upsertImageAsset,
   paragraph,
 } from "./seeds/phase-5-shared.mjs";
@@ -40,14 +41,10 @@ const fixturePath = (filename) =>
 
 // Upload a fixture image (idempotent by filename) → a gallery-image array item.
 // Flat shape (#2363): `galleryImage` IS an image, so the asset ref sits on the
-// item itself instead of a nested `image` field.
+// item itself — spread imageRef's shape, then override its `_type`.
 async function galleryImage(key, filename, { caption, credit } = {}) {
   const assetId = await upsertImageAsset(client, filename, fixturePath(filename));
-  const item = {
-    _key: key,
-    _type: "galleryImage",
-    asset: { _type: "reference", _ref: assetId },
-  };
+  const item = { ...imageRef(assetId), _key: key, _type: "galleryImage" };
   if (caption) item.caption = caption;
   if (credit) item.credit = credit;
   return item;

--- a/apps/web/scripts/seed-1471-photo-galleries-staging.mjs
+++ b/apps/web/scripts/seed-1471-photo-galleries-staging.mjs
@@ -27,7 +27,6 @@ import { fileURLToPath } from "node:url";
 import {
   assertProductionGuard,
   makeClient,
-  imageRef,
   upsertImageAsset,
   paragraph,
 } from "./seeds/phase-5-shared.mjs";
@@ -40,9 +39,15 @@ const fixturePath = (filename) =>
   fileURLToPath(new URL(`../test/fixtures/images/${filename}`, import.meta.url));
 
 // Upload a fixture image (idempotent by filename) → a gallery-image array item.
+// Flat shape (#2363): `galleryImage` IS an image, so the asset ref sits on the
+// item itself instead of a nested `image` field.
 async function galleryImage(key, filename, { caption, credit } = {}) {
   const assetId = await upsertImageAsset(client, filename, fixturePath(filename));
-  const item = { _key: key, _type: "galleryImage", image: imageRef(assetId) };
+  const item = {
+    _key: key,
+    _type: "galleryImage",
+    asset: { _type: "reference", _ref: assetId },
+  };
   if (caption) item.caption = caption;
   if (credit) item.credit = credit;
   return item;

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -75,7 +75,7 @@ const EVENT_SITEMAP_QUERY = `*[_type == "event" && defined(slug.current) && coal
 const GALLERY_SITEMAP_QUERY = `*[_type == "photoGallery" && defined(slug.current)] | order(publishedAt desc) {
   "slug": slug.current,
   "publishedAt": publishedAt,
-  "image": images[0].image.asset->url + "?w=1200&h=630&fit=crop&fm=webp&q=80"
+  "image": images[0].asset->url + "?w=1200&h=630&fit=crop&fm=webp&q=80"
 }`;
 
 const PLAYER_SITEMAP_QUERY = `*[_type == "player" && archived != true && defined(psdId) && psdId != ""] {

--- a/apps/web/src/lib/repositories/photoGallery.repository.ts
+++ b/apps/web/src/lib/repositories/photoGallery.repository.ts
@@ -23,8 +23,8 @@ export const GALLERIES_QUERY =
   "slug": coalesce(slug.current, ""),
   "publishedAt": coalesce(publishedAt, ""),
   "imageCount": coalesce(count(images), 0),
-  "coverUrl": images[0].image.asset->url,
-  "coverLqip": images[0].image.asset->metadata.lqip,
+  "coverUrl": images[0].asset->url,
+  "coverLqip": images[0].asset->metadata.lqip,
   "coverAlt": coalesce(images[0].caption, title, "")
 }`);
 
@@ -46,8 +46,8 @@ export const GALLERY_BY_SLUG_QUERY =
   "descriptionText": pt::text(description),
   "descriptionRich": description,
   "images": images[]{
-    "url": image.asset->url,
-    "lqip": image.asset->metadata.lqip,
+    "url": asset->url,
+    "lqip": asset->metadata.lqip,
     "alt": coalesce(alt, caption, ""),
     "caption": coalesce(caption, ""),
     "credit": coalesce(credit, ^.defaultCredit, "")
@@ -68,8 +68,8 @@ export const GALLERIES_BY_MATCH_QUERY =
   "slug": coalesce(slug.current, ""),
   "publishedAt": coalesce(publishedAt, ""),
   "imageCount": coalesce(count(images), 0),
-  "coverUrl": images[0].image.asset->url,
-  "coverLqip": images[0].image.asset->metadata.lqip,
+  "coverUrl": images[0].asset->url,
+  "coverLqip": images[0].asset->metadata.lqip,
   "coverAlt": coalesce(images[0].caption, title, "")
 }`);
 
@@ -81,8 +81,8 @@ export const GALLERIES_BY_EVENT_QUERY =
   "slug": coalesce(slug.current, ""),
   "publishedAt": coalesce(publishedAt, ""),
   "imageCount": coalesce(count(images), 0),
-  "coverUrl": images[0].image.asset->url,
-  "coverLqip": images[0].image.asset->metadata.lqip,
+  "coverUrl": images[0].asset->url,
+  "coverLqip": images[0].asset->metadata.lqip,
   "coverAlt": coalesce(images[0].caption, title, "")
 }`);
 

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -231,13 +231,10 @@ export type PhotoGallery = {
   }>;
   defaultCredit?: string;
   images?: Array<{
-    image?: {
-      asset?: SanityImageAssetReference;
-      media?: unknown;
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: "image";
-    };
+    asset?: SanityImageAssetReference;
+    media?: unknown;
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
     alt?: string;
     caption?: string;
     credit?: string;
@@ -2307,7 +2304,7 @@ export type PAGE_BY_SLUG_QUERY_RESULT = {
 
 // Source: ../web/src/lib/repositories/photoGallery.repository.ts
 // Variable: GALLERIES_QUERY
-// Query: *[_type == "photoGallery" && defined(slug.current)] | order(publishedAt desc) {  "id": _id,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "imageCount": coalesce(count(images), 0),  "coverUrl": images[0].image.asset->url,  "coverLqip": images[0].image.asset->metadata.lqip,  "coverAlt": coalesce(images[0].caption, title, "")}
+// Query: *[_type == "photoGallery" && defined(slug.current)] | order(publishedAt desc) {  "id": _id,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "imageCount": coalesce(count(images), 0),  "coverUrl": images[0].asset->url,  "coverLqip": images[0].asset->metadata.lqip,  "coverAlt": coalesce(images[0].caption, title, "")}
 export type GALLERIES_QUERY_RESULT = Array<{
   id: string;
   title: string | "";
@@ -2321,7 +2318,7 @@ export type GALLERIES_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/photoGallery.repository.ts
 // Variable: GALLERY_BY_SLUG_QUERY
-// Query: *[_type == "photoGallery" && slug.current == $slug][0] {  "id": _id,  "updatedAt": _updatedAt,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "descriptionText": pt::text(description),  "descriptionRich": description,  "images": images[]{    "url": image.asset->url,    "lqip": image.asset->metadata.lqip,    "alt": coalesce(alt, caption, ""),    "caption": coalesce(caption, ""),    "credit": coalesce(credit, ^.defaultCredit, "")  }}
+// Query: *[_type == "photoGallery" && slug.current == $slug][0] {  "id": _id,  "updatedAt": _updatedAt,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "descriptionText": pt::text(description),  "descriptionRich": description,  "images": images[]{    "url": asset->url,    "lqip": asset->metadata.lqip,    "alt": coalesce(alt, caption, ""),    "caption": coalesce(caption, ""),    "credit": coalesce(credit, ^.defaultCredit, "")  }}
 export type GALLERY_BY_SLUG_QUERY_RESULT = {
   id: string;
   updatedAt: string;
@@ -2366,7 +2363,7 @@ export type GALLERY_SLUGS_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/photoGallery.repository.ts
 // Variable: GALLERIES_BY_MATCH_QUERY
-// Query: *[_type == "photoGallery" && linkedMatch == $matchId && defined(slug.current)] | order(publishedAt asc) {  "id": _id,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "imageCount": coalesce(count(images), 0),  "coverUrl": images[0].image.asset->url,  "coverLqip": images[0].image.asset->metadata.lqip,  "coverAlt": coalesce(images[0].caption, title, "")}
+// Query: *[_type == "photoGallery" && linkedMatch == $matchId && defined(slug.current)] | order(publishedAt asc) {  "id": _id,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "imageCount": coalesce(count(images), 0),  "coverUrl": images[0].asset->url,  "coverLqip": images[0].asset->metadata.lqip,  "coverAlt": coalesce(images[0].caption, title, "")}
 export type GALLERIES_BY_MATCH_QUERY_RESULT = Array<{
   id: string;
   title: string | "";
@@ -2380,7 +2377,7 @@ export type GALLERIES_BY_MATCH_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/photoGallery.repository.ts
 // Variable: GALLERIES_BY_EVENT_QUERY
-// Query: *[_type == "photoGallery" && linkedEvent._ref == $eventId && defined(slug.current)] | order(publishedAt asc) {  "id": _id,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "imageCount": coalesce(count(images), 0),  "coverUrl": images[0].image.asset->url,  "coverLqip": images[0].image.asset->metadata.lqip,  "coverAlt": coalesce(images[0].caption, title, "")}
+// Query: *[_type == "photoGallery" && linkedEvent._ref == $eventId && defined(slug.current)] | order(publishedAt asc) {  "id": _id,  "title": coalesce(title, ""),  "slug": coalesce(slug.current, ""),  "publishedAt": coalesce(publishedAt, ""),  "imageCount": coalesce(count(images), 0),  "coverUrl": images[0].asset->url,  "coverLqip": images[0].asset->metadata.lqip,  "coverAlt": coalesce(images[0].caption, title, "")}
 export type GALLERIES_BY_EVENT_QUERY_RESULT = Array<{
   id: string;
   title: string | "";
@@ -2822,11 +2819,11 @@ declare module "@sanity/client" {
     '*[_type == "homePage"][0] {\n    "matchesSliderPlaceholder": matchesSliderPlaceholder {\n      nextSeasonKickoff,\n      announcementText,\n      announcementHref,\n      "highlightImage": highlightImage {\n        alt,\n        "asset": asset->{\n          _id,\n          url,\n          "lqip": metadata.lqip,\n          "dimensions": metadata.dimensions\n        }\n      }\n    }\n  }': HOMEPAGE_PLACEHOLDER_QUERY_RESULT;
     '*[_type == "jeugdLandingPage"][0] {\n  editorialCards[] {\n    tag, title, description, arrowText, href,\n    "imageUrl": image.asset->url + "?w=900&q=80&fm=webp",\n    position, cardType\n  }\n}': JEUGD_LANDING_PAGE_QUERY_RESULT;
     '*[_type == "page" && slug.current == $slug][0] {\n  "id": _id, "title": coalesce(title, ""), "slug": coalesce(slug.current, ""),\n  "heroImageUrl": heroImage.asset->url + "?w=1600&q=80&fm=webp&fit=max",\n  metaDescription,\n  "ogImageUrl": ogImage.asset->url + "?w=1200&h=630&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(ogImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(ogImage.hotspot.y, 0.5)),\n  body[]{ ..., "fileUrl": file.asset->url, "fileSize": file.asset->size, "fileMimeType": file.asset->mimeType, "fileOriginalFilename": file.asset->originalFilename, "asset": select(_type == "image" => asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }, _type == "articleImage" => image.asset->{ "url": url + "?w=800&q=80&fm=webp&fit=max", title, description, creditLine, metadata{dimensions, lqip} }) }\n}': PAGE_BY_SLUG_QUERY_RESULT;
-    '*[_type == "photoGallery" && defined(slug.current)] | order(publishedAt desc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].image.asset->url,\n  "coverLqip": images[0].image.asset->metadata.lqip,\n  "coverAlt": coalesce(images[0].caption, title, "")\n}': GALLERIES_QUERY_RESULT;
-    '*[_type == "photoGallery" && slug.current == $slug][0] {\n  "id": _id,\n  "updatedAt": _updatedAt,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "descriptionText": pt::text(description),\n  "descriptionRich": description,\n  "images": images[]{\n    "url": image.asset->url,\n    "lqip": image.asset->metadata.lqip,\n    "alt": coalesce(alt, caption, ""),\n    "caption": coalesce(caption, ""),\n    "credit": coalesce(credit, ^.defaultCredit, "")\n  }\n}': GALLERY_BY_SLUG_QUERY_RESULT;
+    '*[_type == "photoGallery" && defined(slug.current)] | order(publishedAt desc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].asset->url,\n  "coverLqip": images[0].asset->metadata.lqip,\n  "coverAlt": coalesce(images[0].caption, title, "")\n}': GALLERIES_QUERY_RESULT;
+    '*[_type == "photoGallery" && slug.current == $slug][0] {\n  "id": _id,\n  "updatedAt": _updatedAt,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "descriptionText": pt::text(description),\n  "descriptionRich": description,\n  "images": images[]{\n    "url": asset->url,\n    "lqip": asset->metadata.lqip,\n    "alt": coalesce(alt, caption, ""),\n    "caption": coalesce(caption, ""),\n    "credit": coalesce(credit, ^.defaultCredit, "")\n  }\n}': GALLERY_BY_SLUG_QUERY_RESULT;
     '*[_type == "photoGallery" && defined(slug.current)] { "slug": coalesce(slug.current, ""), "updatedAt": _updatedAt }': GALLERY_SLUGS_QUERY_RESULT;
-    '*[_type == "photoGallery" && linkedMatch == $matchId && defined(slug.current)] | order(publishedAt asc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].image.asset->url,\n  "coverLqip": images[0].image.asset->metadata.lqip,\n  "coverAlt": coalesce(images[0].caption, title, "")\n}': GALLERIES_BY_MATCH_QUERY_RESULT;
-    '*[_type == "photoGallery" && linkedEvent._ref == $eventId && defined(slug.current)] | order(publishedAt asc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].image.asset->url,\n  "coverLqip": images[0].image.asset->metadata.lqip,\n  "coverAlt": coalesce(images[0].caption, title, "")\n}': GALLERIES_BY_EVENT_QUERY_RESULT;
+    '*[_type == "photoGallery" && linkedMatch == $matchId && defined(slug.current)] | order(publishedAt asc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].asset->url,\n  "coverLqip": images[0].asset->metadata.lqip,\n  "coverAlt": coalesce(images[0].caption, title, "")\n}': GALLERIES_BY_MATCH_QUERY_RESULT;
+    '*[_type == "photoGallery" && linkedEvent._ref == $eventId && defined(slug.current)] | order(publishedAt asc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].asset->url,\n  "coverLqip": images[0].asset->metadata.lqip,\n  "coverAlt": coalesce(images[0].caption, title, "")\n}': GALLERIES_BY_EVENT_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
     '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio,\n  "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {\n    name, season\n  }\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "player" && keeper == true && archived != true].psdId': KEEPER_PSD_IDS_QUERY_RESULT;

--- a/packages/sanity-schemas/CLAUDE.md
+++ b/packages/sanity-schemas/CLAUDE.md
@@ -41,6 +41,7 @@ Image fields use semantic prefixes that reflect the content's role — not a gen
 | ------------------ | ------------------------------------------------------------------ | --------------------------------------------- |
 | `coverImage`       | Editorial content image (article, event)                           | `article`, `event`                            |
 | `heroImage`        | Generic page banner                                                | `page`                                        |
+| `galleryImage`     | Gallery photo — array item carrying alt/caption/credit fields      | `photoGallery`                                |
 | `teamImage`        | Team squad photo                                                   | `team`                                        |
 | `logo`             | Brand mark                                                         | `sponsor`                                     |
 | `photo`            | Person portrait                                                    | `staffMember`                                 |

--- a/packages/sanity-schemas/src/index.ts
+++ b/packages/sanity-schemas/src/index.ts
@@ -10,6 +10,12 @@ export {
   qaPairRespondentPreviewSelect,
   prepareQaPairRespondentPreview,
 } from './preview/qa-pair-respondent-preview'
+export {
+  galleryImagePreviewSelect,
+  prepareGalleryImagePreview,
+  photoGalleryPreviewSelect,
+  preparePhotoGalleryPreview,
+} from './preview/photoGallery-preview'
 export {validateOrganigramMember} from './validation/organigram-members'
 export {validateSubjectsCount} from './validation/subjects-count'
 export type {SubjectsCountContext} from './validation/subjects-count'

--- a/packages/sanity-schemas/src/photoGallery.ts
+++ b/packages/sanity-schemas/src/photoGallery.ts
@@ -68,26 +68,29 @@ export const photoGallery = defineType({
       type: 'array',
       group: 'fotos',
       description:
-        'De foto\'s in de galerij. De eerste foto is automatisch de cover (gebruikt op de overzichtskaart en als deelafbeelding). Sleep om de volgorde te wijzigen.',
+        'De foto\'s in de galerij. De eerste foto is automatisch de cover (gebruikt op de overzichtskaart en als deelafbeelding). Sleep om de volgorde te wijzigen. Maximaal 80 foto\'s per galerij. Splits grote reeksen op in meerdere galerijen.',
+      // A flat array of `image` (not objects wrapping an image) so Sanity's
+      // native multi-file drop/paste applies — one item per dropped file, in
+      // file order. Metadata lives as custom fields on the image itself (#2363).
       of: [
         defineField({
-          name: 'galleryImage',
+          name: 'galleryImage', // keep the name — item `_type` stays "galleryImage"
           title: 'Image',
-          type: 'object',
+          type: 'image',
+          options: {hotspot: true},
+          // `required()` can't gate the asset here: alt/caption/credit live on
+          // this object, so a caption-only item is non-empty yet imageless.
+          validation: (r) =>
+            r.custom((img: {asset?: unknown} | undefined) =>
+              img?.asset ? true : 'Verplicht. Een lege fotoslot wordt niet getoond.',
+            ),
           fields: [
-            defineField({
-              name: 'image',
-              title: 'Image',
-              type: 'image',
-              options: {hotspot: true},
-              validation: (r) => r.required().error('Verplicht. Een lege fotoslot wordt niet getoond.'),
-            }),
             defineField({
               name: 'alt',
               title: 'Alt text',
               type: 'string',
               description:
-                'Beschrijf de foto voor toegankelijkheid (schermlezers) en SEO. Niet hetzelfde als het onderschrift.',
+                'Beschrijf de foto voor toegankelijkheid (schermlezers) en SEO. Niet hetzelfde als het onderschrift. Laat je dit leeg, dan gebruikt de site het onderschrift als alt-tekst.',
               validation: (r) =>
                 r.required().warning('Geef een beschrijvende alt-tekst voor toegankelijkheid.'),
             }),
@@ -106,7 +109,7 @@ export const photoGallery = defineType({
             }),
           ],
           preview: {
-            select: {title: 'caption', subtitle: 'credit', media: 'image'},
+            select: {title: 'caption', subtitle: 'credit', media: 'asset'},
             prepare({title, subtitle, media}) {
               return {title: title || 'Foto', subtitle, media}
             },
@@ -115,7 +118,7 @@ export const photoGallery = defineType({
       ],
       validation: (r) => [
         r.required().min(1).error('Voeg minstens één foto toe — de eerste foto is de cover van de galerij.'),
-        r.max(80).warning("Meer dan 80 foto's kan de galerij traag laden. Splits grote reeksen op in meerdere galerijen."),
+        r.max(80).error("Maximaal 80 foto's per galerij. Verwijder foto's of splits de reeks op in meerdere galerijen."),
       ],
     }),
     defineField({
@@ -137,7 +140,7 @@ export const photoGallery = defineType({
     }),
   ],
   preview: {
-    select: {title: 'title', media: 'images.0.image', publishedAt: 'publishedAt', images: 'images'},
+    select: {title: 'title', media: 'images.0', publishedAt: 'publishedAt', images: 'images'},
     prepare({title, media, publishedAt, images}) {
       const count = Array.isArray(images) ? images.length : 0
       const date = publishedAt ? new Date(publishedAt).toLocaleDateString('nl-BE') : ''

--- a/packages/sanity-schemas/src/photoGallery.ts
+++ b/packages/sanity-schemas/src/photoGallery.ts
@@ -1,5 +1,12 @@
 import {defineField, defineType} from 'sanity'
 
+import {
+  galleryImagePreviewSelect,
+  prepareGalleryImagePreview,
+  photoGalleryPreviewSelect,
+  preparePhotoGalleryPreview,
+} from './preview/photoGallery-preview'
+
 export const photoGallery = defineType({
   name: 'photoGallery',
   title: 'Photo gallery',
@@ -109,10 +116,8 @@ export const photoGallery = defineType({
             }),
           ],
           preview: {
-            select: {title: 'caption', subtitle: 'credit', media: 'asset'},
-            prepare({title, subtitle, media}) {
-              return {title: title || 'Foto', subtitle, media}
-            },
+            select: galleryImagePreviewSelect,
+            prepare: prepareGalleryImagePreview,
           },
         }),
       ],
@@ -140,12 +145,7 @@ export const photoGallery = defineType({
     }),
   ],
   preview: {
-    select: {title: 'title', media: 'images.0', publishedAt: 'publishedAt', images: 'images'},
-    prepare({title, media, publishedAt, images}) {
-      const count = Array.isArray(images) ? images.length : 0
-      const date = publishedAt ? new Date(publishedAt).toLocaleDateString('nl-BE') : ''
-      const subtitle = [count ? `${count} foto's` : '', date].filter(Boolean).join(' · ')
-      return {title, subtitle, media}
-    },
+    select: photoGalleryPreviewSelect,
+    prepare: preparePhotoGalleryPreview,
   },
 })

--- a/packages/sanity-schemas/src/preview/photoGallery-preview.ts
+++ b/packages/sanity-schemas/src/preview/photoGallery-preview.ts
@@ -1,0 +1,40 @@
+/**
+ * Sanity preview select + prepare for photoGallery.
+ *
+ * Two previews: the `galleryImage` array member (caption/credit, thumbnail
+ * from the flattened image's own `asset` — #2363) and the document (title +
+ * photo count + date, first image as cover). The document select reads the
+ * raw `images` array to count it — plain path select, no array deref (see
+ * organigramNode-preview.ts for why derefs by index stall the preview).
+ */
+
+export const galleryImagePreviewSelect = {
+  title: 'caption',
+  subtitle: 'credit',
+  media: 'asset',
+}
+
+export function prepareGalleryImagePreview(
+  selection: Record<keyof typeof galleryImagePreviewSelect, any>,
+) {
+  const {title, subtitle, media} = selection
+  return {title: title || 'Foto', subtitle, media}
+}
+
+export const photoGalleryPreviewSelect = {
+  title: 'title',
+  media: 'images.0',
+  publishedAt: 'publishedAt',
+  images: 'images',
+}
+
+export function preparePhotoGalleryPreview(
+  selection: Record<keyof typeof photoGalleryPreviewSelect, any>,
+) {
+  const {title, media, publishedAt, images} = selection
+  const count = Array.isArray(images) ? images.length : 0
+  const parsed = typeof publishedAt === 'string' ? new Date(publishedAt) : null
+  const date = parsed && !Number.isNaN(parsed.getTime()) ? parsed.toLocaleDateString('nl-BE') : ''
+  const subtitle = [count ? `${count} foto's` : '', date].filter(Boolean).join(' · ')
+  return {title, subtitle, media}
+}


### PR DESCRIPTION
Closes #2363
Closes #2348 (wayfinder map — this PR completes it)

## Changes

- **Schema flatten** (`packages/sanity-schemas/src/photoGallery.ts`): `galleryImage` is now an `image` type carrying `alt`/`caption`/`credit` as custom fields, so Sanity's native multi-file drop/paste creates one item per file, in file order — zero bespoke upload code. The item `_type` stays `"galleryImage"`.
- **Empty-slot guard** moved to `r.custom((img) => img?.asset ? true : …)`: with metadata fields on the image object, a caption-only item is non-empty yet asset-less, so `required()` provably can't gate the asset (the spec's anticipated fallback).
- **Ceiling** (`#2355`): `r.max(80)` upgraded `.warning()` → `.error()` with new copy; ceiling stated upfront in the `images` field description; debunked "traag laden" copy dropped.
- **Alt policy** (`#2354`): validation unchanged (`required().warning`), never seeded from filenames; description now teaches the caption-fallback (`coalesce(alt, caption, "")` on the frontend).
- **GROQ collapse**: `images[].image.asset` → `images[].asset` in the five consuming queries (`photoGallery.repository.ts` ×4, `sitemap.ts` ×1). View-model field names unchanged → no component/story/VR changes.
- **Types**: `sanity.types.ts` regenerated via typegen (drift-checked clean).
- **Seed script**: staging seed emits the flat shape, reusing `imageRef`.
- **Previews** extracted to `src/preview/photoGallery-preview.ts` per the package's Preview Blocks rule; `galleryImage` row added to the image-prefix table in the package CLAUDE.md.

## Explicitly NOT a migration

Decided on the wayfinder map (#2353): corpus is 1 production gallery (3 images) + staging seed data. Manual steps below replace a migration script — none was written, per spec.

## Manual steps (post-merge)

1. **Deploy both studios** (no CI auto-deploy):
   `cd apps/studio && npx sanity deploy` and `cd apps/studio-staging && SANITY_STUDIO_DATASET=staging npx sanity deploy --yes`
2. **Staging**: re-run `apps/web/scripts/seed-1471-photo-galleries-staging.mjs` (idempotent `createOrReplace` — replaces the old-shape items).
3. **Production**: in "Ploegvoorstelling 2026-2027", delete the 3 old-shape items and bulk-drop the queued ~50-photo set — this doubles as the acceptance test (items in file order, metadata empty). Note: once the web app deploys, old-shape items stop rendering until the re-drop.
4. Studio spot-checks: array-item thumbnails + document cover render; an 81st image blocks publish with the new copy; *Add item*-created empty slot fails validation.

## Testing

- `@kcvv/sanity-schemas` build + type-check; `@kcvv/studio` + `@kcvv/studio-staging` lint + build — all pass.
- `@kcvv/web` check-all: lint, type-check, full vitest suite (3301 tests, 290 files) and `next build` — all pass (one unrelated known-flaky page test timed out under load once; green on re-run and in isolation).
- AC grep: `image.asset` returns zero hits in `photoGallery.repository.ts` + `sitemap.ts`.
- Typegen re-run after all commits: no drift.

## Review gate

`/code-review` (Standards + Spec) + `/simplify` (4 agents) ran pre-PR.

**Applied**: preview extraction to `src/preview/` (Preview Blocks rule); `galleryImage` row in the image-prefix table; invalid-date guard in the moved `prepare` (aligns with `article-preview`); seed script reuses `imageRef`.

**Skipped with reason**: cover-projection GROQ duplication (typegen requires statically analyzable inline query strings — documented in-file); shared `formatNlBeDate` helper (drags article/event into the diff); adding `alt` to the cover-query coalesce chain (spec locks cover queries; rendered output stays byte-identical — possible follow-up); typed selection interfaces for previews (matches the `article-preview` peer convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved photo gallery previews with captions, credits, thumbnails, image counts, and localized publication dates.
  - Added clearer gallery image descriptions and consistent preview presentation.

- **Improvements**
  - Gallery images now use a simpler structure, improving consistency across gallery pages, sitemap entries, and linked content.
  - Galleries are now limited to a maximum of 80 images, with validation preventing larger galleries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->