### PR TITLE
fix(ui): lift the sub-24px tap targets on the homepage and chrome (#2394)

### DIFF
--- a/apps/web/src/components/design-system/EditorialLink/EditorialLink.test.tsx
+++ b/apps/web/src/components/design-system/EditorialLink/EditorialLink.test.tsx
@@ -67,4 +67,17 @@ describe("EditorialLink", () => {
     );
     expect(container.firstChild).toHaveClass("custom-class");
   });
+
+  // #2394 — a tripwire for deleting the hit area, not a proof it works: jsdom
+  // computes no layout, so only the real coarse-pointer measurement at 390px
+  // can show the target is big enough. Both halves are asserted because the
+  // padding without the margin would reflow every section header.
+  it("cta variant carries the hit area and its layout-neutralising margin", () => {
+    const { container } = render(
+      <EditorialLink href="/x" variant="cta">
+        X
+      </EditorialLink>,
+    );
+    expect(container.firstChild).toHaveClass("py-2", "-my-2");
+  });
 });

--- a/apps/web/src/components/design-system/EditorialLink/EditorialLink.tsx
+++ b/apps/web/src/components/design-system/EditorialLink/EditorialLink.tsx
@@ -37,6 +37,13 @@ const VARIANT_TYPE: Record<EditorialLinkVariant, string> = {
   inline: "font-medium",
 };
 
