### PR TITLE
test(config): enforce module-scope route imports in eslint (#2378)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -6,6 +6,18 @@ import storybook from "eslint-plugin-storybook";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// The `apps/web/CLAUDE.md` rule "Import the module under test at module scope",
+// in a form that fails the build instead of being re-litigated per file.
+//
+// The `it`/`test` ancestor is what makes this precise: module-scope
+// `await import()` blocks (canonical-urls.test.ts, legacy-redirects.test.ts)
+// must not trip. The three call shapes cover `it(…)`, `it.skip(…)`/`it.only(…)`
+// and `it.each(table)(…)`.
+// Kept on one line: esquery does not parse a selector containing newlines, and
+// it fails *silently* — the rule simply stops matching anything.
+const IN_BODY_ROUTE_IMPORT =
+  ":matches(CallExpression[callee.name=/^(it|test)$/], CallExpression[callee.object.name=/^(it|test)$/], CallExpression[callee.callee.object.name=/^(it|test)$/]) ImportExpression > Literal[value=/\\/(page|layout|route|robots|sitemap|opengraph-image)$/]";
+
 const eslintConfig = [
   ...nextCoreWebVitals,
   ...nextTypescript,
@@ -43,11 +55,20 @@ const eslintConfig = [
     },
   },
   {
-    // Disable img-related rules for test files where we mock Next.js Image
+    // Test-file rules: img rules off (we mock Next.js Image), plus the
+    // module-scope import guard above.
     files: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
     rules: {
       "@next/next/no-img-element": "off",
       "jsx-a11y/alt-text": "off",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: IN_BODY_ROUTE_IMPORT,
+          message:
+            "Hoist this page/route module import to module scope — Vitest charges an in-body dynamic import against testTimeout, which breaks under CI contention (apps/web/CLAUDE.md).",
+        },
+      ],
     },
   },
 ];

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,14 +9,28 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // The `apps/web/CLAUDE.md` rule "Import the module under test at module scope",
 // in a form that fails the build instead of being re-litigated per file.
 //
-// The `it`/`test` ancestor is what makes this precise: module-scope
+// Requiring an `it`/`test` ancestor is what makes this precise: module-scope
 // `await import()` blocks (canonical-urls.test.ts, legacy-redirects.test.ts)
-// must not trip. The three call shapes cover `it(…)`, `it.skip(…)`/`it.only(…)`
-// and `it.each(table)(…)`.
-// Kept on one line: esquery does not parse a selector containing newlines, and
-// it fails *silently* — the rule simply stops matching anything.
-const IN_BODY_ROUTE_IMPORT =
-  ":matches(CallExpression[callee.name=/^(it|test)$/], CallExpression[callee.object.name=/^(it|test)$/], CallExpression[callee.callee.object.name=/^(it|test)$/]) ImportExpression > Literal[value=/\\/(page|layout|route|robots|sitemap|opengraph-image)$/]";
+// must not trip, and neither must hook bodies — those are charged against
+// `hookTimeout`, and CLAUDE.md scopes the convention to `it()` bodies.
+//
+// Vitest composes modifiers into chains (`it.skip`, `test.concurrent.skip`,
+// `it.each(table)(…)`, `test.concurrent.for(table)(…)`), and esquery cannot
+// express an unbounded `.object` walk — so the two call forms are crossed with
+// each chain depth. Three modifiers is past anything Vitest's API composes.
+const TEST_CALL_FORMS = ["callee", "callee.callee"]; // `it(…)` and `it.each(t)(…)`
+const MODIFIER_DEPTHS = ["", ".object", ".object.object", ".object.object.object"];
+
+const TEST_CALLS = TEST_CALL_FORMS.flatMap((form) =>
+  MODIFIER_DEPTHS.map(
+    (depth) => `CallExpression[${form}${depth}.name=/^(it|test)$/]`,
+  ),
+).join(", ");
+
+// Assembled without newlines on purpose: esquery does not parse a selector
+// containing them, and it fails *silently* — the rule keeps loading, `lint`
+// keeps exiting 0, and nothing is checked ever again.
+const IN_BODY_ROUTE_IMPORT = `:matches(${TEST_CALLS}) ImportExpression > Literal[value=/\\/(page|layout|route|robots|sitemap|opengraph-image)$/]`;
 
 const eslintConfig = [
   ...nextCoreWebVitals,

--- a/apps/web/src/app/opengraph-image.test.ts
+++ b/apps/web/src/app/opengraph-image.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect } from "vitest";
 
