### PR TITLE
fix(ui): stop share captures reusing the first image fetched

### DIFF
--- a/apps/web/src/components/share/SharePage/SharePage.test.tsx
+++ b/apps/web/src/components/share/SharePage/SharePage.test.tsx
@@ -71,14 +71,16 @@ describe("SharePage", () => {
     ).toBeInTheDocument();
   });
 
-  it("calls html-to-image toPng when Generate is clicked", async () => {
+  // Two calls: iOS Safari drops nested images on the first rasterization, so
+  // the capture is warmed up once and only the second result is kept.
+  it("calls html-to-image toPng twice when Generate is clicked", async () => {
     const { toPng } = await import("html-to-image");
     const user = userEvent.setup();
 
     render(<SharePage matches={MATCHES} players={PLAYERS} />);
     await user.click(screen.getByRole("button", { name: /genereer/i }));
 
-    expect(toPng).toHaveBeenCalledTimes(1);
+    expect(toPng).toHaveBeenCalledTimes(2);
   });
 
   it("calls toPng with exactly 1080x1920 dimensions and pixelRatio 1", async () => {
@@ -95,6 +97,22 @@ describe("SharePage", () => {
         height: CAPTURE_HEIGHT,
         pixelRatio: 1,
       }),
+    );
+  });
+
+  // Regression: without this, html-to-image keys its resource cache on the URL
+  // minus the query string, so every `/_next/image?url=…` shares one entry and
+  // later captures reuse the first image fetched (wrong player photo / crest).
+  it("captures with includeQueryParams so per-image cache keys stay distinct", async () => {
+    const { toPng } = await import("html-to-image");
+    const user = userEvent.setup();
+
+    render(<SharePage matches={MATCHES} players={PLAYERS} />);
+    await user.click(screen.getByRole("button", { name: /genereer/i }));
+
+    expect(toPng).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ includeQueryParams: true }),
     );
   });
 

--- a/apps/web/src/components/share/SharePage/SharePage.tsx
+++ b/apps/web/src/components/share/SharePage/SharePage.tsx
@@ -489,11 +489,21 @@ export function SharePage({ matches, players }: SharePageProps) {
     setExportError(null);
     clearPreview();
     try {
-      const dataUrl = await toPng(templateRef.current, {
+      const opts = {
         width: captureWidth,
         height: captureHeight,
         pixelRatio: 1,
-      });
+        // html-to-image's resource cache strips the query string from its key
+        // by default, so every `/_next/image?url=…` collapses onto ONE entry —
+        // the first image captured then gets reused for every later one (the
+        // previous scorer's portrait, an opponent crest blown up fullscreen).
+        includeQueryParams: true,
+      };
+      // ponytail: iOS Safari rasterizes the foreignObject before the nested
+      // data-URL images finish decoding, so the first capture drops them (the
+      // crest comes out white). Throw the warm-up away, keep the second.
+      await toPng(templateRef.current, opts);
+      const dataUrl = await toPng(templateRef.current, opts);
       const res = await fetch(dataUrl);
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Problem

Two bugs in the story generator's PNG capture. The live preview was always correct; only the rendered image was wrong, and both symptoms cleared on a page refresh.

1. **The card gets someone else's image.** Generate a goal for Lucas Goovaerts (has a photo), then a goal for Luca Minnen (no photo) without refreshing → Lucas' portrait is still rendered. The other way round — a scorer without a photo first, then Lucas — renders the opponent crest blown up fullscreen instead of Lucas' photo.
2. **The KCVV crest comes out white on the first render**, and only ours. Hitting Genereer a second time fixes it.

## Cause

**1.** `html-to-image` keys its module-level resource cache on the URL with the query string stripped, unless `includeQueryParams` is set:

```js
let key = url.replace(/\?.*/, '')   // html-to-image/lib/dataurl.js:85
if (includeQueryParams) key = url
```

Every remote image on a card goes through the same-origin Next optimizer as `/_next/image?url=…&w=…` (`toSameOriginImage`, `shared/theme.ts`), so player photos and opponent crests all collapsed onto a **single** cache key. The first image fetched in the page session was then handed to every `<img>` in every later capture — hence both directions of the mix-up. The cache lives at module scope, which is why refreshing clears it.

**2.** iOS Safari rasterizes the `foreignObject` before the nested data-URL images finish decoding, so the first capture drops them.

## Fix

`includeQueryParams: true` gives each image its own cache key, and the capture runs a discarded warm-up pass before the one it keeps — automating the "generate twice" workaround.

## Testing

- New regression test asserting `includeQueryParams: true` reaches `toPng`.
- Existing call-count test updated for the warm-up pass.
- 44 SharePage tests, `type-check` and `lint` pass.

Trade-off: capture now takes roughly twice as long. Worth it — the single-pass render was unusable on iOS without a manual retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
