### PR TITLE
fix(ui): gate every skeleton pulse behind motion-safe

### DIFF
--- a/apps/web/src/app/(landing)/jeugd/loading.tsx
+++ b/apps/web/src/app/(landing)/jeugd/loading.tsx
@@ -16,20 +16,20 @@ export default function JeugdLoading() {
 
       <PageContainer width="index" className="py-12 sm:py-16">
         {/* Filosofie / visie block */}
-        <div className="animate-pulse">
+        <div className="motion-safe:animate-pulse">
           <div className="bg-paper-edge mb-4 h-3 w-40" />
           <div className="bg-paper-edge h-32 w-full" />
         </div>
 
         {/* Editorial nav grid */}
-        <div className="mt-16 grid animate-pulse grid-cols-1 gap-5 md:grid-cols-3">
+        <div className="mt-16 grid grid-cols-1 gap-5 motion-safe:animate-pulse md:grid-cols-3">
           {Array.from({ length: 3 }).map((_, i) => (
             <div key={i} className="bg-paper-edge aspect-[16/9]" />
           ))}
         </div>
 
         {/* Youth directory */}
-        <div className="mt-16 animate-pulse space-y-8">
+        <div className="mt-16 space-y-8 motion-safe:animate-pulse">
           <div className="bg-paper-edge h-8 w-44" />
           {Array.from({ length: 3 }).map((_, div) => (
             <div key={div} className="space-y-4">
@@ -45,7 +45,7 @@ export default function JeugdLoading() {
       </PageContainer>
 
       {/* CTA band (full-bleed) */}
-      <div className="bg-jersey-deep-dark border-ink animate-pulse border-y-2">
+      <div className="bg-jersey-deep-dark border-ink border-y-2 motion-safe:animate-pulse">
         <div className="mx-auto flex max-w-[var(--container-index)] flex-col items-center gap-4 px-4 py-12 sm:py-16 md:px-8">
           <div className="bg-cream/15 h-8 w-72 max-w-full" />
           <div className="bg-cream/15 h-4 w-96 max-w-full" />

--- a/apps/web/src/app/(landing)/nieuws/loading.tsx
+++ b/apps/web/src/app/(landing)/nieuws/loading.tsx
@@ -45,7 +45,10 @@ export default function NewsLoading() {
 
       {/* Sticky filter bar — mirrors the page's dark category-filter band. */}
       <div className="bg-ink/95 sticky top-0 z-30 border-b border-white/10 py-3 backdrop-blur-sm">
-        <PageContainer width="index" className="flex animate-pulse gap-2">
+        <PageContainer
+          width="index"
+          className="flex gap-2 motion-safe:animate-pulse"
+        >
           {Array.from({ length: 5 }).map((_, i) => (
             <div key={i} className="bg-cream/15 h-8 w-20" />
           ))}
@@ -55,8 +58,8 @@ export default function NewsLoading() {
       <PageContainer width="index" className="py-6">
         {/* Uitgelicht — uniform 3-up featured grid. */}
         <section className="mb-10">
-          <div className="bg-paper-edge mb-6 h-9 w-48 animate-pulse" />
-          <div className="grid animate-pulse grid-cols-1 gap-6 md:grid-cols-3">
+          <div className="bg-paper-edge mb-6 h-9 w-48 motion-safe:animate-pulse" />
+          <div className="grid grid-cols-1 gap-6 motion-safe:animate-pulse md:grid-cols-3">
             {Array.from({ length: 3 }).map((_, i) => (
               <NewsCardSkeleton key={i} />
             ))}
@@ -64,7 +67,7 @@ export default function NewsLoading() {
         </section>
 
         {/* Chronological listing — 3-column grid. */}
-        <section className="mb-6 grid animate-pulse grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <section className="mb-6 grid grid-cols-1 gap-6 motion-safe:animate-pulse md:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <NewsCardSkeleton key={i} />
           ))}

--- a/apps/web/src/app/(landing)/sponsors/loading.tsx
+++ b/apps/web/src/app/(landing)/sponsors/loading.tsx
@@ -12,7 +12,7 @@ import { PageContainer } from "@/components/design-system";
 export default function SponsorsLoading() {
   return (
     <PageContainer width="index" className="py-10 sm:py-14">
-      <div className="mb-10 grid animate-pulse items-start gap-8 sm:mb-12 lg:grid-cols-[1fr_minmax(280px,360px)] lg:gap-12">
+      <div className="mb-10 grid items-start gap-8 motion-safe:animate-pulse sm:mb-12 lg:grid-cols-[1fr_minmax(280px,360px)] lg:gap-12">
         <div className="flex flex-col gap-3">
           <div className="bg-paper-edge h-3 w-24" />
           <div className="bg-paper-edge h-12 w-72 max-w-full" />
@@ -24,7 +24,7 @@ export default function SponsorsLoading() {
       <ul className={SPONSOR_TILE_GRID_CLASS}>
         {Array.from({ length: 10 }).map((_, i) => (
           <li key={i}>
-            <div className="bg-cream-soft min-h-[70px] animate-pulse" />
+            <div className="bg-cream-soft min-h-[70px] motion-safe:animate-pulse" />
           </li>
         ))}
       </ul>

--- a/apps/web/src/app/(main)/club/[slug]/loading.tsx
+++ b/apps/web/src/app/(main)/club/[slug]/loading.tsx
@@ -20,7 +20,7 @@ export default function ClubPageLoading() {
           `--container-prose` reading column. */}
       <div className="bg-cream w-full px-4 py-12 lg:px-0 lg:py-16">
         <div
-          className="mx-auto w-full animate-pulse space-y-4"
+          className="mx-auto w-full space-y-4 motion-safe:animate-pulse"
           style={{ maxWidth: "var(--container-prose)" }}
         >
           <div className="bg-cream-soft h-5 w-full" />

--- a/apps/web/src/app/(main)/club/loading.tsx
+++ b/apps/web/src/app/(main)/club/loading.tsx
@@ -25,10 +25,10 @@ export default function ClubLoading() {
 
       {/* Editorial nav hub — header + uniform 3-up grid. */}
       <PageContainer width="index" className="py-12">
-        <div className="bg-ink/10 mb-8 h-10 w-72 max-w-full animate-pulse" />
+        <div className="bg-ink/10 mb-8 h-10 w-72 max-w-full motion-safe:animate-pulse" />
         <div
           data-testid="club-hub-skeleton"
-          className="grid animate-pulse grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3"
+          className="grid grid-cols-1 gap-3.5 motion-safe:animate-pulse sm:grid-cols-2 lg:grid-cols-3"
         >
           {Array.from({ length: 9 }).map((_, i) => (
             <div

--- a/apps/web/src/app/(main)/hulp/loading.tsx
+++ b/apps/web/src/app/(main)/hulp/loading.tsx
@@ -15,27 +15,27 @@ export default function HulpLoading() {
       {/* Sticky two-door nav placeholder. */}
       <div className="border-ink bg-cream border-b-2" aria-hidden>
         <div className="mx-auto flex max-w-[var(--container-index)] items-center gap-3 px-4 py-3 md:px-8">
-          <div className="bg-cream-soft h-5 w-16 animate-pulse" />
-          <div className="bg-cream-soft h-5 w-24 animate-pulse" />
-          <div className="bg-cream-soft ml-auto h-9 w-44 animate-pulse" />
+          <div className="bg-cream-soft h-5 w-16 motion-safe:animate-pulse" />
+          <div className="bg-cream-soft h-5 w-24 motion-safe:animate-pulse" />
+          <div className="bg-cream-soft ml-auto h-9 w-44 motion-safe:animate-pulse" />
         </div>
       </div>
 
       <PageContainer width="index" className="py-10 sm:py-14">
         {/* Hero band. */}
-        <div className="bg-jersey-deep-dark border-ink h-56 animate-pulse border-2 shadow-[6px_6px_0_0_var(--color-ink)]" />
+        <div className="bg-jersey-deep-dark border-ink h-56 border-2 shadow-[6px_6px_0_0_var(--color-ink)] motion-safe:animate-pulse" />
 
         {/* Finder placeholder — heading · chips · accordion rows. */}
         <div className="mt-12 space-y-3">
-          <div className="bg-cream-soft h-7 w-56 animate-pulse" />
+          <div className="bg-cream-soft h-7 w-56 motion-safe:animate-pulse" />
           <div className="flex gap-2">
-            <div className="bg-cream-soft h-8 w-20 animate-pulse" />
-            <div className="bg-cream-soft h-8 w-24 animate-pulse" />
-            <div className="bg-cream-soft h-8 w-28 animate-pulse" />
+            <div className="bg-cream-soft h-8 w-20 motion-safe:animate-pulse" />
+            <div className="bg-cream-soft h-8 w-24 motion-safe:animate-pulse" />
+            <div className="bg-cream-soft h-8 w-28 motion-safe:animate-pulse" />
           </div>
-          <div className="border-ink bg-cream h-14 animate-pulse border-2 shadow-[3px_3px_0_0_var(--color-ink)]" />
-          <div className="border-ink bg-cream h-14 animate-pulse border-2 shadow-[3px_3px_0_0_var(--color-ink)]" />
-          <div className="border-ink bg-cream h-14 animate-pulse border-2 shadow-[3px_3px_0_0_var(--color-ink)]" />
+          <div className="border-ink bg-cream h-14 border-2 shadow-[3px_3px_0_0_var(--color-ink)] motion-safe:animate-pulse" />
+          <div className="border-ink bg-cream h-14 border-2 shadow-[3px_3px_0_0_var(--color-ink)] motion-safe:animate-pulse" />
+          <div className="border-ink bg-cream h-14 border-2 shadow-[3px_3px_0_0_var(--color-ink)] motion-safe:animate-pulse" />
         </div>
       </PageContainer>
     </div>

--- a/apps/web/src/app/(main)/hulp/page.tsx
+++ b/apps/web/src/app/(main)/hulp/page.tsx
@@ -151,7 +151,7 @@ export default async function HulpHubPage() {
             <div className="mt-8">
               <Suspense
                 fallback={
-                  <div className="border-ink bg-cream h-40 animate-pulse border-2 shadow-[3px_3px_0_0_var(--color-ink)]" />
+                  <div className="border-ink bg-cream h-40 border-2 shadow-[3px_3px_0_0_var(--color-ink)] motion-safe:animate-pulse" />
                 }
               >
                 <HulpFinder responsibilityPaths={responsibilityPaths} />

--- a/apps/web/src/app/(main)/kalender/loading.tsx
+++ b/apps/web/src/app/(main)/kalender/loading.tsx
@@ -38,7 +38,7 @@ export default function CalendarLoading() {
             {["w-16", "w-28", "w-24", "w-44", "w-28", "w-20"].map((w, i) => (
               <div
                 key={i}
-                className={`${w} border-paper-edge bg-cream-soft h-[32px] animate-pulse rounded-none border-2`}
+                className={`${w} border-paper-edge bg-cream-soft h-[32px] rounded-none border-2 motion-safe:animate-pulse`}
                 data-testid="skeleton-pill"
               />
             ))}
@@ -53,7 +53,7 @@ export default function CalendarLoading() {
             >
               {/* 3-way view toggle */}
               <div
-                className="border-ink inline-flex animate-pulse overflow-hidden border-2"
+                className="border-ink inline-flex overflow-hidden border-2 motion-safe:animate-pulse"
                 data-testid="calendar-skeleton-view-toggle"
               >
                 <div className="bg-cream-soft h-[31px] w-16" />
@@ -62,7 +62,7 @@ export default function CalendarLoading() {
               </div>
 
               {/* Shared period nav */}
-              <div className="flex animate-pulse items-center gap-2">
+              <div className="flex items-center gap-2 motion-safe:animate-pulse">
                 <div className="border-ink bg-cream h-8 w-8 border-2" />
                 <div className="bg-cream-soft h-6 w-32" />
                 <div className="border-ink bg-cream h-8 w-8 border-2" />
@@ -70,13 +70,13 @@ export default function CalendarLoading() {
 
               {/* Subscribe button */}
               <div
-                className="border-ink bg-cream-soft h-[34px] w-28 animate-pulse border-2"
+                className="border-ink bg-cream-soft h-[34px] w-28 border-2 motion-safe:animate-pulse"
                 data-testid="calendar-skeleton-subscribe"
               />
             </div>
 
             {/* Month grid skeleton — 7 columns */}
-            <div className="animate-pulse p-4">
+            <div className="p-4 motion-safe:animate-pulse">
               <div className="border-paper-edge mb-1 grid grid-cols-7 border-b border-dashed">
                 {Array.from({ length: 7 }).map((_, i) => (
                   <div key={i} className="flex justify-center py-2">

--- a/apps/web/src/app/(main)/ploegen/loading.tsx
+++ b/apps/web/src/app/(main)/ploegen/loading.tsx
@@ -8,7 +8,7 @@ import { PageHeroSkeleton } from "@/components/layout/PageHero";
 
 function FlagshipSkeleton() {
   return (
-    <div className="border-ink grid animate-pulse grid-cols-1 border-2 sm:grid-cols-[1.25fr_1fr]">
+    <div className="border-ink grid grid-cols-1 border-2 motion-safe:animate-pulse sm:grid-cols-[1.25fr_1fr]">
       <div className="flex flex-col gap-4 p-6 sm:p-10">
         <div className="bg-paper-edge h-3 w-24" />
         <div className="bg-paper-edge h-10 w-48" />
@@ -30,7 +30,7 @@ export default function TeamsLoading() {
         <FlagshipSkeleton />
       </div>
 
-      <div className="mt-16 animate-pulse space-y-8">
+      <div className="mt-16 space-y-8 motion-safe:animate-pulse">
         <div className="bg-paper-edge h-8 w-48" />
         {Array.from({ length: 3 }).map((_, div) => (
           <div key={div} className="space-y-4">

--- a/apps/web/src/app/(main)/scheurkalender/loading.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/loading.tsx
@@ -10,13 +10,13 @@ import { PageContainer } from "@/components/design-system";
 function ColumnSkeleton({ rows }: { rows: number }) {
   return (
     <>
-      <div className="bg-ink/10 mt-5 mb-[7px] h-7 w-40 animate-pulse first:mt-0.5" />
+      <div className="bg-ink/10 mt-5 mb-[7px] h-7 w-40 first:mt-0.5 motion-safe:animate-pulse" />
       {Array.from({ length: rows }).map((_, row) => (
         <div key={row} className="flex items-center gap-3 py-[5px]">
-          <div className="bg-ink/10 h-2.5 w-[17px] animate-pulse" />
-          <div className="bg-ink/10 h-3.5 w-5 animate-pulse" />
-          <div className="bg-ink/10 h-2.5 w-10 animate-pulse" />
-          <div className="bg-ink/10 h-3 flex-1 animate-pulse" />
+          <div className="bg-ink/10 h-2.5 w-[17px] motion-safe:animate-pulse" />
+          <div className="bg-ink/10 h-3.5 w-5 motion-safe:animate-pulse" />
+          <div className="bg-ink/10 h-2.5 w-10 motion-safe:animate-pulse" />
+          <div className="bg-ink/10 h-3 flex-1 motion-safe:animate-pulse" />
         </div>
       ))}
     </>
@@ -30,8 +30,8 @@ export default function ScheurkalenderLoading() {
         <div className="border-ink border-2 bg-white">
           {/* Masthead */}
           <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
-            <div className="bg-ink/10 h-4 w-56 animate-pulse" />
-            <div className="bg-ink/10 h-3 w-32 animate-pulse" />
+            <div className="bg-ink/10 h-4 w-56 motion-safe:animate-pulse" />
+            <div className="bg-ink/10 h-3 w-32 motion-safe:animate-pulse" />
           </div>
           {/* Two calendar-year columns */}
           <div className="grid grid-cols-2 px-5 pt-1.5 pb-[18px]">

--- a/apps/web/src/app/(main)/spelers/[slug]/loading.tsx
+++ b/apps/web/src/app/(main)/spelers/[slug]/loading.tsx
@@ -13,7 +13,10 @@ import { PageContainer } from "@/components/design-system";
 export default function PlayerDetailLoading() {
   return (
     <div className="min-h-screen" aria-hidden="true">
-      <PageContainer as="section" className="animate-pulse py-12 lg:py-16">
+      <PageContainer
+        as="section"
+        className="py-12 motion-safe:animate-pulse lg:py-16"
+      >
         <div className="grid grid-cols-1 items-start gap-x-10 gap-y-8 sm:grid-cols-[1fr_minmax(220px,320px)]">
           <div className="flex flex-col gap-5">
             <div className="bg-paper-edge h-4 w-24" />
@@ -31,7 +34,7 @@ export default function PlayerDetailLoading() {
       <div className="bg-paper-edge h-[18px] w-full" />
       <PageContainer
         as="section"
-        className="bg-cream animate-pulse py-12 lg:py-16"
+        className="bg-cream py-12 motion-safe:animate-pulse lg:py-16"
       >
         <div className="space-y-3">
           <div className="bg-paper-edge h-4 w-full" />

--- a/apps/web/src/app/(main)/staf/[slug]/loading.tsx
+++ b/apps/web/src/app/(main)/staf/[slug]/loading.tsx
@@ -18,7 +18,10 @@ export default function StaffDetailLoading() {
 
       <div aria-hidden="true">
         {/* Hero footprint — figure left, text right (mirrors PlayerHero). */}
-        <PageContainer as="section" className="animate-pulse py-12 lg:py-16">
+        <PageContainer
+          as="section"
+          className="py-12 motion-safe:animate-pulse lg:py-16"
+        >
           <div className="grid grid-cols-1 items-start gap-x-10 gap-y-8 sm:grid-cols-[minmax(220px,320px)_1fr]">
             <div className="bg-paper-edge aspect-[3/4] w-full max-w-[320px] justify-self-start" />
             <div className="flex flex-col gap-5">
@@ -42,7 +45,7 @@ export default function StaffDetailLoading() {
         {/* Bio footprint — cream band. */}
         <PageContainer
           as="section"
-          className="bg-cream animate-pulse py-12 lg:py-16"
+          className="bg-cream py-12 motion-safe:animate-pulse lg:py-16"
         >
           <div className="space-y-3">
             <div className="bg-paper-edge h-4 w-full" />

--- a/apps/web/src/app/(main)/tegenstander/[clubId]/loading.tsx
+++ b/apps/web/src/app/(main)/tegenstander/[clubId]/loading.tsx
@@ -15,7 +15,7 @@ export default function OpponentLoading() {
       <PageContainer className="pt-8 pb-8">
         {/* Hero card */}
         <div className="border-ink bg-cream shadow-paper-md border-2 p-6">
-          <div className="animate-pulse">
+          <div className="motion-safe:animate-pulse">
             <div className="flex items-center gap-4">
               <div className="bg-ink/10 h-16 w-16 shrink-0 rounded-full" />
               <div className="flex-1 space-y-3">
@@ -32,7 +32,7 @@ export default function OpponentLoading() {
           {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}
-              className="border-ink flex animate-pulse flex-col items-center gap-2 border-r-2 px-1.5 py-4 last:border-r-0"
+              className="border-ink flex flex-col items-center gap-2 border-r-2 px-1.5 py-4 last:border-r-0 motion-safe:animate-pulse"
             >
               <div className="bg-ink/15 h-6 w-6" />
               <div className="bg-ink/10 h-2 w-6" />
@@ -46,10 +46,10 @@ export default function OpponentLoading() {
         </div>
 
         {/* List header */}
-        <div className="bg-ink/15 mb-4 h-6 w-44 animate-pulse" />
+        <div className="bg-ink/15 mb-4 h-6 w-44 motion-safe:animate-pulse" />
 
         {/* Season band */}
-        <div className="mb-2.5 flex animate-pulse items-center gap-2.5">
+        <div className="mb-2.5 flex items-center gap-2.5 motion-safe:animate-pulse">
           <div className="bg-ink/15 h-5 w-28" />
           <div className="border-ink/30 h-0 flex-1 border-t-2 border-dotted" />
           <div className="bg-ink/10 h-2 w-16" />
@@ -62,11 +62,11 @@ export default function OpponentLoading() {
               key={i}
               className="border-ink bg-cream flex items-stretch border-2 shadow-[2px_2px_0_0_var(--color-ink)]"
             >
-              <div className="border-ink/30 flex w-[56px] shrink-0 animate-pulse flex-col items-center justify-center gap-1 border-r-2 border-dashed py-3">
+              <div className="border-ink/30 flex w-[56px] shrink-0 flex-col items-center justify-center gap-1 border-r-2 border-dashed py-3 motion-safe:animate-pulse">
                 <div className="bg-ink/15 h-4 w-5" />
                 <div className="bg-ink/10 h-2 w-6" />
               </div>
-              <div className="flex flex-1 animate-pulse items-center justify-between px-3 py-3">
+              <div className="flex flex-1 items-center justify-between px-3 py-3 motion-safe:animate-pulse">
                 <div className="bg-ink/10 h-3 w-24" />
                 <div className="bg-ink/15 h-5 w-10" />
                 <div className="bg-ink/10 h-3 w-24" />

--- a/apps/web/src/app/(main)/zoeken/loading.tsx
+++ b/apps/web/src/app/(main)/zoeken/loading.tsx
@@ -19,7 +19,7 @@ export default function SearchLoading() {
 
       <PageContainer width="index" className="py-12">
         {/* Filter chips */}
-        <div className="flex animate-pulse gap-2">
+        <div className="flex gap-2 motion-safe:animate-pulse">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
@@ -29,7 +29,7 @@ export default function SearchLoading() {
         </div>
 
         {/* Result rows */}
-        <div className="mt-8 animate-pulse space-y-4">
+        <div className="mt-8 space-y-4 motion-safe:animate-pulse">
           {Array.from({ length: 5 }).map((_, i) => (
             <div
               key={i}

--- a/apps/web/src/components/club/BestuurPage/BoardPageLoading.tsx
+++ b/apps/web/src/components/club/BestuurPage/BoardPageLoading.tsx
@@ -38,8 +38,8 @@ export function BoardPageLoading({ label }: { label: string }) {
 
       {/* "De leden" — staff grid: auto-fill minmax(150px,1fr), border-2 ink cards. */}
       <PageContainer as="section" className="py-12">
-        <div className="bg-paper-edge mb-6 h-9 w-40 animate-pulse" />
-        <div className="grid animate-pulse grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
+        <div className="bg-paper-edge mb-6 h-9 w-40 motion-safe:animate-pulse" />
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4 motion-safe:animate-pulse">
           {Array.from({ length: 8 }).map((_, i) => (
             <div
               key={i}
@@ -59,7 +59,7 @@ export function BoardPageLoading({ label }: { label: string }) {
         aria-hidden="true"
         className="bg-jersey-deep-dark border-ink border-y-2"
       >
-        <PageContainer className="animate-pulse py-12 text-center sm:py-16">
+        <PageContainer className="py-12 text-center motion-safe:animate-pulse sm:py-16">
           <div className="bg-cream/25 mx-auto mb-4 h-9 w-64" />
           <div className="bg-cream/15 mx-auto mb-7 h-4 w-80 max-w-full" />
           <div className="bg-warm/60 mx-auto h-11 w-48" />

--- a/apps/web/src/components/match/MatchEvents/MatchEvents.test.tsx
+++ b/apps/web/src/components/match/MatchEvents/MatchEvents.test.tsx
@@ -336,7 +336,7 @@ describe("MatchEvents", () => {
     it("renders skeleton when loading", () => {
       const { container } = render(<MatchEvents {...defaultProps} isLoading />);
       expect(
-        container.querySelectorAll(".animate-pulse").length,
+        container.querySelectorAll('[class*="animate-pulse"]').length,
       ).toBeGreaterThan(0);
     });
 

--- a/apps/web/src/components/match/MatchEvents/MatchEvents.tsx
+++ b/apps/web/src/components/match/MatchEvents/MatchEvents.tsx
@@ -238,10 +238,10 @@ export function MatchEvents({
       <div className={cn("space-y-3", className)}>
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4">
-            <div className="bg-cream-soft h-6 w-10 animate-pulse" />
-            <div className="bg-cream-soft h-[22px] w-[22px] animate-pulse" />
-            <div className="bg-cream-soft h-5 flex-1 animate-pulse" />
-            <div className="bg-cream-soft h-4 w-12 animate-pulse" />
+            <div className="bg-cream-soft h-6 w-10 motion-safe:animate-pulse" />
+            <div className="bg-cream-soft h-[22px] w-[22px] motion-safe:animate-pulse" />
+            <div className="bg-cream-soft h-5 flex-1 motion-safe:animate-pulse" />
+            <div className="bg-cream-soft h-4 w-12 motion-safe:animate-pulse" />
           </div>
         ))}
       </div>

--- a/apps/web/src/components/match/MatchLineup/MatchLineup.test.tsx
+++ b/apps/web/src/components/match/MatchLineup/MatchLineup.test.tsx
@@ -262,7 +262,7 @@ describe("MatchLineup", () => {
     it("renders skeleton when loading", () => {
       const { container } = render(<MatchLineup {...defaultProps} isLoading />);
       expect(
-        container.querySelectorAll(".animate-pulse").length,
+        container.querySelectorAll('[class*="animate-pulse"]').length,
       ).toBeGreaterThan(0);
     });
 

--- a/apps/web/src/components/match/MatchLineup/MatchLineup.tsx
+++ b/apps/web/src/components/match/MatchLineup/MatchLineup.tsx
@@ -267,12 +267,12 @@ function PlayerRow({ player }: { player: LineupPlayer }) {
 function LineupSkeleton() {
   return (
     <div>
-      <div className="border-ink bg-cream-soft mb-3 h-6 w-32 animate-pulse border-t" />
+      <div className="border-ink bg-cream-soft mb-3 h-6 w-32 border-t motion-safe:animate-pulse" />
       <div className="space-y-2">
         {Array.from({ length: 11 }).map((_, i) => (
           <div key={i} className="flex items-center gap-3">
-            <div className="bg-cream-soft h-7 w-7 animate-pulse" />
-            <div className="bg-cream-soft h-4 flex-1 animate-pulse" />
+            <div className="bg-cream-soft h-7 w-7 motion-safe:animate-pulse" />
+            <div className="bg-cream-soft h-4 flex-1 motion-safe:animate-pulse" />
           </div>
         ))}
       </div>

--- a/apps/web/src/components/organigram/HubSearch/HubSearch.tsx
+++ b/apps/web/src/components/organigram/HubSearch/HubSearch.tsx
@@ -533,10 +533,10 @@ export function HubSearch({
               ))}
               <div aria-hidden className="px-3 py-2.5">
                 <div className="flex items-center gap-3">
-                  <div className="bg-cream-soft h-9 w-9 flex-shrink-0 animate-pulse rounded-full" />
+                  <div className="bg-cream-soft h-9 w-9 flex-shrink-0 rounded-full motion-safe:animate-pulse" />
                   <div className="flex-1 space-y-1.5">
-                    <div className="bg-cream-soft h-2.5 w-1/3 animate-pulse" />
-                    <div className="bg-cream-soft h-2.5 w-3/4 animate-pulse" />
+                    <div className="bg-cream-soft h-2.5 w-1/3 motion-safe:animate-pulse" />
+                    <div className="bg-cream-soft h-2.5 w-3/4 motion-safe:animate-pulse" />
                   </div>
                 </div>
               </div>

--- a/apps/web/src/components/search/SearchMastheadSkeleton.tsx
+++ b/apps/web/src/components/search/SearchMastheadSkeleton.tsx
@@ -16,7 +16,10 @@ import { searchFieldShellClasses } from "./search-field-styles";
 export function SearchMastheadSkeleton() {
   return (
     <SearchMasthead>
-      <div aria-hidden className={`${searchFieldShellClasses} animate-pulse`}>
+      <div
+        aria-hidden
+        className={`${searchFieldShellClasses} motion-safe:animate-pulse`}
+      >
         {/* 3.625rem ≈ SearchForm's input height (py-4 + body-lg line box) so
             the skeleton reserves the same space as the real field. */}
         <div className="h-[3.625rem] flex-1" />


### PR DESCRIPTION
## What

67 of 112 `animate-pulse` uses carried no `motion-safe:` prefix, so a visitor with reduced motion set got an oscillating skeleton across most of the site. Every use is now `motion-safe:animate-pulse` — **110 of 112 guarded**, the other two being test selectors rather than rendered classes.

The homepage's own `(landing)/loading.tsx` was already clean; its siblings in the same route group were not.

DESIGN.md's **Press-Down Rule** already sets the project's position — _"the translate is gated behind `motion-safe:`"_ — but nothing had extended it to skeletons, because nothing had to.

## Count drift

The originating ticket measured **69 unguarded across 20 files** on 2026-08-12. Re-derived against `main` at `064355a6` before touching anything: **67 across 19**. #2555's page-opening collapse had absorbed two.

## The one non-mechanical part

`MatchLineup.test.tsx` and `MatchEvents.test.tsx` both asserted their skeleton with `container.querySelectorAll(".animate-pulse")`. Tailwind emits the prefixed utility as the literal class token `motion-safe:animate-pulse`, so `.animate-pulse` stops matching entirely and both assertions would have gone from "greater than 0" to 0.

They now query `[class*="animate-pulse"]`, which stays true under either spelling.

This is a constraint on #2514: a lint rule banning bare `animate-pulse` must not fire on test selectors, where the bare token is the correct thing to write. Recorded on that ticket.

## Scope notes

- `/scheurkalender`'s 7 uses **are** included. The ticket allowed dropping them if they complicated the sweep; they did not.
- The 12 insertions beyond the 67 replaced lines are prettier re-wrapping lines that the longer class string pushed past the print width. Nothing else changed.

## Visual regression

**No baselines move.** `animate-pulse` animates opacity only, and `motion-safe:` changes nothing for a visitor without a reduced-motion preference — so nothing differs at rest, which is what VR captures.

## Verification

`pnpm --filter @kcvv/web check-all` → **exit 0**. 307 test files, 6538 tests passing, `next build` clean.

Part of #2506
Closes #2507

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Loading skeleton animations now respect users’ reduced-motion preferences across landing pages, club areas, calendars, match views, search, and other loading states.
  * Users who prefer reduced motion see static loading placeholders instead of pulsing animations.

* **Tests**
  * Loading-state checks now recognize skeletons with motion-aware animation classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->