### PR TITLE
perf(matches): dedupe BFF reads and collapse the fan-out waves (#2441)

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -67,6 +67,7 @@ import {
 import { PageContainer, SectionStack } from "@/components/design-system";
 import type { SectionConfig } from "@/components/design-system";
 import { mapMatchesToUpcomingMatches } from "@/lib/mappers";
+import { getTeamMatches } from "@/lib/server/match-data";
 import { DEFAULT_OG_IMAGE, SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildSportsClubJsonLd, buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
@@ -203,14 +204,11 @@ export default async function HomePage() {
   // matches feed. Sorted by slug so a-ploeg renders before b-ploeg.
   const seniorTeams = selectSeniorTeams(teamsResult);
 
+  // Deduped against this route group's layout `<MatchStripSlot>`, which wants
+  // the same A-side psdId — see `getTeamMatches` (#2441).
   const firstTeamsMatches = await Promise.all(
     seniorTeams.map((team) =>
-      runPromise(
-        Effect.gen(function* () {
-          const bff = yield* BffService;
-          return yield* bff.getMatches(Number(team.psdId));
-        }).pipe(Effect.catchAll(() => Effect.succeed(null))),
-      ),
+      getTeamMatches(Number(team.psdId)).catch(() => null),
     ),
   );
 

--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -5,7 +5,10 @@
 
 import { Effect } from "effect";
 import { runPromise } from "@/lib/effect/runtime";
-import { BffService } from "@/lib/effect/services/BffService";
+import {
+  BffService,
+  BFF_FAN_OUT_CONCURRENCY,
+} from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import {
   EventRepository,
@@ -64,8 +67,24 @@ async function fetchCalendarData(): Promise<CalendarData> {
       const teamRepo = yield* TeamRepository;
       const eventRepo = yield* EventRepository;
 
-      // Fetch teams first to know which PSD IDs to query
-      const allTeams = yield* teamRepo.findAll();
+      // Teams first, to know which PSD IDs to query. The merged event feed —
+      // `event` docs + `articleType:event` articles (Phase 6.E, #1968), so
+      // event-articles surface on the calendar alongside matches — depends on
+      // neither the team list nor the match fan-out, so it rides along here
+      // instead of trailing the whole fan-out on a `force-dynamic` route
+      // (#2441). Graceful degradation on failure: a Sanity error yields an
+      // empty feed, not a crash.
+      const [allTeams, feedItems] = yield* Effect.all(
+        [
+          teamRepo.findAll(),
+          eventRepo
+            .findUpcomingForList()
+            .pipe(
+              Effect.catchAll(() => Effect.succeed([] as EventListItemVM[])),
+            ),
+        ],
+        { concurrency: "unbounded" },
+      );
       const teamsWithPsd = allTeams.filter((t) => t.psdId !== null);
 
       // Fetch full-season matches for all teams in parallel.
@@ -82,7 +101,7 @@ async function fetchCalendarData(): Promise<CalendarData> {
             Effect.catchAll(() => Effect.succeed([] as readonly Match[])),
           ),
         ),
-        { concurrency: 5 },
+        { concurrency: BFF_FAN_OUT_CONCURRENCY },
       );
 
       // Flatten, enrich with team label, and deduplicate by match ID.
@@ -100,14 +119,6 @@ async function fetchCalendarData(): Promise<CalendarData> {
           if (!map.has(cal.id)) map.set(cal.id, cal);
           return map;
         }, new Map<number, CalendarMatch>());
-
-      // Fetch the merged event feed — `event` docs + `articleType:event`
-      // articles (Phase 6.E, #1968) — so event-articles surface on the
-      // calendar alongside matches. Graceful degradation on failure: a Sanity
-      // error yields an empty feed, not a crash.
-      const feedItems = yield* eventRepo
-        .findUpcomingForList()
-        .pipe(Effect.catchAll(() => Effect.succeed([] as EventListItemVM[])));
 
       const teamInfos: CalendarTeamInfo[] = teamsWithPsd.map((t) => ({
         id: t.id,

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -1,9 +1,14 @@
 /**
  * (main) route group — detail-page surfaces. The match strip is intentionally
- * absent here per Phase 3 Checkpoint C spec
+ * absent from *this layout* per Phase 3 Checkpoint C spec
  * (`docs/design/mockups/phase-3-c-header-and-matchstrip/matchstrip-locked.md`).
  * Landing pages (homepage + section indexes) live under (landing) which mounts
  * `<MatchStripSlot />` in its own layout.
+ *
+ * It is not absent from the *group*: `/ploegen/[slug]`, `/wedstrijd/[matchId]`
+ * and `/spelers/[slug]` each mount the slot inline. Any read the strip performs
+ * therefore co-renders with those pages — which is why their team-feed reads go
+ * through `getTeamMatches` rather than `bff.getMatches` (#2441).
  */
 export default function MainLayout({
   children,

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -344,43 +344,42 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     isMatchArticle && article.linkedMatch
       ? Number(article.linkedMatch)
       : Number.NaN;
-  const matchDetail: MatchDetail | null = Number.isFinite(matchId)
-    ? await runPromise(
-        Effect.gen(function* () {
-          const bff = yield* BffService;
-          return yield* bff.getMatchDetail(matchId);
-        }).pipe(
-          Effect.catchAll(() => Effect.succeed<MatchDetail | null>(null)),
-        ),
-      )
-    : null;
-  const heroMatch = matchDetail ? toHeroMatchData(matchDetail) : null;
-
   const hasEditorialArticles =
     article.relatedArticles && article.relatedArticles.length > 0;
 
-  let articleRelatedItems: RelatedContentItem[];
-  if (hasEditorialArticles) {
-    articleRelatedItems = mapEditorialArticles(
-      article.relatedArticles ?? undefined,
-    );
-  } else {
-    articleRelatedItems = await runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* bff.getRelated(article.id);
-      }).pipe(
-        Effect.map(mapBffRelatedItems),
-        // Broad catch is intentional: this route uses generateStaticParams,
-        // so the BFF is called at build time for every article. Build
-        // workers (local dev, CI, Vercel) may not reach the Worker, and
-        // rendering must still succeed without a related-items block.
-        // Related content is editorial polish, not load-bearing — falling
-        // back to [] is preferable to failing the article page render.
-        Effect.catchAll(() => Effect.succeed([])),
-      ),
-    );
-  }
+  // The linked match and the related-items block are independent of each
+  // other, so they run as one wave rather than two serialized round-trips
+  // (#2441).
+  const [matchDetail, articleRelatedItems] = await Promise.all([
+    Number.isFinite(matchId)
+      ? runPromise(
+          Effect.gen(function* () {
+            const bff = yield* BffService;
+            return yield* bff.getMatchDetail(matchId);
+          }).pipe(
+            Effect.catchAll(() => Effect.succeed<MatchDetail | null>(null)),
+          ),
+        )
+      : null,
+    hasEditorialArticles
+      ? mapEditorialArticles(article.relatedArticles ?? undefined)
+      : runPromise(
+          Effect.gen(function* () {
+            const bff = yield* BffService;
+            return yield* bff.getRelated(article.id);
+          }).pipe(
+            Effect.map(mapBffRelatedItems),
+            // Broad catch is intentional: this route uses generateStaticParams,
+            // so the BFF is called at build time for every article. Build
+            // workers (local dev, CI, Vercel) may not reach the Worker, and
+            // rendering must still succeed without a related-items block.
+            // Related content is editorial polish, not load-bearing — falling
+            // back to [] is preferable to failing the article page render.
+            Effect.catchAll(() => Effect.succeed<RelatedContentItem[]>([])),
+          ),
+        ),
+  ]);
+  const heroMatch = matchDetail ? toHeroMatchData(matchDetail) : null;
 
   const relatedItems = mergeRelatedItems({
     curated: mapCuratedRelatedContent(article.relatedContent),

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/components/article/EditorialHero";
 import { MatchGoalsBlock } from "@/components/article/blocks/MatchGoalsBlock";
 import { LinkButton } from "@/components/design-system";
-import { toHeroMatchData } from "./utils";
+import { parsePsdMatchId, toHeroMatchData } from "./utils";
 import { ArticleMetadata } from "@/components/article/ArticleMetadata";
 import { ArticleBodyMotion } from "@/components/article/ArticleBodyMotion";
 import {
@@ -333,17 +333,14 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     : undefined;
 
   // matchPreview / matchRecap server-fetch the linked PSD match (5.d-mat).
-  // The match id is a plain string copied from /wedstrijd/[matchId]; guard
-  // against missing/non-numeric values. Match chrome (score bar + Doelpunten)
-  // is enhancement — any BFF failure (404, outage, parse) degrades to no
-  // chrome rather than 404'ing or crashing the article.
+  // The match id is a plain string copied from /wedstrijd/[matchId], so
+  // `parsePsdMatchId` gates it to a positive safe integer. Match chrome
+  // (score bar + Doelpunten) is enhancement — any BFF failure (404, outage,
+  // parse) degrades to no chrome rather than 404'ing or crashing the article.
   const isMatchArticle =
     article.articleType === "matchPreview" ||
     article.articleType === "matchRecap";
-  const matchId =
-    isMatchArticle && article.linkedMatch
-      ? Number(article.linkedMatch)
-      : Number.NaN;
+  const matchId = isMatchArticle ? parsePsdMatchId(article.linkedMatch) : null;
   const hasEditorialArticles =
     article.relatedArticles && article.relatedArticles.length > 0;
 
@@ -351,7 +348,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
   // other, so they run as one wave rather than two serialized round-trips
   // (#2441).
   const [matchDetail, articleRelatedItems] = await Promise.all([
-    Number.isFinite(matchId)
+    matchId !== null
       ? runPromise(
           Effect.gen(function* () {
             const bff = yield* BffService;

--- a/apps/web/src/app/(main)/nieuws/[slug]/utils.test.ts
+++ b/apps/web/src/app/(main)/nieuws/[slug]/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { MatchDetail } from "@kcvv/api-contract";
-import { toHeroMatchData } from "./utils";
+import { parsePsdMatchId, toHeroMatchData } from "./utils";
 
 // Plain-object cast mirrors the wedstrijd/[matchId] utils test fixture —
 // toHeroMatchData only reads fields, so a structural object is sufficient.
@@ -115,5 +115,24 @@ describe("toHeroMatchData", () => {
     expect(data.homeScore).toBeUndefined();
     expect(data.awayScore).toBeUndefined();
     expect(data.kickoffTime).toBe("15:00");
+  });
+});
+
+describe("parsePsdMatchId", () => {
+  it("accepts a positive integer id", () => {
+    expect(parsePsdMatchId("12345")).toBe(12345);
+  });
+
+  it.each([
+    ["zero", "0"],
+    ["a negative id", "-1"],
+    ["a fractional id", "12.5"],
+    ["a value past MAX_SAFE_INTEGER", "9007199254740993"],
+    ["a non-numeric value", "abc"],
+    ["an empty string", ""],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns null for %s, so getMatchDetail is never called", (_, input) => {
+    expect(parsePsdMatchId(input)).toBeNull();
   });
 });

--- a/apps/web/src/app/(main)/nieuws/[slug]/utils.ts
+++ b/apps/web/src/app/(main)/nieuws/[slug]/utils.ts
@@ -10,6 +10,22 @@ import { formatWidgetDate } from "@/lib/utils/dates";
 import { extractMatchTime } from "@/lib/utils/match-time";
 
 /**
+ * Parse the PSD match id off an article's `linkedMatch`. The field is a plain
+ * string an editor copies out of `/wedstrijd/[matchId]`, so it can hold
+ * anything. Only a positive safe integer addresses a real match — `"0"`, a
+ * negative, a fraction or a value past `Number.MAX_SAFE_INTEGER` would reach
+ * the BFF as a guaranteed-miss round-trip. Returns `null` when there is
+ * nothing worth fetching.
+ */
+export function parsePsdMatchId(
+  linkedMatch: string | null | undefined,
+): number | null {
+  if (!linkedMatch) return null;
+  const matchId = Number(linkedMatch);
+  return Number.isSafeInteger(matchId) && matchId > 0 ? matchId : null;
+}
+
+/**
  * Map the BFF `MatchDetail` onto the score-forward hero's `HeroMatchData`
  * (5.d-mat). KCVV side is id-driven, never name-based (see
  * `feedback_psd_match_identification`):

--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd, buildSportsTeamJsonLd } from "@/lib/seo/jsonld";
 import { PageViewTracker, TrackInView } from "@/components/analytics";
 import { MatchStripSlot } from "@/components/layout/MatchStrip";
+import { getTeamMatches } from "@/lib/server/match-data";
 import { StripedSeam } from "@/components/design-system/StripedSeam";
 import { PageContainer } from "@/components/design-system/PageContainer";
 import { TeamHero } from "@/components/team/TeamHero";
@@ -88,28 +89,21 @@ interface BffData {
 
 async function fetchBffData(psdTeamId: number): Promise<BffData | null> {
   try {
-    const [matches, standings] = await runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* Effect.all(
-          [
-            bff
-              .getMatches(psdTeamId)
-              .pipe(
-                Effect.catchAll(() => Effect.succeed([] as readonly Match[])),
-              ),
-            bff
-              .getRanking(psdTeamId)
-              .pipe(
-                Effect.catchAll(() =>
-                  Effect.succeed([] as readonly RankingEntry[]),
-                ),
-              ),
-          ],
-          { concurrency: "unbounded" },
-        );
-      }),
-    );
+    const [matches, standings] = await Promise.all([
+      // Via `getTeamMatches` because this page mounts its own
+      // `<MatchStripSlot />` further down, and on `/ploegen/eerste-elftallen-a`
+      // the strip resolves to this very psdId — the same double-read the
+      // homepage had (#2441).
+      getTeamMatches(psdTeamId).catch(() => [] as readonly Match[]),
+      runPromise(
+        Effect.gen(function* () {
+          const bff = yield* BffService;
+          return yield* bff.getRanking(psdTeamId);
+        }).pipe(
+          Effect.catchAll(() => Effect.succeed([] as readonly RankingEntry[])),
+        ),
+      ),
+    ]);
     return { matches, standings, teamId: psdTeamId };
   } catch {
     return null;
@@ -128,18 +122,21 @@ export default async function TeamPage({ params }: TeamPageProps) {
 
   if (!team) notFound();
 
-  const relatedArticles = await runPromise(
-    Effect.gen(function* () {
-      const repo = yield* ArticleRepository;
-      return yield* repo.findRelated(team.id);
-    }),
-  );
-
   const psdTeamId = team.psdId ? parseInt(team.psdId, 10) : NaN;
-  const bffData =
+
+  // Both depend only on `team`, never on each other, so they share one wave
+  // rather than serializing Sanity behind the BFF pair (#2441).
+  const [relatedArticles, bffData] = await Promise.all([
+    runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ArticleRepository;
+        return yield* repo.findRelated(team.id);
+      }),
+    ),
     Number.isFinite(psdTeamId) && psdTeamId > 0
-      ? await fetchBffData(psdTeamId)
-      : null;
+      ? fetchBffData(psdTeamId)
+      : null,
+  ]);
 
   const standings = bffData?.standings ?? [];
   const scheduleMatches = (bffData?.matches ?? []).map(

--- a/apps/web/src/app/(main)/scheurkalender/page.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/page.tsx
@@ -11,7 +11,10 @@ import type { Metadata } from "next";
 import { Effect } from "effect";
 import { DateTime } from "luxon";
 import { runPromise } from "@/lib/effect/runtime";
-import { BffService } from "@/lib/effect/services/BffService";
+import {
+  BffService,
+  BFF_FAN_OUT_CONCURRENCY,
+} from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import { KCVV_CLUB_ID } from "@/lib/constants";
@@ -97,7 +100,7 @@ async function fetchScheurkalenderData(): Promise<ScheurkalenderData> {
             Effect.catchAll(() => Effect.succeed([] as readonly Match[])),
           ),
         ),
-        { concurrency: 5 },
+        { concurrency: BFF_FAN_OUT_CONCURRENCY },
       );
 
       // League only, labelled by the queried squad (getMatches doesn't set

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/page.tsx
@@ -28,6 +28,7 @@
  * inline `secondary` "Lees ook …" link instead (owner decision, #1914).
  */
 
+import { cache } from "react";
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
@@ -102,12 +103,7 @@ export async function generateMetadata({
   }
 
   try {
-    const match = await runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* bff.getMatchDetail(numericId);
-      }),
-    );
+    const match = await fetchMatchOrNotFound(numericId);
 
     const title = formatMatchTitle(match);
     const description = formatMatchDescription(match);
@@ -124,6 +120,9 @@ export async function generateMetadata({
       },
     };
   } catch {
+    // Also swallows the `notFound()` sentinel for an unknown matchId, which is
+    // fine: the page component awaits the same memoized promise and re-throws
+    // it, so the 404 still renders — with exactly this title.
     return {
       title: "Wedstrijd niet gevonden",
     };
@@ -136,8 +135,16 @@ export async function generateMetadata({
  * surfaces as a 404 page. Other BFF errors (5xx, parse failures, timeouts)
  * bubble up — Next's error boundary handles them, which is what we want
  * for service outages: don't silently disguise them as "not found".
+ *
+ * Wrapped in React `cache()` so `generateMetadata` and the page component
+ * share one read: they run in the same render pass with the same `matchId`,
+ * and Next's `fetch` memoization cannot collapse them because
+ * `@effect/platform` always attaches an `AbortSignal`, which opts the request
+ * out of it (#2441). Per-render only — no TTL, see `BffServiceLive` (#2389).
  */
-async function fetchMatchOrNotFound(matchId: number): Promise<MatchDetail> {
+const fetchMatchOrNotFound = cache(async function fetchMatchOrNotFound(
+  matchId: number,
+): Promise<MatchDetail> {
   return runPromise(
     Effect.gen(function* () {
       const bff = yield* BffService;
@@ -149,6 +156,33 @@ async function fetchMatchOrNotFound(matchId: number): Promise<MatchDetail> {
       // `apps/web/src/app/sitemap.ts` HttpNotFound handler.
       Effect.catchTag("HttpNotFound", () => Effect.sync(() => notFound())),
     ),
+  );
+});
+
+/**
+ * Match-day standings (#2162) — league matches only. A cup/friendly/other
+ * match has no meaningful league table, so we gate on the BFF-surfaced
+ * structured `competitionType` (never on string-matching the Dutch label) and
+ * a resolved `kcvv_team_id`; anything else triggers no ranking fetch at all.
+ * Resilient: a BFF failure degrades to an empty table (auto-hidden), never a
+ * 500 — mirrors the `/ploegen/[slug]` standings fetch.
+ */
+async function fetchStandings(
+  match: MatchDetail,
+): Promise<readonly RankingEntry[]> {
+  if (match.competitionType !== "league" || match.kcvv_team_id == null) {
+    return [];
+  }
+  const standingsTeamId = match.kcvv_team_id;
+  return runPromise(
+    Effect.gen(function* () {
+      const bff = yield* BffService;
+      return yield* bff
+        .getRanking(standingsTeamId)
+        .pipe(
+          Effect.catchAll(() => Effect.succeed([] as readonly RankingEntry[])),
+        );
+    }),
   );
 }
 
@@ -162,27 +196,71 @@ export default async function MatchPage({ params }: MatchPageProps) {
 
   const match = await fetchMatchOrNotFound(numericId);
 
-  // Fetch keeper PSD ids from Sanity (cached for 24h in the repo's
-  // module-scope memo + Sanity CDN — see PlayerRepository.findKeeperPsdIds).
-  // Used to flag KCVV-side keepers; opponent side falls back to the
-  // jersey-#1 heuristic. Returns `undefined` (not an empty Set) on Sanity
-  // failure so `enrichLineupWithKeeperFlag` can detect lookup failure and
-  // degrade BOTH sides to the jersey-#1 heuristic.
-  const keeperPsdIds: ReadonlySet<string> | undefined = await runPromise(
-    Effect.gen(function* () {
-      const repo = yield* PlayerRepository;
-      return yield* repo.findKeeperPsdIds();
-    }).pipe(
-      Effect.catchAllCause((cause) => {
-        console.warn(
-          "[wedstrijd/[matchId]] Sanity keeper lookup failed, " +
-            "falling back to jersey-#1 heuristic on both sides.",
-          { cause },
-        );
-        return Effect.succeed(undefined);
-      }),
-    ),
-  );
+  // These four depend only on `match` / `matchId` and never on each other, so
+  // they run as one wave instead of four serialized round-trips — `max()`
+  // latency rather than `sum()` (#2441). Each keeps its own fallback: none of
+  // them is load-bearing enough to take the page down.
+  const [keeperPsdIds, linkedArticles, galleries, standings] =
+    await Promise.all([
+      // Keeper PSD ids from Sanity (cached for 24h in the repo's module-scope
+      // memo + Sanity CDN — see PlayerRepository.findKeeperPsdIds). Used to
+      // flag KCVV-side keepers; opponent side falls back to the jersey-#1
+      // heuristic. Returns `undefined` (not an empty Set) on Sanity failure so
+      // `enrichLineupWithKeeperFlag` can detect lookup failure and degrade
+      // BOTH sides to the jersey-#1 heuristic.
+      runPromise(
+        Effect.gen(function* () {
+          const repo = yield* PlayerRepository;
+          return yield* repo.findKeeperPsdIds();
+        }).pipe(
+          Effect.catchAllCause((cause) => {
+            console.warn(
+              "[wedstrijd/[matchId]] Sanity keeper lookup failed, " +
+                "falling back to jersey-#1 heuristic on both sides.",
+              { cause },
+            );
+            return Effect.succeed(undefined);
+          }),
+        ),
+      ),
+      // The editorial article(s) linked to this match (#1914). Matches are
+      // BFF/PSD-native, so the link is the article's `linkedMatch` string id —
+      // the route `matchId` itself. Resilient: a Sanity outage degrades to "no
+      // card" rather than 500-ing the whole match page.
+      runPromise(
+        Effect.gen(function* () {
+          const repo = yield* ArticleRepository;
+          return yield* repo.findByLinkedMatch(matchId);
+        }).pipe(
+          Effect.catchAllCause((cause) => {
+            console.warn(
+              "[wedstrijd/[matchId]] linked-article lookup failed; " +
+                "rendering without the article link card.",
+              { cause },
+            );
+            return Effect.succeed<MatchArticleVM[]>([]);
+          }),
+        ),
+      ),
+      // Photo galleries linked to this match (#1471). A match can have several
+      // (warmup / match / viering); the repo returns them chronologically.
+      // Resilient: a Sanity outage degrades to "no galleries".
+      runPromise(
+        Effect.gen(function* () {
+          const repo = yield* PhotoGalleryRepository;
+          return yield* repo.findByLinkedMatch(matchId);
+        }).pipe(
+          Effect.catchAllCause((cause) => {
+            console.warn(
+              "[wedstrijd/[matchId]] gallery lookup failed; rendering without galleries.",
+              { cause },
+            );
+            return Effect.succeed<GalleryCardVM[]>([]);
+          }),
+        ),
+      ),
+      fetchStandings(match),
+    ]);
 
   const homeTeam = transformHomeTeam(match);
   const awayTeam = transformAwayTeam(match);
@@ -215,71 +293,11 @@ export default async function MatchPage({ params }: MatchPageProps) {
   const hasLineup = homeLineup.length > 0 || awayLineup.length > 0;
   const hasEvents = events.length > 0;
 
-  // Fetch the editorial article(s) linked to this match (#1914). Matches are
-  // BFF/PSD-native, so the link is the article's `linkedMatch` string id — the
-  // route `matchId` itself. `selectMatchArticle` applies the per-state truth
-  // table to pick the hero article + (optional) inline secondary link.
-  // Resilient: a Sanity outage degrades to "no card" rather than 500-ing the
-  // whole match page, mirroring the keeper-lookup fallback above.
-  const linkedArticles = await runPromise(
-    Effect.gen(function* () {
-      const repo = yield* ArticleRepository;
-      return yield* repo.findByLinkedMatch(matchId);
-    }).pipe(
-      Effect.catchAllCause((cause) => {
-        console.warn(
-          "[wedstrijd/[matchId]] linked-article lookup failed; " +
-            "rendering without the article link card.",
-          { cause },
-        );
-        return Effect.succeed<MatchArticleVM[]>([]);
-      }),
-    ),
-  );
+  // `selectMatchArticle` applies the per-state truth table to pick the hero
+  // article + (optional) inline secondary link.
   const articleSelection = selectMatchArticle(linkedArticles, match.status);
   const hasArticle = articleSelection !== null;
-
-  // Photo galleries linked to this match (#1471). A match can have several
-  // (warmup / match / viering); the repo returns them chronologically. Resilient:
-  // a Sanity outage degrades to "no galleries" rather than 500-ing the page.
-  const galleries: GalleryCardVM[] = await runPromise(
-    Effect.gen(function* () {
-      const repo = yield* PhotoGalleryRepository;
-      return yield* repo.findByLinkedMatch(matchId);
-    }).pipe(
-      Effect.catchAllCause((cause) => {
-        console.warn(
-          "[wedstrijd/[matchId]] gallery lookup failed; rendering without galleries.",
-          { cause },
-        );
-        return Effect.succeed<GalleryCardVM[]>([]);
-      }),
-    ),
-  );
   const hasGallery = galleries.length > 0;
-
-  // Match-day standings (#2162) — league matches only. A cup/friendly/other
-  // match has no meaningful league table, so we gate on the BFF-surfaced
-  // structured `competitionType` (never on string-matching the Dutch label) and
-  // a resolved `kcvv_team_id`; anything else triggers no ranking fetch at all.
-  // Resilient: a BFF failure degrades to an empty table (auto-hidden), never a
-  // 500 — mirrors the `/ploegen/[slug]` standings fetch.
-  let standings: readonly RankingEntry[] = [];
-  if (match.competitionType === "league" && match.kcvv_team_id != null) {
-    const standingsTeamId = match.kcvv_team_id;
-    standings = await runPromise(
-      Effect.gen(function* () {
-        const bff = yield* BffService;
-        return yield* bff
-          .getRanking(standingsTeamId)
-          .pipe(
-            Effect.catchAll(() =>
-              Effect.succeed([] as readonly RankingEntry[]),
-            ),
-          );
-      }),
-    );
-  }
   const hasStandings = standings.length > 0;
 
   const matchLabel = formatMatchTitle(match);

--- a/apps/web/src/app/api/calendar.ics/route.ts
+++ b/apps/web/src/app/api/calendar.ics/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { Effect } from "effect";
 import { unstable_cache } from "next/cache";
 import { runPromise } from "@/lib/effect/runtime";
-import { BffService } from "@/lib/effect/services/BffService";
+import {
+  BffService,
+  BFF_FAN_OUT_CONCURRENCY,
+} from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import type { Match } from "@kcvv/api-contract";
 import { generateIcal, normalizeCacheKey } from "@/lib/utils/ical";
@@ -14,7 +17,6 @@ export const runtime = "nodejs";
 // freshness window rather than holding fixtures for 12h.
 const CACHE_MAX_AGE = 900;
 const MAX_TEAM_IDS = 20;
-const FETCH_CONCURRENCY = 5;
 
 type Side = "home" | "away" | "all";
 
@@ -43,7 +45,7 @@ async function fetchMatches(
     const bff = yield* BffService;
     const results = yield* Effect.all(
       teamIds.map((id) => bff.getMatches(id)),
-      { concurrency: FETCH_CONCURRENCY },
+      { concurrency: BFF_FAN_OUT_CONCURRENCY },
     );
 
     return results.flat();

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -118,7 +118,8 @@ async function fetchRecentMatchIds(teamPsdIds: string[]): Promise<number[]> {
   try {
     const { Effect } = await import("effect");
     const { runPromise } = await import("@/lib/effect/runtime");
-    const { BffService } = await import("@/lib/effect/services/BffService");
+    const { BffService, BFF_FAN_OUT_CONCURRENCY } =
+      await import("@/lib/effect/services/BffService");
 
     const validTeamIds = teamPsdIds
       .map((id) => parseInt(id, 10))
@@ -141,7 +142,7 @@ async function fetchRecentMatchIds(teamPsdIds: string[]): Promise<number[]> {
     );
 
     const results = await runPromise(
-      Effect.all(effects, { concurrency: "unbounded" }),
+      Effect.all(effects, { concurrency: BFF_FAN_OUT_CONCURRENCY }),
     );
 
     const allMatchIds: number[] = [];

--- a/apps/web/src/lib/effect/services/BffService.ts
+++ b/apps/web/src/lib/effect/services/BffService.ts
@@ -51,6 +51,19 @@ export class BffService extends Context.Tag("BffService")<
 const DEFAULT_TIMEOUT = "30 seconds";
 
 /**
+ * One `Effect.all` concurrency for every per-team BFF fan-out (`/kalender`,
+ * `/scheurkalender`, `sitemap.ts`, `calendar.ics`). Production Sanity returns
+ * 17 teams with a psdId, so this clears the real list in a single wave — the
+ * old value of 5 cost four sequential waves per visitor, which only went
+ * unnoticed while a TTL sat in front of these reads (#2389, #2441).
+ *
+ * Deliberately a ceiling rather than `"unbounded"`: the BFF owns rate limiting
+ * and single-flight (#2328), so the client does not need to throttle, but a
+ * bound keeps an unexpectedly long team list from bursting arbitrarily wide.
+ */
+export const BFF_FAN_OUT_CONCURRENCY = 20;
+
+/**
  * This service adds no cache of its own — do not put one back (#2389). The BFF
  * owns freshness (#2326) and rate limiting + single-flight (#2328), so a second
  * TTL here bought nothing and actively froze: `unstable_cache`'s

--- a/apps/web/src/lib/server/match-data.test.ts
+++ b/apps/web/src/lib/server/match-data.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/components/match/transform", () => ({
 import { runPromise } from "@/lib/effect/runtime";
 import {
   getFirstTeamStripData,
+  getTeamMatches,
   pickFirstTeamPsdId,
   RESULT_RECENCY_MS,
 } from "./match-data";
@@ -69,6 +70,25 @@ describe("pickFirstTeamPsdId", () => {
     expect(
       pickFirstTeamPsdId([{ psdId: "999", age: "U21", slug: "u21" }]),
     ).toBe(null);
+  });
+});
+
+describe("getTeamMatches", () => {
+  it("returns the team's season feed", async () => {
+    runPromiseMock.mockResolvedValueOnce([{ id: 7 }]);
+
+    await expect(getTeamMatches(111)).resolves.toEqual([{ id: 7 }]);
+  });
+
+  // The dedupe itself is React's `cache()`, mocked to a passthrough here. What
+  // this module owns is the contract around it: the helper stays unopinionated
+  // about failure so each call site can pick its own fallback — the homepage
+  // needs `null` to tell an outage from an empty feed (#2399), the strip drops
+  // silently.
+  it("rejects rather than swallowing a BFF failure", async () => {
+    runPromiseMock.mockRejectedValueOnce(new Error("BFF down"));
+
+    await expect(getTeamMatches(111)).rejects.toThrow("BFF down");
   });
 });
 

--- a/apps/web/src/lib/server/match-data.ts
+++ b/apps/web/src/lib/server/match-data.ts
@@ -10,6 +10,7 @@ import {
   selectSeniorTeams,
   type SeniorTeamCandidate,
 } from "@/components/home/FirstTeamsBlock/first-teams";
+import type { Match } from "@kcvv/api-contract";
 import type { ScheduleMatch } from "@/components/match/types";
 
 /**
@@ -37,6 +38,41 @@ export function pickFirstTeamPsdId(
   const first = selectSeniorTeams(teams)[0];
   return first?.psdId ? Number(first.psdId) : null;
 }
+
+/**
+ * A team's full season feed, deduplicated per render.
+ *
+ * The homepage and the `<MatchStrip>` in its layout both want the A side's
+ * feed, and nothing else collapses that into one read: Next's `fetch`
+ * memoization opts out whenever the caller passes an `AbortSignal`, which
+ * `@effect/platform`'s HTTP client always does — so 100% of BFF traffic
+ * bypasses it and the dedupe has to be explicit (#2441).
+ *
+ * This is per-render memoization only. It is not a TTL, and no `unstable_cache`
+ * belongs in front of it — see the note on `BffServiceLive` (#2389). For the
+ * same reason this helper must stay out of `api/calendar.ics/route.ts`, whose
+ * reads *are* wrapped in `unstable_cache`.
+ *
+ * Reach for it on any surface that can co-render `<MatchStripSlot />` — the
+ * (landing) layout mounts it, as do `/ploegen/[slug]`, `/wedstrijd/[matchId]`
+ * and `/spelers/[slug]`. Elsewhere (`/kalender`, `/scheurkalender`,
+ * `sitemap.ts`) call `bff.getMatches` inside your own `Effect.all`: there is no
+ * second reader to dedupe against, and those sites need the tagged error
+ * channel this helper flattens away.
+ *
+ * Rejects on a BFF failure; each call site owns its own fallback, because they
+ * disagree about what "no matches" should mean.
+ */
+export const getTeamMatches = cache(async function getTeamMatches(
+  psdId: number,
+): Promise<readonly Match[]> {
+  return runPromise(
+    Effect.gen(function* () {
+      const bff = yield* BffService;
+      return yield* bff.getMatches(psdId);
+    }),
+  );
+});
 
 /**
  * Fetch the first team's last result and next fixture for `<MatchStrip>`.
@@ -69,12 +105,7 @@ export const getFirstTeamStripData = cache(
       const psdId = pickFirstTeamPsdId(teams);
       if (psdId === null) return null;
 
-      const matches = await runPromise(
-        Effect.gen(function* () {
-          const bff = yield* BffService;
-          return yield* bff.getMatches(psdId);
-        }),
-      );
+      const matches = await getTeamMatches(psdId);
 
       const now = new Date();
       const lastResult = pickLastResult(matches, now);


### PR DESCRIPTION
Closes #2441

## Why

#2389 removed the `unstable_cache` layer in front of the BFF match reads — correct, it froze and served a 10h-stale scoreline — but it was also the only thing collapsing repeat reads within a single render. Nothing replaced it, and nothing can implicitly: Next memoizes `fetch` per render but [opts out whenever the caller passes an `AbortSignal`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/dedupe-fetch.ts), which `@effect/platform`'s HTTP client always attaches. **100% of BFF traffic bypasses Next's fetch memoization**, so the dedupe has to be explicit.

Per-render `cache()` only. **No TTL is reintroduced** — the rule added to `apps/web/CLAUDE.md` in #2439 holds.

## Changes

### 1. `getTeamMatches(psdId)` — one team feed per render

New React `cache()`-wrapped helper in `apps/web/src/lib/server/match-data.ts`. Every surface that can co-render `<MatchStripSlot />` now goes through it:

| Surface | Before | After |
| --- | --- | --- |
| Homepage + layout strip | 4 BFF calls (A-side feed twice) | 3 |
| `/ploegen/eerste-elftallen-a` | A-side feed twice | once |
| `getFirstTeamStripData` | direct `bff.getMatches` | via helper |

The `/ploegen/[slug]` duplicate was **not** in the issue's findings — all four `/simplify` agents surfaced it independently. That page mounts its own `<MatchStripSlot />` (`:202`) *and* fetched the same psdId at `:97`; on the club's most-trafficked team page that is a second full season-feed round-trip per render and per ISR regeneration.

The helper's docblock records the rule for choosing between it and a direct `bff.getMatches` call, so the two-way split stays legible.

### 2. `/wedstrijd/[matchId]` — one `getMatchDetail` per render

`fetchMatchOrNotFound` is now `cache()`-wrapped and called from `generateMetadata` too, instead of that function issuing its own read.

### 3. One fan-out concurrency

`BFF_FAN_OUT_CONCURRENCY` replaces four divergent values (`5`, `5`, `5`, `"unbounded"`) at `sitemap.ts`, `/kalender`, `/scheurkalender` and `calendar.ics`. Production Sanity returns 17 teams with a psdId, so `/kalender` goes from **four sequential waves per visitor to one** (it is `force-dynamic`, so every visitor paid).

Kept as a ceiling rather than `"unbounded"`: the BFF owns rate limiting and single-flight (#2328), so the client does not need to throttle, but a bound stops an unexpectedly long team list bursting arbitrarily wide. All four sites enumerate the same ~17-team set (`TEAM_SITEMAP_QUERY` uses the same `archived != true && showInNavigation != false` filter as `TEAMS_QUERY`), and `calendar.ics` caps at `MAX_TEAM_IDS = 20`.

### 4. Waterfalls collapsed

- `/wedstrijd/[matchId]` — keepers, linked articles, galleries and standings all depend only on `match`/`matchId`, never on each other. Four serialized round-trips became one wave. The `let standings` + `if` block was extracted to a `fetchStandings(match)` arrow-free helper.
- `/nieuws/[slug]` — `getMatchDetail` and `getRelated` are independent.
- `/ploegen/[slug]` — `findRelated` and the BFF pair are independent.
- `/kalender` — the merged event feed trailed the entire 17-team fan-out despite depending on none of it. Now rides along with the team query.

### 5. Stale doc comment

`(main)/layout.tsx` claimed the match strip is absent from the group. Three pages in it mount the slot inline (`/ploegen/[slug]`, `/wedstrijd/[matchId]`, `/spelers/[slug]`) — that stale claim is plausibly why the `/ploegen/[slug]` duplicate survived. Corrected, and it now names the consequence.

## Testing

- `pnpm --filter @kcvv/web check-all` — exit 0 (lint, type-check, 3490 tests in 297 files, `next build`)
- Two tests added for `getTeamMatches`' contract: it returns the feed, and it **rejects rather than swallowing** a BFF failure — each call site owns its own fallback, because they disagree about what "no matches" means (the homepage needs `null` to tell an outage from an empty feed, per #2399).
- No VR baselines needed: no visual change.

## Review gate

`/simplify` ran (4 agents). Applied: the `/ploegen/[slug]` double-fetch, the `/kalender` serialized event feed, the stale layout comment, the `unstable_cache` guard note on `getTeamMatches`, plus comment/annotation trims.

Skipped, with reasons:

- **Extract a shared `runWithFallback` / `getTeamStandings` / `getMatchDetail` helper** — real duplication, but each has exactly two call sites and would pull new abstractions well outside this diff.
- **`cache()` the repeated Sanity reads** (`findBySlug` on `/ploegen/[slug]` + `/nieuws/[slug]`, `TeamRepository.findAll()` on every strip route) — verified these are *already* deduped: `@sanity/client` sets `useAbortSignal` false, so unlike the BFF these do hit Next's fetch memoization. The residual cost is a re-parse/re-map, single-digit ms. Out of scope.
- **Move `BFF_FAN_OUT_CONCURRENCY` out of `BffService.ts` / wrap the fan-out in a helper** — the module already hosts the cross-call-site read-policy prose (#2389's docblock), so the constant is consistent with its existing role; a helper for four one-line call sites is not yet earned.
- **Split `cache()` off the `notFound()` mapping on `/wedstrijd/[matchId]`** — not cleanly implementable: moving the mapping out of the Effect pipeline loses `catchTag` tag discrimination. Behaviour is identical to before (`generateMetadata` swallowing the sentinel produces the same title, and the page re-throws it from the same memoized promise); added a comment so this is not re-litigated in review.

Note: `/code-review` is user-triggered in this environment, so only `/simplify` ran automatically.

## Out of scope

`api/calendar.ics/route.ts` still wraps `bff.getMatches` in its own `unstable_cache` — the issue calls this out as deserving its own ticket. `getTeamMatches`' docblock now explicitly warns it must stay out of that route, or #2389 returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading speed across match, calendar, news, team, and detail pages by fetching related data concurrently.
  * Added consistent limits for parallel match requests to improve reliability.

* **Reliability**
  * Added graceful fallbacks when event feeds, related content, standings, or match data cannot be loaded.
  * Improved match-data reuse during page rendering.

* **Bug Fixes**
  * Invalid match and team identifiers are handled more safely without unnecessary requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->