### PR TITLE
refactor(ui): delete the two dead keyframe blocks

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -233,22 +233,6 @@
   mix-blend-mode: multiply;
 }
 
-/* Fade In Animation (for result cards, modals, etc.) */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-fadeIn {
-  animation: fadeIn 0.3s ease-out;
-}
-
 /* Tailwind v4 Theme Configuration */
 @theme {
   /* ===== Color Palette ===== */
@@ -996,25 +980,6 @@
     var(--color-jersey) 10%,
     transparent
   );
-}
-
-/* ===== Carousel Progress Indicator ===== */
-@keyframes carousel-progress {
-  from {
-    transform: scaleX(0);
-  }
-  to {
-    transform: scaleX(1);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .carousel-progress-fill {
-    transform-origin: left center;
-    animation-name: carousel-progress;
-    animation-timing-function: linear;
-    animation-fill-mode: forwards;
-  }
 }
 
 /* ===== Smooth in-page anchor scrolling ===== */


### PR DESCRIPTION
Part of #2506 · resolves #2509

Two keyframe blocks in `globals.css` had zero consumers. Both only ever referenced themselves.

| Deleted | Evidence |
| --- | --- |
| `@keyframes fadeIn` + `.animate-fadeIn` | Three hits repo-wide: the keyframe, the class, and the `animation:` line joining them. Nothing outside `globals.css` names either. |
| `@keyframes carousel-progress` + `.carousel-progress-fill` | Zero consumers in `src`. `<HomepageHeroCarousel>` was retired by R1.B and its renderer deleted; this animation was not. The six outside hits are all in `docs/design/mockups/phase-4-homepage/round-r1-hero-revisit-comparisons.html`, a standalone mockup carrying its own inline `.carousel-progress` CSS — a name collision, not a consumer. |

Live keyframes left untouched: `kcvv-scarf-scroll` and `kcvv-spinner-dot-pulse` (reached via `.kcvv-spinner-*`), and `spotlight-pop` (2 consumers in `OrganigramExplorer`).

## Rebase hazard for #2650

This removes 16 lines above `globals.css:251` and 19 more above `:1019`, so **every `globals.css` line number in #2650's task list shifts**: `:704`/`:752`/`:763` → `:688`/`:736`/`:747`, `:1182` → `:1147`, and `.spotlight-pop`'s `240ms` at `:1301` → `:1266`. Whichever of the two merges second must re-grep rather than trust the numbers.

## Verification

- `pnpm --filter @kcvv/web check-all` — exit 0 (lint, type-check, vitest, `next build`).
- **No VR baselines.** These rules render on nothing, so no pixel moves at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed legacy fade-in and carousel progress animations.
  * Preserved smooth scrolling for in-page links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->