+// Hit area, not spacing (#2394). The cta variant is the label step at
+// `leading-none` — correct as type, 11px tall as a thumb target. The padding
+// grows it to ~27px and the equal negative margin pulls the box back, so the
+// consumer does not shift by a pixel. The two halves only work as a pair:
+// `py-2` alone would push `<SectionHeader>`'s heading row out of alignment.
+const CTA_HIT_AREA = "py-2 -my-2";
+
 export const EditorialLink = ({
   href,
   children,
@@ -55,6 +62,7 @@ export const EditorialLink = ({
       className={cn(
         "group inline-flex items-center gap-2",
         VARIANT_TYPE[variant],
+        variant === "cta" && CTA_HIT_AREA,
         TEXT_TONE[tone],
         className,
       )}

--- a/apps/web/src/components/home/FirstTeamsBlock/FirstTeamsBlock.tsx
+++ b/apps/web/src/components/home/FirstTeamsBlock/FirstTeamsBlock.tsx
@@ -140,7 +140,8 @@ export function FirstTeamsBlock({
           </div>
           <Link
             href="/kalender"
-            className="text-warm hover:text-cream shrink-0 font-mono text-xs font-semibold tracking-wide uppercase transition-colors"
+            // `py-2 -my-2` — hit area only, no layout shift (#2394).
+            className="text-warm hover:text-cream -my-2 shrink-0 py-2 font-mono text-xs font-semibold tracking-wide uppercase transition-colors"
           >
             Volledige kalender <span aria-hidden="true">→</span>
           </Link>

--- a/apps/web/src/components/home/UpcomingMatches/UpcomingMatchesClient.tsx
+++ b/apps/web/src/components/home/UpcomingMatches/UpcomingMatchesClient.tsx
@@ -63,7 +63,8 @@ export const UpcomingMatchesClient = ({
         <div className="mt-6">
           <Link
             href="/kalender"
-            className="text-ink hover:text-jersey-deep inline-flex items-center gap-1 font-mono text-sm font-bold tracking-wide uppercase underline-offset-4 hover:underline"
+            // `py-2 -my-2` — hit area only, no layout shift (#2394).
+            className="text-ink hover:text-jersey-deep -my-2 inline-flex items-center gap-1 py-2 font-mono text-sm font-bold tracking-wide uppercase underline-offset-4 hover:underline"
           >
             Volledige kalender ↗
           </Link>

--- a/apps/web/src/components/layout/SiteFooter/SiteFooter.tsx
+++ b/apps/web/src/components/layout/SiteFooter/SiteFooter.tsx
@@ -62,9 +62,16 @@ export const SiteFooter = ({ className }: SiteFooterProps) => {
               <ul className="flex flex-col gap-2.5">
                 {column.links.map((link) => (
                   <li key={link.href + link.label}>
+                    {/* `py-1 -my-1` lifts the 20px target to 28px without
+                        moving the row (#2394). `gap-2.5` (10px) stays wider
+                        than the 8px the two neighbouring hit areas borrow from
+                        it, so no two links ever overlap. The hover rule is a
+                        text-decoration rather than the old `border-b`, because
+                        a border sits at the bottom of the padded box (8px
+                        adrift) while a decoration stays on the baseline. */}
                     <Link
                       href={link.href}
-                      className="text-ink-soft hover:text-jersey-deep hover:border-jersey-deep inline-block border-b border-transparent text-[14px] leading-snug font-medium transition-colors duration-150"
+                      className="text-ink-soft hover:text-jersey-deep hover:decoration-jersey-deep -my-1 inline-block py-1 text-[14px] leading-snug font-medium underline decoration-transparent underline-offset-2 transition-colors duration-150"
                     >
                       {link.label}
                     </Link>

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
@@ -35,7 +35,9 @@ const Wordmark = () => (
   <Link
     href="/"
     aria-label="KCVV Elewijt — home"
-    className="font-display inline-block text-[20px] leading-none font-black whitespace-nowrap italic no-underline lg:text-[20px] xl:text-[24px] 2xl:text-[28px]"
+    // `py-1 -my-1` — hit area only, no layout shift (#2394). Not named in the
+    // ticket; the walk measured it at 20px and it is the site's home link.
+    className="font-display -my-1 inline-block py-1 text-[20px] leading-none font-black whitespace-nowrap italic no-underline lg:text-[20px] xl:text-[24px] 2xl:text-[28px]"
   >
     <span className="text-ink">
       KCVV <span className="text-jersey-deep">Elewijt</span>
@@ -154,7 +156,11 @@ function SiteHeaderInner({
                       <Link
                         href={item.href}
                         className={cn(
-                          "font-mono text-[11px] font-semibold tracking-[0.04em] whitespace-nowrap uppercase no-underline transition-colors xl:text-[13px] 2xl:text-[14px]",
+                          // `py-2 -my-2` — hit area only, no layout shift
+                          // (#2394). Desktop-only nav, so it never showed up in
+                          // the 390px walk, but it is the same 11px recipe the
+                          // wordmark above carries.
+                          "-my-2 py-2 font-mono text-[11px] font-semibold tracking-[0.04em] whitespace-nowrap uppercase no-underline transition-colors xl:text-[13px] 2xl:text-[14px]",
                           active
                             ? "text-jersey-deep"
                             : "text-ink hover:text-jersey-deep",

--- a/apps/web/src/components/sponsors/SponsorsBlock/SponsorsBlock.tsx
+++ b/apps/web/src/components/sponsors/SponsorsBlock/SponsorsBlock.tsx
@@ -40,7 +40,8 @@ export const SponsorsBlock = ({ sponsors, className }: SponsorsBlockProps) => {
         <div className="mt-10 flex justify-end">
           <Link
             href="/sponsors"
-            className="text-ink hover:text-jersey-deep inline-flex items-center gap-1 font-mono text-sm font-bold tracking-wide uppercase underline-offset-4 hover:underline"
+            // `py-2 -my-2` — hit area only, no layout shift (#2394).
+            className="text-ink hover:text-jersey-deep -my-2 inline-flex items-center gap-1 py-2 font-mono text-sm font-bold tracking-wide uppercase underline-offset-4 hover:underline"
           >
             Alle sponsors &amp; sympathisanten →
           </Link>


### PR DESCRIPTION
Closes #2394

## What was measured

Reproduced the #2424 walk against **production** under a verified `(pointer: coarse)` / `(hover: none)` iPhone 13 context, per the map's standing rule: **20 of 56 interactive elements under 44px, 18 under 24px**, worst `AL HET NIEUWS →` at 113 × 11px. Re-measured the same way after the fix: **18 sub-24px → 1**.

The survivor is `Naar de inhoud` at 1×1px — the `sr-only` skip link, which becomes visible on focus. Correct as-is, not a defect.

| element | before | after |
|---|---|---|
| `EditorialLink` cta variant (`Al het nieuws →`) | **11px** | 27px |
| `FirstTeamsBlock` `Volledige kalender →` | 16px | 32px |
| `SponsorsBlock` `Alle sponsors & sympathisanten →` | 20px | 36px |
| `UpcomingMatchesClient` `Volledige kalender ↗` | 20px | 36px |
| `SiteHeader` wordmark | 20px | 28px |
| `SiteHeader` desktop nav ×9 | ~14px | 30px |
| `SiteFooter` nav links ×13 | 20px | 27px |

## How

Hit-area padding paired with an **equal negative margin** (`py-2 -my-2` / `py-1 -my-1`), so the touch box grows and nothing reflows. The evidence that it worked: **135 VR snapshots across 8 story files pass unchanged**, so there are no baselines in this PR — the layout genuinely did not move.

The footer needed one extra step: its hover underline was a `border-b` on the link, which would have ended up 8px below the text once the box was padded. It becomes a text-decoration (`decoration-transparent` → `hover:decoration-jersey-deep`), which stays on the baseline regardless of padding. That also drops 14 wrapper spans and matches the seven other files already using `hover:underline` — `border-b border-transparent` was the only instance in the codebase.

## Deviations from the ACs

**AC1 (`TEXT_TONE.light` → `text-jersey-link`) is dropped as superseded.** #2395 locked that `jersey-deep` darkens to `#007c46` and `jersey-link` is **deleted** into it, with *"no component changes a colour class"*. `EditorialLink` doesn't reference `jersey-link` today, so following AC1 would both change a colour class in a component and create a **third** consumer of a token #2416 removes — that ticket enumerates exactly two (`globals.css:708`, `:1009`). The contrast remedy lands in #2416 as a one-token change reaching the identical value. **Consequence: #2394 and #2416 are disjoint** — this PR touches no colour, that one touches no component, so they need no sequencing.

**The AA / WCAG 2.2 framing is not the acceptance test.** #2395: *"No conformance target is adopted: readability is the test and the ratios only break ties."* The tap-target substance stands on its own — an 11px link with zero padding on a phone held outdoors is a problem whatever the rubric says.

**AC3's `NewsCard` half is a non-fix.** That read-more span is `aria-hidden="true"`; the card's real target is an `absolute inset-0` `<Link>` overlay already well over 44px. Padding a decorative span changes nothing. The `FirstTeamsBlock` half of the same AC is real and is fixed.

## Three targets the ACs don't name

- **`UpcomingMatchesClient`'s `Volledige kalender ↗`** — byte-identical class string to the `SponsorsBlock` link, and **invisible to both measurements**: it renders only after `Toon alle wedstrijden` expands, and the agenda was absent from the captured dataset entirely. Found by the review pass, not by walking.
- **The header wordmark** — 20px, and it is the site's home link.
- **The desktop nav links** — 11px, zero padding. Never appear in a 390px walk, but they are the same recipe as the wordmark 120 lines above them, and the ticket's own evidence counts 32 desktop failures.

The line drawn is the homepage plus the global chrome the map admitted in #2406 — not a site-wide sweep. Worth knowing: **`SponsorsBlock` is the broadest-reach fix here**, since `SponsorsSection` also renders on every `/ploegen/[slug]`.

## Testing

- `pnpm --filter @kcvv/web check-all` — lint, type-check, **3487 tests**, build all pass
- Coarse-pointer Playwright measurement before (production) and after (local build)
- 135 VR snapshots across `EditorialLink`, `SectionHeader`, `SponsorsBlock`, `FirstTeamsBlock`, `SiteFooter`, `SiteHeader`, `NewsGrid`, `UpcomingMatches` — all pass, none rewritten
- One class-pair tripwire on `EditorialLink`. It proves nothing about size (jsdom computes no layout) — it guards against someone deleting half the pair, which would silently reflow every `SectionHeader`

## Follow-ups worth their own issues

- `RemovableChip`'s 16×16 remove button — the one genuine straggler outside this charter; filter chrome, so #2429 territory
- `FirstTeamsBlock` hand-rolls what `SectionHeader` already composes, and `SponsorsBlock` hand-rolls a CTA beside an imported `SectionHeader`. Consolidating is a visual change (14px/bold/`text-ink`/underline vs cta's 11px/medium/`jersey-deep`/highlighter-sweep), not a mechanical refactor — deliberately not done in a hit-area ticket
- The chrome now carries four hit-area idioms (`h-11 w-11`, `min-h-11`, `h-6`, `py-N -my-N`); the colofon's `Privacy` and `Cookie-instellingen` pass at exactly 24.0px

## Review gate

`/simplify` ran (reuse · simplification · altitude; efficiency skipped — this diff is CSS classes, no computation). **The review caught the `UpcomingMatchesClient` miss that neither measurement could see** — the strongest argument for the gate so far. Also applied: footer span+`group` → text-decoration, hit area moved out of the `VARIANT_TYPE` map into its own named const, one valueless negative-assertion test dropped, duplicated rationale comments trimmed. Skipped: extracting a shared `hit-area` utility — two live sizes, no logic, no drift-coupling, and a helper would hide the negative margin that every comment insists must stay visible.

`/code-review` is reserved for explicit user invocation in this environment and could not be run from the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased clickable areas for key links across the header, footer, homepage, calendar, sponsor, and call-to-action sections.
  * Preserved existing page layout and link destinations while making links easier to tap or click.
  * Refined footer link hover styling for clearer visual feedback.
* **Tests**
  * Added regression coverage to ensure call-to-action links retain their expanded hit areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->