### PR TITLE
feat(teams): one display name for a team, everywhere a human reads it (#2630)

### DIFF
--- a/apps/web/src/app/(landing)/page.tsx
+++ b/apps/web/src/app/(landing)/page.tsx
@@ -58,7 +58,6 @@ import {
   UpcomingMatches,
   FirstTeamsBlock,
   deriveFirstTeamVM,
-  firstTeamLabel,
   firstTeamsHeading,
   selectSeniorTeams,
   ClubshopBanner,
@@ -221,7 +220,7 @@ export default async function HomePage() {
     const division = team.divisionFull ?? team.division ?? undefined;
     return deriveFirstTeamVM(
       {
-        label: firstTeamLabel(team.slug, team.name),
+        label: team.displayName,
         slug: team.slug,
         ...(division ? { division } : {}),
       },

--- a/apps/web/src/app/(main)/kalender/page.tsx
+++ b/apps/web/src/app/(main)/kalender/page.tsx
@@ -123,7 +123,7 @@ async function fetchCalendarData(): Promise<CalendarData> {
       // so we enrich from the Sanity team name here.
       const deduplicatedMatches = matchArrays
         .flatMap((matches, i) => {
-          const teamLabel = teamsWithPsd[i]!.name;
+          const teamLabel = teamsWithPsd[i]!.displayName;
           return matches.map((m) => ({
             ...transformMatchToCalendar(m),
             team: m.kcvv_team_label ?? teamLabel,
@@ -136,9 +136,9 @@ async function fetchCalendarData(): Promise<CalendarData> {
 
       const teamInfos: CalendarTeamInfo[] = teamsWithPsd.map((t) => ({
         id: t.id,
-        name: t.name,
+        name: t.displayName,
         psdId: Number(t.psdId),
-        label: t.name,
+        label: t.displayName,
       }));
 
       // Compose matches + the event feed into one chronological, discriminated

--- a/apps/web/src/app/(main)/ploegen/[slug]/TeamDetail.stories.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/TeamDetail.stories.tsx
@@ -226,8 +226,7 @@ function TeamDetailAssembly() {
     <>
       <PageContainer>
         <TeamHero
-          name="KCVV Elewijt A"
-          age="A"
+          displayName="A-ploeg"
           teamType="senior"
           divisionFull="Eerste Elftal A – 3e Nat. A"
           division="3NA"

--- a/apps/web/src/app/(main)/ploegen/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/opengraph-image.tsx
@@ -45,11 +45,18 @@ export default async function Image({ params }: ImageProps) {
     Effect.gen(function* () {
       const repo = yield* TeamRepository;
       const team = yield* repo.findBySlug(slug);
-      if (!team?.name) return FALLBACK;
+      if (!team) return FALLBACK;
+      // Same helper as the `<h1>` and the `<title>` — the share card used to be
+      // the third of three names one team could go by (#2630).
+      const displayName = team.displayName;
+      if (displayName === "") return FALLBACK;
+      const meta = team.tagline ?? team.divisionFull ?? team.division;
       return {
         nameTop: "KCVV Elewijt",
-        nameBottom: team.name,
-        ...(team.tagline ? { meta: team.tagline } : {}),
+        nameBottom: displayName,
+        // Falls back to the division: the card has no mono pill of its own, so
+        // unlike the hero this slot is not a duplicate (#2630).
+        ...(meta ? { meta } : {}),
       } satisfies ShareCardProps;
     }).pipe(Effect.catchAll(() => Effect.succeed(FALLBACK))),
   );

--- a/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/page.tsx
@@ -62,21 +62,29 @@ export async function generateMetadata({
   );
   if (!team) return { title: "Team niet gevonden" };
 
+  // Tab, share card and heading all read the one resolved name, so a visitor is
+  // never shown three names for one team (#2630).
+  const displayName = team.displayName;
   const typeLabel = team.teamType === "youth" ? "Jeugdploeg" : "Ploeg";
-  const description = team.tagline
-    ? `${team.name} - ${team.tagline}`
-    : `${team.name} - KCVV Elewijt ${typeLabel}`;
+  // The division moved here from the tagline. Deleting `computeTagline`'s
+  // fallback was about the *hero*, where the mono pill already showed it — a
+  // search result has no pill, so dropping it there too would degrade three
+  // senior descriptions to a bare page type for no gain (#2630).
+  const subtitle = team.tagline ?? team.divisionFull ?? team.division;
+  const description = subtitle
+    ? `${displayName} - ${subtitle}`
+    : `${displayName} - KCVV Elewijt ${typeLabel}`;
 
   return {
-    title: team.name,
+    title: displayName,
     description,
     alternates: { canonical: `${SITE_CONFIG.siteUrl}/ploegen/${slug}` },
     openGraph: {
-      title: team.name,
+      title: displayName,
       description,
       type: "website",
       images: team.teamImageUrl
-        ? [{ url: team.teamImageUrl, alt: `${team.name} teamfoto` }]
+        ? [{ url: team.teamImageUrl, alt: `${displayName} teamfoto` }]
         : [DEFAULT_OG_IMAGE],
     },
   };
@@ -123,6 +131,7 @@ export default async function TeamPage({ params }: TeamPageProps) {
 
   if (!team) notFound();
 
+  const displayName = team.displayName;
   const psdTeamId = team.psdId ? parseInt(team.psdId, 10) : NaN;
 
   // Both depend only on `team`, never on each other, so they share one wave
@@ -190,11 +199,15 @@ export default async function TeamPage({ params }: TeamPageProps) {
         data={buildBreadcrumbJsonLd([
           { name: "Home", url: SITE_CONFIG.siteUrl },
           { name: "Ploegen", url: `${SITE_CONFIG.siteUrl}/ploegen` },
-          { name: team.name, url: `${SITE_CONFIG.siteUrl}/ploegen/${slug}` },
+          { name: displayName, url: `${SITE_CONFIG.siteUrl}/ploegen/${slug}` },
         ])}
       />
       <JsonLd
         data={buildSportsTeamJsonLd({
+          // Deliberately NOT the display name: `SportsTeam.name` is a
+          // machine-readable claim about a federation-registered entity, not a
+          // nickname. The breadcrumb above is a human-facing trail, so that one
+          // follows the heading (#2630).
           name: team.name,
           url: `${SITE_CONFIG.siteUrl}/ploegen/${slug}`,
         })}
@@ -205,8 +218,7 @@ export default async function TeamPage({ params }: TeamPageProps) {
 
       <PageContainer>
         <TeamHero
-          name={team.name}
-          age={team.age}
+          displayName={displayName}
           teamType={team.teamType}
           ageGroup={team.ageGroup}
           division={team.division}

--- a/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/[slug]/wedstrijden/page.tsx
@@ -32,8 +32,9 @@ export async function generateMetadata({
   );
   if (!team) return { title: "Team niet gevonden" };
 
-  const title = `Wedstrijden — ${team.name}`;
-  const description = `Volledig wedstrijdschema van ${team.name}.`;
+  const displayName = team.displayName;
+  const title = `Wedstrijden — ${displayName}`;
+  const description = `Volledig wedstrijdschema van ${displayName}.`;
   const url = `${SITE_CONFIG.siteUrl}/ploegen/${slug}/wedstrijden`;
 
   return {
@@ -46,7 +47,7 @@ export async function generateMetadata({
       url,
       type: "website",
       images: team.teamImageUrl
-        ? [{ url: team.teamImageUrl, alt: `${team.name} teamfoto` }]
+        ? [{ url: team.teamImageUrl, alt: `${displayName} teamfoto` }]
         : [DEFAULT_OG_IMAGE],
     },
   };
@@ -109,6 +110,7 @@ export default async function WedstrijdenPage({
 
   if (!team) notFound();
 
+  const displayName = team.displayName;
   const psdTeamId = team.psdId ? parseInt(team.psdId, 10) : NaN;
   const pageUrl = `${SITE_CONFIG.siteUrl}/ploegen/${slug}/wedstrijden`;
 
@@ -140,7 +142,7 @@ export default async function WedstrijdenPage({
           { name: "Home", url: SITE_CONFIG.siteUrl },
           { name: "Ploegen", url: `${SITE_CONFIG.siteUrl}/ploegen` },
           {
-            name: team.name,
+            name: displayName,
             url: `${SITE_CONFIG.siteUrl}/ploegen/${slug}`,
           },
           { name: "Wedstrijden", url: pageUrl },
@@ -153,7 +155,7 @@ export default async function WedstrijdenPage({
       <PageContainer className="py-12 sm:py-16">
         <PageHero
           register="minimal"
-          kicker={team.name}
+          kicker={displayName}
           headline="Wedstrijden"
         />
 

--- a/apps/web/src/app/(main)/ploegen/page.test.tsx
+++ b/apps/web/src/app/(main)/ploegen/page.test.tsx
@@ -7,6 +7,7 @@ const teams: TeamLandingItem[] = [
   {
     _id: "a",
     name: "Eerste Elftallen A",
+    displayName: "A-ploeg",
     slug: "eerste-elftallen-a",
     psdId: null,
     age: "A",
@@ -20,6 +21,7 @@ const teams: TeamLandingItem[] = [
   {
     _id: "b",
     name: "Eerste Elftallen B",
+    displayName: "B-ploeg",
     slug: "eerste-elftallen-b",
     psdId: null,
     age: "A",
@@ -33,6 +35,7 @@ const teams: TeamLandingItem[] = [
   {
     _id: "u13",
     name: "KCVV Elewijt U13",
+    displayName: "U13",
     slug: "kcvv-elewijt-u13",
     psdId: null,
     age: "U13",

--- a/apps/web/src/app/(main)/ploegen/page.test.tsx
+++ b/apps/web/src/app/(main)/ploegen/page.test.tsx
@@ -3,11 +3,17 @@ import { render, screen } from "@testing-library/react";
 import type { TeamLandingItem } from "@/lib/utils/group-teams";
 
 // Mock the data layer — runPromise resolves the teams array the page maps.
+//
+// Every `displayName` here is deliberately NOT the label this page used to
+// hardcode ("A-ploeg" / "B-ploeg") nor the slug-derived fallback ("U13"). A
+// fixture that agrees with the old constant cannot tell you which one the page
+// rendered, so these are editorial overrides an editor could plausibly type
+// (#2630).
 const teams: TeamLandingItem[] = [
   {
     _id: "a",
     name: "Eerste Elftallen A",
-    displayName: "A-ploeg",
+    displayName: "A-kern",
     slug: "eerste-elftallen-a",
     psdId: null,
     age: "A",
@@ -21,7 +27,7 @@ const teams: TeamLandingItem[] = [
   {
     _id: "b",
     name: "Eerste Elftallen B",
-    displayName: "B-ploeg",
+    displayName: "B-kern",
     slug: "eerste-elftallen-b",
     psdId: null,
     age: "A",
@@ -35,7 +41,7 @@ const teams: TeamLandingItem[] = [
   {
     _id: "u13",
     name: "KCVV Elewijt U13",
-    displayName: "U13",
+    displayName: "U13 Groen",
     slug: "kcvv-elewijt-u13",
     psdId: null,
     age: "U13",
@@ -80,10 +86,23 @@ describe("/ploegen listing — Phase 6.C composition", () => {
     expect(flagships[1]?.getAttribute("data-variant")).toBe("b");
   });
 
-  it("renders the youth directory with the U13 card", async () => {
+  it("names each flagship from the team's display name, not a constant", async () => {
+    // The slot used to be labelled `category="A-ploeg"` inline, which meant an
+    // editor could rename the team and this page would keep the old word.
+    render(await TeamsPage());
+    const flagships = screen.getAllByTestId("team-flagship");
+    expect(flagships[0]?.textContent).toContain("A-kern");
+    expect(flagships[1]?.textContent).toContain("B-kern");
+  });
+
+  it("captions the youth card with the team's display name", async () => {
     render(await TeamsPage());
     expect(screen.getByTestId("youth-directory")).toBeInTheDocument();
     const youthCards = screen.getAllByTestId("youth-team-card");
-    expect(youthCards.some((c) => c.textContent?.includes("U13"))).toBe(true);
+    // "U13 Groen", not the bare age code — the caption used to come off `age`,
+    // which two teams can share (#2630).
+    expect(youthCards.some((c) => c.textContent?.includes("U13 Groen"))).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/src/app/(main)/ploegen/page.tsx
+++ b/apps/web/src/app/(main)/ploegen/page.tsx
@@ -73,7 +73,7 @@ export default async function TeamsPage() {
             <TeamFlagship
               variant="a"
               kicker="Eerste elftal"
-              category="A-ploeg"
+              category={aTeam.displayName}
               division={aTeam.divisionFull ?? aTeam.division}
               season={aTeam.season}
               teamImageUrl={aTeam.teamImageUrl}
@@ -85,7 +85,7 @@ export default async function TeamsPage() {
             <TeamFlagship
               variant="b"
               kicker="Tweede elftal"
-              category="B-ploeg"
+              category={bTeam.displayName}
               division={bTeam.divisionFull ?? bTeam.division}
               season={bTeam.season}
               teamImageUrl={bTeam.teamImageUrl}

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -193,13 +193,21 @@ const searchTeams = (query: string) =>
 
     const queryLower = query.toLowerCase();
 
+    // Matches on both names: the visitor may type what the site shows them
+    // ("A-ploeg", "U16") or what the federation registered ("Eerste Elftallen
+    // A"). Titles with the former, so the result names the page it opens
+    // (#2630).
     return teams
-      .filter((team) => team.name.toLowerCase().includes(queryLower))
+      .filter(
+        (team) =>
+          team.displayName.toLowerCase().includes(queryLower) ||
+          team.name.toLowerCase().includes(queryLower),
+      )
       .map(
         (team): SearchResult => ({
           id: team.id,
           type: "team",
-          title: team.name,
+          title: team.displayName,
           description: team.divisionFull ?? team.division ?? undefined,
           url: `/ploegen/${team.slug}`,
           imageUrl: team.teamImageUrl ?? undefined,

--- a/apps/web/src/components/home/FirstTeamsBlock/first-teams.test.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/first-teams.test.ts
@@ -4,29 +4,15 @@ import type { ScheduleMatch } from "@/components/match/types";
 import type { FirstTeamVM } from "./first-teams";
 import {
   deriveFirstTeamVM,
-  firstTeamLabel,
   firstTeamsHeading,
   selectSeniorTeams,
   SETTLED_LOOKAHEAD_MS,
 } from "./first-teams";
 import { RESERVEN_PSD_ID } from "@/lib/utils/group-teams";
 
-describe("firstTeamLabel", () => {
-  it("maps trailing-letter first-eleven slugs to X-ploeg", () => {
-    expect(firstTeamLabel("eerste-elftallen-a", "Eerste Elftallen A")).toBe(
-      "A-ploeg",
-    );
-    expect(firstTeamLabel("eerste-elftallen-b", "Eerste Elftallen B")).toBe(
-      "B-ploeg",
-    );
-  });
-
-  it("falls back to the CMS name when the slug has no trailing letter", () => {
-    expect(firstTeamLabel("fc-weitse-gans", "FC WEITSE GANS")).toBe(
-      "FC WEITSE GANS",
-    );
-  });
-});
+// The row label moved to `teamDisplayName` (#2630) — covered by
+// `src/lib/utils/team-display-name.test.ts`, which also guards the other
+// seventeen routes this block never saw.
 
 describe("selectSeniorTeams", () => {
   const A = { psdId: "1235", age: "A", slug: "eerste-elftallen-a" };

--- a/apps/web/src/components/home/FirstTeamsBlock/first-teams.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/first-teams.ts
@@ -31,7 +31,7 @@ import { hasScore, isSettledMatch } from "@/lib/utils/match-display";
 import { RESERVEN_PSD_ID } from "@/lib/utils/group-teams";
 
 export interface FirstTeamInput {
-  /** Display label, e.g. "A-ploeg". */
+  /** Display label, e.g. "A-ploeg" — from `teamDisplayName`, never re-derived here. */
   label: string;
   /** Team slug, e.g. "a-ploeg" (drives the team-matches deep link). */
   slug: string;
@@ -44,17 +44,6 @@ export interface FirstTeamVM extends FirstTeamInput {
   result?: ScheduleMatch;
   /** Next scheduled fixture — rendered as the featured jersey-deep `<TeamAgendaRow>`. */
   fixture?: ScheduleMatch;
-}
-
-/**
- * Short row label for a first team. The A/B sides carry a trailing single-letter
- * segment in their slug (`eerste-elftallen-a` → "A-ploeg"); anything else falls
- * back to the CMS `name`. Avoids title-casing the whole slug, which produced
- * "Eerste-elftallen-a".
- */
-export function firstTeamLabel(slug: string, name: string): string {
-  const tail = slug.split("-").pop() ?? "";
-  return /^[a-z]$/i.test(tail) ? `${tail.toUpperCase()}-ploeg` : name;
 }
 
 /** The fields senior-team selection reads — structural, so both call sites fit. */

--- a/apps/web/src/components/home/FirstTeamsBlock/index.ts
+++ b/apps/web/src/components/home/FirstTeamsBlock/index.ts
@@ -2,7 +2,6 @@ export { FirstTeamsBlock, FIRST_TEAMS_ROW_GRID } from "./FirstTeamsBlock";
 export type { FirstTeamsBlockProps } from "./FirstTeamsBlock";
 export {
   deriveFirstTeamVM,
-  firstTeamLabel,
   firstTeamsHeading,
   selectSeniorTeams,
 } from "./first-teams";

--- a/apps/web/src/components/home/index.ts
+++ b/apps/web/src/components/home/index.ts
@@ -42,7 +42,6 @@ export type { UpcomingMatchesProps } from "./UpcomingMatches";
 export {
   FirstTeamsBlock,
   deriveFirstTeamVM,
-  firstTeamLabel,
   firstTeamsHeading,
   selectSeniorTeams,
 } from "./FirstTeamsBlock";

--- a/apps/web/src/components/layout/MatchStrip/MatchStripInContext.stories.tsx
+++ b/apps/web/src/components/layout/MatchStrip/MatchStripInContext.stories.tsx
@@ -3,6 +3,7 @@ import { SiteHeader } from "@/components/layout/SiteHeader";
 import { MatchStripView } from "./MatchStripView";
 import { KCVV_CLUB_ID } from "@/lib/constants";
 import type { TeamNavVM } from "@/lib/repositories/team.repository";
+import { teamDisplayName } from "@/lib/utils/team-display-name";
 import type { ScheduleMatch } from "@/components/match/types";
 import type { MatchStripData } from "@/lib/server/match-data";
 
@@ -20,6 +21,9 @@ import type { MatchStripData } from "@/lib/server/match-data";
 const makeTeam = (over: Partial<TeamNavVM>): TeamNavVM => ({
   id: over.slug ?? "team",
   name: over.name ?? "Team",
+  displayName:
+    over.displayName ??
+    teamDisplayName({ slug: over.slug ?? "team", name: over.name ?? "Team" }),
   slug: over.slug ?? "team",
   age: over.age ?? null,
   psdId: null,

--- a/apps/web/src/components/layout/SiteFooter/footerLinks.test.ts
+++ b/apps/web/src/components/layout/SiteFooter/footerLinks.test.ts
@@ -13,22 +13,26 @@
  */
 
 import { describe, it, expect } from "vitest";
-import {
-  buildMenuItems,
-  buildSeniorMenuItem,
-  seniorNavLabel,
-} from "../menuItems";
+import { buildMenuItems, buildSeniorMenuItem } from "../menuItems";
 import type { TeamNavVM } from "@/lib/repositories/team.repository";
 import { FOOTER_COLUMNS } from "./footerLinks";
 
 /** The two senior sides the nav renders in production. */
 const SENIOR_TEAMS = [
-  { slug: "eerste-elftallen-a", name: "Eerste Elftallen A" },
-  { slug: "eerste-elftallen-b", name: "Eerste Elftallen B" },
+  {
+    slug: "eerste-elftallen-a",
+    name: "Eerste Elftallen A",
+    displayName: "A-ploeg",
+  },
+  {
+    slug: "eerste-elftallen-b",
+    name: "Eerste Elftallen B",
+    displayName: "B-ploeg",
+  },
 ] as TeamNavVM[];
 
 const navHrefs = buildMenuItems(
-  SENIOR_TEAMS.map((t) => buildSeniorMenuItem(t, seniorNavLabel(t.name))),
+  SENIOR_TEAMS.map((t) => buildSeniorMenuItem(t, t.displayName)),
 ).map((i) => i.href);
 
 const footerHrefs = FOOTER_COLUMNS.flatMap((c) => c.links.map((l) => l.href));

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.stories.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.stories.tsx
@@ -2,10 +2,14 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { within, userEvent } from "storybook/test";
 import { SiteHeader } from "./SiteHeader";
 import type { TeamNavVM } from "@/lib/repositories/team.repository";
+import { teamDisplayName } from "@/lib/utils/team-display-name";
 
 const makeTeam = (over: Partial<TeamNavVM>): TeamNavVM => ({
   id: over.slug ?? "team",
   name: over.name ?? "Team",
+  displayName:
+    over.displayName ??
+    teamDisplayName({ slug: over.slug ?? "team", name: over.name ?? "Team" }),
   slug: over.slug ?? "team",
   age: over.age ?? null,
   psdId: null,

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
@@ -99,6 +99,33 @@ describe("SiteHeader", () => {
     ]);
   });
 
+  it("labels a senior entry from the team's display name", () => {
+    // The nav used to re-derive its own label off `name` (`seniorNavLabel`), a
+    // second copy of the same rule — so an editorial rename reached the page
+    // heading and the share card but not the link a click earlier (#2630).
+    // The fixture's override is distinct from the slug-derived label on
+    // purpose: agreeing with it would prove nothing.
+    render(
+      <SiteHeader
+        seniorTeams={[
+          makeTeam({
+            slug: "kcvv-elewijt-a",
+            name: "KCVV Elewijt A",
+            displayName: "A-kern",
+          }),
+        ]}
+      />,
+    );
+    const nav = screen.getAllByRole("navigation", {
+      name: /hoofdnavigatie/i,
+    })[0]!;
+    const labels = Array.from(nav.querySelectorAll("a")).map(
+      (a) => a.textContent,
+    );
+    expect(labels).toContain("A-kern");
+    expect(labels).not.toContain("A-ploeg");
+  });
+
   it("has no dropdown triggers — every nav entry is a plain link", () => {
     render(<SiteHeader seniorTeams={seniorTeams} />);
     expect(document.querySelector("[aria-haspopup]")).toBeNull();

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
@@ -8,10 +8,14 @@ vi.mock("next/navigation", () => ({
 }));
 
 import type { TeamNavVM } from "@/lib/repositories/team.repository";
+import { teamDisplayName } from "@/lib/utils/team-display-name";
 
 const makeTeam = (over: Partial<TeamNavVM>): TeamNavVM => ({
   id: over.slug ?? "team",
   name: over.name ?? "Team",
+  displayName:
+    over.displayName ??
+    teamDisplayName({ slug: over.slug ?? "team", name: over.name ?? "Team" }),
   slug: over.slug ?? "team",
   age: over.age ?? null,
   psdId: null,

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.tsx
@@ -14,7 +14,6 @@ import {
 import {
   buildMenuItems,
   buildSeniorMenuItem,
-  seniorNavLabel,
   isMenuItemActive,
 } from "../menuItems";
 import { NavTakeover, NavTakeoverItem } from "../NavTakeover";
@@ -89,7 +88,7 @@ export function SiteHeader({ seniorTeams, className }: SiteHeaderProps) {
   );
 
   const seniorMenuItems = (seniorTeams ?? []).map((t) =>
-    buildSeniorMenuItem(t, seniorNavLabel(t.name)),
+    buildSeniorMenuItem(t, t.displayName),
   );
   const menuItems = buildMenuItems(seniorMenuItems);
 

--- a/apps/web/src/components/layout/menuItems.test.ts
+++ b/apps/web/src/components/layout/menuItems.test.ts
@@ -3,7 +3,6 @@ import {
   buildMenuItems,
   buildSeniorMenuItem,
   isMenuItemActive,
-  seniorNavLabel,
 } from "./menuItems";
 import type { MenuItem } from "./menuItems";
 import type { TeamNavVM } from "@/lib/repositories/team.repository";
@@ -88,29 +87,9 @@ describe("buildSeniorMenuItem", () => {
   });
 });
 
-describe("seniorNavLabel", () => {
-  it("shortens a trailing single capital to <X>-ploeg", () => {
-    expect(seniorNavLabel("Eerste Elftallen A")).toBe("A-ploeg");
-    expect(seniorNavLabel("KCVV Elewijt B")).toBe("B-ploeg");
-  });
-
-  it("passes a short name through untouched", () => {
-    expect(seniorNavLabel("Reserven")).toBe("Reserven");
-  });
-
-  it("returns a long name whole — width is bounded in CSS, not here", () => {
-    // The desktop row bounds itself with `NAV_LABEL_TRUNCATE` (max-w-[14ch]
-    // truncate). Truncating the string instead would also chop the mobile
-    // drawer, which has no width constraint, and would push the ellipsis into
-    // the link's accessible name.
-    const long = "Koninklijke Voetbalvereniging Elewijt";
-    expect(seniorNavLabel(long)).toBe(long);
-  });
-
-  it("trims surrounding whitespace before deciding", () => {
-    expect(seniorNavLabel("  Eerste Elftallen A  ")).toBe("A-ploeg");
-  });
-});
+// The label the nav renders is no longer derived here: `<SiteHeader>` reads the
+// team's resolved `displayName` (#2630), so the letter → `X-ploeg` rule lives in
+// exactly one place — `src/lib/utils/team-display-name.ts`, tested there.
 
 describe("isMenuItemActive", () => {
   it("marks an item active on its own page", () => {

--- a/apps/web/src/components/layout/menuItems.ts
+++ b/apps/web/src/components/layout/menuItems.ts
@@ -37,25 +37,6 @@ export const buildSeniorMenuItem = (
 ): MenuItem | null =>
   team?.slug ? { label, href: `/ploegen/${team.slug}` } : null;
 
-/**
- * "Eerste Elftallen A" → "A-ploeg". A name whose last word is not a single
- * capital has no short form, so it renders in full.
- *
- * Naming only — this deliberately does **not** cap the length. Senior labels
- * come from Sanity team names, so the nav's width is data-driven and needs
- * bounding (#2409), but the bound belongs at the desktop render site: it is
- * the desktop row that must fit one line at `lg`, and only the desktop row.
- * `SiteHeader` applies `NAV_LABEL_TRUNCATE` there. Capping the string here
- * instead would also chop the mobile drawer — full-width, 22px display type,
- * no width constraint at all — and would put the ellipsis into the link's
- * accessible name, which is the one place the full name must survive.
- */
-export const seniorNavLabel = (name: string): string => {
-  const trimmed = name.trim();
-  const lastWord = trimmed.split(/\s+/).at(-1) ?? trimmed;
-  return /^[A-Z]$/.test(lastWord) ? `${lastWord}-ploeg` : trimmed;
-};
-
 const isReserven = (t: TeamNavVM): boolean => t.psdId === RESERVEN_PSD_ID;
 
 /**

--- a/apps/web/src/components/team/TeamHero/TeamHero.stories.tsx
+++ b/apps/web/src/components/team/TeamHero/TeamHero.stories.tsx
@@ -9,14 +9,13 @@ const meta = {
     docs: {
       description: {
         component:
-          "Phase 6.C hero band for `/ploegen/[slug]`. Category derived from team name (A-ploeg./U13.), landscape squad photo or JerseyShirt fallback. Two-column desktop / artefact-above-headline mobile.",
+          "Phase 6.C hero band for `/ploegen/[slug]`. Headline is the team's display name (`teamDisplayName()`, #2630) — never derived here. Landscape squad photo or JerseyShirt fallback. Two-column desktop / artefact-above-headline mobile.",
       },
     },
   },
   tags: ["autodocs", "vr"],
   argTypes: {
-    name: { control: "text" },
-    age: { control: "text" },
+    displayName: { control: "text" },
     teamType: { control: "select", options: ["senior", "youth"] },
     division: { control: "text" },
     divisionFull: { control: "text" },
@@ -32,8 +31,7 @@ type Story = StoryObj<typeof meta>;
 /** A-team with squad photo — canonical senior hero composition. */
 export const ATeamWithPhoto: Story = {
   args: {
-    name: "KCVV Elewijt A",
-    age: "A",
+    displayName: "A-ploeg",
     teamType: "senior",
     divisionFull: "Eerste Elftal A – 3e Nat. A",
     division: "3NA",
@@ -46,8 +44,7 @@ export const ATeamWithPhoto: Story = {
 /** A-team without squad photo — JerseyShirt fallback in the same frame. */
 export const ATeamNoPhoto: Story = {
   args: {
-    name: "KCVV Elewijt A",
-    age: "A",
+    displayName: "A-ploeg",
     teamType: "senior",
     divisionFull: "Eerste Elftal A – 3e Nat. A",
     division: "3NA",
@@ -59,8 +56,7 @@ export const ATeamNoPhoto: Story = {
 /** Youth U13 — degraded meta (youth band + season; no division), JerseyShirt fallback. */
 export const YouthU13: Story = {
   args: {
-    name: "KCVV Elewijt U13",
-    age: "U13",
+    displayName: "U13",
     teamType: "youth",
     ageGroup: "U13",
     season: "25/26",

--- a/apps/web/src/components/team/TeamHero/TeamHero.test.tsx
+++ b/apps/web/src/components/team/TeamHero/TeamHero.test.tsx
@@ -3,7 +3,7 @@
  *
  * Covers:
  *  - Kicker: "KCVV Elewijt" for senior, "KCVV Elewijt · Jeugd" for youth.
- *  - Headline: category derived from team name (A-ploeg. / B-ploeg. / U13.).
+ *  - Headline: the display name, rendered verbatim — never derived here (#2630).
  *  - Meta row: division + season pills for senior; youth band + season for youth.
  *  - Meta auto-hide when both pills absent.
  *  - Tagline renders and auto-hides.
@@ -16,8 +16,7 @@ import { render, screen } from "@testing-library/react";
 import { TeamHero } from "./TeamHero";
 
 const BASE_SENIOR = {
-  name: "KCVV Elewijt A",
-  age: "A" as const,
+  displayName: "A-ploeg",
   teamType: "senior" as const,
   divisionFull: "Eerste Elftal A – 3e Nat. A",
   season: "25/26",
@@ -35,8 +34,7 @@ describe("TeamHero", () => {
     it("renders 'KCVV Elewijt · Jeugd' for a youth team", () => {
       render(
         <TeamHero
-          name="KCVV Elewijt U13"
-          age="U13"
+          displayName="U13"
           teamType="youth"
           ageGroup="U13"
           season="25/26"
@@ -48,60 +46,28 @@ describe("TeamHero", () => {
     });
   });
 
-  describe("Headline / category (derived from team name)", () => {
-    it("renders 'A-ploeg.' from full PSD name 'KCVV Elewijt Eerste Elftallen A'", () => {
-      render(
-        <TeamHero {...BASE_SENIOR} name="KCVV Elewijt Eerste Elftallen A" />,
-      );
-      const h1 = screen.getByRole("heading", { level: 1 });
-      expect(h1.textContent).toBe("A-ploeg.");
-    });
-
-    it("renders 'A-ploeg.' from short name 'KCVV Elewijt A'", () => {
+  describe("Headline", () => {
+    it("renders the display name verbatim", () => {
       render(<TeamHero {...BASE_SENIOR} />);
       const h1 = screen.getByRole("heading", { level: 1 });
       expect(h1.textContent).toBe("A-ploeg.");
     });
 
-    it("renders 'B-ploeg.' from name ending in B, regardless of age field", () => {
-      render(
-        <TeamHero
-          name="KCVV Elewijt B"
-          age="A"
-          teamType="senior"
-          season="25/26"
-        />,
+    it("never re-derives the heading from the shared age band", () => {
+      // Reserven's `age` is the senior code "A" — the same band the A-ploeg
+      // carries. The hero used to head this page `A-ploeg.` (#2630). The band
+      // no longer reaches the heading at all; it is not even a prop.
+      render(<TeamHero displayName="Reserven" teamType="senior" />);
+      expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+        "Reserven.",
       );
-      const h1 = screen.getByRole("heading", { level: 1 });
-      expect(h1.textContent).toBe("B-ploeg.");
     });
 
-    it("renders 'U13.' from name 'KCVV Elewijt U13'", () => {
-      render(
-        <TeamHero
-          name="KCVV Elewijt U13"
-          age="U13"
-          teamType="youth"
-          ageGroup="U13"
-          season="25/26"
-        />,
+    it("names the section after the team it heads", () => {
+      render(<TeamHero displayName="U10P" teamType="youth" />);
+      expect(screen.getByTestId("team-hero").getAttribute("aria-label")).toBe(
+        "U10P · ploegpagina",
       );
-      const h1 = screen.getByRole("heading", { level: 1 });
-      expect(h1.textContent).toBe("U13.");
-    });
-
-    it("renders 'U17.' from name 'KCVV Elewijt U17'", () => {
-      render(
-        <TeamHero
-          name="KCVV Elewijt U17"
-          age="U17"
-          teamType="youth"
-          ageGroup="U17"
-          season="25/26"
-        />,
-      );
-      const h1 = screen.getByRole("heading", { level: 1 });
-      expect(h1.textContent).toBe("U17.");
     });
   });
 
@@ -116,8 +82,7 @@ describe("TeamHero", () => {
     it("falls back to short division when divisionFull is absent", () => {
       render(
         <TeamHero
-          name="KCVV Elewijt A"
-          age="A"
+          displayName="A-ploeg"
           teamType="senior"
           division="3NA"
           season="25/26"
@@ -130,8 +95,7 @@ describe("TeamHero", () => {
     it("shows youth band and season for a youth team", () => {
       render(
         <TeamHero
-          name="KCVV Elewijt U13"
-          age="U13"
+          displayName="U13"
           teamType="youth"
           ageGroup="U13"
           season="25/26"
@@ -145,8 +109,7 @@ describe("TeamHero", () => {
     it("shows Bovenbouw band for U17", () => {
       render(
         <TeamHero
-          name="KCVV Elewijt U17"
-          age="U17"
+          displayName="U17"
           teamType="youth"
           ageGroup="U17"
           season="25/26"
@@ -160,8 +123,7 @@ describe("TeamHero", () => {
     it("shows Onderbouw band for U9", () => {
       render(
         <TeamHero
-          name="KCVV Elewijt U9"
-          age="U9"
+          displayName="U9"
           teamType="youth"
           ageGroup="U9"
           season="25/26"
@@ -173,7 +135,7 @@ describe("TeamHero", () => {
     });
 
     it("auto-hides meta row when no division and no season", () => {
-      render(<TeamHero name="KCVV Elewijt A" age="A" teamType="senior" />);
+      render(<TeamHero displayName="A-ploeg" teamType="senior" />);
       expect(screen.queryByTestId("team-hero-meta")).toBeNull();
     });
   });
@@ -222,7 +184,7 @@ describe("TeamHero", () => {
     });
 
     it("hides the season stub when season is absent", () => {
-      render(<TeamHero name="KCVV Elewijt A" age="A" teamType="senior" />);
+      render(<TeamHero displayName="A-ploeg" teamType="senior" />);
       expect(screen.queryByTestId("team-hero-season-stub")).toBeNull();
     });
   });

--- a/apps/web/src/components/team/TeamHero/TeamHero.tsx
+++ b/apps/web/src/components/team/TeamHero/TeamHero.tsx
@@ -8,12 +8,13 @@ import { getYouthDivision } from "@/lib/utils/group-teams";
 
 export interface TeamHeroProps {
   /**
-   * Full team name from Sanity (e.g. "KCVV Elewijt A", "KCVV Elewijt U13").
-   * Used as the primary source for the category headline.
+   * What this team is called — the `<h1>`. Resolved by `teamDisplayName()`, the
+   * single helper every surface reads, so the heading, the tab and the share
+   * card cannot name the team three different ways. Never derived here: the
+   * heading used to come off `age`, a shared competition band, which is how
+   * `/ploegen/reserven` came to be headed `A-ploeg.` (#2630).
    */
-  name: string;
-  /** Team age code from Sanity (e.g. "A", "B", "U13"). Used as a fallback only. */
-  age: string | null;
+  displayName: string;
   /** "senior" or "youth" — drives kicker + meta pill logic. */
   teamType: "youth" | "senior";
   /** Age group extracted from `age` (e.g. "U13"). Computed by the repository. */
@@ -31,38 +32,8 @@ export interface TeamHeroProps {
   className?: string;
 }
 
-function assertNever(value: never): never {
-  throw new Error(`Unhandled teamType variant: ${String(value)}`);
-}
-
-function computeCategory(
-  name: string,
-  age: string | null,
-  teamType: "youth" | "senior",
-): string {
-  if (teamType === "youth") {
-    // age field is reliable for youth (U6, U8, U13, U17, …)
-    if (age) return age.toUpperCase();
-    return "Jeugd";
-  }
-  if (teamType === "senior") {
-    // Sanity name is the full PSD name (e.g. "KCVV Elewijt Eerste Elftallen A").
-    // The last word is the single-letter team suffix — more reliable than the age field,
-    // which PSD sometimes sends as "A" for both first and second teams.
-    const lastWord = name.trim().split(/\s+/).pop()?.toUpperCase() ?? "";
-    if (lastWord === "A") return "A-ploeg";
-    if (lastWord === "B") return "B-ploeg";
-    // Fallback to age field if name doesn't end in A/B (edge case)
-    if (age?.toUpperCase() === "A") return "A-ploeg";
-    if (age?.toUpperCase() === "B") return "B-ploeg";
-    return "Ploeg";
-  }
-  return assertNever(teamType);
-}
-
 export function TeamHero({
-  name,
-  age,
+  displayName,
   teamType,
   ageGroup,
   division,
@@ -74,7 +45,6 @@ export function TeamHero({
 }: TeamHeroProps) {
   const hasPhoto =
     teamImageUrl !== undefined && teamImageUrl !== null && teamImageUrl !== "";
-  const category = computeCategory(name, age, teamType);
 
   const kicker = teamType === "youth" ? "KCVV Elewijt · Jeugd" : "KCVV Elewijt";
 
@@ -91,14 +61,20 @@ export function TeamHero({
   const showTagline =
     tagline !== null && tagline !== undefined && tagline !== "";
 
-  // Chest letter on the JerseyShirt fallback: prefer the normalised ageGroup
-  // (e.g. "U13") over the raw age string (which may have a suffix like "U13A").
-  const jerseyLetter = (ageGroup ?? age)?.toUpperCase();
+  // Chest mark on the JerseyShirt fallback. A shirt carries the team's own
+  // name, so it reads the display name — not `age`, which is the shared
+  // competition band and would print `U17` on a page headed `U16.` and `A` on
+  // one headed `Reserven.` (#2630). The 56px overlay fits an age code or a
+  // letter, not a word, so anything longer wears its initial.
+  const jerseyLetter =
+    displayName.length <= 4
+      ? displayName.toUpperCase()
+      : displayName.charAt(0).toUpperCase();
 
   return (
     <section
       data-testid="team-hero"
-      aria-label={`${category} · ploegpagina`}
+      aria-label={`${displayName} · ploegpagina`}
       className={cn(
         "grid grid-cols-1 items-start gap-x-10 gap-y-8 overflow-x-clip sm:grid-cols-[1fr_minmax(300px,420px)]",
         className,
@@ -111,7 +87,7 @@ export function TeamHero({
         </span>
 
         <EditorialHeading level={1} size="display-xl" emphasis={{ text: "." }}>
-          {category}
+          {displayName}
         </EditorialHeading>
 
         {showMeta ? (

--- a/apps/web/src/components/team/YouthDirectory/YouthDirectory.tsx
+++ b/apps/web/src/components/team/YouthDirectory/YouthDirectory.tsx
@@ -18,13 +18,12 @@ const CARD_ROTATIONS = [-1.1, 0.7, -0.5];
 /**
  * Youth-team directory (`/jeugd` + `/ploegen`). Grouped Reserven / Bovenbouw /
  * Middenbouw / Onderbouw (per [[project_youth_divisions]]); each team is a taped
- * polaroid of its squad photo (`team.teamImageUrl`, backfilled in #2070) with
- * the age code as the caption — design locks 7j4 (variant C) + 7j5
+ * polaroid of its squad photo (`team.teamImageUrl`, backfilled in #2070)
+ * captioned with the team's display name — design locks 7j4 (variant C) + 7j5
  * (age-code-only · subtle rotation · newsprint colour). Teams without a photo
  * fall back to the canonical `<JerseyShirt>` illustration. A group with no
- * `range` renders its heading bare, and its teams — whose `age` is not an age
- * code — caption by name (#2414). Empty groups are omitted; the whole block
- * hides when no youth teams exist.
+ * `range` renders its heading bare (#2414). Empty groups are omitted; the whole
+ * block hides when no youth teams exist.
  */
 export function YouthDirectory({ divisions, className }: YouthDirectoryProps) {
   const groups = divisions.filter((d) => d.teams.length > 0);
@@ -48,20 +47,22 @@ export function YouthDirectory({ divisions, className }: YouthDirectoryProps) {
           </h3>
           <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-4 gap-y-7">
             {group.teams.map((team, index) => {
-              // A real age code (U6…U21) captions the card and goes on the
-              // chest. Reserven's age is "A" — a senior code that reads as the
-              // A-ploeg in a youth grid — so non-age teams caption by name and
-              // wear its initial instead. The 56px overlay fits a letter, not
-              // a word, and an empty chest reads as a broken card.
+              // The caption is the team's one display name (#2630) — the same
+              // string its page heads itself with, so the click confirms
+              // itself. The chest keeps reading `age` directly: the 56px
+              // overlay fits a letter or an age code, not a word, and an empty
+              // chest reads as a broken card. Reserven's age is "A" — a senior
+              // code that reads as the A-ploeg in a youth grid — so non-age
+              // teams wear the caption's initial instead.
               const ageCode = isAgeCode(team.age) ? team.age : null;
-              const caption = ageCode ?? team.name;
-              const chestMark = ageCode ?? team.name.charAt(0).toUpperCase();
+              const caption = team.displayName;
+              const chestMark = ageCode ?? caption.charAt(0).toUpperCase();
               return (
                 <Link
                   key={team._id}
                   href={`/ploegen/${team.slug}`}
                   data-testid="youth-team-card"
-                  aria-label={`${team.name} — bekijk ploeg`}
+                  aria-label={`${caption} — bekijk ploeg`}
                   className="block"
                 >
                   <TapedCard

--- a/apps/web/src/components/team/YouthDirectory/youth-directory.fixtures.ts
+++ b/apps/web/src/components/team/YouthDirectory/youth-directory.fixtures.ts
@@ -30,13 +30,13 @@ export function youthTeam(
     staff: null,
     ...overrides,
   };
-  // Resolved *after* the overrides, the way the repository resolves it (#2630),
-  // so a fixture cannot caption a card with a string the real mapper would
-  // never produce — and an override of `slug`/`name` moves the caption with it.
-  return {
-    ...team,
-    displayName: overrides.displayName ?? teamDisplayName(team),
-  };
+  // Resolved *after* the overrides, through the same helper the repository
+  // uses (#2630) — `team` already carries any `displayName` override, so a
+  // blank or whitespace-only one falls back to the slug-derived label exactly
+  // as it would in production, and overriding `slug`/`name` moves the caption
+  // with it. Assigning an override straight through would let a fixture render
+  // a caption the real mapper can never produce.
+  return { ...team, displayName: teamDisplayName(team) };
 }
 
 /**

--- a/apps/web/src/components/team/YouthDirectory/youth-directory.fixtures.ts
+++ b/apps/web/src/components/team/YouthDirectory/youth-directory.fixtures.ts
@@ -3,6 +3,7 @@ import {
   RESERVEN_PSD_ID,
   type TeamLandingItem,
 } from "@/lib/utils/group-teams";
+import { teamDisplayName } from "@/lib/utils/team-display-name";
 
 /**
  * Build a youth `TeamLandingItem` from an age code (e.g. "U13"). Pass a
@@ -15,7 +16,7 @@ export function youthTeam(
   teamImageUrl: string | null = null,
   overrides: Partial<TeamLandingItem> = {},
 ): TeamLandingItem {
-  return {
+  const team = {
     _id: `t-${age}`,
     name: `KCVV Elewijt ${age}`,
     slug: `kcvv-elewijt-${age.toLowerCase()}`,
@@ -29,11 +30,19 @@ export function youthTeam(
     staff: null,
     ...overrides,
   };
+  // Resolved *after* the overrides, the way the repository resolves it (#2630),
+  // so a fixture cannot caption a card with a string the real mapper would
+  // never produce — and an override of `slug`/`name` moves the caption with it.
+  return {
+    ...team,
+    displayName: overrides.displayName ?? teamDisplayName(team),
+  };
 }
 
 /**
- * The reserves — age "A" rather than an age code, so the card captions by name
- * over an initialled jersey and its group heading carries no range (#2414).
+ * The reserves — age "A" rather than an age code, so its slug resolves to the
+ * plain name over an initialled jersey and its group heading carries no range
+ * (#2414).
  */
 export const reservenTeam = (): TeamLandingItem =>
   youthTeam("A", null, {

--- a/apps/web/src/lib/repositories/player.repository.ts
+++ b/apps/web/src/lib/repositories/player.repository.ts
@@ -7,6 +7,7 @@ import type {
   PLAYER_BY_PSD_ID_QUERY_RESULT,
 } from "../sanity/sanity.types";
 import type { SanityPlayerBase } from "../sanity/types";
+import { teamDisplayName } from "../utils/team-display-name";
 
 // ─── GROQ Queries ────────────────────────────────────────────────────────────
 
@@ -29,7 +30,7 @@ export const PLAYER_BY_PSD_ID_QUERY =
   "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",
   bio,
   "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {
-    name, season
+    name, displayName, "slug": slug.current, season
   }
 }`);
 
@@ -62,7 +63,12 @@ export function toPlayerVM(
     celebrationImageUrl?: string | null;
     bio?: PLAYERS_QUERY_RESULT[number]["bio"] | null;
     birthDate?: string | null;
-    currentTeam?: { name?: string | null; season?: string | null } | null;
+    currentTeam?: {
+      name?: string | null;
+      displayName?: string | null;
+      slug?: string | null;
+      season?: string | null;
+    } | null;
   },
 ): PlayerVM {
   const position = row.keeper
@@ -80,7 +86,16 @@ export function toPlayerVM(
     href: row.psdId ? `/spelers/${row.psdId}` : undefined,
     bio: row.bio ?? undefined,
     birthDate: row.birthDate ?? undefined,
-    teamLabel: row.currentTeam?.name ?? undefined,
+    // The team's own name, resolved the same way its page resolves it — a
+    // profile that says `KCVVE  U15` beside a page headed `U15` is the drift
+    // #2630 closes.
+    teamLabel: row.currentTeam
+      ? teamDisplayName({
+          displayName: row.currentTeam.displayName,
+          slug: row.currentTeam.slug ?? "",
+          name: row.currentTeam.name ?? "",
+        })
+      : undefined,
     season: row.currentTeam?.season ?? undefined,
   };
 }

--- a/apps/web/src/lib/repositories/team.repository.test.ts
+++ b/apps/web/src/lib/repositories/team.repository.test.ts
@@ -37,6 +37,7 @@ function makeTeamRow(
     _id: "team-1",
     psdId: "100",
     name: "Eerste Elftallen A",
+    displayName: null,
     slug: "eerste-elftallen-a",
     age: "A",
     gender: "male",
@@ -67,6 +68,7 @@ describe("TeamRepository", () => {
       expect(t).toEqual<TeamNavVM>({
         id: "team-1",
         name: "Eerste Elftallen A",
+        displayName: "A-ploeg",
         slug: "eerste-elftallen-a",
         age: "A",
         psdId: "100",
@@ -120,6 +122,7 @@ describe("TeamRepository", () => {
         _id: "team-1",
         psdId: "100",
         name: "Eerste Elftallen A",
+        displayName: null,
         slug: "eerste-elftallen-a",
         age: "A",
         gender: "male",
@@ -275,8 +278,10 @@ describe("TeamRepository", () => {
       expect(team!.staff[0]?.href).toBeUndefined();
     });
 
-    it("computes tagline fallback: tagline → divisionFull → division", async () => {
-      // tagline null → falls back to divisionFull
+    it("leaves the tagline absent rather than repeating the division (#2630)", async () => {
+      // The tagline sits directly under the mono pill that already shows the
+      // division, so the old `?? divisionFull ?? division` chain made three
+      // senior pages print it twice. The slot is the club's line or nothing.
       mockFetch.mockResolvedValueOnce(makeDetailRow({ tagline: null }));
       const t1 = await runWithRepo(
         Effect.gen(function* () {
@@ -284,11 +289,12 @@ describe("TeamRepository", () => {
           return yield* repo.findBySlug("test");
         }),
       );
-      expect(t1!.tagline).toBe("3de Afdeling VFV A");
+      expect(t1!.divisionFull).toBe("3de Afdeling VFV A");
+      expect(t1!.tagline).toBeUndefined();
 
-      // tagline + divisionFull null → falls back to division
+      // An editorial line still comes through untouched.
       mockFetch.mockResolvedValueOnce(
-        makeDetailRow({ tagline: null, divisionFull: null }),
+        makeDetailRow({ tagline: "Er is maar één plezante compagnie" }),
       );
       const t2 = await runWithRepo(
         Effect.gen(function* () {
@@ -296,23 +302,7 @@ describe("TeamRepository", () => {
           return yield* repo.findBySlug("test");
         }),
       );
-      expect(t2!.tagline).toBe("3de Afdeling");
-
-      // all null → undefined
-      mockFetch.mockResolvedValueOnce(
-        makeDetailRow({
-          tagline: null,
-          divisionFull: null,
-          division: null,
-        }),
-      );
-      const t3 = await runWithRepo(
-        Effect.gen(function* () {
-          const repo = yield* TeamRepository;
-          return yield* repo.findBySlug("test");
-        }),
-      );
-      expect(t3!.tagline).toBeUndefined();
+      expect(t2!.tagline).toBe("Er is maar één plezante compagnie");
     });
 
     it("computes teamType: youth for U-ages, senior otherwise", async () => {
@@ -602,6 +592,7 @@ describe("TeamRepository", () => {
         _id: "team-1",
         psdId: "1",
         name: "Eerste Elftallen A",
+        displayName: null,
         slug: "eerste-elftallen-a",
         age: "A",
         division: "3de Afdeling",
@@ -638,6 +629,7 @@ describe("TeamRepository", () => {
         _id: "team-1",
         psdId: "1",
         name: "Eerste Elftallen A",
+        displayName: "A-ploeg",
         slug: "eerste-elftallen-a",
         age: "A",
         division: "3de Afdeling",

--- a/apps/web/src/lib/repositories/team.repository.ts
+++ b/apps/web/src/lib/repositories/team.repository.ts
@@ -7,6 +7,7 @@ import type {
   TEAM_BY_SLUG_QUERY_RESULT,
   TEAMS_LANDING_QUERY_RESULT,
 } from "../sanity/sanity.types";
+import { teamDisplayName } from "../utils/team-display-name";
 import { toPlayerVM, type PlayerVM } from "./player.repository";
 import type { TeamLandingItem } from "../utils/group-teams";
 import type { TeamStaffMember } from "../team-role-resolution";
@@ -15,14 +16,14 @@ import type { TeamStaffMember } from "../team-role-resolution";
 
 export const TEAMS_QUERY =
   defineQuery(`*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {
-  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,
+  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,
   tagline,
   "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))
 }`);
 
 export const TEAM_BY_SLUG_QUERY =
   defineQuery(`*[_type == "team" && slug.current == $slug][0] {
-  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,
+  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,
   season,
   tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,
   "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),
@@ -43,7 +44,7 @@ export const YOUTH_TEAMS_CONTACT_QUERY =
 
 export const TEAMS_LANDING_QUERY =
   defineQuery(`*[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {
-  _id, psdId, name, "slug": slug.current, age,
+  _id, psdId, name, displayName, "slug": slug.current, age,
   division, divisionFull, season, tagline,
   "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),
   staff[] { role, "member": member-> { firstName, lastName, functionTitle } }
@@ -80,6 +81,14 @@ export interface YouthTeamForContactVM {
 export interface TeamNavVM {
   id: string;
   name: string;
+  /**
+   * What the site calls this team, already resolved (#2630). Never the raw
+   * Sanity override — that is applied here, at the boundary, so no consumer can
+   * render `name` by accident. Read this, not `name`, on any human-facing
+   * surface; `name` is the federation-registered identity and belongs to
+   * JSON-LD.
+   */
+  displayName: string;
   slug: string;
   age: string | null;
   psdId: string | null;
@@ -108,6 +117,14 @@ export interface StaffMemberVM {
 export interface TeamDetailVM {
   id: string;
   name: string;
+  /**
+   * What the site calls this team, already resolved (#2630). Never the raw
+   * Sanity override — that is applied here, at the boundary, so no consumer can
+   * render `name` by accident. Read this, not `name`, on any human-facing
+   * surface; `name` is the federation-registered identity and belongs to
+   * JSON-LD.
+   */
+  displayName: string;
   slug: string;
   age: string | null;
   psdId: string | null;
@@ -132,10 +149,13 @@ type TEAM_BY_SLUG_DETAIL = Exclude<TEAM_BY_SLUG_QUERY_RESULT, null>;
 // ─── Transforms ──────────────────────────────────────────────────────────────
 
 export function toTeamNavVM(row: TEAMS_QUERY_RESULT[number]): TeamNavVM {
+  const name = row.name ?? "";
+  const slug = row.slug ?? "";
   return {
     id: row._id,
-    name: row.name ?? "",
-    slug: row.slug ?? "",
+    name,
+    displayName: teamDisplayName({ displayName: row.displayName, slug, name }),
+    slug,
     age: row.age,
     psdId: row.psdId,
     division: row.division,
@@ -143,10 +163,6 @@ export function toTeamNavVM(row: TEAMS_QUERY_RESULT[number]): TeamNavVM {
     tagline: row.tagline,
     teamImageUrl: row.teamImageUrl,
   };
-}
-
-function computeTagline(row: TEAM_BY_SLUG_DETAIL): string | undefined {
-  return row.tagline ?? row.divisionFull ?? row.division ?? undefined;
 }
 
 function computeTeamType(age: string | null): "youth" | "senior" {
@@ -184,17 +200,25 @@ function toStaffMemberVM(
 }
 
 function toTeamDetailVM(row: TEAM_BY_SLUG_DETAIL): TeamDetailVM {
+  const name = row.name ?? "";
+  const slug = row.slug ?? "";
   return {
     id: row._id,
-    name: row.name ?? "",
-    slug: row.slug ?? "",
+    name,
+    displayName: teamDisplayName({ displayName: row.displayName, slug, name }),
+    slug,
     age: row.age,
     psdId: row.psdId,
     footbelId: row.footbelId,
     division: row.division,
     divisionFull: row.divisionFull,
     season: row.season ?? null,
-    tagline: computeTagline(row),
+    // No `?? divisionFull ?? division` chain (#2630): the mono pill directly
+    // above the tagline already shows the division, so the fallback made three
+    // senior pages print it twice while the fifteen youth pages — where
+    // `divisionFull` is null — got nothing. The slot appears when the club
+    // writes a line and is absent otherwise.
+    tagline: row.tagline ?? undefined,
     teamType: computeTeamType(row.age),
     ageGroup: computeAgeGroup(row.age),
     teamImageUrl: row.teamImageUrl,
@@ -211,10 +235,13 @@ function toTeamDetailVM(row: TEAM_BY_SLUG_DETAIL): TeamDetailVM {
 function toTeamLandingItem(
   row: TEAMS_LANDING_QUERY_RESULT[number],
 ): TeamLandingItem {
+  const name = row.name ?? "";
+  const slug = row.slug ?? "";
   return {
     _id: row._id,
-    name: row.name ?? "",
-    slug: row.slug ?? "",
+    name,
+    displayName: teamDisplayName({ displayName: row.displayName, slug, name }),
+    slug,
     age: row.age ?? "",
     psdId: row.psdId,
     division: row.division,

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -827,6 +827,7 @@ export type Team = {
   >;
   division?: string;
   divisionFull?: string;
+  displayName?: string;
   showInNavigation?: boolean;
   archived?: boolean;
   tagline?: string;
@@ -2430,7 +2431,7 @@ export type PLAYERS_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/player.repository.ts
 // Variable: PLAYER_BY_PSD_ID_QUERY
-// Query: *[_type == "player" && psdId == $psdId][0] {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio,  "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {    name, season  }}
+// Query: *[_type == "player" && psdId == $psdId][0] {  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,  birthDate,  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",  bio,  "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {    name, displayName, "slug": slug.current, season  }}
 export type PLAYER_BY_PSD_ID_QUERY_RESULT = {
   _id: string;
   psdId: string | null;
@@ -2470,6 +2471,8 @@ export type PLAYER_BY_PSD_ID_QUERY_RESULT = {
   }> | null;
   currentTeam: {
     name: string | null;
+    displayName: string | null;
+    slug: string | null;
     season: string | null;
   } | null;
 } | null;
@@ -2648,11 +2651,12 @@ export type STAFF_MEMBERS_PSDID_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/team.repository.ts
 // Variable: TEAMS_QUERY
-// Query: *[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,  tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))}
+// Query: *[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,  tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))}
 export type TEAMS_QUERY_RESULT = Array<{
   _id: string;
   psdId: string | null;
   name: string | null;
+  displayName: string | null;
   slug: string | null;
   age: string | null;
   gender: string | null;
@@ -2665,11 +2669,12 @@ export type TEAMS_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/team.repository.ts
 // Variable: TEAM_BY_SLUG_QUERY
-// Query: *[_type == "team" && slug.current == $slug][0] {  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,  season,  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),  trainingSchedule,  players[]-> {    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"  },  staff[] { role, "member": member-> { _id, psdId, archived, firstName, lastName, functionTitle, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max", "hasBio": count(bio) > 0 } }}
+// Query: *[_type == "team" && slug.current == $slug][0] {  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,  season,  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),  trainingSchedule,  players[]-> {    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"  },  staff[] { role, "member": member-> { _id, psdId, archived, firstName, lastName, functionTitle, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max", "hasBio": count(bio) > 0 } }}
 export type TEAM_BY_SLUG_QUERY_RESULT = {
   _id: string;
   psdId: string | null;
   name: string | null;
+  displayName: string | null;
   slug: string | null;
   age: string | null;
   gender: string | null;
@@ -2776,11 +2781,12 @@ export type YOUTH_TEAMS_CONTACT_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/team.repository.ts
 // Variable: TEAMS_LANDING_QUERY
-// Query: *[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {  _id, psdId, name, "slug": slug.current, age,  division, divisionFull, season, tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),  staff[] { role, "member": member-> { firstName, lastName, functionTitle } }}
+// Query: *[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {  _id, psdId, name, displayName, "slug": slug.current, age,  division, divisionFull, season, tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),  staff[] { role, "member": member-> { firstName, lastName, functionTitle } }}
 export type TEAMS_LANDING_QUERY_RESULT = Array<{
   _id: string;
   psdId: string | null;
   name: string | null;
+  displayName: string | null;
   slug: string | null;
   age: string | null;
   division: string | null;
@@ -2823,7 +2829,7 @@ declare module "@sanity/client" {
     '*[_type == "photoGallery" && linkedMatch == $matchId && defined(slug.current)] | order(publishedAt asc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].asset->url,\n  "coverLqip": images[0].asset->metadata.lqip\n}': GALLERIES_BY_MATCH_QUERY_RESULT;
     '*[_type == "photoGallery" && linkedEvent._ref == $eventId && defined(slug.current)] | order(publishedAt asc) {\n  "id": _id,\n  "title": coalesce(title, ""),\n  "slug": coalesce(slug.current, ""),\n  "publishedAt": coalesce(publishedAt, ""),\n  "imageCount": coalesce(count(images), 0),\n  "coverUrl": images[0].asset->url,\n  "coverLqip": images[0].asset->metadata.lqip\n}': GALLERIES_BY_EVENT_QUERY_RESULT;
     '*[_type == "player" && archived != true] | order(lastName asc) {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio\n}': PLAYERS_QUERY_RESULT;
-    '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio,\n  "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {\n    name, season\n  }\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
+    '*[_type == "player" && psdId == $psdId][0] {\n  _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n  birthDate,\n  "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n  "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "celebrationImageUrl": celebrationImage.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  bio,\n  "currentTeam": *[_type == "team" && archived != true && references(^._id)] | order(name asc)[0] {\n    name, displayName, "slug": slug.current, season\n  }\n}': PLAYER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "player" && keeper == true && archived != true].psdId': KEEPER_PSD_IDS_QUERY_RESULT;
     '*[_type == "responsibility" && active == true] | order(title asc) {\n  "id": slug.current,\n  "role": audience,\n  question,\n  keywords,\n  summary,\n  category,\n  icon,\n  "primaryContact": primaryContact {\n    contactType,\n    teamRole,\n    teamRoleFallback,\n    "position": organigramNode->title,\n    "roleCode": organigramNode->roleCode,\n    "members": organigramNode->members[]->{\n      "id": _id,\n      "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n      email, phone\n    },\n    "nodeId": organigramNode->_id,\n    "role": role,\n    "email": email,\n    "phone": phone,\n    "department": department\n  },\n  "steps": steps[] {\n    description,\n    link,\n    "contact": select(defined(contact) => contact {\n      contactType,\n      teamRole,\n      teamRoleFallback,\n      "position": organigramNode->title,\n      "roleCode": organigramNode->roleCode,\n      "members": organigramNode->members[]->{\n        "id": _id,\n        "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n        email, phone\n      },\n      "nodeId": organigramNode->_id,\n      "role": role,\n      "email": email,\n      "phone": phone,\n      "department": department\n    }, null)\n  },\n  "relatedPaths": coalesce(relatedPaths[]->slug.current, [])\n}': RESPONSIBILITY_PATHS_QUERY_RESULT;
     '*[_type == "sponsor" && active == true] | order(name asc) {\n  "id": _id, "name": coalesce(name, ""), url, type, tier, "featured": coalesce(featured, false), description,\n  "logoUrl": logo.asset->url + "?w=400&q=80&fm=webp&fit=max"\n}': SPONSORS_QUERY_RESULT;
@@ -2831,9 +2837,9 @@ declare module "@sanity/client" {
     '*[_type == "organigramNode" && active == true && roleCode in $roleCodes]{\n  title,\n  roleCode,\n  "members": members[@->archived != true && defined(@->email)]->{\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    email\n  }\n}[count(members) > 0] | order(title asc)': KEY_CONTACTS_QUERY_RESULT;
     '*[_type == "staffMember" && psdId == $psdId && archived != true][0] {\n  _id, psdId, firstName, lastName, email, phone, bio,\n  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "organigramPositions": *[_type == "organigramNode" && ^._id in members[]._ref && active == true] | order(title asc, _id asc) { _id, title, roleCode, department },\n  // Reverse lookup: find responsibilities where this staff member is referenced through organigramNode members.\n  // primaryContact branch: ^.^ = staffMember (parent of responsibility filter, parent of organigramNode filter).\n  // steps branch: ^.^.^ = staffMember (extra caret level because steps[] adds a scope).\n  "responsibilityPaths": *[_type == "responsibility" && active == true && defined(slug.current) && slug.current != "" && (primaryContact.organigramNode._ref in *[_type == "organigramNode" && ^.^._id in members[]._ref]._id || count(steps[defined(contact.organigramNode._ref) && contact.organigramNode._ref in *[_type == "organigramNode" && ^.^.^._id in members[]._ref]._id]) > 0)] | order(title asc, _id asc) { title, "slug": slug.current, category, icon }\n}': STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] | order(lastName asc) {\n  _id, psdId\n}': STAFF_MEMBERS_PSDID_QUERY_RESULT;
-    '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))\n}': TEAMS_QUERY_RESULT;
-    '*[_type == "team" && slug.current == $slug][0] {\n  _id, psdId, name, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  season,\n  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),\n  trainingSchedule,\n  players[]-> {\n    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"\n  },\n  staff[] { role, "member": member-> { _id, psdId, archived, firstName, lastName, functionTitle, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max", "hasBio": count(bio) > 0 } }\n}': TEAM_BY_SLUG_QUERY_RESULT;
+    '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))\n}': TEAMS_QUERY_RESULT;
+    '*[_type == "team" && slug.current == $slug][0] {\n  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  season,\n  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),\n  trainingSchedule,\n  players[]-> {\n    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"\n  },\n  staff[] { role, "member": member-> { _id, psdId, archived, firstName, lastName, functionTitle, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max", "hasBio": count(bio) > 0 } }\n}': TEAM_BY_SLUG_QUERY_RESULT;
     '*[_type == "team" && archived != true && defined(age) && age match "U*"] | order(name asc) {\n  _id, name, "slug": slug.current, age,\n  staff[defined(member) && !member->archived] { role, "member": member-> { _id, firstName, lastName, email, phone } }\n}': YOUTH_TEAMS_CONTACT_QUERY_RESULT;
-    '*[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {\n  _id, psdId, name, "slug": slug.current, age,\n  division, divisionFull, season, tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),\n  staff[] { role, "member": member-> { firstName, lastName, functionTitle } }\n}': TEAMS_LANDING_QUERY_RESULT;
+    '*[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {\n  _id, psdId, name, displayName, "slug": slug.current, age,\n  division, divisionFull, season, tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),\n  staff[] { role, "member": member-> { firstName, lastName, functionTitle } }\n}': TEAMS_LANDING_QUERY_RESULT;
   }
 }

--- a/apps/web/src/lib/utils/group-teams.test.ts
+++ b/apps/web/src/lib/utils/group-teams.test.ts
@@ -11,6 +11,7 @@ const makeTeam = (
 ): TeamLandingItem => ({
   _id: overrides._id ?? "id-1",
   name: overrides.name ?? "Test Team",
+  displayName: overrides.displayName ?? overrides.name ?? "Test Team",
   slug: overrides.slug ?? "test-team",
   age: overrides.age ?? "A",
   psdId: overrides.psdId ?? null,

--- a/apps/web/src/lib/utils/group-teams.ts
+++ b/apps/web/src/lib/utils/group-teams.ts
@@ -1,6 +1,8 @@
 export type TeamLandingItem = {
   _id: string;
   name: string;
+  /** What the site calls this team, resolved at the repository boundary (#2630). */
+  displayName: string;
   slug: string;
   age: string;
   psdId: string | null;
@@ -85,7 +87,12 @@ function sortByAgeDesc(ageOrder: string[]) {
   };
 }
 
-/** Extract the trailing single letter from a team name, e.g. "Eerste Elftallen A" → "A" */
+/**
+ * Extract the trailing single letter from a team name, e.g. "Eerste Elftallen A" → "A".
+ *
+ * Selection only — this decides *which* team fills the A / B flagship slot, not
+ * what the slot is called. What it is called comes from `teamDisplayName`.
+ */
 function nameSuffix(name: string): string {
   return name.trim().split(/\s+/).at(-1) ?? "";
 }

--- a/apps/web/src/lib/utils/team-display-name.test.ts
+++ b/apps/web/src/lib/utils/team-display-name.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The guard that would have caught the shipped bug (#2630 / #2539).
+ *
+ * Three `<h1>` collisions reached production and nothing failed. They were
+ * *code* reaching for a shared field, not bad data, so Studio validation on
+ * `displayName` would have caught nothing either — the assertion has to be that
+ * the eighteen routes are *distinguishable*, at the helper level, with no
+ * network call. `nav-reachability.test.ts` already asserts every nav
+ * destination resolves; this asserts each one names a different team.
+ */
+
+import { describe, it, expect } from "vitest";
+import { teamDisplayName } from "./team-display-name";
+
+/**
+ * The production roster, in route order — measured against production Sanity
+ * (`archived != true && showInNavigation != false`), 18 documents. `name`
+ * carries the double spaces verbatim, because that is what PSD syncs.
+ */
+const ROSTER = [
+  { slug: "eerste-elftallen-a", name: "Eerste Elftallen A" },
+  { slug: "eerste-elftallen-b", name: "Eerste Elftallen B" },
+  { slug: "reserven", name: "Reserven" },
+  { slug: "kcvve-u21", name: "KCVVE U21" },
+  { slug: "kcvve-u19", name: "KCVVE U19" },
+  { slug: "kcvve-u17", name: "KCVVE U17" },
+  { slug: "kcvve-u16", name: "KCVVE U16" },
+  { slug: "kcvve-u15", name: "KCVVE  U15" },
+  { slug: "kcvve-u14", name: "KCVVE U14" },
+  { slug: "kcvve-u13", name: "KCVVE  U13" },
+  { slug: "kcvve-u12", name: "KCVVE U12" },
+  { slug: "kcvve-u11", name: "KCVVE  U11 " },
+  { slug: "kcvve-u10", name: "KCVVE U10" },
+  { slug: "kcvve-u10p", name: "KCVVE U10P" },
+  { slug: "kcvve-u9", name: "KCVVE  U9" },
+  { slug: "kcvve-u8", name: "KCVVE U8" },
+  { slug: "kcvve-u7", name: "KCVVE U7" },
+  { slug: "kcvve-u6", name: "KCVVE  U6" },
+];
+
+describe("teamDisplayName", () => {
+  it("gives the eighteen team routes eighteen distinct names", () => {
+    const names = ROSTER.map((t) => teamDisplayName(t));
+    expect(new Set(names).size).toBe(ROSTER.length);
+  });
+
+  it("heads every page from the slug fallback on day one", () => {
+    // Nobody has typed a `displayName` yet, so this is what the site shows.
+    expect(ROSTER.map((t) => teamDisplayName(t))).toEqual([
+      "A-ploeg",
+      "B-ploeg",
+      "Reserven",
+      "U21",
+      "U19",
+      "U17",
+      "U16",
+      "U15",
+      "U14",
+      "U13",
+      "U12",
+      "U11",
+      "U10",
+      "U10P",
+      "U9",
+      "U8",
+      "U7",
+      "U6",
+    ]);
+  });
+
+  // Scoped deliberately: this asserts the resolved *name* is clean, which is
+  // what the `<title>`, `<h1>`, OG card and directory caption render. The
+  // `<YouthDirectory>` distinguisher sub-line still prints `divisionFull ??
+  // name` verbatim and so still shows `KCVVE  U13` — that slot answers "which
+  // of the two U9s is this", not "what is this team called", and is #2540's.
+  it("resolves no name containing a double space — a slug cannot carry one", () => {
+    const withDoubleSpace = ROSTER.map((t) => teamDisplayName(t)).filter((n) =>
+      n.includes("  "),
+    );
+    expect(withDoubleSpace).toEqual([]);
+  });
+
+  it("prefers the editorial displayName over the derived label", () => {
+    expect(
+      teamDisplayName({
+        displayName: "U10 Groen",
+        slug: "kcvve-u10",
+        name: "KCVVE U10",
+      }),
+    ).toBe("U10 Groen");
+  });
+
+  it("treats a blank displayName as unset", () => {
+    expect(
+      teamDisplayName({
+        displayName: "   ",
+        slug: "kcvve-u10p",
+        name: "KCVVE U10P",
+      }),
+    ).toBe("U10P");
+  });
+
+  it("falls back to the federation name for an unrecognised slug", () => {
+    expect(
+      teamDisplayName({
+        displayName: null,
+        slug: "fc-weitse-gans",
+        name: "FC WEITSE GANS",
+      }),
+    ).toBe("FC WEITSE GANS");
+  });
+});

--- a/apps/web/src/lib/utils/team-display-name.ts
+++ b/apps/web/src/lib/utils/team-display-name.ts
@@ -1,0 +1,76 @@
+/**
+ * One team, one name — everywhere a human reads it (#2630, decided in #2539).
+ *
+ * Three of the eighteen team pages used to head a different team than the one
+ * clicked: `/ploegen/reserven` read `A-ploeg.`, `kcvve-u16` read `U17.`,
+ * `kcvve-u10p` read `U10.` All three were the same bug. `age` is a *competition
+ * band*, and bands are legitimately shared — four teams carry `A`, two carry
+ * `U17`, two carry `U10` (`docs/ubiquitous-language.md` has said so since it was
+ * written) — but `<TeamHero>` used it as the page's identity anyway. The data
+ * was never wrong; the rendering was.
+ *
+ * So identity comes from the slug, which is unique by construction (it is the
+ * route key), with an editorial override on top for the cases a slug cannot
+ * express. `name` stays what it is: the federation-registered name, PSD-synced
+ * and re-patched on every sync, so it is not editable and cannot be the answer.
+ * It survives as the last-resort fallback and as JSON-LD `SportsTeam.name`.
+ */
+
+/**
+ * The fields a display name is resolved from. Structural rather than tied to
+ * one view-model, so `TeamNavVM` / `TeamDetailVM` / `TeamLandingItem` all fit
+ * without adapters.
+ */
+interface TeamNameSource {
+  /** Editorial override (Sanity `displayName`). Empty on all 18 teams today. */
+  displayName?: string | null;
+  /** Route key, e.g. `eerste-elftallen-a`, `kcvve-u10p`. */
+  slug: string;
+  /** Federation-registered name, PSD-synced, e.g. `KCVVE  U15`. */
+  name: string;
+}
+
+/**
+ * Label derived from the slug's last segment — which is also what drops the
+ * `kcvve-` prefix, so no separate strip is needed:
+ *
+ * - an age token → uppercased (`kcvve-u16` → `U16`, `kcvve-u10p` → `U10P`)
+ * - a lone letter → `X-ploeg` (`eerste-elftallen-a` → `A-ploeg`)
+ * - anything else → the federation `name` (`reserven` → `Reserven`)
+ *
+ * This is `firstTeamLabel` (#2211) *extended*: it only ever recognised the lone
+ * letter, so every youth slug fell straight through to the raw name — which is
+ * where the five double-space names (`KCVVE  U15`) came from. A slug cannot
+ * contain a double space, so recognising the age token retires them.
+ *
+ * The lone-letter branch is gated on the slug naming no age band, and that
+ * guard is load-bearing rather than defensive: PSD slugifies the team name, and
+ * the club has already fielded variant youth sides this way (`kcvve-u7-wit`,
+ * `kcvve-u9-groen`, both archived). The day PSD syncs a `KCVVE U9 A`, an
+ * ungated branch would head `/ploegen/kcvve-u9-a` with `A-ploeg.` — the exact
+ * collision this helper exists to close, reintroduced with nobody editing
+ * anything. Such a side falls through to its name until an editor writes a
+ * `displayName`, which is what the field is for.
+ */
+function slugLabel(slug: string, name: string): string {
+  const segments = slug.split("-");
+  const tail = segments.at(-1) ?? "";
+  if (/^u\d{1,2}[a-z]?$/i.test(tail)) return tail.toUpperCase();
+  if (/^[a-z]$/i.test(tail) && !segments.some((s) => /^u\d{1,2}$/i.test(s)))
+    return `${tail.toUpperCase()}-ploeg`;
+  return name;
+}
+
+/**
+ * What this team is called, on every surface a human reads it from: the `<h1>`,
+ * the `<title>`, the OG card, the homepage first-team row, the youth directory
+ * caption. One helper so those cannot drift into three names for one team.
+ *
+ * `displayName` is an escape hatch for what a slug cannot express — separating
+ * two U10 sides by colour, say — not a data-entry task: it is empty on all
+ * eighteen teams and every heading comes from the fallback.
+ */
+export function teamDisplayName(team: TeamNameSource): string {
+  const editorial = team.displayName?.trim() ?? "";
+  return editorial === "" ? slugLabel(team.slug, team.name) : editorial;
+}

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -91,17 +91,17 @@ The type of tournament a match belongs to. Stored on `Match.competition`.
 
 ### Reeks
 
-The specific division a team is placed in for a competition — `3de Afdeling Voetb Vl A`, `Gewestelijke U13`. Distinct from [Competition](#competition), which is the *kind* of tournament.
+The specific division a team is placed in for a competition — `3de Afdeling Voetb Vl A`, `Gewestelijke U13`. Distinct from [Competition](#competition), which is the _kind_ of tournament.
 
 A reeks is named in **two vocabularies** and both are correct: the federation's (PSD `competition.name`, prefixed `Voetbal : <bond> - `) and the club's (Sanity `divisionFull`). `3de Afdeling Voetb Vl A` and `3e Nationale VV A` are the same reeks. The club's name wins on anything a human reads; PSD's fills the gap where no editorial value is set (#2589).
 
-**Only PSD carries a reeks per competition.** A match carries none — the fixture feed knows only `OFFICIAL`/`CUP`/`FRIENDLY`. Sanity carries one per *team*, which cannot name two phases.
+**Only PSD carries a reeks per competition.** A match carries none — the fixture feed knows only `OFFICIAL`/`CUP`/`FRIENDLY`. Sanity carries one per _team_, which cannot name two phases.
 
 ### Competition Phase
 
 A youth season is split in two by the winter break, and **the second half is frequently a different reeks with different opponents** — not a return round. Measured over 2025-2026: U13 shared **0 of 7** opponents between its phases, U17 shared 4 of 7, and U7 had no autumn competition at all. Senior teams do not have this: the A-team plays one continuous home-and-away league (14 of 15 opponents shared).
 
-**Consequences:** a team can hold more than one ranking table in a single season, so a table is identified by PSD `competition_id`, never by its name or its position in the array. Phases are named `Najaar` and `Voorjaar`, and only when the fixtures prove the ordering — see #2589. PSD exposes no phase field; the association's own convention encodes it in the reeks *code* (`G15BS` → a `2` appears in the second phase), which is not a contract and is not parsed.
+**Consequences:** a team can hold more than one ranking table in a single season, so a table is identified by PSD `competition_id`, never by its name or its position in the array. Phases are named `Najaar` and `Voorjaar`, and only when the fixtures prove the ordering — see #2589. PSD exposes no phase field; the association's own convention encodes it in the reeks _code_ (`G15BS` → a `2` appears in the second phase), which is not a contract and is not parsed.
 
 ---
 
@@ -120,6 +120,7 @@ A KCVV team registered with the club and (usually) with the football federation.
 
 - `psdId` — PSD identifier
 - `name` — Official name (from PSD)
+- `displayName` — Editorial override for the [Team Display Name](#team-display-name). Optional; empty on all 18 teams, so every heading currently comes from the slug-derived fallback
 - `age` — Age group: `"A"` (seniors) or `"U{N}"` (youth, e.g. `"U17"`)
 - `gender` — `"mannen"` or `"mixed"`
 - `footbelId` — Federation registration (null for unregistered youth teams)
@@ -132,10 +133,10 @@ A KCVV team registered with the club and (usually) with the football federation.
 
 What a team is **called** on any surface a human reads — the page heading, the browser tab, the share card, a listing row. Distinct from `name`, which is the team's registered identity as PSD holds it.
 
-| Code                | Dutch          | Notes                                             |
-| ------------------- | -------------- | ------------------------------------------------- |
-| `displayName`       | Weergavenaam   | Editorial override on the Team document; optional |
-| `teamDisplayName()` | —              | The single helper every human-facing surface uses |
+| Code                | Dutch        | Notes                                             |
+| ------------------- | ------------ | ------------------------------------------------- |
+| `displayName`       | Weergavenaam | Editorial override on the Team document; optional |
+| `teamDisplayName()` | —            | The single helper every human-facing surface uses |
 
 **Resolution order:** `displayName` → a label derived from the team's slug → `name`.
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -93,7 +93,7 @@ The type of tournament a match belongs to. Stored on `Match.competition`.
 
 The specific division a team is placed in for a competition — `3de Afdeling Voetb Vl A`, `Gewestelijke U13`. Distinct from [Competition](#competition), which is the _kind_ of tournament.
 
-A reeks is named in **two vocabularies** and both are correct: the federation's (PSD `competition.name`, prefixed `Voetbal : <bond> - `) and the club's (Sanity `divisionFull`). `3de Afdeling Voetb Vl A` and `3e Nationale VV A` are the same reeks. The club's name wins on anything a human reads; PSD's fills the gap where no editorial value is set (#2589).
+A reeks is named in **two vocabularies** and both are correct: the federation's (PSD `competition.name`, prefixed `Voetbal : <bond> -` plus a trailing space) and the club's (Sanity `divisionFull`). `3de Afdeling Voetb Vl A` and `3e Nationale VV A` are the same reeks. The club's name wins on anything a human reads; PSD's fills the gap where no editorial value is set (#2589).
 
 **Only PSD carries a reeks per competition.** A match carries none — the fixture feed knows only `OFFICIAL`/`CUP`/`FRIENDLY`. Sanity carries one per _team_, which cannot name two phases.
 

--- a/packages/sanity-schemas/src/team.ts
+++ b/packages/sanity-schemas/src/team.ts
@@ -140,6 +140,14 @@ export const team = defineType({
         'Volledige competitienaam (bijv. "Eerste Elftal A - 3e Nationale A" of "U9 - Wit"). Redactioneel — getoond op de ploegpagina.',
     }),
     defineField({
+      name: 'displayName',
+      title: 'Display name',
+      type: 'string',
+      group: 'identiteit',
+      description:
+        'Naam zoals de site de ploeg toont (titel van de ploegpagina, kaartjes, deelkaart). Redactioneel — laat leeg en de naam wordt afgeleid uit de URL ("A-ploeg", "U13", "Reserven"). Vul enkel in wanneer dat niet volstaat, bijv. om twee U10-ploegen op kleur te onderscheiden.',
+    }),
+    defineField({
       name: 'showInNavigation',
       title: 'Show in navigation',
       type: 'boolean',

--- a/packages/sanity-schemas/src/team.ts
+++ b/packages/sanity-schemas/src/team.ts
@@ -141,7 +141,7 @@ export const team = defineType({
     }),
     defineField({
       name: 'displayName',
-      title: 'Display name',
+      title: 'Weergavenaam',
       type: 'string',
       group: 'identiteit',
       description:


### PR DESCRIPTION
Closes #2630

Spec #2629 · Map #2536 · Decision **#2539**

## The bug

Three of eighteen team pages headed a different team than the one clicked — `/ploegen/reserven` read `A-ploeg.`, `kcvve-u16` read `U17.`, `kcvve-u10p` read `U10.` One bug, one cause: `age` is a **competition band**, bands are legitimately shared (four teams carry `A`, two `U17`, two `U10`), and `<TeamHero>` used it as the page's identity anyway. The data was never wrong; the rendering was.

## Changes

- **`teamDisplayName()`** (`apps/web/src/lib/utils/team-display-name.ts`) — editorial `displayName` → slug-derived label → federation `name`.
- **Resolved at the repository boundary.** `TeamNavVM` / `TeamDetailVM` / `TeamLandingItem` carry `displayName` already resolved, so no consumer can render `name` by accident. This was a review finding, and the right one: four surfaces had already done exactly that.
- **Sanity `displayName`** on the team schema, in the existing editor-owned `identiteit` group beside `division` / `divisionFull`. Both studios inherit it from `@kcvv/sanity-schemas`.
- **Deleted:** `computeCategory` + its `age === "A"` branch; `seniorNavLabel` (a second copy of the letter → `X-ploeg` rule); `computeTagline`'s `?? divisionFull ?? division` chain.
- **The `age` prop is gone from `<TeamHero>`.** Its last use was the JerseyShirt chest, which printed `U17` on a page now headed `U16.` and `A` on one headed `Reserven.` A shirt carries the team's own name, so it reads the display name.

### Surfaces now reading the one name

`<h1>` · `<title>` · OG title · meta description · OG image alt · breadcrumb JSON-LD · homepage first-team row · youth directory caption + card `aria-label` · `/ploegen` A/B flagships · fixtures route (title, description, kicker, breadcrumb) · **site nav** · **search results** · **calendar subscribe chips** · **player profile team chip**.

The last four came out of the review pass, not the AC — all are places a human reads a team's name, and the nav one was a duplicate rule.

### Deliberately unchanged

- **JSON-LD `SportsTeam.name`** stays the registered name — a machine-readable claim about a federation entity, not a nickname. The breadcrumb is a human-facing trail, so that one follows the heading.
- **The division still reaches the meta description and the OG card.** Deleting the tagline fallback was about the *hero*, where the mono pill above already showed it. A search snippet and a share card have no pill, so the chain moved there rather than being dropped — otherwise three senior descriptions degraded to a bare page type.

## Day one

Nobody types anything. Every `displayName` is empty and all eighteen headings come from the fallback:

`A-ploeg.` `B-ploeg.` `Reserven.` `U21.` `U19.` `U17.` `U16.` `U15.` `U14.` `U13.` `U12.` `U11.` `U10.` `U10P.` `U9.` `U8.` `U7.` `U6.`

The five double-space `<title>`s (`KCVVE  U15`, …) are gone as a consequence — a slug cannot carry one.

## Testing

- New `team-display-name.test.ts`: the eighteen production routes yield eighteen **distinct** names, plus the exact day-one list. This is the guard that would have caught the shipped bug — the collision was *code* reaching for a shared field, so Studio validation would have caught nothing.
- `pnpm --filter @kcvv/web check-all` — **passes** (lint, type-check, 6602 tests, build).
- **VR: 60 snapshots across 5 prefixes, zero baselines changed.** Expected zero — every rendered string is byte-identical (`computeCategory("KCVV Elewijt A")` ≡ `displayName="A-ploeg"`; the chest resolves to the same mark in both stories). Nothing to ship, so nothing committed.
- Roster claims verified against production Sanity, not the staging dataset.

## Review gate

`/code-review` (high) + the four `/simplify` agents ran on the branch diff.

**Applied:** the repository-boundary altitude fix; a guard so `kcvve-u9-a` cannot resolve to `A-ploeg` (the club has already fielded variant youth sides — `kcvve-u7-wit`, `kcvve-u9-groen`); the jersey-chest contradiction; the nav duplicate rule; search, calendar and player-profile surfaces; the meta-description/OG division fallback; un-exported `TeamNameSource`.

**Skipped, with reasons:**

- **U16 sits in Bovenbouw and ties with U17 in the sort**, so `/jeugd` now reads `U21, U19, U16, U17`. Real, and this PR makes it *visible* (both cards used to say `U17`), but fixing it means re-deciding which band the team belongs to — the open data question #2539 explicitly deferred to **#2537**.
- **`<YouthDirectory>`'s distinguisher sub-line** still prints `divisionFull ?? name`, so `KCVVE  U13` remains on screen under a clean `U13` caption. That slot answers "which of the two U9s is this", not "what is this team called"; changing it is a design call outside this AC. The test name was narrowed so it does not overclaim.
- **The age-token regex is near-identical to `computeAgeGroup`'s.** Sharing it means exporting a new constant across two modules for three call sites whose anchoring genuinely differs. Noted, not done.

Comment recording the correction posted on **#2570** (the fixtures-route up-link label becomes the display name; the 390px wrap #2442 measured no longer exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editorial team display names across team pages, calendars, navigation, search, player information, and social previews.
  * Added consistent fallback formatting for teams without a custom display name.
  * Team heroes and youth directory cards now show clearer, consistent team labels.
* **Bug Fixes**
  * Improved team search matching and result titles.
  * Corrected team metadata, accessibility labels, and Open Graph text.
* **Documentation**
  * Documented team display-name behavior and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->