### PR TITLE
fix(studio): normalise article tag casing onto one spelling per tag

### DIFF
--- a/apps/studio-staging/migrations/normalize-article-tag-casing/index.ts
+++ b/apps/studio-staging/migrations/normalize-article-tag-casing/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Staging counterpart to `apps/studio/migrations/normalize-article-tag-casing/`.
+ *
+ * See that file for the full contract — both migrations share the same
+ * source in `@kcvv/sanity-studio/migrations`.
+ *
+ * Dry-run first:
+ *   npx sanity@latest migration run normalize-article-tag-casing --project vhb33jaz --dataset staging --dry-run
+ *
+ * Apply:
+ *   npx sanity@latest migration run normalize-article-tag-casing --project vhb33jaz --dataset staging
+ *   npx sanity@latest migration run normalize-article-tag-casing --project vhb33jaz --dataset production
+ */
+import {normalizeArticleTagCasingMigration} from '@kcvv/sanity-studio/migrations'
+
+export default normalizeArticleTagCasingMigration

--- a/apps/studio/migrations/normalize-article-tag-casing/index.ts
+++ b/apps/studio/migrations/normalize-article-tag-casing/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Collapse case-variant article tags onto one canonical spelling.
+ *
+ * Production held `A-Ploeg` (76 articles) alongside `A-ploeg` (1). GROQ `in` is
+ * case-sensitive, so that one article was invisible to every correctly-cased
+ * filter. See `@kcvv/sanity-studio/migrations` for the full contract.
+ *
+ * Dry-run first:
+ *   npx sanity@latest migration run normalize-article-tag-casing --project vhb33jaz --dataset staging --dry-run
+ *
+ * Apply:
+ *   npx sanity@latest migration run normalize-article-tag-casing --project vhb33jaz --dataset staging
+ *   npx sanity@latest migration run normalize-article-tag-casing --project vhb33jaz --dataset production
+ */
+import {normalizeArticleTagCasingMigration} from '@kcvv/sanity-studio/migrations'
+
+export default normalizeArticleTagCasingMigration

--- a/packages/sanity-studio/src/migrations/index.ts
+++ b/packages/sanity-studio/src/migrations/index.ts
@@ -69,3 +69,11 @@ export {
   PSD_PLACEHOLDER_ASSET_REF,
 } from './unset-player-placeholder-psd-image'
 export type {PlayerWithPsdImageDoc as UnsetPlayerPlaceholderPsdImageDoc} from './unset-player-placeholder-psd-image'
+
+export {
+  default as normalizeArticleTagCasingMigration,
+  migrateNormalizeArticleTagCasing,
+  canonicaliseTags,
+  CANONICAL_TAGS,
+} from './normalize-article-tag-casing'
+export type {TaggedArticleDoc as NormalizeArticleTagCasingDoc} from './normalize-article-tag-casing'

