### PR TITLE
fix(ui): a failed read may never be cached as a successful render (#2563)

### DIFF
--- a/apps/web/src/app/(landing)/jeugd/page.tsx
+++ b/apps/web/src/app/(landing)/jeugd/page.tsx
@@ -14,6 +14,7 @@ import {
   groupTeamsForLanding,
   type TeamLandingItem,
 } from "@/lib/utils/group-teams";
+import { degradeSection } from "@/lib/effect/degrade";
 import { SITE_CONFIG } from "@/lib/constants";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonld";
@@ -69,12 +70,21 @@ async function fetchJeugdArticles(): Promise<ArticleVM[]> {
   }
 }
 
+/**
+ * The nav hub is a section, not the page's subject (#2433 rule 3): a failed
+ * read drops it back to its pinned cards, which is what `null` already means
+ * here, rather than taking `/jeugd` down.
+ */
 async function fetchEditorialConfig(): Promise<EditorialCardConfig[] | null> {
   return runPromise(
-    Effect.gen(function* () {
-      const repo = yield* JeugdLandingPageRepository;
-      return yield* repo.getEditorialCards();
-    }).pipe(Effect.provide(JeugdLandingPageRepositoryLive)),
+    degradeSection(
+      Effect.gen(function* () {
+        const repo = yield* JeugdLandingPageRepository;
+        return yield* repo.getEditorialCards();
+      }).pipe(Effect.provide(JeugdLandingPageRepositoryLive)),
+      null,
+      "[jeugd] editorial-cards lookup failed; falling back to the pinned nav cards.",
+    ),
   );
 }
 
@@ -142,4 +152,7 @@ export default async function JeugdPage() {
   );
 }
 
-export const revalidate = 3600;
+// 15m ISR — capped by #2433 rule 5, not by content freshness: the `(landing)`
+// layout mounts `<MatchStripSlot>`, whose BFF read degrades to no strip and is
+// then cached in this page's ISR entry for the whole window.
+export const revalidate = 900;

--- a/apps/web/src/app/(landing)/sponsors/page.tsx
+++ b/apps/web/src/app/(landing)/sponsors/page.tsx
@@ -39,16 +39,16 @@ function mapToSponsor(s: SponsorVM): Sponsor {
 }
 
 export default async function SponsorsPageRoute() {
+  // Uncaught by design (#2433 rule 2/3): the sponsor wall is this page's
+  // subject, and under ISR a caught failure *succeeds* — the empty wall would
+  // be written into the cache and hold for the full window below. A throw
+  // leaves the last good render in place, so the failure is a blip rather than
+  // a day of blank sponsor slots.
   const sponsors = await runPromise(
     Effect.gen(function* () {
       const repo = yield* SponsorRepository;
       return yield* repo.findAll();
-    }).pipe(
-      Effect.catchAll((error) => {
-        console.error("[SponsorsPage] Failed to fetch sponsors:", error);
-        return Effect.succeed([] as SponsorVM[]);
-      }),
-    ),
+    }),
   );
 
   const allSponsors = sponsors.map(mapToSponsor).sort(sortByTierThenName);
@@ -76,6 +76,13 @@ export default async function SponsorsPageRoute() {
   );
 }
 
-// 24h ISR — sponsor list changes rarely; editor publishes invalidate on
-// demand via /api/revalidate (revalidateTag 'sponsors').
-export const revalidate = 86400;
+// 15m ISR — the sponsor list itself changes rarely and editor publishes
+// invalidate it on demand via /api/revalidate (revalidateTag 'sponsors'), so
+// the window is not what keeps this page fresh.
+//
+// It is what bounds a failure. This route sits in the `(landing)` group, whose
+// layout mounts `<MatchStripSlot>` — a BFF read that degrades to no strip and
+// is then written into this page's ISR entry for the whole window (#2433 rule
+// 5, cap 900s). The audit behind #2563 counted BFF routes by what each page
+// file reads and so missed every route that inherits the strip from its layout.
+export const revalidate = 900;

--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -5,6 +5,7 @@
 
 import { Effect } from "effect";
 import { runPromise } from "@/lib/effect/runtime";
