### PR TITLE
chore(config): add a parallel wave runner and a pre-merge conflict check

### DIFF
--- a/.claude/commands/ralph.md
+++ b/.claude/commands/ralph.md
@@ -27,29 +27,22 @@ Or target a specific label or issue:
 
 ## Step 1 — Propose Next Issue
 
-Fetch the backlog and propose:
+Both gates — the `ready` label and zero open blockers — live in one script. Use it rather than re-deriving them:
 
 ```bash
-gh issue list --label ready --state open --json number,title,labels,body \
-  --jq '.[] | "\(.number): \(.title)"' | head -10
+./scripts/unblocked-issues.sh                       # every workable issue, ascending
+./scripts/unblocked-issues.sh --milestone <name>    # one milestone only
 ```
 
-Check for blocking relationships before ranking. An issue with unresolved blockers should not be picked up:
+It exits nonzero when a `blockedBy` query fails, which means the blocker state is unknown. Stop there — an API failure is not the same as "nothing is blocked".
+
+Then read the titles of what it returned:
 
 ```bash
-# For each candidate, check if it has open blockers via GraphQL
-gh api graphql -f query='
-  query {
-    repository(owner: "soniCaH", name: "www.kcvvelewijt.be") {
-      issue(number: '"${CANDIDATE}"') {
-        blockedBy(first: 50) { nodes { number state } }
-      }
-    }
-  }' --jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length'
-# 0 = no open blockers → safe to pick up
+gh issue view <N> --json number,title,milestone --jq '"\(.number): \(.title)"'
 ```
 
-Present the top candidates ranked by: dependencies resolved → smallest scope → label priority.
+Present the top candidates ranked by: smallest scope → label priority.
 
 **Wait for human approval before proceeding.**
 
@@ -176,7 +169,7 @@ gh api graphql -f query="
 gh issue comment $ISSUE_NUM --body "Blocked by #${BLOCKER_NUM}. Blocking relationship set via API."
 ```
 
-When checking if an issue is still blocked, query its blockedBy relationships:
+To diagnose **one** issue — which blockers it has and what state each is in — query the relationship directly. (For the queue-level question, "what can be worked on now", use `./scripts/unblocked-issues.sh` from Step 1 instead of looping this query yourself.)
 
 ```bash
 # List blockers and their state

