### PR TITLE
fix(ui): keep read-more CTAs visible on touch and give the hero its dek (#2393)

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -63,7 +63,7 @@ import {
 } from "@/components/home";
 import {
   EditorialHero,
-  type EditorialHeroProps,
+  toEditorialHeroProps,
 } from "@/components/article/EditorialHero";
 import { PageContainer, SectionStack } from "@/components/design-system";
 import type { SectionConfig } from "@/components/design-system";
@@ -90,81 +90,6 @@ export async function generateMetadata(): Promise<Metadata> {
       images: [DEFAULT_OG_IMAGE],
     },
   };
-}
-
-/**
- * Drop GROQ-nullable fields (`field: string | null`) so the resulting
- * shape matches the non-null `field?: string` API the EditorialHero
- * variant types expect. Generic enough to work for both transfer and
- * event projections.
- */
-function nullsToUndefined<T extends object>(
-  src: T | null | undefined,
-): { [K in keyof T]?: NonNullable<T[K]> } | undefined {
-  if (src == null) return undefined;
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(src)) {
-    if (value !== null) out[key] = value;
-  }
-  return out as { [K in keyof T]?: NonNullable<T[K]> };
-}
-
-/**
- * Map an `ArticleVM` onto `<EditorialHero placement="homepage">` props.
- * Mirrors the per-variant tail the retired `toHeroCarouselArticle`
- * built for `<HomepageHeroCarousel>`: each `articleType` contributes
- * the structured data the variant renderers need (subjects, transfer
- * fact, event fact, category). The discriminated union narrowing
- * surfaces a missing branch at compile time when a new `articleType`
- * lands (e.g. matchPreview / matchRecap from #1470).
- */
-function toEditorialHeroProps(article: ArticleVM): EditorialHeroProps {
-  const shared = {
-    placement: "homepage" as const,
-    slug: article.slug,
-    title: article.title,
-    coverImage: article.coverImageUrl
-      ? { url: article.coverImageUrl, alt: article.title }
-      : undefined,
-    date: article.publishedAt
-      ? formatArticleDate(article.publishedAt)
-      : undefined,
-    // PERF-1 (#2235): the homepage hero cover is the LCP element — eager-load
-    // it. Only this call site sets `priority`; below-fold rows stay lazy.
-    priority: true,
-  };
-
-  const variant = article.articleType ?? "announcement";
-  switch (variant) {
-    case "interview":
-      return { ...shared, variant, subjects: article.subjects };
-    case "event":
-      return {
-        ...shared,
-        variant,
-        feature: nullsToUndefined(article.firstEventFact),
-      };
-    case "transfer":
-      return {
-        ...shared,
-        variant,
-        feature: nullsToUndefined(article.firstTransferFact),
-      };
-    case "announcement":
-      return { ...shared, variant, category: article.tags[0] };
-    case "matchPreview":
-    case "matchRecap":
-      // Homepage hero stays kicker-only (VOORBESCHOUWING / MATCHVERSLAG) — no
-      // `match` data, so no score bar. The score-forward bar only renders on
-      // the detail page, which server-fetches the linked match (5.d-mat).
-      return { ...shared, variant };
-    default: {
-      const _exhaustive: never = variant;
-      throw new Error(
-        `Unhandled articleType in toEditorialHeroProps: ${String(_exhaustive)}`,
-      );
-    }
-  }
 }
 
 /**

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -929,6 +929,26 @@
   padding-right: env(safe-area-inset-right, 0);
 }
 
+/* Read-more affordances ("Lees verder →") sit hidden at rest and are revealed
+   by the card's `group-hover:opacity-100` / `group-focus-*:opacity-100`. That
+   reveal is an *enhancement*, not a gate: where there is no hover there is
+   nothing to reveal, so on a touch device the cue simply stays on and the card
+   advertises that it is tappable (#2393; DESIGN.md — "nothing important hides
+   behind hover").
+
+   Owning the resting state here rather than as a bare `opacity-0` is what
+   keeps this `!important`-free: Tailwind compiles `group-hover:opacity-100` to
+   `.group-hover\:opacity-100:is(…)` at specificity (0,2,0), which outranks this
+   (0,1,0) rule on its own merits — so the reveal wins no matter which order
+   Tailwind happens to emit the two in. */
+@utility reveal-on-hover {
+  opacity: 0;
+  transition: opacity 300ms;
+  @media (hover: none) {
+    opacity: 1;
+  }
+}
+
 /* Hide native scrollbar — cross-browser utility for horizontal scroll containers */
 @utility scrollbar-hide {
   scrollbar-width: none; /* Firefox */

--- a/apps/web/src/components/article/EditorialHero/EditorialHero.test.tsx
+++ b/apps/web/src/components/article/EditorialHero/EditorialHero.test.tsx
@@ -136,6 +136,9 @@ describe("EditorialHero — shell + placement", () => {
     expect(cta).toHaveClass("reveal-on-hover");
     expect(cta).not.toHaveClass("opacity-0");
     expect(cta).toHaveClass("group-hover:opacity-100");
+    // Keyboard reveal rides on the link itself (`group` sits on the <Link>),
+    // so this is `-focus-visible` where NewsCard needs `-focus-within`.
+    expect(cta).toHaveClass("group-focus-visible:opacity-100");
   });
 
   it("collapses the cover figure's offset shadow on group-hover so it presses with the link", () => {

--- a/apps/web/src/components/article/EditorialHero/EditorialHero.test.tsx
+++ b/apps/web/src/components/article/EditorialHero/EditorialHero.test.tsx
@@ -121,6 +121,23 @@ describe("EditorialHero — shell + placement", () => {
     expect(link?.className).not.toContain("hover:-translate-x-[2px]");
   });
 
+  it("reveals '★ Lees verder →' on hover without hiding it from touch readers (#2393)", () => {
+    render(
+      <EditorialHero
+        variant="announcement"
+        {...SHARED}
+        placement="homepage"
+        slug="zomer-2026"
+      />,
+    );
+    const cta = screen.getByText("★ Lees verder →");
+    // `reveal-on-hover` carries the resting `opacity: 0` behind
+    // `(hover: none)`, so the hero's only affordance survives on a phone.
+    expect(cta).toHaveClass("reveal-on-hover");
+    expect(cta).not.toHaveClass("opacity-0");
+    expect(cta).toHaveClass("group-hover:opacity-100");
+  });
+
   it("collapses the cover figure's offset shadow on group-hover so it presses with the link", () => {
     const { container } = render(
       <EditorialHero

--- a/apps/web/src/components/article/EditorialHero/EditorialHero.tsx
+++ b/apps/web/src/components/article/EditorialHero/EditorialHero.tsx
@@ -582,9 +582,12 @@ export function EditorialHero(props: EditorialHeroProps) {
             container so it aligns flush with the divider's right edge
             rather than the outer link's wrapper-padded edge. */}
         <PageContainer width="index" className="mt-2 flex justify-end">
+          {/* `reveal-on-hover` (globals.css) hides the cue at rest only where
+              hovering exists — on touch it stays on, so the hero's one
+              affordance is never invisible (#2393). */}
           <span
             aria-hidden="true"
-            className="text-jersey-deep pointer-events-none font-mono text-xs leading-none font-bold uppercase opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100"
+            className="text-jersey-deep reveal-on-hover pointer-events-none font-mono text-xs leading-none font-bold uppercase group-hover:opacity-100 group-focus-visible:opacity-100"
           >
             ★ Lees verder →
           </span>

--- a/apps/web/src/components/article/EditorialHero/index.ts
+++ b/apps/web/src/components/article/EditorialHero/index.ts
@@ -1,3 +1,4 @@
+export { toEditorialHeroProps } from "./to-editorial-hero-props";
 export {
   EditorialHero,
   type EditorialHeroProps,

--- a/apps/web/src/components/article/EditorialHero/to-editorial-hero-props.test.ts
+++ b/apps/web/src/components/article/EditorialHero/to-editorial-hero-props.test.ts
@@ -103,6 +103,17 @@ describe("toEditorialHeroProps", () => {
     expect(props).toHaveProperty("feature", { playerName: "Jens Peeters" });
   });
 
+  // An article typed `event`/`transfer` whose body carries no matching fact
+  // block projects the whole fact as null, not as an object of nulls — the
+  // variant renderers must get `undefined` so they skip the feature slot.
+  it.each([
+    ["event", { firstEventFact: null }],
+    ["transfer", { firstTransferFact: null }],
+  ] as const)("drops a missing %s fact entirely", (articleType, fact) => {
+    const props = toEditorialHeroProps(article({ articleType, ...fact }));
+    expect(props).toHaveProperty("feature", undefined);
+  });
+
   // Match articles stay kicker-only on the homepage — no `match` payload, so
   // the score-forward bar is detail-page-only.
   it.each(["matchPreview", "matchRecap"] as const)(

--- a/apps/web/src/components/article/EditorialHero/to-editorial-hero-props.test.ts
+++ b/apps/web/src/components/article/EditorialHero/to-editorial-hero-props.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import type { ArticleVM } from "@/lib/repositories/article.repository";
+import { toEditorialHeroProps } from "./to-editorial-hero-props";
+
+/** Only the fields the mapper reads; the rest of the VM is structural. */
+function article(p: Partial<ArticleVM> = {}): ArticleVM {
+  return {
+    id: "article-1",
+    title: "Kampioen! 58 punten en titel in eerste provinciale.",
+    lead: "Met een laatste-speeldagzege wordt de A-ploeg kampioen van de reeks.",
+    slug: "kampioen-58-punten",
+    publishedAt: "2026-05-03T10:00:00Z",
+    featured: true,
+    tags: ["Clubnieuws"],
+    coverImageUrl: "https://cdn.example/cover.jpg",
+    articleType: "announcement",
+    subjects: [],
+    firstTransferFact: null,
+    firstEventFact: null,
+    ...p,
+  } as unknown as ArticleVM;
+}
+
+describe("toEditorialHeroProps", () => {
+  // #2393: the lead reached the VM but never the hero, so the largest element
+  // on the homepage rendered as a headline plus a photograph and no dek.
+  it("forwards the article lead as the hero dek", () => {
+    expect(toEditorialHeroProps(article()).lead).toBe(
+      "Met een laatste-speeldagzege wordt de A-ploeg kampioen van de reeks.",
+    );
+  });
+
+  // ARTICLES_QUERY coalesces a missing lead to "" — that sentinel must not
+  // reach the hero, or it renders an empty dek slot instead of omitting one.
+  it.each([
+    ["the GROQ empty-string sentinel", ""],
+    ["a whitespace-only lead", "   "],
+    ["an absent lead", undefined],
+  ])("drops %s", (_label, lead) => {
+    expect(toEditorialHeroProps(article({ lead })).lead).toBeUndefined();
+  });
+
+  it("keeps the hero pinned to the homepage placement and eager-loads the LCP cover", () => {
+    const props = toEditorialHeroProps(article());
+    expect(props.placement).toBe("homepage");
+    expect(props.priority).toBe(true);
+    expect(props.coverImage).toEqual({
+      url: "https://cdn.example/cover.jpg",
+      alt: "Kampioen! 58 punten en titel in eerste provinciale.",
+    });
+  });
+
+  it("omits the cover when the article has no image", () => {
+    expect(
+      toEditorialHeroProps(article({ coverImageUrl: null })).coverImage,
+    ).toBeUndefined();
+  });
+
+  it("defaults an untyped legacy article to the announcement variant", () => {
+    const props = toEditorialHeroProps(article({ articleType: null }));
+    expect(props.variant).toBe("announcement");
+  });
+
+  it("carries the first tag through as the announcement category", () => {
+    const props = toEditorialHeroProps(article({ tags: ["Jeugd", "A-ploeg"] }));
+    expect(props).toMatchObject({ variant: "announcement", category: "Jeugd" });
+  });
+
+  it("passes interview subjects through untouched", () => {
+    const subjects = [{ _key: "s1", kind: "player" }] as ArticleVM["subjects"];
+    const props = toEditorialHeroProps(
+      article({ articleType: "interview", subjects }),
+    );
+    expect(props).toMatchObject({ variant: "interview", subjects });
+  });
+
+  // The variant renderers take `field?: string`, so GROQ's explicit nulls have
+  // to be stripped rather than forwarded.
+  it("strips GROQ nulls out of the event fact", () => {
+    const props = toEditorialHeroProps(
+      article({
+        articleType: "event",
+        firstEventFact: {
+          title: "Mosselfestijn",
+          location: null,
+        } as ArticleVM["firstEventFact"],
+      }),
+    );
+    expect(props).toMatchObject({ variant: "event" });
+    expect(props).toHaveProperty("feature", { title: "Mosselfestijn" });
+  });
+
+  it("strips GROQ nulls out of the transfer fact", () => {
+    const props = toEditorialHeroProps(
+      article({
+        articleType: "transfer",
+        firstTransferFact: {
+          playerName: "Jens Peeters",
+          note: null,
+        } as ArticleVM["firstTransferFact"],
+      }),
+    );
+    expect(props).toHaveProperty("feature", { playerName: "Jens Peeters" });
+  });
+
+  // Match articles stay kicker-only on the homepage — no `match` payload, so
+  // the score-forward bar is detail-page-only.
+  it.each(["matchPreview", "matchRecap"] as const)(
+    "renders %s as a kicker-only hero with no match data",
+    (articleType) => {
+      const props = toEditorialHeroProps(article({ articleType }));
+      expect(props.variant).toBe(articleType);
+      expect(props).not.toHaveProperty("match");
+    },
+  );
+
+  it("throws when Sanity widens articleType without a matching branch", () => {
+    expect(() =>
+      toEditorialHeroProps(
+        article({ articleType: "podcast" as ArticleVM["articleType"] }),
+      ),
+    ).toThrow(/Unhandled articleType/);
+  });
+});

--- a/apps/web/src/components/article/EditorialHero/to-editorial-hero-props.ts
+++ b/apps/web/src/components/article/EditorialHero/to-editorial-hero-props.ts
@@ -1,0 +1,86 @@
+/**
+ * `ArticleVM` → `<EditorialHero placement="homepage">` props. Lives beside the
+ * hero rather than in the landing page so it can be unit-tested without
+ * pulling the page graph in (see `to-featured-event.ts` for the same split on
+ * the event side).
+ *
+ * Mirrors the per-variant tail the retired `toHeroCarouselArticle` built for
+ * `<HomepageHeroCarousel>`: each `articleType` contributes the structured data
+ * the variant renderers need (subjects, transfer fact, event fact, category).
+ * The discriminated union narrowing surfaces a missing branch at compile time
+ * when a new `articleType` lands (e.g. matchPreview / matchRecap from #1470).
+ */
+import { formatArticleDate } from "@/lib/utils/dates";
+import type { ArticleVM } from "@/lib/repositories/article.repository";
+import type { EditorialHeroProps } from "./EditorialHero";
+
+/**
+ * Drop GROQ-nullable fields (`field: string | null`) so the resulting
+ * shape matches the non-null `field?: string` API the EditorialHero
+ * variant types expect. Generic enough to work for both transfer and
+ * event projections.
+ */
+function nullsToUndefined<T extends object>(
+  src: T | null | undefined,
+): { [K in keyof T]?: NonNullable<T[K]> } | undefined {
+  if (src == null) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(src)) {
+    if (value !== null) out[key] = value;
+  }
+  return out as { [K in keyof T]?: NonNullable<T[K]> };
+}
+
+export function toEditorialHeroProps(article: ArticleVM): EditorialHeroProps {
+  const shared = {
+    placement: "homepage" as const,
+    slug: article.slug,
+    title: article.title,
+    // #2393: the dek used to stop here, so the largest element on the homepage
+    // was a headline plus a photograph and nothing else. `ARTICLES_QUERY`
+    // coalesces `lead` to "", so normalise the sentinel back to undefined the
+    // way the detail page does rather than render an empty dek slot.
+    lead: article.lead?.trim() || undefined,
+    coverImage: article.coverImageUrl
+      ? { url: article.coverImageUrl, alt: article.title }
+      : undefined,
+    date: article.publishedAt
+      ? formatArticleDate(article.publishedAt)
+      : undefined,
+    // PERF-1 (#2235): the homepage hero cover is the LCP element — eager-load
+    // it. Only this call site sets `priority`; below-fold rows stay lazy.
+    priority: true,
+  };
+
+  const variant = article.articleType ?? "announcement";
+  switch (variant) {
+    case "interview":
+      return { ...shared, variant, subjects: article.subjects };
+    case "event":
+      return {
+        ...shared,
+        variant,
+        feature: nullsToUndefined(article.firstEventFact),
+      };
+    case "transfer":
+      return {
+        ...shared,
+        variant,
+        feature: nullsToUndefined(article.firstTransferFact),
+      };
+    case "announcement":
+      return { ...shared, variant, category: article.tags[0] };
+    case "matchPreview":
+    case "matchRecap":
+      // Homepage hero stays kicker-only (VOORBESCHOUWING / MATCHVERSLAG) — no
+      // `match` data, so no score bar. The score-forward bar only renders on
+      // the detail page, which server-fetches the linked match (5.d-mat).
+      return { ...shared, variant };
+    default: {
+      const _exhaustive: never = variant;
+      throw new Error(
+        `Unhandled articleType in toEditorialHeroProps: ${String(_exhaustive)}`,
+      );
+    }
+  }
+}

--- a/apps/web/src/components/article/NewsCard/NewsCard.test.tsx
+++ b/apps/web/src/components/article/NewsCard/NewsCard.test.tsx
@@ -196,12 +196,16 @@ describe("NewsCard", () => {
       expect(article?.className).not.toMatch(/--card-press-x/);
     });
 
-    it("hides the 'Lees verder' affordance at rest, reveals it on hover/focus (#2027)", () => {
+    it("hides the 'Lees verder' affordance at rest, reveals it on hover/focus (#2027, #2393)", () => {
       const { getByTestId } = render(<NewsCard {...defaultProps} />);
       const readMore = getByTestId("newscard-readmore");
-      expect(readMore.className).toMatch(/\bopacity-0\b/);
-      expect(readMore.className).toMatch(/group-hover:opacity-100/);
-      expect(readMore.className).toMatch(/group-focus-within:opacity-100/);
+      // `reveal-on-hover` carries the resting `opacity: 0` *and* the
+      // `(hover: none)` escape hatch that keeps the cue on screen for touch
+      // readers — a bare `opacity-0` here would hide it on phones (#2393).
+      expect(readMore).toHaveClass("reveal-on-hover");
+      expect(readMore).not.toHaveClass("opacity-0");
+      expect(readMore).toHaveClass("group-hover:opacity-100");
+      expect(readMore).toHaveClass("group-focus-within:opacity-100");
     });
   });
 

--- a/apps/web/src/components/article/NewsCard/NewsCard.tsx
+++ b/apps/web/src/components/article/NewsCard/NewsCard.tsx
@@ -364,15 +364,18 @@ export const NewsCard = ({
                   "inline-flex items-center gap-1 font-mono text-[length:var(--text-label)] font-medium tracking-[var(--text-label--tracking)] uppercase",
                   // Hidden at rest, revealed on hover / keyboard focus —
                   // mirrors the homepage hero's "Lees verder" reveal idiom
-                  // (#2027). Opacity-only so the footer row reserves its
-                  // height and nothing reflows. The canonical press-down
-                  // hover stays intact via TapedCard's `interactive="press"`.
+                  // (#2027). `reveal-on-hover` (globals.css) owns the resting
+                  // state and keeps the cue visible where there is no hover to
+                  // reveal it with (#2393). Opacity-only so the footer row
+                  // reserves its height and nothing reflows. The canonical
+                  // press-down hover stays intact via TapedCard's
+                  // `interactive="press"`.
                   // `group-focus-within` (not `-focus-visible`): the `group`
                   // is the non-focusable <article> wrapper and the focusable
                   // <Link> is a descendant, so we react to focus *within* the
                   // card. (EditorialHero can use `-focus-visible` because there
                   // the `group` sits on the <Link> itself.)
-                  "opacity-0 transition-opacity duration-300 group-focus-within:opacity-100 group-hover:opacity-100",
+                  "reveal-on-hover group-focus-within:opacity-100 group-hover:opacity-100",
                   isDark ? "text-cream" : "text-jersey-deep",
                 )}
               >

--- a/apps/web/src/stories/foundation/CardInteractions.mdx
+++ b/apps/web/src/stories/foundation/CardInteractions.mdx
@@ -11,7 +11,7 @@ export const CardDemo = ({ label, reveal, bg = "cream", soft = false, children }
       <div style={{ fontSize: '11px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.14em', color: bg === 'cream' ? 'var(--color-ink-muted)' : 'rgba(245,241,230,0.7)', marginBottom: '8px' }}>{label}</div>
       <div style={{ fontSize: '13px', color: bg === 'cream' ? 'var(--color-ink)' : 'var(--color-cream)', flex: 1 }}>{children}</div>
       {reveal && (
-        <div className="opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-300" style={{ fontFamily: 'var(--font-family-mono)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--color-jersey-deep)' }}>Lees verder →</div>
+        <div className="reveal-on-hover group-hover:opacity-100 group-focus-visible:opacity-100" style={{ fontFamily: 'var(--font-family-mono)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--color-jersey-deep)' }}>Lees verder →</div>
       )}
     </div>
   </div>
@@ -89,6 +89,8 @@ At rest a card casts a hard, un-blurred offset shadow (`shadow-paper-sm` = `4px 
 ## Navigation affordance — the "Lees verder →" reveal
 
 There is **no green accent bar** (the old `clip-path` bar was removed). Navigation cards instead reveal a mono "Lees verder →" cue on hover/focus while the whole card presses down. Hover the card below:
+
+Use the **`reveal-on-hover`** utility for the resting state rather than a bare `opacity-0` — the reveal is an enhancement, not a gate. On a touch device there is no hover to reveal the cue with, so `reveal-on-hover` leaves it on screen instead of hiding the card's only affordance (#2393; DESIGN.md — "nothing important hides behind hover").
 
 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px', marginTop: '16px', marginBottom: '32px' }}>
   <CardDemo label="NewsCard" reveal>


### PR DESCRIPTION
Closes #2393

Every `Lees verder` affordance sat at `opacity-0` until hover, so on the primary device — a phone — it never appeared. Per the #2424 walk, nothing was unreachable (both components wrap the whole composition in a link); ten cues were simply invisible.

## Changes

**The reveal becomes a hover enhancement, not a gate.** A new `reveal-on-hover` utility in `globals.css` owns the resting state and lifts it under `@media (hover: none)`, so on touch the cue stays on. Applied to `NewsCard` and `EditorialHero`; both keep their existing `group-hover:` / `group-focus-*:` reveals unchanged, so behaviour on hover-capable devices is byte-identical.

**Why a utility and not `[@media(hover:none)]:opacity-100` at the call sites.** That was the first implementation and it is subtly broken: Tailwind emits arbitrary-media variants *after* `group-hover:opacity-100`, and at equal specificity the later rule wins — the cue would be re-hidden on desktop. It only worked with an `!important`. Owning the resting state inside the utility inverts that: the reveal outranks it on **specificity** instead (`.group-hover\:opacity-100:is(…)` is (0,2,0) vs the utility's (0,1,0)), so emission order stops mattering and the `!important` disappears. Verified by inspecting the compiled CSS in the real `next build` bundle, not just the class strings.

**`toEditorialHeroProps` now forwards `lead`.** It silently dropped it, so the largest element on the homepage rendered as a headline plus a photograph with neither a dek nor a reveal — the more valuable half of this issue. The mapper moves out of `page.tsx` into a tested sibling module, mirroring `to-featured-event.ts`: the same split #2392 made one commit earlier for the identical "mapper drops an optional field" bug class. It arrives with 14 tests, including the `""`-sentinel normalisation that `ARTICLES_QUERY`'s `coalesce(lead, "")` makes necessary.

**`Foundation/Card Interactions`** is the canonical doc for this idiom and its live demo still shipped the un-fixed class string, so it moves to the utility too rather than teaching the bug back to the next person who copies it.

## Testing

- `pnpm --filter @kcvv/web check-all` — clean (lint, tsgo, **3482 tests**, `next build`).
- **VR: scoped runs for both components, zero drift** — `features-articles-newscard` (13 tests / 39 snapshots) and `features-articles-editorialhero` (19 tests / 57 snapshots), all 96 matched existing baselines, so there are no new baselines to commit. Expected: `test-runner.ts` sets viewports with a plain `page.setViewportSize` and no touch emulation, so `(hover: none)` never matches under VR and the desktop rendering is unchanged by construction. The run confirms that rather than assuming it.
- Cascade verified against the shipped bundle: `.reveal-on-hover{opacity:0;transition:opacity .3s}` followed by `@media (hover:none){.reveal-on-hover{opacity:1}}`, with no `!important` on the path.

## Out of scope (unchanged)

- **`SponsorTile` greyscale** — owner decided 2026-08-06 that greyscale stays on mobile.
- **`TicketStub`'s "Meer details →"** — same idiom on `/kalender` and `/evenementen`, deferred to #2425. It is now a one-token change; see the note added there about `sm:pr-28`.

## Review notes

`/simplify` ran and drove the two structural changes above (the utility and the mapper extraction) plus switching the class assertions to `toHaveClass`, the repo's dominant idiom. **`/code-review` could not be run** — it is gated to explicit user invocation and cannot be triggered by the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent hover and focus reveals for read-more cues on editorial heroes and news cards.
  * Read-more cues remain visible on touch devices and accessible via keyboard focus.
  * Improved homepage article presentation across supported article types, including dates, images, categories, interviews, events, transfers, and matches.

* **Documentation**
  * Updated card interaction guidance to explain touch-device visibility and accessibility behavior.

* **Tests**
  * Expanded coverage for article presentation, article variants, and reveal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->