### PR TITLE
fix(config): stop the branch guard waving commits through to main (#2361)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,6 +30,8 @@ App-specific rules → `apps/web/CLAUDE.md` | api-contract conventions → `pack
 2. **Conventional commits:** `type(scope): description` — scopes: news, matches, events, teams, players, sponsors, calendar, ranking, search, sync, analytics, studio, api, ui, schema, config, deps, deps-dev
 3. **Quality before commit:** `pnpm --filter @kcvv/web lint:fix` then `pnpm --filter @kcvv/web check-all`
 4. **Never:** commit to main, push before checks pass, create PR without asking
+5. **Branch guards:** two layers refuse a commit that would land on `main`/`master` — `.husky/branch-guard.sh` (called first from `.husky/pre-commit`, runs inside git, so it cannot be routed around) and `.claude/hooks/check-branch.sh` (Claude Code `PreToolUse`, fails early with a friendlier message). Both are worktree-aware, allow a detached HEAD, and accept `cd` anywhere in the command as well as an explicit `git -C <dir>`.
+6. **Deliberate commit on main:** `ALLOW_MAIN_COMMIT=1 git commit …`. Prefer it over `--no-verify`, which also skips commitlint and lint-staged.
 
 ## Development Guidelines
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,8 +30,8 @@ App-specific rules → `apps/web/CLAUDE.md` | api-contract conventions → `pack
 2. **Conventional commits:** `type(scope): description` — scopes: news, matches, events, teams, players, sponsors, calendar, ranking, search, sync, analytics, studio, api, ui, schema, config, deps, deps-dev
 3. **Quality before commit:** `pnpm --filter @kcvv/web lint:fix` then `pnpm --filter @kcvv/web check-all`
 4. **Never:** commit to main, push before checks pass, create PR without asking
-5. **Branch guards:** two layers refuse a commit that would land on `main`/`master` — `.husky/branch-guard.sh` (called first from `.husky/pre-commit`, runs inside git, so it cannot be routed around) and `.claude/hooks/check-branch.sh` (Claude Code `PreToolUse`, fails early with a friendlier message). Both are worktree-aware, allow a detached HEAD, and accept `cd` anywhere in the command as well as an explicit `git -C <dir>`.
-6. **Deliberate commit on main:** `ALLOW_MAIN_COMMIT=1 git commit …`. Prefer it over `--no-verify`, which also skips commitlint and lint-staged.
+5. **Branch guards:** two layers refuse a commit that would land on `main`/`master`, both worktree-aware and both allowing a detached HEAD. `.husky/branch-guard.sh` is the backstop — called from `.husky/pre-commit` (first, before `lint-staged`) and from `.husky/pre-merge-commit` (merges, which `pre-commit` does not fire for). It reads the branch inside git, so no command-string trick gets past it. `.claude/hooks/check-branch.sh` is the Claude Code `PreToolUse` layer that fails earlier with a friendlier message; it parses the command, so `cd` may appear anywhere in it and an explicit `git -C <dir>` is honoured. **Not covered:** `git cherry-pick` and `git revert` run no commit hooks at all — a git design choice no hook can close.
+6. **`ALLOW_MAIN_COMMIT=1` is a human escape hatch, not an agent one.** If a guard blocks you, the answer is a worktree (`/ralph`), never this variable — do not reach for it to get past a block, and do not suggest it. It exists so a human can make one deliberate commit on `main` without `--no-verify`, which would also skip commitlint and lint-staged.
 
 ## Development Guidelines
 

--- a/.claude/hooks/check-branch.sh
+++ b/.claude/hooks/check-branch.sh
@@ -1,24 +1,130 @@
-#!/bin/bash
-# Block git commits on main/master. Worktree-aware.
-set -euo pipefail
+#!/usr/bin/env bash
+# Block a `git commit` that would land on main/master. Worktree-aware.
+#
+# This is the fast, friendly layer: it fails early with a helpful message
+# before the tool call runs. `.husky/branch-guard.sh` is the real backstop —
+# it runs inside git and cannot be routed around at all.
+#
+# Design notes (#2361):
+#   - The tool payload is parsed as JSON, never with sed. A `"` anywhere in the
+#     command used to truncate the old parse and silently disarm the guard.
+#   - The command is scanned segment-by-segment (split on && || ; | parens) so
+#     `cd` can appear anywhere, not only first, and the LAST `cd` before the
+#     commit wins. An explicit `git -C <dir>` overrides it.
+#   - Unresolvable targets (`cd $VAR`, missing dir) FAIL CLOSED.
+#
+# Known residual gaps, all covered by .husky/branch-guard.sh: a subshell `cd`
+# that does not persist — `( cd $WT ) && git commit` — `xargs git commit`, and
+# shell aliases or functions. Closing those needs a real shell parser.
+set -uo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | sed -n 's/.*"command" *: *"\([^"]*\)".*/\1/p')
-echo "$COMMAND" | grep -q 'git commit' || exit 0
 
-# If the command starts with "cd /some/path && ...", resolve the branch there.
-TARGET_DIR=$(echo "$COMMAND" | sed -n 's/^cd \([^ &]*\) &&.*/\1/p')
-if [ -n "$TARGET_DIR" ] && [ -d "$TARGET_DIR" ]; then
-  BRANCH=$(git -C "$TARGET_DIR" branch --show-current 2>/dev/null || echo "unknown")
-else
-  BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
-fi
+# Fast path: the overwhelming majority of Bash calls cannot be a commit.
+case "$INPUT" in
+*commit*) ;;
+*) exit 0 ;;
+esac
 
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-  cat <<EOF
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: You are on the main branch. Use /ralph to create a worktree for an issue first."}}
-EOF
+# Without the interpreter we would silently fail OPEN, so fail closed — but
+# only here, where we already know the command mentions `commit`.
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: the branch guard could not run (python3 not found)."}}'
   exit 0
 fi
 
