### PR TITLE
fix(config): pin local VR runner to amd64 so Apple Silicon matches CI (#2370)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -176,4 +176,5 @@ Three independent test layers, each owning a specific concern. Don't blur them �
 Two rules worth knowing before you get there, because getting them wrong costs a CI round:
 
 - **VR baselines ship in the same PR as the code**, captured locally via Docker. Never open the PR first and capture after, and never reach for `@kcvv-bot update-vr-baselines` for a baseline your own change caused — that bot is for drift you cannot reproduce locally.
-- **Scope every capture** — a full run is ~40 min. Filter by story-ID prefix as a bare positional argument (`vr -u ui-button`), never a `--testPathPatterns=` flag; that flag is rejected outright.
+- **Scope every capture** — a full run is ~40 min. Filter by story-ID prefix with `-u <prefix>` (`vr -u ui-button`) — the pattern only scopes when it follows `-u`. A bare positional in check mode is silently ignored (the full suite runs), and a `--testPathPatterns=` flag is rejected outright.
+- **On an unpinned VR container, do not treat a local `vr:check` failure as a regression** without first checking the story against CI's render — arm64 on Apple Silicon drifts on display-serif stories. With the `platform: linux/amd64` pin (the committed default) a local failure is real. See "The amd64 pin — scoped runs only" in `docs/agents/testing-ops.md` (#2370).

--- a/apps/web/docker-compose.vr.yml
+++ b/apps/web/docker-compose.vr.yml
@@ -14,6 +14,11 @@ services:
     # version is owned by Dockerfile.vr's FROM, and a second copy here drifts
     # (it read 1.59.1 long after the base moved to 1.60.0).
     image: kcvv-vr-runner:latest
+    # CI runs this image on amd64 (ubuntu-latest); unpinned builds on Apple
+    # Silicon resolve arm64, which drifts from the committed baselines on
+    # display-serif stories (#2370). Emulated amd64 renders byte-identical to
+    # CI — scoped runs only; see "The amd64 pin" in docs/agents/testing-ops.md.
+    platform: linux/amd64
     init: true
     working_dir: /work/apps/web
     volumes:

--- a/docs/agents/testing-ops.md
+++ b/docs/agents/testing-ops.md
@@ -118,8 +118,12 @@ committed to the repo. Background and rationale: `docs/prd/visual-regression-tes
 
 Prerequisite: Docker Desktop running with **at least 8 GB of memory allocated**
 to the Docker VM. Local runs use the same pinned `mcr.microsoft.com/playwright`
-image as CI so font rendering matches exactly — the tag is set in
-`apps/web/Dockerfile.vr` (`FROM`), which is the single source of truth for it.
+image tag as CI — set in `apps/web/Dockerfile.vr` (`FROM`), the single source
+of truth for it — but the tag alone does not make font rendering match: CI
+runs the image's amd64 build (`ubuntu-latest`), while an unpinned build on
+Apple Silicon resolves arm64, whose Chromium/FreeType antialiases display
+serif differently. `docker-compose.vr.yml` therefore pins
+`platform: linux/amd64` — see "The amd64 pin — scoped runs only" below (#2370).
 
 **Minimum Docker Desktop memory:** 8 GB (measured against the full Phase 2+3
 story surface). Below this floor, Chromium runs out of memory mid-story and
@@ -144,20 +148,44 @@ pnpm --filter @kcvv/web run vr:check
 # Accept the current rendering as the new baseline (commit the resulting PNGs).
 pnpm --filter @kcvv/web run vr:update
 
-# Surgical run — only stories matching the pattern. Pass the regex as a BARE
-# POSITIONAL argument (see "Scoping a VR run" below); update and compare modes
-# both take it.
+# Surgical run — the pattern only scopes when it FOLLOWS `-u` (see "Scoping
+# a VR run" below), so update mode is the only scoped mode. To check a single
+# story without keeping new baselines: scoped update, inspect `git status`,
+# then restore with `git checkout -- test/vr/__snapshots__/`.
 pnpm --filter @kcvv/web run vr:update:story -- ui-button   # update, scoped
-pnpm --filter @kcvv/web run vr:check -- ui-button          # compare, scoped
 
 # Print the diff PNG path(s) for a failed story so the Read tool can inspect them.
 pnpm --filter @kcvv/web run vr:diff layout-pagefooter--standalone
 ```
 
+### The amd64 pin — scoped runs only (#2370)
+
+`docker-compose.vr.yml` pins the `vr` service to `platform: linux/amd64`.
+Measured on the `features-articles-editorialhero` cluster (57 baselines, 19
+tests), same commit, same image tag:
+
+| Build                    | Changed baselines after a scoped `-u` run | Wall-clock             |
+| ------------------------ | ----------------------------------------- | ---------------------- |
+| arm64 (unpinned)         | 52 / 57                                   | 46 s                   |
+| amd64 (pinned, emulated) | **0 / 57**                                | 179 s cold, 164 s warm |
+
+The 0/57 row means architecture was the sole cause of the drift: pinned local
+renders are **byte-identical to the committed baselines CI passes against**,
+so a scoped local capture is trustworthy on Apple Silicon. Two consequences:
+
+- **Scoped runs only.** Emulation costs ~3.6×: the ~40 min full suite projects
+  to ~2.5 h. Never run an unscoped `vr:check` / `vr:update` locally — the full
+  suite is CI's job.
+- **Never remove the pin to speed a run up.** Unpinned arm64 output fails ~83
+  stories that CI passes, and arm64-rendered baselines must never be committed
+  (see "Anti-patterns" below).
+
 ### Scoping a VR run
 
-A full capture is ~40 min, so always scope. **The pattern is a bare positional
-argument — never a `--testPathPattern(s)=` flag.**
+A full capture is ~40 min — ~2.5 h locally under the amd64 pin — so always
+scope. **The pattern must follow `-u` — never a `--testPathPattern(s)=` flag,
+and never a bare positional on its own.** In check mode (no `-u`) a bare
+positional pattern is silently ignored and the whole suite runs.
 
 `test-storybook` parses its CLI with commander against a closed option
 allowlist (`--maxWorkers`, `--testTimeout`, `-u`, `--includeTags`,
@@ -165,8 +193,8 @@ allowlist (`--maxWorkers`, `--testTimeout`, `-u`, `--includeTags`,
 `getParsedCliOptions` in `node_modules/@storybook/test-runner/dist/test-storybook.js`).
 Any unrecognised `--flag` prints the help text and exits 1 — including Jest's
 own `--testPathPatterns`, which is **not** passed through. Positional operands
-(`program.args`) _are_ forwarded verbatim to Jest, and Jest treats a bare
-positional as a test-path regex. That is the only scoping channel.
+(`program.args`) are forwarded to Jest, but only positionals following `-u`
+scope (see above) — making `-u <prefix>` the only working channel (#2370).
 
 The regex matches the synthetic test files the runner writes to a temp dir, one
 per story **title** (component), named from the story ID:
@@ -203,7 +231,8 @@ regression in #2316 is the worked example.
 
 `vr:check` and `vr:update` rebuild Storybook first, then run the test-runner
 inside Docker. First run pulls the Playwright image (~1.3 GB). Steady-state run
-time on a warm cache is ~30 s for the Phase 1 tracer-bullet set.
+time on a warm cache is ~30 s for the Phase 1 tracer-bullet set (measured
+unpinned; expect ~3.6× that under the amd64 pin).
 
 ### Single-worker fallback
 
@@ -525,10 +554,13 @@ component or library. Document the reason inline (one comment line).
 
 When the CI `visual-regression` job fails on a PR, the `vr-diff-comment` job
 automatically pushes the diff PNGs to the orphan branch `vr-diffs/pr-<N>` and
-posts a sticky comment on the PR. The comment embeds baseline / actual / diff
-images inline via `raw.githubusercontent.com` links — no artifact download
-needed. The orphan branch (and the sticky comment) are cleaned up automatically
-when the PR closes via `vr-diff-cleanup.yml`.
+posts a sticky comment on the PR. Only `diff-*.png` is actually pushed — the
+`actual-*.png` URLs the sticky comment embeds 404. Each
+`vr-diffs/diff-<story-id>--<viewport>-diff.png` is a 3-panel composite laid
+out `baseline | diff-mask | actual`, unscaled, so the right third **is** CI's
+exact render: crop `x >= width * 2/3` to verify — or replace — a locally
+regenerated baseline (#2370). The orphan branch (and the sticky comment) are
+cleaned up automatically when the PR closes via `vr-diff-cleanup.yml`.
 
 Locally, `pnpm --filter @kcvv/web run vr:diff <story-id>` prints the on-disk
 path(s) under `apps/web/test/vr/__diff_output__/`. The `vr-diff-output`
@@ -571,3 +603,8 @@ explicitly. A GitHub App is the cleaner long-term replacement.
 - **Do not remove `NODE_OPTIONS=--max-old-space-size=4096` from `docker-compose.vr.yml`.**
   Node.js defaults to ~1.4 GB heap — the test runner OOMs after ~80 story visits
   regardless of Docker memory allocation.
+- **Do not treat a local `vr:check` failure on an unpinned (arm64) container
+  as a regression** without first checking the story against CI's render
+  (extract it per "Inspecting diffs" above) — Apple Silicon drifts on
+  display-serif stories. With the `platform: linux/amd64` pin a local failure
+  is real (see "The amd64 pin — scoped runs only").


### PR DESCRIPTION
Closes #2370

## Experiment (binding protocol from the issue)

Scoped `vr:update:story features-articles-editorialhero` (57 baselines, 19 tests), same commit, same image tag, M-series Mac:

| Leg | Changed baselines (`git status --porcelain` count) | Wall-clock |
| --- | --- | --- |
| arm64 (unpinned) | **D = 52** / 57 | **T_arm = 46 s** |
| amd64 (`platform: linux/amd64`, emulated) | **0** / 57 | **T_amd = 179 s** cold (incl. image build) · 164 s warm re-run |

**Decision rule:** amd64 changed files = 0 with D > 0, and 2 × T_arm (92 s) < T_amd (179 s) ≤ 6 × T_arm (276 s) → **Adopt scoped-only**.

- In `-u` mode the amd64 runner reported `57 passed, 0 updated` and git saw zero byte changes — twice. Architecture was the sole cause of the drift.
- Steady-state emulation factor ≈ 3.6× → the ~40 min full suite projects to ~2.5 h locally: scoped runs only; the full suite stays a CI job.
- Snapshots restored after each leg; `apps/web/test/vr/__snapshots__/` is byte-identical to `main` in this diff (`git status --porcelain` empty).

## Changes

- `apps/web/docker-compose.vr.yml` — `platform: linux/amd64` pin on the `vr` service (kept per the decision rule).
- `docs/agents/testing-ops.md`
  - False-parity sentence corrected: same image tag, but CI is amd64 and unpinned Apple Silicon resolves arm64, which antialiases display serif differently.
  - New "The amd64 pin — scoped runs only (#2370)" section: measured table, scoped-only rule, never-remove-the-pin.
  - Composite-extraction workaround folded into "Inspecting diffs" (which previously claimed the sticky comment embeds baseline/actual/diff — the `actual-*.png` URLs 404; only `diff-*.png` is pushed; right third of the 3-panel composite is CI's exact render, crop `x >= width*2/3`).
  - `-u` scoping corrections: check mode silently ignores a bare positional (the previous "compare, scoped" example was a silent full-suite run); `-u <prefix>` is the only working channel.
  - Anti-patterns list: new unpinned-container entry.
- `apps/web/CLAUDE.md` — line 179 `-u` correction + anti-pattern cross-reference under "Running the suites".

Not changed, per AC: `.storybook/test-runner.ts` (`failureThreshold` stays `0.0005`); zero baselines.

## Review gates

`/code-review` (Standards + Spec) and `/simplify` (4 agents) ran on the branch diff.

**Applied:** scoped the CLAUDE.md anti-pattern bullet to the unpinned case (it read as a blanket rule contradicting the pinned default); dropped the unverified "Rosetta" and "stale image" claims; trimmed the compose comment to a pointer; deduplicated the bare-positional fact and the anti-pattern rule to one canonical statement each inside `testing-ops.md`; folded the composite section into the existing "Inspecting diffs" instead of adding a parallel section; added the missing entry to the established "Anti-patterns" checklist.

**Skipped:** a script guard refusing unscoped local `vr:check` (worth a follow-up issue — prose can't enforce the 2.5 h footgun, but runner/script changes are explicitly out of scope here); stale bare-positional guidance in `docs/prd/redesign-phase-2.md` (historical PRD, outside the issue's file scope); cross-file mirroring of the `-u` rule and anti-pattern between `CLAUDE.md` and `testing-ops.md` (spec-mandated).

## Testing

- `pnpm --filter @kcvv/web check-all` passes (one transient Sanity `ECONNREFUSED` during static export on the first run; build re-run green — unrelated to this docs/config diff).
- Experiment runs above are the functional test of the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