+// No `vi.mock` in this file, so the module-scope form the lint rule requires
+// can be a plain static import.
+import Image, { size, contentType } from "./opengraph-image";
+
 describe("default opengraph-image", () => {
-  it("exports size as 1200x630", async () => {
-    const { size } = await import("./opengraph-image");
+  it("exports size as 1200x630", () => {
     expect(size).toEqual({ width: 1200, height: 630 });
   });
 
-  it("exports contentType as image/png", async () => {
-    const { contentType } = await import("./opengraph-image");
+  it("exports contentType as image/png", () => {
     expect(contentType).toBe("image/png");
   });
 
   it("default export returns a Response", async () => {
-    const { default: Image } = await import("./opengraph-image");
     const response = await Image();
     expect(response).toBeInstanceOf(Response);
     expect(response.headers.get("content-type")).toContain("image/png");

--- a/apps/web/src/app/robots.test.ts
+++ b/apps/web/src/app/robots.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
+// Safe despite the env mutation below: `robots()` reads
+// `process.env.VERCEL_ENV` inside its body at call time, so nothing is captured
+// when the module is evaluated and there is nothing to re-evaluate. (The
+// previous in-body `await import()` bought nothing either — no
+// `vi.resetModules()`, so it returned the same cached module every time.)
+import robots from "./robots";
+
 describe("robots.ts", () => {
   let savedVercelEnv: string | undefined;
 
@@ -15,9 +22,8 @@ describe("robots.ts", () => {
     }
   });
 
-  it("allows full crawl in production", async () => {
+  it("allows full crawl in production", () => {
     process.env.VERCEL_ENV = "production";
-    const { default: robots } = await import("./robots");
     const result = robots();
 
     expect(result).toEqual({
@@ -26,9 +32,8 @@ describe("robots.ts", () => {
     });
   });
 
-  it("disallows crawl in non-production environments", async () => {
+  it("disallows crawl in non-production environments", () => {
     process.env.VERCEL_ENV = "preview";
-    const { default: robots } = await import("./robots");
     const result = robots();
 
     expect(result).toEqual({
@@ -37,9 +42,8 @@ describe("robots.ts", () => {
     });
   });
 
-  it("explicitly allows /llms.txt in production", async () => {
+  it("explicitly allows /llms.txt in production", () => {
     process.env.VERCEL_ENV = "production";
-    const { default: robots } = await import("./robots");
     const result = robots();
     const rules = result.rules as { allow: string[] };
 


### PR DESCRIPTION
Closes #2378

## What this does

Ends a bug class that has now cost three issues. Vitest charges a dynamic import inside an `it()` body against `testTimeout`; a module-scope import is paid during the untimed collect phase. A page graph takes seconds to resolve cold, so an in-body import fails under CI contention — it broke CI in #2362, and #2367 had to hoist another batch by hand.

The rule existed only as prose in `apps/web/CLAUDE.md`. Prose lost twice. This hoists the last six sites and adds the same rule as lint.

| File | Change |
| --- | --- |
| `opengraph-image.test.ts` | 3 sites -> one static import |
| `robots.test.ts` | 3 sites -> one static import |
| `eslint.config.mjs` | `no-restricted-syntax` guard for test files |

## The rule, and why it is precise

The selector keys on an `it`/`test` **ancestor**. That is what stops it flagging the legitimate module-scope `await import()` blocks in `canonical-urls.test.ts` and `legacy-redirects.test.ts` — which are the correct form and must not trip.

Verified in both directions, not just assumed:

- **No false positives:** `pnpm --filter @kcvv/web lint` -> zero findings across `apps/web`. A reviewer independently audited all 43 in-test dynamic imports; `html-to-image`, `next/navigation`, `./article.repository`, `@/lib/effect/runtime`, `./Select`, `./gtm-consent`, `react` and `effect` are all safe. (`html-to-image` cannot match — the regex requires a literal `/` before `opengraph-image`.)
- **It actually fires:** a throwaway probe confirmed errors on `it(…)`, `it.skip(…)`, `it.each(table)(…)` and an aliased `@/app/(main)/share/page`, with module-scope imports and `html-to-image` left alone. Probe deleted; the tree is clean.

## Two corrections worth reading

**1. The issue specified the wrong fix for `robots.test.ts`.** It claimed the file *"cannot be hoisted"* because the tests mutate `process.env.VERCEL_ENV` and rely on the in-body import to force re-evaluation, and therefore needed an inline `eslint-disable`. Both halves are false:

- `robots()` reads the env **inside its function body at call time** (`robots.ts:6`) — nothing is captured at module evaluation, so there is nothing to re-evaluate.
- The file has no `vi.resetModules()`, so all three `await import("./robots")` calls were already returning the same cached module. The in-body form bought nothing.

All three hoist cleanly and **no `eslint-disable` is needed anywhere**, which makes the rule clean-on-green rather than clean-with-exemptions. I wrote that issue after a review agent asserted the re-evaluation claim and repeated it without reading `robots.ts` myself. Corrected on the issue rather than diverging quietly.

**2. A "simplification" silently disabled the rule.** Acting on review feedback I rewrote the selector across several lines for readability. **esquery does not parse a selector containing newlines, and it fails silently** — `no-restricted-syntax` stopped matching anything while the config still looked correct, and `lint` still exited 0. Caught only because I re-ran the negative test after the edit rather than trusting the earlier green. It is one line now, with a comment saying why. A rule that silently stops working is precisely the false-confidence failure #2361 was about.

## Known gap, deliberate

Hook bodies (`beforeEach`, `beforeAll`) are **not** covered — verified. They are charged against `hookTimeout` (10 s) rather than `testTimeout`, and `apps/web/CLAUDE.md` documents the rule for `it()` bodies only. Widening the lint rule past the documented convention is a separate decision; say the word and I will extend both the rule and the prose. Also uncovered: `await import("./page.tsx")` with an explicit extension (the repo imports extensionless).

## Not done from the issue

**Part 2** asked to correct #2367's exemption-list miscount (`article.repository.test.ts` has 6 in-body sites, not the 5 listed — line 219 is missing; four legitimately-exempt files are also absent). #2367 is closed and nothing is gated on that list, so rather than reopen it I have posted the correction as a comment there. Flagging as an unmet AC rather than quietly dropping it.

## Measured

Median of 3 runs on the two touched files:

| | timed `tests` | untimed `import` | wall clock |
| --- | --- | --- | --- |
| before | 63 ms | 16 ms | 466 ms |
| after | **38 ms** | 43 ms | 465 ms |

Exactly the intended shift, wall clock unchanged. Lint cost: 10.60 s -> 10.79 s warm, within noise.

Per the issue, **no timing assertion was added** — the affected tests already pass well inside budget, so a wall-clock threshold could not distinguish done from not-done. The lint rule is the real verification.

## Testing

- `pnpm --filter @kcvv/web check-all` -> exit 0 (292 files, 3357 tests)
- 6/6 tests in the two touched files pass, assertions unchanged

## Review gate

`/code-review` (standards + spec) and `/simplify` (four lenses, one combined pass) both ran.

**Applied:** `:matches()` in place of a `map().join()` over a 3-element array; trimmed the rationale that had been written four times over down to the file-specific halves; refreshed the now-stale "img-related rules" block comment.

**Skipped:** moving the rule to a shared config (no shared eslint package exists, and the Next.js filesystem conventions it keys on exist only in `apps/web` — `packages/sanity-schemas/src/page.ts` would make it a false positive there); a broader `:function ImportExpression` selector (flags `vi.mock` `importActual` factories); raising `testTimeout` instead (hides the resolve cost rather than removing it, and slows real-hang detection for ~600 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by loading route-related modules consistently before tests run.
  * Simplified metadata and robots test execution while preserving existing assertions and coverage.

* **Chores**
  * Added linting rules to flag dynamic route-module imports inside test cases and guide the preferred usage pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->