### PR TITLE
refactor(ui): running text measures 680, read from the prose container token (#2560)

### DIFF
--- a/apps/web/src/app/(main)/club/ultras/UltrasSection.tsx
+++ b/apps/web/src/app/(main)/club/ultras/UltrasSection.tsx
@@ -45,7 +45,9 @@ export function UltrasSection({
           {heading}
         </EditorialHeading>
       </header>
-      <div className="text-body-md text-ink-soft [&_strong]:text-ink flex flex-col gap-5 leading-relaxed [&_strong]:font-semibold">
+      {/* #2436: only <p> children clamp to the prose token — the embedded
+          <TapedFigure>/<PullQuote> blocks keep the container's full width. */}
+      <div className="text-body-md text-ink-soft [&_strong]:text-ink flex flex-col gap-5 leading-relaxed [&_strong]:font-semibold [&>p]:max-w-[var(--container-prose)]">
         {children}
       </div>
     </section>

--- a/apps/web/src/app/(main)/club/ultras/loading.tsx
+++ b/apps/web/src/app/(main)/club/ultras/loading.tsx
@@ -21,7 +21,9 @@ function SectionSkeleton({ withImage = false }: { withImage?: boolean }) {
         <div className="bg-paper-edge h-3 w-28" />
         <div className="bg-paper-edge h-8 w-56" />
       </div>
-      <div className="space-y-3">
+      {/* Paragraph bars take the prose token like the real copy (#2436); the
+          figure below keeps the container's full width. */}
+      <div className="max-w-[var(--container-prose)] space-y-3">
         <div className="bg-paper-edge h-4 w-full" />
         <div className="bg-paper-edge h-4 w-full" />
         <div className="bg-paper-edge h-4 w-5/6" />

--- a/apps/web/src/app/(main)/club/ultras/page.test.tsx
+++ b/apps/web/src/app/(main)/club/ultras/page.test.tsx
@@ -22,6 +22,19 @@ describe("/club/ultras page", () => {
     expect(screen.getByText("Lid worden")).toBeInTheDocument();
   });
 
+  it("measures its running text at the prose token, leaving media at container width", () => {
+    render(<UltrasPage />);
+
+    // #2436: only direct-child <p> clamp to the prose token. jsdom does not
+    // resolve the arbitrary variant, so assert both halves of what makes it
+    // apply — the copy is a <p>, and its direct parent carries the clamp.
+    const paragraph = screen.getByText(/De naam KCVV Ultras werd/);
+    expect(paragraph.tagName).toBe("P");
+    expect(paragraph.parentElement?.className).toContain(
+      "[&>p]:max-w-[var(--container-prose)]",
+    );
+  });
+
   it("renders the raffle callout stats", () => {
     render(<UltrasPage />);
 

--- a/apps/web/src/app/(main)/hulp/page.tsx
+++ b/apps/web/src/app/(main)/hulp/page.tsx
@@ -140,7 +140,7 @@ export default async function HulpHubPage() {
             >
               Veelgestelde vragen
             </EditorialHeading>
-            <p className="text-ink-soft mt-3 max-w-[60ch] text-base leading-relaxed">
+            <p className="text-ink-soft mt-3 max-w-[var(--container-prose)] text-base leading-relaxed">
               Kies je rol of een categorie en blader door de antwoorden — elk
               antwoord geeft je de stappen én de juiste contactpersoon. Of zoek
               hierboven op een naam, functie of vraag.
@@ -179,7 +179,7 @@ export default async function HulpHubPage() {
             >
               Het organigram — wie-is-wie
             </EditorialHeading>
-            <p className="text-ink-soft mt-3 max-w-[60ch] text-base leading-relaxed">
+            <p className="text-ink-soft mt-3 max-w-[var(--container-prose)] text-base leading-relaxed">
               Het bestuur, de jeugdwerking en alle vrijwilligers per afdeling.
             </p>
 

--- a/apps/web/src/components/club/BestuurPage/BestuurPage.tsx
+++ b/apps/web/src/components/club/BestuurPage/BestuurPage.tsx
@@ -81,8 +81,13 @@ export function BestuurPage({ header, body, staff = [] }: BestuurPageProps) {
 
       {showDescription ? (
         <PageContainer as="section" className="pt-12">
-          <div className="border-jersey-deep text-ink font-body max-w-3xl border-l-4 pl-6 text-base leading-relaxed [&_p]:mb-4 [&_p:last-child]:mb-0">
-            <PortableText value={body} components={bodyComponents} />
+          {/* Shared by /club/bestuur, /club/angels and /club/jeugdbestuur (#2436).
+              The rule + gutter sit outside the clamp so the text column measures
+              the full prose token, not the token minus its own padding. */}
+          <div className="border-jersey-deep border-l-4 pl-6">
+            <div className="text-ink font-body max-w-[var(--container-prose)] text-base leading-relaxed [&_p]:mb-4 [&_p:last-child]:mb-0">
+              <PortableText value={body} components={bodyComponents} />
+            </div>
           </div>
         </PageContainer>
       ) : null}


### PR DESCRIPTION
Closes #2560

Consolidates every reading measure onto `--container-prose` (680), per decision #2436. Decision #2434 is recorded as holding as written — the three-width rule stands, no route changes its container, and the default width stays optional.

## Changes

| Route(s) | Was | Now |
| --- | --- | --- |
| `/club/ultras` | unmeasured (full container) | `[&>p]:max-w-[var(--container-prose)]` on the section flow |
| `/club/bestuur`, `/club/angels`, `/club/jeugdbestuur` | `max-w-3xl` (768) | the token, with the rule + gutter moved outside the clamp |
| `/hulp` | `max-w-[60ch]` ×2 | the token |
| `/club/ultras` skeleton | `w-full` paragraph bars | the token |

Two judgement calls:

- **The `/club/ultras` clamp rides the paragraphs, not the flow.** `[&>p]` leaves the sibling `<TapedFigure>` / `<PullQuote>` / `<RaffleCallout>` blocks at the container's full width — text measured, media escaping, which is the shape `<ArticleBody>` renders. The paragraphs stay **left-aligned** rather than centred because the section heading above them is unclamped and anchors the left edge; centring only the copy would misalign the two.
- **`BestuurPage` gained one wrapper div.** The clamp previously shared a box with `border-l-4 pl-6`, and under `box-sizing: border-box` that 28px comes out of the 680 — a 652px text column, i.e. the same silent drift the ticket exists to remove. The rule and gutter now sit outside the clamp.

**`/privacy` and `/club/word-lid` needed no change.** The ticket's "5 files / 7 routes" is stale: #2555 already absorbed both lead clamps into `<PageHero>`, which reads the token. Those two routes are correct on current `main`, so this is 5 files / 7 routes with two already satisfied.

## A third `ch` was found, tried, and split out → #2645

`VolledigOrganigram.tsx:162` carries a third `max-w-[60ch]` that #2436's audit missed — it is two components deep (`/hulp` → `OrganigramOverview` → `VolledigOrganigram`), so a route-file grep never reached it. At `text-sm` it resolves to a third absolute width, which is exactly the drift the `ch` ban targets.

Converting it to the token was attempted in this PR and **VR caught a real regression**: the caption is a flex item in a `justify-between` toolbar row next to two buttons, so at 680 it claims the whole row, the button group wraps to a second line, and the chart shifts down (`volledigorganigram--default--tablet` 4.99% / 39270px; `organigramoverview--default--tablet` 0.19% / 1506px).

The `60ch` is doing real layout work at ~432px. The unit is the defect but 680 is not automatically the value, so that is a decision, not a consolidation — reverted here and filed as **#2645**. This PR now carries **zero VR drift**.

## Not in scope

- **Whether 680 is the right measure** — parked as fog on #2556, per the ticket. Consolidating onto the token is what makes that a one-line change later.
- **Refactoring `UltrasSection` into an explicit `Prose` wrapper + escape classes.** The review flagged `[&>p]` as convention rather than enforcement — true, but the component is page-local (`app/(main)/club/ultras/`), not shared infrastructure, and all three of its block children are known. A future `<ul>` is a one-line fix in the same file.

## Review gate

`/code-review` (medium) and `/simplify` both ran on the branch diff.

**Applied:** the `BestuurPage` border-box shortfall (raised independently by the correctness and altitude passes); the skeleton parity regression on `/club/ultras`; a strengthened test assertion (the first version was a tautology — it now also asserts the copy is a `<p>`, which is what makes the variant match); prettier class ordering; three over-long comments trimmed.

**Skipped:** the `UltrasSection` altitude refactor (reason above). The reuse and efficiency passes returned clean.

## Testing

- `pnpm --filter @kcvv/web lint:fix` then `check-all` — exit 0, **6539 tests pass** (307 files).
- One new test on `/club/ultras` covering the clamp.
- **VR:** no baselines needed. The first push drifted two organigram snapshots; that cause is reverted and split to #2645, so the remaining surfaces carry no VR story (`Ultras.stories.tsx` is autodocs-only and not VR-tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