--- a/packages/sanity-studio/src/migrations/normalize-article-tag-casing.test.ts
+++ b/packages/sanity-studio/src/migrations/normalize-article-tag-casing.test.ts
@@ -1,0 +1,103 @@
+import {at, set} from 'sanity/migrate'
+import {describe, expect, it} from 'vitest'
+import {
+  CANONICAL_TAGS,
+  canonicaliseTags,
+  migrateNormalizeArticleTagCasing,
+  type TaggedArticleDoc,
+} from './normalize-article-tag-casing'
+
+describe('canonicaliseTags', () => {
+  it('rewrites the production collision A-ploeg → A-Ploeg', () => {
+    expect(canonicaliseTags(['A-ploeg'])).toEqual(['A-Ploeg'])
+  })
+
+  it('returns null when every tag is already canonical', () => {
+    expect(canonicaliseTags(['A-Ploeg', 'Jeugd'])).toBeNull()
+  })
+
+  it('collapses a doc carrying both casings into one entry', () => {
+    expect(canonicaliseTags(['A-Ploeg', 'A-ploeg'])).toEqual(['A-Ploeg'])
+  })
+
+  it('preserves the original order of untouched tags', () => {
+    expect(canonicaliseTags(['Jeugd', 'a-ploeg', 'Sponsor'])).toEqual([
+      'Jeugd',
+      'A-Ploeg',
+      'Sponsor',
+    ])
+  })
+
+  it('catches casing variants that do not exist in production yet', () => {
+    expect(canonicaliseTags(['A-PLOEG', 'jeugd'])).toEqual(['A-Ploeg', 'Jeugd'])
+  })
+
+  it('capitalises B-ploeg → B-Ploeg to match A-Ploeg (club decision)', () => {
+    expect(canonicaliseTags(['B-ploeg'])).toEqual(['B-Ploeg'])
+  })
+
+  it('normalises both team tags in one pass', () => {
+    expect(canonicaliseTags(['A-ploeg', 'B-ploeg'])).toEqual([
+      'A-Ploeg',
+      'B-Ploeg',
+    ])
+  })
+
+  it('never invents a rename for an unknown tag', () => {
+    expect(canonicaliseTags(['Kampioenenviering'])).toBeNull()
+  })
+
+  it('keeps an unknown tag verbatim while fixing a known one beside it', () => {
+    expect(canonicaliseTags(['a-ploeg', 'Kampioenenviering'])).toEqual([
+      'A-Ploeg',
+      'Kampioenenviering',
+    ])
+  })
+})
+
+describe('migrateNormalizeArticleTagCasing', () => {
+  it('patches tags[] when a variant is present', () => {
+    const doc: TaggedArticleDoc = {_type: 'article', tags: ['A-ploeg', 'Jeugd']}
+    expect(migrateNormalizeArticleTagCasing(doc)).toEqual([
+      at('tags', set(['A-Ploeg', 'Jeugd'])),
+    ])
+  })
+
+  it('is idempotent — a second run produces no patch', () => {
+    const doc: TaggedArticleDoc = {_type: 'article', tags: ['A-Ploeg', 'Jeugd']}
+    expect(migrateNormalizeArticleTagCasing(doc)).toBeUndefined()
+  })
+
+  it('skips documents with no tags field', () => {
+    expect(migrateNormalizeArticleTagCasing({_type: 'article'})).toBeUndefined()
+  })
+
+  it('skips an empty tags array', () => {
+    expect(
+      migrateNormalizeArticleTagCasing({_type: 'article', tags: []}),
+    ).toBeUndefined()
+  })
+
+  it('skips a non-array tags value rather than coercing it', () => {
+    expect(
+      migrateNormalizeArticleTagCasing({_type: 'article', tags: 'A-ploeg'}),
+    ).toBeUndefined()
+  })
+
+  it('bails out when tags[] holds a non-string, leaving it for a human', () => {
+    expect(
+      migrateNormalizeArticleTagCasing({
+        _type: 'article',
+        tags: ['A-ploeg', 42],
+      }),
+    ).toBeUndefined()
+  })
+})
+
+describe('CANONICAL_TAGS', () => {
+  it('maps every key to a value whose lowercase form is that key', () => {
+    for (const [key, value] of Object.entries(CANONICAL_TAGS)) {
+      expect(value.toLowerCase()).toBe(key)
+    }
+  })
+})

