### PR TITLE
feat(analytics): instrument the global chrome and homepage paid surfaces (#2419, #2400)

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -466,7 +466,13 @@ function toBannerSection(
     key: `banner-${slot}`,
     bg: "transparent",
     content: (
-      <TrackInView eventName="banner_impression" params={{ position: slot }}>
+      // `destination` matches what `banner_click` sends, so impressions and
+      // clicks join on it. The slot alone can't identify the creative — the
+      // three slots are fixed but their campaigns rotate.
+      <TrackInView
+        eventName="banner_impression"
+        params={{ position: slot, destination: banner.href ?? "" }}
+      >
         <BannerSlot
           image={banner.imageUrl}
           alt={banner.alt}

--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -31,7 +31,11 @@ import {
   toHomepageArticles,
 } from "@/lib/repositories/article.repository";
 import { formatArticleDate } from "@/lib/utils/dates";
-import { HomepageRepository } from "@/lib/repositories/homepage.repository";
+import {
+  HomepageRepository,
+  type BannerSlotVM,
+} from "@/lib/repositories/homepage.repository";
+import { TrackInView } from "@/components/analytics";
 import {
   EventRepository,
   type EventVM,
@@ -43,6 +47,7 @@ import {
 } from "@/lib/repositories/team.repository";
 import {
   BannerSlot,
+  HomepageAnalytics,
   FeaturedEventBand,
   toFeaturedEventBandEvent,
   FeaturedUitgelichtRow,
@@ -334,21 +339,7 @@ export default async function HomePage() {
       }
     : null;
 
-  const bannerSlotASection: SectionConfig | null = banners.bannerSlotA
-    ? {
-        key: "banner-a",
-        bg: "transparent",
-        content: (
-          <BannerSlot
-            image={banners.bannerSlotA.imageUrl}
-            alt={banners.bannerSlotA.alt}
-            href={banners.bannerSlotA.href}
-          />
-        ),
-        paddingTop: "pt-0",
-        paddingBottom: "pb-0",
-      }
-    : null;
+  const bannerSlotASection = toBannerSection("a", banners.bannerSlotA);
 
   const latestNewsSection: SectionConfig | null =
     newsGridArticles.length > 0
@@ -378,21 +369,7 @@ export default async function HomePage() {
         }
       : null;
 
-  const bannerSlotBSection: SectionConfig | null = banners.bannerSlotB
-    ? {
-        key: "banner-b",
-        bg: "transparent",
-        content: (
-          <BannerSlot
-            image={banners.bannerSlotB.imageUrl}
-            alt={banners.bannerSlotB.alt}
-            href={banners.bannerSlotB.href}
-          />
-        ),
-        paddingTop: "pt-0",
-        paddingBottom: "pb-0",
-      }
-    : null;
+  const bannerSlotBSection = toBannerSection("b", banners.bannerSlotB);
 
   const youthSection: SectionConfig = {
     key: "youth",
@@ -409,26 +386,21 @@ export default async function HomePage() {
     paddingTop: "pt-0",
   };
 
-  const bannerSlotCSection: SectionConfig | null = banners.bannerSlotC
-    ? {
-        key: "banner-c",
-        bg: "transparent",
-        content: (
-          <BannerSlot
-            image={banners.bannerSlotC.imageUrl}
-            alt={banners.bannerSlotC.alt}
-            href={banners.bannerSlotC.href}
-          />
-        ),
-        paddingTop: "pt-0",
-        paddingBottom: "pb-0",
-      }
-    : null;
+  const bannerSlotCSection = toBannerSection("c", banners.bannerSlotC);
 
   const sponsorsSection: SectionConfig = {
     key: "sponsors",
     bg: "transparent",
-    content: <SponsorsSection />,
+    content: (
+      // The block sits near the bottom of the spine, so a mount-time event
+      // would count every homepage load as a sponsor impression (#2400).
+      <TrackInView
+        eventName="sponsor_impression"
+        params={{ source: "homepage" }}
+      >
+        <SponsorsSection />
+      </TrackInView>
+    ),
     paddingTop: "pt-0",
     paddingBottom: "pb-0",
   };
@@ -454,28 +426,58 @@ export default async function HomePage() {
           { name: "Home", url: SITE_CONFIG.siteUrl },
         ])}
       />
-      <SectionStack
-        sections={[
-          heroSection,
-          // #2387: "Dit weekend." sits directly under the hero, ahead of the
-          // editorial rows. The result used to land ~2,200px down on a phone,
-          // behind the hero and three Uitgelicht cards, which contradicted
-          // product principle 1 ("the result is the headline").
-          firstTeamsSection,
-          uitgelichtSection,
-          featuredEventSection,
-          bannerSlotASection,
-          latestNewsSection,
-          upcomingMatchesSection,
-          bannerSlotBSection,
-          youthSection,
-          bannerSlotCSection,
-          sponsorsSection,
-          clubshopSection,
-        ]}
-      />
+      <HomepageAnalytics>
+        <SectionStack
+          sections={[
+            heroSection,
+            // #2387: "Dit weekend." sits directly under the hero, ahead of the
+            // editorial rows. The result used to land ~2,200px down on a phone,
+            // behind the hero and three Uitgelicht cards, which contradicted
+            // product principle 1 ("the result is the headline").
+            firstTeamsSection,
+            uitgelichtSection,
+            featuredEventSection,
+            bannerSlotASection,
+            latestNewsSection,
+            upcomingMatchesSection,
+            bannerSlotBSection,
+            youthSection,
+            bannerSlotCSection,
+            sponsorsSection,
+            clubshopSection,
+          ]}
+        />
+      </HomepageAnalytics>
     </>
   );
+}
+
+/**
+ * One homepage banner slot, instrumented (#2400). The three slots differ only
+ * in their content and scroll depth, so they share a builder rather than three
+ * near-identical literals — `position` is what tells them apart in GA4.
+ */
+function toBannerSection(
+  slot: "a" | "b" | "c",
+  banner: BannerSlotVM | null,
+): SectionConfig | null {
+  if (!banner) return null;
+  return {
+    key: `banner-${slot}`,
+    bg: "transparent",
+    content: (
+      <TrackInView eventName="banner_impression" params={{ position: slot }}>
+        <BannerSlot
+          image={banner.imageUrl}
+          alt={banner.alt}
+          href={banner.href}
+          slot={slot}
+        />
+      </TrackInView>
+    ),
+    paddingTop: "pt-0",
+    paddingBottom: "pb-0",
+  };
 }
 
 /**

--- a/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
+++ b/apps/web/src/components/home/BannerSlot/BannerSlot.tsx
@@ -9,6 +9,13 @@ export interface BannerSlotProps {
   alt: string;
   /** Optional click-through URL — wraps in <a> when set */
   href?: string;
+  /**
+   * Which of the three homepage slots this is. Emitted as the inert
+   * `data-banner-slot` marker that `<HomepageAnalytics>` delegates on, and as
+   * the `position` param on the banner events (#2400) — the slots sit at very
+   * different scroll depths, so an undifferentiated banner event says nothing.
+   */
+  slot?: "a" | "b" | "c";
   /** Additional CSS classes */
   className?: string;
 }
@@ -23,6 +30,7 @@ export const BannerSlot = ({
   image,
   alt,
   href,
+  slot,
   className,
 }: BannerSlotProps) => {
   const inner = (
@@ -55,6 +63,7 @@ export const BannerSlot = ({
           href={href}
           target="_blank"
           rel="noopener noreferrer"
+          data-banner-slot={slot}
           className="group block transition-all duration-300 motion-safe:hover:translate-x-1 motion-safe:hover:translate-y-1"
         >
           {inner}

--- a/apps/web/src/components/home/HomepageAnalytics/HomepageAnalytics.test.tsx
+++ b/apps/web/src/components/home/HomepageAnalytics/HomepageAnalytics.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+import { hashMemberId } from "@/lib/analytics/hash-member-id";
+import { HomepageAnalytics } from "./HomepageAnalytics";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+describe("HomepageAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fires sponsor_click with a hashed id, tier and homepage source", async () => {
+    render(
+      <HomepageAnalytics>
+        <a
+          href="https://sponsor.example"
+          data-sponsor-id="s-1"
+          data-sponsor-tier="hoofdsponsor"
+        >
+          Sponsor
+        </a>
+      </HomepageAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Sponsor" }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("sponsor_click", {
+      sponsor_id: hashMemberId("s-1"),
+      tier: "hoofdsponsor",
+      source: "homepage",
+    });
+  });
+
+  it("never sends the raw sponsor id", async () => {
+    render(
+      <HomepageAnalytics>
+        <a href="https://x.example" data-sponsor-id="raw-secret">
+          Sponsor
+        </a>
+      </HomepageAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Sponsor" }));
+
+    const params = mockTrackEvent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.sponsor_id).not.toBe("raw-secret");
+    expect(params.sponsor_id).toBe(hashMemberId("raw-secret"));
+  });
+
+  it("fires banner_click with the slot position and destination", async () => {
+    render(
+      <HomepageAnalytics>
+        <a href="https://campaign.example" data-banner-slot="b">
+          Banner
+        </a>
+      </HomepageAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Banner" }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("banner_click", {
+      position: "b",
+      destination: "https://campaign.example",
+    });
+  });
+
+  it("resolves a click on a child element up to the marked banner link", async () => {
+    render(
+      <HomepageAnalytics>
+        <a href="https://campaign.example" data-banner-slot="c">
+          <img alt="Campagne" src="/banner.png" />
+        </a>
+      </HomepageAnalytics>,
+    );
+
+    await userEvent.click(screen.getByAltText("Campagne"));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("banner_click", {
+      position: "c",
+      destination: "https://campaign.example",
+    });
+  });
+
+  it("ignores clicks on unmarked links", async () => {
+    render(
+      <HomepageAnalytics>
+        <a href="/test-route">Nieuws</a>
+      </HomepageAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Nieuws" }));
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it("omits tier when the tile carries none", async () => {
+    render(
+      <HomepageAnalytics>
+        <a href="https://x.example" data-sponsor-id="s-2">
+          Sponsor
+        </a>
+      </HomepageAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Sponsor" }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("sponsor_click", {
+      sponsor_id: hashMemberId("s-2"),
+      source: "homepage",
+    });
+  });
+});

--- a/apps/web/src/components/home/HomepageAnalytics/HomepageAnalytics.tsx
+++ b/apps/web/src/components/home/HomepageAnalytics/HomepageAnalytics.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
+import { useSponsorAnalytics } from "@/hooks/useSponsorAnalytics";
+import { readSponsorAttrs } from "@/lib/analytics/sponsor-attrs";
+import { trackEvent } from "@/lib/analytics/track-event";
+
+export interface HomepageAnalyticsProps {
+  children: ReactNode;
+}
+
+/**
+ * Page-scoped click analytics for the homepage's paid surfaces (#2400): the
+ * `<SponsorsBlock>` tiles and the three `<BannerSlot>`s, neither of which
+ * emitted anything while `/sponsors` and `<ClubshopBanner>` both did.
+ *
+ * One native listener on the spine reads the inert markers the (server-
+ * rendered) components already emit — `data-sponsor-id` / `data-sponsor-tier`
+ * on a tile link, `data-banner-slot` on a banner link — so nothing below has to
+ * become a Client Component or grow an `onClick`.
+ *
+ * Impressions are *not* handled here: they need per-surface visibility, which
+ * `<TrackInView>` already provides at each call site.
+ *
+ * No PII — the Sanity sponsor id is hashed by `useSponsorAnalytics`, and a
+ * banner's `href` is a club-authored campaign URL.
+ */
+export function HomepageAnalytics({ children }: HomepageAnalyticsProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { trackSponsorClick } = useSponsorAnalytics();
+
+  useDelegatedClick(ref, {
+    selector: "[data-sponsor-id], [data-banner-slot]",
+    onMatch: (el) => {
+      const slot = el.getAttribute("data-banner-slot");
+      if (slot) {
+        trackEvent("banner_click", {
+          position: slot,
+          destination: el.getAttribute("href") ?? "",
+        });
+        return;
+      }
+
+      const sponsor = readSponsorAttrs(el);
+      if (!sponsor) return;
+      trackSponsorClick({ ...sponsor, source: "homepage" });
+    },
+  });
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/apps/web/src/components/home/HomepageAnalytics/index.ts
+++ b/apps/web/src/components/home/HomepageAnalytics/index.ts
@@ -1,0 +1,2 @@
+export { HomepageAnalytics } from "./HomepageAnalytics";
+export type { HomepageAnalyticsProps } from "./HomepageAnalytics";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -33,6 +33,9 @@ export type { NewsCardProps } from "@/components/article/NewsCard";
 export { BannerSlot } from "./BannerSlot";
 export type { BannerSlotProps } from "./BannerSlot";
 
+export { HomepageAnalytics } from "./HomepageAnalytics";
+export type { HomepageAnalyticsProps } from "./HomepageAnalytics";
+
 export { UpcomingMatches } from "./UpcomingMatches";
 export type { UpcomingMatchesProps } from "./UpcomingMatches";
 

--- a/apps/web/src/components/layout/SiteFooter/FooterAnalytics.test.tsx
+++ b/apps/web/src/components/layout/SiteFooter/FooterAnalytics.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+import { FooterAnalytics } from "./FooterAnalytics";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+describe("FooterAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fires footer_link_click with the destination and column", async () => {
+    render(
+      <FooterAnalytics>
+        <a href="/hulp" data-footer-column="Bij de club">
+          Hulp
+        </a>
+      </FooterAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Hulp" }));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("footer_link_click", {
+      destination: "/hulp",
+      category: "Bij de club",
+    });
+  });
+
+  it("resolves a click on a child element up to the marked link", async () => {
+    render(
+      <FooterAnalytics>
+        <a href="/test-route" data-footer-column="Ontdek">
+          <span>Nieuws</span>
+        </a>
+      </FooterAnalytics>,
+    );
+
+    await userEvent.click(screen.getByText("Nieuws"));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("footer_link_click", {
+      destination: "/test-route",
+      category: "Ontdek",
+    });
+  });
+
+  it("ignores clicks on unmarked links", async () => {
+    render(
+      <FooterAnalytics>
+        <a href="/privacy">Privacy</a>
+      </FooterAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Privacy" }));
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it("ignores a marked link whose column is empty", async () => {
+    render(
+      <FooterAnalytics>
+        <a href="/x" data-footer-column="">
+          Half-marked
+        </a>
+      </FooterAnalytics>,
+    );
+
+    await userEvent.click(screen.getByRole("link", { name: "Half-marked" }));
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it("applies className to the delegating element so it can be the grid", () => {
+    const { container } = render(
+      <FooterAnalytics className="grid grid-cols-3">
+        <span>child</span>
+      </FooterAnalytics>,
+    );
+
+    expect(container.firstElementChild).toHaveClass("grid", "grid-cols-3");
+  });
+});

--- a/apps/web/src/components/layout/SiteFooter/FooterAnalytics.tsx
+++ b/apps/web/src/components/layout/SiteFooter/FooterAnalytics.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
+import { useNavigationAnalytics } from "@/hooks/useNavigationAnalytics";
+
+export interface FooterAnalyticsProps {
+  children: ReactNode;
+  /** Applied to the delegating element, which *is* the directory grid. */
+  className?: string;
+}
+
+/**
+ * Client analytics shell for the footer directory (#2419). One native listener
+ * reads the inert `data-footer-column` marker off the server-rendered
+ * `<SiteFooter>` links below, so the footer itself stays a Server Component and
+ * no link grows an `onClick`. The destination comes off the anchor's own
+ * `href` — a new footer link never repeats its route in a second attribute.
+ *
+ * It renders the grid `<div>` rather than wrapping one, so the delegation costs
+ * zero extra DOM nodes.
+ */
+export function FooterAnalytics({ children, className }: FooterAnalyticsProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { trackFooterClick } = useNavigationAnalytics();
+
+  useDelegatedClick(ref, {
+    selector: "[data-footer-column]",
+    onMatch: (el) => {
+      const destination = el.getAttribute("href");
+      const column = el.getAttribute("data-footer-column");
+      if (!destination || !column) return;
+      trackFooterClick({ destination, column });
+    },
+  });
+
+  return (
+    <div ref={ref} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/SiteFooter/SiteFooter.tsx
+++ b/apps/web/src/components/layout/SiteFooter/SiteFooter.tsx
@@ -4,6 +4,7 @@ import { FacebookLogo, InstagramLogo } from "@/lib/icons.redesign";
 import { EXTERNAL_LINKS } from "@/lib/constants";
 import { cn } from "@/lib/utils/cn";
 import { CookiePreferencesButton } from "./CookiePreferencesButton";
+import { FooterAnalytics } from "./FooterAnalytics";
 import { FOOTER_ADDRESS_LINE, FOOTER_COLUMNS } from "./footerLinks";
 
 export interface SiteFooterProps {
@@ -47,7 +48,7 @@ export const SiteFooter = ({ className }: SiteFooterProps) => {
 
       {/* Directory — 3-col task-oriented link grid */}
       <div className="mx-auto max-w-[1440px] px-6 py-10 md:px-10 md:py-12">
-        <div className="grid grid-cols-1 gap-10 md:grid-cols-3 md:gap-7">
+        <FooterAnalytics className="grid grid-cols-1 gap-10 md:grid-cols-3 md:gap-7">
           {FOOTER_COLUMNS.map((column) => (
             <div key={column.heading}>
               <h3 className="border-jersey-deep text-ink mb-3 border-b-[1.5px] pb-2 font-mono text-[11px] font-bold tracking-[0.1em] uppercase">
@@ -65,6 +66,7 @@ export const SiteFooter = ({ className }: SiteFooterProps) => {
                         adrift) while a decoration stays on the baseline. */}
                     <Link
                       href={link.href}
+                      data-footer-column={column.heading}
                       className="text-ink-soft hover:text-jersey-deep hover:decoration-jersey-deep -my-1 inline-block py-1 text-[14px] leading-snug font-medium underline decoration-transparent underline-offset-2 transition-colors duration-150"
                     >
                       {link.label}
@@ -74,7 +76,7 @@ export const SiteFooter = ({ className }: SiteFooterProps) => {
               </ul>
             </div>
           ))}
-        </div>
+        </FooterAnalytics>
       </div>
 
       {/* Ink bottom bar — colofon. `pb-safe` extends the ink through the iOS

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
@@ -6,6 +6,11 @@ import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils/cn";
 import { Button, getButtonClasses } from "@/components/design-system/Button";
 import { List, MagnifyingGlass } from "@/lib/icons.redesign";
+import { useDelegatedClick } from "@/hooks/useDelegatedClick";
+import {
+  useNavigationAnalytics,
+  type NavSource,
+} from "@/hooks/useNavigationAnalytics";
 import {
   buildMenuItems,
   buildSeniorMenuItem,
@@ -51,8 +56,37 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
   const pathname = usePathname();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const hamburgerRef = useRef<HTMLButtonElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
+  const { trackNavClick } = useNavigationAnalytics();
 
-  const handleClose = useCallback(() => setDrawerOpen(false), []);
+  // One native listener on the (always-mounted) `<header>` reads the inert
+  // `data-nav-source` marker off whichever link was hit — #2419's delegation
+  // requirement. The destination comes off the anchor's own `href`, so a new
+  // nav entry never has to repeat its route in a second attribute. The
+  // takeover is handled separately below.
+  useDelegatedClick(headerRef, {
+    selector: "[data-nav-source]",
+    onMatch: (el) => {
+      const destination = el.getAttribute("href");
+      const source = el.getAttribute("data-nav-source") as NavSource | null;
+      if (!destination || !source) return;
+      trackNavClick({ destination, source });
+    },
+  });
+
+  // The takeover is a JSX sibling of `<header>`, so the delegated listener
+  // above cannot reach it. It could get its own — but the panel is client-only
+  // (delegation elsewhere exists to keep Server Components server-rendered,
+  // which buys nothing here) and every row already owns an `onNavigate`
+  // callback for the drawer close. Tracking rides that rather than adding a
+  // second mechanism and a persistently-mounted wrapper to hang it on.
+  const handleTakeoverNavigate = useCallback(
+    (destination: string) => {
+      trackNavClick({ destination, source: "takeover" });
+      setDrawerOpen(false);
+    },
+    [trackNavClick],
+  );
 
   const seniorMenuItems = (seniorTeams ?? []).map((t) =>
     buildSeniorMenuItem(t, seniorNavLabel(t.name)),
@@ -64,6 +98,7 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
   return (
     <>
       <header
+        ref={headerRef}
         className={cn(
           "bg-cream border-paper-edge sticky top-0 z-50 border-b",
           className,
@@ -91,6 +126,7 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
           <Link
             href="/zoeken"
             aria-label="Zoeken"
+            data-nav-source="mobile"
             className="text-ink hover:text-jersey-deep inline-flex h-11 w-11 items-center justify-center transition-colors"
           >
             <MagnifyingGlass size={20} aria-hidden="true" />
@@ -111,6 +147,7 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
                     // the flat nav also lost the `aria-current` the dropdown
                     // rows used to carry.
                     aria-current={isActive(item.href) ? "page" : undefined}
+                    data-nav-source="desktop"
                     className={cn(
                       // `py-2 -my-2` — hit area only, no layout shift (#2394).
                       // Desktop-only nav, so it never showed up in the 390px
@@ -138,12 +175,14 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
             <Link
               href="/zoeken"
               aria-label="Zoeken"
+              data-nav-source="desktop"
               className="text-ink hover:text-jersey-deep inline-flex items-center transition-colors"
             >
               <MagnifyingGlass size={18} aria-hidden="true" />
             </Link>
             <Link
               href="/club/word-lid"
+              data-nav-source="desktop"
               className="border-ink text-ink hover:border-jersey-deep hover:text-jersey-deep inline-flex items-center border px-2.5 py-1.5 font-mono text-[11px] font-semibold tracking-[0.04em] whitespace-nowrap uppercase no-underline transition-colors duration-150 xl:px-3.5 xl:py-2 xl:text-[13px] 2xl:text-[14px]"
             >
               Word lid
@@ -164,13 +203,13 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
             label={item.label}
             href={item.href}
             active={isActive(item.href)}
-            onNavigate={handleClose}
+            onNavigate={() => handleTakeoverNavigate(item.href)}
           />
         ))}
         <div className="mt-6">
           <Link
             href="/club/word-lid"
-            onClick={handleClose}
+            onClick={() => handleTakeoverNavigate("/club/word-lid")}
             className={getButtonClasses({
               variant: "primary",
               size: "md",

--- a/apps/web/src/components/sponsors/SponsorsAnalytics/SponsorsAnalytics.tsx
+++ b/apps/web/src/components/sponsors/SponsorsAnalytics/SponsorsAnalytics.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useEffect, useRef, type ReactNode } from "react";
-import {
-  useSponsorAnalytics,
-  type SponsorTier,
-} from "@/hooks/useSponsorAnalytics";
+import { useSponsorAnalytics } from "@/hooks/useSponsorAnalytics";
+import { readSponsorAttrs } from "@/lib/analytics/sponsor-attrs";
 import { useDelegatedClick } from "@/hooks/useDelegatedClick";
 
 export interface SponsorsAnalyticsProps {
@@ -45,16 +43,13 @@ export function SponsorsAnalytics({ children }: SponsorsAnalyticsProps) {
         return;
       }
 
-      const sponsorId = el.getAttribute("data-sponsor-id");
-      if (!sponsorId) return;
-      const tier = (el.getAttribute("data-sponsor-tier") || undefined) as
-        | SponsorTier
-        | undefined;
+      const sponsor = readSponsorAttrs(el);
+      if (!sponsor) return;
 
       if (el.hasAttribute("data-sponsor-featured")) {
-        trackSponsorFeaturedClick({ sponsorId, tier });
+        trackSponsorFeaturedClick(sponsor);
       } else {
-        trackSponsorClick({ sponsorId, tier });
+        trackSponsorClick(sponsor);
       }
     },
   });

--- a/apps/web/src/hooks/useNavigationAnalytics.test.ts
+++ b/apps/web/src/hooks/useNavigationAnalytics.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@/lib/analytics/track-event", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from "@/lib/analytics/track-event";
+import { useNavigationAnalytics } from "./useNavigationAnalytics";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+describe("useNavigationAnalytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fires nav_link_click with the destination and source", () => {
+    const { result } = renderHook(() => useNavigationAnalytics());
+    act(() =>
+      result.current.trackNavClick({
+        destination: "/kalender",
+        source: "desktop",
+      }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith("nav_link_click", {
+      destination: "/kalender",
+      source: "desktop",
+    });
+  });
+
+  it.each(["desktop", "mobile", "takeover"] as const)(
+    "carries source=%s verbatim",
+    (source) => {
+      const { result } = renderHook(() => useNavigationAnalytics());
+      act(() =>
+        result.current.trackNavClick({ destination: "/jeugd", source }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith("nav_link_click", {
+        destination: "/jeugd",
+        source,
+      });
+    },
+  );
+
+  it("fires footer_link_click with the column under the `category` key", () => {
+    const { result } = renderHook(() => useNavigationAnalytics());
+    act(() =>
+      result.current.trackFooterClick({
+        destination: "/club/vrijwilliger",
+        column: "Aansluiten",
+      }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith("footer_link_click", {
+      destination: "/club/vrijwilliger",
+      category: "Aansluiten",
+    });
+  });
+
+  it("never sends a `column` key — the taxonomy dimension is `category`", () => {
+    const { result } = renderHook(() => useNavigationAnalytics());
+    act(() =>
+      result.current.trackFooterClick({ destination: "/hulp", column: "X" }),
+    );
+    const params = mockTrackEvent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params).not.toHaveProperty("column");
+  });
+
+  it("returns stable callbacks across re-renders", () => {
+    const { result, rerender } = renderHook(() => useNavigationAnalytics());
+    const first = result.current;
+    rerender();
+    expect(result.current.trackNavClick).toBe(first.trackNavClick);
+    expect(result.current.trackFooterClick).toBe(first.trackFooterClick);
+  });
+});

--- a/apps/web/src/hooks/useNavigationAnalytics.ts
+++ b/apps/web/src/hooks/useNavigationAnalytics.ts
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+import { trackEvent } from "@/lib/analytics/track-event";
+
+/**
+ * Which chrome surface a nav click came from. The split is the point of #2419:
+ * the `lg` one-line nav budget that decided #2409 only binds on `desktop`, so a
+ * future restructure needs to know how much traffic that row actually carries
+ * versus the takeover it collapses into.
+ */
+export type NavSource = "desktop" | "mobile" | "takeover";
+
+interface NavClickInput {
+  /** The link's own `href` — a route literal from `menuItems`, never user input. */
+  destination: string;
+  source: NavSource;
+}
+
+interface FooterClickInput {
+  destination: string;
+  /** The column heading, so the footer's intent-based grouping can be judged. */
+  column: string;
+}
+
+/**
+ * Analytics for the global chrome — the nav bar, the mobile takeover and the
+ * footer directory (#2419). Both events carry only route literals and column
+ * headings authored in `menuItems.ts` / `footerLinks.ts`, so there is nothing
+ * to hash or sanitize: no id, no user input, no PII.
+ *
+ * `column` is sent as the existing `category` dataLayer key rather than a new
+ * one — the taxonomy already declares more params than GA4's 50 event-scoped
+ * custom-dimension cap allows, and `event_name = footer_link_click` segments
+ * the column values cleanly from `category`'s other producers.
+ */
+export function useNavigationAnalytics() {
+  const trackNavClick = useCallback(
+    ({ destination, source }: NavClickInput) => {
+      trackEvent("nav_link_click", { destination, source });
+    },
+    [],
+  );
+
+  const trackFooterClick = useCallback(
+    ({ destination, column }: FooterClickInput) => {
+      trackEvent("footer_link_click", { destination, category: column });
+    },
+    [],
+  );
+
+  return { trackNavClick, trackFooterClick };
+}

--- a/apps/web/src/hooks/useSponsorAnalytics.test.ts
+++ b/apps/web/src/hooks/useSponsorAnalytics.test.ts
@@ -49,6 +49,29 @@ describe("useSponsorAnalytics", () => {
     expect(params.sponsor_id).toBe(hashMemberId("raw-secret-id"));
   });
 
+  it("carries source when the tile sat on the homepage", () => {
+    const { result } = renderHook(() => useSponsorAnalytics());
+    act(() =>
+      result.current.trackSponsorClick({
+        sponsorId: "hp-1",
+        tier: "hoofdsponsor",
+        source: "homepage",
+      }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith("sponsor_click", {
+      sponsor_id: hashMemberId("hp-1"),
+      tier: "hoofdsponsor",
+      source: "homepage",
+    });
+  });
+
+  it("omits source on the /sponsors page", () => {
+    const { result } = renderHook(() => useSponsorAnalytics());
+    act(() => result.current.trackSponsorClick({ sponsorId: "sp-1" }));
+    const params = mockTrackEvent.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params).not.toHaveProperty("source");
+  });
+
   it("omits tier when absent", () => {
     const { result } = renderHook(() => useSponsorAnalytics());
     act(() => result.current.trackSponsorClick({ sponsorId: "x" }));

--- a/apps/web/src/hooks/useSponsorAnalytics.ts
+++ b/apps/web/src/hooks/useSponsorAnalytics.ts
@@ -8,6 +8,12 @@ interface SponsorClickInput {
   /** Internal Sanity sponsor id — hashed before it leaves the client. */
   sponsorId: string;
   tier?: SponsorTier;
+  /**
+   * Which surface the tile sat on — `homepage` for `<SponsorsBlock>`, omitted
+   * on `/sponsors` (#2400). Without it the two surfaces are indistinguishable
+   * in GA4 and neither can be judged on its own.
+   */
+  source?: "homepage";
 }
 
 /**
@@ -25,10 +31,11 @@ export function useSponsorAnalytics() {
   }, []);
 
   const trackSponsorClick = useCallback(
-    ({ sponsorId, tier }: SponsorClickInput) => {
+    ({ sponsorId, tier, source }: SponsorClickInput) => {
       trackEvent("sponsor_click", {
         sponsor_id: hashMemberId(sponsorId),
         ...(tier ? { tier } : {}),
+        ...(source ? { source } : {}),
       });
     },
     [],

--- a/apps/web/src/lib/analytics/sponsor-attrs.test.ts
+++ b/apps/web/src/lib/analytics/sponsor-attrs.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { readSponsorAttrs } from "./sponsor-attrs";
+
+function el(attrs: Record<string, string>): HTMLElement {
+  const node = document.createElement("a");
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v);
+  return node;
+}
+
+describe("readSponsorAttrs", () => {
+  it("reads the id and tier", () => {
+    expect(
+      readSponsorAttrs(
+        el({ "data-sponsor-id": "s-1", "data-sponsor-tier": "hoofdsponsor" }),
+      ),
+    ).toEqual({ sponsorId: "s-1", tier: "hoofdsponsor" });
+  });
+
+  it("returns null when there is no sponsor id", () => {
+    expect(readSponsorAttrs(el({ "data-banner-slot": "a" }))).toBeNull();
+  });
+
+  it("returns null on an empty sponsor id rather than an empty-string id", () => {
+    expect(readSponsorAttrs(el({ "data-sponsor-id": "" }))).toBeNull();
+  });
+
+  it("coerces an absent tier to undefined, never an empty string", () => {
+    expect(
+      readSponsorAttrs(el({ "data-sponsor-id": "s-2" }))?.tier,
+    ).toBeUndefined();
+  });
+
+  it("coerces an empty tier attribute to undefined", () => {
+    expect(
+      readSponsorAttrs(
+        el({ "data-sponsor-id": "s-3", "data-sponsor-tier": "" }),
+      )?.tier,
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/analytics/sponsor-attrs.ts
+++ b/apps/web/src/lib/analytics/sponsor-attrs.ts
@@ -1,0 +1,25 @@
+import type { SponsorTier } from "@/hooks/useSponsorAnalytics";
+
+export interface SponsorAttrs {
+  sponsorId: string;
+  tier?: SponsorTier;
+}
+
+/**
+ * Read the inert markers `<SponsorTile>` / `<HoofdSponsorTile>` emit off a
+ * delegated click target, or `null` when the element carries no sponsor id.
+ *
+ * Two surfaces delegate on those tiles — `<SponsorsAnalytics>` for `/sponsors`
+ * and `<HomepageAnalytics>` for the homepage block (#2400) — so the attribute
+ * names and the empty-string coercion live here rather than in both.
+ */
+export function readSponsorAttrs(el: HTMLElement): SponsorAttrs | null {
+  const sponsorId = el.getAttribute("data-sponsor-id");
+  if (!sponsorId) return null;
+  return {
+    sponsorId,
+    tier: (el.getAttribute("data-sponsor-tier") || undefined) as
+      | SponsorTier
+      | undefined,
+  };
+}

--- a/scripts/analytics-taxonomy.mjs
+++ b/scripts/analytics-taxonomy.mjs
@@ -40,6 +40,9 @@ export const prefixes = [
   "clubshop_banner_",
   "kalender_",
   "sponsor_",
+  "banner_",
+  "nav_",
+  "footer_",
   "jeugd_",
   "hub_",
   "board_",
@@ -121,6 +124,16 @@ export const params = [
   // ── Sponsors ────────────────────────────────────────────────────────────
   { parameterName: "sponsor_id", displayName: "Sponsor ID hashed" },
   { parameterName: "tier", displayName: "Sponsor tier" },
+  // ── Global chrome + homepage banners (#2419 / #2400) ────────────────────
+  // No new params: `nav_link_click` / `footer_link_click` reuse `destination`
+  // + `source` + `category` (the footer column), and `banner_impression` /
+  // `banner_click` reuse `position` (the a/b/c slot) + `destination`. GA4 caps
+  // event-scoped custom dimensions at 50 and this list is already past it, so
+  // these families deliberately mint none — `event_name` segments them.
+  // Note `position` is a 1-indexed rank everywhere else (search results, hub
+  // rows); the banner families overload it with the a/b/c slot letter, which
+  // matches the Sanity field names (`bannerSlotA`) an editor would change.
+  // Any report on `position` therefore has to filter by `event_name` first.
   // ── Jeugd nav hub ───────────────────────────────────────────────────────
   { parameterName: "card_type", displayName: "Card type" },
   { parameterName: "tag", displayName: "Card tag" },

--- a/scripts/sync-gtm.mjs
+++ b/scripts/sync-gtm.mjs
@@ -66,7 +66,11 @@
  * container (account owned by kevin.van.ransbeeck@gmail.com — auth as that user):
  *   GTM_ACCOUNT_ID=4702633562
  *   GTM_CONTAINER_ID=247406304
- *   GTM_WORKSPACE_ID=10       (Default Workspace; or a fresh workspace's id)
+ *   GTM_WORKSPACE_ID  OPTIONAL and normally omitted — the script discovers the
+ *                     writable workspace itself. Workspace ids ROTATE (creating
+ *                     a version consumes the workspace and GTM opens a fresh
+ *                     one under a new id), so a pinned value works exactly once
+ *                     and then fails with "Workspace is already submitted".
  *   GTM_TRIGGER_NAME  (default "Custom Event — KCVV Analytics")
  *   GTM_TAG_NAME      (default "GA4 Event — KCVV Custom Events")
  *   GTM_DLV_PREFIX    (default "dlv - ")  — matches the live container convention
@@ -93,14 +97,17 @@ const PUBLISH = process.argv.includes("--publish");
 
 const ACCOUNT_ID = reqEnv("GTM_ACCOUNT_ID");
 const CONTAINER_ID = reqEnv("GTM_CONTAINER_ID");
-const WORKSPACE_ID = reqEnv("GTM_WORKSPACE_ID");
+// Optional — see `resolveWorkspace()`. Pinning it is usually WRONG.
+const WORKSPACE_ID = process.env.GTM_WORKSPACE_ID;
 const TRIGGER_NAME = process.env.GTM_TRIGGER_NAME ?? "Custom Event — KCVV Analytics";
 const TAG_NAME = process.env.GTM_TAG_NAME ?? "GA4 Event — KCVV Custom Events";
 const DLV_PREFIX = process.env.GTM_DLV_PREFIX ?? "dlv - ";
 const WRITE_PACE_MS = Number(process.env.GTM_WRITE_PACE_MS ?? 4000);
 
 const API = "https://tagmanager.googleapis.com/tagmanager/v2";
-const WS = `${API}/accounts/${ACCOUNT_ID}/containers/${CONTAINER_ID}/workspaces/${WORKSPACE_ID}`;
+const CONTAINER = `${API}/accounts/${ACCOUNT_ID}/containers/${CONTAINER_ID}`;
+/** Workspace base URL. Assigned once by `resolveWorkspace()` in `main()`. */
+let WS;
 
 const TOKEN = getToken();
 
@@ -151,7 +158,12 @@ async function api(method, url, body, attempt = 0) {
   const text = await res.text();
   const json = text ? JSON.parse(text) : {};
   if (!res.ok) {
-    throw new Error(`${method} ${url} → ${res.status}: ${json?.error?.message ?? text}`);
+    const err = new Error(`${method} ${url} → ${res.status}: ${json?.error?.message ?? text}`);
+    // Carry the status as data. Sniffing it out of the message is unreliable —
+    // the fingerprint-guarded PUT URL contains the word "fingerprint", so a
+    // text match there flags every failure as a concurrency conflict.
+    err.status = res.status;
+    throw err;
   }
   return json;
 }
@@ -192,7 +204,7 @@ async function updateEntity(path, mutate, label) {
   try {
     return await write("PUT", url, updated);
   } catch (e) {
-    if (String(e.message).includes("409") || /fingerprint/i.test(e.message)) {
+    if (e.status === 409) {
       throw new Error(
         `${label}: changed in GTM while this run was in flight. Nothing was written — re-run the script.`,
       );
@@ -281,7 +293,44 @@ function tagParamRow(name) {
   };
 }
 
+/**
+ * Pick the workspace to write into.
+ *
+ * A workspace id is NOT stable and must not be pinned in a runbook: creating a
+ * version consumes the workspace (it becomes that version, and further writes
+ * fail with `400: Workspace is already submitted`), and GTM opens a fresh
+ * "Default Workspace" under a NEW id. A pinned id therefore works exactly once
+ * — it went stale between #1974 and #2419, where id 10 had become version 10.
+ *
+ * The list endpoint returns only writable workspaces, so anything it hands
+ * back is a valid target. `GTM_WORKSPACE_ID` still overrides, for the rare case
+ * of a deliberately separate workspace.
+ */
+async function resolveWorkspace() {
+  if (WORKSPACE_ID) return `${CONTAINER}/workspaces/${WORKSPACE_ID}`;
+
+  const spaces = (await api("GET", `${CONTAINER}/workspaces`)).workspace ?? [];
+  if (spaces.length === 0) {
+    throw new Error(
+      "No writable workspace in this container. Open GTM and create one, or set GTM_WORKSPACE_ID.",
+    );
+  }
+  const chosen =
+    spaces.find((w) => w.name === "Default Workspace") ??
+    (spaces.length === 1 ? spaces[0] : null);
+  if (!chosen) {
+    throw new Error(
+      `Several workspaces and no "Default Workspace" — set GTM_WORKSPACE_ID to one of: ` +
+        spaces.map((w) => `${w.workspaceId} (${w.name})`).join(", "),
+    );
+  }
+  console.log(`Workspace: ${chosen.workspaceId} (${chosen.name})`);
+  return `${CONTAINER}/workspaces/${chosen.workspaceId}`;
+}
+
 async function main() {
+  WS = await resolveWorkspace();
+
   // ── Load live entities ────────────────────────────────────────────────
   const [variablesList, triggersList, tagsList] = await Promise.all([
     api("GET", `${WS}/variables`),

--- a/scripts/sync-gtm.mjs
+++ b/scripts/sync-gtm.mjs
@@ -102,7 +102,25 @@ const WORKSPACE_ID = process.env.GTM_WORKSPACE_ID;
 const TRIGGER_NAME = process.env.GTM_TRIGGER_NAME ?? "Custom Event — KCVV Analytics";
 const TAG_NAME = process.env.GTM_TAG_NAME ?? "GA4 Event — KCVV Custom Events";
 const DLV_PREFIX = process.env.GTM_DLV_PREFIX ?? "dlv - ";
-const WRITE_PACE_MS = Number(process.env.GTM_WRITE_PACE_MS ?? 4000);
+const WRITE_PACE_MS = positivePace(process.env.GTM_WRITE_PACE_MS, 4000);
+
+/**
+ * Pacing is the script's main defence against the write quota, and a bad value
+ * disables it *silently*: `Number("")` is 0 and `Number("abc")` is NaN, and
+ * both make the `since < WRITE_PACE_MS` comparison false forever. Anything not
+ * a finite positive number falls back to the default, loudly.
+ */
+function positivePace(raw, fallback) {
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.warn(
+      `WARNING: GTM_WRITE_PACE_MS=${JSON.stringify(raw)} is not a positive number; using ${fallback}ms.`,
+    );
+    return fallback;
+  }
+  return n;
+}
 
 const API = "https://tagmanager.googleapis.com/tagmanager/v2";
 const CONTAINER = `${API}/accounts/${ACCOUNT_ID}/containers/${CONTAINER_ID}`;
@@ -180,8 +198,15 @@ function write(method, url, body) {
   writeChain = writeChain.then(async () => {
     const since = Date.now() - lastWriteAt;
     if (lastWriteAt > 0 && since < WRITE_PACE_MS) await sleep(WRITE_PACE_MS - since);
-    lastWriteAt = Date.now();
-    return api(method, url, body);
+    try {
+      return await api(method, url, body);
+    } finally {
+      // Stamp on the way OUT, not in. `api()` may have burned a minute of
+      // retries internally; measuring the next gap from the start of that
+      // would let the following write fire instantly, precisely when the
+      // quota is most stressed. `finally` so a throw still paces the retry.
+      lastWriteAt = Date.now();
+    }
   });
   return writeChain;
 }
@@ -242,6 +267,22 @@ function dlvResource(key) {
 /** The dataLayer key a DLV variable reads (its `name` parameter value). */
 function dlvKey(variable) {
   return variable.parameter?.find((p) => p.key === "name")?.value;
+}
+
+/**
+ * Tokens in a live trigger RegEx that the taxonomy does not know about — a
+ * prefix somebody added in the GTM UI, or one this file dropped. Overwriting
+ * the RegEx would delete them, so both the plan and the write re-check.
+ * Tolerates an anchored/grouped live value (`^(a|b|c)$`).
+ */
+function unknownIn(regexValue) {
+  const canonicalTokens = buildTriggerRegex().split("|");
+  return (regexValue ?? "")
+    .replace(/^\^?\(?/, "")
+    .replace(/\)?\$?$/, "")
+    .split("|")
+    .filter(Boolean)
+    .filter((t) => !canonicalTokens.includes(t));
 }
 
 /** The arg1 (regex) value of a customEvent trigger's matchRegex filter. */
@@ -328,6 +369,18 @@ async function resolveWorkspace() {
   return `${CONTAINER}/workspaces/${chosen.workspaceId}`;
 }
 
+/**
+ * Both `create_version` and `:publish` return `compilerError` alongside a 200,
+ * so success has to be read out of the body rather than the status line.
+ */
+function assertCompiled(response, label) {
+  if (!response?.compilerError) return;
+  throw new Error(
+    `${label} failed to compile. GTM returned compilerError — open the version in the ` +
+      `GTM UI to see which tag/trigger/variable is broken. Nothing further was published.`,
+  );
+}
+
 async function main() {
   WS = await resolveWorkspace();
 
@@ -352,15 +405,8 @@ async function main() {
 
   // ── 1. Trigger regex (abort if live has an unknown token) ─────────────
   const canonical = buildTriggerRegex();
-  const canonicalTokens = canonical.split("|");
   const liveRegex = triggerRegexParam(trigger)?.value ?? "";
-  // Tolerate an anchored/grouped live regex (`^(a|b|c)$`) when token-checking.
-  const liveTokens = liveRegex
-    .replace(/^\^?\(?/, "")
-    .replace(/\)?\$?$/, "")
-    .split("|")
-    .filter(Boolean);
-  const unknownTokens = liveTokens.filter((t) => !canonicalTokens.includes(t));
+  const unknownTokens = unknownIn(liveRegex);
   const regexNeedsUpdate = liveRegex !== canonical;
   if (unknownTokens.length > 0) {
     const msg =
@@ -384,8 +430,15 @@ async function main() {
   const dlvsToCreate = dlvCandidates.filter((k) => !liveVarNames.has(`${DLV_PREFIX}${k}`));
 
   // ── 3. GA4 tag param rows to add (deduped by name) ────────────────────
+  // A row's value is a `{{dlv - <key>}}` reference. For a name-conflicted key
+  // that reference RESOLVES — to the foreign variable holding the name — so
+  // adding the row would quietly feed the GA4 param from the wrong source.
+  // Worse than a missing param; skip until the conflict is resolved by hand.
+  const conflicted = new Set(dlvNameConflicts);
   const liveTagParams = new Set(tagParamNames(tag));
-  const tagRowsToAdd = TAXONOMY_KEY_LIST.filter((k) => !liveTagParams.has(k));
+  const tagRowsToAdd = TAXONOMY_KEY_LIST.filter(
+    (k) => !liveTagParams.has(k) && !conflicted.has(k),
+  );
 
   // ── Orphan report (read-only) ─────────────────────────────────────────
   const orphanDlvs = [...liveDlvByKey.keys()].filter((k) => !TAXONOMY_KEYS.has(k));
@@ -428,6 +481,18 @@ async function main() {
         const param = triggerRegexParam(updated);
         if (param) {
           if (param.value === canonical) return false;
+          // The plan-time abort checked the trigger as it looked at load.
+          // `fingerprint` only covers the window from this re-read to the PUT,
+          // so a UI edit landing before it would be clobbered silently — and
+          // dropping someone's manually-added prefix is exactly the failure
+          // that check exists to prevent. Re-run it against what we just read.
+          const fresh = unknownIn(param.value);
+          if (fresh.length > 0 && !FORCE_REGEX) {
+            throw new Error(
+              `trigger regex gained token(s) absent from the taxonomy since the plan: ${fresh.join(", ")}\n` +
+                `  → add them to scripts/analytics-taxonomy.mjs, or rerun with --force-regex to overwrite.`,
+            );
+          }
           param.value = canonical;
         } else {
           // Live trigger has no matchRegex filter yet — append one, preserving
@@ -498,6 +563,11 @@ async function main() {
   });
   const created = version?.containerVersion;
   const id = created?.containerVersionId ?? "(see GTM UI)";
+  // GTM reports a failed compile in the RESPONSE BODY, not the HTTP status, so
+  // a broken version arrives as a 200. Printing "✓" on it would be a false
+  // success — and since --publish pushes it live, a loud failure here is the
+  // only thing between a compile error and production.
+  assertCompiled(version, `container version ${id}`);
 
   if (!PUBLISH) {
     console.log(`\n✓ Created UNPUBLISHED container version ${id}. Review + publish it in the GTM UI.`);
@@ -507,7 +577,8 @@ async function main() {
   if (!created?.path) {
     throw new Error(`Version ${id} created, but no path came back — publish it in the GTM UI.`);
   }
-  await write("POST", `${API}/${created.path}:publish`);
+  const published = await write("POST", `${API}/${created.path}:publish`);
+  assertCompiled(published, `publish of container version ${id}`);
   console.log(`\n✓ Created AND PUBLISHED container version ${id}. Events reach GA4 from now on.`);
   console.log(`  Roll back by re-publishing the previous version in the GTM UI.`);
 }

--- a/scripts/sync-gtm.mjs
+++ b/scripts/sync-gtm.mjs
@@ -14,12 +14,27 @@
  *               exit WITHOUT writing anything.
  *   --dump      Read-only: print the live trigger, GA4 tag, and DLVs as JSON,
  *               so the exact resource shapes can be confirmed. No writes.
+ *   --publish   Publish the version it creates, instead of leaving it for a
+ *               manual review + publish in the GTM UI. Reversible: GTM keeps
+ *               every version, and re-publishing the previous one rolls back.
  *   Abort       A real run aborts (non-zero) if the live trigger RegEx contains a
  *               token NOT in the taxonomy, instead of dropping it. --dry-run only
  *               warns. --force-regex overwrites the RegEx with the canonical one
  *               (use once the orphan tokens are confirmed stale).
  *   Orphans     Live DLV keys / tag param rows / regex tokens the taxonomy no
  *               longer contains are PRINTED (read-only) and never auto-deleted.
+ *
+ * UNATTENDED WRITES — GTM v2's write quota is low and bursty callers get 429s,
+ * so every mutating call goes through one serialized, paced queue (see
+ * `write()`): a fixed gap between writes, then exponential backoff on top for
+ * whatever still bounces. A full sync is therefore SLOW by design — minutes,
+ * not seconds — and that is the trade for a run that finishes on its own.
+ *
+ * There is no bulk-create endpoint for variables in GTM API v2, so DLVs cost
+ * one request each; "batching" here means paced + resumable, not fewer calls.
+ * The run is idempotent: it re-reads live state before planning AND again
+ * before the create loop, so an interrupted run can simply be re-run and picks
+ * up whatever is still missing without ever duplicating.
  *
  * AUTH — Google blocks gcloud's built-in OAuth client from requesting these
  * sensitive scopes for ADC. Use a user-owned OAuth client (one-time):
@@ -29,7 +44,14 @@
  *   4. gcloud auth application-default login \
  *        --client-id-file=<that>.json \
  *        --scopes=https://www.googleapis.com/auth/tagmanager.edit.containers,\
- *                 https://www.googleapis.com/auth/tagmanager.edit.containerversions
+ *                 https://www.googleapis.com/auth/tagmanager.edit.containerversions,\
+ *                 https://www.googleapis.com/auth/tagmanager.publish
+ *
+ * The third scope is needed ONLY for --publish; the first two cover a normal
+ * run. While the consent screen is in "Testing" status Google expires the
+ * refresh token after 7 days, so step 4 has to be repeated periodically — a
+ * `invalid_grant: Bad Request` from `print-access-token` is that expiry, not a
+ * broken setup.
  *
  * ENV (required unless noted) — live values for the KCVV `GTM-P36Q8LHM`
  * container (account owned by kevin.van.ransbeeck@gmail.com — auth as that user):
@@ -39,11 +61,14 @@
  *   GTM_TRIGGER_NAME  (default "Custom Event — KCVV Analytics")
  *   GTM_TAG_NAME      (default "GA4 Event — KCVV Custom Events")
  *   GTM_DLV_PREFIX    (default "dlv - ")  — matches the live container convention
+ *   GTM_WRITE_PACE_MS (default 4000) — minimum gap between two write calls.
+ *                     Raise it if 429s still show up; the run just takes longer.
  *
  * Usage:
  *   node scripts/sync-gtm.mjs --dump
  *   node scripts/sync-gtm.mjs --dry-run
- *   node scripts/sync-gtm.mjs            # writes to the workspace + creates a version
+ *   node scripts/sync-gtm.mjs            # writes + creates an UNPUBLISHED version
+ *   node scripts/sync-gtm.mjs --publish  # writes + creates + publishes it
  */
 
 import { execSync } from "child_process";
@@ -54,6 +79,8 @@ const DUMP = process.argv.includes("--dump");
 // Overwrite the live trigger RegEx even if it carries tokens absent from the
 // taxonomy (e.g. stale/superseded ones). Without it, a real run aborts on those.
 const FORCE_REGEX = process.argv.includes("--force-regex");
+// Publish the created version too, so a run needs no follow-up in the GTM UI.
+const PUBLISH = process.argv.includes("--publish");
 
 const ACCOUNT_ID = reqEnv("GTM_ACCOUNT_ID");
 const CONTAINER_ID = reqEnv("GTM_CONTAINER_ID");
@@ -61,6 +88,7 @@ const WORKSPACE_ID = reqEnv("GTM_WORKSPACE_ID");
 const TRIGGER_NAME = process.env.GTM_TRIGGER_NAME ?? "Custom Event — KCVV Analytics";
 const TAG_NAME = process.env.GTM_TAG_NAME ?? "GA4 Event — KCVV Custom Events";
 const DLV_PREFIX = process.env.GTM_DLV_PREFIX ?? "dlv - ";
+const WRITE_PACE_MS = Number(process.env.GTM_WRITE_PACE_MS ?? 4000);
 
 const API = "https://tagmanager.googleapis.com/tagmanager/v2";
 const WS = `${API}/accounts/${ACCOUNT_ID}/containers/${CONTAINER_ID}/workspaces/${WORKSPACE_ID}`;
@@ -102,9 +130,11 @@ async function api(method, url, body, attempt = 0) {
     signal: AbortSignal.timeout(30_000),
   });
   // GTM API v2 has a low per-minute write quota; back off + retry on 429/5xx.
-  if ((res.status === 429 || res.status >= 500) && attempt < 6) {
+  // Writes are already paced by `write()`, so a 429 here means the quota is
+  // tighter than GTM_WRITE_PACE_MS assumes — wait it out rather than give up.
+  if ((res.status === 429 || res.status >= 500) && attempt < 8) {
     const retryAfter = Number(res.headers.get("retry-after"));
-    const waitMs = retryAfter > 0 ? retryAfter * 1000 : Math.min(2000 * 2 ** attempt, 30000);
+    const waitMs = retryAfter > 0 ? retryAfter * 1000 : Math.min(2000 * 2 ** attempt, 60000);
     console.warn(`  …${res.status} on ${method} ${url.split("/").pop()}; retrying in ${Math.round(waitMs / 1000)}s`);
     await sleep(waitMs);
     return api(method, url, body, attempt + 1);
@@ -117,13 +147,63 @@ async function api(method, url, body, attempt = 0) {
   return json;
 }
 
+/**
+ * Every mutating call goes through here: one at a time, never closer together
+ * than GTM_WRITE_PACE_MS. Serialising on a single promise chain keeps the gap
+ * honest even though callers `await` in a loop, and means a burst can never
+ * form in the first place — `api()`'s backoff is then only a safety net.
+ */
+let writeChain = Promise.resolve();
+let lastWriteAt = 0;
+function write(method, url, body) {
+  writeChain = writeChain.then(async () => {
+    const since = Date.now() - lastWriteAt;
+    if (lastWriteAt > 0 && since < WRITE_PACE_MS) await sleep(WRITE_PACE_MS - since);
+    lastWriteAt = Date.now();
+    return api(method, url, body);
+  });
+  return writeChain;
+}
+
+/**
+ * Re-read an entity by path, then PUT it with GTM's optimistic-concurrency
+ * `fingerprint`. Two things this buys over PUTting the copy fetched at plan
+ * time: the mutation applies to whatever the entity looks like NOW (a paced
+ * run can spend minutes between planning and writing), and a concurrent edit
+ * in the GTM UI makes the write fail loudly instead of silently reverting it.
+ */
+async function updateEntity(path, mutate, label) {
+  const fresh = await api("GET", `${API}/${path}`);
+  const updated = structuredClone(fresh);
+  if (mutate(updated) === false) {
+    console.log(`• ${label}: already up to date on re-read; skipped`);
+    return null;
+  }
+  const url = `${API}/${path}?fingerprint=${encodeURIComponent(fresh.fingerprint ?? "")}`;
+  try {
+    return await write("PUT", url, updated);
+  } catch (e) {
+    if (String(e.message).includes("409") || /fingerprint/i.test(e.message)) {
+      throw new Error(
+        `${label}: changed in GTM while this run was in flight. Nothing was written — re-run the script.`,
+      );
+    }
+    throw e;
+  }
+}
+
 /** Find the entity named `name` in a `GET list` response keyed by `key`. */
 function findByName(list, key, name) {
   return (list[key] ?? []).find((e) => e.name === name);
 }
 
-/** The taxonomy's full set of dataLayer keys (== GA4 param names). */
+/**
+ * The taxonomy's dataLayer keys (== GA4 param names), deduped. The Set is what
+ * every plan is built from, so a key listed twice in the taxonomy (easy to do
+ * when a param serves two event families) can never become two DLVs.
+ */
 const TAXONOMY_KEYS = new Set(params.map((p) => p.parameterName));
+const TAXONOMY_KEY_LIST = [...TAXONOMY_KEYS];
 
 /** DLV resource for a dataLayer key. The key lives in the `name` parameter. */
 function dlvResource(key) {
@@ -164,6 +244,24 @@ function tagParamNames(tag) {
     .filter(Boolean);
 }
 
+/**
+ * Index a live variables list two ways: DLVs by the dataLayer key they read
+ * (how we decide a key is already covered) and ALL variable names (how we
+ * avoid POSTing a name the container already uses for something else).
+ */
+function indexVariables(variablesList) {
+  const byKey = new Map();
+  const names = new Set();
+  for (const v of variablesList.variable ?? []) {
+    if (v.name) names.add(v.name);
+    if (v.type === "v") {
+      const key = dlvKey(v);
+      if (key) byKey.set(key, v);
+    }
+  }
+  return { byKey, names };
+}
+
 function tagParamRow(name) {
   return {
     type: "map",
@@ -192,13 +290,7 @@ async function main() {
     return;
   }
 
-  const liveDlvByKey = new Map();
-  for (const v of variablesList.variable ?? []) {
-    if (v.type === "v") {
-      const key = dlvKey(v);
-      if (key) liveDlvByKey.set(key, v);
-    }
-  }
+  const { byKey: liveDlvByKey, names: liveVarNames } = indexVariables(variablesList);
 
   // ── 1. Trigger regex (abort if live has an unknown token) ─────────────
   const canonical = buildTriggerRegex();
@@ -226,11 +318,16 @@ async function main() {
   }
 
   // ── 2. DLVs to create (deduped by dataLayer key) ──────────────────────
-  const dlvsToCreate = params.map((p) => p.parameterName).filter((k) => !liveDlvByKey.has(k));
+  const dlvCandidates = TAXONOMY_KEY_LIST.filter((k) => !liveDlvByKey.has(k));
+  // A variable already holding the target NAME but reading a different key is
+  // not ours to overwrite, and POSTing it again would either 409 or leave two
+  // same-named variables. Report it and let a human decide.
+  const dlvNameConflicts = dlvCandidates.filter((k) => liveVarNames.has(`${DLV_PREFIX}${k}`));
+  const dlvsToCreate = dlvCandidates.filter((k) => !liveVarNames.has(`${DLV_PREFIX}${k}`));
 
   // ── 3. GA4 tag param rows to add (deduped by name) ────────────────────
   const liveTagParams = new Set(tagParamNames(tag));
-  const tagRowsToAdd = params.map((p) => p.parameterName).filter((k) => !liveTagParams.has(k));
+  const tagRowsToAdd = TAXONOMY_KEY_LIST.filter((k) => !liveTagParams.has(k));
 
   // ── Orphan report (read-only) ─────────────────────────────────────────
   const orphanDlvs = [...liveDlvByKey.keys()].filter((k) => !TAXONOMY_KEYS.has(k));
@@ -244,7 +341,17 @@ async function main() {
     console.log(`  canonical: ${canonical}`);
   }
   console.log(`DLVs to create (${dlvsToCreate.length}): ${dlvsToCreate.join(", ") || "—"}`);
+  if (dlvNameConflicts.length > 0) {
+    console.log(
+      `  ! name already taken by a non-DLV / mismatched variable (${dlvNameConflicts.length}), skipped: ${dlvNameConflicts.join(", ")}`,
+    );
+  }
   console.log(`GA4 tag param rows to add (${tagRowsToAdd.length}): ${tagRowsToAdd.join(", ") || "—"}`);
+  const writeCount =
+    (regexNeedsUpdate ? 1 : 0) + dlvsToCreate.length + (tagRowsToAdd.length > 0 ? 1 : 0) + 1;
+  console.log(
+    `Writes: ${writeCount}, paced ${WRITE_PACE_MS}ms apart → ~${Math.ceil((writeCount * WRITE_PACE_MS) / 1000)}s minimum.`,
+  );
   console.log("── Orphan report (read-only; nothing deleted) ─────");
   console.log(`  regex tokens not in taxonomy (${unknownTokens.length}): ${unknownTokens.join(", ") || "—"}`);
   console.log(`  DLV keys not in taxonomy (${orphanDlvs.length}): ${orphanDlvs.join(", ") || "—"}`);
@@ -257,52 +364,94 @@ async function main() {
 
   // ── Apply ───────────────────────────────────────────────────────────────
   if (regexNeedsUpdate) {
-    const updated = structuredClone(trigger);
-    const param = triggerRegexParam(updated);
-    if (param) {
-      param.value = canonical;
-    } else {
-      // Live trigger has no matchRegex filter yet — append one, preserving any
-      // other existing filter conditions on the trigger.
-      updated.customEventFilter = [
-        ...(updated.customEventFilter ?? []),
-        {
-          type: "matchRegex",
-          parameter: [
-            { type: "template", key: "arg0", value: "{{_event}}" },
-            { type: "template", key: "arg1", value: canonical },
-          ],
-        },
-      ];
-    }
-    await api("PUT", `${API}/${trigger.path}`, updated);
+    await updateEntity(
+      trigger.path,
+      (updated) => {
+        const param = triggerRegexParam(updated);
+        if (param) {
+          if (param.value === canonical) return false;
+          param.value = canonical;
+        } else {
+          // Live trigger has no matchRegex filter yet — append one, preserving
+          // any other existing filter conditions on the trigger.
+          updated.customEventFilter = [
+            ...(updated.customEventFilter ?? []),
+            {
+              type: "matchRegex",
+              parameter: [
+                { type: "template", key: "arg0", value: "{{_event}}" },
+                { type: "template", key: "arg1", value: canonical },
+              ],
+            },
+          ];
+        }
+      },
+      "trigger regex",
+    );
     console.log(`✓ trigger regex updated`);
   }
 
-  for (const key of dlvsToCreate) {
-    await api("POST", `${WS}/variables`, dlvResource(key));
-    console.log(`✓ DLV created: ${DLV_PREFIX}${key}`);
+  // Re-read the variables right before creating any. Cheap insurance for two
+  // cases: a trigger write above that spent minutes in backoff, and a re-run of
+  // an interrupted sync, which must see the DLVs the previous attempt already
+  // created rather than duplicate them.
+  if (dlvsToCreate.length > 0) {
+    const { byKey: freshDlvByKey, names: freshNames } = indexVariables(
+      await api("GET", `${WS}/variables`),
+    );
+    for (const key of dlvsToCreate) {
+      if (freshDlvByKey.has(key)) {
+        console.log(`• DLV already present, skipped: ${DLV_PREFIX}${key}`);
+        continue;
+      }
+      if (freshNames.has(`${DLV_PREFIX}${key}`)) {
+        console.log(`! name taken by another variable, skipped: ${DLV_PREFIX}${key}`);
+        continue;
+      }
+      await write("POST", `${WS}/variables`, dlvResource(key));
+      console.log(`✓ DLV created: ${DLV_PREFIX}${key}`);
+    }
   }
 
   if (tagRowsToAdd.length > 0) {
-    const updated = structuredClone(tag);
-    let list = tagParamList(updated);
-    if (!list) {
-      list = { type: "list", key: "eventSettingsTable", list: [] };
-      updated.parameter = [...(updated.parameter ?? []), list];
-    }
-    list.list = [...(list.list ?? []), ...tagRowsToAdd.map(tagParamRow)];
-    await api("PUT", `${API}/${tag.path}`, updated);
+    await updateEntity(
+      tag.path,
+      (updated) => {
+        // Re-dedupe against the freshly-read tag, not the planned snapshot.
+        const present = new Set(tagParamNames(updated));
+        const rows = tagRowsToAdd.filter((k) => !present.has(k));
+        if (rows.length === 0) return false;
+        let list = tagParamList(updated);
+        if (!list) {
+          list = { type: "list", key: "eventSettingsTable", list: [] };
+          updated.parameter = [...(updated.parameter ?? []), list];
+        }
+        list.list = [...(list.list ?? []), ...rows.map(tagParamRow)];
+      },
+      "GA4 tag param rows",
+    );
     console.log(`✓ GA4 tag param rows added: ${tagRowsToAdd.length}`);
   }
 
-  // ── Unpublished version for owner review ────────────────────────────────
-  const version = await api("POST", `${WS}:create_version`, {
+  // ── Container version ───────────────────────────────────────────────────
+  const version = await write("POST", `${WS}:create_version`, {
     name: "KCVV analytics taxonomy sync",
-    notes: "Automated by scripts/sync-gtm.mjs (#1974). Review the diff and publish.",
+    notes: `Automated by scripts/sync-gtm.mjs (#1974). Trigger RegEx: ${canonical}`,
   });
-  const id = version?.containerVersion?.containerVersionId ?? "(see GTM UI)";
-  console.log(`\n✓ Created UNPUBLISHED container version ${id}. Review + publish it in the GTM UI.`);
+  const created = version?.containerVersion;
+  const id = created?.containerVersionId ?? "(see GTM UI)";
+
+  if (!PUBLISH) {
+    console.log(`\n✓ Created UNPUBLISHED container version ${id}. Review + publish it in the GTM UI.`);
+    return;
+  }
+
+  if (!created?.path) {
+    throw new Error(`Version ${id} created, but no path came back — publish it in the GTM UI.`);
+  }
+  await write("POST", `${API}/${created.path}:publish`);
+  console.log(`\n✓ Created AND PUBLISHED container version ${id}. Events reach GA4 from now on.`);
+  console.log(`  Roll back by re-publishing the previous version in the GTM UI.`);
 }
 
 main().catch((e) => {

--- a/scripts/sync-gtm.mjs
+++ b/scripts/sync-gtm.mjs
@@ -41,15 +41,24 @@
  *   1. GCP Console → enable "Tag Manager API" (+ "Google Analytics Admin API").
  *   2. OAuth consent screen → add yourself as a Test user.
  *   3. Credentials → create an OAuth client ID, type "Desktop app", download JSON.
- *   4. gcloud auth application-default login \
- *        --client-id-file=<that>.json \
- *        --scopes=https://www.googleapis.com/auth/tagmanager.edit.containers,\
- *                 https://www.googleapis.com/auth/tagmanager.edit.containerversions,\
- *                 https://www.googleapis.com/auth/tagmanager.publish
+ *   4. gcloud auth application-default login --client-id-file=<that>.json \
+ *        --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/tagmanager.edit.containers,https://www.googleapis.com/auth/tagmanager.edit.containerversions,https://www.googleapis.com/auth/tagmanager.publish
  *
- * The third scope is needed ONLY for --publish; the first two cover a normal
- * run. While the consent screen is in "Testing" status Google expires the
- * refresh token after 7 days, so step 4 has to be repeated periodically — a
+ * Three gotchas on step 4, each of which fails in a way that does NOT name the
+ * real cause:
+ *   - `cloud-platform` is MANDATORY. gcloud rejects any ADC `--scopes` list
+ *     without it ("cloud-platform scope is required but not requested").
+ *   - Keep `--scopes` on the SAME line as the rest, or put the `\` at the very
+ *     end of a line. A `\` followed by a space mid-line escapes that space
+ *     instead of continuing the line, so gcloud never sees the flag and
+ *     silently falls back to its DEFAULT ADC scopes — which include
+ *     `sqlservice.login` and blow up with "Some requested scopes were
+ *     invalid". That error is a symptom of the typo, not of a bad scope list.
+ *   - `tagmanager.publish` is needed ONLY for --publish; the two edit scopes
+ *     cover a normal run.
+ *
+ * While the consent screen is in "Testing" status Google expires the refresh
+ * token after 7 days, so step 4 has to be repeated periodically — an
  * `invalid_grant: Bad Request` from `print-access-token` is that expiry, not a
  * broken setup.
  *


### PR DESCRIPTION
Closes #2419
Closes #2400

The two issues are the chrome half and the homepage half of one omission, and both edit `scripts/analytics-taxonomy.mjs` and need a single `sync-gtm.mjs` run — splitting them would mean two conflicting taxonomy edits and two GTM container versions.

## Events

| Surface | Event | Params |
| --- | --- | --- |
| Nav link (bar, mobile bar, takeover) | `nav_link_click` | `destination`, `source` = `desktop` \| `mobile` \| `takeover` |
| Footer directory link | `footer_link_click` | `destination`, `category` = column heading |
| Homepage sponsors block | `sponsor_impression` / `sponsor_click` | `sponsor_id` (hashed), `tier`, `source` = `homepage` |
| Homepage banner slots | `banner_impression` / `banner_click` | `position` = `a` \| `b` \| `c`, `destination` |

**No new GA4 dimensions.** The taxonomy already declares 62 params against GA4's 50 event-scoped custom-dimension cap, so these families reuse `destination` / `source` / `category` / `position` and are segmented by `event_name`. Three new prefixes only: `nav_`, `footer_`, `banner_`.

## Delegation

One native listener per surface reads inert `data-*` markers, so `SiteFooter`, `SponsorsBlock` and `BannerSlot` all stay Server Components and no link grows an `onClick`.

- Destinations come off the anchors' own `href` rather than a duplicated `data-*-dest` attribute — a new nav or footer entry never repeats its route.
- `FooterAnalytics` *renders* the directory grid `<div>` rather than wrapping one, so delegation costs zero extra DOM nodes.
- Impressions use the existing `<TrackInView>` rather than mount-time events — the sponsors block sits near the bottom of the spine, where mount ≠ seen.

**One deliberate exception to the delegation AC:** the `NavTakeover` rows use their existing `onNavigate` callback instead. The panel is a JSX sibling of `<header>` (so the header's listener can't reach it) *and* unmounts entirely when closed, while `useDelegatedClick` subscribes once on `[ref, selector]`. Giving it delegation would mean a persistently-mounted wrapper plus a second mechanism, to protect server rendering the panel doesn't have — every row already owns an `onNavigate` for the drawer close. Flagging it explicitly rather than burying it.

## `sync-gtm.mjs` — now runs unattended

Previously a real run fired writes in a bare loop and leaned on 429 backoff to clean up after itself, then left a version to publish by hand.

- **Paced writes.** All mutations go through one serialized queue, `GTM_WRITE_PACE_MS` apart (default 4s), so the low write quota is never tripped in the first place. The existing backoff stays as a safety net (now 8 attempts, 60s ceiling). A run is *slow by design* — the plan prints its own ETA.
- **Fresh reads before every write.** Because a paced run takes minutes, `updateEntity()` re-reads each entity and PUTs with GTM's `fingerprint`, so a concurrent GTM UI edit fails loudly instead of being silently reverted. The DLV loop re-reads too.
- **Self-dedup.** The plan is built from a de-duplicated key set, and a DLV whose target *name* is already taken by a different variable is reported and skipped rather than creating a duplicate. An interrupted run can simply be re-run.
- **`--publish`** finishes the job instead of leaving a version to click through. Documented as reversible (re-publish the previous version).
- Header now documents the `tagmanager.publish` scope `--publish` needs, and that a `invalid_grant` is the 7-day Testing-status token expiry rather than a broken setup.

There is no bulk-create endpoint for GTM variables in API v2, so "batched" here means paced + resumable, not fewer calls — stated in the script header rather than implied.

## Testing

- `pnpm --filter @kcvv/web check-all` — green (304 files, 3538 tests, exit 0)
- New unit tests: `useNavigationAnalytics`, `FooterAnalytics`, `HomepageAnalytics`, `sponsor-attrs`, plus `source` cases on `useSponsorAnalytics`
- Privacy assertions encode the policy, not the wire format (`hashMemberId(id)`, never the raw id)

## Review gate

`/simplify` ran — applied: destinations read from `href` instead of duplicated `data-*-dest` attributes; sponsor-attribute extraction extracted to a shared `readSponsorAttrs` used by both `SponsorsAnalytics` and `HomepageAnalytics`; three comment-accuracy fixes. Skipped: eliminating the first `updateEntity` re-read as redundant (saves ~300ms on a multi-minute paced run at the cost of a conditional in the freshness guarantee), and merging the three delegated-click wrappers (the generalizable part is already the hook; what remains is domain branching).

`/code-review` has not run — it is reserved for explicit user invocation in this environment.

## Not done here

The GTM container has **not** been synced: the ADC refresh token has expired (`invalid_grant`), and re-auth is an interactive browser consent. **Events do not reach GA4 until `node scripts/sync-gtm.mjs --publish` runs against a live token.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added analytics tracking for homepage banner views and clicks, including placement and destination.
  - Added sponsor impression and homepage sponsor-click tracking.
  - Added navigation and footer-link tracking across desktop, mobile, takeover, and footer sections.
  - Added optional publishing support for analytics configuration.

- **Improvements**
  - Standardized sponsor metadata and analytics event naming.
  - Improved tracking for nested links and supported navigation interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->