### PR TITLE
fix(ui): forward the event location and stop calling midweek fixtures a weekend (#2392)

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -45,8 +45,8 @@ import type { Match } from "@/lib/effect/schemas";
 import {
   BannerSlot,
   FeaturedEventBand,
+  toFeaturedEventBandEvent,
   FeaturedUitgelichtRow,
-  type FeaturedEventBandEvent,
   type UitgelichtArticle,
   type ArticleType as UitgelichtArticleType,
   NewsGrid,
@@ -55,6 +55,7 @@ import {
   FirstTeamsBlock,
   deriveFirstTeamVM,
   firstTeamLabel,
+  firstTeamsHeading,
   selectSeniorTeams,
   ClubshopBanner,
   YouthBackdrop,
@@ -205,23 +206,6 @@ function toUitgelichtArticle(article: ArticleVM): UitgelichtArticle {
     date: article.publishedAt ? formatArticleDate(article.publishedAt) : "",
     articleType: toUitgelichtArticleType(article.articleType),
     badge: article.tags[0],
-  };
-}
-
-function toFeaturedEventBandEvent(
-  event: EventVM | null,
-): FeaturedEventBandEvent | null {
-  if (!event || !event.dateStart) return null;
-  const isExternalLink = event.href && event.href !== "#" && event.href !== "";
-  return {
-    title: event.title,
-    slug: event.slug,
-    dateStart: event.dateStart,
-    dateEnd: event.dateEnd ?? null,
-    coverImage: event.coverImageUrl
-      ? { url: event.coverImageUrl, alt: event.title }
-      : null,
-    externalLink: isExternalLink ? { url: event.href, label: null } : null,
   };
 }
 
@@ -390,28 +374,15 @@ export default async function HomePage() {
   // "Eerste ploegen" — A/B last result + next fixture, carrying the
   // result→next-fixture transition. Self-contained dark band (own StripedSeam
   // top/bottom + padding), so the SectionStack wrapper stays flush (#2211).
-  // HP-4: "Dit weekend." only when a fixture is actually within the coming
-  // week; otherwise a calmer label so pre-season (next match ~weeks out)
-  // doesn't read oddly.
-  const soonestFixtureMs = Math.min(
-    ...firstTeamVMs.map(
-      (t) => t.fixture?.date.getTime() ?? Number.POSITIVE_INFINITY,
-    ),
-  );
-  const firstTeamsHeading =
-    Number.isFinite(soonestFixtureMs) &&
-    soonestFixtureMs - now.getTime() <= 7 * 24 * 60 * 60 * 1000
-      ? "Dit weekend."
-      : "Volgende wedstrijd.";
+  // HP-4: `firstTeamsHeading` owns when the block may claim "Dit weekend."
+  const heading = firstTeamsHeading(firstTeamVMs, now);
   const firstTeamsSection: SectionConfig | null = firstTeamVMs.some(
     (t) => t.result || t.fixture,
   )
     ? {
         key: "first-teams",
         bg: "transparent",
-        content: (
-          <FirstTeamsBlock teams={firstTeamVMs} heading={firstTeamsHeading} />
-        ),
+        content: <FirstTeamsBlock teams={firstTeamVMs} heading={heading} />,
         paddingTop: "pt-0",
         paddingBottom: "pb-0",
       }

--- a/apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
+++ b/apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
@@ -35,9 +35,10 @@ export interface FeaturedEventBandEvent {
   dateEnd?: string | null;
   coverImage: FeaturedEventBandImage | null;
   externalLink?: FeaturedEventBandLink | null;
-  /** Falls back to "Kantine" per locked spec — schema field arrives in
-   *  the Phase 6 events redesign. */
-  location?: string | null;
+  /** Falls back to "Kantine" per locked spec when empty — most club events are
+   *  there. Required (though nullable) so a mapper cannot silently omit it and
+   *  let the default overwrite a real venue, which is how #2392 happened. */
+  location: string | null;
 }
 
 export interface FeaturedEventBandProps {

--- a/apps/web/src/components/home/FeaturedEventBand/index.ts
+++ b/apps/web/src/components/home/FeaturedEventBand/index.ts
@@ -1,4 +1,5 @@
 export { FeaturedEventBand } from "./FeaturedEventBand";
+export { toFeaturedEventBandEvent } from "./to-featured-event";
 export type {
   FeaturedEventBandProps,
   FeaturedEventBandEvent,

--- a/apps/web/src/components/home/FeaturedEventBand/to-featured-event.test.ts
+++ b/apps/web/src/components/home/FeaturedEventBand/to-featured-event.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import type { EventVM } from "@/lib/repositories/event.repository";
+import { toFeaturedEventBandEvent } from "./to-featured-event";
+
+/** Only the fields the mapper reads; the rest of the VM is structural. */
+function event(p: Partial<EventVM> = {}): EventVM {
+  return {
+    id: "event-1",
+    title: "Mosselfestijn",
+    slug: "mosselfestijn",
+    dateStart: "2026-09-12T18:00:00Z",
+    dateEnd: null,
+    eventType: null,
+    location: null,
+    coverImageUrl: "https://cdn.example/cover.jpg",
+    href: "#",
+    featuredOnHome: true,
+    ...p,
+  } as unknown as EventVM;
+}
+
+describe("toFeaturedEventBandEvent", () => {
+  // #2392: the CMS `location` reached the VM but never the band, so an editor's
+  // real venue was overwritten by the "Kantine" default on every event.
+  it("forwards the CMS location", () => {
+    const vm = toFeaturedEventBandEvent(
+      event({ location: "Sportpark Driesput, Elewijt" }),
+    );
+    expect(vm?.location).toBe("Sportpark Driesput, Elewijt");
+  });
+
+  it("returns null for no event or a missing start date", () => {
+    expect(toFeaturedEventBandEvent(null)).toBe(null);
+    expect(toFeaturedEventBandEvent(event({ dateStart: "" }))).toBe(null);
+  });
+
+  it("maps the cover image and drops it when the URL is absent", () => {
+    expect(toFeaturedEventBandEvent(event())?.coverImage).toEqual({
+      url: "https://cdn.example/cover.jpg",
+      alt: "Mosselfestijn",
+    });
+    expect(
+      toFeaturedEventBandEvent(event({ coverImageUrl: null }))?.coverImage,
+    ).toBe(null);
+  });
+
+  it("treats placeholder hrefs as no external link", () => {
+    expect(toFeaturedEventBandEvent(event({ href: "#" }))?.externalLink).toBe(
+      null,
+    );
+    expect(toFeaturedEventBandEvent(event({ href: "" }))?.externalLink).toBe(
+      null,
+    );
+    expect(
+      toFeaturedEventBandEvent(event({ href: "https://tickets.example" }))
+        ?.externalLink,
+    ).toEqual({ url: "https://tickets.example", label: null });
+  });
+});

--- a/apps/web/src/components/home/FeaturedEventBand/to-featured-event.ts
+++ b/apps/web/src/components/home/FeaturedEventBand/to-featured-event.ts
@@ -1,0 +1,27 @@
+/**
+ * `EventVM` → `<FeaturedEventBand>` props. Lives beside the band rather than in
+ * the landing page so it can be unit-tested without pulling the page graph in
+ * (see `first-teams.ts` for the same split on the match side).
+ */
+import type { EventVM } from "@/lib/repositories/event.repository";
+import type { FeaturedEventBandEvent } from "./FeaturedEventBand";
+
+export function toFeaturedEventBandEvent(
+  event: EventVM | null,
+): FeaturedEventBandEvent | null {
+  if (!event || !event.dateStart) return null;
+  const isExternalLink = event.href && event.href !== "#" && event.href !== "";
+  return {
+    title: event.title,
+    slug: event.slug,
+    dateStart: event.dateStart,
+    dateEnd: event.dateEnd ?? null,
+    // #2392: the CMS venue used to stop here, so the band's "Kantine" default
+    // overwrote every editor-set location instead of only filling the blanks.
+    location: event.location ?? null,
+    coverImage: event.coverImageUrl
+      ? { url: event.coverImageUrl, alt: event.title }
+      : null,
+    externalLink: isExternalLink ? { url: event.href, label: null } : null,
+  };
+}

--- a/apps/web/src/components/home/FirstTeamsBlock/FirstTeamsBlock.tsx
+++ b/apps/web/src/components/home/FirstTeamsBlock/FirstTeamsBlock.tsx
@@ -21,10 +21,10 @@ import type { FirstTeamVM } from "./first-teams";
 export interface FirstTeamsBlockProps {
   teams: FirstTeamVM[];
   /**
-   * Section heading. The homepage passes a fixture-aware label (HP-4) —
-   * "Dit weekend." only when a fixture is actually within the coming week,
-   * a calmer "Volgende wedstrijd." when the next match is weeks out
-   * (pre-season). Defaults to "Dit weekend." so stories/tests stay stable.
+   * Section heading. The homepage passes a fixture-aware label (HP-4) derived
+   * by `firstTeamsHeading`, which owns the rule — see its docblock in
+   * `first-teams.ts`. Defaults to "Dit weekend." so stories/tests stay stable;
+   * that default is an unconditional claim, so real callers must pass one.
    */
   heading?: string;
 }

--- a/apps/web/src/components/home/FirstTeamsBlock/first-teams.test.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/first-teams.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { Match } from "@/lib/effect/schemas";
+import type { ScheduleMatch } from "@/components/match/types";
+import type { FirstTeamVM } from "./first-teams";
 import {
   deriveFirstTeamVM,
   firstTeamLabel,
+  firstTeamsHeading,
   SETTLED_LOOKAHEAD_MS,
 } from "./first-teams";
 
@@ -488,5 +491,67 @@ describe("deriveFirstTeamVM", () => {
     );
     expect(noScore.result?.homeScore).toBeUndefined();
     expect(noScore.result?.awayScore).toBeUndefined();
+  });
+});
+
+describe("firstTeamsHeading", () => {
+  // Tuesday 2026-06-23 12:00 UTC — every case below is relative to this.
+  const TUESDAY = new Date("2026-06-23T12:00:00Z");
+
+  /** Only `fixture.date` is read, so the rest of the VM stays structural. */
+  function team(fixtureIso?: string): FirstTeamVM {
+    return {
+      label: "A-ploeg",
+      slug: "eerste-elftallen-a",
+      ...(fixtureIso
+        ? { fixture: { date: new Date(fixtureIso) } as ScheduleMatch }
+        : {}),
+    };
+  }
+
+  it("says 'Dit weekend.' for a Saturday fixture inside the window", () => {
+    expect(firstTeamsHeading([team("2026-06-27T19:00:00Z")], TUESDAY)).toBe(
+      "Dit weekend.",
+    );
+  });
+
+  it("says 'Dit weekend.' for a Sunday fixture inside the window", () => {
+    expect(firstTeamsHeading([team("2026-06-28T15:00:00Z")], TUESDAY)).toBe(
+      "Dit weekend.",
+    );
+  });
+
+  // The #2392 regression: a midweek cup tie is not "dit weekend".
+  it("says 'Volgende wedstrijd.' for a midweek fixture inside the window", () => {
+    expect(firstTeamsHeading([team("2026-06-24T19:30:00Z")], TUESDAY)).toBe(
+      "Volgende wedstrijd.",
+    );
+  });
+
+  it("says 'Volgende wedstrijd.' for a Saturday fixture beyond the window", () => {
+    expect(firstTeamsHeading([team("2026-07-04T19:00:00Z")], TUESDAY)).toBe(
+      "Volgende wedstrijd.",
+    );
+  });
+
+  it("picks the soonest fixture across teams", () => {
+    const teams = [team("2026-06-27T19:00:00Z"), team("2026-06-24T19:30:00Z")];
+    expect(firstTeamsHeading(teams, TUESDAY)).toBe("Volgende wedstrijd.");
+  });
+
+  it("says 'Volgende wedstrijd.' when no team has a fixture", () => {
+    expect(firstTeamsHeading([team(), team()], TUESDAY)).toBe(
+      "Volgende wedstrijd.",
+    );
+    expect(firstTeamsHeading([], TUESDAY)).toBe("Volgende wedstrijd.");
+  });
+
+  // The BFF packs the Belgian kickoff wall-clock into the Date's UTC fields, so
+  // a late Sunday kickoff must stay Sunday. Re-zoning to Europe/Brussels would
+  // add a phantom +2h and roll it into Monday.
+  it("keeps a late Sunday kickoff on the weekend", () => {
+    expect(firstTeamsHeading([team("2026-06-28T22:30:00Z")], TUESDAY)).toBe(
+      "Dit weekend.",
+    );
   });
 });

--- a/apps/web/src/components/home/FirstTeamsBlock/first-teams.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/first-teams.ts
@@ -211,3 +211,36 @@ export function deriveFirstTeamVM(
     ...(fixture ? { fixture: transformMatchToSchedule(fixture) } : {}),
   };
 }
+
+/** How far ahead a fixture may sit and still be called "this weekend". */
+const WEEKEND_LOOKAHEAD_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Heading above the "Eerste ploegen" block. "Dit weekend." is a claim about the
+ * *day*, so it needs both tests: the soonest fixture must fall inside the coming
+ * week (otherwise pre-season, with the next match weeks out, reads oddly) *and*
+ * land on a Saturday or Sunday. Gating on the window alone announced a Wednesday
+ * cup tie as a weekend fixture (#2392).
+ *
+ * The weekday is read off UTC, deliberately un-zoned. The BFF encodes the
+ * Belgian kickoff wall-clock straight into the Date's UTC fields
+ * (`parseDateString`, `apps/api/src/psd/transforms.ts`), so re-zoning to
+ * Europe/Brussels would add a phantom offset and roll a ≥22:00 Sunday kickoff
+ * into Monday. `/scheurkalender` reads the calendar day the same way.
+ */
+export function firstTeamsHeading(
+  teams: readonly FirstTeamVM[],
+  now: Date,
+): string {
+  const soonest = Math.min(
+    ...teams.map((t) => t.fixture?.date.getTime() ?? Number.POSITIVE_INFINITY),
+  );
+  // No fixture ⇒ Infinity ⇒ fails this test, so no separate empty guard.
+  if (soonest - now.getTime() > WEEKEND_LOOKAHEAD_MS)
+    return "Volgende wedstrijd.";
+
+  const weekday = new Date(soonest).getUTCDay(); // 0 = Sunday, 6 = Saturday
+  return weekday === 0 || weekday === 6
+    ? "Dit weekend."
+    : "Volgende wedstrijd.";
+}

--- a/apps/web/src/components/home/FirstTeamsBlock/index.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/index.ts
@@ -3,6 +3,7 @@ export type { FirstTeamsBlockProps } from "./FirstTeamsBlock";
 export {
   deriveFirstTeamVM,
   firstTeamLabel,
+  firstTeamsHeading,
   selectSeniorTeams,
 } from "./first-teams";
 export type {

--- a/apps/web/src/components/home/Homepage.stories.tsx
+++ b/apps/web/src/components/home/Homepage.stories.tsx
@@ -105,6 +105,7 @@ const mockFeaturedEvent: FeaturedEventBandEvent = {
   slug: "sponsoravond-2026",
   dateStart: "2099-06-15T19:00:00.000Z",
   dateEnd: null,
+  location: "Sportpark Driesput, Elewijt",
   coverImage: {
     url: fixtureImage("event-cover", 0),
     alt: "Sponsoravond cover",

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -18,7 +18,10 @@ export type {
   ArticleType,
 } from "./FeaturedUitgelichtRow";
 
-export { FeaturedEventBand } from "./FeaturedEventBand";
+export {
+  FeaturedEventBand,
+  toFeaturedEventBandEvent,
+} from "./FeaturedEventBand";
 export type {
   FeaturedEventBandProps,
   FeaturedEventBandEvent,
@@ -37,6 +40,7 @@ export {
   FirstTeamsBlock,
   deriveFirstTeamVM,
   firstTeamLabel,
+  firstTeamsHeading,
   selectSeniorTeams,
 } from "./FirstTeamsBlock";
 export type { FirstTeamsBlockProps, FirstTeamVM } from "./FirstTeamsBlock";

--- a/docs/pre-go-live-remarks.md
+++ b/docs/pre-go-live-remarks.md
@@ -36,7 +36,7 @@ Excluded: **HULP-2** (organigram — owner-handled).
 - ☐ **HP-1** `[layout]` MatchStrip — inner container isn't full viewport width on a 32" display; should span the full page width.
 - ☐ **HP-2** `[layout]` MatchStrip — right-align the "Competitie" part; left-align date/aftrap.
 - ☐ **HP-3** `[layout]` Featured hero — widen its container to match the "Uitgelicht" grid below it.
-- ☐ **HP-4** `[copy]` "Eerste ploegen" block — "Dit weekend." copy reads weird pre-season when the next match is ~4 weeks out. Needs conditional/smarter wording.
+- ☑ **HP-4** `[copy]` "Eerste ploegen" block — "Dit weekend." copy reads weird pre-season when the next match is ~4 weeks out. Needs conditional/smarter wording. _(#2392: `firstTeamsHeading` gates on a ≤7-day window **and** a Saturday/Sunday kickoff; anything else reads "Volgende wedstrijd.")_
 - ☐ **HP-5** `[design]` "Laatste nieuws" — add a highlight accent (à la EditorialHeading emphasis).
 - ☐ **HP-6** `[design]` "Met dank aan onze sponsors" — same: add a highlight accent.
 - ☐ **HP-7** `[layout]` "ALLE SPONSORS & SYMPATHISANTEN" link — right-align like all other "browse all" links.


### PR DESCRIPTION
Closes #2392

The issue reported three places inventing data. Verified each against production first — one was a false positive, one was a different (worse) bug than described, one held. Full evidence in [this comment](https://github.com/soniCaH/www.kcvvelewijt.be/issues/2392#issuecomment-5241744343).

## Changes

### The featured-event band printed "Kantine" for every event

`location` is not a future schema field — it ships, and it reaches the homepage. It just never made the last hop:

```text
packages/sanity-schemas/src/event.ts:85   defineField({ name: 'location' })   exists
event.repository.ts:22,30,35              GROQ selects `location`             fetched
event.repository.ts:139                   EventVM.location: string | null     on the VM
(landing)/page.tsx                        toFeaturedEventBandEvent()          DROPPED IT
FeaturedEventBand.tsx:98                  location?.trim() || "Kantine"       always "Kantine"
```

So an editor who set "Sportpark Driesput, Elewijt" still got "Kantine". The mapper now forwards it.

`FeaturedEventBandEvent.location` also went from `location?: string | null` to `location: string | null`. Optionality was the structural cause — omitting an optional prop is never a type error, which is why this compiled for the whole life of the bug. Making it required-but-nullable turned the omission into a compile error that pointed straight at the one remaining unset call site.

**"Kantine" stays the default** for events with no location (owner decision, 2026-08-10) — it just no longer overrides a real value.

### "Dit weekend." for a Wednesday cup tie

The heading tested only the ≤7-day window, never the weekday. `firstTeamsHeading` now requires both.

The weekday is read off **UTC, deliberately un-zoned**. The BFF packs the Belgian kickoff wall-clock straight into the Date's UTC fields (`parseDateString`, `apps/api/src/psd/transforms.ts:323`), so converting to `Europe/Brussels` would add a phantom offset and roll a ≥22:00 Sunday kickoff into Monday — the trap `/scheurkalender` already documents. A first pass at this PR got that backwards; the review gate caught it.

### Not changed — the "KCVV as its own opponent" report

Dropped as a false positive. The club books placeholder fixtures against itself to reserve a pitch, and one is live in production:

```text
id 3421 · 2026-08-22 19:00 · "Vriendschappelijk"
homeTeam { id: 1235, KCVV Elewijt }  awayTeam { id: 1235, KCVV Elewijt }  isHome: true
```

`isHome` is `true`, so `opponent = awayTeam` = KCVV. It renders KCVV as its own opponent because the opponent *is* KCVV. The issue's premise — "PSD does not reliably send `is_home`" — is also false in production: 117 matches across `/`, `/kalender` and `/ploegen/eerste-elftallen-a/wedstrijden`, zero undefined. The branch the issue wanted patched never fires.

## Testing

- `pnpm --filter @kcvv/web check-all` — exit 0 (lint, type-check, 3467 tests, build)
- New: `to-featured-event.test.ts` (5 cases), `firstTeamsHeading` (7 cases incl. the midweek regression and the late-Sunday timezone case)
- **No VR baselines needed.** `Pages/Home` carries only `autodocs` (never VR-tested); the two VR-tagged stories, `Features/Home/FeaturedEventBand` and `Features/Home/FirstTeamsBlock`, render identically — neither passes the changed props.

## Review gate

`/simplify` ran 4 agents. Applied: the un-zoned weekday correction above (a real defect in the first pass), a dead `Number.isFinite` guard, an unexported constant, a duplicated rule comment, a stale `heading` prop JSDoc, one tautological test, and the `docs/pre-go-live-remarks.md` HP-4 checkbox.

Skipped as out of scope, worth follow-ups:

- `toUitgelichtArticle` drops `ArticleVM.lead` → `UitgelichtArticle.dek` in exactly the same way this PR just fixed for `location`. `FeaturedUitgelichtRow.tsx:14-16` says the field was left unmapped until `ARTICLES_QUERY` surfaced `lead`; it has since. Adjacent to #2393's `lead` AC — whether the 3-up card should carry a dek is a design call, not a bug fix.
- `FirstTeamsBlock`'s `heading` still defaults to `"Dit weekend."` — the exact unconditional claim this PR exists to prevent. Harmless today (the only production caller passes the computed value), but a second consumer would re-ship it. Making it required touches three story/test files.
- `page.tsx` now has an unexplained mapper split: one moved out, four stayed inline. Worth one convention line in `apps/web/CLAUDE.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homepage team sections now show context-aware headings based on upcoming fixture timing.
  * Featured events now consistently display location details and valid external links.
* **Bug Fixes**
  * Improved handling of missing event data, start dates, images, and placeholder links.
* **Documentation**
  * Updated pre-launch documentation to reflect the new homepage wording behavior.
* **Tests**
  * Added coverage for weekend detection, fixture selection, event mapping, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->