### PR TITLE
fix(matches): every match date reads its wall-clock off UTC, and a guard that says so (#2601)

### DIFF
--- a/apps/web/src/app/(main)/kalender/utils.test.ts
+++ b/apps/web/src/app/(main)/kalender/utils.test.ts
@@ -14,6 +14,8 @@ import {
   buildMonthAgenda,
   groupFeedByDay,
   buildKalenderItemListEntries,
+  formatEventTime,
+  formatMatchTime,
 } from "./utils";
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import type { EventListItemVM } from "@/lib/repositories/event.repository";
@@ -544,6 +546,42 @@ describe("groupFeedByDay", () => {
     const map = groupFeedByDay(matches, events);
     expect(map.get("2026-09-12")!.matches.map((m) => m.id)).toEqual([2, 1]);
     expect(map.get("2026-09-12")!.events.map((e) => e.id)).toEqual(["e1"]);
+  });
+
+  /**
+   * A match date is wall-clock and an event datetime is an instant, so the two
+   * sources bucket through different parses. Read as an instant, a late kickoff
+   * lands on tomorrow's day in the grid and disappears from the day the
+   * supporter is actually looking at (#2601).
+   */
+  it("buckets a 22:00 kickoff on its own day, where an event at 22:00 rolls over", () => {
+    const map = groupFeedByDay(
+      [makeCalendarMatch({ id: 1, date: "2026-09-12T22:00:00" })],
+      [makeCalendarEvent({ id: "e1", dateStart: "2026-09-12T22:00:00" })],
+    );
+
+    expect(map.get("2026-09-12")!.matches.map((m) => m.id)).toEqual([1]);
+    expect(map.get("2026-09-13")!.events.map((e) => e.id)).toEqual(["e1"]);
+  });
+});
+
+// ── formatMatchTime ───────────────────────────────────────────────────────
+
+describe("formatMatchTime", () => {
+  it("reads the kickoff's own wall clock rather than converting it", () => {
+    expect(formatMatchTime("2026-09-12T15:00:00")).toBe("15:00");
+    // The instant parse is the defect it replaces — two hours late in summer.
+    expect(formatEventTime("2026-09-12T15:00:00")).toBe("17:00");
+  });
+
+  it("shows no time for a fixture the feed sends without one", () => {
+    // A timeless fixture arrives as midnight. Converted it read "02:00" — a
+    // kickoff the club never announced.
+    expect(formatMatchTime("2026-09-12T00:00:00")).toBeNull();
+  });
+
+  it("returns null for an unparseable date", () => {
+    expect(formatMatchTime("not-a-date")).toBeNull();
   });
 });
 

--- a/apps/web/src/app/(main)/kalender/utils.ts
+++ b/apps/web/src/app/(main)/kalender/utils.ts
@@ -154,15 +154,27 @@ export type CalendarFeedItem =
     };
 
 /**
- * ISO → epoch ms sort key; an unparseable date sorts to the end (not NaN).
+ * Feed item → epoch ms sort key; an unparseable date sorts to the end (not
+ * NaN). Keyed per item rather than per comparison — the comparator runs
+ * O(n log n) times and a Luxon parse is ~1.5µs, which a full season of fixtures
+ * turns into tens of milliseconds on a `force-dynamic` route.
  *
- * Deliberately *not* `toDisplayZone`: the result is an instant, and neither a
- * zone nor a locale can change one. Reading the input as UTC is the same
- * offset-less contract the shared parse uses, without paying for a zone
- * resolution per comparison.
+ * The two sources need different reads to produce the *same* kind of number.
+ * An event's `dateStart` is already an instant, so reading it as UTC is the
+ * stored contract and no zone can change the result. A match's is wall-clock in
+ * its UTC fields, so the same read is two hours out — which is a real ordering
+ * bug, not a cosmetic one: it interleaved a 15:00 kickoff *after* a 16:00
+ * Brussels event in the page's `ItemList` JSON-LD, and kept a match "upcoming"
+ * for two hours past kickoff in the `>= nowMs` cutoff below (#2601).
+ * `toMatchDisplayZone` returns a correct instant, so `toMillis()` is comparable
+ * with the event key.
  */
-function toFeedSortKey(iso: string): number {
-  const ms = DateTime.fromISO(iso, { zone: "utc" }).toMillis();
+function toFeedSortKey(item: CalendarFeedItem): number {
+  const dt =
+    item.source === "match"
+      ? toMatchDisplayZone(item.dateStart)
+      : DateTime.fromISO(item.dateStart, { zone: "utc" });
+  const ms = dt.toMillis();
   return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
 }
 
@@ -209,11 +221,9 @@ export function buildCalendarFeed(
     }),
   );
 
-  // Key once per item, not twice per comparison — the comparator runs
-  // O(n log n) times and a Luxon parse is ~1.5µs, which a full season of
-  // fixtures turns into tens of milliseconds on a `force-dynamic` route.
+  // Key once per item, not twice per comparison — see `toFeedSortKey`.
   return [...matchItems, ...eventItems]
-    .map((item) => ({ item, key: toFeedSortKey(item.dateStart) }))
+    .map((item) => ({ item, key: toFeedSortKey(item) }))
     .sort((a, b) => a.key - b.key)
     .map(({ item }) => item);
 }