+import { degradeSection } from "@/lib/effect/degrade";
 import {
   BffService,
   BFF_FAN_OUT_CONCURRENCY,
@@ -64,6 +65,15 @@ interface CalendarData {
   teams: CalendarTeamInfo[];
 }
 
+/**
+ * The team list is this page's subject — without it there is no calendar to
+ * filter — so its failure is uncaught by design (#2433 rule 2/3) and takes the
+ * page down to the one global boundary. An empty feed would assert "the club
+ * plays nothing", which is the lie #2399 exists to stop telling. The reads
+ * *inside* are sections and stay caught — one team's fixtures failing must not
+ * cost the other twenty-seven, and the event feed is a second stream layered on
+ * the matches, not the calendar itself.
+ */
 async function fetchCalendarData(): Promise<CalendarData> {
   return runPromise(
     Effect.gen(function* () {
@@ -81,11 +91,11 @@ async function fetchCalendarData(): Promise<CalendarData> {
       const [allTeams, feedItems] = yield* Effect.all(
         [
           teamRepo.findAll(),
-          eventRepo
-            .findUpcomingForList()
-            .pipe(
-              Effect.catchAll(() => Effect.succeed([] as EventListItemVM[])),
-            ),
+          degradeSection(
+            eventRepo.findUpcomingForList(),
+            [] as EventListItemVM[],
+            "[Calendar] event-feed lookup failed; rendering matches only.",
+          ),
         ],
         { concurrency: "unbounded" },
       );
@@ -145,15 +155,7 @@ async function fetchCalendarData(): Promise<CalendarData> {
         feed,
         teams: teamInfos,
       };
-    }).pipe(
-      Effect.catchAll((error) => {
-        console.error("[Calendar] Failed to fetch calendar data:", error);
-        return Effect.succeed({
-          feed: [],
-          teams: [],
-        } as CalendarData);
-      }),
-    ),
+    }),
   );
 }
 

--- a/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/nieuws/[slug]/page.tsx
@@ -236,7 +236,8 @@ export async function generateStaticParams() {
     // Exclude matchPreview/matchRecap from the prebuild set: their hero +
     // Doelpunten require a per-article PSD fetch, so prebuilding them would
     // hammer the rate-limited BFF at build time. They render on-demand via
-    // ISR instead (revalidate stays 3600). See #1470 / feedback_no_psd_prerendering.
+    // ISR instead, on the route `revalidate` at the bottom of this file.
+    // See #1470 / feedback_no_psd_prerendering.
     return articles
       .filter(
         (a) =>
@@ -626,17 +627,20 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
   );
 }
 
-// 24h ISR — article publishes invalidate on demand via /api/revalidate
-// (revalidatePath '/nieuws/<slug>' + revalidateTag 'articles').
+// 15m ISR — article publishes invalidate on demand via /api/revalidate
+// (revalidatePath '/nieuws/<slug>' + revalidateTag 'articles'), so the window
+// is not what keeps the editorial content fresh.
 //
-// Cache-freshness audit (#2330): this is a webhook-fresh Sanity surface, so the
-// route keeps its 24h ISR window. Match articles (matchPreview/matchRecap) embed
-// live PSD chrome via getMatchDetail, but they are excluded from
-// generateStaticParams (see its filter) and render on demand via ISR. The route
-// `revalidate` is static, not per-article, so aligning the embedded match to the
-// BFF window would force the whole news corpus to revalidate every 15 min —
-// contradicting "Sanity content is webhook-fresh and unaffected". The chrome is
-// post-hoc enhancement (recap scores are final; any BFF failure degrades to no
-// chrome) and the acute live-match surfaces (homepage, team pages, calendar) are
-// handled separately, so this timer stays.
-export const revalidate = 86400;
+// It is what bounds a failure. Two BFF-fed sections render here — the linked
+// match card and the auto related row — and both degrade to nothing rather than
+// throwing (#2433 rule 3/4). A degraded render *succeeds*, so it is written into
+// the cache and repeated for the whole window: at 24h a one-second blip cost a
+// day of missing match chrome. #2433 rule 5 caps any route carrying a BFF-fed
+// section at 900s, which is the window the section reads' own freshness
+// (`/ploegen/[slug]`, `<MatchStrip>`) already runs at.
+//
+// This overturns the #2330 cache-freshness audit, which kept 24h on the grounds
+// that Sanity is webhook-fresh and the PSD chrome is post-hoc enhancement. Both
+// remain true; what the audit did not weigh is that a *failed* enhancement is
+// cached exactly as long as a successful one.
+export const revalidate = 900;

--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import type { PortableTextBlock } from "@portabletext/react";
 import { runPromise } from "@/lib/effect/runtime";
+import { degradeSection } from "@/lib/effect/degrade";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { BffService } from "@/lib/effect/services/BffService";
 import { ArticleRepository } from "@/lib/repositories/article.repository";
