### PR TITLE
refactor(ui): one zone-pinned date parse, one home per shape (#2561)

### DIFF
--- a/apps/web/src/app/(main)/kalender/utils.ts
+++ b/apps/web/src/app/(main)/kalender/utils.ts
@@ -12,6 +12,7 @@ import {
 import type { MatchStatus, ScheduleMatch } from "@/components/match/types";
 import { getScoreDisplay, type ScoreDisplay } from "@/lib/utils/match-display";
 import { capitalize } from "@/lib/utils/capitalize";
+import { CLUB_TIMEZONE, toDisplayZone } from "@/lib/utils/dates";
 import type { ItemListEntry } from "@/lib/seo/jsonld";
 export type { ScoreDisplay } from "@/lib/utils/match-display";
 
@@ -148,10 +149,29 @@ export type CalendarFeedItem =
       event: CalendarEvent;
     };
 
-/** ISO → epoch ms sort key; an unparseable date sorts to the end (not NaN). */
+/**
+ * ISO → epoch ms sort key; an unparseable date sorts to the end (not NaN).
+ *
+ * Deliberately *not* `toDisplayZone`: the result is an instant, and neither a
+ * zone nor a locale can change one. Reading the input as UTC is the same
+ * offset-less contract the shared parse uses, without paying for a zone
+ * resolution per comparison.
+ */
 function toFeedSortKey(iso: string): number {
-  const ms = DateTime.fromISO(iso).toMillis();
+  const ms = DateTime.fromISO(iso, { zone: "utc" }).toMillis();
   return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
+}
+
+/**
+ * First of a calendar month in the club's zone — the month grid, the month nav
+ * label and the agenda window all start from the same construction rather than
+ * `DateTime.local()`, which would take the runtime zone.
+ */
+function clubMonthStart(year: number, month: number): DateTime {
+  return DateTime.fromObject(
+    { year, month, day: 1 },
+    { zone: CLUB_TIMEZONE, locale: "nl" },
+  );
 }
 
 /**
@@ -185,9 +205,13 @@ export function buildCalendarFeed(
     }),
   );
 
-  return [...matchItems, ...eventItems].sort(
-    (a, b) => toFeedSortKey(a.dateStart) - toFeedSortKey(b.dateStart),
-  );
+  // Key once per item, not twice per comparison — the comparator runs
+  // O(n log n) times and a Luxon parse is ~1.5µs, which a full season of
+  // fixtures turns into tens of milliseconds on a `force-dynamic` route.
+  return [...matchItems, ...eventItems]
+    .map((item) => ({ item, key: toFeedSortKey(item.dateStart) }))
+    .sort((a, b) => a.key - b.key)
+    .map(({ item }) => item);
 }
 
 /**
@@ -206,10 +230,7 @@ export function buildKalenderItemListEntries(
   const nowMs = options.nowMs ?? Date.now();
   const limit = options.limit ?? 30;
   return feed
-    .filter((item) => {
-      const ms = DateTime.fromISO(item.dateStart).toMillis();
-      return !Number.isNaN(ms) && ms >= nowMs;
-    })
+    .filter((item) => toFeedSortKey(item.dateStart) >= nowMs)
     .slice(0, limit)
     .map((item) =>
       item.source === "match"
@@ -219,13 +240,6 @@ export function buildKalenderItemListEntries(
           }
         : { name: item.event.title, url: `${siteUrl}${item.event.href}` },
     );
-}
-
-const TIMEZONE = "Europe/Brussels";
-
-/** Parse an ISO string into the club's local timezone */
-function toLocalDate(iso: string): DateTime {
-  return DateTime.fromISO(iso, { zone: TIMEZONE });
 }
 
 /** A single day's bucketed feed — matches + events, each time-sorted. */
@@ -250,6 +264,9 @@ function ensureDayFeed(map: Map<string, DayFeed>, day: string): DayFeed {
  * every grid cell / month day. Multi-day events surface under every day they
  * span (same semantics as `getEventsForDay`); buckets are time-sorted to match
  * the per-day helpers. Consumers `useMemo` this on `[matches, events]`.
+ *
+ * Matches bucket through `toDisplayZone` too, not `toMatchDisplayZone`; the two
+ * only disagree for a kickoff at/after 22:00, which the PSD feed does not carry.
  */
 export function groupFeedByDay(
   matches: CalendarMatch[],
@@ -258,19 +275,19 @@ export function groupFeedByDay(
   const map = new Map<string, DayFeed>();
 
   for (const match of matches) {
-    const dt = toLocalDate(match.date);
+    const dt = toDisplayZone(match.date);
     if (!dt.isValid) continue;
     ensureDayFeed(map, dt.toISODate()!).matches.push(match);
   }
 
   for (const event of events) {
-    const start = toLocalDate(event.dateStart);
+    const start = toDisplayZone(event.dateStart);
     if (!start.isValid) continue;
     // The start day always carries the event…
     ensureDayFeed(map, start.toISODate()!).events.push(event);
     // …and every later day it spans (inclusive), for a valid multi-day end.
     if (event.dateEnd) {
-      const end = toLocalDate(event.dateEnd);
+      const end = toDisplayZone(event.dateEnd);
       if (end.isValid) {
         let cursor = start.startOf("day").plus({ days: 1 });
         const last = end.startOf("day");
@@ -297,7 +314,7 @@ export const EMPTY_DAY_FEED: DayFeed = { matches: [], events: [] };
  * Always starts on Monday and ends on Sunday, producing 35 or 42 cells.
  */
 export function getDaysInMonth(year: number, month: number): string[] {
-  const firstOfMonth = DateTime.local(year, month, 1);
+  const firstOfMonth = clubMonthStart(year, month);
   // ISO weekday: 1=Monday, 7=Sunday
   const startOffset = firstOfMonth.weekday - 1;
   const gridStart = firstOfMonth.minus({ days: startOffset });
@@ -314,7 +331,7 @@ export function getDaysInMonth(year: number, month: number): string[] {
 
 /** Returns 7 YYYY-MM-DD strings (Mon-Sun) for the week containing `dateStr` */
 export function getDaysInWeek(dateStr: string): string[] {
-  const dt = DateTime.fromISO(dateStr);
+  const dt = toDisplayZone(dateStr);
   const monday = dt.startOf("week"); // Luxon weeks start on Monday by default
   const days: string[] = [];
   for (let i = 0; i < 7; i++) {
@@ -373,20 +390,22 @@ export function calendarMatchToScheduleMatch(
   };
 }
 
+// The date labels below are route chrome, not site vocabulary — a week-range
+// label is not a shape any other route renders — so they stay local (#2430
+// rule 2). What they may not do is invent their own zone or locale handling:
+// each parses through the shared `toDisplayZone` and formats with Luxon's
+// `toFormat`, never `toLocale*`, which would resolve month and weekday names
+// from whatever ICU data the runtime happens to ship.
+
 /**
  * Day-detail / agenda day heading — `"Zaterdag 12 september"` (weekday
  * capitalised, club locale). Used by the grid's selected-day detail and the
  * agenda's per-day groups so both read identically.
  */
 export function formatDayDetailHeading(day: string): string {
-  const dt = DateTime.fromISO(day, { zone: TIMEZONE });
+  const dt = toDisplayZone(day);
   if (!dt.isValid) return day;
-  return capitalize(
-    dt.toLocaleString(
-      { weekday: "long", day: "numeric", month: "long" },
-      { locale: "nl-BE" },
-    ),
-  );
+  return capitalize(dt.toFormat("cccc d MMMM"));
 }
 
 /**
@@ -418,11 +437,7 @@ export function formatItemCount(
  * sync.
  */
 export function formatMonthNavLabel(year: number, month: number): string {
-  const monthName = DateTime.local(year, month, 1).toLocaleString(
-    { month: "long" },
-    { locale: "nl-BE" },
-  );
-  return `${capitalize(monthName)} '${String(year).slice(-2)}`;
+  return `${capitalize(clubMonthStart(year, month).toFormat("MMMM"))} '${String(year).slice(-2)}`;
 }
 
 /**
@@ -431,12 +446,12 @@ export function formatMonthNavLabel(year: number, month: number): string {
  */
 export function formatWeekRangeLabel(weekStart: string): string {
   const days = getDaysInWeek(weekStart);
-  const first = DateTime.fromISO(days[0]!);
-  const last = DateTime.fromISO(days[6]!);
+  const first = toDisplayZone(days[0]!);
+  const last = toDisplayZone(days[6]!);
   const sameMonth = first.month === last.month && first.year === last.year;
   return sameMonth
-    ? `${first.day} - ${last.day} ${first.toLocaleString({ month: "long", year: "numeric" }, { locale: "nl-BE" })}`
-    : `${first.day} ${first.toLocaleString({ month: "long" }, { locale: "nl-BE" })} - ${last.day} ${last.toLocaleString({ month: "long", year: "numeric" }, { locale: "nl-BE" })}`;
+    ? `${first.day} - ${last.day} ${first.toFormat("MMMM yyyy")}`
+    : `${first.day} ${first.toFormat("MMMM")} - ${last.day} ${last.toFormat("MMMM yyyy")}`;
 }
 
 /**
@@ -445,7 +460,7 @@ export function formatWeekRangeLabel(weekStart: string): string {
  * spurious midnight time.
  */
 export function formatEventTime(iso: string): string | null {
-  const dt = DateTime.fromISO(iso, { zone: TIMEZONE });
+  const dt = toDisplayZone(iso);
   if (!dt.isValid) return null;
   const time = dt.toFormat("HH:mm");
   return time === "00:00" ? null : time;
@@ -476,7 +491,7 @@ export function buildMonthAgenda(
   month: number,
 ): AgendaDayGroup[] {
   const byDay = groupFeedByDay(matches, events);
-  const first = DateTime.local(year, month, 1);
+  const first = clubMonthStart(year, month);
   const daysInMonth = first.daysInMonth!;
 
   const groups: AgendaDayGroup[] = [];

--- a/apps/web/src/app/(main)/scheurkalender/page.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/page.tsx
@@ -9,7 +9,6 @@
 
 import type { Metadata } from "next";
 import { Effect } from "effect";
-import { DateTime } from "luxon";
 import { runPromise } from "@/lib/effect/runtime";
 import {
   BffService,
@@ -18,6 +17,11 @@ import {
 import { TeamRepository } from "@/lib/repositories/team.repository";
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import { KCVV_CLUB_ID } from "@/lib/constants";
+import {
+  clubToday,
+  toDisplayZone,
+  toMatchDisplayZone,
+} from "@/lib/utils/dates";
 import {
   ScheurkalenderPage,
   type ScheurkalenderMatch,
@@ -31,8 +35,6 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-const TZ = "Europe/Brussels";
-
 interface ScheurkalenderData {
   matches: ScheurkalenderMatch[];
   season: string;
@@ -45,7 +47,7 @@ function squadLabel(name: string): "A" | "B" {
 
 /** Belgian season label (e.g. "25/26") for the calendar day in `isoDate`. */
 function seasonLabel(isoDate: string): string {
-  const dt = DateTime.fromISO(isoDate, { zone: TZ });
+  const dt = toDisplayZone(isoDate);
   const startYear = dt.month >= 7 ? dt.year : dt.year - 1;
   const twoDigit = (year: number) => String(year % 100).padStart(2, "0");
   return `${twoDigit(startYear)}/${twoDigit(startYear + 1)}`;
@@ -61,10 +63,10 @@ function toScheurkalenderMatch(
   const opponent = kcvvIsHome ? match.away_team.name : match.home_team.name;
   return {
     id: match.id,
-    // The BFF encodes the local kickoff wall-clock into the Date's UTC fields,
-    // so read the calendar day off UTC — re-zoning a late kickoff (≥22:00)
+    // `toMatchDisplayZone` reads the calendar day off UTC, which is where the
+    // BFF put the local kickoff wall-clock; re-zoning a late kickoff (≥22:00)
     // to Brussels would roll it to the next day (and possibly next weekend).
-    date: DateTime.fromJSDate(match.date, { zone: "utc" }).toISODate() ?? "",
+    date: toMatchDisplayZone(match.date).toISODate() ?? "",
     ...(match.time ? { time: match.time } : {}),
     opponent,
     kcvvLabel: label,
@@ -123,9 +125,7 @@ async function fetchScheurkalenderData(): Promise<ScheurkalenderData> {
           (a.time ?? "").localeCompare(b.time ?? ""),
       );
 
-      const season = seasonLabel(
-        matches[0]?.date ?? DateTime.now().setZone(TZ).toISODate()!,
-      );
+      const season = seasonLabel(matches[0]?.date ?? clubToday());
 
       return { matches, season };
     }),

--- a/apps/web/src/app/(main)/share/page.tsx
+++ b/apps/web/src/app/(main)/share/page.tsx
@@ -7,6 +7,8 @@ import { runPromise } from "@/lib/effect/runtime";
 import { BffService } from "@/lib/effect/services/BffService";
 import { PlayerRepository } from "@/lib/repositories/player.repository";
 import type { Match } from "@/lib/effect/schemas/match.schema";
+import { toMatchDisplayZone } from "@/lib/utils/dates";
+import { capitalize } from "@/lib/utils/capitalize";
 import { SharePage } from "@/components/share/SharePage/SharePage";
 import type {
   MatchOption,
@@ -18,13 +20,10 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+/** `Zaterdag · 15:00` — one consumer, so the shape stays local (#2430 rule 2). */
 function formatDateTime(match: Match): string | undefined {
-  const weekday = new Date(match.date).toLocaleDateString("nl-BE", {
-    weekday: "long",
-    timeZone: "Europe/Brussels",
-  });
-  const capitalised = weekday.charAt(0).toUpperCase() + weekday.slice(1);
-  return match.time ? `${capitalised} · ${match.time}` : capitalised;
+  const weekday = capitalize(toMatchDisplayZone(match.date).toFormat("cccc"));
+  return match.time ? `${weekday} · ${match.time}` : weekday;
 }
 
 function toMatchOption(match: Match): MatchOption {

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/utils.ts
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/lib/effect/schemas/match.schema";
 import type { MatchHeroTeam } from "@/components/match/MatchHero";
 import type { LineupPlayer } from "@/components/match/MatchLineup";
+import { toMatchDisplayZone } from "@/lib/utils/dates";
 
 /**
  * Convert a match's home team into props suitable for the MatchHero component.
@@ -119,20 +120,20 @@ export function formatMatchTitle(match: MatchDetail): string {
 }
 
 /**
- * Build an SEO-friendly description for a match by combining its title, competition, and localized date.
+ * Build an SEO-friendly description for a match by combining its title,
+ * competition, and date.
+ *
+ * `zaterdag 12 september 2026` has one consumer — this page's metadata — so the
+ * shape stays local (#2430 rule 2). The parse does not: a BFF match date is
+ * Belgian wall-clock in its UTC fields, so it reads through `toMatchDisplayZone`.
  *
  * @param match - The match details used to generate the description
- * @returns A string in the form "<title> - <competition> op <date>" where `<date>` is formatted using the "nl-BE" locale with weekday, year, month, and day
+ * @returns A string in the form "<title> - <competition> op <date>"
  */
 export function formatMatchDescription(match: MatchDetail): string {
   const title = formatMatchTitle(match);
   const competition = match.competition || "Wedstrijd";
-  const dateStr = match.date.toLocaleDateString("nl-BE", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  const dateStr = toMatchDisplayZone(match.date).toFormat("cccc d MMMM yyyy");
 
   return `${title} - ${competition} op ${dateStr}`;
 }

--- a/apps/web/src/app/__tests__/cross-page-consistency.test.ts
+++ b/apps/web/src/app/__tests__/cross-page-consistency.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Cross-page consistency guard
+ *
+ * The spec cut from #2425 decides thirty-four things that repeat across the
+ * site's 31 public routes. A decision that lives only in a merged PR is a
+ * decision the next route quietly re-invents, so each one that can be checked
+ * statically lands here as a rule, and every later ticket sliced from #2556
+ * appends to this file rather than starting a guard of its own.
+ *
+ * Shape, matching the two guards already in this directory: glob the tree,
+ * assert one rule per file, and let an empty case list fail the run on its own
+ * — vitest rejects an `it.each` with no cases, which is the property that makes
+ * a guard trustworthy. A rule that silently matches nothing is worse than no
+ * rule, because it reads like coverage.
+ *
+ * **Boundary:** the glob is `apps/web/src`. The BFF Worker (`apps/api`) is a
+ * separate deploy with its own zone literal and its own `toLocale*` call, and
+ * nothing here sees them — "site-wide" means this app, not this repo.
+ *
+ * @see https://github.com/soniCaH/www.kcvvelewijt.be/issues/2561
+ */
+
+import { describe, it, expect } from "vitest";
+import { globSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const srcDir = resolve(__dirname, "../..");
+
+/** Every first-party source file, tests and stories included. */
+const sourceFiles = globSync(["**/*.ts", "**/*.tsx"], { cwd: srcDir }).sort();
+
+/**
+ * Rules match code, not prose. Every banned pattern here is also the natural
+ * way to *explain* the ban, so a docblock saying "replaces the raw
+ * `toLocaleDateString`" would otherwise fail the file it documents — and the
+ * fix a reader would reach for is deleting the explanation.
+ *
+ * One ordered alternation, not two passes. String literals come first, so a
+ * comment-shaped substring inside one — this repo writes Storybook titles
+ * ending in a slash-star wildcard — is consumed as a string before it can open
+ * a phantom comment that swallows every declaration up to the next closing
+ * delimiter. Literals are then re-emitted **verbatim**, because a rule may need
+ * to read one: the zone below *is* a string.
+ */
+const COMMENT_OR_STRING =
+  /"(?:\\[\s\S]|[^"\\])*"|'(?:\\[\s\S]|[^'\\])*'|`(?:\\[\s\S]|[^`\\])*`|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
+
+/**
+ * This file is the one no rule can read. It states every banned pattern twice —
+ * once in prose and once as a regex literal — and a regex literal is quote-dense
+ * enough (`["']`) that any tokenizer segments it as a string, which throws the
+ * rest of the scan out of step. Excluded explicitly rather than left to luck.
+ */
+const SELF = "app/__tests__/cross-page-consistency.test.ts";
+
+/** Read and strip once per file — every rule below scans the same tree. */
+const code = new Map(
+  sourceFiles
+    .filter((relPath) => relPath !== SELF)
+    .map((relPath) => [
+      relPath,
+      readFileSync(resolve(srcDir, relPath), "utf8").replace(
+        COMMENT_OR_STRING,
+        (token) => (token.startsWith("/") ? "" : token),
+      ),
+    ]),
+);
+
+/** Every file a rule may scan — the tree minus this file. */
+const scannableSources = sourceFiles.filter((relPath) => relPath !== SELF);
+
+// ---------------------------------------------------------------------------
+// Rule 1 (#2430) — dates format through Luxon's `toFormat`, never `toLocale*`
+// ---------------------------------------------------------------------------
+
+/**
+ * `toLocale*` resolves month and weekday names from whatever ICU data the
+ * runtime happens to ship, which differs between Node, the browser and CI — so
+ * the same date renders differently depending on where it is rendered, and
+ * surfaces as visual-regression drift. `@/lib/utils/dates` states the rule; this
+ * holds it site-wide. There is no allowlist: the shared date module itself
+ * complies, so nothing needs an exemption.
+ *
+ * `toLocaleDateString` / `toLocaleTimeString` / `Intl.DateTimeFormat` are
+ * unambiguously dates. Bare `.toLocaleString(` is not — it is also how a number
+ * is formatted — so it counts only in a file that imports Luxon, which is the
+ * only way a `DateTime.toLocaleString` call can be reached.
+ */
+const ALWAYS_BANNED =
+  /\.toLocaleDateString\s*\(|\.toLocaleTimeString\s*\(|\bIntl\.DateTimeFormat\b/;
+const LUXON_IMPORT = /from\s+["']luxon["']/;
+const BARE_TO_LOCALE_STRING = /\.toLocaleString\s*\(/;
+
+describe("dates format through Luxon `toFormat` (#2430)", () => {
+  it.each(scannableSources)(
+    "%s — no `toLocale*` date formatting",
+    (relPath) => {
+      const source = code.get(relPath)!;
+      expect(ALWAYS_BANNED.test(source)).toBe(false);
+
+      if (LUXON_IMPORT.test(source)) {
+        expect(BARE_TO_LOCALE_STRING.test(source)).toBe(false);
+      }
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Rule 2 (#2430) — the club timezone has one home
+// ---------------------------------------------------------------------------
+
+/**
+ * A second zone literal is how the site ended up with four date homes and half
+ * of them unpinned: each new one looked local and harmless. The zone is
+ * `CLUB_TIMEZONE` in `@/lib/utils/dates`, and it is club-scoped rather than
+ * event-scoped precisely because the narrow name is why non-event formatters
+ * kept assuming it did not apply to them.
+ *
+ * Scoped to production source: a test or story may legitimately hold the zone
+ * as data — `ical.test.ts` asserts the `TZID:` line of rendered iCal output,
+ * which is the literal string, not a pin. The exemption for the home itself is
+ * applied at this rule's own `it.each`, not baked into `productionSources` —
+ * `dates.ts` is the file later rules will most want to check hardest, and it
+ * must not inherit a blanket pass it never asked for.
+ */
+const CLUB_TIMEZONE_HOME = "lib/utils/dates.ts";
+const ZONE_LITERAL = /["']Europe\/Brussels["']/;
+
+/** Everything a rule about shipped behaviour should hold — no tests, no stories. */
+const productionSources = scannableSources.filter(
+  (relPath) => !/\.(test|stories)\.tsx?$/.test(relPath),
+);
+
+describe("the club timezone has one home (#2430)", () => {
+  it.each(productionSources.filter((f) => f !== CLUB_TIMEZONE_HOME))(
+    "%s — no second zone literal",
+    (relPath) => {
+      expect(ZONE_LITERAL.test(code.get(relPath)!)).toBe(false);
+    },
+  );
+});

--- a/apps/web/src/components/article/blocks/EventDetailBlock/EventDetailBlock.tsx
+++ b/apps/web/src/components/article/blocks/EventDetailBlock/EventDetailBlock.tsx
@@ -5,14 +5,18 @@ import { MonoLabel } from "@/components/design-system/MonoLabel";
 import { getButtonClasses } from "@/components/design-system/Button";
 import {
   DEFAULT_TICKET_LABEL,
-  formatTimeRange,
   resolveEventRange,
   type EventFactValue,
   type ResolvedEvent,
   type ResolvedEventRange,
   type ResolvedSession,
 } from "../EventFact/types";
-import { formatWidgetDate } from "@/lib/utils/dates";
+import { formatTimeRange } from "../EventFact/format-time-range";
+import {
+  CLUB_TIMEZONE,
+  formatWidgetDate,
+  toDisplayZone,
+} from "@/lib/utils/dates";
 import { cn } from "@/lib/utils/cn";
 
 export interface EventDetailBlockProps {
@@ -67,7 +71,7 @@ export function deriveIsPast(
   // event flips to "past" up to ~2h early around the UTC midnight
   // boundary (Brussels is UTC+1/+2). The reference dates are timezone-less
   // calendar dates, so the only zone that matters is the club's.
-  const today = DateTime.fromJSDate(now).setZone("Europe/Brussels").toISODate();
+  const today = toDisplayZone(now).toISODate();
   if (!today) return false;
   const range = resolveEventRange(value.date, value.endDate, value.sessions);
   const reference =
@@ -163,7 +167,7 @@ function buildGoogleCalendarUrl(
     range.kind === "single" ? range.date.dateIso : range.start.dateIso;
   const endIso =
     range.kind === "single" ? range.date.dateIso : range.end.dateIso;
-  const zone = "Europe/Brussels";
+  const zone = CLUB_TIMEZONE;
 
   // Per-day sessions carry their own hours (the panel shows "Zie schema"),
   // so the top-level start/end don't describe the whole span — model the

--- a/apps/web/src/components/article/blocks/EventFact/format-time-range.test.ts
+++ b/apps/web/src/components/article/blocks/EventFact/format-time-range.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { formatTimeRange } from "./format-time-range";
+
+describe("formatTimeRange", () => {
+  it("joins both ends with a dash when present", () => {
+    expect(formatTimeRange("10:00", "17:00")).toBe("10:00 - 17:00");
+  });
+
+  it("returns just the start time when end is missing", () => {
+    expect(formatTimeRange("10:00", undefined)).toBe("10:00");
+  });
+
+  it("returns just the end time when start is missing", () => {
+    expect(formatTimeRange(undefined, "17:00")).toBe("17:00");
+  });
+
+  it("returns undefined when both are missing — caller skips the slot", () => {
+    expect(formatTimeRange(undefined, undefined)).toBeUndefined();
+    expect(formatTimeRange("", "")).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/article/blocks/EventFact/format-time-range.ts
+++ b/apps/web/src/components/article/blocks/EventFact/format-time-range.ts
@@ -1,0 +1,21 @@
+/**
+ * Not a date formatter — it joins two already-formatted `HH:mm` strings, with no
+ * parse, locale or zone, so the club-zone rule does not reach it. It lives here
+ * rather than in `./types.ts` because a types module is not a home for
+ * behaviour (#2430).
+ *
+ * Format the time range for an event row. Returns:
+ *   - `"10:00 - 17:00"` when both ends are present
+ *   - `"10:00"` when only `startTime` is set
+ *   - `undefined` when nothing is set (so the caller can skip the slot)
+ */
+export function formatTimeRange(
+  startTime?: string,
+  endTime?: string,
+): string | undefined {
+  const start = startTime?.trim();
+  const end = endTime?.trim();
+  if (!start && !end) return undefined;
+  if (start && end) return `${start} - ${end}`;
+  return start ?? end;
+}

--- a/apps/web/src/components/article/blocks/EventFact/index.ts
+++ b/apps/web/src/components/article/blocks/EventFact/index.ts
@@ -1,9 +1,9 @@
 export {
   resolveEventDate,
   resolveEventRange,
-  formatTimeRange,
   DEFAULT_TICKET_LABEL,
 } from "./types";
+export { formatTimeRange } from "./format-time-range";
 export type {
   EventFactValue,
   EventFactSession,

--- a/apps/web/src/components/article/blocks/EventFact/types.test.ts
+++ b/apps/web/src/components/article/blocks/EventFact/types.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   resolveEventDate,
   resolveEventRange,
-  formatTimeRange,
   DEFAULT_TICKET_LABEL,
 } from "./types";
 
@@ -50,25 +49,6 @@ describe("resolveEventDate", () => {
     const out = resolveEventDate("2026-01-01");
     if (!out.hasDate) throw new Error("expected hasDate: true");
     expect(out.weekday).toBe("donderdag");
-  });
-});
-
-describe("formatTimeRange", () => {
-  it("joins both ends with a dash when present", () => {
-    expect(formatTimeRange("10:00", "17:00")).toBe("10:00 - 17:00");
-  });
-
-  it("returns just the start time when end is missing", () => {
-    expect(formatTimeRange("10:00", undefined)).toBe("10:00");
-  });
-
-  it("returns just the end time when start is missing", () => {
-    expect(formatTimeRange(undefined, "17:00")).toBe("17:00");
-  });
-
-  it("returns undefined when both are missing — caller skips the slot", () => {
-    expect(formatTimeRange(undefined, undefined)).toBeUndefined();
-    expect(formatTimeRange("", "")).toBeUndefined();
   });
 });
 

--- a/apps/web/src/components/article/blocks/EventFact/types.ts
+++ b/apps/web/src/components/article/blocks/EventFact/types.ts
@@ -232,21 +232,4 @@ export function resolveEventRange(
   };
 }
 
-/**
- * Format the time range for an event row. Returns:
- *   - `"10:00 - 17:00"` when both ends are present
- *   - `"10:00"` when only `startTime` is set
- *   - `undefined` when nothing is set (so the caller can skip the slot)
- */
-export function formatTimeRange(
-  startTime?: string,
-  endTime?: string,
-): string | undefined {
-  const start = startTime?.trim();
-  const end = endTime?.trim();
-  if (!start && !end) return undefined;
-  if (start && end) return `${start} - ${end}`;
-  return start ?? end;
-}
-
 export const DEFAULT_TICKET_LABEL = "Inschrijven";

--- a/apps/web/src/components/article/blocks/EventFactInline/EventFactInline.tsx
+++ b/apps/web/src/components/article/blocks/EventFactInline/EventFactInline.tsx
@@ -6,11 +6,11 @@ import { cn } from "@/lib/utils/cn";
 import { capitalize } from "@/lib/utils/capitalize";
 import {
   DEFAULT_TICKET_LABEL,
-  formatTimeRange,
   resolveEventRange,
   type EventFactValue,
   type ResolvedEventRange,
 } from "../EventFact/types";
+import { formatTimeRange } from "../EventFact/format-time-range";
 
 export interface EventFactInlineProps {
   value: EventFactValue;

--- a/apps/web/src/components/calendar/CalendarMonth/CalendarMonth.tsx
+++ b/apps/web/src/components/calendar/CalendarMonth/CalendarMonth.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { DateTime } from "luxon";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
+import { clubToday, toDisplayZone } from "@/lib/utils/dates";
 import { TeamAgendaRow } from "@/components/team/TeamMatchesSection/TeamAgendaRow";
 import { EVENT_TYPE_FILL } from "@/components/event/event-type-style";
 import { EventTypeTag } from "../calendar-tags";
@@ -200,7 +200,7 @@ export function CalendarMonth({
   );
   const selected = byDay.get(selectedDate) ?? EMPTY_DAY_FEED;
 
-  const today = DateTime.now().toISODate()!;
+  const today = clubToday();
 
   return (
     <div>
@@ -222,7 +222,7 @@ export function CalendarMonth({
         data-testid="month-grid"
       >
         {days.map((day) => {
-          const dt = DateTime.fromISO(day);
+          const dt = toDisplayZone(day);
           const isCurrentMonth = dt.month === currentMonth;
           const isToday = day === today;
           const isSelected = day === selectedDate;
@@ -233,10 +233,7 @@ export function CalendarMonth({
               key={day}
               type="button"
               onClick={() => onSelectDate(day)}
-              aria-label={dt.toLocaleString(
-                { day: "numeric", month: "long" },
-                { locale: "nl-BE" },
-              )}
+              aria-label={dt.toFormat("d MMMM")}
               aria-pressed={isSelected}
               className={cn(
                 "border-paper-edge flex min-h-[108px] flex-col items-stretch border-r border-b border-dashed p-1.5 text-left transition-colors last:border-r-0",

--- a/apps/web/src/components/calendar/CalendarWeek/CalendarWeek.tsx
+++ b/apps/web/src/components/calendar/CalendarWeek/CalendarWeek.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useMemo } from "react";
-import { DateTime } from "luxon";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
+import { clubToday, toDisplayZone } from "@/lib/utils/dates";
 import { PRESS_DOWN_CLASSES } from "@/components/design-system/press-down";
 import { MatchStatusBadge } from "@/components/match/MatchStatusBadge";
 import { EVENT_TYPE_FILL } from "@/components/event/event-type-style";
@@ -97,7 +97,7 @@ export function CalendarWeek({
     () => groupFeedByDay(matches, events),
     [matches, events],
   );
-  const today = DateTime.now().toISODate()!;
+  const today = clubToday();
 
   return (
     <div
@@ -105,7 +105,7 @@ export function CalendarWeek({
       data-testid="week-grid"
     >
       {days.map((day, i) => {
-        const dt = DateTime.fromISO(day);
+        const dt = toDisplayZone(day);
         const { matches: dayMatches, events: dayEvents } =
           byDay.get(day) ?? EMPTY_DAY_FEED;
         const isToday = day === today;

--- a/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.tsx
+++ b/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { DateTime } from "luxon";
 import { cn } from "@/lib/utils/cn";
+import { clubToday, toDisplayZone } from "@/lib/utils/dates";
 import { trackEvent } from "@/lib/analytics/track-event";
 import { CalendarMonth } from "../CalendarMonth";
 import { CalendarWeek } from "../CalendarWeek";
@@ -100,13 +101,15 @@ export function CalendarWidget({ feed, teams, today }: CalendarWidgetProps) {
   // One shared period anchor for all three views (6.D lock — switching Maand /
   // Week / Agenda keeps the navigated window). Month + Agenda page by month,
   // Week pages by week; both derive from this single cursor, seeded from
-  // `today` (defaults to the real clock).
-  const seedDay = today ?? DateTime.now().toISODate()!;
+  // `today` defaults to the club's clock: the seed is evaluated once on the UTC
+  // server and again in the visitor's zone at hydration, so an unpinned one can
+  // open the widget on a different day than the grid rings as today.
+  const seedDay = today ?? clubToday();
   const [cursor, setCursor] = useState<string>(seedDay);
   const [selectedDate, setSelectedDate] = useState(seedDay);
   const [subscribePanelOpen, setSubscribePanelOpen] = useState(false);
 
-  const cursorDt = DateTime.fromISO(cursor);
+  const cursorDt = toDisplayZone(cursor);
   const currentMonth = cursorDt.month;
   const currentYear = cursorDt.year;
   const weekStart = cursorDt.startOf("week").toISODate()!;

--- a/apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
+++ b/apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
 import Image from "next/image";
 import { DateTime } from "luxon";
+import { toDisplayZone } from "@/lib/utils/dates";
 import {
   EditorialHeading,
   LinkButton,
@@ -48,12 +49,6 @@ export interface FeaturedEventBandProps {
   now?: DateTime;
 }
 
-const LOCALE = "nl";
-// KCVV is in Belgium — pin formatting to Europe/Brussels so DST and TZ
-// drift in deploy / CI / test environments doesn't change the rendered
-// "when" line. Sanity stores event datetimes in UTC; readers are in BE.
-const TZ = "Europe/Brussels";
-
 /**
  * Formats the "when" line per locked spec:
  *  - Same day, with time:    "26 apr · 19:00–21:00" or "26 apr · 19:00"
@@ -61,10 +56,10 @@ const TZ = "Europe/Brussels";
  *  - Multi-day:               "26 apr 10:00 – 28 apr 12:00" (no separator dot)
  */
 function formatDateTime(dateStart: string, dateEnd?: string | null): string {
-  const start = DateTime.fromISO(dateStart).setZone(TZ).setLocale(LOCALE);
-  const end = dateEnd
-    ? DateTime.fromISO(dateEnd).setZone(TZ).setLocale(LOCALE)
-    : null;
+  // Belgian wall-clock and nl locale both come from the shared parse — the
+  // rendered "when" line must not drift with the deploy/CI/test timezone.
+  const start = toDisplayZone(dateStart);
+  const end = dateEnd ? toDisplayZone(dateEnd) : null;
 
   const sameDay =
     !end || end.startOf("day").valueOf() === start.startOf("day").valueOf();
@@ -93,7 +88,7 @@ export const FeaturedEventBand = ({
   // Drop-if-empty per locked spec: null event, missing cover image, or
   // start time already past — caller doesn't have to filter upstream.
   if (!event || !event.coverImage) return null;
-  const start = DateTime.fromISO(event.dateStart);
+  const start = toDisplayZone(event.dateStart);
   if (!start.isValid || start < now) return null;
 
   const location = event.location?.trim() || "Kantine";

--- a/apps/web/src/components/scheurkalender/PrintDate.test.tsx
+++ b/apps/web/src/components/scheurkalender/PrintDate.test.tsx
@@ -1,25 +1,31 @@
 /**
  * PrintDate Component Tests
+ *
+ * The component renders the *Belgian* calendar day (via `formatArticleDate`),
+ * not the host's. The reference values below are pinned the same way — a bare
+ * `new Date().getDate()` would disagree with the render on any CI run between
+ * 22:00 UTC and midnight, and disagree on the year for a 31 December run.
  */
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import { PrintDate } from "./PrintDate";
+import { toDisplayZone } from "@/lib/utils/dates";
 
 describe("PrintDate", () => {
+  const belgianNow = () => toDisplayZone(new Date());
+
   it("renders a non-empty date string", () => {
     const { container } = render(<PrintDate />);
     expect(container.textContent?.trim()).not.toBe("");
   });
 
-  it("renders the current year", () => {
+  it("renders the current Belgian year", () => {
     const { container } = render(<PrintDate />);
-    expect(container.textContent).toContain(
-      new Date().getFullYear().toString(),
-    );
+    expect(container.textContent).toContain(belgianNow().toFormat("yyyy"));
   });
 
-  it("renders the current day number", () => {
+  it("renders the current Belgian day number", () => {
     const { container } = render(<PrintDate />);
-    expect(container.textContent).toContain(new Date().getDate().toString());
+    expect(container.textContent).toContain(belgianNow().toFormat("d"));
   });
 });

--- a/apps/web/src/components/scheurkalender/PrintDate.tsx
+++ b/apps/web/src/components/scheurkalender/PrintDate.tsx
@@ -1,17 +1,11 @@
 "use client";
 
+import { formatArticleDate } from "@/lib/utils/dates";
+
 /**
  * PrintDate — renders the current date at browser/print time.
  * Must be a client component so it's not frozen to the ISR build timestamp.
  */
 export function PrintDate() {
-  return (
-    <>
-      {new Date().toLocaleDateString("nl-BE", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      })}
-    </>
-  );
+  return <>{formatArticleDate(new Date())}</>;
 }

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -21,17 +21,18 @@
  */
 
 import { DateTime } from "luxon";
+import { toDisplayZone } from "@/lib/utils/dates";
+import { capitalize } from "@/lib/utils/capitalize";
 import { PageContainer } from "@/components/design-system";
 import { PrintButton } from "./PrintButton";
 import { PrintDate } from "./PrintDate";
 
-// KCVV is in Belgium — pin date/week derivation to Europe/Brussels so the
-// weekday, day-of-month, and ISO-week bucket are stable across server/DST.
-const TZ = "Europe/Brussels";
-
 export interface ScheurkalenderMatch {
   id: number;
-  /** ISO calendar date (`YYYY-MM-DD`); kickoff time lives in `time`. */
+  /**
+   * ISO calendar date (`YYYY-MM-DD`); kickoff time lives in `time`. The route
+   * already read the day off the match Date's UTC fields (`toMatchDisplayZone`).
+   */
   date: string;
   /** Kickoff time as `HH:MM`. */
   time?: string;
@@ -73,7 +74,7 @@ function groupByWeekend(matches: ScheurkalenderMatch[]): Weekend[] {
   const order: string[] = [];
   const buckets = new Map<string, ScheurkalenderMatch[]>();
   for (const match of matches) {
-    const dt = DateTime.fromISO(match.date, { zone: TZ });
+    const dt = toDisplayZone(match.date);
     const key = `${dt.weekYear}-W${String(dt.weekNumber).padStart(2, "0")}`;
     let bucket = buckets.get(key);
     if (!bucket) {
@@ -87,9 +88,7 @@ function groupByWeekend(matches: ScheurkalenderMatch[]): Weekend[] {
     const bucket = buckets.get(key)!;
     // Anchor on the weekend's Saturday so a Sat/Sun pair never straddles two
     // month headings (e.g. 31 Jan + 1 Feb both belong to January).
-    const monday = DateTime.fromISO(bucket[0]!.date, { zone: TZ }).startOf(
-      "week",
-    );
+    const monday = toDisplayZone(bucket[0]!.date).startOf("week");
     return { key, saturday: monday.plus({ days: 5 }), matches: bucket };
   });
 }
@@ -104,10 +103,9 @@ function groupByMonth(weekends: Weekend[]): MonthGroup[] {
       last.weekends.push(weekend);
       continue;
     }
-    const monthName = weekend.saturday.setLocale("nl").toFormat("LLLL");
     groups.push({
       key,
-      monthName: monthName.charAt(0).toUpperCase() + monthName.slice(1),
+      monthName: capitalize(weekend.saturday.toFormat("LLLL")),
       yearSuffix: `’${weekend.saturday.toFormat("yy")}`,
       weekends: [weekend],
     });
@@ -129,7 +127,7 @@ function splitByYear(weekends: Weekend[]): Weekend[][] {
 }
 
 function FixtureRow({ match }: { match: ScheurkalenderMatch }) {
-  const dt = DateTime.fromISO(match.date, { zone: TZ });
+  const dt = toDisplayZone(match.date);
   const kcvvName = (
     <>
       KCVV Elewijt <span className="text-jersey-deep">{match.kcvvLabel}</span>

--- a/apps/web/src/components/search/SearchResult.tsx
+++ b/apps/web/src/components/search/SearchResult.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { SearchResult as SearchResultType } from "./SearchInterface";
 import { MonoLabel, StampBadge } from "@/components/design-system";
+import { toDisplayZone } from "@/lib/utils/dates";
 
 export interface SearchResultProps {
   /**
@@ -32,15 +33,8 @@ const typeLabels = {
   team: "Team",
 } as const;
 
-const formatDate = (date: string) =>
-  new Date(date).toLocaleDateString("nl-BE", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-    // Pin to the club's zone so a date renders identically on the UTC
-    // SSR/build host and a Belgian client (no off-by-one / hydration drift).
-    timeZone: "Europe/Brussels",
-  });
+/** `12 sep 2026` — one consumer, so the shape stays local (#2430 rule 2). */
+const formatDate = (date: string) => toDisplayZone(date).toFormat("d MMM yyyy");
 
 /**
  * Individual search result row — postmark-stamp paper card (8s2-redux).

--- a/apps/web/src/lib/repositories/event.repository.ts
+++ b/apps/web/src/lib/repositories/event.repository.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect";
 import { defineQuery } from "groq";
 import { DateTime } from "luxon";
 import { fetchGroq } from "../sanity/fetch-groq";
-import { EVENT_TIMEZONE } from "../utils/event-datetime";
+import { CLUB_TIMEZONE, clubToday } from "../utils/dates";
 import type { EventType } from "@/components/event/event-type-style";
 import type {
   EVENTS_QUERY_RESULT,
@@ -143,7 +143,7 @@ export interface EventListItemVM {
 /**
  * Build an event ISO from an `eventFact`'s calendar `date` + optional `time`
  * (`HH:mm`). The fact date is a Brussels wall-clock day, so it is encoded as an
- * offset-aware ISO in `EVENT_TIMEZONE`: `parseEventDateTime` then round-trips it
+ * offset-aware ISO in `CLUB_TIMEZONE`: `parseEventDateTime` then round-trips it
  * to the same local time (its explicit-offset branch wins over the
  * `{ zone: "utc" }` default). A missing/invalid `time` yields local midnight,
  * which `<TicketStub>` reads as all-day and renders without a time — matching
@@ -163,7 +163,7 @@ function articleFactToIso(
     typeof time === "string" && /^([01]\d|2[0-3]):[0-5]\d$/.test(time)
       ? time
       : "00:00";
-  const dt = DateTime.fromISO(`${date}T${hhmm}`, { zone: EVENT_TIMEZONE });
+  const dt = DateTime.fromISO(`${date}T${hhmm}`, { zone: CLUB_TIMEZONE });
   return dt.isValid ? dt.toISO() : null;
 }
 
@@ -249,7 +249,7 @@ export const EventRepositoryLive = Layer.succeed(EventRepository, {
       events: fetchGroq<EVENTS_QUERY_RESULT>(EVENTS_QUERY),
       articles: fetchGroq<EVENT_ARTICLES_QUERY_RESULT>(EVENT_ARTICLES_QUERY, {
         // Brussels-local calendar day — see EVENT_ARTICLES_QUERY's $today note.
-        today: DateTime.now().setZone(EVENT_TIMEZONE).toISODate(),
+        today: clubToday(),
       }),
     }).pipe(
       Effect.map(({ events, articles }) => mergeEventFeed(events, articles)),

--- a/apps/web/src/lib/utils/dates.test.ts
+++ b/apps/web/src/lib/utils/dates.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { formatWidgetDate, formatDayMonth } from "./dates";
+import {
+  formatArticleDate,
+  formatWidgetDate,
+  formatDayMonth,
+  toDisplayZone,
+  toMatchDisplayZone,
+} from "./dates";
 
 /**
  * These formatters render Belgian wall-clock, not the runtime's zone. Vercel is
@@ -36,5 +42,75 @@ describe("Belgian display zone", () => {
   it("returns empty output for an invalid date", () => {
     expect(formatWidgetDate("not-a-date")).toBe("");
     expect(formatDayMonth("not-a-date")).toEqual({ day: "", month: "" });
+  });
+
+  it("reads offset-less input as UTC, not as the runtime's zone", () => {
+    // The stored contract. Read as UTC this is 23:30 → 01:30 Brussels on the
+    // 4th; read as runtime-local on a UTC host it would be the same, which is
+    // exactly why the bug survived — assert the Brussels day, not the host's.
+    expect(formatDayMonth("2026-08-03T23:30:00")).toEqual({
+      day: "4",
+      month: "aug",
+    });
+  });
+});
+
+/**
+ * `formatArticleDate` was the one `dates.ts` export not routed through the
+ * shared parse: bare `DateTime.fromISO`, so it took the runtime zone and had no
+ * validity guard. #2402 deferred the fix here (#2430 rule 3).
+ */
+describe("formatArticleDate", () => {
+  it("renders the Belgian day for an article published just before UTC midnight", () => {
+    // Published 23:30 UTC on the 15th → 01:30 Brussels on the 16th. The site
+    // showed the 15th; the 16th is the correction.
+    expect(formatArticleDate("2026-01-15T23:30:00Z")).toBe("16 januari 2026");
+  });
+
+  it("renders an ordinary daytime publish unchanged", () => {
+    expect(formatArticleDate("2024-01-15T10:00:00Z")).toBe("15 januari 2024");
+  });
+
+  it("returns empty output for an invalid date", () => {
+    expect(formatArticleDate("not-a-date")).toBe("");
+  });
+
+  it("agrees between a Date instance and its ISO string", () => {
+    const iso = "2026-01-15T23:30:00Z";
+    expect(formatArticleDate(new Date(iso))).toBe(formatArticleDate(iso));
+  });
+});
+
+/**
+ * A BFF match date is not an instant: `parseDateString` in the Workers app
+ * builds it with `Date.UTC(…)` from PSD's Belgian local kickoff string, so its
+ * UTC fields already *are* wall-clock. The two parses must therefore disagree
+ * on a late kickoff — that disagreement is the whole point of having both.
+ */
+describe("toMatchDisplayZone", () => {
+  it("keeps a 22:00 kickoff on its own day where toDisplayZone would not", () => {
+    // The Date a BFF `Match` carries for a 22:00 Belgian kickoff on 3 August.
+    const kickoff = new Date(Date.UTC(2026, 7, 3, 22, 0));
+    expect(toMatchDisplayZone(kickoff).toISODate()).toBe("2026-08-03");
+    expect(toDisplayZone(kickoff).toISODate()).toBe("2026-08-04");
+  });
+
+  it("agrees with toDisplayZone for an ordinary afternoon kickoff", () => {
+    const kickoff = new Date(Date.UTC(2026, 7, 8, 15, 0));
+    expect(toMatchDisplayZone(kickoff).toISODate()).toBe(
+      toDisplayZone(kickoff).toISODate(),
+    );
+  });
+
+  it("reads the kickoff hour off UTC rather than converting it", () => {
+    const kickoff = new Date(Date.UTC(2026, 7, 8, 15, 0));
+    expect(toMatchDisplayZone(kickoff).toFormat("HH:mm")).toBe("15:00");
+  });
+
+  it("carries the nl locale so callers format without re-stating it", () => {
+    const kickoff = new Date(Date.UTC(2026, 8, 12, 15, 0));
+    expect(toMatchDisplayZone(kickoff).toFormat("cccc d MMMM yyyy")).toBe(
+      "zaterdag 12 september 2026",
+    );
   });
 });

--- a/apps/web/src/lib/utils/dates.ts
+++ b/apps/web/src/lib/utils/dates.ts
@@ -1,19 +1,64 @@
 import { DateTime } from "luxon";
-import { EVENT_TIMEZONE } from "./event-datetime";
+import { capitalize } from "./capitalize";
 
 /**
- * Parse into Belgian wall-clock, so the rendered calendar date does not depend
- * on where the code runs. Vercel is UTC, the browser is the visitor's own zone,
- * and `<MatchStripView>` formats in both — an unpinned late-evening kickoff
- * renders one day on the server and the next in the browser. Offset-less ISO
- * input is read as UTC, the same contract `parseEventDateTime` uses.
+ * KCVV is in Belgium, and every date the site renders is Belgian wall-clock.
+ *
+ * The constant is **club**-scoped on purpose: it governs articles, galleries,
+ * search and match metadata, not only events. Its previous event-scoped name
+ * (`EVENT_TIMEZONE`, in `./event-datetime`) is precisely why every non-event
+ * formatter kept assuming it did not apply to them and reached for the runtime
+ * zone instead (#2430). Storage stays UTC; this is presentation only.
  */
-function toDisplayZone(date: Date | string): DateTime {
+export const CLUB_TIMEZONE = "Europe/Brussels";
+
+/**
+ * The site's single date parse: a stored UTC instant → Belgian wall-clock, nl
+ * locale. Every formatter goes through it — the shared ones below and the
+ * route-local ones that render a shape with only one consumer — so a rendered
+ * calendar date never depends on where the code runs. Vercel is UTC, the
+ * browser is the visitor's own zone, and `<MatchStripView>` formats in both: an
+ * unpinned late-evening kickoff renders one day on the server and the next
+ * after hydration. Offset-less ISO input is read as UTC (the stored contract)
+ * rather than the runtime zone.
+ *
+ * **Not for PSD match dates** — see `toMatchDisplayZone`.
+ */
+export function toDisplayZone(date: Date | string): DateTime {
   const dt =
     typeof date === "string"
       ? DateTime.fromISO(date, { zone: "utc" })
       : DateTime.fromJSDate(date);
-  return dt.setZone(EVENT_TIMEZONE);
+  return dt.setZone(CLUB_TIMEZONE).setLocale("nl");
+}
+
+/**
+ * The parse for a PSD match date, which is **not** a true instant. The BFF
+ * builds it with `Date.UTC(…)` straight from PSD's Belgian local kickoff
+ * string (`apps/api/src/psd/transforms.ts` · `parseDateString`), so the Date's
+ * UTC fields already *are* Belgian wall-clock. Reading them off UTC is
+ * therefore the pin; putting one through `toDisplayZone` adds a phantom
+ * +1/+2h and rolls a ≥22:00 kickoff onto the next day.
+ *
+ * Two data sources, opposite conventions — check which one you hold before
+ * zoning it. Sanity `event` datetimes are real UTC instants (`toDisplayZone`);
+ * anything reached through a BFF `Match` is wall-clock (this).
+ *
+ * `keepLocalTime` carries the wall clock across to the club zone instead of
+ * leaving the result sitting in UTC. `toFormat` and `toISODate` read the same
+ * either way, but the returned DateTime is now a *correct instant* too — so
+ * `toISO()`, `toMillis()` and a comparison against `Date.now()` all mean what
+ * they say, which matters the moment one of these feeds an ICS or JSON-LD.
+ */
+export function toMatchDisplayZone(date: Date): DateTime {
+  return DateTime.fromJSDate(date, { zone: "utc" })
+    .setZone(CLUB_TIMEZONE, { keepLocalTime: true })
+    .setLocale("nl");
+}
+
+/** Today's calendar date in the club's zone — `YYYY-MM-DD`. */
+export function clubToday(): string {
+  return DateTime.now().setZone(CLUB_TIMEZONE).toISODate()!;
 }
 
 /**
@@ -21,11 +66,9 @@ function toDisplayZone(date: Date | string): DateTime {
  * @param date - Date object or ISO string
  */
 export const formatArticleDate = (date: Date | string): string => {
-  const dt =
-    typeof date === "string"
-      ? DateTime.fromISO(date)
-      : DateTime.fromJSDate(date);
-  return dt.setLocale("nl").toFormat("d MMMM yyyy");
+  const dt = toDisplayZone(date);
+  if (!dt.isValid) return "";
+  return dt.toFormat("d MMMM yyyy");
 };
 
 /**
@@ -35,8 +78,7 @@ export const formatArticleDate = (date: Date | string): string => {
 export const formatWidgetDate = (date: Date | string): string => {
   const dt = toDisplayZone(date);
   if (!dt.isValid) return "";
-  const s = dt.setLocale("nl").toFormat("ccc d MMMM");
-  return s.charAt(0).toUpperCase() + s.slice(1);
+  return capitalize(dt.toFormat("ccc d MMMM"));
 };
 
 /**
@@ -45,12 +87,13 @@ export const formatWidgetDate = (date: Date | string): string => {
  * Locale-pinned through Luxon like every other formatter here — `toLocale*`
  * would resolve the month name from whatever ICU data the runtime happens to
  * ship, which differs between Node, the browser and CI and would surface as
- * visual-regression drift.
+ * visual-regression drift. `src/app/__tests__/cross-page-consistency.test.ts`
+ * holds that ban site-wide.
  */
 export const formatDayMonth = (
   date: Date | string,
 ): { day: string; month: string } => {
-  const dt = toDisplayZone(date).setLocale("nl");
+  const dt = toDisplayZone(date);
   if (!dt.isValid) return { day: "", month: "" };
   return { day: dt.toFormat("d"), month: dt.toFormat("MMM") };
 };

--- a/apps/web/src/lib/utils/event-datetime.ts
+++ b/apps/web/src/lib/utils/event-datetime.ts
@@ -1,23 +1,19 @@
-import { DateTime } from "luxon";
-
-/**
- * KCVV is in Belgium and Sanity stores `event` datetimes in UTC. Pin all event
- * date/time presentation to Europe/Brussels so the weekday, day, month, start
- * time, and all-day (local-midnight) detection use Belgian wall-clock —
- * independent of the server timezone (Vercel runs UTC). Mirrors the zone
- * pinning already in `FeaturedEventBand` and `kalender/utils`.
- */
-export const EVENT_TIMEZONE = "Europe/Brussels";
+import type { DateTime } from "luxon";
+import { toDisplayZone } from "./dates";
 
 /**
  * Parse a (UTC) ISO event datetime into a Brussels-zoned, nl-locale DateTime.
- * `{ zone: "utc" }` interprets offset-less inputs as UTC (the stored contract)
- * rather than the runtime-local zone, so the result is environment-independent;
- * for the usual `Z`-suffixed Sanity values the explicit offset already wins, so
- * this is a no-op there.
+ *
+ * The event domain's name for the site's one date parse — Sanity stores `event`
+ * datetimes as real UTC instants, which is exactly `toDisplayZone`'s contract
+ * (offset-less input read as UTC, never the runtime zone). It delegates rather
+ * than re-deriving, so the zone lives in one place (#2430); the wrapper stays
+ * because `parseEventDateTime(event.dateStart)` is what reads right at the
+ * event call sites.
+ *
+ * Do **not** reach for this on a BFF `Match` date — that one is Belgian
+ * wall-clock already, see `toMatchDisplayZone` in `./dates`.
  */
 export function parseEventDateTime(iso: string): DateTime {
-  return DateTime.fromISO(iso, { zone: "utc" })
-    .setZone(EVENT_TIMEZONE)
-    .setLocale("nl");
+  return toDisplayZone(iso);
 }

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -2,8 +2,10 @@ import ical from "ical-generator";
 import { getVtimezoneComponent } from "@touch4it/ical-timezones";
 import { DateTime } from "luxon";
 import type { Match } from "@kcvv/api-contract";
+// Doubles as the calendar's `TZID` — an iCal protocol value, not only a display
+// pin — so it is read from the one home rather than restated.
+import { CLUB_TIMEZONE as TIMEZONE } from "./dates";
 
-const TIMEZONE = "Europe/Brussels";
 const HOME_VENUE_FALLBACK = "Sportpark Elewijt, Elewijt, België";
 
 export interface IcalOptions {


### PR DESCRIPTION
Closes #2561

A date was parsed eight ways across four homes, half of them not pinned to the club's timezone. Every date now parses through one exported helper, and `toLocale*` is banned by a new consistency guard.

## Changes

**`lib/utils/dates.ts` is the one home.** It owns `CLUB_TIMEZONE` — renamed from the event-scoped `EVENT_TIMEZONE`, whose narrow name is exactly why non-event formatters kept assuming it did not apply to them — and exports `toDisplayZone`. `parseEventDateTime` now delegates to it instead of re-deriving the zone, which makes rule 1 true without renaming its 21 call sites.

**`toMatchDisplayZone` is a second, deliberately different parse.** This departs from #2430's resolution comment, which said `wedstrijd/[matchId]` "gains a zone pin it lacks". A BFF match date is not an instant: `parseDateString` in the Worker builds it with `Date.UTC(…)` straight from PSD's Belgian local kickoff string, so its UTC fields already *are* Belgian wall-clock. The pin is therefore a UTC read carried across with `keepLocalTime`, not a Brussels conversion — converting one instead adds a phantom +1/+2h and rolls a ≥22:00 kickoff onto the next day. Verified against `apps/api/src/psd/transforms.ts` and the rule comment on `/scheurkalender`, which now consumes the helper rather than restating it.

**`formatArticleDate` was the only `dates.ts` export not routed through the shared parse**, and it lacked the validity guard both siblings have. Both fixed — this closes the timezone bug #2402 deferred here.

**Nine `toLocale*` call sites convert to Luxon `toFormat`.** I diffed every shape against its previous output: byte-identical on this runtime. The point is that the output no longer depends on which ICU data the runtime happens to ship.

**`clubToday()` replaces five copies of `DateTime.now().setZone(…).toISODate()`** — three of them unpinned, so the month grid, the week grid and the widget's seed could disagree for a reader outside Belgium (one tab click apart).

**`formatTimeRange` leaves `types.ts`** for its own module. It joins two `HH:mm` strings — no parse, locale or zone — so it is not a date formatter; it moved because a types module is not a home for behaviour.

## Visible consequences — flagged, not hidden

- **Some article dates shift by one day.** Any article published between 23:00 and 24:00 UTC previously rendered the earlier date; pinned, it renders the Belgian one. **That is the correction, not a regression** — it is visible across `/`, `/nieuws`, `/nieuws/[slug]`, `/galerij` and `/galerij/[slug]`.
- `/wedstrijd/[matchId]` metadata was unpinned, so a late kickoff could put the wrong date in the description served to Google.
- **No VR baselines move.** Output is byte-identical, and none of the affected components carry VR-tagged stories.

## The new seam

`src/app/__tests__/cross-page-consistency.test.ts` — the guard every later ticket cut from #2556 appends to. Same shape as the two guards already in that directory: glob the tree, one rule per file, and an empty case list fails the run on its own (vitest rejects an `it.each` with no cases). Two rules ship: no `toLocale*` date formatting, and no second zone literal outside `dates.ts`.

Mutation-checked three ways — a planted `toLocaleDateString` fails, a planted zone literal fails, and an empty glob errors rather than passing silently.

Its boundary is stated honestly in the docblock: the glob is `apps/web/src`, so the BFF Worker's own zone literal and `toLocaleDateString` are outside it.

## Scope

25 files, not the ticket's estimated 10. The extras are the guard and its test, the `formatTimeRange` split, the colocated `dates.test.ts` cases, and consolidating five further `"Europe/Brussels"` literals so rule 2 can hold at all.

## Deferred — one coherent follow-up

Three places still send a PSD match date through the event parse or no parse at all. All are pre-existing, all now have `toMatchDisplayZone` available, and all change user-visible times or a subscribed calendar feed, so they want their own ticket and their own tests rather than riding along here:

- `lib/utils/ical.ts:59` — the no-kickoff-time fallback converts a match date to Brussels, putting a midnight fixture at 01:00/02:00 in the ICS. The branch directly above it reads Y/M/D off UTC correctly.
- `components/team/TeamMatchesSection/TeamAgendaRow.tsx` — `formatKickoff` runs in a client component with no zone at all, so a timeless fixture prints 15:00 server-side and 17:00 in a Belgian browser (a hydration mismatch too). Same class in `MatchHero`, `ploegen/[slug]/wedstrijden`, `MatchStripView` and `UpcomingMatchesClient`.
- `CalendarAgenda` / `groupFeedByDay` — matches bucket and format through `toDisplayZone`; behaviour-preserving here, and the two parses only disagree at/after 22:00, which the PSD feed does not carry.

That ticket is also the right home for guard rule 3 — banning a bare `DateTime.from*` with no zone — which is the rule that makes these two load-bearing. It cannot land before the migration without failing on every file above.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, 5264 tests, build).
- Colocated vitest on the date helpers, including the case where the two parses must disagree.
- Pre-PR review gate run: `/code-review` (high) and `/simplify`. Applied: the guard's comment-stripper (it mis-segmented Storybook titles ending in a slash-star wildcard, hiding real declarations from the rules), the `clubToday` extraction, a `/kalender` sort-key regression I had introduced (keying inside the comparator, measured 47.7ms → 3.1ms at 500 fixtures), `PrintDate`'s tests (they asserted host-zone values against a now-Belgian render), and comment trimming. Skipped with reason: replacing the guard with an ESLint `no-restricted-syntax` rule (the ticket specifies a test-directory guard with the empty-case-list property), deleting `event-datetime.ts` (22 refs of churn the ticket did not ask for), and the PSD wall-clock migration above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