+PY=$(
+  cat <<'PYEOF'
+import json, os, re, subprocess, sys
+
+def emit_deny(reason):
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason}}))
+    sys.exit(0)
+
+def allow():
+    sys.exit(0)
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    allow()  # not a payload we understand — nothing we can assert about it
+
+cmd = (data.get("tool_input") or {}).get("command") or ""
+session_cwd = data.get("cwd") or os.getcwd()
+
+# Newlines are command separators; then collapse whitespace so `git\tcommit`
+# and `git  commit` normalise to `git commit`.
+norm = re.sub(r"\s+", " ", cmd.replace("\n", " ; ")).strip()
+
+# `git [global flags] commit` at the start of a segment, allowing VAR=x
+# prefixes and the common `bash -c "..."` wrapper.
+GIT_COMMIT = re.compile(
+    r"""^(?:(?:ba|z)?sh\s+-[a-z]*c\s*["']\s*)?      # optional  bash -c "
+         (?:\w+=\S*\s+)*                            # optional  VAR=value
+         git
+         (?:\s+(?:-[cC]\s+\S+|--?[A-Za-z][\w-]*(?:=\S*)?))*   # global flags
+         \s+commit(?![\w-])""",   # `commit`, not `commit-tree`
+    re.VERBOSE,
+)
+
+def resolve(raw, base):
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        raw = raw[1:-1]
+    if not raw or "$" in raw or "`" in raw:
+        return None            # shell-expanded — we cannot know
+    raw = os.path.expanduser(raw)
+    if not os.path.isabs(raw):
+        if not base:
+            return None
+        raw = os.path.join(base, raw)
+    return os.path.realpath(raw)
+
+segments = re.split(r"\s*(?:&&|\|\||;|\||\(|\))\s*", norm)
+cur, target, found = session_cwd, None, False
+
+for seg in segments:
+    seg = seg.strip()
+    if not seg:
+        continue
+    m = re.match(r"""^cd\s+(?!-)("[^"]*"|'[^']*'|\S+)""", seg)
+    if m:
+        cur = resolve(m.group(1), cur)
+        continue
+    if GIT_COMMIT.search(seg):
+        found = True
+        c = re.search(r"(?:^|\s)-C\s+(\S+)", seg)
+        target = resolve(c.group(1), cur) if c else cur
+        break
+
+if not found:
+    allow()                    # no `git commit` in command position
+if target is None:
+    emit_deny("BLOCKED: the branch guard cannot resolve the directory this "
+              "commit would run in (shell variable or missing path). Use a "
+              "literal absolute path, or run the commit from the worktree.")
+
+if not os.path.isdir(target):
+    emit_deny("BLOCKED: the branch guard cannot resolve the directory this "
+              "commit would run in (%s does not exist)." % target)
+
+try:
+    branch = subprocess.run(["git", "-C", target, "branch", "--show-current"],
+                            capture_output=True, text=True,
+                            timeout=3).stdout.strip()
+except Exception:
+    branch = ""
+
+if branch in ("main", "master"):
+    emit_deny("BLOCKED: that commit would land on %s in %s. Use /ralph to "
+              "create a worktree for an issue first." % (branch, target))
+
+allow()   # feature branch, detached HEAD, or not a repo — git will sort it out
+PYEOF
+)
+
+printf '%s' "$INPUT" | python3 -c "$PY"
 exit 0

--- a/.claude/hooks/check-branch.sh
+++ b/.claude/hooks/check-branch.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Block a `git commit` that would land on main/master. Worktree-aware.
 #
 # This is the fast, friendly layer: it fails early with a helpful message
 # before the tool call runs. `.husky/branch-guard.sh` is the real backstop —
-# it runs inside git and cannot be routed around at all.
+# it runs inside git and cannot be routed around by a command string at all.
 #
 # Design notes (#2361):
 #   - The tool payload is parsed as JSON, never with sed. A `"` anywhere in the
@@ -18,13 +18,22 @@
 # shell aliases or functions. Closing those needs a real shell parser.
 set -uo pipefail
 
-INPUT=$(cat)
+# Same escape hatch as .husky/branch-guard.sh, for an exported variable. The
+# far more common `ALLOW_MAIN_COMMIT=1 git commit …` prefix form is handled
+# below, where the command itself is parsed.
+[ "${ALLOW_MAIN_COMMIT:-}" = "1" ] && exit 0
 
-# Fast path: the overwhelming majority of Bash calls cannot be a commit.
-case "$INPUT" in
-*commit*) ;;
-*) exit 0 ;;
-esac
+# A builtin read rather than $(cat) — this runs on every Bash tool call, and
+# not forking is ~25% of the fast path.
+IFS= read -r -d '' INPUT
+
+# Fast path: `commit` as the git subcommand is always followed by a separator,
+# so this skips `commitlint`, `uncommitted`, `commits`, `commit-tree` … without
+# paying for an interpreter. Only the trailing boundary is checked: this scans
+# the raw JSON, where `git<TAB>commit` arrives as the six characters `git\tco…`
+# — a leading boundary would read the `t` of `\t` as a word character and wave
+# the command through.
+[[ $INPUT =~ commit([^A-Za-z-]|$) ]] || exit 0
 
 # Without the interpreter we would silently fail OPEN, so fail closed — but
 # only here, where we already know the command mentions `commit`.
@@ -33,8 +42,10 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 0
 fi
 