--- a/.claude/skills/ralph-afk/AFK-BRIEF.md
+++ b/.claude/skills/ralph-afk/AFK-BRIEF.md
@@ -1,0 +1,154 @@
+# AFK brief template
+
+The brief is what gets passed as the `prompt` to each spawned `Agent()`. The spawned agent does **not** see the orchestrator's conversation — the brief must be self-contained: read-list, acceptance criteria, bootstrap, verification, commit guidance, PR shape, hard rules.
+
+Fill in everything inside `<…>`. Quote acceptance criteria **verbatim** from the issue so the wording cannot drift between issue and PR.
+
+## Template
+
+````text
+You are implementing GitHub issue #<N> on the KCVV Elewijt codebase — a pnpm + Turborepo monorepo (Next.js on Vercel, Sanity Studio, a Cloudflare Workers BFF, TypeScript strict, Effect, Tailwind v4). This is a self-contained brief; you will not see any prior conversation. Work it end-to-end.
+
+You are running autonomously. Do NOT ask the user what to do. Do NOT stop to present options.
+
+## Shell rule — applies to EVERY bash call
+
+A fresh shell here defaults to Node 16, which breaks commitlint and Playwright with misleading errors. `nvm use` does not persist between calls. Prefix EVERY command:
+
+  source ~/.nvm/nvm.sh && nvm use >/dev/null 2>&1 && <your command>
+
+## Read first (in this order)
+
+1. /Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/.claude/CLAUDE.md   (project-wide rules: git workflow, commit scopes, package conventions)
+2. /Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/apps/web/CLAUDE.md  (web-app rules)
+3. gh issue view <N> --comments
+   Read the COMMENTS, not just the body. Parked decisions and scope changes live in comments in this repo.
+4. <the PRD the issue names, e.g. docs/prd/<name>.md — read it from the MAIN checkout path>
+5. docs/ubiquitous-language.md  (glossary — use these exact terms, do not drift to synonyms)
+6. <any ADR or design doc the issue calls out, e.g. docs/adr/…>
+
+Before writing code, re-validate the acceptance criteria against what is actually in the repo today. If a criterion is already satisfied, or contradicts current code, say so in the PR body rather than silently reinterpreting it.
+
+## Create and bootstrap your worktree
+
+Work ONLY inside your own worktree. Never edit the main checkout at
+/Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be — read from it, never write to it.
+
+  source ~/.nvm/nvm.sh && nvm use >/dev/null 2>&1
+  cd /Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be
+  git fetch origin main
+  git worktree add ../kcvv-issue-<N> -b feat/issue-<N> origin/main
+  cd ../kcvv-issue-<N>
+
+  # Install with corepack pnpm (pinned 10.34.3). NEVER the homebrew pnpm on PATH — it is 8.x
+  # and silently downgrades pnpm-lock.yaml from lockfileVersion 9.0 to 6.0 (a ~22k-line diff).
+  corepack pnpm install --frozen-lockfile
+
+  # Guard: the lockfile must be untouched. This must print nothing.
+  git status --short pnpm-lock.yaml
+  # If it is dirty: git checkout -- pnpm-lock.yaml && corepack pnpm install --frozen-lockfile
+
+  # Materialise packages/api-contract/dist/ — without this, check-all shows TS6305 errors
+  # that look real but are turbo cache-replay artifacts from a removed peer worktree.
+  corepack pnpm turbo build --filter=@kcvv/api-contract --force
+
+  # next build needs Sanity env vars; .env.local is gitignored so a fresh worktree has none.
+  /bin/cp -f /Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/apps/web/.env.local apps/web/.env.local
+
+## Implement
+
+Acceptance criteria from #<N>, verbatim:
+
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] …
+
+Work them one at a time, test-first. Prior art to mirror: <file:line references>.
+
+Before writing any new file that lands in a folder with two or more existing peers (a JSON-LD builder, a `use*Analytics` hook, a repository, a story), grep the peers first and match their return type, import order, and how they omit optional fields. Peer-drift is the most-flagged class in review here.
+
+<Include only the lines below that this issue actually touches:>
+- New user-facing feature? It needs analytics — events, GTM, and GA4 — per the PRD requirement.
+- Schema change? Edit packages/sanity-schemas/src/<file>.ts only. Both studios consume it; there are no per-studio copies.
+- Adding or removing a dependency? Do NOT let pnpm rewrite the lockfile. Run the add once to resolve the version, then `git checkout origin/main -- pnpm-lock.yaml`, hand-insert the 3 blocks (importers / packages / snapshots) in prettier style at their alphabetical positions, and validate with `corepack pnpm install --frozen-lockfile` — it must print "Already up to date" without rewriting.
+- Visual change to a VR-tagged story? Capture the new baselines in THIS PR, scoped: `-u <story-id-prefix>`. Never run an unscoped update — it rewrites unrelated baselines.
+- Changed the architecture CLAUDE.md describes (new package, renamed path, schema ownership)? Update .claude/CLAUDE.md in this PR.
+- Renamed or removed a route, or changed a club fact? Re-verify apps/web/public/llms.txt against the live route tree.
+- Touched a plan or doc file? Re-read it and confirm its paths, script names, and snippets still match the tree.
+- New fenced code block in any .md? It needs a language identifier (```bash, ```typescript, ```text) or markdownlint MD040 fails.
+
+## Verify
+
+  source ~/.nvm/nvm.sh && nvm use >/dev/null 2>&1 && cd /Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/../kcvv-issue-<N> && corepack pnpm --filter @kcvv/web lint:fix
+  source ~/.nvm/nvm.sh && nvm use >/dev/null 2>&1 && cd /Users/kevinvanransbeeck/Sites/KCVV/www.kcvvelewijt.be/../kcvv-issue-<N> && corepack pnpm --filter @kcvv/web check-all
+
+Both must pass before you go further. `check-all` exists only in apps/web and packages/sanity-studio — apps/api has none.
+
+## Pre-PR review gate — required, not optional
+
+After the quality gate passes, run BOTH against your branch diff (`git diff origin/main...HEAD`):
+
+1. `/code-review` at high effort — fix every confirmed finding; refute false positives with a one-line reason.
+2. `/simplify` — apply the genuine wins; skip out-of-scope findings with a brief reason.
+
+Then re-run the quality gate above. Note in the PR body what you applied and what you skipped. This gate exists to cut CodeRabbitAI round-trips; skipping it costs the reviewer more than it saves you.
+
+## Commit
+
+Conventional commits, in ENGLISH even though the issue may be Dutch. Lowercase subject.
+
+Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+Allowed scopes: news, matches, events, teams, players, sponsors, calendar, ranking, search, sync, analytics, studio, api, ui, schema, config, deps, deps-dev
+
+`club` and `seo` are NOT scopes — use `ui`. If your natural framing is "redesign", "design", "closeout", "cleanup" or "audit", pick the scope by the DOMAIN you touched, not by that word. The canonical list is commitlint.config.js — read it rather than learning it from a hook rejection.
+
+Prefer several small commits over one large one. Never use --no-verify. Never set ALLOW_MAIN_COMMIT.
+
+## Push and open the PR
+
+  git push -u origin feat/issue-<N>
+
+  gh pr create --base main \
+    --title "<type>(<scope>): <description> (#<N>)" \
+    --body "Closes #<N>
+
+  ## Changes
+
+  - …
+
+  ## Testing
+
+  - pnpm --filter @kcvv/web check-all passes
+  - /code-review + /simplify run; applied: … · skipped: …
+  - <any manual verification>" \
+    --label "ready-for-review"
+
+Use `Closes #<N>` only if this PR fully resolves the issue. If it is one part of a larger issue, use `Part of #<N>` instead — a stray "Closes" auto-closes work that is not done.
+
+Then flip the issue label. The PR's --label flag labels the PR, not the issue:
+
+  gh issue edit <N> --remove-label "in-progress" --add-label "ready-for-review"
+
+## Do NOT
+
+- Push to main, or commit in the main checkout.
+- Bypass hooks (--no-verify) or set ALLOW_MAIN_COMMIT=1.
+- Remove your worktree — the human reviews it before merge.
+- Merge your own PR.
+- Work around a blocker. If something blocks you — missing env, ambiguous criterion, an upstream bug, an AC that contradicts the code — comment on issue #<N>, prefix the comment with "> *This was generated by AI during AFK execution.*", and STOP. Report the comment URL.
+- Skip the quality gate or the review gate.
+
+## Report when done
+
+Report: the PR URL, the exact verification commands you ran and their result, anything you skipped or deferred and why, and any open question the reviewer should decide.
+````
+
+## Notes on filling the template
+
+- **Read-first list**: only what the agent needs to make decisions. A missing constraint costs a re-do; a dumped repo costs tokens. `gh issue view <N> --comments` is non-negotiable here — parked decisions live in comments.
+- **Acceptance criteria**: verbatim. Paraphrasing drifts the criteria between issue and PR, and then triage cannot tell whether the slice shipped what it promised.
+- **Prior art `file:line` references**: the single highest-leverage line in the brief. Peer-drift is this repo's most-flagged review class.
+- **Prune the conditional block**: delete the lines under "Implement" that this issue does not touch. A brief that warns about VR baselines on a docs-only issue teaches the agent to skim.
+- **Worktree path**: `../kcvv-issue-<N>` on branch `feat/issue-<N>`, always from `origin/main`. This matches `scripts/ralph.sh` so both tools can find and clean up the same worktrees.
+- **Do not hand the agent `isolation: "worktree"`** — see SKILL.md step 3. The brief creates the worktree the repo's way on purpose.
+- **AI-disclaimer on blocker comments**: matches the `/triage-issue` convention, so the tracker stays consistent about which comments came from an agent.

--- a/.claude/skills/ralph-afk/SKILL.md
+++ b/.claude/skills/ralph-afk/SKILL.md
@@ -14,6 +14,8 @@ This skill reuses `/ralph`'s conventions exactly — same labels, same `blockedB
 
 ## Process
 
+**You** run every step here, in the main checkout, as the orchestrator. Spawned agents run only what their brief tells them, inside their own worktree — they never call `unblocked-issues.sh` or `wave-check.sh`. Both scripts are repo-root-relative, so run them from the repository root; they need `gh` and `git` on PATH and nothing else.
+
 ### 0. Prune merged worktrees
 
 Prior runs leave worktrees behind. Garbage-collect the merged ones before computing the wave:
@@ -37,32 +39,22 @@ Leave worktrees whose PR is still open — those are under review. Report what y
 
 If the user passed explicit issue numbers, use those (still subject to the hard rules below). Otherwise build the wave automatically:
 
-1. Query the queue. Pass `--limit` — `gh` caps at 30 silently, and a capped list reads exactly like a complete one:
+1. Get the eligible set. Both gates — the `ready` label and zero open blockers — live in one script, which `scripts/ralph.sh` and `/ralph` use too:
 
    ```bash
-   gh issue list --label ready --state open --limit 200 --json number,title,milestone,labels
+   ./scripts/unblocked-issues.sh
    ```
 
-2. For each candidate, check GitHub's native blocking relationships — **not** a markdown section:
+   It prints every eligible issue number, ascending. A **nonzero exit** means a `blockedBy` query failed and the set is incomplete — report that and stop, rather than building a wave from a partial queue.
+
+2. Read the titles, so you can judge scope and collisions:
 
    ```bash
-   gh api graphql -f query='
-     query {
-       repository(owner: "soniCaH", name: "www.kcvvelewijt.be") {
-         issue(number: '"${N}"') {
-           blockedBy(first: 50) { nodes { number state } }
-         }
-       }
-     }' --jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length'
+   gh issue view <N> --json number,title,milestone --jq '"\(.number) · \(.title) · \(.milestone.title // "no milestone")"'
    ```
 
-   `0` = unblocked. If the GraphQL call **fails**, treat the issue as blocked and say so — never assume unblocked on an error.
-
-   Check **every** issue the query returns, not the first screenful — the wave is only correct if the blocker check is exhaustive.
-
-3. **Eligible** = `ready` label AND zero open blockers.
-4. **Mutually compatible** = drop pairs that would collide at merge. See "Collision classes" below.
-5. **Cap the wave.** Default **4** agents. The bottleneck is human PR review, not agent capacity — a wave of 12 just builds a review queue. Go wider only if the user asks.
+3. **Mutually compatible** = drop pairs that would collide at merge. See "Collision classes" below.
+4. **Cap the wave.** Default **4** agents. The bottleneck is human PR review, not agent capacity — a wave of 12 just builds a review queue. Go wider only if the user asks.
 
 Present the proposed wave as a numbered list: issue number · title · milestone · one-line scope · why it is compatible with the others. Ask: launch all / drop some / stop.
 
@@ -142,7 +134,7 @@ This skill is **stateless across invocations**. Every run re-queries GitHub, so 
 
 - **The orchestrator does not auto-loop.** When the wave's PRs are open, it stops. Downstream issues only unblock once blockers close, which needs merges the orchestrator cannot do.
 - **Hands-free continuation** — wrap in `/loop`, e.g. `/loop 45m /ralph-afk`. Each tick re-picks the latest unblocked wave; a tick with nothing eligible reports "no work" and exits. Use 45m+, not 5m — a wave takes far longer than that to produce reviewable PRs.
-- **Drained** = `gh issue list --label ready --state open --limit 200` is empty, or everything left is blocked. Say so explicitly.
+- **Drained** = `./scripts/unblocked-issues.sh` prints nothing on a zero exit. Say so explicitly, and distinguish it from a nonzero exit, which means the queue could not be read at all.
 
 ## Hard rules
 

--- a/.claude/skills/ralph-afk/SKILL.md
+++ b/.claude/skills/ralph-afk/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: ralph-afk
+description: Spawn a parallel wave of autonomous agents to implement unblocked `ready` issues, one git worktree each. Use when the user wants to ralph afk, go AFK, run parallel agents, run a wave, or work the issue queue while away from keyboard.
+argument-hint: "[issue-number...]"
+---
+
+# Ralph AFK
+
+Run the queue while the user is away. Pick the currently-unblocked `ready` issues, spawn one autonomous agent per issue in its own worktree (in parallel, in one message), and report PR URLs as they land.
+
+Sequential human-in-the-loop counterpart: `/ralph` (`.claude/commands/ralph.md`) and `scripts/ralph.sh`. Brief template: [AFK-BRIEF.md](AFK-BRIEF.md).
+
+This skill reuses `/ralph`'s conventions exactly — same labels, same `blockedBy` gate, same worktree paths, same quality gates. It only changes the shape: a parallel wave instead of one issue at a time. If a convention here ever disagrees with `.claude/commands/ralph.md`, that file wins.
+
+## Process
+
+### 0. Prune merged worktrees
+
+Prior runs leave worktrees behind. Garbage-collect the merged ones before computing the wave:
+
+```bash
+source ~/.nvm/nvm.sh && nvm use >/dev/null 2>&1
+git fetch --prune origin
+git worktree list
+```
+
+For each `../kcvv-issue-<N>` whose PR is merged (`gh pr view --json state` on branch `feat/issue-<N>`):
+
+```bash
+git worktree remove ../kcvv-issue-<N> --force
+git branch -d feat/issue-<N>   # safe — refuses if unmerged
+```
+
+Leave worktrees whose PR is still open — those are under review. Report what you pruned.
+
+### 1. Determine the wave
+
+If the user passed explicit issue numbers, use those (still subject to the hard rules below). Otherwise build the wave automatically:
+
+1. Query the queue:
+
+   ```bash
+   gh issue list --label ready --state open --json number,title,milestone,labels
+   ```
+
+2. For each candidate, check GitHub's native blocking relationships — **not** a markdown section:
+
+   ```bash
+   gh api graphql -f query='
+     query {
+       repository(owner: "soniCaH", name: "www.kcvvelewijt.be") {
+         issue(number: '"${N}"') {
+           blockedBy(first: 50) { nodes { number state } }
+         }
+       }
+     }' --jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length'
+   ```
+
+   `0` = unblocked. If the GraphQL call **fails**, treat the issue as blocked and say so — never assume unblocked on an error.
+
+3. **Eligible** = `ready` label AND zero open blockers.
+4. **Mutually compatible** = drop pairs that would collide at merge. See "Collision classes" below.
+5. **Cap the wave.** Default **4** agents. The bottleneck is human PR review, not agent capacity — a wave of 12 just builds a review queue. Go wider only if the user asks.
+
+Present the proposed wave as a numbered list: issue number · title · milestone · one-line scope · why it is compatible with the others. Ask: launch all / drop some / stop.
+
+### Collision classes (KCVV-specific)
+
+Separate worktrees mean agents never fight at run time, but they still collide at merge. Within one wave, allow **at most one** issue that touches each of these:
+
+| Collision class                          | Why it collides                                                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `pnpm-lock.yaml` (adds/removes a dep)    | The lockfile is prettier-formatted; every agent hand-edits the same 3 blocks. Two = guaranteed conflict. |
+| Visual-regression baselines              | A scoped `-u` run rewrites baseline PNGs. Two agents capturing baselines overwrite each other.           |
+| `packages/api-contract/src/`             | Every downstream app type-checks against it; two concurrent contract changes break each other's build.   |
+| `packages/sanity-schemas/src/`           | Shared by both studios; concurrent schema edits conflict.                                                |
+| Design tokens / `DESIGN.md` / global CSS | Site-wide; two edits to the same token file conflict and both invalidate the whole VR suite.             |
+| The same route or component file         | Obvious. Check the issue's stated file list.                                                             |
+
+When in doubt, keep both — but if two issues plausibly land in the same file, serialize them across waves. It is cheaper than a merge fight.
+
+### 2. Draft one self-contained brief per issue
+
+Fill [AFK-BRIEF.md](AFK-BRIEF.md) per issue. The spawned agent does **not** see this conversation, so the brief must stand alone: issue number, worktree path, read-list, acceptance criteria **verbatim**, bootstrap commands, quality gates, commit/PR shape, hard rules.
+
+Show the briefs (collapsed if many). Wait for "launch".
+
+### 3. Spawn the wave in parallel
+
+In a **single message**, one `Agent()` call per issue:
+
+```text
+Agent({ description: "Issue <N> — <short title>",
+        subagent_type: "general-purpose",
+        prompt: "<self-contained brief from step 2>" })
+```
+
+**Do not pass `isolation: "worktree"`.** The harness worktree does not follow this repo's `../kcvv-issue-<N>` + `feat/issue-<N>` convention and skips the KCVV bootstrap (corepack pnpm, api-contract build, `.env.local`). The brief has the agent create its own worktree the repo way, so `/ralph` and `scripts/ralph.sh` can find and clean up after it.
+
+Flip labels for the whole wave **before** spawning, so `gh issue list --label in-progress` is honest while agents run:
+
+```bash
+gh issue edit <N> --remove-label "ready" --add-label "in-progress"
+```
+
+### 4. Report back as agents finish
+
+You are notified as each background agent completes. For each:
+
+- Capture the PR URL.
+- Note blockers it hit (the brief tells agents to comment-and-stop, never to work around a blocker).
+- Surface failures immediately — do not silently move on.
+
+If an agent finished **without** opening a PR, roll its label back so the queue stays truthful:
+
+```bash
+gh issue edit <N> --remove-label "in-progress" --add-label "ready"
+```
+
+When the wave is done, present a table: issue · PR URL · status (opened / blocked / failed) · what it skipped.
+
+### 5. Check the merge order before the user merges anything
+
+Every branch in the wave came off the same `origin/main`, so merging one can break the others. Run this and include its output with the table above:
+
+```bash
+./scripts/wave-check.sh
+```
+
+It is read-only — no checkout, no working-tree change. It reports which branches no longer merge into `main` (rebase those), which pairs collide, and the exact files they fight over. Read the filenames before reacting: a collision in `pnpm-lock.yaml` means the wave broke the collision-class rule in step 1 and one branch just needs the lockfile re-derived; a collision in a route or component is a real design overlap worth a human decision.
+
+Tell the user the safe merge order: everything that collides with nothing merges in any order, and each colliding pair gets one merged first, the other rebased after.
+
+### 6. Optional follow-up wave
+
+After the user merges, "again" / "next wave" re-runs from step 0. Newly-unblocked issues become eligible.
+
+## Lifecycle between waves
+
+This skill is **stateless across invocations**. Every run re-queries GitHub, so the dependency graph reflects whatever has been merged since.
+
+- **The orchestrator does not auto-loop.** When the wave's PRs are open, it stops. Downstream issues only unblock once blockers close, which needs merges the orchestrator cannot do.
+- **Hands-free continuation** — wrap in `/loop`, e.g. `/loop 45m /ralph-afk`. Each tick re-picks the latest unblocked wave; a tick with nothing eligible reports "no work" and exits. Use 45m+, not 5m — a wave takes far longer than that to produce reviewable PRs.
+- **Drained** = `gh issue list --label ready --state open` is empty, or everything left is blocked. Say so explicitly.
+
+## Hard rules
+
+- Never spawn for an issue without the `ready` label. Route the user to `/spec` instead.
+- Never spawn for an issue with open blockers, even if the user names it explicitly. Say which blocker is open and stop.
+- Never spawn two issues from the same collision class in one wave.
+- Never let an agent work in the main checkout. Every agent works only inside its `../kcvv-issue-<N>` worktree.
+- Never suggest `ALLOW_MAIN_COMMIT=1`. It is a human escape hatch, not an agent one. If a branch guard blocks an agent, the answer is the worktree.
+- Do not clean up a spawned agent's worktree — the human reviews it before merge.
+- If an agent fails or stalls, do not retry it autonomously. Surface it; the user decides whether to re-run it under `/ralph` for closer supervision.

--- a/.claude/skills/ralph-afk/SKILL.md
+++ b/.claude/skills/ralph-afk/SKILL.md
@@ -26,7 +26,13 @@ git fetch --prune origin
 git worktree list
 ```
 
-For each `../kcvv-issue-<N>` whose PR is merged (`gh pr view --json state` on branch `feat/issue-<N>`):
+For each `../kcvv-issue-<N>`, name the branch explicitly — a bare `gh pr view` reads the _current_ branch, which here is whatever the main checkout is on, not the worktree's:
+
+```bash
+gh pr view "feat/issue-<N>" --json state,url --jq '.state'
+```
+
+When that prints `MERGED`:
 
 ```bash
 git worktree remove ../kcvv-issue-<N> --force
@@ -37,7 +43,15 @@ Leave worktrees whose PR is still open — those are under review. Report what y
 
 ### 1. Determine the wave
 
-If the user passed explicit issue numbers, use those (still subject to the hard rules below). Otherwise build the wave automatically:
+If the user passed explicit issue numbers, put each one through the same gate the automatic path uses — a named issue is not a pre-approved one:
+
+```bash
+gh issue view <N> --json state,labels --jq '"\(.state) \([.labels[].name] | join(","))"'
+```
+
+Keep it only when the state is `OPEN`, the labels include `ready`, and `./scripts/unblocked-issues.sh` lists it. Anything else stops with the reason, per the hard rules below.
+
+Otherwise build the wave automatically:
 
 1. Get the eligible set. Both gates — the `ready` label and zero open blockers — live in one script, which `scripts/ralph.sh` and `/ralph` use too:
 

--- a/.claude/skills/ralph-afk/SKILL.md
+++ b/.claude/skills/ralph-afk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ralph-afk
-description: Spawn a parallel wave of autonomous agents to implement unblocked `ready` issues, one git worktree each. Use when the user wants to ralph afk, go AFK, run parallel agents, run a wave, or work the issue queue while away from keyboard.
+description: Spawn a wave of parallel agents to implement unblocked `ready` issues, one git worktree each. Use for ralph afk, running a wave, or working the issue queue unattended.
 argument-hint: "[issue-number...]"
 ---
 
@@ -37,10 +37,10 @@ Leave worktrees whose PR is still open — those are under review. Report what y
 
 If the user passed explicit issue numbers, use those (still subject to the hard rules below). Otherwise build the wave automatically:
 
-1. Query the queue:
+1. Query the queue. Pass `--limit` — `gh` caps at 30 silently, and a capped list reads exactly like a complete one:
 
    ```bash
-   gh issue list --label ready --state open --json number,title,milestone,labels
+   gh issue list --label ready --state open --limit 200 --json number,title,milestone,labels
    ```
 
 2. For each candidate, check GitHub's native blocking relationships — **not** a markdown section:
@@ -57,6 +57,8 @@ If the user passed explicit issue numbers, use those (still subject to the hard 
    ```
 
    `0` = unblocked. If the GraphQL call **fails**, treat the issue as blocked and say so — never assume unblocked on an error.
+
+   Check **every** issue the query returns, not the first screenful — the wave is only correct if the blocker check is exhaustive.
 
 3. **Eligible** = `ready` label AND zero open blockers.
 4. **Mutually compatible** = drop pairs that would collide at merge. See "Collision classes" below.
@@ -75,7 +77,7 @@ Separate worktrees mean agents never fight at run time, but they still collide a
 | `packages/api-contract/src/`             | Every downstream app type-checks against it; two concurrent contract changes break each other's build.   |
 | `packages/sanity-schemas/src/`           | Shared by both studios; concurrent schema edits conflict.                                                |
 | Design tokens / `DESIGN.md` / global CSS | Site-wide; two edits to the same token file conflict and both invalidate the whole VR suite.             |
-| The same route or component file         | Obvious. Check the issue's stated file list.                                                             |
+| The same route or component file         | Check the file list each issue states; two issues editing one file conflict line-for-line.               |
 
 When in doubt, keep both — but if two issues plausibly land in the same file, serialize them across waves. It is cheaper than a merge fight.
 
@@ -109,7 +111,6 @@ You are notified as each background agent completes. For each:
 
 - Capture the PR URL.
 - Note blockers it hit (the brief tells agents to comment-and-stop, never to work around a blocker).
-- Surface failures immediately — do not silently move on.
 
 If an agent finished **without** opening a PR, roll its label back so the queue stays truthful:
 
@@ -141,14 +142,13 @@ This skill is **stateless across invocations**. Every run re-queries GitHub, so 
 
 - **The orchestrator does not auto-loop.** When the wave's PRs are open, it stops. Downstream issues only unblock once blockers close, which needs merges the orchestrator cannot do.
 - **Hands-free continuation** — wrap in `/loop`, e.g. `/loop 45m /ralph-afk`. Each tick re-picks the latest unblocked wave; a tick with nothing eligible reports "no work" and exits. Use 45m+, not 5m — a wave takes far longer than that to produce reviewable PRs.
-- **Drained** = `gh issue list --label ready --state open` is empty, or everything left is blocked. Say so explicitly.
+- **Drained** = `gh issue list --label ready --state open --limit 200` is empty, or everything left is blocked. Say so explicitly.
 
 ## Hard rules
 
-- Never spawn for an issue without the `ready` label. Route the user to `/spec` instead.
-- Never spawn for an issue with open blockers, even if the user names it explicitly. Say which blocker is open and stop.
-- Never spawn two issues from the same collision class in one wave.
-- Never let an agent work in the main checkout. Every agent works only inside its `../kcvv-issue-<N>` worktree.
-- Never suggest `ALLOW_MAIN_COMMIT=1`. It is a human escape hatch, not an agent one. If a branch guard blocks an agent, the answer is the worktree.
-- Do not clean up a spawned agent's worktree — the human reviews it before merge.
-- If an agent fails or stalls, do not retry it autonomously. Surface it; the user decides whether to re-run it under `/ralph` for closer supervision.
+Step 1's gate is not a default the user can wave through. These bind even when the user names issues explicitly.
+
+- **Spawn only for an issue carrying `ready` with zero open blockers.** When the user names one that fails either test, say which test it failed — a missing label routes to `/spec`, an open blocker gets named — and stop.
+- **One issue per collision class per wave.** The table in step 1 is the list.
+- **Every agent works only inside its own `../kcvv-issue-<N>` worktree**, which survives until the human merges. The main checkout is theirs to read, never to write. When a branch guard blocks an agent, the fix is the worktree — `ALLOW_MAIN_COMMIT=1` is a human escape hatch and stays one.
+- **A failed or stalled agent goes back to the user, not back into the queue.** They decide whether to re-run it under `/ralph` for closer supervision.

--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -34,75 +34,26 @@ pick_next_issue() {
     return
   fi
 
-  local args=(--label "ready" --state open --json number --jq 'sort_by(.number) | .[].number')
+  # "ready, and no open blockers" lives in exactly one place.
+  # --first stops at the first match instead of querying blockedBy for the
+  # whole queue, which matters because this runs once per loop iteration.
+  local args=(--first)
   if [ -n "$MILESTONE" ]; then
     args+=(--milestone "$MILESTONE")
   fi
-
-  local candidates
-  if ! candidates=$(gh issue list "${args[@]}" 2>&1); then
-    echo "❌ gh issue list failed: ${candidates}" >&2
-    return 1
+  local skip_list="${SKIPPED_ISSUES[*]+${SKIPPED_ISSUES[*]}}"
+  if [ -n "$skip_list" ]; then
+    args+=(--exclude "$skip_list")
   fi
 
-  if [ -z "$candidates" ]; then
-    echo ""
-    return
-  fi
-
-  # Filter out skipped issues
-  local filtered=""
-  for num in $candidates; do
-    local is_skipped=false
-    for s in ${SKIPPED_ISSUES[@]+"${SKIPPED_ISSUES[@]}"}; do
-      if [ "$num" = "$s" ]; then is_skipped=true; break; fi
-    done
-    if [ "$is_skipped" = false ]; then
-      filtered="${filtered:+$filtered$'\n'}$num"
-    fi
-  done
-  candidates="$filtered"
-
-  if [ -z "$candidates" ]; then
-    echo ""
-    return
-  fi
-
-  # Filter out issues with open blockers (checked via GraphQL blockedBy)
-  local any_graphql_failed=false
-  for num in $candidates; do
-    local open_blockers
-    if ! open_blockers=$(gh api graphql -f query="
-      query {
-        repository(owner: \"soniCaH\", name: \"www.kcvvelewijt.be\") {
-          issue(number: ${num}) {
-            blockedBy(first: 50) {
-              nodes { state }
-            }
-          }
-        }
-      }" --jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length' 2>&1); then
-      echo "⚠️  Warning: blockedBy query failed for issue #${num}, skipping: ${open_blockers}" >&2
-      any_graphql_failed=true
-      continue
-    fi
-
-    if [ "$open_blockers" = "0" ]; then
-      echo "$num"
-      return
-    fi
-  done
-
-  if [ "$any_graphql_failed" = true ]; then
-    echo "❌ One or more blockedBy GraphQL queries failed — cannot reliably determine ready issues." >&2
-    return 1
-  fi
-
-  echo ""
+  # A nonzero exit here means the blocker state is unknown, not that the queue
+  # is empty — the caller aborts rather than guessing.
+  "${REPO_ROOT}/scripts/unblocked-issues.sh" "${args[@]}"
 }
 
 count_ready() {
-  local args=(--label "ready" --state open --json number --jq 'length')
+  # --limit is required: gh caps at 30 silently.
+  local args=(--label "ready" --state open --limit 200 --json number --jq 'length')
   if [ -n "$MILESTONE" ]; then
     args+=(--milestone "$MILESTONE")
   fi

--- a/scripts/unblocked-issues.sh
+++ b/scripts/unblocked-issues.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Print the `ready` issues that have no open blockers, ascending, one per line.
+#
+# Single source of truth for "what can be worked on right now". Consumed by
+# scripts/ralph.sh, .claude/commands/ralph.md, and .claude/skills/ralph-afk/.
+#
+# Blocking is GitHub's native `blockedBy` relationship, set with the addBlockedBy
+# mutation — not a label and not a markdown section. An issue can be `ready`
+# (well-specified) and blocked at the same time; both gates must pass.
+#
+# Usage:
+#   ./scripts/unblocked-issues.sh                       # every unblocked ready issue
+#   ./scripts/unblocked-issues.sh --first               # stop at the first one
+#   ./scripts/unblocked-issues.sh --milestone typed-kv  # one milestone only
+#   ./scripts/unblocked-issues.sh --exclude "12 34"     # skip these numbers
+#
+# Exits 1 if any blockedBy query failed, so a caller can never mistake an API
+# failure for "nothing is blocked". Prints nothing and exits 0 when the queue
+# is genuinely empty.
+set -euo pipefail
+
+OWNER="soniCaH"
+REPO="www.kcvvelewijt.be"
+
+MILESTONE=""
+EXCLUDE=""
+FIRST_ONLY=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --milestone) shift; MILESTONE="${1:-}" ;;
+    --milestone=*) MILESTONE="${1#*=}" ;;
+    --exclude) shift; EXCLUDE="${1:-}" ;;
+    --exclude=*) EXCLUDE="${1#*=}" ;;
+    --first) FIRST_ONLY=true ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift || true
+done
+
+# --limit is required: gh caps at 30 silently, and a capped list is
+# indistinguishable from a complete one.
+ARGS=(--label "ready" --state open --limit 200 --json number --jq 'sort_by(.number) | .[].number')
+if [ -n "$MILESTONE" ]; then
+  ARGS+=(--milestone "$MILESTONE")
+fi
+
+if ! CANDIDATES=$(gh issue list "${ARGS[@]}" 2>&1); then
+  echo "gh issue list failed: ${CANDIDATES}" >&2
+  exit 1
+fi
+
+[ -z "$CANDIDATES" ] && exit 0
+
+ANY_FAILED=false
+
+for num in $CANDIDATES; do
+  skip=false
+  for e in $EXCLUDE; do
+    if [ "$num" = "$e" ]; then skip=true; break; fi
+  done
+  [ "$skip" = true ] && continue
+
+  if ! open_blockers=$(gh api graphql -f query="
+    query {
+      repository(owner: \"${OWNER}\", name: \"${REPO}\") {
+        issue(number: ${num}) {
+          blockedBy(first: 50) { nodes { state } }
+        }
+      }
+    }" --jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length' 2>&1); then
+    echo "warning: blockedBy query failed for #${num}: ${open_blockers}" >&2
+    ANY_FAILED=true
+    continue
+  fi
+
+  if [ "$open_blockers" = "0" ]; then
+    echo "$num"
+    [ "$FIRST_ONLY" = true ] && exit 0
+  fi
+done
+
+if [ "$ANY_FAILED" = true ]; then
+  echo "one or more blockedBy queries failed — the unblocked set is incomplete" >&2
+  exit 1
+fi

--- a/scripts/wave-check.sh
+++ b/scripts/wave-check.sh
@@ -14,15 +14,48 @@ set -euo pipefail
 
 git fetch --quiet --prune origin
 
-# Open PRs, as their head branch names.
+# ── merge-tree, run once, with the three outcomes kept apart ──────────────────
+# Exit 0 = clean, 1 = conflict, anything else = git could not answer. A missing
+# ref also exits 1, which is why refs are verified before this is trusted.
+# Sets MT_OUT to the conflicted paths (empty when clean).
+MT_OUT=""
+merge_check() {
+  local rc=0 out
+  out=$(git merge-tree --write-tree --name-only "$1" "$2" 2>&1) || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    echo "git merge-tree failed (exit ${rc}) comparing $1 and $2:" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+  # Output shape: OID line, then conflicted paths, then a blank line and git's
+  # own prose. Drop the OID, stop at the blank line.
+  MT_OUT=$(printf '%s\n' "$out" | tail -n +2 | sed -e '/^$/q' -e '/^$/d')
+  return "$rc"
+}
+
+# ── collect the open PR head branches ─────────────────────────────────────────
+# Capture first and check the exit status: a gh failure inside a process
+# substitution would otherwise read as "no open PRs" and report all-clear.
+if ! PR_BRANCHES=$(gh pr list --state open --limit 100 --json headRefName --jq '.[].headRefName' 2>&1); then
+  echo "gh pr list failed: ${PR_BRANCHES}" >&2
+  exit 1
+fi
+
 # ponytail: while-read, not `mapfile` — macOS ships bash 3.2, which has no mapfile.
 BRANCHES=()
 while IFS= read -r line; do
-  [ -n "$line" ] && BRANCHES+=("$line")
-done < <(gh pr list --state open --limit 100 --json headRefName --jq '.[].headRefName' | sort)
+  [ -n "$line" ] || continue
+  # A PR from a fork has no branch on origin; merge-tree would exit 1 on the
+  # missing ref and be misread as a conflict. Say so instead.
+  if git rev-parse --verify --quiet "origin/${line}^{commit}" >/dev/null; then
+    BRANCHES+=("$line")
+  else
+    printf "  skipped   %s — no such branch on origin (fork PR?)\n" "$line"
+  fi
+done <<<"$(printf '%s\n' "$PR_BRANCHES" | sort)"
 
-if [ ${#BRANCHES[@]-0} -eq 0 ]; then
-  echo "No open PRs."
+if [ ${#BRANCHES[@]} -eq 0 ]; then
+  echo "No open PRs with a branch on origin."
   exit 0
 fi
 
@@ -32,18 +65,19 @@ echo ""
 # ── 1. Does each branch still merge cleanly into main? ────────────────────────
 echo "── vs origin/main ──"
 CLEAN=()
-for b in ${BRANCHES[@]+"${BRANCHES[@]}"}; do
-  if git merge-tree --write-tree "origin/main" "origin/${b}" >/dev/null 2>&1; then
+for b in "${BRANCHES[@]}"; do
+  if merge_check "origin/main" "origin/${b}"; then
     printf "  clean     %s\n" "$b"
     CLEAN+=("$b")
   else
     printf "  CONFLICTS %s  → rebase on main before merging\n" "$b"
+    printf '%s\n' "$MT_OUT" | sed 's/^/              /'
   fi
 done
 echo ""
 
 # ── 2. Do any two of the clean ones fight each other? ─────────────────────────
-if [ ${#CLEAN[@]-0} -lt 2 ]; then
+if [ ${#CLEAN[@]} -lt 2 ]; then
   echo "Fewer than two mergeable branches — nothing to compare."
   exit 0
 fi
@@ -54,13 +88,10 @@ for ((i = 0; i < ${#CLEAN[@]}; i++)); do
   for ((j = i + 1; j < ${#CLEAN[@]}; j++)); do
     a="${CLEAN[$i]}"
     b="${CLEAN[$j]}"
-    if ! git merge-tree --write-tree "origin/${a}" "origin/${b}" >/dev/null 2>&1; then
+    if ! merge_check "origin/${a}" "origin/${b}"; then
       printf "  COLLIDE   %s  ↔  %s\n" "$a" "$b"
-      # Name the files, so you can see whether it is a real fight or the lockfile.
-      # Output shape: OID line, then conflicted paths, then a blank line and
-      # git's own prose. Drop the OID, stop at the blank line.
-      git merge-tree --write-tree --name-only "origin/${a}" "origin/${b}" 2>/dev/null |
-        tail -n +2 | sed -e '/^$/q' -e '/^$/d' -e 's/^/              /'
+      # The filenames say whether this is a real fight or just the lockfile.
+      printf '%s\n' "$MT_OUT" | sed 's/^/              /'
       FOUND=1
     fi
   done

--- a/scripts/wave-check.sh
+++ b/scripts/wave-check.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Wave check — do the open PR branches collide with main, or with each other?
+#
+# Run this after a /ralph-afk wave opens its PRs, BEFORE you start merging.
+# It tells you which PRs are safe to merge in any order, and which pairs will
+# fight, so you merge the fighters one at a time instead of discovering the
+# conflict halfway through.
+#
+# Usage: ./scripts/wave-check.sh
+#
+# ponytail: pairwise O(n²) on merge-tree. Fine to ~15 open PRs; if a wave ever
+# gets bigger than that, group by changed-file sets first.
+set -euo pipefail
+
+git fetch --quiet --prune origin
+
+# Open PRs, as their head branch names.
+# ponytail: while-read, not `mapfile` — macOS ships bash 3.2, which has no mapfile.
+BRANCHES=()
+while IFS= read -r line; do
+  [ -n "$line" ] && BRANCHES+=("$line")
+done < <(gh pr list --state open --limit 100 --json headRefName --jq '.[].headRefName' | sort)
+
+if [ ${#BRANCHES[@]-0} -eq 0 ]; then
+  echo "No open PRs."
+  exit 0
+fi
+
+echo "Open PR branches: ${#BRANCHES[@]}"
+echo ""
+
+# ── 1. Does each branch still merge cleanly into main? ────────────────────────
+echo "── vs origin/main ──"
+CLEAN=()
+for b in ${BRANCHES[@]+"${BRANCHES[@]}"}; do
+  if git merge-tree --write-tree "origin/main" "origin/${b}" >/dev/null 2>&1; then
+    printf "  clean     %s\n" "$b"
+    CLEAN+=("$b")
+  else
+    printf "  CONFLICTS %s  → rebase on main before merging\n" "$b"
+  fi
+done
+echo ""
+
+# ── 2. Do any two of the clean ones fight each other? ─────────────────────────
+if [ ${#CLEAN[@]-0} -lt 2 ]; then
+  echo "Fewer than two mergeable branches — nothing to compare."
+  exit 0
+fi
+
+echo "── pairwise ──"
+FOUND=0
+for ((i = 0; i < ${#CLEAN[@]}; i++)); do
+  for ((j = i + 1; j < ${#CLEAN[@]}; j++)); do
+    a="${CLEAN[$i]}"
+    b="${CLEAN[$j]}"
+    if ! git merge-tree --write-tree "origin/${a}" "origin/${b}" >/dev/null 2>&1; then
+      printf "  COLLIDE   %s  ↔  %s\n" "$a" "$b"
+      # Name the files, so you can see whether it is a real fight or the lockfile.
+      # Output shape: OID line, then conflicted paths, then a blank line and
+      # git's own prose. Drop the OID, stop at the blank line.
+      git merge-tree --write-tree --name-only "origin/${a}" "origin/${b}" 2>/dev/null |
+        tail -n +2 | sed -e '/^$/q' -e '/^$/d' -e 's/^/              /'
+      FOUND=1
+    fi
+  done
+done
+
+if [ "$FOUND" -eq 0 ]; then
+  echo "  none — merge them in any order."
+else
+  echo ""
+  echo "Merge one of each colliding pair, then rebase the other before merging it."
+fi


### PR DESCRIPTION
Adds a parallel counterpart to `/ralph`, plus the pre-merge check that a parallel wave needs.

## Changes

**`.claude/skills/ralph-afk/`** — a wave runner. It computes the set of mutually-unblocked `ready` issues, shows the proposed wave for approval, then spawns one agent per issue in its own worktree.

It is a port of the `ralph-afk` skill from the `uitbetaling` repo, re-tailored to this one:

| Source repo | Here |
| --- | --- |
| label `ready-for-agent` | `ready`, with the `ready` → `in-progress` → `ready-for-review` transitions this repo requires |
| a `## Blocked by` markdown section | the native `blockedBy` GraphQL query already used by `scripts/ralph.sh` |
| worktree `.claude/worktrees/slice-NN-slug` | `../kcvv-issue-<N>` on `feat/issue-<N>`, so `scripts/ralph.sh` finds and cleans up the same worktrees |
| `npm install` | `corepack pnpm install --frozen-lockfile`, a lockfile-drift guard, a forced `@kcvv/api-contract` build, and `.env.local` |
| no commit rules | the commitlint type/scope enums, English subject, `Closes` vs `Part of` |
| no review gate | `/code-review` + `/simplify` before the PR, per `/ralph` step 5.5 |

It also carries a **collision table**: within one wave, at most one issue may touch `pnpm-lock.yaml`, VR baselines, `packages/api-contract/src/`, `packages/sanity-schemas/src/`, or the design tokens. Those are the surfaces that fight at merge rather than at run time.

The skill deliberately does **not** pass `isolation: "worktree"` to spawned agents — the harness worktree ignores this repo's naming and skips the bootstrap above. The reasoning is recorded in the skill.

**`scripts/wave-check.sh`** — every branch in a wave comes off the same `origin/main`, so merging one can break the others. This reports which branches no longer merge into `main`, which pairs collide, and the exact files they collide on. Read-only: no checkout, no working-tree change. Step 5 of the skill runs it before any merge.

## Testing

- `scripts/wave-check.sh` runs clean against the current open PRs on bash 3.2 (the macOS system bash — it avoids `mapfile` and guards empty-array expansion under `set -u`)
- Conflict detection verified against purpose-built git objects: a divergent pair is reported as conflicting with the right filename, an identical pair as clean, and the working tree is untouched either way
- `prettier --check` passes on both Markdown files
- The wave computation in step 1 was run against the live queue: 54 `ready` issues, 35 currently unblocked
- No shell linting exists in CI, so `wave-check.sh` is checked by running it

## Notes

- No issue number — this is tooling, so the commit uses `chore(config)` and the PR closes nothing.
- Committed from a worktree without `node_modules`, so husky and lint-staged did not run. Formatting was verified by hand with `prettier --check`; `.sh` files are outside prettier's scope.
- `docs/research/gauntlet-loop.md` was written while scoping this and is intentionally **not** included — it is unrelated research and belongs in its own commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for running autonomous implementation workflows across parallel issue waves.
  * Added procedures for worktree setup, issue eligibility, acceptance criteria, verification, review, commits, and pull requests.
  * Added a utility to detect branch conflicts and determine safe merge ordering.

* **Documentation**
  * Added self-contained instructions for autonomous issue implementation and completion reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->