@@ -234,7 +244,7 @@ export function buildKalenderItemListEntries(
   const nowMs = options.nowMs ?? Date.now();
   const limit = options.limit ?? 30;
   return feed
-    .filter((item) => toFeedSortKey(item.dateStart) >= nowMs)
+    .filter((item) => toFeedSortKey(item) >= nowMs)
     .slice(0, limit)
     .map((item) =>
       item.source === "match"
@@ -464,25 +474,25 @@ export function formatWeekRangeLabel(weekStart: string): string {
  * item (`00:00`) — mirrors `<TicketStub>`'s rule so an all-day event shows no
  * spurious midnight time.
  */
-export function formatEventTime(iso: string): string | null {
-  const dt = toDisplayZone(iso);
+const clockShape = (dt: DateTime): string | null => {
   if (!dt.isValid) return null;
   const time = dt.toFormat("HH:mm");
   return time === "00:00" ? null : time;
+};
+
+export function formatEventTime(iso: string): string | null {
+  return clockShape(toDisplayZone(iso));
 }
 
 /**
  * The same rule over a *match* date, which is wall-clock rather than an
- * instant. Split from `formatEventTime` rather than sharing it: put through the
- * instant parse, a 15:00 kickoff read "17:00" and a fixture the feed sends with
- * no time at all read "02:00" — a made-up kickoff where the agenda should show
- * none (#2601).
+ * instant. Put through the instant parse, a 15:00 kickoff read "17:00" and a
+ * fixture the feed sends with no time at all read "02:00" — a made-up kickoff
+ * where the agenda should show none (#2601). As in `@/lib/utils/dates`, the
+ * fork is at the parse and the shape is written once.
  */
 export function formatMatchTime(iso: string): string | null {
-  const dt = toMatchDisplayZone(iso);
-  if (!dt.isValid) return null;
-  const time = dt.toFormat("HH:mm");
-  return time === "00:00" ? null : time;
+  return clockShape(toMatchDisplayZone(iso));
 }
 
 /** One day's worth of feed items in the agenda's labelled wall. */

--- a/apps/web/src/app/(main)/kalender/utils.ts
+++ b/apps/web/src/app/(main)/kalender/utils.ts
@@ -12,7 +12,11 @@ import {
 import type { MatchStatus, ScheduleMatch } from "@/components/match/types";
 import { getScoreDisplay, type ScoreDisplay } from "@/lib/utils/match-display";
 import { capitalize } from "@/lib/utils/capitalize";
-import { CLUB_TIMEZONE, toDisplayZone } from "@/lib/utils/dates";
+import {
+  CLUB_TIMEZONE,
+  toDisplayZone,
+  toMatchDisplayZone,
+} from "@/lib/utils/dates";
 import type { ItemListEntry } from "@/lib/seo/jsonld";
 export type { ScoreDisplay } from "@/lib/utils/match-display";
 
@@ -265,8 +269,9 @@ function ensureDayFeed(map: Map<string, DayFeed>, day: string): DayFeed {
  * span (same semantics as `getEventsForDay`); buckets are time-sorted to match
  * the per-day helpers. Consumers `useMemo` this on `[matches, events]`.
  *
- * Matches bucket through `toDisplayZone` too, not `toMatchDisplayZone`; the two
- * only disagree for a kickoff at/after 22:00, which the PSD feed does not carry.
+ * Matches bucket through `toMatchDisplayZone` and events through
+ * `toDisplayZone` — the two sources carry opposite conventions, and a match
+ * bucketed as an instant lands on the wrong day for any kickoff at/after 22:00.
  */
 export function groupFeedByDay(
   matches: CalendarMatch[],
@@ -275,7 +280,7 @@ export function groupFeedByDay(
   const map = new Map<string, DayFeed>();
 
   for (const match of matches) {
-    const dt = toDisplayZone(match.date);
+    const dt = toMatchDisplayZone(match.date);
     if (!dt.isValid) continue;
     ensureDayFeed(map, dt.toISODate()!).matches.push(match);
   }
@@ -461,6 +466,20 @@ export function formatWeekRangeLabel(weekStart: string): string {
  */
 export function formatEventTime(iso: string): string | null {
   const dt = toDisplayZone(iso);
+  if (!dt.isValid) return null;
+  const time = dt.toFormat("HH:mm");
+  return time === "00:00" ? null : time;
+}
+
+/**
+ * The same rule over a *match* date, which is wall-clock rather than an
+ * instant. Split from `formatEventTime` rather than sharing it: put through the
+ * instant parse, a 15:00 kickoff read "17:00" and a fixture the feed sends with
+ * no time at all read "02:00" — a made-up kickoff where the agenda should show
+ * none (#2601).
+ */
+export function formatMatchTime(iso: string): string | null {
+  const dt = toMatchDisplayZone(iso);
   if (!dt.isValid) return null;
   const time = dt.toFormat("HH:mm");
   return time === "00:00" ? null : time;

--- a/apps/web/src/app/(main)/nieuws/[slug]/utils.test.ts
+++ b/apps/web/src/app/(main)/nieuws/[slug]/utils.test.ts
@@ -84,11 +84,15 @@ describe("toHeroMatchData", () => {
     expect(toHeroMatchData(makeMatch()).matchDate).toBe("Zo 13 september");
   });
 
+  // Spelled `Date.UTC(…)`, the way the BFF builds a match date from PSD's
+  // Belgian local kickoff string — an offset-less `new Date("…T19:45:00")` is
+  // read as *local* time, a shape no source emits, and it is exactly what made
+  // reading the date with `getHours()` look correct (#2601).
   it("derives kickoff from the date when `time` is absent (shared extractMatchTime)", () => {
     const data = toHeroMatchData(
       makeMatch({
         time: undefined,
-        date: new Date("2026-09-13T19:45:00"),
+        date: new Date(Date.UTC(2026, 8, 13, 19, 45)),
       }),
     );
     expect(data.kickoffTime).toBe("19:45");
@@ -98,7 +102,7 @@ describe("toHeroMatchData", () => {
     const data = toHeroMatchData(
       makeMatch({
         time: undefined,
-        date: new Date("2026-09-13T00:00:00"),
+        date: new Date(Date.UTC(2026, 8, 13, 0, 0)),
       }),
     );
     expect(data.kickoffTime).toBeUndefined();

--- a/apps/web/src/app/(main)/nieuws/[slug]/utils.ts
+++ b/apps/web/src/app/(main)/nieuws/[slug]/utils.ts
@@ -6,7 +6,7 @@
 import type { MatchDetail } from "@kcvv/api-contract";
 import type { HeroMatchData } from "@/components/article/EditorialHero";
 import { KCVV_CLUB_ID } from "@/lib/constants";
-import { formatWidgetDate } from "@/lib/utils/dates";
+import { formatMatchWidgetDate } from "@/lib/utils/dates";
 import { extractMatchTime } from "@/lib/utils/match-time";
 
 /**
@@ -55,6 +55,6 @@ export function toHeroMatchData(match: MatchDetail): HeroMatchData {
     kickoffTime: extractMatchTime(match),
     status: match.status,
     competition: match.competition,
-    matchDate: formatWidgetDate(match.date),
+    matchDate: formatMatchWidgetDate(match.date),
   };
 }

--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
@@ -1,7 +1,7 @@
 import { Effect } from "effect";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { DateTime } from "luxon";
+import { toMatchDisplayZone } from "@/lib/utils/dates";
 import { runPromise } from "@/lib/effect/runtime";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { BffService } from "@/lib/effect/services/BffService";
@@ -66,7 +66,7 @@ function groupByMonth(matches: ScheduleMatch[]): MonthGroup[] {
   const grouped = new Map<string, MonthGroup>();
 
   for (const m of sorted) {
-    const dt = DateTime.fromJSDate(m.date).setLocale("nl");
+    const dt = toMatchDisplayZone(m.date);
     const key = dt.toFormat("yyyy-MM");
     if (!grouped.has(key)) {
       const monthName =

--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/utils.test.ts
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/utils.test.ts
@@ -2,7 +2,7 @@
  * Match Detail Page Utils Tests
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   transformHomeTeam,
   transformAwayTeam,
@@ -144,34 +144,70 @@ describe("transformLineupPlayer", () => {
   });
 });
 
+/**
+ * Kickoffs are spelled the way the BFF spells them — `Date.UTC(…)`, because
+ * `parseDateString` builds a match date from PSD's Belgian local string without
+ * converting, so its UTC fields *are* the wall clock. These fixtures previously
+ * used `new Date("…T15:30:00")`, which Node reads as *local* time: a shape no
+ * source emits, and the reason reading the date with `getHours()` looked
+ * correct (#2601).
+ */
 describe("extractMatchTime", () => {
+  const at = (hour: number, minute = 0) =>
+    new Date(Date.UTC(2025, 11, 7, hour, minute));
+
   it("returns provided time if available", () => {
     const match = createMatchDetail({ time: "15:00" });
     expect(extractMatchTime(match)).toBe("15:00");
   });
 
   it("extracts time from date when time not provided", () => {
-    const match = createMatchDetail({
-      date: new Date("2025-12-07T15:30:00"),
-      time: undefined,
-    });
+    const match = createMatchDetail({ date: at(15, 30), time: undefined });
     expect(extractMatchTime(match)).toBe("15:30");
   });
 
   it("returns undefined for midnight time (likely no time set)", () => {
-    const match = createMatchDetail({
-      date: new Date("2025-12-07T00:00:00"),
-      time: undefined,
-    });
+    const match = createMatchDetail({ date: at(0, 0), time: undefined });
     expect(extractMatchTime(match)).toBeUndefined();
   });
 
   it("handles single digit hours and minutes", () => {
-    const match = createMatchDetail({
-      date: new Date("2025-12-07T09:05:00"),
-      time: undefined,
-    });
+    const match = createMatchDetail({ date: at(9, 5), time: undefined });
     expect(extractMatchTime(match)).toBe("09:05");
+  });
+
+  it("returns undefined rather than 'NaN:NaN' for an unparseable date", () => {
+    const match = createMatchDetail({ date: new Date(NaN), time: undefined });
+    expect(extractMatchTime(match)).toBeUndefined();
+  });
+
+  describe("across runtime zones", () => {
+    let savedTz: string | undefined;
+    beforeEach(() => {
+      savedTz = process.env.TZ;
+    });
+    afterEach(() => {
+      if (savedTz !== undefined) process.env.TZ = savedTz;
+      else delete process.env.TZ;
+    });
+
+    it.each(["UTC", "Europe/Brussels", "America/New_York"])(
+      "reads the kickoff off the date's own wall clock under TZ=%s",
+      (tz) => {
+        process.env.TZ = tz;
+        const match = createMatchDetail({ date: at(15, 30), time: undefined });
+        expect(extractMatchTime(match)).toBe("15:30");
+      },
+    );
+
+    it.each(["UTC", "Europe/Brussels", "America/New_York"])(
+      "still reads a timeless fixture as no kickoff under TZ=%s",
+      (tz) => {
+        process.env.TZ = tz;
+        const match = createMatchDetail({ date: at(0, 0), time: undefined });
+        expect(extractMatchTime(match)).toBeUndefined();
+      },
+    );
   });
 });
 

--- a/apps/web/src/app/__tests__/cross-page-consistency.test.ts
+++ b/apps/web/src/app/__tests__/cross-page-consistency.test.ts
@@ -139,3 +139,58 @@ describe("the club timezone has one home (#2430)", () => {
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// Rule 3 (#2601) — no date is parsed in whatever zone the code happens to run in
+// ---------------------------------------------------------------------------
+
+/**
+ * This is the rule that makes rule 2 load-bearing. Pinning the zone to one
+ * constant achieves nothing while half the site's parses never name a zone at
+ * all: those take the *runtime's*, which is UTC on Vercel, the visitor's in the
+ * browser, and the machine's in CI. On a client component that is a hydration
+ * mismatch rather than merely a wrong time, and it shipped as one — a fixture
+ * without a kickoff time printed 15:00 on the server and 17:00 in a Belgian
+ * browser (#2601).
+ *
+ * The two banned shapes:
+ *
+ * - **A parse with no options object.** A `DateTime.from…(value)` call whose
+ *   only argument is the value has no `{ zone }`, so it lands in the runtime
+ *   zone. The site's two parses — `toDisplayZone` for a stored instant,
+ *   `toMatchDisplayZone` for a BFF match date's wall clock — both live in
+ *   `dates.ts`, and a caller reaching past them is the drift this catches.
+ * - **`DateTime.now()` / `DateTime.local(…)`** unless immediately re-zoned.
+ *
+ * Deliberately conservative in one direction: a single argument containing a
+ * nested call (`fromISO(build())`) is not matched, because a regex that reached
+ * through the inner `)` would flag `fromISO(iso.trim(), { zone })` — a false
+ * positive on a correctly zoned call, which is the failure mode that gets a
+ * guard deleted. Zoning is checked by shape, not by which zone is named: `{
+ * zone: "utc" }` is a legitimate answer for stored data, and rule 2 already
+ * holds the club zone to one home.
+ *
+ * **What it cannot see:** a parse that names a zone and names the wrong one.
+ * The worst defect #2601 fixed was of that kind — the ICS feed converted a
+ * match date it should have read, so it was zoned, pinned, and two hours late.
+ * Choosing between the two parses stays a reading decision, held by
+ * `toMatchDisplayZone`'s docblock and by tests, not by this rule.
+ */
+const UNZONED_PARSE =
+  /\bDateTime\.(?:fromJSDate|fromISO|fromMillis|fromSeconds|fromFormat|fromObject|fromHTTP|fromRFC2822|fromSQL)\s*\([^,()]*\)/;
+const UNPINNED_NOW =
+  /\bDateTime\.(?:now|local)\s*\([^()]*\)(?!\s*\.setZone\s*\()/;
+
+/** The two parses' home, and the only file allowed to reach for either shape. */
+const DATE_PARSE_HOME = "lib/utils/dates.ts";
+
+describe("no date is parsed in the runtime zone (#2601)", () => {
+  it.each(productionSources.filter((f) => f !== DATE_PARSE_HOME))(
+    "%s — every Luxon parse names a zone",
+    (relPath) => {
+      const source = code.get(relPath)!;
+      expect(UNZONED_PARSE.test(source)).toBe(false);
+      expect(UNPINNED_NOW.test(source)).toBe(false);
+    },
+  );
+});

--- a/apps/web/src/app/__tests__/cross-page-consistency.test.ts
+++ b/apps/web/src/app/__tests__/cross-page-consistency.test.ts
@@ -176,23 +176,27 @@ describe("the club timezone has one home (#2430)", () => {
  *   recover it and there is no escape hatch.
  * - `now()` / `local(…)` have no input to misread, so `.setZone` settles them.
  *
- * Deliberately conservative in one known way, stated because a rule whose reach
- * is unstated reads as broader coverage than it has: a single argument
- * containing a **nested call** (`fromISO(build())`) is not matched. A regex that
- * reached through the inner `)` would flag `fromISO(iso.trim(), { zone })` — a
- * false positive on a correctly zoned call, the failure mode that gets a guard
- * deleted.
+ * **Arguments are split by a balanced scan, not by a regex.** The first version
+ * of this rule matched the argument list with `[^,()]*`, which cannot span a
+ * nested call — so `fromISO(value.trim())` and `fromJSDate(getDate())` were
+ * silently unreachable, and `fromFormat`'s arm could never fire at all because
+ * its format argument is mandatory. Widening the character class instead would
+ * have flagged `fromISO(iso.trim(), { zone })`, a false positive on correct
+ * code, which is the failure mode that gets a guard deleted. Counting *real*
+ * arguments is the only version that gets both right, and it is a dozen lines.
  *
- * `fromObject` and `fromFormat` get their own arms rather than riding the
- * one-argument pattern, which cannot reach them: a comma inside `{ year, month
- * }` ends the match, and `fromFormat`'s format argument is mandatory — so on
- * the shared pattern the `fromObject` arm fired only for a single-key object
- * and the `fromFormat` arm could never fire at all. `fromObject({…})` is
- * exactly the shape this ticket deleted from `ical.ts`.
+ * The scan skips string and template literals, so a comma inside a format
+ * string (`fromFormat(psd, "dd, MM yyyy")`) does not read as an extra argument
+ * and hide an unzoned call.
  *
- * Zoning is checked by shape, not by which zone is named: `{ zone: "utc" }` is
- * a legitimate answer for stored data, and rule 2 already holds the club zone
- * to one home.
+ * An options argument that is an **object literal** must actually mention
+ * `zone`: `fromISO(iso, { locale: "nl" })` names an option but not a zone, and
+ * parses in the runtime zone exactly like the bare call. An options argument
+ * passed as an identifier is accepted — the rule cannot see inside it, and
+ * guessing would be the false positive again.
+ *
+ * Which zone is named is not checked: `{ zone: "utc" }` is a legitimate answer
+ * for stored data, and rule 2 already holds the club zone to one home.
  *
  * **What it cannot see:** a parse that names a zone and names the wrong one.
  * The worst defect #2601 fixed was of that kind — the ICS feed converted a
@@ -202,28 +206,123 @@ describe("the club timezone has one home (#2430)", () => {
  * a reading decision, held by `toMatchDisplayZone`'s docblock and by tests.
  */
 
-/** Instant input — a later `.setZone` is a genuine fix, so it is accepted. */
-const UNZONED_INSTANT_PARSE =
-  /\bDateTime\.(?:fromJSDate|fromMillis|fromSeconds)\s*\([^,()]*\)(?!\s*\.setZone\s*\()/;
+/** Every Luxon entry point that can land a value in the runtime zone. */
+const PARSE_CALL =
+  /\bDateTime\.(fromJSDate|fromISO|fromMillis|fromSeconds|fromFormat|fromObject|fromHTTP|fromRFC2822|fromSQL|now|local)\s*\(/g;
 
-/** Text input — the zone must be named at read time; no escape hatch. */
-const UNZONED_TEXT_PARSE =
-  /\bDateTime\.(?:fromISO|fromHTTP|fromRFC2822|fromSQL)\s*\([^,()]*\)/;
+/**
+ * Instant input: the parse-time zone cannot change which moment these denote,
+ * so a later `.setZone` is a genuine fix — `fromJSDate(d).setZone(z)` is
+ * `toDisplayZone`'s own body. Text and parts input get no such hatch, because
+ * an offset-less value has already been read in the runtime zone by then.
+ */
+const RE_ZONABLE = new Set([
+  "fromJSDate",
+  "fromMillis",
+  "fromSeconds",
+  "now",
+  "local",
+]);
 
-/** Parts/format input, whose own commas put them out of the patterns above. */
-const UNZONED_FROM_OBJECT = /\bDateTime\.fromObject\s*\(\s*\{[^{}]*\}\s*\)/;
-const UNZONED_FROM_FORMAT = /\bDateTime\.fromFormat\s*\([^,()]*,[^,()]*\)/;
+/** `fromFormat(text, format, opts?)` — its options sit one place further along. */
+const OPTIONS_INDEX: Record<string, number> = { fromFormat: 2 };
 
-const UNPINNED_NOW =
-  /\bDateTime\.(?:now|local)\s*\([^()]*\)(?!\s*\.setZone\s*\()/;
+/**
+ * `now()` and `local(y, m, d, …)` read the clock rather than an input, and take
+ * their options *last* rather than at a fixed slot — so their options argument
+ * is found by looking for a trailing object literal, not by counting.
+ */
+const CLOCK_READS = new Set(["now", "local"]);
 
-const RUNTIME_ZONE_PARSES = [
-  UNZONED_INSTANT_PARSE,
-  UNZONED_TEXT_PARSE,
-  UNZONED_FROM_OBJECT,
-  UNZONED_FROM_FORMAT,
-  UNPINNED_NOW,
-];
+function optionsArg(method: string, args: string[]): string | undefined {
+  if (!CLOCK_READS.has(method)) return args[OPTIONS_INDEX[method] ?? 1];
+  const last = args.at(-1)?.trim();
+  return last?.startsWith("{") ? last : undefined;
+}
+
+/**
+ * Split a call's arguments at depth 0, honouring nesting and string literals.
+ * `open` is the index of the call's `(`. Returns `null` for an unterminated
+ * call, which a truncated or unparseable file can produce — treated as "not a
+ * finding" rather than crashing the run.
+ */
+function topLevelArgs(source: string, open: number): string[] | null {
+  const args: string[] = [];
+  let depth = 0;
+  let start = open + 1;
+  let quote: string | null = null;
+
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i]!;
+    if (quote) {
+      if (ch === "\\") i++;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") quote = ch;
+    else if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") {
+      if (--depth > 0) continue;
+      args.push(source.slice(start, i));
+      // A zero-argument call reads as one empty argument; report none.
+      return args.length === 1 && args[0]!.trim() === "" ? [] : args;
+    } else if (ch === "," && depth === 1) {
+      args.push(source.slice(start, i));
+      start = i + 1;
+    }
+  }
+  return null;
+}
+
+/** An options argument counts only if it could carry a zone. */
+function namesZone(arg: string | undefined): boolean {
+  if (arg === undefined) return false;
+  const trimmed = arg.trim();
+  // An object literal is readable, so read it. Anything else — an identifier, a
+  // spread, a call — is opaque, and accepted rather than guessed at.
+  return trimmed.startsWith("{") ? /\bzone\b/.test(trimmed) : true;
+}
+
+/** Every unzoned parse in one file, as the source text that produced it. */
+function findRuntimeZoneParses(source: string): string[] {
+  const found: string[] = [];
+  for (const match of source.matchAll(PARSE_CALL)) {
+    const method = match[1]!;
+    const open = match.index + match[0].length - 1;
+    const args = topLevelArgs(source, open);
+    if (args === null) continue;
+
+    if (namesZone(optionsArg(method, args))) continue;
+    if (
+      RE_ZONABLE.has(method) &&
+      /^\s*\.setZone\s*\(/.test(source.slice(open + rest(source, open)))
+    ) {
+      continue;
+    }
+    found.push(match[0]);
+  }
+  return found;
+}
+
+/** Offset from a call's `(` to just past its matching `)`. */
+function rest(source: string, open: number): number {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i]!;
+    if (quote) {
+      if (ch === "\\") i++;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") quote = ch;
+    else if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") {
+      if (--depth === 0) return i - open + 1;
+    }
+  }
+  return source.length - open;
+}
 
 /** The two parses' home, and the only file allowed to reach for either shape. */
 const DATE_PARSE_HOME = "lib/utils/dates.ts";
@@ -232,47 +331,68 @@ describe("no date is parsed in the runtime zone (#2601)", () => {
   it.each(productionSources.filter((f) => f !== DATE_PARSE_HOME))(
     "%s — every Luxon parse names a zone",
     (relPath) => {
-      const source = code.get(relPath)!;
-      for (const pattern of RUNTIME_ZONE_PARSES) {
-        expect(pattern.exec(source)?.[0]).toBeUndefined();
-      }
+      expect(findRuntimeZoneParses(code.get(relPath)!)).toEqual([]);
     },
   );
 });
 
 /**
  * The rule's own coverage, asserted against the shapes it exists to catch and
- * the near-misses it must leave alone. Without this, the regexes above are five
- * claims nothing checks — and two of them silently matched nothing when first
+ * the near-misses it must leave alone. Without this the detector is a claim
+ * nothing checks — and two of its arms silently matched nothing when first
  * written, which reads like coverage while providing none.
  */
 describe("rule 3 catches what it claims to (#2601)", () => {
   it.each([
-    ["DateTime.fromJSDate(date)", true],
-    ["DateTime.fromISO(iso)", true],
-    ["DateTime.fromISO(cursor).plus({ months: 1 })", true],
-    ["DateTime.now()", true],
-    ["DateTime.local(2026, 8, 3)", true],
-    ["DateTime.fromObject({ year, month, day: 1 })", true],
-    ["DateTime.fromObject({ year: 2026 })", true],
-    ['DateTime.fromFormat(psd, "yyyy-MM-dd HH:mm")', true],
-    ["DateTime.fromSQL(row.kickoff)", true],
-    ["DateTime.fromMillis(ms)", true],
+    ["DateTime.fromJSDate(date)"],
+    ["DateTime.fromISO(iso)"],
+    ["DateTime.fromISO(cursor).plus({ months: 1 })"],
+    ["DateTime.now()"],
+    ["DateTime.local(2026, 8, 3)"],
+    ["DateTime.fromObject({ year, month, day: 1 })"],
+    ["DateTime.fromObject({ year: 2026 })"],
+    ['DateTime.fromFormat(psd, "yyyy-MM-dd HH:mm")'],
+    ["DateTime.fromSQL(row.kickoff)"],
+    ["DateTime.fromMillis(ms)"],
+    // Nested calls — unreachable under the original `[^,()]*` argument match.
+    ["DateTime.fromISO(value.trim())"],
+    ["DateTime.fromJSDate(getDate())"],
+    ['DateTime.fromFormat(value.trim(), "yyyy-MM-dd")'],
+    ["DateTime.fromISO(build(a, b))"],
+    // A comma inside the format string must not read as an options argument.
+    ['DateTime.fromFormat(psd, "dd, MM yyyy")'],
+    // Options present, but not a zone among them.
+    ['DateTime.fromISO(iso, { locale: "nl" })'],
+    // A parse's zone must be named at read time; `.setZone` comes too late.
+    ["DateTime.fromISO(iso).setZone(CLUB_TIMEZONE)"],
   ])("flags %s", (snippet) => {
-    expect(RUNTIME_ZONE_PARSES.some((p) => p.test(snippet))).toBe(true);
+    expect(findRuntimeZoneParses(snippet)).toHaveLength(1);
   });
 
   it.each([
-    ['DateTime.fromISO(iso, { zone: "utc" })', false],
-    ['DateTime.fromISO(iso.trim(), { zone: "utc" })', false],
-    ["DateTime.fromJSDate(d, { zone: CLUB_TIMEZONE })", false],
+    ['DateTime.fromISO(iso, { zone: "utc" })'],
+    ['DateTime.fromISO(iso.trim(), { zone: "utc" })'],
+    ["DateTime.fromJSDate(d, { zone: CLUB_TIMEZONE })"],
     // Instant input: a later re-zone is a real fix, so it must not be flagged.
-    ["DateTime.fromJSDate(d).setZone(CLUB_TIMEZONE)", false],
-    ["DateTime.fromMillis(ms).setZone(CLUB_TIMEZONE)", false],
-    ["DateTime.now().setZone(CLUB_TIMEZONE)", false],
-    ["DateTime.fromObject({ year, month }, { zone: CLUB_TIMEZONE })", false],
-    ['DateTime.fromFormat(psd, "yyyy-MM-dd", { zone: CLUB_TIMEZONE })', false],
+    ["DateTime.fromJSDate(d).setZone(CLUB_TIMEZONE)"],
+    ["DateTime.fromMillis(ms).setZone(CLUB_TIMEZONE)"],
+    ["DateTime.now().setZone(CLUB_TIMEZONE)"],
+    ["DateTime.fromJSDate(getDate()).setZone(CLUB_TIMEZONE)"],
+    ['DateTime.local(2026, 8, 3, { zone: "utc" })'],
+    ["DateTime.fromObject({ year, month }, { zone: CLUB_TIMEZONE })"],
+    ['DateTime.fromFormat(psd, "yyyy-MM-dd", { zone: CLUB_TIMEZONE })'],
+    // Opaque options are accepted rather than guessed at.
+    ["DateTime.fromISO(iso, opts)"],
+    ["DateTime.utc(2026, 8, 3)"],
   ])("leaves %s alone", (snippet) => {
-    expect(RUNTIME_ZONE_PARSES.some((p) => p.test(snippet))).toBe(false);
+    expect(findRuntimeZoneParses(snippet)).toEqual([]);
+  });
+
+  it("reports every offender in a file, not just the first", () => {
+    expect(
+      findRuntimeZoneParses(
+        "DateTime.fromISO(a); DateTime.fromJSDate(b); DateTime.now();",
+      ),
+    ).toHaveLength(3);
   });
 });

--- a/apps/web/src/app/__tests__/cross-page-consistency.test.ts
+++ b/apps/web/src/app/__tests__/cross-page-consistency.test.ts
@@ -162,24 +162,68 @@ describe("the club timezone has one home (#2430)", () => {
  *   `dates.ts`, and a caller reaching past them is the drift this catches.
  * - **`DateTime.now()` / `DateTime.local(…)`** unless immediately re-zoned.
  *
- * Deliberately conservative in one direction: a single argument containing a
- * nested call (`fromISO(build())`) is not matched, because a regex that reached
- * through the inner `)` would flag `fromISO(iso.trim(), { zone })` — a false
- * positive on a correctly zoned call, which is the failure mode that gets a
- * guard deleted. Zoning is checked by shape, not by which zone is named: `{
- * zone: "utc" }` is a legitimate answer for stored data, and rule 2 already
- * holds the club zone to one home.
+ * **A later `.setZone` rescues some of these and not others**, which is why the
+ * constructors are split into two lists rather than one.
+ *
+ * - `fromJSDate` / `fromMillis` / `fromSeconds` take an **instant**. The
+ *   parse-time zone cannot change which moment they denote, so
+ *   `fromJSDate(d).setZone(z)` really is zone-correct — it is `toDisplayZone`'s
+ *   own body. Flagging it would make the rule fail a correct helper, and the
+ *   cheap fix for that is deleting the rule.
+ * - `fromISO` / `fromSQL` / `fromHTTP` / `fromRFC2822` / `fromFormat` /
+ *   `fromObject` take **text or parts**. An offset-less input has already been
+ *   read in the runtime zone by the time `setZone` runs, so no later call can
+ *   recover it and there is no escape hatch.
+ * - `now()` / `local(…)` have no input to misread, so `.setZone` settles them.
+ *
+ * Deliberately conservative in one known way, stated because a rule whose reach
+ * is unstated reads as broader coverage than it has: a single argument
+ * containing a **nested call** (`fromISO(build())`) is not matched. A regex that
+ * reached through the inner `)` would flag `fromISO(iso.trim(), { zone })` — a
+ * false positive on a correctly zoned call, the failure mode that gets a guard
+ * deleted.
+ *
+ * `fromObject` and `fromFormat` get their own arms rather than riding the
+ * one-argument pattern, which cannot reach them: a comma inside `{ year, month
+ * }` ends the match, and `fromFormat`'s format argument is mandatory — so on
+ * the shared pattern the `fromObject` arm fired only for a single-key object
+ * and the `fromFormat` arm could never fire at all. `fromObject({…})` is
+ * exactly the shape this ticket deleted from `ical.ts`.
+ *
+ * Zoning is checked by shape, not by which zone is named: `{ zone: "utc" }` is
+ * a legitimate answer for stored data, and rule 2 already holds the club zone
+ * to one home.
  *
  * **What it cannot see:** a parse that names a zone and names the wrong one.
  * The worst defect #2601 fixed was of that kind — the ICS feed converted a
  * match date it should have read, so it was zoned, pinned, and two hours late.
- * Choosing between the two parses stays a reading decision, held by
- * `toMatchDisplayZone`'s docblock and by tests, not by this rule.
+ * Nor can it see a date read without Luxon at all (`date.getHours()`, which is
+ * how `lib/utils/match-time.ts` drifted). Choosing between the two parses stays
+ * a reading decision, held by `toMatchDisplayZone`'s docblock and by tests.
  */
-const UNZONED_PARSE =
-  /\bDateTime\.(?:fromJSDate|fromISO|fromMillis|fromSeconds|fromFormat|fromObject|fromHTTP|fromRFC2822|fromSQL)\s*\([^,()]*\)/;
+
+/** Instant input — a later `.setZone` is a genuine fix, so it is accepted. */
+const UNZONED_INSTANT_PARSE =
+  /\bDateTime\.(?:fromJSDate|fromMillis|fromSeconds)\s*\([^,()]*\)(?!\s*\.setZone\s*\()/;
+
+/** Text input — the zone must be named at read time; no escape hatch. */
+const UNZONED_TEXT_PARSE =
+  /\bDateTime\.(?:fromISO|fromHTTP|fromRFC2822|fromSQL)\s*\([^,()]*\)/;
+
+/** Parts/format input, whose own commas put them out of the patterns above. */
+const UNZONED_FROM_OBJECT = /\bDateTime\.fromObject\s*\(\s*\{[^{}]*\}\s*\)/;
+const UNZONED_FROM_FORMAT = /\bDateTime\.fromFormat\s*\([^,()]*,[^,()]*\)/;
+
 const UNPINNED_NOW =
   /\bDateTime\.(?:now|local)\s*\([^()]*\)(?!\s*\.setZone\s*\()/;
+
+const RUNTIME_ZONE_PARSES = [
+  UNZONED_INSTANT_PARSE,
+  UNZONED_TEXT_PARSE,
+  UNZONED_FROM_OBJECT,
+  UNZONED_FROM_FORMAT,
+  UNPINNED_NOW,
+];
 
 /** The two parses' home, and the only file allowed to reach for either shape. */
 const DATE_PARSE_HOME = "lib/utils/dates.ts";
@@ -189,8 +233,46 @@ describe("no date is parsed in the runtime zone (#2601)", () => {
     "%s — every Luxon parse names a zone",
     (relPath) => {
       const source = code.get(relPath)!;
-      expect(UNZONED_PARSE.test(source)).toBe(false);
-      expect(UNPINNED_NOW.test(source)).toBe(false);
+      for (const pattern of RUNTIME_ZONE_PARSES) {
+        expect(pattern.exec(source)?.[0]).toBeUndefined();
+      }
     },
   );
+});
+
+/**
+ * The rule's own coverage, asserted against the shapes it exists to catch and
+ * the near-misses it must leave alone. Without this, the regexes above are five
+ * claims nothing checks — and two of them silently matched nothing when first
+ * written, which reads like coverage while providing none.
+ */
+describe("rule 3 catches what it claims to (#2601)", () => {
+  it.each([
+    ["DateTime.fromJSDate(date)", true],
+    ["DateTime.fromISO(iso)", true],
+    ["DateTime.fromISO(cursor).plus({ months: 1 })", true],
+    ["DateTime.now()", true],
+    ["DateTime.local(2026, 8, 3)", true],
+    ["DateTime.fromObject({ year, month, day: 1 })", true],
+    ["DateTime.fromObject({ year: 2026 })", true],
+    ['DateTime.fromFormat(psd, "yyyy-MM-dd HH:mm")', true],
+    ["DateTime.fromSQL(row.kickoff)", true],
+    ["DateTime.fromMillis(ms)", true],
+  ])("flags %s", (snippet) => {
+    expect(RUNTIME_ZONE_PARSES.some((p) => p.test(snippet))).toBe(true);
+  });
+
+  it.each([
+    ['DateTime.fromISO(iso, { zone: "utc" })', false],
+    ['DateTime.fromISO(iso.trim(), { zone: "utc" })', false],
+    ["DateTime.fromJSDate(d, { zone: CLUB_TIMEZONE })", false],
+    // Instant input: a later re-zone is a real fix, so it must not be flagged.
+    ["DateTime.fromJSDate(d).setZone(CLUB_TIMEZONE)", false],
+    ["DateTime.fromMillis(ms).setZone(CLUB_TIMEZONE)", false],
+    ["DateTime.now().setZone(CLUB_TIMEZONE)", false],
+    ["DateTime.fromObject({ year, month }, { zone: CLUB_TIMEZONE })", false],
+    ['DateTime.fromFormat(psd, "yyyy-MM-dd", { zone: CLUB_TIMEZONE })', false],
+  ])("leaves %s alone", (snippet) => {
+    expect(RUNTIME_ZONE_PARSES.some((p) => p.test(snippet))).toBe(false);
+  });
 });

--- a/apps/web/src/components/calendar/CalendarAgenda/CalendarAgenda.tsx
+++ b/apps/web/src/components/calendar/CalendarAgenda/CalendarAgenda.tsx
@@ -15,6 +15,7 @@ import {
   formatDayDetailHeading,
   formatItemCount,
   formatEventTime,
+  formatMatchTime,
   formatMonthNavLabel,
   getMatchDotType,
   type AgendaDayGroup,
@@ -43,7 +44,7 @@ const OUTCOME_UNDERLINE: Record<"win" | "draw" | "loss", string | undefined> = {
  */
 function AgendaMatchRow({ match }: { match: CalendarMatch }) {
   const isHome = match.isHome ?? getMatchDotType(match) === "home";
-  const when = match.time ?? formatEventTime(match.date) ?? "";
+  const when = match.time ?? formatMatchTime(match.date) ?? "";
   const isPlayed = isPlayedMatch(match.status);
   const hasScore =
     typeof match.homeScore === "number" && typeof match.awayScore === "number";

--- a/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.tsx
+++ b/apps/web/src/components/calendar/CalendarWidget/CalendarWidget.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { DateTime } from "luxon";
 import { cn } from "@/lib/utils/cn";
 import { clubToday, toDisplayZone } from "@/lib/utils/dates";
 import { trackEvent } from "@/lib/analytics/track-event";
@@ -130,7 +129,7 @@ export function CalendarWidget({ feed, teams, today }: CalendarWidgetProps) {
   }
 
   function stepPeriod(direction: 1 | -1) {
-    const next = DateTime.fromISO(cursor).plus(
+    const next = toDisplayZone(cursor).plus(
       view === "week" ? { weeks: direction } : { months: direction },
     );
     setCursor(next.toISODate()!);

--- a/apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
+++ b/apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/home/FeaturedEventBand/FeaturedEventBand.tsx
 import Image from "next/image";
 import { DateTime } from "luxon";
-import { toDisplayZone } from "@/lib/utils/dates";
+import { CLUB_TIMEZONE, toDisplayZone } from "@/lib/utils/dates";
 import {
   EditorialHeading,
   LinkButton,
@@ -44,7 +44,7 @@ export interface FeaturedEventBandEvent {
 
 export interface FeaturedEventBandProps {
   event: FeaturedEventBandEvent | null;
-  /** Render reference time. Defaults to `DateTime.now()`. Tests override
+  /** Render reference time. Defaults to now in the club's zone. Tests override
    *  to make the past/future split deterministic without freezing `Date`. */
   now?: DateTime;
 }
@@ -83,7 +83,10 @@ function formatDateTime(dateStart: string, dateEnd?: string | null): string {
 
 export const FeaturedEventBand = ({
   event,
-  now = DateTime.now(),
+  // Zone-pinned like every other date this file reads. The comparison below is
+  // between instants, so the zone cannot change the outcome — it is stated so
+  // the file holds no unpinned parse for the next reader to copy.
+  now = DateTime.now().setZone(CLUB_TIMEZONE),
 }: FeaturedEventBandProps) => {
   // Drop-if-empty per locked spec: null event, missing cover image, or
   // start time already past — caller doesn't have to filter upstream.

--- a/apps/web/src/components/home/UpcomingMatches/UpcomingMatchesClient.tsx
+++ b/apps/web/src/components/home/UpcomingMatches/UpcomingMatchesClient.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils/cn";
-import { formatWidgetDate } from "@/lib/utils/dates";
+import { formatMatchWidgetDate } from "@/lib/utils/dates";
 import { FilterTabs, type FilterTab } from "@/components/design-system";
 import { House, Bus } from "@/lib/icons.redesign";
 import { HOME_AWAY_WORD } from "@/lib/utils/match-display";
@@ -259,7 +259,7 @@ const MatchRow = ({ match, kcvvTeamId }: MatchRowProps) => {
     : awayIsKcvv
       ? "away"
       : undefined;
-  const dateLabel = formatWidgetDate(match.date);
+  const dateLabel = formatMatchWidgetDate(match.date);
   const when = [dateLabel, match.time].filter(Boolean).join(" · ");
   // Venue last, and only when present. PSD supplies no venue field today —
   // `apps/api/src/psd/transforms.ts` hardcodes `undefined` — so in production

--- a/apps/web/src/components/layout/MatchStrip/MatchStripView.tsx
+++ b/apps/web/src/components/layout/MatchStrip/MatchStripView.tsx
@@ -13,7 +13,7 @@ import {
   type MatchRowKind,
 } from "@/lib/utils/match-display";
 import { KCVV_CLUB_ID } from "@/lib/constants";
-import { formatWidgetDate, formatDayMonth } from "@/lib/utils/dates";
+import { formatMatchWidgetDate, formatMatchDayMonth } from "@/lib/utils/dates";
 import type { MatchStripData } from "@/lib/server/match-data";
 import type { ScheduleMatch, ScheduleTeam } from "@/components/match/types";
 
@@ -193,7 +193,7 @@ function Score({
  * is the trade #2388's own note proposed.
  */
 function StripDate({ date, kind }: { date: Date; kind: MatchRowKind }) {
-  const { day, month } = formatDayMonth(date);
+  const { day, month } = formatMatchDayMonth(date);
   return (
     <span className="text-ink text-mono-sm w-14 shrink-0 font-mono font-bold whitespace-nowrap tabular-nums">
       {day}{" "}
@@ -224,7 +224,7 @@ function LedgerLinkRow({
 }) {
   const home = isKcvvHome(match);
   const opponent = opponentOf(match);
-  const dateLabel = formatWidgetDate(match.date);
+  const dateLabel = formatMatchWidgetDate(match.date);
   // The `aria-label` replaces the row's contents as its accessible name, so the
   // score has to be spelled out here or a screen-reader user never hears it.
   // Stated KCVV-first and side-by-side with each name, since "3-1" alone does
@@ -364,7 +364,7 @@ function DesktopSlider({
         {/* No venue glyph: both teams render in scoreboard order here, so the
             layout already says who was at home. */}
         <div className="text-ink text-mono-sm mt-1.5 text-center font-mono font-semibold">
-          {formatWidgetDate(showing.date)}
+          {formatMatchWidgetDate(showing.date)}
           {!isResultSlide && showing.time ? ` · ${showing.time}` : ""}
           {showing.competition ? ` · ${showing.competition}` : ""}
         </div>

--- a/apps/web/src/components/match/MatchHero/MatchHero.tsx
+++ b/apps/web/src/components/match/MatchHero/MatchHero.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { DateTime } from "luxon";
+import { toMatchDisplayZone } from "@/lib/utils/dates";
 import { TapedCard } from "@/components/design-system/TapedCard";
 import { cn } from "@/lib/utils/cn";
 import type { MatchStatus } from "../types";
@@ -51,7 +51,7 @@ interface StubDateParts {
 }
 
 function formatStubDate(date: Date): StubDateParts {
-  const dt = DateTime.fromJSDate(date).setLocale("nl");
+  const dt = toMatchDisplayZone(date);
   return {
     weekday: dt.toFormat("ccc").replace(/\.$/, "").toUpperCase(),
     day: dt.toFormat("d"),
@@ -60,7 +60,7 @@ function formatStubDate(date: Date): StubDateParts {
 }
 
 function formatSeasonLabel(date: Date): string {
-  const dt = DateTime.fromJSDate(date);
+  const dt = toMatchDisplayZone(date);
   const startYear = dt.month >= 7 ? dt.year : dt.year - 1;
   const endYear = startYear + 1;
   const tail = (y: number) => y.toString().slice(-2).padStart(2, "0");

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.test.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.test.tsx
@@ -12,7 +12,7 @@
  *  - Symmetric scoreboard: both sides keep an even split (score stays centred)
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TeamAgendaRow } from "./TeamAgendaRow";
@@ -103,6 +103,65 @@ describe("TeamAgendaRow", () => {
       expect(screen.queryByLabelText("15 aug")).not.toBeInTheDocument();
       // the row itself still renders.
       expect(screen.getByTestId("team-agenda-row")).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The row is a client component, so every date it formats is rendered twice —
+   * once on Vercel (UTC) and once in the visitor's browser. A BFF match date
+   * carries Belgian wall-clock in its UTC fields, so reading it in the runtime
+   * zone printed 22:00 on the server and 18:00 in New York: a React text
+   * mismatch on every fixture the feed sends without a `time` (#2601).
+   *
+   * `process.env.TZ` moves Luxon's system zone live, which is what makes the
+   * two halves of the mismatch reachable from one process. Restored, never
+   * deleted — an adjacent block reads the same variable.
+   */
+  describe("Runtime-zone independence", () => {
+    const TIMELESS: ScheduleMatch = {
+      ...BASE,
+      // 22:00 Belgian kickoff, as the BFF spells it. Late enough that a
+      // converting parse rolls it into the next day.
+      date: new Date(Date.UTC(2026, 7, 3, 22, 0)),
+      time: undefined,
+    };
+
+    let savedTz: string | undefined;
+    beforeEach(() => {
+      savedTz = process.env.TZ;
+    });
+    afterEach(() => {
+      if (savedTz !== undefined) process.env.TZ = savedTz;
+      else delete process.env.TZ;
+    });
+
+    /** The row's rendered kickoff, day and month under one runtime zone. */
+    function renderIn(tz: string): string {
+      process.env.TZ = tz;
+      const { unmount } = render(<TeamAgendaRow match={TIMELESS} />);
+      const text = screen.getByTestId("team-agenda-row").textContent ?? "";
+      const stub = screen
+        .getByTestId("team-agenda-row")
+        .querySelector("[aria-label]");
+      unmount();
+      return `${text}|${stub?.getAttribute("aria-label")}`;
+    }
+
+    it("renders identically on a UTC host and in a far-off browser zone", () => {
+      expect(renderIn("America/New_York")).toBe(renderIn("UTC"));
+    });
+
+    it("renders identically on a UTC host and in the visitor's own zone", () => {
+      expect(renderIn("Europe/Brussels")).toBe(renderIn("UTC"));
+    });
+
+    it("prints the fixture's own wall clock, not a converted one", () => {
+      process.env.TZ = "America/New_York";
+      render(<TeamAgendaRow match={TIMELESS} />);
+      expect(screen.getByTestId("team-agenda-row").textContent).toContain(
+        "22:00",
+      );
+      expect(screen.getByLabelText("3 aug")).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
+++ b/apps/web/src/components/team/TeamMatchesSection/TeamAgendaRow.tsx
@@ -16,9 +16,9 @@
  */
 import { Fragment } from "react";
 import Link from "next/link";
-import { DateTime } from "luxon";
 import { Crest, PRESS_DOWN_CLASSES } from "@/components/design-system";
 import { cn } from "@/lib/utils/cn";
+import { toMatchDisplayZone } from "@/lib/utils/dates";
 import {
   getResultColor,
   HOME_AWAY_A11Y_NAME,
@@ -117,13 +117,17 @@ function computeOutcome(
   return getResultColor(match.homeScore, match.awayScore, isHome);
 }
 
+// `"use client"`: every date below renders twice, once on the UTC host and once
+// in the visitor's browser, so an unpinned parse is a React text mismatch and
+// not merely a wrong time. A BFF match date carries Belgian wall-clock in its
+// UTC fields — `toMatchDisplayZone` is the parse that reads it (#2601).
+
 function formatDay(date: Date): string {
-  return DateTime.fromJSDate(date).setLocale("nl").toFormat("d");
+  return toMatchDisplayZone(date).toFormat("d");
 }
 
 function formatMonth(date: Date): string {
-  return DateTime.fromJSDate(date)
-    .setLocale("nl")
+  return toMatchDisplayZone(date)
     .toFormat("MMM")
     .replace(/\.$/, "")
     .toLowerCase();
@@ -131,7 +135,7 @@ function formatMonth(date: Date): string {
 
 function formatKickoff(match: ScheduleMatch): string {
   if (match.time) return match.time;
-  return DateTime.fromJSDate(match.date).setLocale("nl").toFormat("HH:mm");
+  return toMatchDisplayZone(match.date).toFormat("HH:mm");
 }
 
 /**

--- a/apps/web/src/lib/repositories/event.repository.ts
+++ b/apps/web/src/lib/repositories/event.repository.ts
@@ -214,7 +214,9 @@ export function mergeEventFeed(
   // rather than poisoning the comparator with NaN; `<EventMonthList>` then drops
   // it when grouping.
   const sortKey = (iso: string): number => {
-    const ms = DateTime.fromISO(iso).toMillis();
+    // Offset-less input reads as UTC — the stored contract — rather than as
+    // whatever zone the render happens to run in.
+    const ms = DateTime.fromISO(iso, { zone: "utc" }).toMillis();
     return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
   };
   return [...fromEvents, ...fromArticles].sort(

--- a/apps/web/src/lib/utils/dates.test.ts
+++ b/apps/web/src/lib/utils/dates.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   formatArticleDate,
   formatWidgetDate,
-  formatDayMonth,
+  formatMatchDayMonth,
+  formatMatchWidgetDate,
   toDisplayZone,
   toMatchDisplayZone,
 } from "./dates";
@@ -14,44 +15,37 @@ import {
  * would render one calendar date on the server and the next after hydration.
  */
 describe("Belgian display zone", () => {
-  it("rolls a late CEST kickoff onto the next Belgian day", () => {
+  it("rolls a late CEST publish onto the next Belgian day", () => {
     // 22:30 UTC is 00:30 the following day in Brussels (summer, +02:00).
-    const late = "2026-08-03T22:30:00Z";
-    expect(formatWidgetDate(late)).toBe("Di 4 augustus");
-    expect(formatDayMonth(late)).toEqual({ day: "4", month: "aug" });
+    expect(formatWidgetDate("2026-08-03T22:30:00Z")).toBe("Di 4 augustus");
   });
 
-  it("rolls a late CET kickoff onto the next Belgian day", () => {
+  it("rolls a late CET publish onto the next Belgian day", () => {
     // 23:30 UTC is 00:30 the following day in Brussels (winter, +01:00).
-    const late = "2026-01-15T23:30:00Z";
-    expect(formatWidgetDate(late)).toBe("Vr 16 januari");
-    expect(formatDayMonth(late)).toEqual({ day: "16", month: "jan" });
+    expect(formatWidgetDate("2026-01-15T23:30:00Z")).toBe("Vr 16 januari");
   });
 
   it("treats a Date instance the same as the equivalent ISO string", () => {
     const iso = "2026-08-03T22:30:00Z";
-    expect(formatDayMonth(new Date(iso))).toEqual(formatDayMonth(iso));
     expect(formatWidgetDate(new Date(iso))).toBe(formatWidgetDate(iso));
+    expect(toDisplayZone(new Date(iso)).toISO()).toBe(
+      toDisplayZone(iso).toISO(),
+    );
   });
 
-  it("leaves an ordinary afternoon kickoff on its own day", () => {
-    const kickoff = "2026-08-08T16:00:00Z";
-    expect(formatDayMonth(kickoff)).toEqual({ day: "8", month: "aug" });
+  it("leaves an ordinary afternoon on its own day", () => {
+    expect(formatWidgetDate("2026-08-08T16:00:00Z")).toBe("Za 8 augustus");
   });
 
   it("returns empty output for an invalid date", () => {
     expect(formatWidgetDate("not-a-date")).toBe("");
-    expect(formatDayMonth("not-a-date")).toEqual({ day: "", month: "" });
   });
 
   it("reads offset-less input as UTC, not as the runtime's zone", () => {
     // The stored contract. Read as UTC this is 23:30 → 01:30 Brussels on the
     // 4th; read as runtime-local on a UTC host it would be the same, which is
     // exactly why the bug survived — assert the Brussels day, not the host's.
-    expect(formatDayMonth("2026-08-03T23:30:00")).toEqual({
-      day: "4",
-      month: "aug",
-    });
+    expect(formatWidgetDate("2026-08-03T23:30:00")).toBe("Di 4 augustus");
   });
 });
 
@@ -112,5 +106,51 @@ describe("toMatchDisplayZone", () => {
     expect(toMatchDisplayZone(kickoff).toFormat("cccc d MMMM yyyy")).toBe(
       "zaterdag 12 september 2026",
     );
+  });
+
+  /**
+   * `/kalender` carries its matches as ISO strings (`CalendarMatch.date` is
+   * `match.date.toISOString()`), so the wall-clock parse has to accept the
+   * serialised form of the same value or that route is forced back onto the
+   * instant parse.
+   */
+  it("reads a serialised match date the same as the Date it came from", () => {
+    const kickoff = new Date(Date.UTC(2026, 7, 3, 22, 0));
+    expect(toMatchDisplayZone(kickoff.toISOString()).toISO()).toBe(
+      toMatchDisplayZone(kickoff).toISO(),
+    );
+  });
+
+  it("reads an offset-less serialised match date as wall-clock too", () => {
+    expect(toMatchDisplayZone("2026-08-03T22:00:00").toFormat("HH:mm")).toBe(
+      "22:00",
+    );
+  });
+});
+
+/**
+ * The widget and day/month shapes over the match parse. `<MatchStrip>`,
+ * `<UpcomingMatches>` and an article's match block all render one of them for a
+ * fixture, while `<EventDetailBlock>` renders the widget shape for a Sanity
+ * datetime — so the fork is at the parse and not at the format.
+ */
+describe("match-date formatters", () => {
+  it("keeps a 22:00 kickoff on its own day where the instant parse would not", () => {
+    const kickoff = new Date(Date.UTC(2026, 7, 3, 22, 0));
+    expect(formatMatchDayMonth(kickoff)).toEqual({ day: "3", month: "aug" });
+    expect(formatMatchWidgetDate(kickoff)).toBe("Ma 3 augustus");
+    // The disagreement is the point — the instant parse rolls it over.
+    expect(formatWidgetDate(kickoff)).toBe("Di 4 augustus");
+  });
+
+  it("renders an ordinary afternoon kickoff identically to the instant parse", () => {
+    const kickoff = new Date(Date.UTC(2026, 7, 8, 15, 0));
+    expect(formatMatchWidgetDate(kickoff)).toBe(formatWidgetDate(kickoff));
+    expect(formatMatchDayMonth(kickoff)).toEqual({ day: "8", month: "aug" });
+  });
+
+  it("returns empty output for an invalid date", () => {
+    expect(formatMatchWidgetDate(new Date(NaN))).toBe("");
+    expect(formatMatchDayMonth(new Date(NaN))).toEqual({ day: "", month: "" });
   });
 });

--- a/apps/web/src/lib/utils/dates.ts
+++ b/apps/web/src/lib/utils/dates.ts
@@ -49,11 +49,31 @@ export function toDisplayZone(date: Date | string): DateTime {
  * either way, but the returned DateTime is now a *correct instant* too — so
  * `toISO()`, `toMillis()` and a comparison against `Date.now()` all mean what
  * they say, which matters the moment one of these feeds an ICS or JSON-LD.
+ *
+ * Accepts the serialised form as well, because `/kalender` carries its matches
+ * as `date.toISOString()` — reading that back through `toDisplayZone` is the
+ * same defect one `JSON.stringify` later.
+ *
+ * **Why this is a docblock and not a branded type.** Weighed and declined in
+ * #2601. A brand on `Match.date` in `@kcvv/api-contract` would not by itself
+ * make the wrong choice a compile error: a branded `Date` is a *subtype* of
+ * `Date`, so `toDisplayZone` keeps accepting it, and turning that into an error
+ * means negatively typing every Sanity date to exclude the brand. The brand
+ * would also have to be threaded through `ScheduleMatch`, `UpcomingMatch`,
+ * `MatchHeroProps` and `CalendarMatch` — where it dies outright, that one
+ * carries its date as a `string` — or it is lost at the first mapper
+ * (`components/match/transform.ts` assigns `date: match.date` straight across).
+ * What holds the invariant instead: two differently-*named* parses, formatters
+ * named after the source they read, and rule 3 of
+ * `src/app/__tests__/cross-page-consistency.test.ts`, which fails any parse
+ * that names no zone at all.
  */
-export function toMatchDisplayZone(date: Date): DateTime {
-  return DateTime.fromJSDate(date, { zone: "utc" })
-    .setZone(CLUB_TIMEZONE, { keepLocalTime: true })
-    .setLocale("nl");
+export function toMatchDisplayZone(date: Date | string): DateTime {
+  const dt =
+    typeof date === "string"
+      ? DateTime.fromISO(date, { zone: "utc" })
+      : DateTime.fromJSDate(date, { zone: "utc" });
+  return dt.setZone(CLUB_TIMEZONE, { keepLocalTime: true }).setLocale("nl");
 }
 
 /** Today's calendar date in the club's zone — `YYYY-MM-DD`. */
@@ -72,28 +92,46 @@ export const formatArticleDate = (date: Date | string): string => {
 };
 
 /**
+ * The compact shapes below are written once and given one entry point per
+ * parse, because both are rendered over a Sanity datetime (an instant) and over
+ * a BFF match date (wall-clock). The fork is at the *parse*, never at the
+ * format, so a caller picking the wrong one is picking a wrong *name* rather
+ * than passing a silently-off-by-two-hours argument.
+ *
+ * Locale-pinned through Luxon like every other formatter here — `toLocale*`
+ * would resolve the month and weekday names from whatever ICU data the runtime
+ * happens to ship, which differs between Node, the browser and CI and would
+ * surface as visual-regression drift.
+ * `src/app/__tests__/cross-page-consistency.test.ts` holds that ban site-wide.
+ */
+const widgetShape = (dt: DateTime): string =>
+  dt.isValid ? capitalize(dt.toFormat("ccc d MMMM")) : "";
+
+const dayMonthShape = (dt: DateTime): { day: string; month: string } =>
+  dt.isValid
+    ? { day: dt.toFormat("d"), month: dt.toFormat("MMM") }
+    : { day: "", month: "" };
+
+/**
  * Format date in compact widget format (e.g., "Za 22 maart")
  * Uses abbreviated weekday with capitalised first letter, no year.
  */
-export const formatWidgetDate = (date: Date | string): string => {
-  const dt = toDisplayZone(date);
-  if (!dt.isValid) return "";
-  return capitalize(dt.toFormat("ccc d MMMM"));
-};
+export const formatWidgetDate = (date: Date | string): string =>
+  widgetShape(toDisplayZone(date));
+
+/** Same shape for a BFF match date — see `toMatchDisplayZone`. */
+export const formatMatchWidgetDate = (date: Date | string): string =>
+  widgetShape(toMatchDisplayZone(date));
 
 /**
  * Compact day + abbreviated month, e.g. `{ day: "3", month: "aug" }`.
  *
- * Locale-pinned through Luxon like every other formatter here — `toLocale*`
- * would resolve the month name from whatever ICU data the runtime happens to
- * ship, which differs between Node, the browser and CI and would surface as
- * visual-regression drift. `src/app/__tests__/cross-page-consistency.test.ts`
- * holds that ban site-wide.
+ * Match-only: `<MatchStrip>`'s date stub is the one surface that renders this
+ * shape, and it renders a fixture. The instant-parse twin was deleted with the
+ * last caller (#2601) rather than left standing as the easier import to reach
+ * for — the whole defect class this file guards against is a caller picking the
+ * parse that happens to be in scope.
  */
-export const formatDayMonth = (
+export const formatMatchDayMonth = (
   date: Date | string,
-): { day: string; month: string } => {
-  const dt = toDisplayZone(date);
-  if (!dt.isValid) return { day: "", month: "" };
-  return { day: dt.toFormat("d"), month: dt.toFormat("MMM") };
-};
+): { day: string; month: string } => dayMonthShape(toMatchDisplayZone(date));

--- a/apps/web/src/lib/utils/dates.ts
+++ b/apps/web/src/lib/utils/dates.ts
@@ -55,16 +55,15 @@ export function toDisplayZone(date: Date | string): DateTime {
  * same defect one `JSON.stringify` later.
  *
  * **Why this is a docblock and not a branded type.** Weighed and declined in
- * #2601. A brand on `Match.date` in `@kcvv/api-contract` would not by itself
- * make the wrong choice a compile error: a branded `Date` is a *subtype* of
- * `Date`, so `toDisplayZone` keeps accepting it, and turning that into an error
- * means negatively typing every Sanity date to exclude the brand. The brand
- * would also have to be threaded through `ScheduleMatch`, `UpcomingMatch`,
- * `MatchHeroProps` and `CalendarMatch` — where it dies outright, that one
- * carries its date as a `string` — or it is lost at the first mapper
- * (`components/match/transform.ts` assigns `date: match.date` straight across).
- * What holds the invariant instead: two differently-*named* parses, formatters
- * named after the source they read, and rule 3 of
+ * #2601. A brand on `Match.date` in `@kcvv/api-contract` would have to survive
+ * the trip to the surface that renders it, and it does not: `ScheduleMatch`,
+ * `UpcomingMatch` and `MatchHeroProps` would each have to adopt it,
+ * `CalendarMatch` cannot — it carries its date as a `string` — and the very
+ * first mapper drops it anyway (`components/match/transform.ts` assigns
+ * `date: match.date` straight across, silently widening the brand away). So the
+ * brand would guard the one place already holding the invariant and none of the
+ * places that lose it. What holds it instead: two differently-*named* parses,
+ * formatters named after the source they read, and rule 3 of
  * `src/app/__tests__/cross-page-consistency.test.ts`, which fails any parse
  * that names no zone at all.
  */
@@ -92,9 +91,9 @@ export const formatArticleDate = (date: Date | string): string => {
 };
 
 /**
- * The compact shapes below are written once and given one entry point per
- * parse, because both are rendered over a Sanity datetime (an instant) and over
- * a BFF match date (wall-clock). The fork is at the *parse*, never at the
+ * The widget shape is rendered over both sources — a Sanity datetime, which is
+ * an instant, and a BFF match date, which is wall-clock — so it is written once
+ * and given one entry point per parse. The fork is at the *parse*, never at the
  * format, so a caller picking the wrong one is picking a wrong *name* rather
  * than passing a silently-off-by-two-hours argument.
  *
@@ -106,11 +105,6 @@ export const formatArticleDate = (date: Date | string): string => {
  */
 const widgetShape = (dt: DateTime): string =>
   dt.isValid ? capitalize(dt.toFormat("ccc d MMMM")) : "";
-
-const dayMonthShape = (dt: DateTime): { day: string; month: string } =>
-  dt.isValid
-    ? { day: dt.toFormat("d"), month: dt.toFormat("MMM") }
-    : { day: "", month: "" };
 
 /**
  * Format date in compact widget format (e.g., "Za 22 maart")
@@ -126,12 +120,18 @@ export const formatMatchWidgetDate = (date: Date | string): string =>
 /**
  * Compact day + abbreviated month, e.g. `{ day: "3", month: "aug" }`.
  *
- * Match-only: `<MatchStrip>`'s date stub is the one surface that renders this
- * shape, and it renders a fixture. The instant-parse twin was deleted with the
- * last caller (#2601) rather than left standing as the easier import to reach
- * for — the whole defect class this file guards against is a caller picking the
- * parse that happens to be in scope.
+ * Match-only, and so not split in two like the widget shape above:
+ * `<MatchStrip>`'s date stub is the one surface that renders it, and it renders
+ * a fixture. The instant-parse twin was deleted with its last caller (#2601)
+ * rather than left standing as the easier import to reach for — the whole
+ * defect class this file guards against is a caller picking whichever parse
+ * happens to be in scope.
  */
 export const formatMatchDayMonth = (
   date: Date | string,
-): { day: string; month: string } => dayMonthShape(toMatchDisplayZone(date));
+): { day: string; month: string } => {
+  const dt = toMatchDisplayZone(date);
+  return dt.isValid
+    ? { day: dt.toFormat("d"), month: dt.toFormat("MMM") }
+    : { day: "", month: "" };
+};

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -139,6 +139,57 @@ describe("generateIcal", () => {
     expect(output).toContain("DTSTART;TZID=Europe/Brussels:20250715T150000");
   });
 
+  /**
+   * The `time`-less branch. A BFF match date carries Belgian wall-clock in its
+   * UTC fields, so converting it to Brussels adds a phantom +1/+2h — and this
+   * feed is *subscribed*, so a wrong DTSTART follows people into their calendar
+   * app until they unsubscribe. The branch shipped untested (#2601).
+   */
+  describe("a fixture with no kickoff time", () => {
+    it("emits the date's own wall clock rather than converting it", () => {
+      const match = makeMatch({
+        date: new Date(Date.UTC(2025, 2, 22, 15, 0)),
+        time: undefined,
+      });
+      const output = generateIcal([match]);
+
+      expect(output).toContain("DTSTART;TZID=Europe/Brussels:20250322T150000");
+    });
+
+    it("keeps a midnight fixture at midnight, in winter too", () => {
+      const match = makeMatch({
+        date: new Date(Date.UTC(2025, 0, 15, 0, 0)),
+        time: undefined,
+      });
+      const output = generateIcal([match]);
+
+      expect(output).toContain("DTSTART;TZID=Europe/Brussels:20250115T000000");
+    });
+
+    it("agrees with the same kickoff spelled out in `time`", () => {
+      const date = new Date(Date.UTC(2025, 6, 15, 15, 0));
+      const implicit = generateIcal([makeMatch({ date, time: undefined })]);
+      const explicit = generateIcal([makeMatch({ date, time: "15:00" })]);
+
+      // The event's own DTSTART, not the VTIMEZONE transition rules above it —
+      // those are identical whatever the fixture, so a looser match passes
+      // while the two branches disagree by two hours.
+      const dtstart = (ics: string) => /^DTSTART;TZID=.*$/m.exec(ics)?.[0];
+      expect(dtstart(implicit)).toBe(dtstart(explicit));
+      expect(dtstart(implicit)).toBeDefined();
+    });
+
+    it("keeps a 22:00 kickoff on its own day", () => {
+      const match = makeMatch({
+        date: new Date(Date.UTC(2025, 7, 3, 22, 0)),
+        time: undefined,
+      });
+      const output = generateIcal([match]);
+
+      expect(output).toContain("DTSTART;TZID=Europe/Brussels:20250803T220000");
+    });
+  });
+
   it("sorts matches by date", () => {
     const earlier = makeMatch({
       id: 1,

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -4,7 +4,7 @@ import { DateTime } from "luxon";
 import type { Match } from "@kcvv/api-contract";
 // Doubles as the calendar's `TZID` — an iCal protocol value, not only a display
 // pin — so it is read from the one home rather than restated.
-import { CLUB_TIMEZONE as TIMEZONE } from "./dates";
+import { CLUB_TIMEZONE as TIMEZONE, toMatchDisplayZone } from "./dates";
 
 const HOME_VENUE_FALLBACK = "Sportpark Elewijt, Elewijt, België";
 
@@ -40,22 +40,23 @@ function buildLocation(match: Match): string | undefined {
   return undefined;
 }
 
+/**
+ * The fixture's kickoff as a Brussels wall-clock DateTime, which is what a
+ * `DTSTART;TZID=Europe/Brussels` line means.
+ *
+ * A BFF match date is not an instant — its UTC fields already *are* Belgian
+ * wall-clock — so `toMatchDisplayZone` reads it and `match.time`, when the feed
+ * carries one, only overrides the hour and minute. Converting instead (the
+ * pre-#2601 `time`-less branch) put every such fixture in the subscribed feed
+ * one or two hours late, and rolled a 22:00 kickoff onto the next day.
+ */
 function buildStartDateTime(match: Match): DateTime {
-  const d = new Date(match.date);
-  if (match.time) {
-    const [hours, minutes] = match.time.split(":").map(Number);
-    return DateTime.fromObject(
-      {
-        year: d.getUTCFullYear(),
-        month: d.getUTCMonth() + 1,
-        day: d.getUTCDate(),
-        hour: hours,
-        minute: minutes,
-      },
-      { zone: TIMEZONE },
-    );
-  }
-  return DateTime.fromJSDate(d, { zone: TIMEZONE });
+  // Minute precision, as the pre-#2601 `fromObject` call implicitly had: PSD
+  // never sends seconds, and a stray one would land in a DTSTART line.
+  const start = toMatchDisplayZone(match.date).startOf("minute");
+  if (!match.time) return start;
+  const [hours, minutes] = match.time.split(":").map(Number);
+  return start.set({ hour: hours, minute: minutes });
 }
 
 export function normalizeCacheKey(

--- a/apps/web/src/lib/utils/match-time.ts
+++ b/apps/web/src/lib/utils/match-time.ts
@@ -1,4 +1,5 @@
 import type { MatchDetail } from "@kcvv/api-contract";
+import { toMatchDisplayZone } from "./dates";
 
 /**
  * Returns the match kickoff time as "HH:MM" when available.
@@ -9,6 +10,12 @@ import type { MatchDetail } from "@kcvv/api-contract";
  * the match page and the matchPreview/matchRecap hero derive kickoff through
  * this single helper (shared to avoid the two surfaces drifting).
  *
+ * The read goes through `toMatchDisplayZone` rather than `getHours()`, which
+ * takes the *runtime* zone: right on Vercel by accident, two hours out on a
+ * Belgian dev machine, and — worse — turning a timeless fixture's midnight into
+ * a "02:00" kickoff the club never announced. Rule 3 of the cross-page guard
+ * cannot see this one, because it is not a Luxon call at all (#2601).
+ *
  * @returns The time as `HH:MM` if available, `undefined` otherwise.
  */
 export function extractMatchTime(match: MatchDetail): string | undefined {
@@ -18,11 +25,12 @@ export function extractMatchTime(match: MatchDetail): string | undefined {
 
   const date = match.date;
   if (date instanceof Date) {
-    const hours = date.getHours();
-    const minutes = date.getMinutes();
-    if (hours !== 0 || minutes !== 0) {
-      return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
-    }
+    const dt = toMatchDisplayZone(date);
+    // An invalid date used to fall through to `"NaN:NaN"`; it now reads as no
+    // kickoff, which is what an unparseable one means.
+    if (!dt.isValid) return undefined;
+    const time = dt.toFormat("HH:mm");
+    if (time !== "00:00") return time;
   }
 
   return undefined;

--- a/apps/web/src/lib/utils/season.test.ts
+++ b/apps/web/src/lib/utils/season.test.ts
@@ -1,5 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { groupBySeason, type Season } from "./season";
+
+/**
+ * The only caller groups BFF matches, whose dates the Workers app builds with
+ * `Date.UTC(…)` from PSD's Belgian local kickoff string — so a kickoff is
+ * spelled here the way the producer spells it. A locally-constructed
+ * `new Date(y, m, d)` is a shape no source emits, and it is what made an
+ * unpinned parse look correct: local midnight and its UTC fields agree only in
+ * the zone the test happens to run in (#2601).
+ */
+const kickoff = (
+  year: number,
+  monthIndex: number,
+  day: number,
+  hour = 15,
+): Date => new Date(Date.UTC(year, monthIndex, day, hour));
 
 // `deriveSeason` is module-private (only `groupBySeason` consumes it), so we
 // assert its boundary + label behaviour through the public API: a single-item
@@ -9,36 +24,68 @@ const seasonOf = (date: Date): Season =>
 
 describe("season derivation (via groupBySeason)", () => {
   it("places a spring match (Jan–Jun) in the season that started the prior July", () => {
-    expect(seasonOf(new Date(2026, 4, 18))).toEqual({
+    expect(seasonOf(kickoff(2026, 4, 18))).toEqual({
       key: "2025-2026",
       label: "Seizoen '25–'26",
     });
   });
 
   it("places an autumn match (Jul–Dec) in the season that starts that July", () => {
-    expect(seasonOf(new Date(2025, 10, 24))).toEqual({
+    expect(seasonOf(kickoff(2025, 10, 24))).toEqual({
       key: "2025-2026",
       label: "Seizoen '25–'26",
     });
   });
 
   it("treats July as the start of the new season (boundary)", () => {
-    expect(seasonOf(new Date(2025, 6, 1)).key).toBe("2025-2026");
+    expect(seasonOf(kickoff(2025, 6, 1)).key).toBe("2025-2026");
   });
 
   it("treats June as still belonging to the prior season (boundary)", () => {
-    expect(seasonOf(new Date(2025, 5, 30)).key).toBe("2024-2025");
+    expect(seasonOf(kickoff(2025, 5, 30)).key).toBe("2024-2025");
   });
 
   it("lands an August cup match in the upcoming season", () => {
-    expect(seasonOf(new Date(2026, 7, 5))).toEqual({
+    expect(seasonOf(kickoff(2026, 7, 5))).toEqual({
       key: "2026-2027",
       label: "Seizoen '26–'27",
     });
   });
 
   it("formats the label with two-digit years and an en-dash", () => {
-    expect(seasonOf(new Date(2024, 8, 1)).label).toBe("Seizoen '24–'25");
+    expect(seasonOf(kickoff(2024, 8, 1)).label).toBe("Seizoen '24–'25");
+  });
+
+  /**
+   * The boundary is where an unpinned read costs a whole season: a 30 June
+   * evening kickoff read east of UTC crosses into July and moves the match to
+   * the season that has not started yet.
+   */
+  describe("across runtime zones", () => {
+    let savedTz: string | undefined;
+    beforeEach(() => {
+      savedTz = process.env.TZ;
+    });
+    afterEach(() => {
+      if (savedTz !== undefined) process.env.TZ = savedTz;
+      else delete process.env.TZ;
+    });
+
+    it.each(["UTC", "Europe/Brussels", "America/New_York", "Asia/Tokyo"])(
+      "keeps a 30 June evening kickoff in the closing season under TZ=%s",
+      (tz) => {
+        process.env.TZ = tz;
+        expect(seasonOf(kickoff(2025, 5, 30, 22)).key).toBe("2024-2025");
+      },
+    );
+
+    it.each(["UTC", "Europe/Brussels", "America/New_York", "Asia/Tokyo"])(
+      "keeps a 1 July early kickoff in the opening season under TZ=%s",
+      (tz) => {
+        process.env.TZ = tz;
+        expect(seasonOf(kickoff(2025, 6, 1, 0)).key).toBe("2025-2026");
+      },
+    );
   });
 });
 
@@ -47,10 +94,10 @@ describe("groupBySeason", () => {
 
   it("groups items by season preserving input order across and within groups", () => {
     const items = [
-      make("2026-08-05T12:00:00", 1), // '26–'27
-      make("2026-05-18T12:00:00", 2), // '25–'26
-      make("2026-04-12T12:00:00", 3), // '25–'26
-      make("2024-08-25T12:00:00", 4), // '24–'25
+      make("2026-08-05T12:00:00Z", 1), // '26–'27
+      make("2026-05-18T12:00:00Z", 2), // '25–'26
+      make("2026-04-12T12:00:00Z", 3), // '25–'26
+      make("2024-08-25T12:00:00Z", 4), // '24–'25
     ];
     const groups = groupBySeason(items, (m) => m.date);
 

--- a/apps/web/src/lib/utils/season.ts
+++ b/apps/web/src/lib/utils/season.ts
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import { toMatchDisplayZone } from "./dates";
 
 /** A football season spanning roughly Aug→May (e.g. 2025–2026). */
 export interface Season {
@@ -23,9 +23,14 @@ function twoDigit(year: number): string {
  * runs roughly August→May, with cup fixtures already in July, so the boundary
  * is month ≥ 7 (July) → the *new* season: an August Beker match lands in the
  * upcoming season rather than the one that just ended.
+ *
+ * Every caller groups *matches*, whose dates carry Belgian wall-clock in their
+ * UTC fields — so the month is read through `toMatchDisplayZone`. Unpinned, a
+ * 30 June evening kickoff read in a browser east of UTC crossed into July and
+ * moved a whole season boundary.
  */
 function deriveSeason(date: Date): Season {
-  const { year, month } = DateTime.fromJSDate(date);
+  const { year, month } = toMatchDisplayZone(date);
   const startYear = month >= 7 ? year : year - 1;
   const endYear = startYear + 1;
   return {


### PR DESCRIPTION
Closes #2601

A BFF match date is **not an instant**. `parseDateString` (`apps/api/src/psd/transforms.ts`) builds it as `new Date(Date.UTC(y, m-1, d, hh, mm))` straight from PSD's Belgian *local* kickoff string, so the Date's UTC fields already **are** Belgian wall-clock. #2561 named the correct parse (`toMatchDisplayZone`) but deliberately stopped short of migrating the consumers. This migrates all of them and lands the guard that keeps them migrated.

## Confirmed defects, measured

**1. The subscribed ICS feed was one to two hours late.** `buildStartDateTime` converted the date instead of reading it, on every fixture the feed sends without a `time`:

| fixture | before | after |
| --- | --- | --- |
| 15:00 kickoff, March | `20250322T160000` | `20250322T150000` |
| midnight / all-day, January | `20250115T010000` | `20250115T000000` |
| 22:00 kickoff, August | `20250804T000000` (next day) | `20250803T220000` |

The branch shipped with **no test coverage at all**; it has four now. This is a *subscribed* feed, so a shipped regression follows people into their calendar app.

**2. `<TeamAgendaRow>` had a hydration mismatch.** A client component reading the kickoff in the runtime zone. Reproduced before fixing, on a 22:00 fixture with no `time`:

| runtime zone | rendered |
| --- | --- |
| UTC (Vercel) | `3 aug · 22:00` |
| `America/New_York` | `3 aug · 18:00` |
| `Europe/Brussels` | `4 aug · 00:00` |

Three tests pin `process.env.TZ` and assert server/browser parity.

**3. The shared kickoff helper read the date with `getHours()`.** Found in review. `lib/utils/match-time.ts` is correct on Vercel *by accident* (UTC host) and two hours out under `pnpm dev`; it turned a timeless fixture's midnight into an invented `"02:00"`, and returned the string `"NaN:NaN"` for an unparseable date. Reached from `/wedstrijd/[matchId]` and the news match hero.

**4. `/kalender` ordered matches against events wrongly.** `toFeedSortKey` keyed a match date as an instant, so a 15:00 kickoff sorted *after* a 16:00 Brussels event in the page's `ItemList` JSON-LD, and the `>= nowMs` cutoff kept a match "upcoming" for two hours past kickoff.

## Also migrated

`MatchHero`, `season.ts` (an unpinned 30 June evening kickoff moved a whole season boundary), `/ploegen/[slug]/wedstrijden`, `<MatchStripView>`, `<UpcomingMatchesClient>`, the news match block, `/kalender`'s day bucketing, and the agenda's `match.time` fallback — which showed a converted `"02:00"` where a timeless fixture should show no time at all.

`toMatchDisplayZone` now accepts the serialised form too, because `/kalender` carries its matches as `date.toISOString()`. The compact display shapes are written once and forked at the *parse*, so the two conventions are told apart by name (`formatMatchWidgetDate` vs `formatWidgetDate`, `formatMatchTime` vs `formatEventTime`) rather than by argument. `formatDayMonth` is deleted with its last caller.

## Guard rule 3

`src/app/__tests__/cross-page-consistency.test.ts` gains: a Luxon parse outside `lib/utils/dates.ts` must name a zone. Verified to fire on six pre-fix files. Three unrelated unpinned parses (`FeaturedEventBand`, `CalendarWidget`, `event.repository`) are pinned so it could land.

The rule's own coverage is now asserted by 18 cases, because two of its five patterns were **silently matching nothing** when first written — `fromFormat`'s format argument is mandatory and `fromObject`'s own commas ended the match. A rule that matches nothing reads like coverage while providing none, which is this file's stated standard.

**Stated blind spots**, rather than left implied:

- It cannot see a parse that names a zone and names the *wrong* one — which is what defect 1 was.
- It cannot see a date read without Luxon at all — which is what defect 3 was.
- Instant-input constructors (`fromJSDate`/`fromMillis`/`fromSeconds`) take a `.setZone` escape hatch because a later re-zone genuinely fixes them; text-input ones do not, because an offset-less input has already been read wrong by then.

## Test fixtures were wrong, not just the code

Three test files spelled kickoffs `new Date("…T15:30:00")`, which Node reads as **local** time — a shape no source emits, and precisely why the unpinned reads looked correct. Rewritten onto `Date.UTC(…)`, with the boundary cases asserted across UTC, Brussels, New York and Tokyo.

## The branded-type AC

Assessed and **declined**; reasoning recorded in `toMatchDisplayZone`'s docblock. A brand on `Match.date` would have to survive to the surface that renders it and does not: `components/match/transform.ts` assigns `date: match.date` straight across and silently widens it away, and `CalendarMatch` cannot carry it at all — its date is a `string`. The brand would guard the one place already holding the invariant and none of the places that lose it.

## Out of scope, and why

Normalising the convention at the BFF boundary (`apps/api/src/psd/transforms.ts`). Verified rather than assumed: `apps/api/src/cache/kv-cache.ts` JSON-stringifies the transformed value, so re-meaning the wire format would decode every cached entry one to two hours wrong until TTL. Worth noting the unlock is one line — version the KV key prefix so stale entries are unreachable — which makes this a scheduling constraint rather than a permanent one.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint · type-check · test · build).
- 5897 tests pass, up from 5868 on `main`.
- Test strength verified by reverting each fix in place: ical 4 fail, kalender 3, `TeamAgendaRow` 3, season 3. No test passes against the old behaviour.
- The ICS rewrite was diffed old-vs-new across 15 edge inputs (malformed `time`, DST spring-forward and fall-back, invalid `Date`). Every difference is either the intended fix or immaterial — on the ambiguous fall-back hour the emitted `DTSTART` line is byte-identical, since `TZID` transmits wall-clock rather than offset.

## Review gate

`/code-review` and `/simplify` both run. Applied: the four defects above plus three cleanups (shared `clockShape`, inlined `dayMonthShape`, a wrong clause dropped from the branded-type note). Skipped: sharing an 8-line TZ save/restore between two test files (worth it at a third caller, not two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calendar and match date displays across time zones.
  * Match kickoff times now consistently preserve their scheduled wall-clock time, including midnight and late-night matches.
  * Improved handling of event dates, upcoming matches, agenda views, season boundaries, and iCalendar entries.
  * Invalid or missing dates and kickoff times are handled safely without displaying incorrect values.

* **Tests**
  * Added broad coverage for timezone-independent date formatting, boundary cases, and cross-page consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->