### PR TITLE
fix(matches): keep Reserven out of the homepage first-teams block

### DIFF
--- a/apps/web/src/components/home/FirstTeamsBlock/first-teams.test.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/first-teams.test.ts
@@ -6,8 +6,10 @@ import {
   deriveFirstTeamVM,
   firstTeamLabel,
   firstTeamsHeading,
+  selectSeniorTeams,
   SETTLED_LOOKAHEAD_MS,
 } from "./first-teams";
+import { RESERVEN_PSD_ID } from "@/lib/utils/group-teams";
 
 describe("firstTeamLabel", () => {
   it("maps trailing-letter first-eleven slugs to X-ploeg", () => {
@@ -23,6 +25,22 @@ describe("firstTeamLabel", () => {
     expect(firstTeamLabel("fc-weitse-gans", "FC WEITSE GANS")).toBe(
       "FC WEITSE GANS",
     );
+  });
+});
+
+describe("selectSeniorTeams", () => {
+  const A = { psdId: "1235", age: "A", slug: "eerste-elftallen-a" };
+  const B = { psdId: "1236", age: "A", slug: "eerste-elftallen-b" };
+  // Reserven's Sanity `age` is "A", the same senior code the first teams carry.
+  const RESERVEN = { psdId: RESERVEN_PSD_ID, age: "A", slug: "reserven" };
+  const U15 = { psdId: "222", age: "U15", slug: "u15" };
+
+  it("keeps only A and B, in that order", () => {
+    expect(selectSeniorTeams([B, U15, RESERVEN, A])).toEqual([A, B]);
+  });
+
+  it("drops Reserven even though its age is a senior code", () => {
+    expect(selectSeniorTeams([RESERVEN])).toEqual([]);
   });
 });
 

--- a/apps/web/src/components/home/FirstTeamsBlock/first-teams.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/first-teams.ts
@@ -28,6 +28,7 @@ import type { Match } from "@/lib/effect/schemas";
 import type { ScheduleMatch } from "@/components/match/types";
 import { transformMatchToSchedule } from "@/components/match/transform";
 import { hasScore, isSettledMatch } from "@/lib/utils/match-display";
+import { RESERVEN_PSD_ID } from "@/lib/utils/group-teams";
 
 export interface FirstTeamInput {
   /** Display label, e.g. "A-ploeg". */
@@ -64,16 +65,27 @@ export interface SeniorTeamCandidate {
 }
 
 /**
- * Senior (non-youth) teams that carry a `psdId`, sorted by slug so
+ * First teams (A/B) that carry a `psdId`, sorted by slug so
  * `eerste-elftallen-a` precedes `-b`. Shared by the homepage's
  * `<FirstTeamsBlock>` wiring and the landing strip's first-team lookup — the
  * two used to hold identical copies of this filter and could drift apart.
+ *
+ * Youth teams drop out on their `U*` age; Reserven needs a test of its own
+ * because its Sanity `age` is the senior code "A", so the age filter passes it
+ * through. It only surfaced here once #2414 flipped its `showInNavigation` on
+ * and the teams query stopped dropping it upstream. `groupTeamsForLanding`
+ * keeps it out of `/ploegen`'s A/B slots the same way, on the name suffix.
  */
 export function selectSeniorTeams<T extends SeniorTeamCandidate>(
   teams: readonly T[],
 ): T[] {
   return teams
-    .filter((t) => t.psdId && !(t.age ?? "").toUpperCase().startsWith("U"))
+    .filter(
+      (t) =>
+        t.psdId &&
+        t.psdId !== RESERVEN_PSD_ID &&
+        !(t.age ?? "").toUpperCase().startsWith("U"),
+    )
     .sort((a, b) => a.slug.localeCompare(b.slug));
 }
 


### PR DESCRIPTION
## What

The homepage "Eerste ploegen" block started rendering a third row, **Reserven**, alongside A-ploeg and B-ploeg. It should only ever show the two first teams.

## Why it happened

`selectSeniorTeams` admitted any team that carries a `psdId` and whose `age` is not a `U*` code. Reserven's Sanity `age` is `"A"` — the same senior code the first teams carry — so the age filter never excluded it. Nothing else did either: it was invisible only because its `showInNavigation` was off, which kept it out of the teams query entirely. #2414 flipped that flag on to give Reserven its own group on `/ploegen` and in the nav, and the homepage block inherited it as a side effect.

## Fix

Exclude it on `RESERVEN_PSD_ID` — the same handle `groupTeamsForLanding` already uses to give Reserven its own group rather than an A/B slot.

```ts
.filter(
  (t) =>
    t.psdId &&
    t.psdId !== RESERVEN_PSD_ID &&
    !(t.age ?? "").toUpperCase().startsWith("U"),
)
```

`selectSeniorTeams` is shared with `pickFirstTeamPsdId` (the landing `<MatchStrip>`), which takes `[0]` of the slug-sorted list — `eerste-elftallen-a` already sorted ahead of `reserven`, so the strip is unaffected.

**Knock-on, and intended:** the homepage agenda below de-dupes against whatever the first-teams block claims (`seniorPsdIds`). With Reserven out of the block, its fixtures now appear in "Komende wedstrijden" with the other non-A/B teams.

## Tests

Two cases on `selectSeniorTeams` in `first-teams.test.ts` — both verified failing against the old predicate. Ran the home / server / app / group-teams surface: 497 tests pass, `tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
