### PR TITLE
test(config): hoist the remaining in-body page imports out of it() bodies (#2367)

### DIFF
--- a/apps/web/src/app/(main)/canonical-urls.test.ts
+++ b/apps/web/src/app/(main)/canonical-urls.test.ts
@@ -25,12 +25,21 @@ vi.mock("next/navigation", () => ({
 const { runPromise } = await import("@/lib/effect/runtime");
 const mockRunPromise = vi.mocked(runPromise);
 
-// Import all page modules upfront (mocks are already in place)
-const nieuws = await import("./nieuws/[slug]/page");
+// Import all page modules upfront (mocks are already in place). Module scope
+// is deliberate: Vitest charges an import inside an `it()` body against
+// `testTimeout`, while these are paid during the untimed collect phase (#2362).
+const nieuwsDetail = await import("./nieuws/[slug]/page");
 const spelers = await import("./spelers/[slug]/page");
 const staf = await import("./staf/[slug]/page");
 const ploegen = await import("./ploegen/[slug]/page");
 const wedstrijd = await import("./wedstrijd/[matchId]/page");
+const privacy = await import("./privacy/page");
+const clubSlug = await import("./club/[slug]/page");
+const bestuur = await import("./club/bestuur/page");
+const home = await import("../(landing)/page");
+const nieuwsIndex = await import("../(landing)/nieuws/page");
+const tegenstander = await import("./tegenstander/[clubId]/page");
+const share = await import("./share/page");
 
 // ── Fixtures ───────────────────────────────────────────────────────
 
@@ -82,7 +91,7 @@ describe("Canonical URLs on dynamic routes", () => {
 
   it("/nieuws/[slug] includes canonical URL", async () => {
     mockRunPromise.mockResolvedValueOnce(articleFixture);
-    const metadata = await nieuws.generateMetadata({
+    const metadata = await nieuwsDetail.generateMetadata({
       params: Promise.resolve({ slug: "test-article" }),
     });
     expect(metadata).toHaveProperty(
@@ -141,8 +150,8 @@ describe("Canonical URLs backfilled via buildPageMetadata", () => {
     vi.clearAllMocks();
   });
 
-  it("static page (/privacy) includes canonical URL", async () => {
-    const { metadata } = await import("./privacy/page");
+  it("static page (/privacy) includes canonical URL", () => {
+    const { metadata } = privacy;
     expect(metadata).toHaveProperty(
       "alternates.canonical",
       `${SITE_CONFIG.siteUrl}/privacy`,
@@ -157,7 +166,6 @@ describe("Canonical URLs backfilled via buildPageMetadata", () => {
       heroImageUrl: null,
       body: [],
     });
-    const clubSlug = await import("./club/[slug]/page");
     const metadata = await clubSlug.generateMetadata({
       params: Promise.resolve({ slug: "inschrijven" }),
     });
@@ -173,7 +181,6 @@ describe("Canonical URLs backfilled via buildPageMetadata", () => {
       tagline: null,
       teamImageUrl: null,
     });
-    const bestuur = await import("./club/bestuur/page");
     const metadata = await bestuur.generateMetadata();
     expect(metadata).toHaveProperty(
       "alternates.canonical",
@@ -184,7 +191,6 @@ describe("Canonical URLs backfilled via buildPageMetadata", () => {
 
 describe("Static listing canonicals (#2228)", () => {
   it("/ (homepage) canonicalizes to the site root", async () => {
-    const home = await import("../(landing)/page");
     const metadata = await home.generateMetadata();
     expect(metadata).toHaveProperty(
       "alternates.canonical",
@@ -193,15 +199,14 @@ describe("Static listing canonicals (#2228)", () => {
   });
 
   it("/nieuws canonicalizes to /nieuws, including ?categorie views", async () => {
-    const nieuws = await import("../(landing)/nieuws/page");
-    const base = await nieuws.generateMetadata({
+    const base = await nieuwsIndex.generateMetadata({
       searchParams: Promise.resolve({}),
     });
     expect(base).toHaveProperty(
       "alternates.canonical",
       `${SITE_CONFIG.siteUrl}/nieuws`,
     );
-    const filtered = await nieuws.generateMetadata({
+    const filtered = await nieuwsIndex.generateMetadata({
       searchParams: Promise.resolve({ categorie: "Jeugd" }),
     });
     expect(filtered).toHaveProperty(
@@ -212,14 +217,14 @@ describe("Static listing canonicals (#2228)", () => {
 });
 
 describe("Noindex routes do NOT have canonical URLs", () => {
-  it("/tegenstander/[clubId] has robots noindex and no canonical", async () => {
-    const { metadata } = await import("./tegenstander/[clubId]/page");
+  it("/tegenstander/[clubId] has robots noindex and no canonical", () => {
+    const { metadata } = tegenstander;
     expect(metadata.robots).toEqual({ index: false, follow: false });
     expect(metadata).not.toHaveProperty("alternates");
   });
 
-  it("/share has robots noindex and no canonical", async () => {
-    const { metadata } = await import("./share/page");
+  it("/share has robots noindex and no canonical", () => {
+    const { metadata } = share;
     expect(metadata.robots).toEqual({ index: false, follow: false });
     expect(metadata).not.toHaveProperty("alternates");
   });

--- a/apps/web/src/app/metadata.test.ts
+++ b/apps/web/src/app/metadata.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { metadata } from "./layout";
+// Module scope is deliberate: Vitest charges an import inside an `it()` body
+// against `testTimeout`, while this is paid during the untimed collect phase
+// (#2362). There are no `vi.mock` calls here, so a static import is safe.
+import { metadata as privacyMetadata } from "./(main)/privacy/page";
 
 describe("root layout metadata", () => {
   it("SITE_CONFIG.siteUrl is a valid absolute URL for metadataBase", () => {
@@ -23,9 +27,8 @@ describe("root layout metadata", () => {
     expect(title.template).toBe("%s | KCVV Elewijt");
   });
 
-  it("static pages do not hardcode the brand suffix in their title", async () => {
-    const { metadata: privacy } = await import("./(main)/privacy/page");
-    expect(privacy.title).toBe("Privacyverklaring");
-    expect(String(privacy.title)).not.toContain("| KCVV Elewijt");
+  it("static pages do not hardcode the brand suffix in their title", () => {
+    expect(privacyMetadata.title).toBe("Privacyverklaring");
+    expect(String(privacyMetadata.title)).not.toContain("| KCVV Elewijt");
   });
 });


### PR DESCRIPTION
Closes #2367

## What this does

Moves eight `await import()` calls of Next.js page modules out of `it()` bodies and up to module scope. Pure relocation — not one assertion changed.

Vitest charges an import inside an `it()` body against `testTimeout` (5000 ms default); a module-scope import is paid during the untimed collect phase. #2362 fixed the five files in its Scope; these two were outside it and kept the same shape as the three tests that deterministically failed under CI contention.

| File | Sites | Form |
| --- | --- | --- |
| `apps/web/src/app/(main)/canonical-urls.test.ts` | 7 | joined to the module-scope block the file already had |
| `apps/web/src/app/metadata.test.ts` | 1 | static `import` (no `vi.mock` in the file) |

## Measured effect

Same machine, same command, `origin/main` vs this branch:

| | timed `tests` phase | worst single test | untimed `import` |
| --- | --- | --- | --- |
| `origin/main` | 366 ms | 101 ms | 4.95 s |
| this branch | **22 ms** | **13 ms** | 4.92 s |

The collect phase did **not** grow — the seven added modules were already in the graph via shared deps. Total wall clock actually dropped slightly.

Per the issue, **no timing assertion was added**: it was measured during spec as already passing on `main`, so it cannot distinguish done from not-done and would only add a flaky gate. The structural grep is the real verification.

## Two deliberate judgement calls

**1. `canonical-urls.test.ts` keeps `await import()` instead of switching to static `import`.** `apps/web/CLAUDE.md` prefers a static import unless a `vi.mock` factory closes over a file-scope `const`. Neither factory here closes over anything, so the exception does not technically apply — and the review confirmed a static conversion passes with no TDZ. I left it as `await import()` anyway, to match the block immediately above it. Splitting page imports across two idioms in one file reads worse than the default preference buys. `metadata.test.ts`, which has no such block, uses a static import.

**2. `nieuws` → `nieuwsDetail`.** Hoisting put the `/nieuws/[slug]` detail page and the `(landing)/nieuws` listing in the same scope, where a bare `nieuws` no longer says which is which. Two lines beyond the eight named sites, fixing an ambiguity this change introduced.

## The spec's grep gate is not satisfiable as written

AC 3 asks that the repo-wide grep return **only** the "Out of scope" exemptions. It does not, and cannot — the exemption list is incomplete. Verified independently by review:

- **`opengraph-image.test.ts` (3 sites) and `robots.test.ts` (3 sites)** are genuine same-class violations the list never classified: both are Next.js **route** modules imported inside `it()` bodies, which `apps/web/CLAUDE.md:170` covers explicitly.
- **`article.repository.test.ts` has 6 in-body sites, not 5** — the issue lists 303/328/344/362/380 and misses line 219. Same classification (lib module, warm cache), so still not a violation.
- `Select.test.tsx`, `SharePage.test.tsx` (×5), `gtm-consent.test.ts`, `TeamEnrolmentCta.test.tsx` are all correctly *not* violations, but are absent from the list.

I did **not** expand the diff, per the issue's own instruction: *"If the implementer disagrees with any classification above, say so in the PR rather than silently expanding the diff."* The six route-module sites measure 36 ms worst case, so there is no flake to remove, and both files sit outside the declared Scope.

Filed as a follow-up rather than folded in — see the linked issue. That follow-up also carries the review's strongest suggestion: **an eslint rule to end this bug class**, which has now cost two issues and would otherwise queue a third by construction.

## Testing

- `pnpm --filter @kcvv/web check-all` -> exit 0 (292 files, 3357 tests)
- 16/16 tests in the two touched files pass, assertions byte-identical apart from one local rename

## Review gate

`/code-review` ran both axes (standards + spec). `/simplify`'s four lenses ran as one combined pass rather than four agents — proportionate to a 25-line pure relocation, and noted here rather than quietly skipped.

**Applied:** the `nieuwsDetail` rename (flagged independently by two reviewers); corrected the commit message's overstated "the last such imports" claim.

**Skipped:** collapsing the twelve import lines into a loop (`await import()` needs a statically analysable specifier; a template would break Vite's transform and all type inference); sharing the import block with `legacy-redirects.test.ts` (Vitest's module registry and `vi.mock` set are per-file — a shared helper would resolve against the wrong mocks); hoisting `robots.test.ts` / `opengraph-image.test.ts` and adding the eslint rule (both out of Scope, both in the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved metadata and canonical URL test setup for more consistent validation.
  * Updated coverage for privacy, club, board, homepage, news, opponent, sharing, dynamic, static, listing, and noindex routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->