-PY=$(
-  cat <<'PYEOF'
+# Read the program with the same forkless builtin, then hand it to python3 as
+# an argument so stdin stays free for the payload. Passing the program on
+# stdin instead measured ~60ms slower per call.
+IFS= read -r -d '' PY <<'PYEOF'
 import json, os, re, subprocess, sys
 
 def emit_deny(reason):
@@ -59,13 +70,20 @@ session_cwd = data.get("cwd") or os.getcwd()
 # and `git  commit` normalise to `git commit`.
 norm = re.sub(r"\s+", " ", cmd.replace("\n", " ; ")).strip()
 
+# Unwrap `bash -c "…"` so the inner command is scanned like any other. The
+# splitter below is quote-blind, so without this a `cd` inside the wrapper is
+# shredded along with it and the commit is attributed to the wrong directory.
+norm = re.sub(r"""(?:ba|z)?sh\s+-[a-z]*c\s+(["'])(.*?)\1""", r" ; \2 ; ", norm)
+
 # `git [global flags] commit` at the start of a segment, allowing VAR=x
-# prefixes and the common `bash -c "..."` wrapper.
+# prefixes. Both the VAR= prefix and the global flags are captured: the escape
+# hatch is read from the first, and `-C` from the second. Reading `-C` from the
+# whole segment instead would misfire on `git commit --amend -C HEAD`, where
+# `-C` is commit's own "reuse this commit's message" flag, not a directory.
 GIT_COMMIT = re.compile(
-    r"""^(?:(?:ba|z)?sh\s+-[a-z]*c\s*["']\s*)?      # optional  bash -c "
-         (?:\w+=\S*\s+)*                            # optional  VAR=value
+    r"""^((?:\w+=\S*\s+)*)                          # optional  VAR=value
          git
-         (?:\s+(?:-[cC]\s+\S+|--?[A-Za-z][\w-]*(?:=\S*)?))*   # global flags
+         ((?:\s+(?:-[cC]\s+\S+|--?[A-Za-z][\w-]*(?:=\S*)?))*) # global flags
          \s+commit(?![\w-])""",   # `commit`, not `commit-tree`
     re.VERBOSE,
 )
@@ -94,9 +112,13 @@ for seg in segments:
     if m:
         cur = resolve(m.group(1), cur)
         continue
-    if GIT_COMMIT.search(seg):
+    hit = GIT_COMMIT.search(seg)
+    if hit:
+        env_prefix, global_flags = hit.group(1), hit.group(2)
+        if "ALLOW_MAIN_COMMIT=1" in env_prefix:
+            allow()            # documented escape hatch — see branch-guard.sh
         found = True
-        c = re.search(r"(?:^|\s)-C\s+(\S+)", seg)
+        c = re.search(r"(?:^|\s)-C\s+(\S+)", global_flags)
         target = resolve(c.group(1), cur) if c else cur
         break
 
@@ -124,7 +146,6 @@ if branch in ("main", "master"):
 
 allow()   # feature branch, detached HEAD, or not a repo — git will sort it out
 PYEOF
-)
 
 printf '%s' "$INPUT" | python3 -c "$PY"
 exit 0

--- a/.husky/branch-guard.sh
+++ b/.husky/branch-guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Refuse a commit whose repository is on main/master.
+#
+# This is the real backstop. It runs inside git, in the repository the commit
+# actually lands in, so it cannot be routed around by `git -C`, `bash -c`,
+# xargs, aliases or any quoting trick — unlike a hook that parses a command
+# string. It covers humans and non-Claude tooling too.
+#
+#   Escape hatch:  ALLOW_MAIN_COMMIT=1 git commit -m "…"
+#
+# Prefer that over `--no-verify`, which also skips commitlint and lint-staged.
+#
+# Usage: branch-guard.sh [directory]   (defaults to the current directory)
+set -uo pipefail
+
+[ "${ALLOW_MAIN_COMMIT:-}" = "1" ] && exit 0
+
+TARGET=${1:-.}
+
+# Empty on a detached HEAD — a detached-HEAD commit cannot advance main.
+# Non-zero exit means "not a repository", which is git's problem, not ours.
+BRANCH=$(git -C "$TARGET" branch --show-current 2>/dev/null) || exit 0
+
+case "$BRANCH" in
+main | master)
+  echo "" >&2
+  echo "🚫 BLOCKED: that commit would land on '$BRANCH' in $TARGET." >&2
+  echo "" >&2
+  echo "   Use /ralph to create a worktree for an issue first." >&2
+  echo "   If you really meant this one commit: ALLOW_MAIN_COMMIT=1 git commit …" >&2
+  echo "" >&2
+  exit 1
+  ;;
+esac
+
+exit 0

--- a/.husky/branch-guard.sh
+++ b/.husky/branch-guard.sh
@@ -23,12 +23,14 @@ BRANCH=$(git -C "$TARGET" branch --show-current 2>/dev/null) || exit 0
 
 case "$BRANCH" in
 main | master)
-  echo "" >&2
-  echo "🚫 BLOCKED: that commit would land on '$BRANCH' in $TARGET." >&2
-  echo "" >&2
-  echo "   Use /ralph to create a worktree for an issue first." >&2
-  echo "   If you really meant this one commit: ALLOW_MAIN_COMMIT=1 git commit …" >&2
-  echo "" >&2
+  cat >&2 <<EOF
+
+🚫 BLOCKED: that commit would land on '$BRANCH' in $TARGET.
+
+   Use /ralph to create a worktree for an issue first.
+   If you really meant this one commit: ALLOW_MAIN_COMMIT=1 git commit …
+
+EOF
   exit 1
   ;;
 esac

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Branch guard first — before lint-staged and a full monorepo type-check, so a
+# commit that was never going to land does not cost a type-check to find out.
+# Bypass with ALLOW_MAIN_COMMIT=1; see .husky/branch-guard.sh.
+bash .husky/branch-guard.sh || exit 1
+
 # Activate Node version from .nvmrc without sourcing full nvm.sh
 # This is fast (~0ms) vs sourcing nvm.sh (~200-500ms)
 if [ -f ".nvmrc" ] && [ -d "${NVM_DIR:-$HOME/.nvm}/versions/node" ]; then

--- a/.husky/pre-merge-commit
+++ b/.husky/pre-merge-commit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# `pre-commit` does not fire for merge commits, so without this hook the guard
+# would miss `git merge --no-ff` onto main. This one fires exactly there and
+# nowhere else, so a plain commit still pays for the guard only once.
+# Bypass with ALLOW_MAIN_COMMIT=1; see .husky/branch-guard.sh.
+#
+# `git cherry-pick` and `git revert` run no commit hooks at all. That is a git
+# design choice, not something a hook can close.
+bash .husky/branch-guard.sh || exit 1

--- a/apps/web/test/hooks/check-branch.test.ts
+++ b/apps/web/test/hooks/check-branch.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Regression fixture for the two branch guards that stop a commit landing on
+ * `main` (#2361):
+ *
+ *   - `.claude/hooks/check-branch.sh` — the Claude Code `PreToolUse` hook. Fast,
+ *     friendly, best-effort: it parses a Bash tool payload and decides
+ *     allow/deny before the command runs.
+ *   - `.husky/branch-guard.sh` — the real backstop. Runs inside git, in the
+ *     repository the commit actually lands in.
+ *
+ * Both live outside every workspace, so nothing else in CI would ever exercise
+ * them. This file is their only home: it is collected by the existing
+ * `apps/web` vitest config (no `include` override; only `test/e2e/**` is
+ * excluded) and therefore rides `pnpm --filter @kcvv/web test` and `check-all`.
+ *
+ * Fixtures are throwaway `git init` repos under `os.tmpdir()` — the commits
+ * made here are never in this repository.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/** Worktree-safe: resolves the checkout we are running in, not a `../..` walk. */
+const repoRoot = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).stdout.trim();
+
+const CHECK_BRANCH = join(repoRoot, ".claude", "hooks", "check-branch.sh");
+const BRANCH_GUARD = join(repoRoot, ".husky", "branch-guard.sh");
+
+/**
+ * Fixture paths are only known once `beforeAll` has run, but `it.each` builds
+ * its table at collect time — so cases carry `{TOKEN}` placeholders that are
+ * expanded per-case at run time. Placeholders also keep a literal `$VAR` in a
+ * command meaningful: that is the "unresolvable target" case, which must deny.
+ */
+const tokens: Record<string, string> = {};
+const expand = (value: string) =>
+  value.replace(/\{(\w+)\}/g, (_, key: string) => tokens[key] ?? `{${key}}`);
+
+/** Isolate fixture repos from the developer's global git config and hooks. */
+const gitEnv = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
+
+const git = (cwd: string, ...args: string[]) => {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", env: gitEnv });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+};
+
+const initRepo = (name: string, branch: string) => {
+  const dir = join(tokens.TMPROOT, name);
+  mkdirSync(dir);
+  git(dir, "init", "-b", branch);
+  git(dir, "config", "user.email", "hook-test@example.com");
+  git(dir, "config", "user.name", "Hook Test");
+  git(dir, "commit", "--allow-empty", "--no-verify", "-m", "init");
+  return dir;
+};
+
+beforeAll(() => {
+  tokens.TMPROOT = mkdtempSync(join(tmpdir(), "kcvv-branch-guard-"));
+  tokens.MAIN = initRepo("main-repo", "main");
+  tokens.FEAT = initRepo("feat-repo", "feat/issue-2361");
+
+  tokens.DETACHED = initRepo("detached-repo", "main");
+  git(tokens.DETACHED, "checkout", "--detach");
+
+  // A linked worktree of the `main` repo, checked out on a feature branch —
+  // the guards must report the worktree's branch, not the parent's.
+  tokens.WORKTREE = join(tokens.TMPROOT, "main-repo-wt");
+  git(
+    tokens.MAIN,
+    "worktree",
+    "add",
+    tokens.WORKTREE,
+    "-b",
+    "feat/from-worktree",
+  );
+
+  tokens.NOREPO = join(tokens.TMPROOT, "not-a-repo");
+  mkdirSync(tokens.NOREPO);
+});
+
+afterAll(() => {
+  if (tokens.TMPROOT) rmSync(tokens.TMPROOT, { recursive: true, force: true });
+});
+
+type Decision = "allow" | "deny";
+
+/** Pipe a `PreToolUse` payload into the hook and read back its decision. */
+const runHook = (payload: string, env: Record<string, string> = {}) => {
+  const result = spawnSync("bash", [CHECK_BRANCH], {
+    input: payload,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  // The hook always exits 0 — a denial is expressed in its JSON, not its code.
+  expect(result.status, result.stderr).toBe(0);
+
+  const stdout = result.stdout.trim();
+  if (!stdout) return "allow" satisfies Decision;
+  return JSON.parse(stdout).hookSpecificOutput.permissionDecision as Decision;
+};
+
+const runHookOn = (
+  command: string,
+  cwd: string,
+  env: Record<string, string> = {},
+) =>
+  runHook(
+    JSON.stringify({
+      tool_input: { command: expand(command) },
+      cwd: expand(cwd),
+    }),
+    env,
+  );
+
+type Case = {
+  name: string;
+  command: string;
+  cwd: string;
+  /** Extra environment for the hook process — `HOME` drives `~` expansion. */
+  env?: Record<string, string>;
+};
+
+/**
+ * Every shape in the issue's "Selected cases" table, plus the fail-closed and
+ * pass-through shapes the rewrite is responsible for.
+ */
+const DENIED: Case[] = [
+  // The workflow `.claude/CLAUDE.md` prescribes — a `"` before `git commit`
+  // truncated the old sed parse and silently disarmed the guard.
+  {
+    name: 'a quoted argument before the commit — pnpm --filter "@kcvv/web" check-all && git commit',
+    command: 'pnpm --filter "@kcvv/web" check-all && git commit -m x',
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a redirect before the commit",
+    command:
+      'printf "msg" > /tmp/kcvv-hook-msg && git commit -F /tmp/kcvv-hook-msg',
+    cwd: "{MAIN}",
+  },
+  {
+    name: "git -C into main from a feature checkout",
+    command: "git -C {MAIN} commit -m x",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "git -C into main from a linked worktree",
+    command: "git -C {MAIN} commit -m x",
+    cwd: "{WORKTREE}",
+  },
+  {
+    name: "a cd-to-elsewhere then git -C bypass",
+    command: "cd {NOREPO} && git -C {MAIN} commit -m x",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a bash -c wrapper",
+    command: 'bash -c "git commit -m x"',
+    cwd: "{MAIN}",
+  },
+  {
+    name: "two spaces between git and commit",
+    command: "git  commit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a tab between git and commit",
+    command: "git\tcommit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a -c global flag",
+    command: "git -c user.name=x commit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a --no-pager global flag",
+    command: "git --no-pager commit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a semicolon separator",
+    command: "cd {MAIN} ; git commit -m x",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a newline separator",
+    command: "cd {MAIN}\ngit commit -m x",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a decoy command key in the command itself",
+    command: `echo '{"command": "harmless"}' && git commit -m x`,
+    cwd: "{MAIN}",
+  },
+  { name: "a bare commit on main", command: "git commit -m x", cwd: "{MAIN}" },
+  {
+    name: "a tilde path into main",
+    command: "cd ~/main-repo && git commit -m x",
+    cwd: "{FEAT}",
+    env: { HOME: "{TMPROOT}" },
+  },
+  // Fail closed: we cannot attribute the commit to a directory, so we refuse.
+  {
+    name: "an unexpanded shell variable as the target",
+    command: "cd $WT && git commit -m x",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a target directory that does not exist",
+    command: "cd /no/such/dir && git commit -m x",
+    cwd: "{FEAT}",
+  },
+];
+
+const ALLOWED: Case[] = [
+  // The `cd`-must-come-first constraint is gone.
+  {
+    name: "cd arriving after an nvm preamble",
+    command:
+      "source ~/.nvm/nvm.sh && nvm use && cd {FEAT} && git commit -F msg",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a tilde path into a feature checkout",
+    command: "cd ~/feat-repo && git commit -F msg",
+    cwd: "{MAIN}",
+    env: { HOME: "{TMPROOT}" },
+  },
+  {
+    name: "a subshell",
+    command: "( cd {FEAT} && git commit -F msg )",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a semicolon separator",
+    command: "cd {FEAT} ; git commit -F msg",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a commit inside a linked worktree",
+    command: "cd {WORKTREE} && git commit -m x",
+    cwd: "{MAIN}",
+  },
+  // A detached-HEAD commit cannot advance main.
+  {
+    name: "a detached HEAD",
+    command: "cd {DETACHED} && git commit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "the word commit in prose",
+    command: "echo git commit later",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "commit-tree, which is not commit",
+    command: "git commit-tree abc123",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a directory that is not a repository",
+    command: "cd {NOREPO} && git commit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "a bare commit on a feature branch",
+    command: "git commit -m x",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a command with no commit in it",
+    command: "pnpm --filter @kcvv/web check-all",
+    cwd: "{MAIN}",
+  },
+];
+
+describe(".claude/hooks/check-branch.sh", () => {
+  it.each(DENIED)("blocks $name", ({ command, cwd, env }) => {
+    const expandedEnv = Object.fromEntries(
+      Object.entries(env ?? {}).map(([key, value]) => [key, expand(value)]),
+    );
+    expect(runHookOn(command, cwd, expandedEnv)).toBe("deny");
+  });
+
+  it.each(ALLOWED)("allows $name", ({ command, cwd, env }) => {
+    const expandedEnv = Object.fromEntries(
+      Object.entries(env ?? {}).map(([key, value]) => [key, expand(value)]),
+    );
+    expect(runHookOn(command, cwd, expandedEnv)).toBe("allow");
+  });
+
+  // Deliberate, documented in the issue's "Residual gaps": a payload the hook
+  // cannot parse is not a command it can attribute to a directory, and failing
+  // closed there would deny unrelated Bash calls on any payload-shape change.
+  // `.husky/branch-guard.sh` covers the case. Do not "fix" this.
+  it("allows a payload it cannot parse", () => {
+    expect(runHook("not json at all, but it does say commit")).toBe("allow");
+  });
+
+  it("allows empty input", () => {
+    expect(runHook("")).toBe("allow");
+  });
+});
+
+describe(".husky/branch-guard.sh", () => {
+  const runGuard = (
+    args: string[],
+    options: { cwd?: string; env?: Record<string, string> } = {},
+  ) =>
+    spawnSync("bash", [BRANCH_GUARD, ...args], {
+      encoding: "utf8",
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+    }).status;
+
+  it("refuses a repository on main", () => {
+    expect(runGuard([tokens.MAIN])).toBe(1);
+  });
+
+  it("allows a repository on a feature branch", () => {
+    expect(runGuard([tokens.FEAT])).toBe(0);
+  });
+
+  it("allows a detached HEAD", () => {
+    expect(runGuard([tokens.DETACHED])).toBe(0);
+  });
+
+  it("allows a linked worktree on a feature branch", () => {
+    expect(runGuard([tokens.WORKTREE])).toBe(0);
+  });
+
+  it("defaults to the current directory", () => {
+    expect(runGuard([], { cwd: tokens.MAIN })).toBe(1);
+    expect(runGuard([], { cwd: tokens.FEAT })).toBe(0);
+  });
+
+  it("is bypassed by ALLOW_MAIN_COMMIT=1", () => {
+    expect(runGuard([tokens.MAIN], { env: { ALLOW_MAIN_COMMIT: "1" } })).toBe(
+      0,
+    );
+  });
+});

--- a/apps/web/test/hooks/check-branch.test.ts
+++ b/apps/web/test/hooks/check-branch.test.ts
@@ -17,7 +17,13 @@
  * made here are never in this repository.
  */
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -34,18 +40,24 @@ const BRANCH_GUARD = join(repoRoot, ".husky", "branch-guard.sh");
 /**
  * Fixture paths are only known once `beforeAll` has run, but `it.each` builds
  * its table at collect time — so cases carry `{TOKEN}` placeholders that are
- * expanded per-case at run time. Placeholders also keep a literal `$VAR` in a
- * command meaningful: that is the "unresolvable target" case, which must deny.
+ * expanded per-case at run time.
  */
 const tokens: Record<string, string> = {};
 const expand = (value: string) =>
   value.replace(/\{(\w+)\}/g, (_, key: string) => tokens[key] ?? `{${key}}`);
 
-/** Isolate fixture repos from the developer's global git config and hooks. */
+/**
+ * Isolate fixture repos from the developer's global git config and hooks, and
+ * supply an identity so the fixture commits need no `git config` round-trips.
+ */
 const gitEnv = {
   ...process.env,
   GIT_CONFIG_GLOBAL: "/dev/null",
   GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_AUTHOR_NAME: "Hook Test",
+  GIT_AUTHOR_EMAIL: "hook-test@example.com",
+  GIT_COMMITTER_NAME: "Hook Test",
+  GIT_COMMITTER_EMAIL: "hook-test@example.com",
 };
 
 const git = (cwd: string, ...args: string[]) => {
@@ -60,8 +72,6 @@ const initRepo = (name: string, branch: string) => {
   const dir = join(tokens.TMPROOT, name);
   mkdirSync(dir);
   git(dir, "init", "-b", branch);
-  git(dir, "config", "user.email", "hook-test@example.com");
-  git(dir, "config", "user.name", "Hook Test");
   git(dir, "commit", "--allow-empty", "--no-verify", "-m", "init");
   return dir;
 };
@@ -88,6 +98,18 @@ beforeAll(() => {
 
   tokens.NOREPO = join(tokens.TMPROOT, "not-a-repo");
   mkdirSync(tokens.NOREPO);
+
+  // A PATH holding only the shell and git, for the tests that need some other
+  // tool to be absent — python3 for the hook, npx/pnpm for pre-commit. Node
+  // resolves a spawned binary against the child's PATH, so `bash` itself has
+  // to be reachable through it.
+  tokens.SHIMBIN = join(tokens.TMPROOT, "shim-bin");
+  mkdirSync(tokens.SHIMBIN);
+  symlinkSync("/bin/bash", join(tokens.SHIMBIN, "bash"));
+  const gitBin = spawnSync("sh", ["-c", "command -v git"], {
+    encoding: "utf8",
+  }).stdout.trim();
+  symlinkSync(gitBin, join(tokens.SHIMBIN, "git"));
 });
 
 afterAll(() => {
@@ -111,6 +133,7 @@ const runHook = (payload: string, env: Record<string, string> = {}) => {
   return JSON.parse(stdout).hookSpecificOutput.permissionDecision as Decision;
 };
 
+/** As `runHook`, but every field — command, cwd and env — is token-expanded. */
 const runHookOn = (
   command: string,
   cwd: string,
@@ -121,7 +144,9 @@ const runHookOn = (
       tool_input: { command: expand(command) },
       cwd: expand(cwd),
     }),
-    env,
+    Object.fromEntries(
+      Object.entries(env).map(([key, value]) => [key, expand(value)]),
+    ),
   );
 
 type Case = {
@@ -170,6 +195,13 @@ const DENIED: Case[] = [
     command: 'bash -c "git commit -m x"',
     cwd: "{MAIN}",
   },
+  // The segment splitter is quote-blind, so a wrapper has to be unwrapped
+  // before splitting or the `cd` inside it is lost with it.
+  {
+    name: "a cd into main inside a bash -c wrapper",
+    command: 'bash -c "cd {MAIN} && git commit -m x"',
+    cwd: "{FEAT}",
+  },
   {
     name: "two spaces between git and commit",
     command: "git  commit -m x",
@@ -206,6 +238,11 @@ const DENIED: Case[] = [
     cwd: "{MAIN}",
   },
   { name: "a bare commit on main", command: "git commit -m x", cwd: "{MAIN}" },
+  {
+    name: "an amend reusing a message, on main",
+    command: "git commit --amend -C HEAD",
+    cwd: "{MAIN}",
+  },
   {
     name: "a tilde path into main",
     command: "cd ~/main-repo && git commit -m x",
@@ -280,6 +317,36 @@ const ALLOWED: Case[] = [
     command: "git commit -m x",
     cwd: "{FEAT}",
   },
+  // `-C` after `commit` is commit's own "reuse this commit's message" flag,
+  // not a directory — reading it as one denied ordinary amends outright.
+  {
+    name: "an amend reusing a message, on a feature branch",
+    command: "git commit --amend -C HEAD",
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a -C mentioned inside the commit message",
+    command: 'git commit -m "revert -C flag handling"',
+    cwd: "{FEAT}",
+  },
+  {
+    name: "a cd into a feature checkout inside a bash -c wrapper",
+    command: 'bash -c "cd {FEAT} && git commit -m x"',
+    cwd: "{MAIN}",
+  },
+  // The escape hatch documented in .claude/CLAUDE.md must not be blocked by
+  // the layer that runs first.
+  {
+    name: "the ALLOW_MAIN_COMMIT escape hatch, as a prefix",
+    command: "ALLOW_MAIN_COMMIT=1 git commit -m x",
+    cwd: "{MAIN}",
+  },
+  {
+    name: "the ALLOW_MAIN_COMMIT escape hatch, exported",
+    command: "git commit -m x",
+    cwd: "{MAIN}",
+    env: { ALLOW_MAIN_COMMIT: "1" },
+  },
   {
     name: "a command with no commit in it",
     command: "pnpm --filter @kcvv/web check-all",
@@ -289,17 +356,11 @@ const ALLOWED: Case[] = [
 
 describe(".claude/hooks/check-branch.sh", () => {
   it.each(DENIED)("blocks $name", ({ command, cwd, env }) => {
-    const expandedEnv = Object.fromEntries(
-      Object.entries(env ?? {}).map(([key, value]) => [key, expand(value)]),
-    );
-    expect(runHookOn(command, cwd, expandedEnv)).toBe("deny");
+    expect(runHookOn(command, cwd, env)).toBe("deny");
   });
 
   it.each(ALLOWED)("allows $name", ({ command, cwd, env }) => {
-    const expandedEnv = Object.fromEntries(
-      Object.entries(env ?? {}).map(([key, value]) => [key, expand(value)]),
-    );
-    expect(runHookOn(command, cwd, expandedEnv)).toBe("allow");
+    expect(runHookOn(command, cwd, env)).toBe("allow");
   });
 
   // Deliberate, documented in the issue's "Residual gaps": a payload the hook
@@ -312,6 +373,17 @@ describe(".claude/hooks/check-branch.sh", () => {
 
   it("allows empty input", () => {
     expect(runHook("")).toBe("allow");
+  });
+
+  // Without an interpreter the hook would silently fail OPEN, so it fails
+  // closed instead — even on a feature branch, which is what makes this a
+  // fail-closed test rather than a coincidental main detection.
+  it("denies when python3 is unavailable", () => {
+    // Everything the hook does before probing for python3 is a shell builtin,
+    // so a PATH with only `bash` on it is enough to reach the probe.
+    expect(runHookOn("git commit -m x", "{FEAT}", { PATH: "{SHIMBIN}" })).toBe(
+      "deny",
+    );
   });
 });
 
@@ -351,5 +423,71 @@ describe(".husky/branch-guard.sh", () => {
     expect(runGuard([tokens.MAIN], { env: { ALLOW_MAIN_COMMIT: "1" } })).toBe(
       0,
     );
+  });
+});
+
+/**
+ * The guard is only worth anything if `.husky/pre-commit` actually calls it,
+ * and calls it *first* — the whole point of extracting it was to fail before
+ * paying for `lint-staged` + a full monorepo type-check. That single line is
+ * the load-bearing path and the thing most likely to regress silently, so
+ * drive the real hook rather than reading the file.
+ */
+describe(".husky/pre-commit wiring", () => {
+  /** Printed by pre-commit once it has moved past the branch guard. */
+  const PAST_THE_GUARD = "Running pre-commit checks";
+
+  /**
+   * Both hooks resolve the guard relative to the working-tree root, so a
+   * fixture needs its own `.husky/` holding the script under test.
+   */
+  const linkGuardInto = (cwd: string) => {
+    const husky = join(cwd, ".husky");
+    mkdirSync(husky, { recursive: true });
+    const link = join(husky, "branch-guard.sh");
+    if (!existsSync(link)) symlinkSync(BRANCH_GUARD, link);
+  };
+
+  const runPreCommit = (cwd: string) => {
+    linkGuardInto(cwd);
+    return spawnSync("bash", [join(repoRoot, ".husky", "pre-commit")], {
+      cwd,
+      encoding: "utf8",
+      // A bash-only PATH: past the guard, `npx lint-staged` and the monorepo
+      // type-check are not this test's business and would cost seconds of
+      // real work. They fail as not-found, which is all we need — the marker
+      // printed between the guard and lint-staged is what is asserted on.
+      env: { ...gitEnv, PATH: tokens.SHIMBIN },
+    });
+  };
+
+  it("blocks on main before reaching lint-staged", () => {
+    const result = runPreCommit(tokens.MAIN);
+    expect(result.status).toBe(1);
+    expect(result.stdout).not.toContain(PAST_THE_GUARD);
+  });
+
+  it("proceeds past the guard on a feature branch", () => {
+    const result = runPreCommit(tokens.FEAT);
+    expect(result.stdout).toContain(PAST_THE_GUARD);
+  });
+
+  // `pre-commit` does not fire for merge commits — verified against git — so
+  // `git merge --no-ff` onto main would otherwise walk straight past Layer 1.
+  const runPreMergeCommit = (cwd: string) =>
+    spawnSync("bash", [join(repoRoot, ".husky", "pre-merge-commit")], {
+      cwd,
+      encoding: "utf8",
+      env: { ...gitEnv, PATH: tokens.SHIMBIN },
+    }).status;
+
+  it("blocks a merge commit on main", () => {
+    linkGuardInto(tokens.MAIN);
+    expect(runPreMergeCommit(tokens.MAIN)).toBe(1);
+  });
+
+  it("allows a merge commit on a feature branch", () => {
+    linkGuardInto(tokens.FEAT);
+    expect(runPreMergeCommit(tokens.FEAT)).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #2361

## What was broken

`.claude/hooks/check-branch.sh` is the guardrail that stops an agent committing to `main`. It parsed the tool payload with `sed`, and `[^"]*` stops at the `"` that JSON encodes as `\"` — so any quote before the `git commit` truncated the parse and the guard exited 0. `pnpm --filter "@kcvv/web" check-all && git commit -m x`, the exact command `.claude/CLAUDE.md` prescribes, was waved straight through. It also matched `git commit` as a bare substring and read the target directory from one over-anchored `^cd … &&` regex, so `cd` had to come literally first.

That combination scored 24 correct / 10 false positives / 15 false negatives across 48 command shapes — and it blocked a legitimate worktree commit during a session while leaving several routes to a `main` commit wide open. False confidence, which is worse than no guard.

## Two layers

**Layer 1 — `.husky/branch-guard.sh`, the backstop.** Reads the branch inside git, in the repository the commit actually lands in, so no `-C`, `bash -c`, xargs, subshell or quoting trick reaches around it. Called from the first executable line of `.husky/pre-commit`, before `npx lint-staged`, so a doomed commit doesn't cost a full monorepo type-check to discover.

**Layer 2 — `.claude/hooks/check-branch.sh`, fast and friendly.** Parses the payload as JSON (never `sed`), splits the command on `&& || ; | ( )` and scans segment by segment so `cd` may appear anywhere and the last one before the commit wins, honours an explicit `git -C <dir>`, matches `git [global flags] commit` anchored at a segment start, and **fails closed** when it can't resolve the target.

An unparseable payload still allows, deliberately — Layer 1 covers it, and failing closed there would deny unrelated `Bash` calls on any future payload-shape change. Per the issue's "Residual gaps", not a defect.

## What the pre-PR review gate found

`/code-review` and `/simplify` both ran. Three defects, all reproduced by hand before fixing — **two of them in the script the issue shipped as validated**:

| Defect | Symptom |
| --- | --- |
| `-C` searched across the whole segment | `git commit --amend -C HEAD` denied on a feature branch, as was any commit whose message mentioned `-C`. Now confined to the captured global-flag span before `commit`. |
| `ALLOW_MAIN_COMMIT=1` not honoured by Layer 2 | The escape hatch this branch documents was denied by the layer that runs first. Both the `VAR=` prefix form and an exported variable now allow. |
| `bash -c "cd <dir> && git commit"` | The segment splitter is quote-blind and shredded the wrapper, losing the `cd`. Wrappers are unwrapped before splitting — which also let the match regex drop its own wrapper alternation. |

**And one gap in the layering itself:** `pre-commit` does not fire for merge commits (verified against git), so `git merge --no-ff` onto `main` walked past Layer 1 entirely. `.husky/pre-merge-commit` closes it. `git cherry-pick` and `git revert` run **no** commit hooks at all — a git design choice no hook can close, now documented rather than papered over.

## Escape hatch

`ALLOW_MAIN_COMMIT=1 git commit …`, honoured by both layers. Preferred over `--no-verify`, which also skips commitlint and lint-staged. It is opt-in per command — nothing sets it, no session exports it, and it is not sticky. `.claude/CLAUDE.md` frames it explicitly as a human escape hatch that agents must not reach for.

## Hot path

Layer 2 runs on **every** Bash tool call. The payload is now read with a shell builtin instead of `$(cat)`, and the fast-path test requires a trailing word boundary so `commitlint`, `uncommitted` and `commits` no longer pay for an interpreter. Measured over 200 runs each, interleaved to cancel drift:

```text
read builtin + boundary   6.2 ms/call
$(cat) + boundary         8.5 ms/call
$(cat) + old glob         8.8 ms/call   <- previous behaviour
```

Passing the python program on stdin instead of `-c` was tried and measured ~60 ms/call *slower*; reverted.

## Testing

`apps/web/test/hooks/check-branch.test.ts` — 48 cases, driving both scripts as subprocesses against throwaway `git init` repos in `os.tmpdir()`. It lives in `apps/web` because that is the only workspace where tests actually run; `.claude/` and `.husky/` are in no workspace, so nothing would ever have run a test placed beside them. An odd home for a repo-root hook, and the accepted trade against inventing a second test idiom.

Covers every row of the issue's Selected-cases table, both fail-closed paths, the missing-`python3` path, the deliberate allow-on-unparseable-payload, and — new since the review — the `.husky` wiring itself, which is the load-bearing line and had no test at all.

- `pnpm --filter @kcvv/web check-all` -> exit 0 (292 files, 3357 tests)
- Slowest single case 233 ms against the 5 s `testTimeout`; file total ~8.5 s
- Merge blocking verified end-to-end in a scratch repo wired with the real `.husky/`

## Applied vs skipped from `/simplify`

**Applied:** fast-path and payload-read costs above; `bash -c` unwrapping; `branch-guard.sh` message as one heredoc; fixture identity moved to `GIT_*` env instead of six `git config` spawns; token expansion folded into one helper so the two `it.each` bodies stop duplicating it; the wiring tests.

**Skipped:** moving fixtures to module scope (import-time `git init` is worse than a `beforeAll`); merging the two case tables (two tables read better once the duplication was gone); refactoring the `found` flag and merging the two fail-closed messages (churn on validated code, and the messages say different things); async `spawn` + `it.concurrent` for ~5 s (per-test budget is 233 ms against 5 s — not the failure mode #2362 was about); replacing `git rev-parse --show-toplevel` with a `../..` walk (the issue explicitly requires `rev-parse`).

Not exhaustively reproduced: the full 48-shape audit set from the issue. Its artifacts lived in `/tmp/kcvv-hook-audit/` and are gone; the 48 cases here cover every shape the issue names plus the ones the review added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
