### PR TITLE
fix(matches): widen the matchstrip result window to 15 days

### DIFF
--- a/apps/web/src/lib/server/match-data.test.ts
+++ b/apps/web/src/lib/server/match-data.test.ts
@@ -139,6 +139,23 @@ describe("getFirstTeamStripData", () => {
     expect(data?.result?.id).toBe(1);
   });
 
+  it("keeps last weekend's result across a bye weekend", async () => {
+    // The one absolute-valued assertion in this file, deliberately: every other
+    // window test derives its dates from `RESULT_RECENCY_MS`, so all of them
+    // still pass if the constant is narrowed. This one fails — which is the
+    // point, since the window's whole job is to outlast a gap in the calendar.
+    // Ten days back is a fortnight-ago Saturday seen from the next weekend.
+    mockFetches(TEAMS, [
+      { id: 1, status: "finished", date: hoursAgo(10 * 24) },
+      { id: 2, status: "scheduled", date: hoursAhead(48) },
+    ]);
+
+    const data = await getFirstTeamStripData();
+
+    expect(data?.result?.id).toBe(1);
+    expect(data?.fixture?.id).toBe(2);
+  });
+
   it("returns the fixture alone when there is no recent result", async () => {
     mockFetches(TEAMS, [{ id: 2, status: "scheduled", date: hoursAhead(6) }]);
 

--- a/apps/web/src/lib/server/match-data.ts
+++ b/apps/web/src/lib/server/match-data.ts
@@ -15,10 +15,21 @@ import type { ScheduleMatch } from "@/components/match/types";
 
 /**
  * How long a played match stays newsworthy enough to headline the strip.
- * Past this, the strip drops back to fixture-only — a result from a fortnight
- * ago at the top of every landing page reads as stale, not as news.
+ * Past this, the strip drops back to fixture-only.
+ *
+ * Sized against the fixture calendar, not against a news cycle. The original
+ * 72 h (#2387) expired on the Tuesday evening after a Saturday kickoff, so the
+ * strip ran fixture-only for most of every week, and one bye weekend blanked
+ * the result slot entirely. Fifteen days clears a skipped weekend with room to
+ * spare, while a genuinely dormant strip — winter break, end of season — still
+ * falls back to the fixture alone rather than headlining a stale scoreline.
+ *
+ * Only the past arm of this window is load-bearing. The check is symmetric
+ * (`Math.abs`, #2423) so that a forfeit awarded before kickoff can reach the
+ * slot, but how far ahead one may be dated is `pickLastResult`'s own, tighter
+ * `SETTLED_LOOKAHEAD_MS` — widening here admits no future match it would not.
  */
-export const RESULT_RECENCY_MS = 72 * 60 * 60 * 1000;
+export const RESULT_RECENCY_MS = 15 * 24 * 60 * 60 * 1000;
 
 export interface MatchStripData {
   /** Most recent played match, only when inside `RESULT_RECENCY_MS`. */


### PR DESCRIPTION
## Problem

The landing-page `<MatchStrip>` stopped showing the last result while a perfectly good one existed.

Reported live on 2026-08-12: the A side played **Ohr Huldenberg 2–1 KCVV on Sat 8 Aug 18:00** (match `3521`, `finished`), yet the strip showed only tonight's fixture against VK Ninove — no scoreline, and no ← → switch to reach one.

The data path was healthy the whole time. `pickLastResult` still returned that match, and the homepage "Eerste ploegen" block a few hundred pixels lower rendered it correctly. The strip alone dropped it, at its own `RESULT_RECENCY_MS` gate in `apps/web/src/lib/server/match-data.ts`.

That constant was `72 * 60 * 60 * 1000`, straight from #2387's acceptance criteria. Seventy-two hours from a Saturday-evening kickoff expires on the **Tuesday evening** after — so the strip ran fixture-only for Wednesday, Thursday and Friday of every ordinary week, and over a bye weekend it never showed a result at all.

There is a second-order effect worth naming, because it is what makes the strip look broken rather than merely quiet: with `result === null`, `bothSides` goes false in `MatchStripView`, the two-slide switch is not rendered, and the label freezes on "Volgende". The user cannot tell that a result exists and is being withheld.

## Change

```diff
-export const RESULT_RECENCY_MS = 72 * 60 * 60 * 1000;
+export const RESULT_RECENCY_MS = 15 * 24 * 60 * 60 * 1000;
```

Fifteen days is sized against the fixture calendar rather than a news cycle: it clears one skipped weekend with room to spare, while a genuinely dormant strip — winter break, end of season — still falls back to the fixture alone rather than headlining a stale scoreline.

The doc comment now records that reasoning, plus one thing a reader would otherwise have to re-derive: **only the past arm of this window is load-bearing.** The check is symmetric (`Math.abs`, from #2423) so that a forfeit awarded before kickoff can reach the result slot, but how far *ahead* a settled match may be dated is governed by `pickLastResult`'s own, tighter `SETTLED_LOOKAHEAD_MS` (still 72 h). Widening here admits no future match that the old value did not.

Against live data: the 8 Aug result now holds until **Sun 23 Aug**, so the strip carries it through to the next match instead of blanking on the Tuesday.

## Test

Adds `keeps last weekend's result across a bye weekend` — a result 10 days back must still reach the slot.

It is the only absolute-valued assertion in the file, deliberately. Every other window test derives its dates from `RESULT_RECENCY_MS`, so all of them stay green no matter what the constant is set to; none would have failed on a revert to 72 h. This one does, which is the whole point — the window's job is to outlast a gap in the calendar, and that is not a property the existing tests can express.

Verified red-then-green: with the constant temporarily returned to 72 h the new test fails and the other sixteen pass; at 15 days all seventeen pass.

## Verification

- `pnpm --filter @kcvv/web check-all` — lint, type-check, 17/17 in `match-data.test.ts`, and `next build` all pass.
- Ran the neighbouring suites too (`FirstTeamsBlock`, `MatchStrip`) — 83/83, no other consumer of the constant.
- No VR baselines needed: no story or snapshot reads `RESULT_RECENCY_MS`, and no markup changed.

## Notes

No issue number — this came out of a live debugging session on prod, not the backlog. Root cause was confirmed against the deployed site and the BFF (`/match/3521/detail`) before any code was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
