### PR TITLE
docs(api): record that staging deliberately has no Slack webhook

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -50,16 +50,16 @@ pnpm --filter @kcvv/api dev                        # wrangler dev on :8787
 
 ## Environment variables
 
-| Variable                   | Where set                            | Notes                                                                                                  |
-| -------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `PSD_API_BASE_URL`         | `wrangler.toml [vars]`               | Public, safe to commit                                                                                 |
-| `FOOTBALISTO_LOGO_CDN_URL` | `wrangler.toml [vars]`               | Public, safe to commit                                                                                 |
-| `PSD_API_KEY`              | `wrangler secret put` / CF dashboard | Never in toml                                                                                          |
-| `PSD_API_AUTH`             | `wrangler secret put` / CF dashboard | Never in toml                                                                                          |
-| `CACHE_LONG_TTL`           | `wrangler.toml [env.staging.vars]`   | Overrides hardTtl to 365d                                                                              |
-| `PSD_API_CLUB`             | `wrangler secret put` / CF dashboard | Never in toml                                                                                          |
-| `RESEND_API_KEY`           | `wrangler secret put` / CF dashboard | Never in toml — see `docs/prd/email-delivery.md`                                                       |
-| `SLACK_ALERT_WEBHOOK_URL`  | `wrangler secret put` / CF dashboard | Never in toml — Slack incoming-webhook for PSD incident/drift alerts (#2329); absent → alerting no-ops |
+| Variable                   | Where set                            | Notes                                                                                                                                                                                                               |
+| -------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PSD_API_BASE_URL`         | `wrangler.toml [vars]`               | Public, safe to commit                                                                                                                                                                                              |
+| `FOOTBALISTO_LOGO_CDN_URL` | `wrangler.toml [vars]`               | Public, safe to commit                                                                                                                                                                                              |
+| `PSD_API_KEY`              | `wrangler secret put` / CF dashboard | Never in toml                                                                                                                                                                                                       |
+| `PSD_API_AUTH`             | `wrangler secret put` / CF dashboard | Never in toml                                                                                                                                                                                                       |
+| `CACHE_LONG_TTL`           | `wrangler.toml [env.staging.vars]`   | Overrides hardTtl to 365d                                                                                                                                                                                           |
+| `PSD_API_CLUB`             | `wrangler secret put` / CF dashboard | Never in toml                                                                                                                                                                                                       |
+| `RESEND_API_KEY`           | `wrangler secret put` / CF dashboard | Never in toml — see `docs/prd/email-delivery.md`                                                                                                                                                                    |
+| `SLACK_ALERT_WEBHOOK_URL`  | `wrangler secret put` / CF dashboard | Never in toml — Slack incoming-webhook for PSD incident/drift alerts (#2329). **Production only** — deliberately unset on staging, where `CACHE_LONG_TTL` makes every key drift by design; absent → alerting no-ops |
 
 ## Deployment
 
@@ -73,8 +73,13 @@ wrangler secret put PSD_API_KEY --env staging
 wrangler secret put PSD_API_AUTH --env staging
 wrangler secret put PSD_API_CLUB --env staging
 wrangler secret put RESEND_API_KEY --env staging
-wrangler secret put SLACK_ALERT_WEBHOOK_URL --env staging
 ```
+
+`SLACK_ALERT_WEBHOOK_URL` is intentionally **not** in that list. Staging runs with
+`CACHE_LONG_TTL="true"` (365d hard TTL), so serving months-old cache is its designed
+behaviour — but the drift check reads it as "refreshes are not landing" and nudges once
+per day per key, forever. With the secret absent, `postSlack` no-ops and staging stays
+silent. Don't re-add it.
 
 ## Cache
 


### PR DESCRIPTION
## Why

The alert channel flooded today with `PSD data drifting stale` warnings. Almost all of them came from **staging**, not production.

The arithmetic in the message gives the sender away — `staleAge + timeToCliff = hardTtl`:

| Line | Sum | Env |
| --- | --- | --- |
| `related:article-drupal-*` — 5d18h + 359d5h | ~365d | staging |
| `ranking:team:*` — 67d23h + 297d0h | ~365d | staging |
| `matches:window` — 1d16h + 5d7h | ~7d | production |

`HARD_TTL_LONG` (365d) only applies when `CACHE_LONG_TTL="true"`, which is set in `[env.staging.vars]` alone. Both workers posted to the same webhook and the message carries no environment label, so staging noise was indistinguishable from a real production incident.

Serving months-old cache is exactly what staging is configured to do — it exists to keep PSD quota off the shared budget. The read-path drift check added in #2335 reads that as "refreshes are not landing" and nudges once per day per key, forever.

## What changed

Operationally: `SLACK_ALERT_WEBHOOK_URL` was deleted from `kcvv-api-staging`. `postSlack` already no-ops when the webhook is absent (`apps/api/src/psd/slack-alert.ts:82`), so **no code change was needed** — this PR is documentation only.

- Env-var table now marks the secret production-only and says why.
- The staging setup block no longer lists it, with a note explaining why it must not be re-added.

Production alerting is untouched.

## Not addressed here

Two related findings, left for a follow-up if they prove real:

- An unrefreshable `ranking:team:*` key nudges forever on staging: an empty ranking raises `ResourceNotFoundError`, `shouldServeStale` covers `UpstreamUnavailable` only, so `backgroundRefresh` never persists and `fetchedAt` stays frozen. Bounded on production by the 7d hard cliff.
- `handleRelated` is `Effect<…, never, …>` with `Effect.orDie` throughout, so a Vectorize failure is a defect that `fetch.pipe(Effect.either)` does not catch — that refresh would die without persisting or marking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified production-only configuration for Slack alert notifications.
  * Documented staging behavior, including why the alert setting remains unset and how resulting no-op alerts are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->