@@ -127,11 +128,18 @@ export default async function TeamPage({ params }: TeamPageProps) {
   // Both depend only on `team`, never on each other, so they share one wave
   // rather than serializing Sanity behind the BFF pair (#2441).
   const [relatedArticles, bffData] = await Promise.all([
+    // Same section, same verdict as `/spelers/[slug]` and `/staf/[slug]`
+    // (#2433 rule 3/4): "Verder lezen." is polish, and its absence asserts
+    // nothing, so it hides rather than taking the team page down.
     runPromise(
-      Effect.gen(function* () {
-        const repo = yield* ArticleRepository;
-        return yield* repo.findRelated(team.id);
-      }),
+      degradeSection(
+        Effect.gen(function* () {
+          const repo = yield* ArticleRepository;
+          return yield* repo.findRelated(team.id);
+        }),
+        [],
+        "[ploegen/[slug]] related-articles lookup failed; rendering without the Verder lezen row.",
+      ),
     ),
     Number.isFinite(psdTeamId) && psdTeamId > 0
       ? fetchBffData(psdTeamId)

--- a/apps/web/src/app/(main)/spelers/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/spelers/[slug]/page.tsx
@@ -36,6 +36,7 @@ import { runPromise } from "@/lib/effect/runtime";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { PlayerRepository } from "@/lib/repositories/player.repository";
 import { ArticleRepository } from "@/lib/repositories/article.repository";
+import { degradeSection } from "@/lib/effect/degrade";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd, buildPersonJsonLd } from "@/lib/seo/jsonld";
 import { BioBlock, PlayerHero, QuotesBlock } from "@/components/player";
@@ -129,11 +130,18 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
 
   if (!player) notFound();
 
+  // "Verder lezen." is a section, not the subject (#2433 rule 3), and its
+  // absence asserts nothing — the visitor was never promised a read-next row —
+  // so it auto-hides rather than announcing the failure (rule 4).
   const relatedArticles = await runPromise(
-    Effect.gen(function* () {
-      const repo = yield* ArticleRepository;
-      return yield* repo.findRelated(player.id);
-    }),
+    degradeSection(
+      Effect.gen(function* () {
+        const repo = yield* ArticleRepository;
+        return yield* repo.findRelated(player.id);
+      }),
+      [],
+      "[spelers/[slug]] related-articles lookup failed; rendering without the Verder lezen row.",
+    ),
   );
 
   const fullName = `${player.firstName} ${player.lastName}`.trim() || "Speler";
@@ -228,6 +236,14 @@ export default async function PlayerPage({ params }: PlayerPageProps) {
   );
 }
 
-// 24h ISR — player data is PSD-synced + editor-published; on-demand
-// revalidation keeps it fresh via /api/revalidate (revalidateTag 'players').
-export const revalidate = 86400;
+// 15m ISR — player data is PSD-synced + editor-published and on-demand
+// revalidation keeps it fresh via /api/revalidate (revalidateTag 'players'),
+// so the window is not what keeps this page current.
+//
+// It is what bounds a failure. This route mounts `<MatchStripSlot>` inline, a
+// BFF read that degrades to no strip, and the "Verder lezen." row above now
+// degrades to nothing as well — both are then written into this page's ISR
+// entry for the whole window (#2433 rule 5, cap 900s). `/api/revalidate` busts
+// a profile on a `player` change only, never on an article publish, so nothing
+// else shortens it.
+export const revalidate = 900;

--- a/apps/web/src/app/(main)/staf/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/staf/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { runPromise } from "@/lib/effect/runtime";
 import { SITE_CONFIG, DEFAULT_OG_IMAGE } from "@/lib/constants";
 import { StaffRepository } from "@/lib/repositories/staff.repository";
 import { ArticleRepository } from "@/lib/repositories/article.repository";
+import { degradeSection } from "@/lib/effect/degrade";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { buildBreadcrumbJsonLd, buildPersonJsonLd } from "@/lib/seo/jsonld";
 import { VerderLezenRow } from "@/components/article/VerderLezenRow";
@@ -93,11 +94,18 @@ export default async function StafPage({ params }: StaffPageProps) {
 
   if (!member) notFound();
 
+  // "Verder lezen." is a section, not the subject (#2433 rule 3), and its
+  // absence asserts nothing — the visitor was never promised a read-next row —
+  // so it auto-hides rather than announcing the failure (rule 4).
   const relatedArticles = await runPromise(
-    Effect.gen(function* () {
-      const repo = yield* ArticleRepository;
-      return yield* repo.findRelated(member.id);
-    }),
+    degradeSection(
+      Effect.gen(function* () {
+        const repo = yield* ArticleRepository;
+        return yield* repo.findRelated(member.id);
+      }),
+      [],
+      "[staf/[slug]] related-articles lookup failed; rendering without the Verder lezen row.",
+    ),
   );
 
   const fullName = `${member.firstName} ${member.lastName}`.trim() || "Staf";

--- a/apps/web/src/app/__tests__/cross-page-consistency.test.ts
+++ b/apps/web/src/app/__tests__/cross-page-consistency.test.ts
@@ -524,3 +524,105 @@ describe("rule 4 catches what it claims to (#2555)", () => {
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// Rule 5 (#2563) — a BFF-fed route may not cache a failure for longer than 900s
+// ---------------------------------------------------------------------------
+
+/**
+ * #2433 rule 5: a section that failed to load keeps the page, and that render
+ * *succeeds* — so it is written into the ISR cache like any other, and the
+ * revalidate window is how long the site repeats it. A degraded render
+ * self-heals at the next window; at 86400 it outlives the blip that wrote it by
+ * a day. The cap is **900s**, which is what `/ploegen/[slug]` already runs.
+ * (The notice such a section is meant to carry is #2576's; today every degrade
+ * is silent, which makes the window the only thing bounding it.)
+ *
+ * Scoped to the BFF because the BFF is the read that fails: Sanity is
+ * webhook-fresh, and #2433 left long windows on Sanity-only routes deliberately
+ * — `/staf/[slug]` is the one route that degrades a Sanity section and keeps
+ * 86400, flagged there rather than silently capped here.
+ *
+ * **A route is BFF-fed if it or any layout above it reaches the BFF.** Scoping
+ * this to "the page file names `BffService`" is what let #2433 count 8 BFF
+ * routes: `(landing)/layout.tsx` mounts `<MatchStripSlot>` for the whole group,
+ * so `/sponsors` and `/jeugd` inherit a BFF read without naming one, and
+ * `/spelers/[slug]` mounts the same slot inline. Its read goes through a
+ * per-render `cache()`, not a TTL, so it lands in each page's ISR entry. The
+ * layout chain is walked here because it is the mechanism; the component graph
+ * below the page is not, so a *new* BFF-reading component would need its name
+ * added to `BFF_SIGNAL`.
+ *
+ * **Two deliberate imprecisions.** The `code` map strips comments but re-emits
+ * string literals, so an import path alone counts as a signal — over-inclusive,
+ * which is the safe direction for a cap. And a BFF-fed page that declares no
+ * window at all is skipped: today those are `force-dynamic` or await
+ * `searchParams` and cache nothing, and inferring the difference statically
+ * costs more than it catches.
+ */
+const REVALIDATE_CAP_SECONDS = 900;
+const BFF_SIGNAL =
+  /\b(BffService|MatchStripSlot|getTeamMatches|getFirstTeamStripData)\b/;
+const REVALIDATE_WINDOW = /\bexport const revalidate\s*=\s*(\d+)/;
+
+/** Every `layout.tsx` that wraps this route, root first. */
+const layoutChain = (relPath: string): string[] => {
+  const dirs = relPath.split("/").slice(0, -1);
+  return dirs
+    .map((_, i) => `${dirs.slice(0, i + 1).join("/")}/layout.tsx`)
+    .filter((layoutPath) => code.has(layoutPath));
+};
+
+/** The page's own source plus every layout it renders inside. */
+const reachesTheBff = (relPath: string): boolean =>
+  [relPath, ...layoutChain(relPath)].some((f) => BFF_SIGNAL.test(code.get(f)!));
+
+/** BFF-fed route files that declare a window — 9 today, never 0. */
+const bffFedRouteFiles = productionSources.filter(
+  (relPath) =>
+    /(^|\/)page\.tsx$/.test(relPath) &&
+    reachesTheBff(relPath) &&
+    REVALIDATE_WINDOW.test(code.get(relPath)!),
+);
+
+describe("a BFF-fed route caps its cache window (#2563)", () => {
+  it.each(bffFedRouteFiles)(
+    `%s — revalidate stays at or under ${REVALIDATE_CAP_SECONDS}s`,
+    (relPath) => {
+      const seconds = Number(REVALIDATE_WINDOW.exec(code.get(relPath)!)![1]);
+      expect(seconds).toBeLessThanOrEqual(REVALIDATE_CAP_SECONDS);
+    },
+  );
+});
+
+/**
+ * The list is derived, so an edit that empties it would read as a pass on every
+ * route. Pinned by name, and the layout-chain detector is asserted against the
+ * two routes that motivated it — one that inherits the strip and one that looks
+ * like it should but does not.
+ */
+describe("rule 5 checks the routes it claims to (#2563)", () => {
+  it.each([
+    ["app/(landing)/page.tsx"],
+    ["app/(landing)/jeugd/page.tsx"],
+    ["app/(landing)/sponsors/page.tsx"],
+    ["app/(main)/nieuws/[slug]/page.tsx"],
+    ["app/(main)/ploegen/[slug]/page.tsx"],
+    ["app/(main)/spelers/[slug]/page.tsx"],
+    ["app/(main)/wedstrijd/[matchId]/page.tsx"],
+  ])("covers %s", (relPath) => {
+    expect(bffFedRouteFiles).toContain(relPath);
+  });
+
+  it("sees a route that inherits the strip from its layout", () => {
+    const sponsors = "app/(landing)/sponsors/page.tsx";
+    expect(BFF_SIGNAL.test(code.get(sponsors)!)).toBe(false);
+    expect(layoutChain(sponsors)).toContain("app/(landing)/layout.tsx");
+    expect(reachesTheBff(sponsors)).toBe(true);
+  });
+
+  it("leaves a Sanity-only route alone", () => {
+    expect(reachesTheBff("app/(main)/staf/[slug]/page.tsx")).toBe(false);
+    expect(bffFedRouteFiles).not.toContain("app/(main)/staf/[slug]/page.tsx");
+  });
+});

--- a/apps/web/src/app/__tests__/failed-read-boundaries.test.ts
+++ b/apps/web/src/app/__tests__/failed-read-boundaries.test.ts
@@ -109,10 +109,12 @@ describe("a failed subject takes the page down (#2563)", () => {
 });
 
 describe("a failed section keeps the page (#2563)", () => {
-  // `/jeugd` logs both caught reads; the assertion is that the page survives
-  // them, not that it stays quiet.
+  // Every degrade here logs — `degradeSection` warns with the cause, `/jeugd`'s
+  // two `try/catch` fetchers use `console.error`. The assertion is that the page
+  // survives, not that it stays quiet, so both channels are silenced.
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
   afterEach(() => {
     vi.restoreAllMocks();

--- a/apps/web/src/app/__tests__/failed-read-boundaries.test.ts
+++ b/apps/web/src/app/__tests__/failed-read-boundaries.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A failed read may never be cached as a successful render (#2563)
+ *
+ * #2433 rule 2: under ISR a throw and a catch have *opposite* persistence. A
+ * regeneration that throws leaves the last good page in place; a regeneration
+ * that catches to `[]` *succeeds*, so the empty render is written into the
+ * cache and the last good one is destroyed. Rule 3 splits which is right by
+ * what failed: the page's **subject** takes the page down, a **section** keeps
+ * it.
+ *
+ * Both halves are asserted here against the real Effect pipelines — Sanity is
+ * mocked at its client, one level below every repository, so each page's own
+ * `catch`/no-catch decision is what the assertion actually reads.
+ *
+ * **Sanity reads fail as defects, not as typed errors.** `fetchGroq` ends in
+ * `Effect.orDie`, so every repository method is typed `Effect<A>` with `E =
+ * never` and a `catchAll` on one is inert — which is why the two subject
+ * catches this ticket removes were already unreachable, and why every section
+ * degrade goes through `degradeSection` (`lib/effect/degrade.ts`). The subject
+ * cases below are therefore regression cover rather than a behaviour change:
+ * they fail the day someone reaches for `catchAllCause` on a subject read.
+ *
+ * **This file pins the routes #2563 touched; it is not the growth guard.** A
+ * route added later is not covered here — the rule that scales is rule 5 in
+ * `cross-page-consistency.test.ts`. `/ploegen/[slug]` gets the same degrade as
+ * the two profiles below and is left to that guard plus its own page tests,
+ * because standing its subject up needs a full team + BFF fixture to assert
+ * what these two already assert.
+ *
+ * `/kalender` is `force-dynamic` and caches nothing, so its case rests on
+ * #2399's honesty argument alone rather than on ISR persistence.
+ *
+ * @see https://github.com/soniCaH/www.kcvvelewijt.be/issues/2563
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Sanity is unreachable for every read in this file. Repositories left
+// unmocked below therefore die; the two mocked below are the page subjects
+// that must survive so their sections can be the thing that fails.
+vi.mock("@/lib/sanity/client", () => ({
+  sanityClient: {
+    fetch: vi.fn(() => Promise.reject(new Error("Sanity is unreachable"))),
+  },
+}));
+
+vi.mock("@/lib/repositories/player.repository", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@/lib/repositories/player.repository")
+    >();
+  const { Effect, Layer } = await import("effect");
+  const player = {
+    id: "player-1",
+    firstName: "Jan",
+    lastName: "Peeters",
+    position: "Middenvelder",
+  };
+  return {
+    ...mod,
+    PlayerRepositoryLive: Layer.succeed(mod.PlayerRepository, {
+      findAll: () => Effect.succeed([player]),
+      findByPsdId: () => Effect.succeed(player),
+      findKeeperPsdIds: () => Effect.succeed(new Set<string>()),
+    }),
+  };
+});
+
+vi.mock("@/lib/repositories/staff.repository", async (importOriginal) => {
+  const mod =
+    await importOriginal<
+      typeof import("@/lib/repositories/staff.repository")
+    >();
+  const { Effect, Layer } = await import("effect");
+  const member = {
+    id: "staff-1",
+    psdId: "42",
+    firstName: "An",
+    lastName: "Willems",
+    href: "/staf/42",
+    organigramPositions: [],
+    responsibilityPaths: [],
+  };
+  return {
+    ...mod,
+    StaffRepositoryLive: Layer.succeed(mod.StaffRepository, {
+      findAll: () => Effect.succeed([]),
+      findByPsdId: () => Effect.succeed(member),
+      findKeyContacts: () => Effect.succeed([]),
+      findAllForStaticParams: () => Effect.succeed([]),
+    }),
+  };
+});
+
+import SponsorsPage from "@/app/(landing)/sponsors/page";
+import CalendarPage from "@/app/(main)/kalender/page";
+import JeugdPage from "@/app/(landing)/jeugd/page";
+import PlayerPage from "@/app/(main)/spelers/[slug]/page";
+import StaffPage from "@/app/(main)/staf/[slug]/page";
+
+describe("a failed subject takes the page down (#2563)", () => {
+  it("/sponsors — the sponsor wall is the subject, so the page throws", async () => {
+    await expect(SponsorsPage()).rejects.toThrow();
+  });
+
+  it("/kalender — the team list is the subject, so the page throws", async () => {
+    await expect(CalendarPage()).rejects.toThrow();
+  });
+});
+
+describe("a failed section keeps the page (#2563)", () => {
+  // `/jeugd` logs both caught reads; the assertion is that the page survives
+  // them, not that it stays quiet.
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("/spelers/[slug] — a failed related-articles read leaves the profile", async () => {
+    await expect(
+      PlayerPage({ params: Promise.resolve({ slug: "42" }) }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("/staf/[slug] — a failed related-articles read leaves the profile", async () => {
+    await expect(
+      StaffPage({ params: Promise.resolve({ slug: "42" }) }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("/jeugd — a failed editorial-cards read leaves the page", async () => {
+    await expect(JeugdPage()).resolves.toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/effect/degrade.ts
+++ b/apps/web/src/lib/effect/degrade.ts
@@ -1,0 +1,35 @@
+import { Effect } from "effect";
+
+/**
+ * Degrade a failed **section** read to a fallback, and say so in the logs.
+ *
+ * #2433 rule 3 splits a failed read by what it was: the page's **subject**
+ * takes the page down to the one global boundary, a **section** keeps the page.
+ * This is the section half — the subject half is a bare read with no handler at
+ * all, which is the whole point of not having a `degradePage` next to this.
+ *
+ * **Why `catchAllCause` and not `catchAll`.** Every Sanity read ends in
+ * `Effect.orDie` (`lib/sanity/fetch-groq.ts`), so a repository method is typed
+ * `Effect<A>` — `E = never` — and its failures arrive as *defects*. An
+ * `Effect.catchAll` on one type-checks, reads like a guard, and never runs. The
+ * site had eight of those before #2563 and the compiler flagged none of them,
+ * which is why the correct spelling lives here under a name rather than being
+ * re-derived per call site.
+ *
+ * `note` is logged with the cause because these are defects: a section that
+ * quietly disappears may be a Sanity blip, or may be a broken GROQ projection
+ * that would otherwise never surface anywhere.
+ *
+ * @see https://github.com/soniCaH/www.kcvvelewijt.be/issues/2563
+ */
+export const degradeSection = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+  fallback: A,
+  note: string,
+): Effect.Effect<A, never, R> =>
+  self.pipe(
+    Effect.catchAllCause((cause) => {
+      console.warn(note, { cause });
+      return Effect.succeed(fallback);
+    }),
+  );

--- a/apps/web/src/lib/repositories/article.repository.ts
+++ b/apps/web/src/lib/repositories/article.repository.ts
@@ -370,10 +370,18 @@ export const ArticleRepositoryLive = Layer.succeed(ArticleRepository, {
       revalidate: SANITY_LIST_REVALIDATE,
       tags: [SANITY_TAGS.articles],
     }),
+  // Tagged like `findAll` above rather than left to inherit the route segment's
+  // window (#2563): `/nieuws/[slug]` dropped from 86400 to 900 under #2433 rule
+  // 5, and an inherited Data-Cache entry would have taken every Sanity read on
+  // the prebuilt news corpus down with it — 96× the read volume to bound a
+  // failure the article body never had. Publishes still bust it on demand,
+  // `/api/revalidate` already fires `revalidateTag('articles')`.
   findBySlug: (slug) =>
-    fetchGroq<ARTICLE_BY_SLUG_QUERY_RESULT>(ARTICLE_BY_SLUG_QUERY, {
-      slug,
-    }).pipe(
+    fetchGroq<ARTICLE_BY_SLUG_QUERY_RESULT>(
+      ARTICLE_BY_SLUG_QUERY,
+      { slug },
+      { revalidate: SANITY_LIST_REVALIDATE, tags: [SANITY_TAGS.articles] },
+    ).pipe(
       Effect.map((row) => (row ? filterPublishedRelatedArticles(row) : null)),
     ),
   findPaginated: ({ offset, limit, category }) =>
@@ -383,10 +391,14 @@ export const ArticleRepositoryLive = Layer.succeed(ArticleRepository, {
       category: category ?? "",
     }).pipe(Effect.map((rows) => rows.map(widenToArticleVM))),
   findTags: () => fetchGroq<ARTICLE_TAGS_QUERY_RESULT>(ARTICLE_TAGS_QUERY),
+  // Tagged for the same reason as `findBySlug` — this one is read by four
+  // routes, three of which also had their window shortened by #2563.
   findRelated: (documentId) =>
-    fetchGroq<RELATED_ARTICLES_QUERY_RESULT>(RELATED_ARTICLES_QUERY, {
-      documentId,
-    }).pipe(Effect.map((rows) => rows.map(widenToArticleVM))),
+    fetchGroq<RELATED_ARTICLES_QUERY_RESULT>(
+      RELATED_ARTICLES_QUERY,
+      { documentId },
+      { revalidate: SANITY_LIST_REVALIDATE, tags: [SANITY_TAGS.articles] },
+    ).pipe(Effect.map((rows) => rows.map(widenToArticleVM))),
   findByLinkedMatch: (matchId) =>
     // The GROQ filter already constrains `articleType` to the two match
     // variants, but typegen widens it to the full article union. Narrow back

--- a/apps/web/src/lib/sanity/fetch-groq.ts
+++ b/apps/web/src/lib/sanity/fetch-groq.ts
@@ -9,6 +9,16 @@ export interface GroqCacheOptions {
   tags?: string[];
 }
 
+/**
+ * Every Sanity read in the app goes through here, and every one of them ends in
+ * `Effect.orDie` — so a repository method is typed `Effect<A>` with `E = never`
+ * and a failed read arrives at the caller as a **defect**, not a typed error.
+ *
+ * Consequence worth knowing before writing a handler: `Effect.catchAll` on a
+ * repository read type-checks, reads like a guard, and never runs. Degrade a
+ * section with `degradeSection` (`lib/effect/degrade.ts`), which catches the
+ * cause; leave a subject read bare so it takes the page down (#2433 rule 2/3).
+ */
 export const fetchGroq = <T>(
   query: string,
   params?: Record<string, unknown>,


### PR DESCRIPTION
Closes #2563

Under ISR a throw and a catch have opposite persistence: a throw leaves the last good page in place, a catch *succeeds* and is written into the cache. #2433 split that by what failed — the page's **subject** takes the page down, a **section** keeps the page — and capped how long a degraded render may be repeated.

## What the code actually said

The ticket's motivating harm (a blip on the sponsor read blanking the wall for 24h) **was not reachable**. `fetchGroq` ends in `Effect.orDie`, so every Sanity repository method is typed `Effect<A>` with `E = never` and a failed read arrives as a **defect**. `Effect.catchAll` on one type-checks, reads like a guard and never runs — so `/sponsors` and `/kalender` already threw.

The bite was the other way round: the three routes where a *section* read had no handler at all took the whole page down over editorial polish. That is what changed.

## Changes

**Subject reads throw (2 routes)** — `/sponsors`, `/kalender` lose their outer catch. Both were inert; removing them makes the intent explicit and matches every other subject read on the site.

**Section reads degrade (5 sites)** — `/spelers/[slug]`, `/staf/[slug]`, `/ploegen/[slug]` (the "Verder lezen." row), `/jeugd` (editorial nav-hub config), `/kalender` (the event feed, whose `catchAll` was inert for the same reason). All five go through a new `degradeSection()` in `lib/effect/degrade.ts`, which catches the **cause** and logs it — these are defects, so a broken GROQ projection would otherwise vanish in silence on every profile page.

**Cache windows capped at 900s (4 routes)** — `/nieuws/[slug]` 86400 → 900, `/sponsors` 86400 → 900, `/jeugd` 3600 → 900, `/spelers/[slug]` 86400 → 900.

`article.repository`'s `findBySlug` / `findRelated` now carry explicit Sanity cache options instead of inheriting the segment window, so the shorter windows do not multiply Sanity reads 96×. Publishes still bust them — `/api/revalidate` already fires `revalidateTag('articles')`.

**Guards**

- `cross-page-consistency` **rule 5**: a BFF-fed route declaring a window stays at or under 900s. A route counts as BFF-fed when it *or any layout above it* reaches the BFF.
- New `failed-read-boundaries` test: subject failures reject, section failures resolve — asserted against the real Effect pipelines with Sanity mocked at its client, so each page's own catch/no-catch decision is what the assertion reads.

## Two places this departs from the ticket's counts

**7 routes, not 6, and 4 cache windows, not 1.**

1. `/ploegen/[slug]` has the same uncaught `findRelated` as the two profiles. #2433's table missed it. Fixing 2 of 3 identical sections is the divergence this map exists to delete.
2. `(landing)/layout.tsx` mounts `<MatchStripSlot>` for the whole group, and `/spelers/[slug]` mounts it inline. Its read goes through a per-render `cache()`, **not** a TTL, so it lands in each page's ISR entry. That makes `/sponsors`, `/jeugd` and `/spelers/[slug]` BFF-fed without naming `BffService` — which is how the audit counted 8 BFF routes. Rule 5's normative sentence ("a route carrying a BFF-fed section may not sit above 900s") covers them, so they are capped rather than left as the guard's documented blind spot.

## Left out, deliberately

- **`/staf/[slug]` stays at 86400.** It is the one route that now degrades a section and keeps a 24h window — it reads no BFF, so rule 5's cap does not reach it. Flagged rather than silently widened; worth a follow-up decision.
- **Eight more inert `Effect.catchAll` on repository reads survive**, four of them on `(landing)/page.tsx` plus `SponsorsSection` — the homepage is #2402's, explicitly out of #2433's scope. `(landing)/nieuws/page.tsx:54` is the other one. Each means a section failure 500s instead of degrading.
- **A guard banning the inert spelling** (`catchAll` on a `*Repository` read) is the rule that would make this unwriteable. It cannot land until the homepage sites above are fixed, or it fails on day one.
- **Restoring a typed `SanityReadError`** instead of `orDie` is the deep fix — ~40 call sites and every repository signature. ADR-sized, not this ticket.

## Testing

- `pnpm --filter @kcvv/web lint:fix` then `check-all` — exit 0, 6599 tests pass, build clean.
- Build output confirms the windows: `/sponsors` 15m, `/jeugd` 15m, `/nieuws/[slug]` 15m, `/staf/*` 1d.
- Review gate: `/code-review` (high) + `/simplify` (4 agents). Applied: the shared `degradeSection` helper, cause logging, `/ploegen/[slug]`, the `/kalender` inert inner catch, the layout-chain widening, all four window caps, the Sanity cache options, unnecessary casts and imports dropped, a non-tautological meta-test, static imports in the new test, a docblock on `fetchGroq` where the `orDie` actually lives, and two stale comments. Skipped: the homepage `catchAll` sites (out of scope, #2402) and generalizing the boundaries test to every route (rule 5 is the growth guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