--- a/packages/sanity-studio/src/migrations/normalize-article-tag-casing.ts
+++ b/packages/sanity-studio/src/migrations/normalize-article-tag-casing.ts
@@ -1,0 +1,116 @@
+import {at, defineMigration, set} from 'sanity/migrate'
+
+/**
+ * Collapse case-variant duplicates in `article.tags[]` onto one canonical
+ * spelling per tag.
+ *
+ * Production held both `A-Ploeg` (76 articles) and `A-ploeg` (1). GROQ's `in`
+ * operator is case-sensitive, so `"A-Ploeg" in tags` silently skipped that one
+ * article — it was invisible to every correctly-cased filter, tag listing and
+ * related-content query.
+ *
+ * The canonical form is an **explicit per-tag decision**, not a derived rule.
+ * Two kinds of change are folded in here, and they are different in kind:
+ *
+ * 1. **Casing collisions — a bug.** `A-ploeg` and `A-Ploeg` are the same tag
+ *    spelled two ways, and the odd one out is unreachable.
+ * 2. **Cross-tag inconsistency — an editorial decision.** `A-Ploeg` capitalised
+ *    the P while `B-ploeg` did not. That is not a bug (nothing breaks), but the
+ *    club chose consistency, so `B-ploeg` → `B-Ploeg` is included deliberately.
+ *
+ * The distinction is recorded because it governs future entries: a new casing
+ * collision should simply be added, while a cross-tag rename needs a decision
+ * first. The map is the record of those decisions.
+ *
+ * Matching is on the lowercased form, so variants that do not exist yet
+ * (`a-PLOEG`, `jeugd`) are caught too. A tag whose lowercase form is absent
+ * from the map passes through untouched — the migration never invents a rename.
+ *
+ * Idempotent: a document already on canonical spellings produces no patch.
+ *
+ * Exported separately from `defineMigration` so unit tests can exercise the
+ * branching without a Sanity dataset.
+ */
+export interface TaggedArticleDoc {
+  _id?: string
+  _type?: string
+  tags?: unknown
+}
+
+type Patch = ReturnType<typeof at>
+
+/**
+ * Canonical spelling per tag. Keyed by lowercase form.
+ *
+ * Add a row when a new casing collision appears. Changing an existing value is
+ * a content decision, not a fix — it renames the tag everywhere.
+ */
+export const CANONICAL_TAGS: Readonly<Record<string, string>> = {
+  'a-ploeg': 'A-Ploeg',
+  // Was `B-ploeg` in production; capitalised to match `A-Ploeg` by club decision.
+  'b-ploeg': 'B-Ploeg',
+  jeugd: 'Jeugd',
+  evenement: 'Evenement',
+  corona: 'Corona',
+  transfernieuws: 'Transfernieuws',
+  clubinfo: 'Clubinfo',
+  sponsor: 'Sponsor',
+  'beker van zemst': 'Beker Van Zemst',
+  'beker van brabant': 'Beker Van Brabant',
+  'football manager': 'Football Manager',
+}
+
+/**
+ * Canonicalise one tag list: rewrite known case-variants, drop entries that
+ * collapse onto an already-present canonical value, preserve original order.
+ *
+ * Returns `null` when nothing changes, so callers can skip the patch entirely.
+ */
+export function canonicaliseTags(tags: readonly string[]): string[] | null {
+  const out: string[] = []
+  const seen = new Set<string>()
+  let changed = false
+
+  for (const tag of tags) {
+    const canonical = CANONICAL_TAGS[tag.toLowerCase()] ?? tag
+    if (canonical !== tag) changed = true
+    // A doc carrying both `A-Ploeg` and `A-ploeg` collapses to a single entry.
+    if (seen.has(canonical)) {
+      changed = true
+      continue
+    }
+    seen.add(canonical)
+    out.push(canonical)
+  }
+
+  return changed ? out : null
+}
+
+export function migrateNormalizeArticleTagCasing(
+  doc: TaggedArticleDoc,
+): Patch[] | undefined {
+  if (!Array.isArray(doc.tags)) return undefined
+  if (doc.tags.length === 0) return undefined
+
+  // Bail on malformed entries rather than coercing them: a non-string in
+  // tags[] is a data problem for a human to look at, not something a migration
+  // should quietly rewrite.
+  const tags = doc.tags.filter((t): t is string => typeof t === 'string')
+  if (tags.length !== doc.tags.length) return undefined
+
+  const next = canonicaliseTags(tags)
+  if (next === null) return undefined
+
+  return [at('tags', set(next))]
+}
+
+export default defineMigration({
+  title: 'Collapse case-variant article tags onto one canonical spelling',
+  documentTypes: ['article'],
+
+  migrate: {
+    document(doc) {
+      return migrateNormalizeArticleTagCasing(doc as TaggedArticleDoc)
+    },
+  },
+})


### PR DESCRIPTION
## What

A Sanity migration that collapses case-variant article tags onto one canonical spelling per tag, plus the club's decision to make the two team tags consistent with each other.

## Why

Production held both `A-Ploeg` (76 articles) and `A-ploeg` (1). GROQ's `in` operator is case-sensitive, so `"A-Ploeg" in tags` silently skipped that one article — it was invisible to every correctly-cased filter, tag listing and related-content query. Nothing errored; the article simply never appeared.

Found while checking whether a per-age-band news stream was feasible (it is not — youth is a single flat `Jeugd` tag), during the website research sweep in `docs/research/`.

## Two kinds of change, deliberately distinguished

The map folds in two things that look alike but are not, and the distinction is documented because it governs future entries:

1. **Casing collisions are a bug.** `A-ploeg` / `A-Ploeg` is one tag spelled two ways and the odd one out is unreachable. A new collision can simply be added to the map.
2. **Cross-tag inconsistency is an editorial decision.** `A-Ploeg` capitalised the P while `B-ploeg` did not. Nothing was broken by that — but the club chose consistency, so `B-ploeg` → `B-Ploeg` is included on purpose. Changing an existing value renames a tag everywhere, so it needs a decision first rather than being treated as a fix.

Unknown tags pass through untouched — the migration never invents a rename. Matching is on the lowercased form, so variants that do not exist yet (`a-PLOEG`, `jeugd`) are caught too. Idempotent: canonical documents produce no patch.

## Already applied

Both datasets were migrated before this PR was opened, with approval:

| dataset | processed | mutations | result |
| --- | --- | --- | --- |
| staging | 160 | 21 | zero lowercase variants |
| production | 125 | 22 | distinct tags 12 → 11; `A-Ploeg` 77, `B-Ploeg` 22 |

Article counts unchanged in both. Staging's own seed-only tags (`Beker`, `Competitie`, `Mededeling`, …) were left untouched, which is the safety property worth noting.

## Tests

16 unit tests on the pure `canonicaliseTags` / `migrateNormalizeArticleTagCasing` functions — collisions, idempotency, order preservation, unknown-tag pass-through, malformed input, and a map-integrity check asserting every key is its value's lowercase form. `pnpm --filter @kcvv/sanity-studio check-all` passes: 41 files, 279 tests, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
