### PR TITLE
chore(config): gitignore the impeccable per-developer files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,11 @@ storybook-static
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 
+# impeccable — shared config.json and design.json ARE committed;
+# per-developer consent and the hook's dedup cache are not
+.impeccable/config.local.json
+.impeccable/hook.cache.json
+
 # playwright
 test-results/
 playwright-report/


### PR DESCRIPTION
Five-line follow-up to 3707b240, which committed the shared Impeccable design-hook config (`apps/web/.impeccable/config.json`).

The other two files the hook writes must **not** travel, and neither had a repo-level ignore:

| File | What it is | Was protected by |
| --- | --- | --- |
| `.impeccable/config.local.json` | Per-developer install consent | `.git/info/exclude` — **machine-local**, so any other clone (including cloud agents) could commit its own copy |
| `.impeccable/hook.cache.json` | The hook's finding-dedup cache | Nothing |

Adds both to the root `.gitignore`, with a comment noting that `config.json` and `design.json` are deliberately committed.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
