### PR TITLE
test(config): stop tests burning the 5s budget on module loads and live I/O (#2362)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -165,6 +165,10 @@ Three independent test layers, each owning a specific concern. Don't blur them �
 
 `Pages/*` Storybook stories exist as design references but are **not** VR-tested — page composition correctness is the e2e suite's job. See `docs/prd/page-level-testing-rework.md` for the rationale.
 
+### Import the module under test at module scope
+
+**Never `await import()` a page, layout, or route module inside an `it()` body** — Vitest charges dynamic imports against `testTimeout`, while top-level imports are paid during the untimed collect phase. A page graph takes ~3 s to resolve, so an in-body import fails deterministically under CI contention (#2362). The same goes for any module the code under test dynamically imports. Hoist it below the `vi.mock` calls (Vitest hoists those above all module-level code). Prefer a static `import`; use `await import()` only when a mock factory closes over a `const` in the file, which a static import would hoist above → TDZ (see `(main)/ploegen/page.test.tsx`).
+
 ### Running the suites
 
 `docs/agents/testing-ops.md` is the operational manual for the bottom two layers — how to run and scope a VR capture, the Docker memory floor, the `vr` / `vr-skip` / `vr.disable` tag contracts, the decision tree on a failing VR job, baseline-update flow, e2e local workflow, and CI path triggers. **Read it before running or debugging either suite**; don't reconstruct the commands from memory.

--- a/apps/web/src/app/(landing)/jeugd/page.test.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.test.tsx
@@ -38,13 +38,16 @@ vi.mock(
   },
 );
 
+// Imported at module scope — see CLAUDE.md "Import the module under test at
+// module scope".
+const { default: JeugdPage } = await import("./page");
+
 describe("/jeugd page — cream tracer composition", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("renders the JeugdHero heading on cream (no SectionStack transitions)", async () => {
-    const JeugdPage = (await import("./page")).default;
     const { container } = render(await JeugdPage());
 
     expect(
@@ -60,7 +63,6 @@ describe("/jeugd page — cream tracer composition", () => {
   });
 
   it("renders the filosofie/visie block with the #visie anchor", async () => {
-    const JeugdPage = (await import("./page")).default;
     const { container } = render(await JeugdPage());
 
     const visie = container.querySelector("section#visie");
@@ -72,7 +74,6 @@ describe("/jeugd page — cream tracer composition", () => {
   });
 
   it("no longer renders the legacy 'Word ook lid' CTA", async () => {
-    const JeugdPage = (await import("./page")).default;
     render(await JeugdPage());
 
     expect(
@@ -81,7 +82,6 @@ describe("/jeugd page — cream tracer composition", () => {
   });
 
   it("renders the closing JeugdCtaBand linking to /club/word-lid", async () => {
-    const JeugdPage = (await import("./page")).default;
     render(await JeugdPage());
 
     const cta = screen.getByRole("region", { name: "Schrijf je in" });
@@ -97,14 +97,12 @@ describe("/jeugd page — cream tracer composition", () => {
   });
 
   it("fires jeugd_view on page view", async () => {
-    const JeugdPage = (await import("./page")).default;
     render(await JeugdPage());
 
     expect(trackEvent).toHaveBeenCalledWith("jeugd_view", undefined);
   });
 
   it("fires jeugd_card_click when a nav-hub card is clicked", async () => {
-    const JeugdPage = (await import("./page")).default;
     render(await JeugdPage());
 
     screen.getByText("Word lid van KCVV").click();
@@ -116,7 +114,6 @@ describe("/jeugd page — cream tracer composition", () => {
   });
 
   it("empty data: drops the divisions section, keeps a nav-only hub + the CTA", async () => {
-    const JeugdPage = (await import("./page")).default;
     const { container } = render(await JeugdPage());
 
     // 0 youth teams → <YouthDirectory> returns null (section dropped).

--- a/apps/web/src/app/(main)/evenementen/page.test.tsx
+++ b/apps/web/src/app/(main)/evenementen/page.test.tsx
@@ -17,6 +17,10 @@ vi.mock("@/lib/repositories/event.repository", () => ({
 const { runPromise } = await import("@/lib/effect/runtime");
 const mockRunPromise = vi.mocked(runPromise);
 
+// Imported at module scope — see CLAUDE.md "Import the module under test at
+// module scope".
+const { default: EvenementenPage } = await import("./page");
+
 function makeEvent(overrides: Partial<EventListItemVM> = {}): EventListItemVM {
   return {
     id: "event-1",
@@ -39,7 +43,6 @@ describe("/evenementen page", () => {
   it("renders the page heading", async () => {
     mockRunPromise.mockResolvedValue([]);
 
-    const EvenementenPage = (await import("./page")).default;
     render(await EvenementenPage());
 
     expect(
@@ -50,7 +53,6 @@ describe("/evenementen page", () => {
   it("renders an empty-state message when there are no upcoming events", async () => {
     mockRunPromise.mockResolvedValue([]);
 
-    const EvenementenPage = (await import("./page")).default;
     render(await EvenementenPage());
 
     expect(screen.getByText(/Geen evenementen gepland/i)).toBeInTheDocument();
@@ -72,7 +74,6 @@ describe("/evenementen page", () => {
       }),
     ]);
 
-    const EvenementenPage = (await import("./page")).default;
     render(await EvenementenPage());
 
     // Event-doc ticket → detail route; article ticket → the article itself.

--- a/apps/web/src/app/(main)/ploegen/page.test.tsx
+++ b/apps/web/src/app/(main)/ploegen/page.test.tsx
@@ -50,20 +50,23 @@ vi.mock("@/lib/repositories/team.repository", () => ({
   TeamRepository: {},
 }));
 
+// Imported at module scope, but dynamically: a static import would hoist above
+// `teams` (line 6) and the `vi.mock` factory closing over it would hit TDZ.
+// See CLAUDE.md "Import the module under test at module scope".
+const { default: TeamsPage } = await import("./page");
+
 describe("/ploegen listing — Phase 6.C composition", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("renders the editorial page header", async () => {
-    const TeamsPage = (await import("./page")).default;
     render(await TeamsPage());
     const h1 = screen.getByRole("heading", { level: 1 });
     expect(h1.textContent).toContain("Onze ploegen");
   });
 
   it("renders A and B flagships", async () => {
-    const TeamsPage = (await import("./page")).default;
     render(await TeamsPage());
     const flagships = screen.getAllByTestId("team-flagship");
     expect(flagships).toHaveLength(2);
@@ -72,7 +75,6 @@ describe("/ploegen listing — Phase 6.C composition", () => {
   });
 
   it("renders the youth directory with the U13 card", async () => {
-    const TeamsPage = (await import("./page")).default;
     render(await TeamsPage());
     expect(screen.getByTestId("youth-directory")).toBeInTheDocument();
     const youthCards = screen.getAllByTestId("youth-team-card");

--- a/apps/web/src/app/not-found.test.ts
+++ b/apps/web/src/app/not-found.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 
+import { metadata } from "./not-found";
+
 /**
  * The global 404 must not be indexed. The 404 status already signals this, but
  * the explicit `metadata.robots` noindex is belt-and-braces (mirrors the
@@ -8,8 +10,7 @@ import { describe, it, expect } from "vitest";
  * export metadata; it relies on the non-indexable 500 status instead.)
  */
 describe("not-found metadata", () => {
-  it("carries robots noindex", async () => {
-    const { metadata } = await import("./not-found");
+  it("carries robots noindex", () => {
     expect(metadata.robots).toEqual({ index: false, follow: false });
   });
 });

--- a/apps/web/src/app/sitemap.test.ts
+++ b/apps/web/src/app/sitemap.test.ts
@@ -1,18 +1,42 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// `fetchRecentMatchIds` resolves the Effect runtime unconditionally, so this
+// keeps ~800 ms of module loading out of the timed test body. See CLAUDE.md
+// "Import the module under test at module scope".
+import "@/lib/effect/runtime";
 
 import sitemap from "./sitemap";
 
 const mockFetch = vi.fn();
 
-vi.mock("@/lib/sanity/client", () => ({
-  sanityClient: {
+// Mocked at the SDK boundary rather than at `@/lib/sanity/client`, because
+// `sitemap()` reaches the wrapper through six concurrent `await import()`s and
+// only the first resolved through a module-level mock — the other five escaped
+// to `api.sanity.io` on every test (#2362). Intercepting `createClient` means no
+// real SanityClient is ever constructed, so the escape is impossible however the
+// wrapper is imported.
+vi.mock("@sanity/client", () => ({
+  createClient: () => ({
     fetch: (...args: unknown[]) => mockFetch(...args),
-  },
+  }),
 }));
+
+/** `sitemap()` issues exactly one Sanity query per `fetchFromSanity` call. */
+const SANITY_QUERY_COUNT = 6;
 
 describe("sitemap.ts", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+  });
+
+  // The zero-outbound-request guard: a short count means a query escaped the
+  // mock, which is a real network round-trip. A `fetch` spy cannot do this job —
+  // `@sanity/client` uses the Node http(s) transport via `get-it`, so it reads 0
+  // either way.
+  afterEach(() => {
+    expect(mockFetch, "a Sanity query escaped the mock").toHaveBeenCalledTimes(
+      SANITY_QUERY_COUNT,
+    );
   });
 
   it("returns all static routes with correct metadata", async () => {


### PR DESCRIPTION
Closes #2362

## The bug

Two distinct causes, both burning a 5000 ms `testTimeout` on work that shouldn't be inside a timed test body.

**Part 1 — `sitemap.test.ts` made real network calls.** `fetchFromSanity` reaches the client via `await import("@/lib/sanity/client")`, and `sitemap()` fires six of those concurrently in a `Promise.all`. Only the first resolved through the module-level `vi.mock`; the other five escaped to `api.sanity.io` on every test. Fixed by mocking `@sanity/client`'s `createClient` instead — the issue's stated preferred option — so no real `SanityClient` is ever constructed and the escape is structurally impossible. `sitemap.ts` is untouched.

**Part 2 — page module graphs imported inside `it()` bodies.** Hoisted to module scope in the four page tests, so resolution is paid during the untimed collect phase.

## Results

| Test | Before | After |
|---|---|---|
| `(landing)/jeugd/page.test.tsx` | 3179 ms | 78 ms |
| `(main)/evenementen/page.test.tsx` | 3076 ms | 34 ms |
| `not-found.test.ts` | 3007 ms | 1 ms |
| `sitemap.test.ts` (test 1) | 775 ms | 50 ms |
| `(main)/ploegen/page.test.tsx` | 450 ms | 52 ms |

- Full suite under 8 CPU burners (the issue's reproduction case): **3301/3301 pass, zero timeouts** — quiet 73.3 s vs loaded 119.9 s, so contention was real.
- `pnpm --filter @kcvv/web check-all`: **EXIT=0**, 290 files / 3301 tests.
- Zero `Dataset not found` lines remain in the test output.

## One deliberate deviation from the ACs

AC1 asks for the no-network guard to be "asserted in-test via a `fetch` spy". **I did not write one, because it would be a permanently-green no-op.** `@sanity/client` resolves `get-it`'s node build (`follow-redirects`), not `globalThis.fetch` — verified with a probe: a real `sanityClient.fetch` reached the network and returned `Dataset not found` while `vi.spyOn(globalThis, "fetch")` recorded **0 calls**. A spy would read 0 both before and after the fix — exactly the false-confidence pattern #2361 is about.

The substitute is `expect(mockFetch).toHaveBeenCalledTimes(6)` in an `afterEach`. It was mutation-checked rather than assumed: reverting to the old wrapper-level mock fails all three tests with `expected 6 times, but got 1` — that `1` being `fetchArticleSlugs`, exactly matching the issue's diagnosis.

## Scope note for the reviewer

`apps/web/CLAUDE.md` (+9 lines) is **not** something #2362 asked for — its Scope names 5 files and no docs. It's here because the pattern otherwise recurs, and because the four duplicated explanatory comments were a symptom of a missing written rule. Easy to drop if you'd rather keep the branch strictly to Scope.

## Pre-PR review gate

`/code-review` (both axes) and `/simplify` (4 agents) ran; all findings triaged.

**Applied:** documented the convention in `apps/web/CLAUDE.md` and collapsed 4 duplicated comment blocks into pointers to it · trimmed the Effect warm-up from 3 imports to 1 (verified `runtime.ts` statically imports the other two) · converted it to a side-effect `import` · `not-found.test.ts` uses a plain static import (it has no `vi.mock`, so nothing constrained it) · `ploegen` keeps `await import()` with a comment naming the real reason — a static import would hoist above the `teams` const its mock factory closes over and hit TDZ · shortened the assertion message and the CLAUDE.md section.

**Skipped, with reasons:** a global `setupFiles` no-network guard — post-fix live-network exposure is 0 files (`sitemap.ts:100` was the only module reaching Sanity via `await import()`), and it would need to patch `node:http`/`node:https`; worth a follow-up, not this PR. An ESLint rule banning `await import()` in `it()` bodies — the only cheap selector fires on ~30 sites across 12 files, most of them legitimate re-imports-after-mock, needing ~12 disable comments. Extracting a shared Sanity mock — the 12 existing mocks sit at the wrapper boundary, a different and non-interchangeable shape.

## Follow-up (not in this PR)

`(main)/canonical-urls.test.ts` (7 sites) and `metadata.test.ts:27` still `await import()` page modules inside `it()` bodies — same latent flake, outside #2362's declared Scope. Filing separately.

## Note

#2359 merged at 13:16 today while this was in progress, so the "blocks #2359" urgency is moot. This branch is rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
