### PR TITLE
docs(ui): keep the mockups, critiques and research that never got committed

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
     ]
   },
   "enabledPlugins": {
-    "vercel@claude-plugins-official": true,
+    "vercel@claude-plugins-official": false,
     "superpowers@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true
   }

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,14 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [],
+    "ignoreValues": [
+      {
+        "rule": "overused-font",
+        "value": "fraunces",
+        "createdAt": "2026-08-13T10:34:02.147Z",
+        "reason": "Google stand-in for freight-display-pro in mockup files"
+      }
+    ]
+  }
+}

--- a/apps/web/.impeccable/critique/2026-08-12T12-00-55Z__src-app-main-nieuws-slug-page-tsx.md
+++ b/apps/web/.impeccable/critique/2026-08-12T12-00-55Z__src-app-main-nieuws-slug-page-tsx.md
@@ -1,0 +1,153 @@
+---
+target: news article detail page (/nieuws/[slug])
+total_score: 23
+max_score: 40
+na_heuristics:
+p0_count: 3
+p1_count: 2
+timestamp: 2026-08-12T12-00-55Z
+slug: src-app-main-nieuws-slug-page-tsx
+---
+
+Method: dual-agent (A: a8acc03ce56c756a1 design review · B: a141e9177e76ff7b9 detector + browser evidence). Surface mode: Read. Live evidence from `kcvv-nextjs.vercel.app` across four real articles (interview, squad reveal, recruitment post, 2023 transfer archive).
+
+## Design Health Score
+
+| #         | Heuristic                       | Score     | Key Issue                                                                                                                                                                                                                                                          |
+| --------- | ------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1         | Visibility of System Status     | 2         | `loading.tsx` is an exemplary skeleton, but the hero cover is `loading="lazy"` (no `priority` at this call site) so the LCP element paints as an empty taped frame — and the one promise the page makes, "1 MIN LEZEN", is wrong by ~6× on a 1,279-word interview. |
+| 2         | Match System / Real World       | 3         | Dutch is plain and warm, but `ArticleMetadata` hard-defaults the byline to "KCVV ELEWIJT" while the hero and credits on the same page say "Kevin".                                                                                                                 |
+| 3         | User Control and Freedom        | 1         | No back link, no breadcrumb, and on 2 of 4 articles no related row. `<main>` contained one link (the Facebook share). `ArticleMetadata.tsx:46` justifies dropping the breadcrumb by citing a back link that was never built.                                       |
+| 4         | Consistency and Standards       | 2         | IBM Plex Mono renders nowhere on the site. Article endings differ by accident: interview = EndMark + credits; squad reveal = EndMark + nothing; 2023 archive piece = the full "Verder lezen." row.                                                                 |
+| 5         | Error Prevention                | 2         | The reading-time reader walks a `qaBlock` shape that does not exist, and no type catches it. Nothing stops an editor pasting a bare `forms.gle` URL as the sole CTA.                                                                                               |
+| 6         | Recognition Rather Than Recall  | 3         | Kicker/credit-chip context is good, but `QASectionDivider` renders `<aside role="separator">`, so the article body contains zero `<h2>`.                                                                                                                           |
+| 7         | Flexibility and Efficiency      | 2         | Not n/a — share exists but as two 16×16px icon-only controls; no print treatment, no jump list for an 11-question Q&A, no keyboard route to the next article.                                                                                                      |
+| 8         | Aesthetic and Minimalist Design | 3         | Hero is excellent. The same date renders three times in two casings, and the desktop column runs 101–110 characters per line.                                                                                                                                      |
+| 9         | Error Recovery                  | 3         | `not-found.tsx` / `error.tsx` are strong and on-voice with correct `noindex`; docked because `[slug]` has no segment-level `not-found`, so a dead article slug offers no route back to the archive.                                                                |
+| 10        | Help and Documentation          | 2         | Not n/a — `/hulp` exists and is in the nav. The recruitment article, exactly where a parent needs help, offers a raw Google Forms URL and links to neither `/hulp` nor `/club/word-lid`.                                                                           |
+| **Total** |                                 | **23/40** | **Acceptable — significant improvements needed**                                                                                                                                                                                                                   |
+
+Heuristic 1 was moved from Assessment A's 3 to 2 during synthesis: the wrong reading time is a status promise, not just an error-prevention gap.
+
+## Design Specificity Verdict
+
+The hero is unmistakably KCVV. Everything below the metadata bar is a generic publication template wearing cream paint.
+
+**LLM assessment.** The hero earns its keep — `★ INTERVIEW · 27 APRIL 2026 ★` kicker, 72px Freight Big Pro with a single jersey-deep italic accent, subject credit-chip, `TapedFigure` cover with a tape strip at a sub-degree tilt, fanned into six authored variants by `renderArticleHero` (`page.tsx:96-197`). `EndMark` and `ArticleCredits` are real fanzine artefacts. But the 680px reading column — where the reader spends 95% of their time — got a drop cap and nothing else. Between the metadata bar and `EndMark`, the fanzine vocabulary DESIGN.md enumerates (tape, stamps, perforations, striped seams, highlighter strokes) appears zero times on three of four articles. The `/nieuws` index is far more characterful than its own destination: the reader clicks from a loud, specific room into a quiet, generic one. And the club's single uncopyable asset goes unused — the B-squad announcement names ~25 players and links to none of them, despite `resolveInternalLinkHref` already routing `player`/`team`/`staffMember`.
+
+**Deterministic scan.** `detect.mjs` exit 2, 49 findings — 38 in shipped components (30 `design-system-font-size`, 8 `design-system-color`). Off-ramp size histogram: 10px×16, 15px×3, 13px×3, 9px×2, plus singletons at 12/17/20/22/26/30px. Concentrated in `EventDetailBlock`, `EventFactInline`, `HtmlTableBlock`, `TransferFactCard`, `SubjectAvatar`, `_variant-parts.tsx`. The 8 colour findings are all `DownloadButton.tsx:38-49`, including `#6b7280` — a direct hit on The No-Grey-UI Rule.
+
+**False positives.** Exactly one drives the exit code: `broken-image` at `NewsCard.test.tsx:10`, a Vitest `next/image` mock. Nothing fired on DESIGN.md's deliberate deviations — no finding against sharp corners, 0-blur shadows, press-down hover, cream ground or sub-degree rotation.
+
+**Visual overlays.** None — no user-visible overlay exists. Mutation preflight passed (no CSP header, no CSP meta, injected script executed), but Chrome mixed-content blocked `http://localhost:8400/detect.js` on an `https://` page; the script tag never fired `onload` or `onerror`. Live server started on port 8400 and confirmed stopped. All browser evidence is direct DOM measurement instead.
+
+## Overall Impression
+
+A superb front door with no room behind it. The hero, the skeleton and the serializer are genuinely well-made — `blockHasRenderableOutput`, `socialBrandFor`'s dot-prefixed suffix check, `buildComponents` exported so a guard can assert schema coverage. Then the reader crosses the metadata bar into an undifferentiated 109-character-per-line text field, reads for six minutes, and hits a wall with no exit.
+
+The single biggest opportunity is the ending. Peak-end scores this page on how it finishes, and the flagship interview finishes in a void: `💚🤍 #KCVVE`, `★ EINDE GESPREK ★`, 70px of empty cream, credits, more cream, footer. The 2023 archive piece has a better ending than the 2026 flagship.
+
+## What's Working
+
+1. **The hero variant system is design work, not configuration.** Six authored variants off one shell, with a documented graceful-degrade path when PSD returns null (`page.tsx:335-343`). It survives missing data by design — exactly what PRODUCT.md principle 3 demands.
+2. **`loading.tsx` is a model of the no-radius-on-skeletons rule.** It mirrors the real composition step-for-step — 1040 hero, `StripedSeam`, 1040 metadata rule, 680 prose, 1040 related row — using `border-2 border-ink`, `bg-paper-edge`, `shadow-paper-md`, `motion-safe:animate-pulse`.
+3. **Image alt coverage is clean.** 0 images missing `alt` across all four articles, with descriptive Dutch alts. Empty `alt=""` only where correct — decorative avatar, header logo (also `aria-hidden`).
+
+## Priority Issues
+
+### [P0] IBM Plex Mono renders nowhere on the site
+
+**What.** The shipped CSS carries two `.font-mono` rules: the project's `.font-mono{font-family:var(--font-family-mono)}` in `@layer base` (`globals.css:651`, block 569–678), and Tailwind v4's generated `.font-mono{font-family:var(--font-mono)}` in `@layer utilities`, which wins. `--font-mono` is never defined in the repo, so it resolves to Tailwind's default `ui-monospace, SFMono-Regular, Menlo…`. Confirmed three ways: both rules present in the deployed bundle; `--font-mono:ui-monospace, SFMono-Regular…` shipped verbatim; live DOM showing 0 of 411 elements resolving to any IBM Plex face, all 16 registered FontFace entries `unloaded`, `document.fonts.check('12px "IBM Plex Mono"')` false.
+
+**Why it matters.** DESIGN.md calls the mono register "the system's connective tissue" and "the most-used non-body style in the system". 251 uses across 105 files — every kicker, date, score, timestamp, pill, stamp and nav item on the site — render in SF Mono. `stories/foundation/Typography.mdx:201` documents the register using `var(--font-mono)`, so Storybook shows the wrong font too.
+
+**Fix.** Define `--font-mono` in `@theme` (or rename `--font-family-mono` to it). One line. Then delete the `@layer base` `.font-mono` override, which exists only to fight a namespace it should have occupied.
+
+**Suggested command.** `/impeccable typeset`
+
+### [P0] "1 MIN LEZEN" on a 1,279-word interview — reading time ignores every Q&A answer
+
+**What.** `reading-time.ts:35` reads `extractBodyText(pair.answer)`. `packages/sanity-schemas/src/qaBlock.ts` stores answers at `qaPair.respondents[].answer` — there is no `pair.answer`, so only question strings are counted. Verified in both files.
+
+**Why it matters.** Reading time is the one explicit contract the page makes with a scanning reader, and it under-reports by ~6× on the article type where it matters most. `AnyBlockItem.pairs` is structurally wrong, so no type-check catches it.
+
+**Fix.** Walk respondents — `(pair.respondents ?? []).map(r => extractBodyText(r.answer)).join(" ")` — correct the type, and add a regression test built from the real `qaPair` fixture shape.
+
+**Suggested command.** `/impeccable harden`
+
+### [P0] The article has no exit — two of four end in a void
+
+**What.** `<VerderLezenRow>` returns `null` at 0 items. On the flagship interview and the B-squad reveal, `<main>` contained one link (the Facebook sharer). No back link, no breadcrumb: `ArticleMetadata.tsx:46` trades the breadcrumb away citing a `"< Terug naar nieuws"` back link "on the hero"; `grep -rn "Terug naar"` returns only that comment. It was never built.
+
+**Why it matters.** The two articles with no exit are the club's newest and best content. A reader who finishes them is dumped into the footer.
+
+**Fix.** Build the back link `ArticleMetadata.tsx:46` already assumes, and make `VerderLezenRow` fall back to the 3 most recent articles (already fetched for `generateStaticParams`) rather than rendering nothing.
+
+**Suggested command.** `/impeccable shape`
+
+### [P1] Desktop reading measure runs 101–110 characters per line
+
+**What.** Measured live at 1440px: the column is 680px exactly (correct per the locked rule), but paragraphs at `text-body-md` (16px) yield 109 CPL on the drop-cap paragraph and 101–103 CPL in Q&A answers. At 500px the same paragraph measures 73 CPL and reads fine — a desktop/tablet failure that worsens as the viewport widens toward the cap.
+
+**Why it matters.** 100+ CPL is roughly double the 45–75 range; the eye loses the line-return on every wrap. This is the core Read-mode fundamental and the one the page fails. It also answers ticket 11 of the typeset map, which was scoped to measure exactly this and had not yet run.
+
+**Fix.** Promote article prose to `body-lg` (1.125rem / lh 1.55) at `md:` and up — an existing DESIGN.md token, no new token, no container change. Lands ~97 CPL. Do not narrow the container; 680 is one of the three legal widths.
+
+**Suggested command.** `/impeccable typeset`
+
+### [P1] Section headings are `role="separator"`; the body has no `<h2>` and skips h1 → h3
+
+**What.** `QASectionDivider.tsx` renders `<aside role="separator" aria-label={plain}>`, and `ArticleBody`'s `buildComponents` maps the `h2` block style straight into it. Live audit: the squad article's only headings are `H1` plus the footer's `H2`/`H3`; "Technische staf" is an `<aside>`. The interview's 11 questions are `<h3>` under an `<h1>` with nothing between.
+
+**Why it matters.** Heading navigation is the standard screen-reader primitive for long-form and it is unavailable. A separator's `aria-label` never appears in a heading list. Sighted readers lose the grouping too.
+
+**Fix.** Give `QASectionDivider` a heading-level prop, render the title span as a real `<h2>` inside the existing flex row with the rules and `✦` glyphs `aria-hidden`, and keep `role="separator"` only on the `dotted` variant. Zero visual change — the title is already its own flex child, so the three-centerline alignment contract holds.
+
+**Suggested command.** `/impeccable harden`
+
+## Persona Red Flags
+
+**Casey (distracted mobile, one thumb)** — closest to PRODUCT.md's stated scene. The two share controls measure 16×16 CSS px (`ArticleMetadata.tsx:129,139`, verified at 1440 and 375) and sit at the far right of the metadata bar; sharing to a WhatsApp group is the likeliest mobile action on this page. Lands on an empty taped frame where the photo should be. Reads "1 MIN LEZEN", commits, is interrupted at question 4 of 11, and returns to no progress indicator, no section list and no heading structure. Finishes with nowhere to go.
+
+**Sam (screen reader + keyboard)** — heading navigation is useless; the document's only headings are the `<h1>` and the footer's. Tab order through `<main>` on the interview has two stops, then the footer. Focus is visible everywhere, but it is the UA default (`outline: auto 1px rgb(31,31,31)`), not DESIGN.md's specified 2px jersey-deep ring at 2px offset. The `qaBlock` respondent label renders as a mono-caps `<p>` unassociated with its answer, so each answer arrives without its speaker attached.
+
+**Rita, 68, long-time supporter, low digital confidence** (project-specific, derived from PRODUCT.md's explicit "less-digital visitors") — the only two controls on the entire article are unlabelled 16×16 glyphs; PRODUCT.md names this exact failure ("no unlabelled icons"). The recruitment article's call to action is a raw `https://forms.gle/LXxfaSdz5rvpM14FA` in body text — no button, no "Schrijf je in", no link to `/club/word-lid` sitting in the nav. No back link means her route to the news list is browser chrome, the affordance this audience is least fluent with.
+
+## Cognitive Load
+
+4 of 8 fail — critical band.
+
+- FAIL Visual grouping — sections are separators, not headings.
+- FAIL Visual hierarchy — 49–72px H1 → 11px mono → a flat 16px field for 1,279 words, nothing between.
+- FAIL Working memory — no breadcrumb, back link, or section index to re-enter by.
+- FAIL Minimal choices — inverted: zero onward options at the end of two articles. Zero is as much a decision-point failure as ten.
+
+Passing: single focus, chunking, one-thing-at-a-time, progressive disclosure.
+
+## Emotional Journey
+
+- **Peak** — the hero, ~1.5s in. On mobile especially: kicker stars, 49px serif headline with the accent phrase in jersey-deep italic, subject chip, italic lead, taped photo.
+- **Valley 1** — immediately after the metadata bar. The register collapses from a composed hero into an undifferentiated 109-CPL text field, abruptly and unearned.
+- **Valley 2** — "1 MIN LEZEN" on a six-minute read.
+- **Valley 3** — the recruitment CTA: a naked `forms.gle` URL at the moment of highest intent.
+- **End** — a dead stop into the footer. Peak-end scores the page here, and the ending is nothing.
+
+## Minor Observations
+
+- 4px horizontal overflow at 375px on the transferoverzicht article — sole offender is the `VerderLezenRow` scroll-right arrow at `right: 379`. The interview measures 0px.
+- 18 shipped sites below the 11px label floor (16 × `text-[10px]`, 2 × `text-[9px]`), rendering as low as 9.5px live. Contrast is fine (4.72:1); size is the risk. This is the article-page slice of the typeset map's 63-use sub-11px cluster.
+- 22 `🔄` emoji as table icons at 15px inside `<td>` on the transferoverzicht article, plus `💚🤍` closing the interview body. These arrive as CMS content, so they are not a UI violation as written — but the system gives editors no sign-off primitive and no table-icon vocabulary, so they improvise with what Facebook taught them.
+- Press-down hover ungated at `VideoBlock.tsx:331` — `hover:translate-x-1 hover:translate-y-1` with no `motion-safe:`.
+- The date renders three times in two casings (hero kicker, metadata bar, credits).
+- The article ends three times — `EndMark` → 70px cream → credits → more cream → footer.
+- Hero (1040) and body (680) left edges do not align, creating an unarticulated ~75px step at the metadata bar. `loading.tsx` puts a `StripedSeam` at exactly that junction; the real page has none.
+- `/nieuws` shows "A-PLOEG" twice in the filter row — the known Sanity title-case / GROQ case-sensitivity trap.
+- No segment-level `not-found.tsx` under `nieuws/[slug]/`; a dead article slug falls through to the global 404, whose actions are "Naar de homepage" and "Zoeken" — neither is "back to the news archive".
+- Seven undocumented file-type colours in `DownloadButton` (`#c0392b` `#2563b3` `#15803d` `#f97316` `#7c3aed` `#0f766e` `#d97706`), plausibly intentional file-type coding but off-palette and undocumented.
+
+## Questions to Consider
+
+1. If the reading column is where the reader spends 95% of their time, why is it the only part of the page the design system never touches? What would it look like if one fanzine primitive per ~400 words were the standard, and the body were treated as a designed surface rather than the gap between designed surfaces?
+2. The club's one genuinely uncopyable asset is a live player/team/match database. Why does an article naming 25 players link to zero of them? Should player-name linking be an authoring affordance, or resolved automatically against the PSD roster at render time?
+3. The 2023 archive article has a better ending than the 2026 flagship interview. What is the ending of an article actually for here — and should a recruitment article end somewhere different from a match recap? Match articles are currently the only type with an authored closer.
+4. `ArticleMetadata` asserts the author is "KCVV Elewijt" while the credits block says "Kevin". Is a per-article byline something the club wants at all, or is the honest answer that everything is by the club and the `author` field should be removed rather than papered over with a default in a third place?

--- a/apps/web/.impeccable/critique/2026-08-12T12-56-34Z__src-app-main-ploegen.md
+++ b/apps/web/.impeccable/critique/2026-08-12T12-56-34Z__src-app-main-ploegen.md
@@ -1,0 +1,162 @@
+---
+target: the /ploegen team surface (index, [slug] detail, wedstrijden)
+total_score: 15
+max_score: 36
+na_heuristics: 10
+p0_count: 2
+p1_count: 3
+timestamp: 2026-08-12T12-56-34Z
+slug: src-app-main-ploegen
+---
+
+Method: dual-agent (A: design review · B: detector + browser evidence)
+
+Target: `src/app/(main)/ploegen` — the team index, `/ploegen/[slug]` detail, and `/ploegen/[slug]/wedstrijden`.
+Baseline: `main` at `e19f8235`, measured 2026-08-12 against `https://kcvv-nextjs.vercel.app` (the apex still serves the old Gatsby site).
+Mode: **Operate** with a Read tail — the visitor is completing a task ("find my kid's team", "where is the first team in the table").
+
+## Design Health Score
+
+| #         | Heuristic                       | Score     | Key Issue                                                                                                                                                                |
+| --------- | ------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1         | Visibility of System Status     | 1         | No `aria-current` anywhere on the sticky section nav (grep returns nothing); no active state, no freshness signal, and `Klassement` vanishes with no trace on every page |
+| 2         | Match System / Real World       | 1         | Three routes publish an `<h1>` that names a different team; `DEFENDER` and `attacker` ship untranslated on Dutch squad cards                                             |
+| 3         | User Control and Freedom        | 1         | `/ploegen/[slug]/wedstrijden` has no visible back link, and the global nav has no `/ploegen` entry — browser-back is the only exit                                       |
+| 4         | Consistency and Standards       | 2         | On `/wedstrijden` the `<h1>` and all eight `<h2>` month headings render at the same 72px; team detail has no content `<h2>` at all                                       |
+| 5         | Error Prevention                | 2         | Two `/ploegen` cards read "U17", two read "U10"; the only discriminator is a 10px sub-line                                                                               |
+| 6         | Recognition Rather Than Recall  | 2         | `<title>`, `<h1>` and OG card give three different names for the same team                                                                                               |
+| 7         | Flexibility and Efficiency      | 2         | No filter or jump on a 5307px, 39-row fixture page; `AgendaScrollToNext` scrolls unrequested                                                                             |
+| 8         | Aesthetic and Minimalist Design | 3         | Genuinely strong chrome; deductions for the meta pill duplicating the tagline verbatim, and the same fixture rendering twice within one mobile screen                    |
+| 9         | Error Recovery                  | 1         | 13 of 16 `/wedstrijden` routes are "GEEN WEDSTRIJDEN GEPLAND." in 14px muted mono, then ~250px of empty cream, then the footer                                           |
+| 10        | Help and Documentation          | n/a       | No task on this surface requires instruction; the club's help surface is `/hulp`                                                                                         |
+| **Total** |                                 | **15/36** | **Poor (42%)**                                                                                                                                                           |
+
+The band is harsh and the split is the point: the **composition** would score well above this. What fails is the **content contract** — six independent places where a component demands a field the pipeline does not supply, and the page silently erases itself instead of saying so.
+
+## Design Specificity Verdict
+
+**Strongly authored at the composition layer, category-interchangeable at the data layer — and the data layer is what the visitor actually reads.**
+
+**LLM assessment.** The chrome is unmistakably KCVV and could not be swapped for a template club: the mirrored A/B flagship pair on `/ploegen` flips grid track order rather than reordering DOM (`TeamFlagship.tsx:146`) with the B-ploeg content right-aligned so the mirror is complete; the youth directory is taped polaroids on a sub-degree tilt pool (`YouthDirectory.tsx:16`, `CARD_ROTATIONS = [-1.1, 0.7, -0.5]`) reading as a scrapbook page; `TeamHero` pairs a taped landscape figure with a dashed "Seizoen" ticket stub (`TeamHero.tsx:180-193`); and `TeamAgendaRow` locks the score dead-centre and truncates names rather than borrowing width (`TeamAgendaRow.tsx:11-14`, the #2397 decision).
+
+What that chrome frames is thinner than a Twizzit page. The squad grid is the largest surface on the page and is a wall of identical placeholder jerseys — 29 players on the flagship team, **3 with a photo**. The position grouping `SquadGrid.tsx:17-22` designs in four ordered buckets collapses to two in production (`Doelmannen 4`, `Spelers 25`). `StandingsTable` renders on **zero** of 16 team pages. `TeamEditorial` — 175 lines, three authored blocks with a pull-quote lift — renders on **zero** of 16. A template club that actually filled its fields would beat this on the exact metric PRODUCT.md calls "punch above the division".
+
+**Deterministic scan.** `detect.mjs` over `src/app/(main)/ploegen` + `src/components/team`: **exit 2, 7 findings, all `design-system-font-size`, all in shipped components, none in tests or stories** — 9px at `PlayerCard.tsx:74`, `TeamAgendaRow.tsx:382,405`, `TeamStaff.tsx:113,120`; 10px at `TeamAgendaRow.tsx:148`, `YouthDirectory.tsx:110`. No ignore file, no suppression comments.
+
+What did **not** fire is the more useful signal. All 65 rules loaded, and every rule that would punish this project's deliberate deviations stayed silent: `design-system-radius`, `gpt-thin-border-wide-shadow`, `hover-color-rules`, `cream-palette`, `ai-color-palette`, `kicker-above-heading`, `oversized-h1`, `italic-serif-display`. The detector and the committed world are not in tension here, so all 7 survivors are real drift.
+
+The file scan **structurally under-reports**: URL mode needs puppeteer (`detect-url.mjs:344` exits 1 without it), so the browser-rendered rules — `tiny-text`, `undersized-ui-text`, `low-contrast`, `skipped-heading`, `text-overflow`, `clipped-overflow-container` — never ran. The browser pass found all six conditions present.
+
+**Visual overlays.** None. `live-server.mjs` was not started and no script was injected, so there is no user-visible overlay in the browser. Script injection did work during measurement, so the step would likely have succeeded; it simply was not run.
+
+## Overall Impression
+
+This surface was designed well and then starved. Every band that has data looks like the club; every band that doesn't disappears without a word, and five of the six sections a first-team page implies exist are absent on a U6 page. The single biggest opportunity is not a redesign — it is deciding what a section says when it has nothing to say, because that one rule would repair the standings, the fixtures, the training times, the editorial block and the youth pages simultaneously.
+
+## What's Working
+
+1. **`TeamAgendaRow`'s two-layout split is the best thing on this surface.** Desktop is a symmetric scoreboard; mobile (`TeamAgendaRow.tsx:392-442`) collapses to a KCVV-centric row — opponent crest, opponent name, a `House`/`Bus` icon carrying a real `aria-label`, then the score. Measured 68px tall at 390px. It answers "who, home or away, what happened" one-handed in a glance, and the home/away affordance is a labelled icon rather than a hover. This is PRODUCT principle #1 executed properly.
+
+2. **The `/ploegen` mirrored flagship pair.** `TeamFlagship.tsx:146` flips grid track order instead of DOM order and `:80` right-aligns the B-ploeg content, so the mirror is complete rather than half-done, while source order keeps the photo first so mobile stacks identically for both. It makes the A/B relationship legible without a word of copy.
+
+3. **The auto-hide architecture is right even though its output is wrong.** `page.tsx:160-175` derives the section flags once and feeds _both_ the render gates and the nav list, with the invariant stated in the comment. Verified live: the U6 nav lists exactly the two sections that exist, and every anchor resolves to a real DOM id on all six pages measured. That single-source discipline prevents the far more common bug of a nav link that scrolls to nothing.
+
+## Priority Issues
+
+### [P0] Three routes publish an `<h1>` that names a different team
+
+Measured across all 18 team pages:
+
+| Route                         | `<h1>`         | `<title>`          |
+| ----------------------------- | -------------- | ------------------ |
+| `/ploegen/eerste-elftallen-a` | `A-ploeg.`     | Eerste Elftallen A |
+| `/ploegen/reserven`           | **`A-ploeg.`** | Reserven           |
+| `/ploegen/kcvve-u17`          | `U17.`         | KCVVE U17          |
+| `/ploegen/kcvve-u16`          | **`U17.`**     | KCVVE U16          |
+| `/ploegen/kcvve-u10`          | `U10.`         | KCVVE U10          |
+| `/ploegen/kcvve-u10p`         | **`U10.`**     | KCVVE U10P         |
+
+Two different causes. **Reserven is code**: its Sanity `name` is plainly `"Reserven"` (confirmed via the JSON-LD `SportsTeam.name` and `<title>`), so `nameSuffix` returns `"RESERVEN"`, the A/B suffix test fails, and the fallback at `TeamHero.tsx:56` catches `age === "A"` and returns `"A-ploeg"`. **U16→U17 and U10P→U10 are data**: for youth, `computeCategory` returns the Sanity `age` verbatim (`TeamHero.tsx:43-46`), and `kcvve-u16` carries `age = "U17"`.
+
+**Why it matters.** PRODUCT.md stakes the club's uncopyable asset on competitive data "rendered as first-class pages (`/ploegen/[slug]`)", and the third success criterion is "show the club is serious". A page that misnames its own subject falsifies both. A supporter clicking _Reserven_ from `/ploegen` lands on a page headed `A-ploeg.` and reasonably concludes the click failed.
+
+**Fix.** Delete the `age`-based senior fallback at `TeamHero.tsx:56-57` and return the Sanity `name` when the suffix test fails. Separately, resolve whether `kcvve-u16` is genuinely a U16 side carrying a wrong `age`, or a U16-named side that really plays U17 — that is a club-data question, not a code one. Add a uniqueness assertion to `ploegen/page.test.tsx`: no two `/ploegen/*` routes may produce the same `<h1>`.
+
+**Suggested command:** `/impeccable clarify`
+
+### [P0] Zero of 16 team pages renders a `Klassement`, and no page says why
+
+`#klassement` exists on **zero** of the six pages measured, including the two 368KB senior pages. `StandingsTable.tsx:15` returns `null` on an empty array, `page.tsx:215` then gates the whole section including its seam, and `page.tsx:170` drops "Klassement" from the nav. Nothing is left behind — not a heading, not a line of copy. `#info` is likewise absent everywhere: `TeamEditorial` renders on 0 of 16 teams.
+
+**Why it matters.** `apps/web/CLAUDE.md`'s feature→route map names `/ploegen/[slug]` as _the_ home of the league table. DESIGN.md's Navigation section justifies deleting all four nav dropdowns on the claim that "in-page section anchors on `/ploegen/[slug]`" index the page better than a transient panel could. That index is measured at **3 anchors on a senior page and 2 on a youth page**, and the highest-value one has never rendered. Nothing distinguishes "the season hasn't started" from "the sync is broken".
+
+**Fix.** Keep the render gate but stop letting it erase the idea. Render `#klassement` whenever the team is in a league competition — the signal already exists as `competitionType === "league"`, never `standings.length` — with the table replaced by one line of paper-register copy. Apply the identical pattern to `showMatches` so youth pages stop silently losing their fixtures band.
+
+**Suggested command:** `/impeccable harden`
+
+### [P1] `/ploegen/[slug]/wedstrijden` is a one-way door onto a dead-end empty state
+
+Two defects on one route. **No exit:** every `<a href>` in the body starts `/wedstrijd/`; links matching `/ploegen*` number **zero**. The breadcrumb exists only as JSON-LD (`wedstrijden/page.tsx:139`), and the global nav carries no `/ploegen` entry. **The empty state is 13 of 16 pages:** every youth `/wedstrijden` route renders `"Geen wedstrijden gepland."` in 14px muted mono (`wedstrijden/page.tsx:168-174`), then ~250px of blank cream, then the footer.
+
+**Why it matters.** PRODUCT.md names youth parents as a co-equal primary audience whose first listed need is _schedule_. This is the route that serves it, reached from "Volledige kalender →", and for every U6–U21 parent it is a blank page with no way out. PRODUCT's Accessibility section — "no interaction that must be discovered" — makes browser-back an unacceptable answer for the less-digital visitor.
+
+**Fix.** Add a visible back link above the kicker mirroring the JSON-LD breadcrumb that already exists, and replace the bare string with a bordered paper note carrying a reason, a link to `/kalender`, and a link back to the team. Reuse `TicketStub` or `TapedCard`, not new markup.
+
+**Suggested command:** `/impeccable onboard`
+
+### [P1] English position values leak onto squad cards and silently gut the position grouping
+
+`player.repository.ts:68-70` falls through to the raw `positionPsd`. Live: one card on `/ploegen/eerste-elftallen-a` reads **`DEFENDER`**; the single card on `/ploegen/reserven` reads **`attacker`**. Sanity's own schema constrains `position` to Dutch, so any player whose Sanity field is unset renders English. Second-order: `SquadGrid.tsx:19` matches the exact string `"Verdediger"`, so those players also miss their bucket — the flagship team partitions into `Doelmannen 4` / `Spelers 25`, and three of the four designed groups never fire.
+
+**Why it matters.** PRODUCT.md Operating Context: "Language: Dutch throughout the UI (labels, slugs, display values)." And it means the four-group front-to-back ordering is design work that has never reached a user.
+
+**Fix.** Map `positionPsd` through a `PSD_POSITION_LABELS` record before the fallback chain — exactly as `TeamStaff.tsx:28-33` already does for function codes — and make `SquadGrid` match case-insensitively so an unmapped future value degrades to the catch-all instead of shipping raw English.
+
+**Suggested command:** `/impeccable clarify`
+
+### [P1] The team detail page has no `<h2>`, so its three advertised sections are invisible to heading navigation
+
+`grep "level={2}\|<h2"` across `StandingsTable`, `TeamMatchesSection`, `SquadGrid` and `TeamStaff` returns **nothing**. Measured heading order on `/ploegen/eerste-elftallen-a`: `H1 "A-ploeg." → H3 "Doelmannen" → H3 "Spelers" → H2 "Met dank aan onze sponsors."` The first `<h2>` a screen-reader user reaches is the sponsor block; `#staf` has no heading at any level; every team-detail page skips h1→h3. On a youth page the only content `<h2>` is `TeamEnrolmentCta` — the recruitment ad.
+
+**Why it matters.** The sticky nav advertises three sections that do not exist in the heading outline, so the two navigation systems disagree. `TeamSectionNav` also carries no `aria-current` and no focus style (both greps empty), and real keyboard Tab yields Chrome's default `outline: rgb(0,95,204) auto 1px` rather than DESIGN.md's 2px jersey-deep ring at 2px offset — only 1 of 87 focusable elements on the A-team page opts into the spec'd utility.
+
+**Fix.** Give each gated section a real `<h2>` inside its `PageContainer`, add `aria-current` to the section nav, and decide whether the focus ring is opt-in per element or a base-layer default (site-wide question — see #2530).
+
+**Suggested command:** `/impeccable harden`
+
+## Persona Red Flags
+
+**Wendy, mother of a U8, checking training times on a Thursday evening** (project-specific, derived from PRODUCT.md's second primary audience). Her task fails completely and every step is measured: `/ploegen/kcvve-u8` has no training schedule (`TeamEditorial` renders on 0 of 16 teams), no contact block, no fixtures section. The section nav offers exactly two links. Staff is three cards, **two of which read `STAF`** — she cannot tell which one is the trainer, and there is no phone or email. The largest, most prominent band on her child's page is **"Word lid — Sluit je aan bij de jeugd van Elewijt"** at display-lg on jersey-deep. Her child joined last season. Following "Volledige kalender →" gives "GEEN WEDSTRIJDEN GEPLAND." and no way back. She leaves with nothing, having been sold a membership she already has.
+
+**Casey (distracted mobile, sideline).** "Volledige kalender →" measures **19.25px tall** with zero vertical padding — the only route to the full fixture list. Section-nav links measure **27px**. On `/ploegen/eerste-elftallen-a` at 390px the same fixture (`12 aug · VK Ninove · 20:00`) renders twice inside the first ~600px — once in `MatchStripSlot`, once as "Eerstvolgende". The competition caption under every score is 9px; on the A-team page **53 elements render `#6b6b6b` at ≤11px, 42 of them at 9px**. In daylight that line is gone. And `/ploegen/eerste-elftallen-a/wedstrijden` overflows horizontally by **31px** at 390px, traced to two elements in the `sm:hidden` mobile row (`TeamAgendaRow.tsx:392` and `:423-428`).
+
+**Sam (screen reader / keyboard).** Navigating by heading on a team page goes team name → position group → _sponsors_; the three sections the nav advertises never appear. No `aria-current`, so activating an anchor gives no confirmation of position. No focus style on the section nav.
+
+**Jordan (confused first-timer).** Clicks `A-PLOEG` in the nav and lands on a page headed "A-ploeg."; clicks `Reserven` from `/ploegen` and lands on **another page headed "A-ploeg."** He concludes he has not navigated. The tab says "Eerste Elftallen A", the heading says "A-ploeg.", the share card says "Eerste Elftallen A".
+
+**Riley (edge-case stress tester).** `/ploegen/kcvve-u10p` has `squad = 0`, an `<h1>` duplicating `kcvve-u10`, and is still a tappable card on `/ploegen`. The A-team fixture list publishes **"KCVV Elewijt — 19:00 — KCVV Elewijt"** on 22 Aug as a clickable row (known pitch-reservation data, published unqualified). The sticky nav stays pinned at `top: 64px` while the site footer is on screen.
+
+## Minor Observations
+
+- **`Reserven` — a senior side — is filed under `<h2>Jeugdwerking</h2>`** on `/ploegen`, as the _first_ group above Bovenbouw.
+- **Every youth card carries a redundant second line.** `YouthDirectory.tsx:108-113` gates the sub-line on a comparison that is true for all 16 cards because every name carries the "KCVVE " prefix. 13 cards repeat the caption, 1 contradicts it, only 2 are load-bearing — and for those 2 the discriminator sits at 10px under a 24px display line. The hierarchy is exactly inverted.
+- **The hero meta pill and the tagline render verbatim identical strings** — `"3e Nationale VV A"` twice on the A-team, `"Reserven VV AH"` twice on Reserven.
+- **The "Seizoen" ticket stub never renders for senior teams**: `season` is null on all of them, so one of the hero's most characterful artefacts is invisible on the club's three most-visited pages.
+- **Five team `<title>`s carry a double space** (`KCVVE  U15`, `KCVVE  U13`, `KCVVE  U11 `, `KCVVE  U9`, `KCVVE  U6`) — stray whitespace in the Sanity `name` field.
+- **Zero eager images across all six pages.** No `next/image` `priority` anywhere on this surface; every LCP candidate is `loading="lazy"` with no `fetchpriority`.
+- **Loading-skeleton parity, four defects.** `[slug]/loading.tsx:73` draws a `rounded-full h-16 w-16` circle where `PlayerCard.tsx:37` renders an `aspect-[3/4]` rectangle — a staff-card shape standing in for a squad card, breaking the sharp-corner rule too. `:49` uses `border-y-2` where `TeamSectionNav.tsx:31` deliberately dropped the top border. `:51` renders 4 nav pills where real pages render 2–3. And `ploegen/loading.tsx:43` draws youth cards at `h-20`/`minmax(120px,1fr)` against a measured real card of 212px at `minmax(150px,1fr)`.
+- **`ploegen/loading.tsx` uses bare `animate-pulse`** (lines 10, 25, 36) while its sibling `[slug]/loading.tsx` correctly uses `motion-safe:animate-pulse`.
+- **Sticky chrome overlaps its own anchors.** Header 65px + section nav 47.75px = 112.75px against a `scroll-margin-top` of 104px at five sites, so an anchor jump lands ~8px behind the bar. The nav also sits 1px under the header.
+- **`#ffffff` is the one off-palette colour** in `<main>` (11× on the A-team page), used as `text-white` on jersey-deep — the open reconciliation already tracked in #2421.
+- **IBM Plex Mono renders nowhere** (`document.fonts.check` false on all six pages; 43–210 `.font-mono` elements per page fall back to the system stack). Site-wide, already owned by #2533 / #2520 — recorded here only because every type judgement on this surface is currently made against the wrong face.
+- **`StandingsTable` has no `<caption>` and no visible heading** — only `role="region" aria-label="Klassement"`. When it does start rendering it will land as an unheaded table under a nav link.
+- **`auto-fill` leaves ragged tracks**: at 1372px the youth grid computes 7 columns; the `Reserven` group holds 1 card and ~1050px of empty page.
+- **Ruled out, not findings.** Section anchors and `AgendaScrollToNext` do work — smooth scroll is throttled while the extension backgrounds the tab. The "blank" flagship photos in early captures were pre-paint artefacts. Zero site-origin console errors on all six pages. No off-palette neutral grey: `#6b6b6b` is the palette's own `ink-muted`.
+
+## Questions to Consider
+
+1. DESIGN.md deleted four nav dropdowns on the argument that in-page section anchors on `/ploegen/[slug]` index the page better than a transient panel could. That index measures 3 links on a senior page and 2 on a youth page, with no active state, and the nav has no `/ploegen` entry to reach the index that would list them. Is the claim still true, or was it true only of the page the PRD imagined?
+2. PRODUCT principle #3 says "a layout that needs a field the source may omit is a broken layout." `SquadGrid` needs four position values and PSD supplies one for 24 of 29; `TeamEditorial` needs a training schedule and Sanity has none for any team; `StandingsTable` needs a table and none exists anywhere. By the project's own rule, are these three broken layouts — or is the content pipeline the unfinished deliverable and the components innocent?
+3. The homepage refuses to rank its two audiences and defends the refusal at length (principle #6). The team page ranks them by omission: senior pages get fixtures, youth pages get a recruitment ad. What is the youth team page's tail?
+4. `page.tsx:8` describes the auto-hide as degrading gracefully. A U6 page showing squad, staff and a sales pitch — with no trace of the fixtures, table, training times or contact a first-team page implies exist — reads as unbuilt, not degraded. Would one line of paper-register copy per absent section cost anything the design cares about?
+5. Three of sixteen team pages ship a heading naming a different team and no test caught it. `nav-reachability.test.ts` guards that every nav destination resolves; nothing guards that every destination is distinguishable. Is `<h1>` uniqueness across a route family a design invariant worth a test, or is that the CMS's problem?

--- a/docs/design/mockups/2508-motion-speeds/index.html
+++ b/docs/design/mockups/2508-motion-speeds/index.html
@@ -1,0 +1,1029 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>#2508 — the five speeds, in a natural environment</title>
+    <link rel="stylesheet" href="https://use.typekit.net/cvo5raz.css" />
+    <style>
+      /* ==========================================================
+         Real tokens, copied from apps/web/src/app/globals.css.
+         Do not invent values here — this page is a measuring tool.
+         ========================================================== */
+      :root {
+        --cream: #f5f1e6;
+        --cream-soft: #ede8da;
+        --cream-deep: #e1d7bf;
+        --ink: #0a0a0a;
+        --ink-soft: #1f1f1f;
+        --ink-muted: #6b6b6b;
+        --jersey: #4acf52;
+        --jersey-deep: #007c46;
+        --jersey-bright: #22c55e;
+        --warm: #f0c264;
+        --card-red: #c93f1c;
+        --paper-edge: #d9d2bd;
+
+        --shadow-paper-sm: 4px 4px 0 0 #0a0a0a;
+        --shadow-paper-md: 6px 6px 0 0 #0a0a0a;
+        --shadow-paper-lift: 8px 8px 0 0 #0a0a0a;
+        --shadow-paper-sm-soft: 4px 4px 0 0 #6b6b6b;
+
+        --font-body:
+          "freight-sans-pro", -apple-system, system-ui, "Segoe UI", Roboto,
+          sans-serif;
+        --font-display:
+          "freight-big-pro", georgia, "Times New Roman", serif;
+
+        /* Q2 picked one ease-out curve. Round 1 pinned it to the site's
+           reveal curve, cubic-bezier(0.22, 1, 0.36, 1) — easeOutQuint.
+           That curve front-loads ~90% of the travel into the first
+           quarter of the time, so on a 4px move it HIDES duration.
+           SETTLED (Q5): plain ease-out. Duration reads through it, and it
+           responds instantly to the pointer. Quint is REJECTED; it stays on
+           the switcher only as evidence. */
+        --ease: cubic-bezier(0, 0, 0.58, 1);
+
+        /* Q1 is what this page is for. The switcher writes here. */
+        --speed: 300ms;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--cream);
+        color: var(--ink);
+        font-family: var(--font-body);
+        font-size: 17px;
+        line-height: 1.5;
+      }
+      h1,
+      h2,
+      h3 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        margin: 0;
+        line-height: 1.05;
+      }
+      p {
+        margin: 0 0 1em;
+      }
+      .wrap {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 0 24px;
+      }
+      .mono {
+        font-family: "Consolas", "Liberation Mono", monospace;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-weight: 700;
+      }
+
+      /* ---------- sticky switcher ---------- */
+      .bar {
+        position: sticky;
+        top: 0;
+        z-index: 40;
+        background: var(--ink);
+        color: var(--cream);
+        border-bottom: 2px solid var(--ink);
+      }
+      .bar .wrap {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: center;
+        padding-top: 14px;
+        padding-bottom: 14px;
+      }
+      .bar .mono {
+        color: var(--cream-deep);
+      }
+      .speeds {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .speeds button {
+        font-family: inherit;
+        font-size: 14px;
+        font-weight: 700;
+        cursor: pointer;
+        padding: 7px 14px;
+        border: 2px solid var(--cream);
+        border-radius: 0;
+        background: transparent;
+        color: var(--cream);
+        transition: background-color 150ms var(--ease), color 150ms var(--ease);
+      }
+      .speeds button:hover {
+        background: var(--cream);
+        color: var(--ink);
+      }
+      .speeds button[aria-pressed="true"] {
+        background: var(--jersey-deep);
+        border-color: var(--jersey-deep);
+        color: #fff;
+      }
+
+      /* ---------- page furniture ---------- */
+      header.intro {
+        padding: 48px 0 32px;
+      }
+      header.intro h1 {
+        font-size: clamp(34px, 5vw, 54px);
+        margin-bottom: 14px;
+      }
+      header.intro p,
+      header.intro ul {
+        max-width: 680px;
+        color: var(--ink-soft);
+      }
+      header.intro ul {
+        padding-left: 20px;
+        margin: 0 0 1em;
+      }
+      header.intro li {
+        margin-bottom: 6px;
+      }
+      code {
+        font-family: "Consolas", "Liberation Mono", monospace;
+        font-size: 0.88em;
+        background: var(--cream-deep);
+        padding: 1px 5px;
+      }
+      section {
+        padding: 40px 0 56px;
+        border-top: 2px solid var(--ink);
+      }
+      .sec-head {
+        margin-bottom: 28px;
+      }
+      .sec-head h2 {
+        font-size: 30px;
+        margin-bottom: 8px;
+      }
+      .sec-head p {
+        max-width: 680px;
+        color: var(--ink-soft);
+        margin: 0;
+      }
+      .kicker {
+        color: var(--jersey-deep);
+        display: block;
+        margin-bottom: 8px;
+      }
+
+      /* ==========================================================
+         §1  NATURAL ENVIRONMENT
+         Everything below runs at var(--speed).
+         ========================================================== */
+      .env {
+        position: relative;
+        overflow: hidden;
+        border: 2px solid var(--ink);
+        background: var(--cream);
+        box-shadow: var(--shadow-paper-md);
+      }
+
+      /* ---- the drawer: 320px of real travel ----
+         Small moves cannot show duration. This one can. */
+      .scrim {
+        position: absolute;
+        inset: 0;
+        z-index: 5;
+        background: rgba(10, 10, 10, 0.55);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity var(--speed) var(--ease);
+      }
+      .env.open .scrim {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .drawer {
+        position: absolute;
+        z-index: 6;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: min(320px, 82%);
+        padding: 26px 24px;
+        background: var(--cream);
+        border-left: 2px solid var(--ink);
+        transform: translateX(100%);
+        transition: transform var(--speed) var(--ease);
+      }
+      .env.open .drawer {
+        transform: translateX(0);
+      }
+      .drawer h3 {
+        font-size: 24px;
+        margin-bottom: 18px;
+      }
+      .drawer a {
+        display: block;
+        color: var(--ink);
+        text-decoration: none;
+        font-weight: 700;
+        font-size: 19px;
+        padding: 9px 0;
+        border-bottom: 2px solid var(--paper-edge);
+      }
+      .menu-btn {
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding: 7px 13px;
+        border: 2px solid var(--cream);
+        background: transparent;
+        color: var(--cream);
+        cursor: pointer;
+        border-radius: 0;
+      }
+
+      /* site nav — the 150ms chrome job */
+      .env-nav {
+        display: flex;
+        align-items: center;
+        gap: 26px;
+        padding: 16px 22px;
+        background: var(--ink);
+        flex-wrap: wrap;
+      }
+      .env-nav .brand {
+        font-family: var(--font-display);
+        color: var(--cream);
+        font-size: 20px;
+        font-weight: 700;
+        margin-right: auto;
+      }
+      .env-nav a {
+        color: var(--cream-deep);
+        text-decoration: none;
+        font-weight: 700;
+        font-size: 15px;
+        border-bottom: 2px solid transparent;
+        padding-bottom: 2px;
+        transition:
+          color var(--speed) var(--ease),
+          border-color var(--speed) var(--ease);
+      }
+      .env-nav a:hover {
+        color: #fff;
+        border-bottom-color: var(--jersey);
+      }
+
+      .env-body {
+        padding: 26px 22px 32px;
+      }
+
+      /* chips — the other 150ms chrome job */
+      .chips {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-bottom: 26px;
+      }
+      .chip {
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding: 6px 13px;
+        border: 2px solid var(--ink);
+        background: var(--cream-soft);
+        color: var(--ink);
+        cursor: pointer;
+        border-radius: 0;
+        transition:
+          background-color var(--speed) var(--ease),
+          color var(--speed) var(--ease);
+      }
+      .chip:hover,
+      .chip[aria-pressed="true"] {
+        background: var(--jersey-deep);
+        color: #fff;
+      }
+
+      /* news cards — the 300ms press-down job */
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 22px;
+        margin-bottom: 34px;
+      }
+      .card {
+        display: block;
+        text-decoration: none;
+        color: inherit;
+        background: var(--cream-soft);
+        border: 2px solid var(--ink);
+        box-shadow: var(--shadow-paper-md);
+        padding: 0 0 18px;
+        /* THE PRESS-DOWN — PRESS_DOWN_CLASSES, at var(--speed) */
+        transition:
+          transform var(--speed) var(--ease),
+          box-shadow var(--speed) var(--ease);
+      }
+      .card:hover {
+        transform: translate(4px, 4px);
+        box-shadow: none;
+      }
+      .card .photo {
+        height: 132px;
+        border-bottom: 2px solid var(--ink);
+        background: repeating-linear-gradient(
+          135deg,
+          var(--cream-deep) 0 12px,
+          var(--paper-edge) 12px 24px
+        );
+      }
+      .card .meta {
+        padding: 14px 16px 0;
+      }
+      .card h3 {
+        font-size: 21px;
+        margin: 6px 0 0;
+      }
+
+      /* timeline reveal — the 500ms entering job */
+      .reveal-head {
+        display: flex;
+        align-items: baseline;
+        gap: 16px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
+      .replay {
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        padding: 7px 14px;
+        border: 2px solid var(--ink);
+        background: var(--warm);
+        color: var(--ink);
+        cursor: pointer;
+        border-radius: 0;
+        box-shadow: var(--shadow-paper-sm);
+        transition:
+          transform 150ms var(--ease),
+          box-shadow 150ms var(--ease);
+      }
+      .replay:hover {
+        transform: translate(4px, 4px);
+        box-shadow: none;
+      }
+      .timeline {
+        border-left: 2px solid var(--ink);
+        padding-left: 26px;
+        display: grid;
+        gap: 18px;
+      }
+      .t-row {
+        position: relative;
+        opacity: 0;
+        transition: opacity var(--speed) var(--ease);
+      }
+      .t-row .bullet {
+        position: absolute;
+        left: -34px;
+        top: 12px;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: 2px solid var(--ink);
+        background: var(--cream);
+        transition: background-color var(--speed) var(--ease);
+      }
+      .t-card {
+        border: 2px solid var(--ink);
+        background: var(--cream-soft);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 13px 16px;
+        transform: translateX(-22px);
+        transition: transform var(--speed) var(--ease);
+      }
+      .t-row.in {
+        opacity: 1;
+      }
+      .t-row.in .t-card {
+        transform: translateX(0);
+      }
+      .t-row.in .bullet {
+        background: var(--jersey-deep);
+      }
+      .t-row:nth-child(2) .t-card,
+      .t-row:nth-child(2) {
+        transition-delay: 90ms;
+      }
+      .t-row:nth-child(3) .t-card,
+      .t-row:nth-child(3) {
+        transition-delay: 180ms;
+      }
+      .t-row:nth-child(4) .t-card,
+      .t-row:nth-child(4) {
+        transition-delay: 270ms;
+      }
+
+      /* ==========================================================
+         §2  SIDE BY SIDE — same card, all five speeds at once
+         ========================================================== */
+      .rail {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(178px, 1fr));
+        gap: 20px;
+      }
+      .lane {
+        display: grid;
+        gap: 10px;
+        align-content: start;
+      }
+      .lane-label {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+      }
+      .lane-label .n {
+        font-family: var(--font-display);
+        font-size: 27px;
+        font-weight: 700;
+      }
+      .lane-label .who {
+        color: var(--ink-muted);
+        font-size: 12px;
+        line-height: 1.25;
+      }
+      .swatch {
+        border: 2px solid var(--ink);
+        background: var(--cream-soft);
+        box-shadow: var(--shadow-paper-md);
+        padding: 16px;
+        min-height: 108px;
+        cursor: pointer;
+        transition:
+          transform var(--d) var(--ease),
+          box-shadow var(--d) var(--ease),
+          background-color var(--d) var(--ease);
+      }
+      .swatch:hover {
+        transform: translate(4px, 4px);
+        box-shadow: none;
+        background: var(--warm);
+      }
+      .swatch strong {
+        font-family: var(--font-display);
+        font-size: 19px;
+        display: block;
+      }
+      .swatch span {
+        color: var(--ink-muted);
+        font-size: 13px;
+      }
+      .lane[data-today] .swatch {
+        border-style: dashed;
+      }
+
+      /* ==========================================================
+         §3  LOOPS — reference only. Q3 is settled.
+         ========================================================== */
+      .loops {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 26px;
+      }
+      .loop-card {
+        border: 2px solid var(--ink);
+        background: var(--cream-soft);
+        box-shadow: var(--shadow-paper-sm);
+        padding: 20px;
+      }
+      .loop-card .mono {
+        color: var(--ink-muted);
+        display: block;
+        margin-bottom: 14px;
+      }
+
+      @keyframes kcvv-scarf-scroll {
+        0% {
+          background-position: 0 0;
+        }
+        100% {
+          background-position: 80px 0;
+        }
+      }
+      .scarf {
+        position: relative;
+        display: inline-block;
+        overflow: hidden;
+        width: 180px;
+        height: 28px;
+        border: 2px solid var(--ink);
+        background: var(--cream);
+        box-shadow: var(--shadow-paper-sm);
+      }
+      .scarf::before {
+        content: "";
+        position: absolute;
+        inset: -200px;
+        transform: rotate(-45deg);
+        animation: kcvv-scarf-scroll 1.5s linear infinite;
+        background: repeating-linear-gradient(
+          90deg,
+          var(--jersey) 0px,
+          var(--jersey) 20px,
+          var(--cream) 20px,
+          var(--cream) 40px,
+          var(--ink) 40px,
+          var(--ink) 60px,
+          var(--cream) 60px,
+          var(--cream) 80px
+        );
+      }
+
+      @keyframes kcvv-spinner-dot-pulse {
+        0%,
+        80%,
+        100% {
+          opacity: 0.2;
+          transform: scale(0.85);
+        }
+        40% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+      .dots {
+        display: inline-flex;
+        gap: 4px;
+        align-items: center;
+      }
+      .dots span {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--jersey-deep);
+        animation: kcvv-spinner-dot-pulse 1.2s ease-in-out infinite;
+      }
+      .dots span:nth-child(2) {
+        animation-delay: 0.15s;
+      }
+      .dots span:nth-child(3) {
+        animation-delay: 0.3s;
+      }
+
+      @keyframes tw-pulse {
+        50% {
+          opacity: 0.5;
+        }
+      }
+      .skel {
+        display: grid;
+        gap: 9px;
+      }
+      .skel i {
+        display: block;
+        height: 13px;
+        background: var(--cream-deep);
+        border: 2px solid var(--paper-edge);
+        animation: tw-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+      }
+      .skel i:nth-child(2) {
+        width: 82%;
+      }
+      .skel i:nth-child(3) {
+        width: 61%;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .scarf::before,
+        .dots span,
+        .skel i {
+          animation: none;
+        }
+      }
+
+      /* ---------- verdict box ---------- */
+      .verdict {
+        border: 2px solid var(--ink);
+        background: var(--warm);
+        box-shadow: var(--shadow-paper-md);
+        padding: 24px 26px;
+        margin-bottom: 8px;
+      }
+      .verdict h2 {
+        font-size: 25px;
+        margin-bottom: 12px;
+      }
+      .verdict ol {
+        margin: 0;
+        padding-left: 22px;
+      }
+      .verdict li {
+        margin-bottom: 7px;
+      }
+      footer {
+        border-top: 2px solid var(--ink);
+        padding: 26px 0 60px;
+        color: var(--ink-muted);
+        font-size: 14px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="bar">
+      <div class="wrap">
+        <span class="mono">Speed</span>
+        <div class="speeds" id="speeds">
+          <button data-speed="150ms">150</button>
+          <button data-speed="240ms">240</button>
+          <button data-speed="300ms" aria-pressed="true">300</button>
+          <button data-speed="500ms">500</button>
+          <button data-speed="mixed">as today</button>
+        </div>
+        <span class="mono">Curve</span>
+        <div class="speeds" id="curves">
+          <button data-ease="linear">linear</button>
+          <button data-ease="cubic-bezier(0, 0, 0.58, 1)" aria-pressed="true">
+            ease-out ✓
+          </button>
+          <button data-ease="cubic-bezier(0.22, 1, 0.36, 1)">
+            quint (rejected)
+          </button>
+        </div>
+        <span class="mono" id="readout" style="color: var(--warm)"
+          >300ms · ease-out</span
+        >
+      </div>
+    </div>
+
+    <div class="wrap">
+      <header class="intro">
+        <span class="mono kicker">#2508 · Q1 · one page, five speeds</span>
+        <h1>How fast should this site move?</h1>
+        <p>
+          The site uses five speeds today and writes none of them down. Change
+          the speed at the top. Then hover the nav, hover a card, press a chip,
+          and replay the timeline. Judge how it <em>feels</em>, not what the
+          number says.
+        </p>
+        <p>
+          <strong>Round 2 fix.</strong> The first version of this page locked
+          the curve to <code>cubic-bezier(0.22, 1, 0.36, 1)</code> — the Q2
+          pick. Every speed felt the same, and that was the page's fault: that
+          curve puts about 90% of the travel in the first quarter of the time,
+          so on a 4px press-down the rest is invisible. Two things are new:
+        </p>
+        <ul>
+          <li>
+            <strong>A curve switch</strong>, top right. Try
+            <code>linear</code> first — speed becomes obvious. Then switch back
+            to <code>quint</code> and watch it disappear again.
+          </li>
+          <li>
+            <strong>A drawer</strong> in the strip below (the
+            <em>Menu ▸</em> button). It travels 320px, not 4px. Duration is
+            unmissable there.
+          </li>
+        </ul>
+        <p>
+          If speed only reads on the drawer and never on a hover, that is not a
+          broken test — that is the answer.
+        </p>
+      </header>
+    </div>
+
+    <!-- ================= §1 NATURAL ENVIRONMENT ================= -->
+    <section>
+      <div class="wrap">
+        <div class="sec-head">
+          <span class="mono kicker">§1 — natural environment</span>
+          <h2>A page, not a swatch</h2>
+          <p>
+            Four real jobs on one strip: nav links (chrome), filter chips
+            (chrome), news cards (the press-down), and a timeline (something
+            entering the screen). All of them run at the speed you picked above.
+          </p>
+        </div>
+
+        <div class="env">
+          <nav class="env-nav">
+            <span class="brand">KCVV ELEWIJT</span>
+            <a href="#">Nieuws</a>
+            <a href="#">Ploegen</a>
+            <a href="#">Kalender</a>
+            <a href="#">Club</a>
+            <button class="menu-btn" id="menu-open">Menu ▸</button>
+          </nav>
+
+          <div class="scrim" id="scrim"></div>
+          <aside class="drawer">
+            <h3>Menu</h3>
+            <a href="#">Nieuws</a>
+            <a href="#">Ploegen</a>
+            <a href="#">Kalender</a>
+            <a href="#">Club</a>
+            <a href="#">Sponsors</a>
+            <button
+              class="replay"
+              id="menu-close"
+              style="margin-top: 20px; background: var(--cream-deep)"
+            >
+              Sluiten ✕
+            </button>
+          </aside>
+
+          <div class="env-body">
+            <div class="chips">
+              <button class="chip" aria-pressed="true">Alles</button>
+              <button class="chip">Eerste elftal</button>
+              <button class="chip">Jeugd</button>
+              <button class="chip">Club</button>
+            </div>
+
+            <div class="cards">
+              <a class="card" href="#">
+                <div class="photo"></div>
+                <div class="meta">
+                  <span class="mono" style="color: var(--jersey-deep)"
+                    >Wedstrijdverslag</span
+                  >
+                  <h3>Drie punten in de slotminuut</h3>
+                </div>
+              </a>
+              <a class="card" href="#">
+                <div class="photo"></div>
+                <div class="meta">
+                  <span class="mono" style="color: var(--jersey-deep)"
+                    >Jeugd</span
+                  >
+                  <h3>U15 wint de derby</h3>
+                </div>
+              </a>
+              <a class="card" href="#">
+                <div class="photo"></div>
+                <div class="meta">
+                  <span class="mono" style="color: var(--jersey-deep)"
+                    >Club</span
+                  >
+                  <h3>Kantine krijgt nieuwe toog</h3>
+                </div>
+              </a>
+            </div>
+
+            <div class="reveal-head">
+              <span class="mono">Timeline — something entering the screen</span>
+              <button class="replay" id="replay">Replay ↻</button>
+            </div>
+            <div class="timeline" id="timeline">
+              <div class="t-row">
+                <span class="bullet"></span>
+                <div class="t-card"><strong>1909</strong> — de eerste ploeg</div>
+              </div>
+              <div class="t-row">
+                <span class="bullet"></span>
+                <div class="t-card"><strong>1966</strong> — eigen terrein</div>
+              </div>
+              <div class="t-row">
+                <span class="bullet"></span>
+                <div class="t-card"><strong>1994</strong> — de fusie</div>
+              </div>
+              <div class="t-row">
+                <span class="bullet"></span>
+                <div class="t-card"><strong>2018</strong> — nieuwe kantine</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= §2 SIDE BY SIDE ================= -->
+    <section>
+      <div class="wrap">
+        <div class="sec-head">
+          <span class="mono kicker">§2 — side by side</span>
+          <h2>The same card, five speeds at once</h2>
+          <p>
+            Drag your pointer across all five without stopping. The switcher
+            above does not touch this row — each lane is pinned to its own
+            speed. The dashed lane is what the site does today.
+          </p>
+        </div>
+
+        <div class="rail">
+          <div class="lane" style="--d: 150ms">
+            <div class="lane-label">
+              <span class="n">150</span
+              ><span class="who">chrome<br />9 uses</span>
+            </div>
+            <div class="swatch">
+              <strong>Hover me</strong><span>150ms</span>
+            </div>
+          </div>
+          <div class="lane" style="--d: 240ms">
+            <div class="lane-label">
+              <span class="n">240</span
+              ><span class="who">organigram<br />2 uses</span>
+            </div>
+            <div class="swatch">
+              <strong>Hover me</strong><span>240ms</span>
+            </div>
+          </div>
+          <div class="lane" style="--d: 300ms">
+            <div class="lane-label">
+              <span class="n">300</span
+              ><span class="who">the press-down<br />44 uses</span>
+            </div>
+            <div class="swatch">
+              <strong>Hover me</strong><span>300ms</span>
+            </div>
+          </div>
+          <div class="lane" style="--d: 500ms">
+            <div class="lane-label">
+              <span class="n">500</span
+              ><span class="who">scroll reveals<br />4 uses</span>
+            </div>
+            <div class="swatch">
+              <strong>Hover me</strong><span>500ms</span>
+            </div>
+          </div>
+          <div class="lane" data-today style="--d: 150ms">
+            <div class="lane-label">
+              <span class="n">?</span
+              ><span class="who"
+                >no duration set<br />67 of 121 transitions</span
+              >
+            </div>
+            <div class="swatch">
+              <strong>Hover me</strong
+              ><span>Tailwind default — 150ms</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= §3 LOOPS ================= -->
+    <section>
+      <div class="wrap">
+        <div class="sec-head">
+          <span class="mono kicker">§3 — loops · already settled (Q3)</span>
+          <h2>The three things that loop</h2>
+          <p>
+            Not a choice — shown so the speed you pick sits next to what already
+            runs forever. All three mean the same thing: the system is busy.
+          </p>
+        </div>
+
+        <div class="loops">
+          <div class="loop-card">
+            <span class="mono">Scarf · 1.5s · linear</span>
+            <div class="scarf"></div>
+          </div>
+          <div class="loop-card">
+            <span class="mono">Dots · 1.2s · ease-in-out</span>
+            <div class="dots"><span></span><span></span><span></span></div>
+          </div>
+          <div class="loop-card">
+            <span class="mono">Skeleton · 2s · Tailwind default · 109 uses</span>
+            <div class="skel"><i></i><i></i><i></i></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= VERDICT ================= -->
+    <section>
+      <div class="wrap">
+        <div class="verdict">
+          <h2>What to look for — in this order</h2>
+          <ol>
+            <li>
+              Set curve to <strong>linear</strong>. Open the
+              <strong>drawer</strong> at 150ms, then at 500ms. That is the full
+              range this site could ever use.
+            </li>
+            <li>
+              Stay on <strong>linear</strong>. Now hover a card at 150ms and at
+              500ms. Can you feel it on a 4px move?
+            </li>
+            <li>
+              Switch back to <strong>quint</strong>. Repeat both. How much of
+              the difference survives the curve?
+            </li>
+            <li>
+              Last: can you tell <strong>240 from 300</strong> anywhere at all?
+              If not, 240 does not deserve a name.
+            </li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <div class="wrap">
+        Working file for
+        <strong
+          >#2508 — Write DESIGN.md's Motion section</strong
+        >, under map #2506. Tokens copied from
+        <code>apps/web/src/app/globals.css</code>. Not a shipped page.
+      </div>
+    </footer>
+
+    <script>
+      // ---- speed switcher ----
+      const MIXED = {
+        nav: "150ms",
+        chip: "150ms",
+        card: "300ms",
+        reveal: "500ms",
+      };
+      const readout = document.getElementById("readout");
+      let curSpeed = "300ms";
+      let curCurve = "ease-out";
+      const say = () => (readout.textContent = curSpeed + " · " + curCurve);
+
+      // ---- curve switcher (this is the real finding) ----
+      const curves = document.getElementById("curves");
+      curves.addEventListener("click", (e) => {
+        const btn = e.target.closest("button[data-ease]");
+        if (!btn) return;
+        for (const b of curves.querySelectorAll("button"))
+          b.setAttribute("aria-pressed", String(b === btn));
+        document.documentElement.style.setProperty("--ease", btn.dataset.ease);
+        curCurve = btn.textContent.trim().split(" ")[0];
+        say();
+        replay();
+      });
+
+      // ---- drawer: 320px of travel, where duration is unmissable ----
+      const env = document.querySelector(".env");
+      document
+        .getElementById("menu-open")
+        .addEventListener("click", () => env.classList.add("open"));
+      for (const id of ["menu-close", "scrim"])
+        document
+          .getElementById(id)
+          .addEventListener("click", () => env.classList.remove("open"));
+
+      const speeds = document.getElementById("speeds");
+      speeds.addEventListener("click", (e) => {
+        const btn = e.target.closest("button[data-speed]");
+        if (!btn) return;
+        for (const b of speeds.querySelectorAll("button"))
+          b.setAttribute("aria-pressed", String(b === btn));
+        const v = btn.dataset.speed;
+        curSpeed = v === "mixed" ? "mixed" : v;
+        say();
+        if (v === "mixed") {
+          // each job back on its real, current value
+          env.style.setProperty("--speed", MIXED.card);
+          env.querySelector(".env-nav").style.setProperty("--speed", MIXED.nav);
+          env.querySelector(".chips").style.setProperty("--speed", MIXED.chip);
+          env
+            .querySelector(".timeline")
+            .style.setProperty("--speed", MIXED.reveal);
+        } else {
+          env.style.setProperty("--speed", v);
+          for (const el of env.querySelectorAll(".env-nav, .chips, .timeline"))
+            el.style.removeProperty("--speed");
+        }
+        replay();
+      });
+
+      // ---- timeline reveal: on scroll, and on demand ----
+      const timeline = document.getElementById("timeline");
+      const rows = [...timeline.querySelectorAll(".t-row")];
+      const io = new IntersectionObserver(
+        (entries) => {
+          for (const en of entries)
+            if (en.isIntersecting) en.target.classList.add("in");
+        },
+        { threshold: 0.4 },
+      );
+      for (const r of rows) io.observe(r);
+
+      function replay() {
+        for (const r of rows) r.classList.remove("in");
+        // one frame later so the browser re-runs the transition
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            for (const r of rows) r.classList.add("in");
+          }),
+        );
+      }
+      document.getElementById("replay").addEventListener("click", replay);
+    </script>
+  </body>
+</html>

--- a/docs/design/mockups/2512-outcome-word/index.html
+++ b/docs/design/mockups/2512-outcome-word/index.html
@@ -1,0 +1,932 @@
+<title>Outcome Mark Inventory</title>
+<style>
+  /* Single-theme on purpose: every row below has to render on the site's own
+     cream sheet to be honest, so the page commits to the KCVV palette and
+     paints every colour explicitly rather than following the viewer's theme. */
+  :root {
+    --cream: #f5f1e6;
+    --cream-soft: #ede8da;
+    --cream-deep: #e1d7bf;
+    --paper-edge: #d9d2bd;
+    --ink: #0a0a0a;
+    --ink-soft: #1f1f1f;
+    --ink-muted: #6b6b6b;
+    --jersey-deep: #007c46;
+    --alert: #b84a3a;
+    --warm: #f0c264;
+
+    --band-win: #a2c9b0;   /* color-mix(jersey-deep 34%, cream) */
+    --band-loss: #deb2a5;  /* color-mix(alert 38%, cream) */
+    --band-draw: #c6c3bc;  /* color-mix(ink-muted 34%, cream) — proposed */
+
+    /* Freight rides Adobe Typekit and cannot load here. Georgia stands in for
+       the display face; the shapes differ, the register does not. */
+    --display: Georgia, "Times New Roman", serif;
+    --body: system-ui, -apple-system, "Segoe UI", sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    padding: 0 20px 96px;
+    background: var(--cream);
+    color: var(--ink);
+    font-family: var(--body);
+    font-size: 16px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 1000px; margin: 0 auto; }
+
+  /* ── masthead ─────────────────────────────────────────────── */
+
+  .masthead {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 56px 0 28px;
+    border-bottom: 2px solid var(--ink);
+  }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+  }
+  .masthead h1 {
+    margin: 0;
+    font-family: var(--display);
+    font-size: clamp(30px, 5vw, 46px);
+    font-style: italic;
+    font-weight: 700;
+    line-height: 1.04;
+    text-wrap: balance;
+  }
+  .standfirst {
+    margin: 0;
+    max-width: 62ch;
+    font-size: 17px;
+    color: var(--ink-soft);
+  }
+  .masthead a { color: var(--jersey-deep); }
+
+  /* ── the rule ─────────────────────────────────────────────── */
+
+  .rule {
+    margin: 40px 0 0;
+    padding: 24px 26px;
+    background: var(--cream-soft);
+    border: 2px solid var(--ink);
+    box-shadow: 6px 6px 0 0 var(--ink);
+  }
+  .rule p {
+    margin: 0;
+    font-family: var(--display);
+    font-size: clamp(19px, 2.6vw, 25px);
+    font-style: italic;
+    line-height: 1.34;
+    text-wrap: balance;
+  }
+  .rule .src {
+    margin-top: 14px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    color: var(--ink-muted);
+    font-style: normal;
+  }
+
+  /* ── section headings ─────────────────────────────────────── */
+
+  h2 {
+    margin: 64px 0 6px;
+    font-family: var(--display);
+    font-size: 27px;
+    font-style: italic;
+    font-weight: 700;
+    line-height: 1.15;
+  }
+  .lede {
+    margin: 0 0 26px;
+    max-width: 66ch;
+    color: var(--ink-soft);
+  }
+  .lede code, .cell code, .note code {
+    font-family: var(--mono);
+    font-size: 0.86em;
+    background: var(--cream-deep);
+    padding: 1px 4px;
+  }
+
+  /* ── band swatches ────────────────────────────────────────── */
+
+  .swatches {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: 16px;
+  }
+  .swatch {
+    border: 2px solid var(--ink);
+    background: var(--cream);
+    padding: 20px 18px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .swatch .demo {
+    font-family: var(--display);
+    font-size: 26px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    align-self: flex-start;
+    padding: 0 6px;
+  }
+  .swatch dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 2px 12px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--ink-muted);
+  }
+  .swatch dt { letter-spacing: 0.06em; text-transform: uppercase; }
+  .swatch dd { margin: 0; color: var(--ink); font-variant-numeric: tabular-nums; }
+  .swatch h3 {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+  .new {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 6px;
+    background: var(--warm);
+    border: 1px solid var(--ink);
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    vertical-align: 2px;
+  }
+
+  /* ── surface cards ────────────────────────────────────────── */
+
+  .surface {
+    margin-top: 34px;
+    border: 2px solid var(--ink);
+    background: var(--cream);
+  }
+  .surface > header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px 14px;
+    padding: 16px 20px;
+    border-bottom: 2px solid var(--ink);
+    background: var(--cream-soft);
+  }
+  .surface h3 {
+    margin: 0;
+    font-family: var(--display);
+    font-size: 21px;
+    font-style: italic;
+    font-weight: 700;
+  }
+  .where {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    color: var(--ink-muted);
+  }
+  .verdict {
+    margin-left: auto;
+    padding: 3px 10px;
+    border: 1px solid var(--ink);
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .verdict.keep { background: transparent; color: var(--ink-muted); }
+  .verdict.change { background: var(--warm); }
+
+  .panes {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+  @media (min-width: 780px) {
+    .panes.two { grid-template-columns: 1fr 1fr; }
+  }
+  .pane { padding: 20px; }
+  .panes.two .pane + .pane { border-top: 2px dashed var(--paper-edge); }
+  @media (min-width: 780px) {
+    .panes.two .pane + .pane {
+      border-top: 0;
+      border-left: 2px dashed var(--paper-edge);
+    }
+  }
+  .pane > h4 {
+    margin: 0 0 4px;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+  }
+  .pane > .note {
+    margin: 0 0 16px;
+    font-size: 13px;
+    color: var(--ink-soft);
+    max-width: 46ch;
+  }
+
+  /* a labelled viewport frame around the rendered rows */
+  .frame {
+    border: 1px dashed var(--paper-edge);
+    padding: 12px;
+    overflow-x: auto;
+  }
+  .frame > .vp {
+    display: block;
+    margin-bottom: 10px;
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+  }
+  .stack { display: flex; flex-direction: column; gap: 8px; }
+  .phone { width: 344px; }
+  .desk { width: 600px; }
+
+  /* ── rendered row primitives ──────────────────────────────── */
+
+  .band { padding: 0 6px; }
+  .band.win  { box-shadow: inset 0 -9px 0 var(--band-win); }
+  .band.loss { box-shadow: inset 0 -9px 0 var(--band-loss); }
+  .band.draw { box-shadow: inset 0 -9px 0 var(--band-draw); }
+  .band.none { box-shadow: none; }
+  /* the drifted /kalender copy: -4px, full strength, no cream mix */
+  .band.drift-win  { box-shadow: inset 0 -4px 0 var(--jersey-deep); padding: 0 4px; }
+  .band.drift-loss { box-shadow: inset 0 -4px 0 var(--alert); padding: 0 4px; }
+  .band.drift-none { box-shadow: none; padding: 0 4px; }
+
+  .crest {
+    width: 22px; height: 22px; flex: none;
+    border: 1px solid var(--ink);
+    border-radius: 50%;
+    display: grid; place-items: center;
+    font-family: var(--mono); font-size: 8px; font-weight: 700;
+    background: var(--cream-deep);
+  }
+  .crest.sm { width: 18px; height: 18px; font-size: 7px; }
+
+  /* card row — <TeamAgendaRow> */
+  .agendarow {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 12px;
+    background: var(--cream);
+    border: 2px solid var(--ink);
+    box-shadow: 2px 2px 0 0 var(--ink);
+  }
+  .agendarow .who { min-width: 0; flex: 1; }
+  .agendarow .team {
+    display: block;
+    font-family: var(--display);
+    font-weight: 700; font-style: italic; font-size: 15px;
+    line-height: 1.1;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .caption {
+    display: block;
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    margin-top: 2px;
+  }
+  .caption .word { color: var(--ink); font-weight: 700; }
+  .glyph { flex: none; font-size: 12px; color: var(--ink-muted); }
+  .score {
+    flex: none;
+    font-family: var(--display);
+    font-size: 17px; font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  /* desktop scoreboard variant */
+  .scoreboard {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px;
+    background: var(--cream);
+    border: 2px solid var(--ink);
+    box-shadow: 2px 2px 0 0 var(--ink);
+  }
+  .scoreboard .stub {
+    flex: none; width: 52px;
+    font-family: var(--mono); font-size: 11px; font-weight: 700;
+    line-height: 1.15;
+  }
+  .scoreboard .stub em {
+    display: block; font-style: normal;
+    font-size: 9px; letter-spacing: 0.06em;
+    text-transform: uppercase; color: var(--ink-muted);
+  }
+  .scoreboard .nm {
+    flex: 1; min-width: 0;
+    font-family: var(--display); font-weight: 700; font-style: italic;
+    font-size: 15px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .scoreboard .nm.r { text-align: right; }
+
+  /* /kalender agenda list row — flat, no card */
+  .agendalist {
+    display: grid;
+    grid-template-columns: 44px 1fr auto;
+    align-items: center; gap: 10px;
+    padding: 8px 6px;
+    border-bottom: 1px dashed var(--paper-edge);
+  }
+  .agendalist .t {
+    font-family: var(--mono); font-size: 11px; color: var(--ink-muted);
+  }
+  .agendalist .mid {
+    display: flex; align-items: center; gap: 7px; min-width: 0;
+  }
+  .agendalist .fix {
+    min-width: 0; flex: 1;
+    font-size: 13px; font-weight: 600;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .agendalist .sc {
+    flex: none;
+    font-family: var(--display); font-size: 15px; font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .agendalist .tag {
+    flex: none;
+    font-family: var(--mono); font-size: 9px;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    border: 1px solid var(--ink); padding: 1px 5px;
+  }
+  /* MatchStrip ledger row */
+  .ledger {
+    display: flex; align-items: center; gap: 10px;
+    padding: 9px 12px;
+    background: var(--cream);
+    border-bottom: 1px solid rgb(10 10 10 / 0.15);
+  }
+  .ledger .stub {
+    flex: none;
+    font-family: var(--mono); font-size: 11px; font-weight: 700;
+    line-height: 1.15;
+    font-variant-numeric: tabular-nums;
+  }
+  .ledger .stub.w14 { width: 56px; }
+  .ledger .stub .mo { color: var(--ink-muted); font-weight: 500; text-transform: uppercase; }
+  .ledger .stub .kw {
+    display: block;
+    font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase;
+    line-height: 1.15;
+  }
+  .ledger .stub .kw.green { color: var(--jersey-deep); }
+  .ledger .stub .kw.inky { color: var(--ink); }
+  .ledger .opp {
+    flex: 1; min-width: 0;
+    font-family: var(--display); font-weight: 700; font-style: italic; font-size: 15px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .ledger .sc {
+    flex: none;
+    font-family: var(--mono); font-size: 14px; font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* strip desktop slide */
+  .slide {
+    display: flex; align-items: center; justify-content: center; gap: 14px;
+    padding: 12px 16px;
+    background: var(--cream);
+    border-top: 2px solid var(--jersey-deep);
+  }
+  .slide .nm {
+    font-family: var(--display); font-weight: 700; font-style: italic; font-size: 15px;
+    max-width: 40%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .slide .sc {
+    font-family: var(--mono); font-size: 15px; font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .callout {
+    margin-top: 14px;
+    padding: 12px 14px;
+    border-left: 4px solid var(--alert);
+    background: var(--cream-soft);
+    font-size: 13px;
+    max-width: 62ch;
+  }
+  .callout strong { font-weight: 700; }
+
+  /* ── summary table ────────────────────────────────────────── */
+
+  .tablewrap { overflow-x: auto; border: 2px solid var(--ink); }
+  table { border-collapse: collapse; width: 100%; min-width: 760px; background: var(--cream); }
+  th, td {
+    text-align: left;
+    padding: 11px 14px;
+    border-bottom: 1px solid var(--paper-edge);
+    font-size: 13px;
+    vertical-align: top;
+  }
+  thead th {
+    background: var(--ink);
+    color: var(--cream);
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-bottom: 0;
+  }
+  tbody tr:last-child td { border-bottom: 0; }
+  td.yes { color: var(--jersey-deep); font-weight: 700; }
+  td.no { color: var(--ink-muted); }
+  td.act { background: var(--warm); font-weight: 700; }
+
+  footer {
+    margin-top: 72px;
+    padding-top: 22px;
+    border-top: 2px solid var(--ink);
+    font-size: 13px;
+    color: var(--ink-muted);
+    max-width: 66ch;
+  }
+  footer p { margin: 0 0 10px; }
+  footer a { color: var(--jersey-deep); }
+</style>
+
+<div class="wrap">
+
+  <header class="masthead">
+    <span class="eyebrow">#2512 · Homepage delight walk · 17 Aug 2026</span>
+    <h1>Where the outcome word goes</h1>
+    <p class="standfirst">
+      Five surfaces draw the win/loss band. Only some print a word beside it.
+      This page shows every one of them as it renders today, and exactly what
+      changes. The answer turned out to be much smaller than the question:
+      <strong>one surface changes its word, one loses a duplicate band, and the
+      draw gets a colour everywhere.</strong> Decision record for
+      <a href="https://github.com/soniCaH/www.kcvvelewijt.be/issues/2512">#2512</a>,
+      under map
+      <a href="https://github.com/soniCaH/www.kcvvelewijt.be/issues/2506">#2506</a>.
+    </p>
+  </header>
+
+  <section class="rule">
+    <p>
+      The word appears only where nothing else in the row assigns the score.
+      Two clubs either side of it, or a <em>Thuis</em>/<em>Uit</em> tag beside
+      it, and the row already names who won — the word is then noise.
+    </p>
+    <p class="src">
+      Half of this was already written — <code>TeamAgendaRow.tsx:287–301</code>
+      (#2404) argues the two-club case. #2512 added the venue-tag case and made
+      it one rule for all five surfaces.
+    </p>
+  </section>
+
+  <h2>First, the band</h2>
+  <p class="lede">
+    Q1 = B made the tint a complete three-case system, so the draw needs a
+    colour. Q5 = A picks <code>--color-ink-muted</code> mixed 34% into cream —
+    the only neutral that matches the other two bands in strength. Ratios are
+    against cream <code>#f5f1e6</code>; #2513 measured 1.62 and 1.69 reading
+    fine outdoors on a phone.
+  </p>
+
+  <div class="swatches">
+    <div class="swatch">
+      <h3>Winst</h3>
+      <span class="demo band win">4 – 0</span>
+      <dl>
+        <dt>Mix</dt><dd>jersey-deep 34%</dd>
+        <dt>Hex</dt><dd>#a2c9b0</dd>
+        <dt>Ratio</dt><dd>1.62 : 1</dd>
+      </dl>
+    </div>
+    <div class="swatch">
+      <h3>Gelijkspel <span class="new">nieuw</span></h3>
+      <span class="demo band draw">2 – 2</span>
+      <dl>
+        <dt>Mix</dt><dd>ink-muted 34%</dd>
+        <dt>Hex</dt><dd>#c6c3bc</dd>
+        <dt>Ratio</dt><dd>1.54 : 1</dd>
+      </dl>
+    </div>
+    <div class="swatch">
+      <h3>Verlies</h3>
+      <span class="demo band loss">0 – 3</span>
+      <dl>
+        <dt>Mix</dt><dd>alert 38%</dd>
+        <dt>Hex</dt><dd>#deb2a5</dd>
+        <dt>Ratio</dt><dd>1.69 : 1</dd>
+      </dl>
+    </div>
+  </div>
+
+  <h2>Then the word, surface by surface</h2>
+  <p class="lede">
+    Ordered by how much has to change. Every row below is drawn at the width it
+    actually renders at.
+  </p>
+
+  <!-- 1 ───────────────────────────────────────────────────── -->
+  <article class="surface">
+    <header>
+      <h3>1 · TeamAgendaRow, phone</h3>
+      <span class="where">&lt;640px · homepage, /ploegen/*, /kalender maandrooster, /tegenstander/*</span>
+      <span class="verdict keep">Woord staat er al</span>
+    </header>
+    <div class="panes">
+      <div class="pane">
+        <h4>Vandaag — en na deze beslissing</h4>
+        <p class="note">
+          The opponent stands alone, so the row cannot say who won without the
+          word. It already does: <code>mobileKindWord</code> is ungated. Only
+          the draw row changes, and only its band.
+        </p>
+        <div class="frame">
+          <span class="vp">344px</span>
+          <div class="stack phone">
+            <div class="agendarow">
+              <span class="crest">KLL</span>
+              <span class="who">
+                <span class="team">K Lyra-Lierse</span>
+                <span class="caption"><span class="word">Winst</span> · 2e Provinciale B</span>
+              </span>
+              <span class="glyph">▲</span>
+              <span class="score band win">4 – 0</span>
+            </div>
+            <div class="agendarow">
+              <span class="crest">SKB</span>
+              <span class="who">
+                <span class="team">SK Berlaar-Heikant</span>
+                <span class="caption"><span class="word">Gelijk</span> · 2e Provinciale B</span>
+              </span>
+              <span class="glyph">▲</span>
+              <span class="score band draw">2 – 2</span>
+            </div>
+            <div class="agendarow">
+              <span class="crest">VCH</span>
+              <span class="who">
+                <span class="team">VC Herentals</span>
+                <span class="caption"><span class="word">Verlies</span> · 2e Provinciale B</span>
+              </span>
+              <span class="glyph">▼</span>
+              <span class="score band loss">0 – 3</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+
+  <!-- 2 ───────────────────────────────────────────────────── -->
+  <article class="surface">
+    <header>
+      <h3>2 · TeamAgendaRow, desktop</h3>
+      <span class="where">≥640px · same five call sites</span>
+      <span class="verdict keep">Geen woord nodig</span>
+    </header>
+    <div class="panes">
+      <div class="pane">
+        <h4>Vandaag — ongewijzigd</h4>
+        <p class="note">
+          Both clubs are printed either side of the score, in home–away order,
+          with KCVV among them. “Verlies” would restate the row and stack into a
+          column of one word down a season. Four of five call sites pass no
+          <code>kind</code> and so print nothing — that is correct, not a gap.
+        </p>
+        <div class="frame">
+          <span class="vp">600px</span>
+          <div class="stack desk">
+            <div class="scoreboard">
+              <span class="stub">08 SEP</span>
+              <span class="nm">KCVV Elewijt</span>
+              <span class="score band win">4 – 0</span>
+              <span class="nm r">K Lyra-Lierse</span>
+            </div>
+            <div class="scoreboard">
+              <span class="stub">15 SEP</span>
+              <span class="nm">SK Berlaar-Heikant</span>
+              <span class="score band draw">2 – 2</span>
+              <span class="nm r">KCVV Elewijt</span>
+            </div>
+            <div class="scoreboard">
+              <span class="stub">22 SEP</span>
+              <span class="nm">VC Herentals</span>
+              <span class="score band loss">3 – 0</span>
+              <span class="nm r">KCVV Elewijt</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+
+  <!-- 3 ───────────────────────────────────────────────────── -->
+  <article class="surface">
+    <header>
+      <h3>3 · MatchStrip, desktop slide</h3>
+      <span class="where">≥640px · /, /spelers/*, /ploegen/*, /wedstrijd/*</span>
+      <span class="verdict keep">Geen woord nodig</span>
+    </header>
+    <div class="panes">
+      <div class="pane">
+        <h4>Vandaag — ongewijzigd</h4>
+        <p class="note">
+          Same shape as surface 2: both names around the score, and no word
+          column exists on this layout at all. <code>&lt;StripDate&gt;</code>
+          renders only inside the mobile ledger row.
+        </p>
+        <div class="frame">
+          <span class="vp">600px</span>
+          <div class="stack desk">
+            <div class="slide">
+              <span class="nm">KCVV</span>
+              <span class="sc band win">4 – 0</span>
+              <span class="nm">K Lyra-Lierse</span>
+            </div>
+            <div class="slide">
+              <span class="nm">SK Berlaar-Heikant</span>
+              <span class="sc band draw">2 – 2</span>
+              <span class="nm">KCVV</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+
+  <!-- 4 ───────────────────────────────────────────────────── -->
+  <article class="surface">
+    <header>
+      <h3>4 · MatchStrip, phone ledger</h3>
+      <span class="where">&lt;640px · /, /spelers/*, /ploegen/*, /wedstrijd/*</span>
+      <span class="verdict change">Woord wijzigt</span>
+    </header>
+    <div class="panes two">
+      <div class="pane">
+        <h4>Vandaag</h4>
+        <p class="note">
+          The opponent stands alone — same shape as surface 1 — but the word
+          column prints the <em>slot</em> word, not the outcome. Every result row
+          says the same thing. And it is green: on a loss row, green sits beside
+          a dusty-red band.
+        </p>
+        <div class="frame">
+          <span class="vp">344px</span>
+          <div class="stack phone">
+            <div class="ledger">
+              <span class="stub w14">08 <span class="mo">sep</span><span class="kw green">Uitslag</span></span>
+              <span class="crest sm">KLL</span>
+              <span class="opp">K Lyra-Lierse</span>
+              <span class="sc band win">4 – 0</span>
+            </div>
+            <div class="ledger">
+              <span class="stub w14">15 <span class="mo">sep</span><span class="kw green">Uitslag</span></span>
+              <span class="crest sm">SKB</span>
+              <span class="opp">SK Berlaar-Heikant</span>
+              <span class="sc band none">2 – 2</span>
+            </div>
+            <div class="ledger">
+              <span class="stub w14">22 <span class="mo">sep</span><span class="kw green">Uitslag</span></span>
+              <span class="crest sm">VCH</span>
+              <span class="opp">VC Herentals</span>
+              <span class="sc band loss">0 – 3</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pane">
+        <h4>Besloten</h4>
+        <p class="note">
+          Slot word → outcome word, green → ink. The column stays
+          <code>w-14</code>, so the opponent name loses nothing.
+        </p>
+        <div class="frame">
+          <span class="vp">344px</span>
+          <div class="stack phone">
+            <div class="ledger">
+              <span class="stub w14">08 <span class="mo">sep</span><span class="kw inky">Winst</span></span>
+              <span class="crest sm">KLL</span>
+              <span class="opp">K Lyra-Lierse</span>
+              <span class="sc band win">4 – 0</span>
+            </div>
+            <div class="ledger">
+              <span class="stub w14">15 <span class="mo">sep</span><span class="kw inky">Gelijk</span></span>
+              <span class="crest sm">SKB</span>
+              <span class="opp">SK Berlaar-Heikant</span>
+              <span class="sc band draw">2 – 2</span>
+            </div>
+            <div class="ledger">
+              <span class="stub w14">22 <span class="mo">sep</span><span class="kw inky">Verlies</span></span>
+              <span class="crest sm">VCH</span>
+              <span class="opp">VC Herentals</span>
+              <span class="sc band loss">0 – 3</span>
+            </div>
+          </div>
+        </div>
+        <p class="callout">
+          <strong>“Gelijk”, not “Gelijkspel”.</strong> The column is sized for
+          “Volgende” (8 characters). “Gelijkspel” is 10 and would have forced
+          <code>w-16</code>, taking 8px off a <code>truncate</code>d opponent
+          name — the exact trade #2388 fought. “Gelijk” is 6 and fits, so the
+          width question never arises.
+        </p>
+      </div>
+    </div>
+  </article>
+
+  <!-- 5 ───────────────────────────────────────────────────── -->
+  <article class="surface">
+    <header>
+      <h3>5 · CalendarAgenda — /kalender agendalijst</h3>
+      <span class="where">alle breedtes · standaardweergave op telefoon (<code>CalendarWidget.tsx:86</code>)</span>
+      <span class="verdict change">Alleen de band wijzigt</span>
+    </header>
+    <div class="panes two">
+      <div class="pane">
+        <h4>Vandaag</h4>
+        <p class="note">
+          Its own drifted band — <code>-4px</code>, full strength, no cream mix
+          — and no word anywhere. Both club names are printed, and on a phone
+          the second one truncates.
+        </p>
+        <div class="frame">
+          <span class="vp">344px</span>
+          <div class="stack phone">
+            <div class="agendalist">
+              <span class="t">14:30</span>
+              <span class="mid">
+                <span class="crest sm">KCV</span>
+                <span class="fix">KCVV Elewijt — K Lyra-Lierse</span>
+                <span class="sc band drift-win">4 – 0</span>
+              </span>
+              <span class="tag">Thuis</span>
+            </div>
+            <div class="agendalist">
+              <span class="t">15:00</span>
+              <span class="mid">
+                <span class="crest sm">SKB</span>
+                <span class="fix">SK Berlaar-Heikant — KCVV Elewijt</span>
+                <span class="sc band drift-none">2 – 2</span>
+              </span>
+              <span class="tag">Uit</span>
+            </div>
+            <div class="agendalist">
+              <span class="t">19:30</span>
+              <span class="mid">
+                <span class="crest sm">VCH</span>
+                <span class="fix">VC Herentals — KCVV Elewijt</span>
+                <span class="sc band drift-loss">3 – 0</span>
+              </span>
+              <span class="tag">Uit</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="pane">
+        <h4>Besloten — band ja, woord nee</h4>
+        <p class="note">
+          Local copy deleted, shared band adopted (thinner, paler, three cases).
+          <strong>No word.</strong> The venue tag already assigns the score.
+        </p>
+        <div class="frame">
+          <span class="vp">344px</span>
+          <div class="stack phone">
+            <div class="agendalist">
+              <span class="t">14:30</span>
+              <span class="mid">
+                <span class="crest sm">KCV</span>
+                <span class="fix">KCVV Elewijt — K Lyra-Lierse</span>
+                <span class="sc band win">4 – 0</span>
+              </span>
+              <span class="tag">Thuis</span>
+            </div>
+            <div class="agendalist">
+              <span class="t">15:00</span>
+              <span class="mid">
+                <span class="crest sm">SKB</span>
+                <span class="fix">SK Berlaar-Heikant — KCVV Elewijt</span>
+                <span class="sc band draw">2 – 2</span>
+              </span>
+              <span class="tag">Uit</span>
+            </div>
+            <div class="agendalist">
+              <span class="t">19:30</span>
+              <span class="mid">
+                <span class="crest sm">VCH</span>
+                <span class="fix">VC Herentals — KCVV Elewijt</span>
+                <span class="sc band loss">0 – 3</span>
+              </span>
+              <span class="tag">Uit</span>
+            </div>
+          </div>
+        </div>
+        <p class="callout">
+          <strong>Why the word is redundant here, truncation and all.</strong>
+          The home club is always printed first, and
+          <code>&lt;MatchVenueTag&gt;</code> says which side KCVV is on. Read
+          <em>Uit</em> and the second number is ours — no matter how hard the
+          names clip. This row is not colour-only, so the rule from the top of
+          the page does not reach it.
+        </p>
+      </div>
+    </div>
+  </article>
+
+  <h2>The whole change, on one line each</h2>
+  <p class="lede">
+    Exactly one surface changes its word. Every surface gains a draw band.
+  </p>
+
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Surface</th>
+          <th>What assigns the score</th>
+          <th>Word today</th>
+          <th>Word after</th>
+          <th>Band after</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>TeamAgendaRow · phone</td>
+          <td class="no">nothing — the word must</td>
+          <td class="yes">Winst / Gelijkspel / Verlies</td>
+          <td>“Gelijkspel” → “Gelijk”</td>
+          <td>draw gains grey</td>
+        </tr>
+        <tr>
+          <td>TeamAgendaRow · desktop</td>
+          <td class="yes">both names, home–away</td>
+          <td class="no">none (homepage excepted)</td>
+          <td class="no">unchanged</td>
+          <td>draw gains grey</td>
+        </tr>
+        <tr>
+          <td>MatchStrip · desktop slide</td>
+          <td class="yes">both names, home–away</td>
+          <td class="no">none</td>
+          <td class="no">unchanged</td>
+          <td>draw gains grey</td>
+        </tr>
+        <tr>
+          <td>MatchStrip · phone ledger</td>
+          <td class="no">nothing — the word must</td>
+          <td class="no">“Uitslag”, green</td>
+          <td class="act">outcome word, ink, w-14 holds</td>
+          <td>draw gains grey</td>
+        </tr>
+        <tr>
+          <td>CalendarAgenda · /kalender</td>
+          <td class="yes">Thuis / Uit tag</td>
+          <td class="no">none</td>
+          <td class="no">stays none</td>
+          <td class="act">local copy deleted</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <footer>
+    <p>
+      <strong>Read this for placement and register, not for type.</strong>
+      Freight rides Adobe Typekit and cannot load in a standalone file; Georgia
+      stands in for the display face and the system mono for IBM Plex Mono.
+      Crests are placeholders. Band colours, hex values and column widths are
+      the real ones.
+    </p>
+    <p>
+      Working file: <code>docs/design/mockups/2512-outcome-word/index.html</code>.
+      Sibling instruments:
+      <code>docs/design/mockups/homepage-delight/candidates.html</code>,
+      <code>docs/design/mockups/2508-motion-speeds/index.html</code>.
+    </p>
+  </footer>
+
+</div>

--- a/docs/design/mockups/2607-loading-skeletons/2607-content-field-compare.html
+++ b/docs/design/mockups/2607-loading-skeletons/2607-content-field-compare.html
@@ -1,0 +1,478 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>#2607 — Q4: what fills the space below the invariant opening?</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-ink: #0a0a0a;
+        --color-paper-edge: #d9d2bd;
+        --color-jersey-deep: #007c46;
+        --font-display: Georgia, "Times New Roman", serif;
+        --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 32px 24px 80px;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: var(--font-body);
+        line-height: 1.5;
+      }
+      .page-head,
+      .panel {
+        max-width: 1120px;
+        margin: 0 auto;
+      }
+      .page-head {
+        margin-bottom: 34px;
+      }
+      h1 {
+        font-family: var(--font-display);
+        font-size: 32px;
+        margin: 0 0 8px;
+      }
+      .kicker {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--color-jersey-deep);
+        margin: 0 0 10px;
+      }
+      .lede {
+        max-width: 66ch;
+        font-size: 15px;
+        margin: 0 0 18px;
+      }
+
+      .locked {
+        border: 2px dashed var(--color-ink);
+        background: var(--color-cream-soft);
+        padding: 12px 16px;
+        font-size: 13px;
+        max-width: 760px;
+        margin-bottom: 8px;
+      }
+      .locked h3 {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        margin: 0 0 6px;
+      }
+      .locked p {
+        margin: 0 0 6px;
+      }
+      .locked p:last-child {
+        margin-bottom: 0;
+      }
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.9em;
+        background: rgba(0, 0, 0, 0.05);
+        padding: 0 3px;
+      }
+
+      .panel {
+        border-top: 2px solid var(--color-ink);
+        padding-top: 18px;
+        margin-bottom: 44px;
+      }
+      .panel-head {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+      }
+      .tag {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 700;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 2px 8px;
+      }
+      .panel h2 {
+        font-family: var(--font-display);
+        font-size: 22px;
+        margin: 0;
+      }
+      .panel .rule {
+        font-size: 14px;
+        max-width: 70ch;
+        margin: 6px 0 16px;
+      }
+      .row {
+        display: flex;
+        gap: 20px;
+        flex-wrap: wrap;
+        align-items: flex-start;
+      }
+      .col-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin-bottom: 6px;
+        color: #5a5347;
+      }
+      .mini {
+        width: 290px;
+        height: 470px;
+        overflow: hidden;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        position: relative;
+      }
+      .mini-inner {
+        padding: 10px;
+      }
+      .bar {
+        background: var(--color-paper-edge);
+      }
+      .seam {
+        height: 10px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--color-ink) 0 5px,
+          var(--color-cream) 5px 10px
+        );
+        margin: 8px -10px;
+      }
+      .navstrip {
+        border-bottom: 2px solid var(--color-ink);
+        margin: 8px -10px 0;
+        padding: 9px 10px;
+        background: var(--color-cream);
+      }
+      .heroblock {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+      .heroblock .words {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .figure {
+        width: 100px;
+        aspect-ratio: 3/2;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .verdict {
+        margin-top: 14px;
+        font-size: 13.5px;
+        max-width: 76ch;
+        border-left: 3px solid var(--color-jersey-deep);
+        padding-left: 12px;
+      }
+      .verdict b {
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
+      .r-kicker {
+        font-family: var(--font-mono);
+        font-size: 8px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-jersey-deep);
+      }
+      .r-h1 {
+        font-family: var(--font-display);
+        font-size: 28px;
+        line-height: 1;
+        margin: 3px 0 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page-head">
+      <p class="kicker">#2607 · drill Q4 · 2026-08-14</p>
+      <h1>What fills the space below the invariant opening?</h1>
+
+      <div class="locked">
+        <h3>★ Locked — 2026-08-14</h3>
+        <p>
+          <b>Q1</b> — the rule governs all three files, including
+          <code>[slug]/wedstrijden/loading.tsx</code>, which the ticket omitted
+          and which is the only <code>force-dynamic</code> route on the surface.
+        </p>
+        <p>
+          <b>Q2 — rule D.</b> A skeleton draws its route's fixed opening at full
+          fidelity, then one content field. The test is
+          <b>"is this knowable before the fetch?"</b> Rule A (mirror) was ruled
+          <i>impossible</i>, not merely costly: <code>loading.tsx</code> accepts
+          no parameters, and every count is derived from the PSD fetch the
+          skeleton exists to cover.
+        </p>
+        <p>
+          <b>Q3</b> — hero-first streaming is decided and spun out as its own
+          ticket; not built here.
+        </p>
+      </div>
+
+      <p class="lede" style="margin-top: 18px">
+        What D fixes per route, mechanically: <b>[slug]</b> → hero + nav strip
+        (no pills; 2–5 is data, but the strip itself always renders since #2540
+        puts <code>#staf</code> and <code>#info</code> on 18 of 18, clearing
+        <code>TeamSectionNav</code>'s <code>length &lt;= 1</code> null-guard).
+        <b>/ploegen</b> → the editorial header only. Both flagship blocks are
+        gated at <code>page.tsx:83,95</code> (<code>{aTeam ? … : null}</code>),
+        so 0, 1 or 2 render and the count is not knowable — they fail D's test
+        exactly as the 1/4/4/7 youth groups do. Only
+        <code>Onze ploegen</code> and its tagline are hardcoded.
+        <b>/wedstrijden</b> → the editorial header. Everything below is this
+        question.
+      </p>
+    </div>
+
+    <!-- 1 -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">1</span>
+        <h2>Flat field</h2>
+      </div>
+      <p class="rule">
+        One <code>bg-paper-edge</code> slab holding the space the content will
+        occupy.
+      </p>
+      <div class="row">
+        <div>
+          <p class="col-label">/ploegen/[slug]</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+              <div class="navstrip"></div>
+              <div class="seam"></div>
+              <div class="bar" style="height: 300px; width: 100%"></div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <p class="col-label">/wedstrijden (force-dynamic)</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="bar" style="height: 7px; width: 45%"></div>
+              <div
+                class="bar"
+                style="height: 24px; width: 60%; margin: 6px 0 12px"
+              ></div>
+              <div class="bar" style="height: 340px; width: 100%"></div>
+            </div>
+          </div>
+        </div>
+        <p class="verdict" style="flex: 1; min-width: 280px">
+          Reserves the space, so nothing jumps when content lands. But a single
+          large flat rectangle is the one skeleton idiom this site has no
+          vocabulary for — every other surface is bars, borders and seams.
+          <b>It reads as a failed image, not as loading.</b>
+        </p>
+      </div>
+    </section>
+
+    <!-- 2 -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">2</span>
+        <h2>Bordered empty box</h2>
+      </div>
+      <p class="rule">
+        A <code>border-2 border-ink</code> cream box — the paper register's own
+        framing device.
+      </p>
+      <div class="row">
+        <div>
+          <p class="col-label">/ploegen/[slug]</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+              <div class="navstrip"></div>
+              <div class="seam"></div>
+              <div
+                style="
+                  height: 300px;
+                  border: 2px solid var(--color-ink);
+                  background: var(--color-cream);
+                "
+              ></div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <p class="col-label">/wedstrijden (force-dynamic)</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="bar" style="height: 7px; width: 45%"></div>
+              <div
+                class="bar"
+                style="height: 24px; width: 60%; margin: 6px 0 12px"
+              ></div>
+              <div
+                style="
+                  height: 340px;
+                  border: 2px solid var(--color-ink);
+                  background: var(--color-cream);
+                "
+              ></div>
+            </div>
+          </div>
+        </div>
+        <p class="verdict" style="flex: 1; min-width: 280px">
+          Native to the design language — but on this site an ink-bordered box
+          <i>is</i> a component: a card, a table, a flagship block.
+          <b>Drawing one promises a single framed element</b>, and what arrives
+          is a seam, three headings and a grid.
+        </p>
+      </div>
+    </section>
+
+    <!-- 3 -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">3</span>
+        <h2>Nothing</h2>
+      </div>
+      <p class="rule">
+        The invariant opening, then cream. The page grows downward as content
+        arrives.
+      </p>
+      <div class="row">
+        <div>
+          <p class="col-label">/ploegen/[slug]</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+              <div class="navstrip"></div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <p class="col-label">/wedstrijden (force-dynamic)</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="bar" style="height: 7px; width: 45%"></div>
+              <div
+                class="bar"
+                style="height: 24px; width: 60%; margin: 6px 0 12px"
+              ></div>
+            </div>
+          </div>
+        </div>
+        <p class="verdict" style="flex: 1; min-width: 280px">
+          Promises absolutely nothing, and is the least code. But
+          <code>/wedstrijden</code> shows this on <i>every</i> request, and a
+          bare header over empty cream is
+          <b>indistinguishable from the 14 teams whose fixture page is
+            genuinely empty</b> — the exact confusion #2540 was written to end.
+        </p>
+      </div>
+    </section>
+
+    <!-- 4 -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">4</span>
+        <h2>Neutral bars</h2>
+      </div>
+      <p class="rule">
+        A seam, then a few <code>paper-edge</code> bars of varying width — the
+        vocabulary all three files already use for the hero. No boxes, no
+        cards, no borders: nothing that names a component or implies a count.
+      </p>
+      <div class="row">
+        <div>
+          <p class="col-label">/ploegen/[slug]</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+              <div class="navstrip"></div>
+              <div class="seam"></div>
+              <div style="display: flex; flex-direction: column; gap: 10px">
+                <div class="bar" style="height: 14px; width: 42%"></div>
+                <div class="bar" style="height: 9px; width: 96%"></div>
+                <div class="bar" style="height: 9px; width: 88%"></div>
+                <div class="bar" style="height: 9px; width: 64%"></div>
+                <div
+                  class="bar"
+                  style="height: 14px; width: 34%; margin-top: 14px"
+                ></div>
+                <div class="bar" style="height: 9px; width: 92%"></div>
+                <div class="bar" style="height: 9px; width: 70%"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <p class="col-label">/wedstrijden (force-dynamic)</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="bar" style="height: 7px; width: 45%"></div>
+              <div
+                class="bar"
+                style="height: 24px; width: 60%; margin: 6px 0 14px"
+              ></div>
+              <div style="display: flex; flex-direction: column; gap: 10px">
+                <div class="bar" style="height: 14px; width: 42%"></div>
+                <div class="bar" style="height: 9px; width: 96%"></div>
+                <div class="bar" style="height: 9px; width: 88%"></div>
+                <div class="bar" style="height: 9px; width: 64%"></div>
+                <div
+                  class="bar"
+                  style="height: 14px; width: 34%; margin-top: 14px"
+                ></div>
+                <div class="bar" style="height: 9px; width: 92%"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="verdict" style="flex: 1; min-width: 280px">
+          Says <i>something is coming and it is made of words</i> without naming
+          a component or a count. It reuses the bar vocabulary already in all
+          three files, so nothing new enters the design language, and it reads
+          as loading rather than as empty on the one route that shows it every
+          time.
+          <b>The bars are not countable the way cards are</b> — a reader does
+          not check whether four bars became four items.
+        </p>
+      </div>
+    </section>
+  </body>
+</html>

--- a/docs/design/mockups/2607-loading-skeletons/2607-skeleton-rule-compare.html
+++ b/docs/design/mockups/2607-loading-skeletons/2607-skeleton-rule-compare.html
@@ -1,0 +1,916 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>#2607 — Q2: what does a loading skeleton draw?</title>
+    <style>
+      :root {
+        --color-cream: #f5f1e6;
+        --color-cream-soft: #ede8da;
+        --color-ink: #0a0a0a;
+        --color-paper-edge: #d9d2bd;
+        --color-jersey-deep: #007c46;
+        /* Stand-in faces: freight-big-pro / freight-sans-pro / IBM Plex Mono
+           are Typekit-served and not available offline. Shapes are what this
+           drill compares, not the faces. */
+        --font-display: Georgia, "Times New Roman", serif;
+        --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 32px 24px 80px;
+        background: var(--color-cream);
+        color: var(--color-ink);
+        font-family: var(--font-body);
+        line-height: 1.5;
+      }
+
+      .page-head {
+        max-width: 1080px;
+        margin: 0 auto 40px;
+      }
+
+      h1 {
+        font-family: var(--font-display);
+        font-size: 34px;
+        margin: 0 0 8px;
+        letter-spacing: -0.01em;
+      }
+
+      .kicker {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--color-jersey-deep);
+        margin: 0 0 10px;
+      }
+
+      .lede {
+        max-width: 62ch;
+        font-size: 15px;
+        margin: 0 0 16px;
+      }
+
+      .facts {
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+        padding: 14px 18px;
+        max-width: 720px;
+        font-size: 13px;
+      }
+
+      .facts b {
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
+
+      .facts ul {
+        margin: 8px 0 0;
+        padding-left: 18px;
+      }
+
+      .facts li {
+        margin-bottom: 4px;
+      }
+
+      /* ---- panels ---- */
+      .panel {
+        max-width: 1080px;
+        margin: 0 auto 56px;
+        border-top: 2px solid var(--color-ink);
+        padding-top: 20px;
+      }
+
+      .panel-head {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        margin-bottom: 4px;
+      }
+
+      .tag {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        font-weight: 700;
+        background: var(--color-ink);
+        color: var(--color-cream);
+        padding: 2px 8px;
+      }
+
+      .panel h2 {
+        font-family: var(--font-display);
+        font-size: 24px;
+        margin: 0;
+      }
+
+      .panel .rule {
+        font-size: 14px;
+        max-width: 66ch;
+        margin: 6px 0 18px;
+      }
+
+      .row {
+        display: flex;
+        gap: 22px;
+        align-items: flex-start;
+        flex-wrap: wrap;
+      }
+
+      .col {
+        width: 300px;
+      }
+
+      .col-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        margin-bottom: 6px;
+        color: #5a5347;
+      }
+
+      .col-label.now {
+        color: var(--color-jersey-deep);
+        font-weight: 700;
+      }
+
+      /* mini page frame */
+      .mini {
+        width: 300px;
+        height: 560px;
+        overflow: hidden;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        position: relative;
+      }
+
+      .mini::after {
+        content: "";
+        position: absolute;
+        inset: auto 0 0 0;
+        height: 46px;
+        background: linear-gradient(transparent, var(--color-cream));
+      }
+
+      .mini-inner {
+        padding: 10px;
+      }
+
+      /* skeleton primitives */
+      .bar {
+        background: var(--color-paper-edge);
+      }
+      .seam {
+        height: 10px;
+        background: repeating-linear-gradient(
+          -45deg,
+          var(--color-ink) 0 5px,
+          var(--color-cream) 5px 10px
+        );
+        margin: 8px -10px;
+      }
+      .navstrip {
+        border-bottom: 2px solid var(--color-ink);
+        margin: 8px -10px 0;
+        padding: 6px 10px;
+        display: flex;
+        gap: 6px;
+        background: var(--color-cream);
+      }
+      .pill {
+        height: 11px;
+        width: 44px;
+        background: var(--color-paper-edge);
+      }
+      .pill.real {
+        background: none;
+        border: none;
+        font-family: var(--font-mono);
+        font-size: 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        width: auto;
+        height: auto;
+        padding: 1px 0;
+        color: var(--color-ink);
+      }
+      .heroblock {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+      .heroblock .words {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .figure {
+        width: 104px;
+        aspect-ratio: 3/2;
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream-soft);
+      }
+      .figure.taped {
+        position: relative;
+      }
+      .figure.taped::before {
+        content: "";
+        position: absolute;
+        top: -6px;
+        left: 26px;
+        width: 42px;
+        height: 12px;
+        background: rgba(217, 210, 189, 0.9);
+        transform: rotate(-3deg);
+      }
+
+      .card {
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        aspect-ratio: 3/4;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-end;
+        padding: 4px;
+        gap: 3px;
+      }
+      .card .ph {
+        flex: 1;
+        width: 100%;
+        background: var(--color-cream-soft);
+      }
+      .grid4 {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 5px;
+      }
+      .grid3 {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 5px;
+      }
+      .agendarow {
+        border: 2px solid var(--color-ink);
+        background: var(--color-cream);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 6px;
+        margin-bottom: 4px;
+      }
+
+      /* real-page type */
+      .r-kicker {
+        font-family: var(--font-mono);
+        font-size: 8px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--color-jersey-deep);
+      }
+      .r-h1 {
+        font-family: var(--font-display);
+        font-size: 30px;
+        line-height: 1;
+        margin: 3px 0 5px;
+      }
+      .r-h2 {
+        font-family: var(--font-display);
+        font-size: 15px;
+        margin: 0 0 5px;
+      }
+      .r-body {
+        font-size: 9px;
+        line-height: 1.35;
+        color: #3a352c;
+      }
+      .r-status {
+        font-family: var(--font-mono);
+        font-size: 8.5px;
+        line-height: 1.4;
+        color: #5a5347;
+        border-left: 2px solid var(--color-paper-edge);
+        padding-left: 6px;
+      }
+      .r-name {
+        font-size: 8px;
+        text-align: center;
+        line-height: 1.2;
+      }
+
+      .verdict {
+        margin-top: 14px;
+        font-size: 13.5px;
+        max-width: 74ch;
+        border-left: 3px solid var(--color-jersey-deep);
+        padding-left: 12px;
+      }
+      .verdict b {
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
+      .cost {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        border: 1px solid var(--color-ink);
+        padding: 1px 6px;
+        margin-top: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page-head">
+      <p class="kicker">#2607 · drill Q2 · 2026-08-14</p>
+      <h1>What does a team-page loading skeleton draw?</h1>
+      <p class="lede">
+        One skeleton per route has to serve every team on it. The two extremes
+        below are the same file: a U9 page with 3 nav pills and 6 squad cards,
+        and the A-team with 5 pills and 29 cards. Each panel is a candidate
+        rule, shown as the skeleton and then what it actually resolves into.
+      </p>
+      <div class="facts">
+        <b>Fixed before this question</b>
+        <ul>
+          <li>
+            <b>#2540</b> — the competitive block has four states. A team with no
+            fixtures gets one unheaded status line and
+            <b>no #klassement / #wedstrijden sections and no nav entries</b>.
+            With fixtures, both sections render with their own h2 and seam.
+          </li>
+          <li>
+            <b>The loaded shape moves during the season.</b> Every youth page is
+            3 pills today (0 fixtures for season 9) and becomes 5 the week the
+            reeksen publish. The skeleton cannot be pinned to one of them.
+          </li>
+          <li>
+            <b>#2541</b> — a squad that partitions into one group renders with
+            no heading; U9 is one group of 6, the A-team is 4 + 1 + 24.
+          </li>
+          <li>
+            <b>#2602</b> — youth directory groups are 1 / 4 / 4 / 7, cards 230px
+            desktop.
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- ================= A ================= -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">A</span>
+        <h2>Mirror — the skeleton previews the composition</h2>
+      </div>
+      <p class="rule">
+        The skeleton reproduces the loaded page section for section with a
+        representative count: hero, nav pills, section shells, a grid of cards.
+        This is what all three files attempt today.
+      </p>
+      <div class="row">
+        <div class="col">
+          <p class="col-label">Skeleton</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+              <div class="navstrip">
+                <div class="pill"></div>
+                <div class="pill"></div>
+                <div class="pill"></div>
+                <div class="pill"></div>
+                <div class="pill"></div>
+              </div>
+              <div class="seam"></div>
+              <div class="bar" style="height: 12px; width: 40%"></div>
+              <div
+                class="bar"
+                style="height: 64px; width: 100%; margin-top: 6px"
+              ></div>
+              <div class="seam"></div>
+              <div
+                class="bar"
+                style="height: 12px; width: 34%; margin-bottom: 6px"
+              ></div>
+              <div class="grid4">
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+                <div class="card"><div class="ph"></div></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <p class="col-label now">Loads as → /ploegen/kcvve-u9</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <p class="r-kicker">Jeugd · Onderbouw</p>
+                  <p class="r-h1">U9.</p>
+                  <p class="r-body">Seizoen 2026–2027</p>
+                </div>
+                <div class="figure taped"></div>
+              </div>
+              <div class="navstrip">
+                <span class="pill real">Spelers</span>
+                <span class="pill real">Staf</span>
+                <span class="pill real">Info</span>
+              </div>
+              <div class="seam"></div>
+              <p class="r-status">
+                Deze ploeg speelt dit seizoen nog geen officiële wedstrijden.
+              </p>
+              <div class="seam"></div>
+              <div class="grid3" style="margin-top: 4px">
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Lars V.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Vic D.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Noah P.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Elias M.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Jef K.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Milan S.</p>
+                </div>
+              </div>
+              <div class="seam"></div>
+              <p class="r-h2">Staf.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <p class="col-label now">Loads as → /ploegen/eerste-elftallen-a</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <p class="r-kicker">Senioren</p>
+                  <p class="r-h1">A-ploeg.</p>
+                  <p class="r-body">3e Nationale · Seizoen 2026–2027</p>
+                </div>
+                <div class="figure taped"></div>
+              </div>
+              <div class="navstrip">
+                <span class="pill real">Klassement</span>
+                <span class="pill real">Wedstrijden</span>
+                <span class="pill real">Spelers</span>
+                <span class="pill real">Staf</span>
+              </div>
+              <div class="seam"></div>
+              <p class="r-h2">Klassement.</p>
+              <div
+                style="
+                  border: 2px solid var(--color-ink);
+                  padding: 4px;
+                  font-size: 8px;
+                "
+              >
+                <div style="display: flex; justify-content: space-between">
+                  <span>1. Grimbergen</span><span>30</span>
+                </div>
+                <div
+                  style="
+                    display: flex;
+                    justify-content: space-between;
+                    background: var(--color-cream-soft);
+                  "
+                >
+                  <span>2. KCVV Elewijt</span><span>28</span>
+                </div>
+                <div style="display: flex; justify-content: space-between">
+                  <span>3. Kampenhout</span><span>25</span>
+                </div>
+              </div>
+              <div class="seam"></div>
+              <p class="r-h2">Wedstrijden.</p>
+              <div class="agendarow">
+                <div class="bar" style="height: 7px; width: 26px"></div>
+                <div style="flex: 1; font-size: 8px">Elewijt — Wolvertem</div>
+              </div>
+              <div class="agendarow">
+                <div class="bar" style="height: 7px; width: 26px"></div>
+                <div style="flex: 1; font-size: 8px">Kampenhout — Elewijt</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="verdict">
+        The skeleton promises <b>5 pills, a table and 8 cards</b>. The U9 page
+        delivers 3 pills, no table, no card grid at that position — the reader
+        watches two whole sections evaporate. On the A-team it under-promises
+        instead: 8 cards become 29. <b>A mirror can only be right for one team</b>,
+        and the map has eighteen.
+        <span class="cost">mispromises 17 of 18 pages</span>
+      </p>
+    </section>
+
+    <!-- ================= B ================= -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">B</span>
+        <h2>Structure without quantity</h2>
+      </div>
+      <p class="rule">
+        The skeleton draws only what is invariant on every team page — the hero
+        and the nav strip as an empty bar — then one undifferentiated content
+        field. No pill count, no section shells, no card grid: nothing that
+        implies how much is coming.
+      </p>
+      <div class="row">
+        <div class="col">
+          <p class="col-label">Skeleton</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+              <div class="navstrip"></div>
+              <div class="seam"></div>
+              <div
+                class="bar"
+                style="height: 200px; width: 100%; margin-top: 6px"
+              ></div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <p class="col-label now">Loads as → /ploegen/kcvve-u9</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <p class="r-kicker">Jeugd · Onderbouw</p>
+                  <p class="r-h1">U9.</p>
+                  <p class="r-body">Seizoen 2026–2027</p>
+                </div>
+                <div class="figure taped"></div>
+              </div>
+              <div class="navstrip">
+                <span class="pill real">Spelers</span>
+                <span class="pill real">Staf</span>
+                <span class="pill real">Info</span>
+              </div>
+              <div class="seam"></div>
+              <p class="r-status">
+                Deze ploeg speelt dit seizoen nog geen officiële wedstrijden.
+              </p>
+              <div class="seam"></div>
+              <div class="grid3" style="margin-top: 4px">
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Lars V.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Vic D.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Noah P.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Elias M.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Jef K.</p>
+                </div>
+                <div class="card">
+                  <div class="ph"></div>
+                  <p class="r-name">Milan S.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <p class="col-label now">Loads as → /ploegen/eerste-elftallen-a</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="mini-inner" style="padding: 0">
+                <div class="heroblock">
+                  <div class="words">
+                    <p class="r-kicker">Senioren</p>
+                    <p class="r-h1">A-ploeg.</p>
+                    <p class="r-body">3e Nationale · Seizoen 2026–2027</p>
+                  </div>
+                  <div class="figure taped"></div>
+                </div>
+                <div class="navstrip">
+                  <span class="pill real">Klassement</span>
+                  <span class="pill real">Wedstrijden</span>
+                  <span class="pill real">Spelers</span>
+                  <span class="pill real">Staf</span>
+                </div>
+                <div class="seam"></div>
+                <p class="r-h2">Klassement.</p>
+                <div
+                  style="
+                    border: 2px solid var(--color-ink);
+                    padding: 4px;
+                    font-size: 8px;
+                  "
+                >
+                  <div style="display: flex; justify-content: space-between">
+                    <span>1. Grimbergen</span><span>30</span>
+                  </div>
+                  <div
+                    style="
+                      display: flex;
+                      justify-content: space-between;
+                      background: var(--color-cream-soft);
+                    "
+                  >
+                    <span>2. KCVV Elewijt</span><span>28</span>
+                  </div>
+                </div>
+                <div class="seam"></div>
+                <p class="r-h2">Wedstrijden.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="verdict">
+        Nothing the skeleton draws is contradicted by either page. The hero
+        geometry is genuinely identical on all eighteen, so the h1 and the taped
+        figure land where they were promised — the part of the transition a
+        reader actually tracks. Below the nav it commits to
+        <b>occupied space, not to what occupies it</b>.
+        <span class="cost">wrong on 0 of 18 · loses the section preview</span>
+      </p>
+    </section>
+
+    <!-- ================= C ================= -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">C</span>
+        <h2>Hero only — the skeleton stops at the fold</h2>
+      </div>
+      <p class="rule">
+        Only the invariant hero is drawn. No nav strip, no content field. The
+        page below the hero appears when it appears.
+      </p>
+      <div class="row">
+        <div class="col">
+          <p class="col-label">Skeleton</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <div class="bar" style="height: 7px; width: 60%"></div>
+                  <div class="bar" style="height: 26px; width: 78%"></div>
+                  <div class="bar" style="height: 9px; width: 45%"></div>
+                </div>
+                <div class="figure"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <p class="col-label now">Loads as → /ploegen/kcvve-u9</p>
+          <div class="mini">
+            <div class="mini-inner">
+              <div class="heroblock">
+                <div class="words">
+                  <p class="r-kicker">Jeugd · Onderbouw</p>
+                  <p class="r-h1">U9.</p>
+                  <p class="r-body">Seizoen 2026–2027</p>
+                </div>
+                <div class="figure taped"></div>
+              </div>
+              <div class="navstrip">
+                <span class="pill real">Spelers</span>
+                <span class="pill real">Staf</span>
+                <span class="pill real">Info</span>
+              </div>
+              <div class="seam"></div>
+              <p class="r-status">
+                Deze ploeg speelt dit seizoen nog geen officiële wedstrijden.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <p class="col-label">Cost</p>
+          <div
+            class="mini"
+            style="
+              height: auto;
+              min-height: 120px;
+              border-style: dashed;
+              padding: 12px;
+            "
+          >
+            <p class="r-body" style="font-size: 11px">
+              On <b>/ploegen/[slug]/wedstrijden</b> — the one route that is
+              <code>force-dynamic</code> and therefore renders this skeleton on
+              <i>every</i> request — there is no hero. Rule C leaves that page
+              with an empty screen for the whole fetch.
+            </p>
+          </div>
+        </div>
+      </div>
+      <p class="verdict">
+        Honest, and cheapest to maintain — but it under-serves exactly the route
+        that shows a skeleton most often. A rule for this surface has to survive
+        the fixtures page, which opens with an editorial header rather than a
+        hero.
+        <span class="cost">wrong on 0 of 18 · blank on the most-seen route</span>
+      </p>
+    </section>
+
+    <!-- ================= D ================= -->
+    <section class="panel">
+      <div class="panel-head">
+        <span class="tag">D</span>
+        <h2>Invariant-only, per route</h2>
+      </div>
+      <p class="rule">
+        Same discipline as B, but the invariant is computed per route rather
+        than assumed to be the hero: each skeleton draws its own route's fixed
+        opening at full fidelity, then one content field. For
+        <code>[slug]</code> that is hero + nav strip; for
+        <code>wedstrijden</code> the editorial header; for
+        <code>/ploegen</code> the header plus the two flagship blocks, which are
+        the only genuinely fixed count on the surface (always exactly two).
+      </p>
+      <div class="row">
+        <div class="col">
+          <p class="col-label">/ploegen skeleton</p>
+          <div class="mini" style="height: 400px">
+            <div class="mini-inner">
+              <div class="bar" style="height: 7px; width: 40%"></div>
+              <div
+                class="bar"
+                style="height: 24px; width: 70%; margin: 6px 0"
+              ></div>
+              <div style="display: flex; flex-direction: column; gap: 8px">
+                <div
+                  style="
+                    border: 2px solid var(--color-ink);
+                    display: grid;
+                    grid-template-columns: 1.25fr 1fr;
+                    height: 76px;
+                  "
+                >
+                  <div style="padding: 8px">
+                    <div class="bar" style="height: 6px; width: 50%"></div>
+                    <div
+                      class="bar"
+                      style="height: 16px; width: 70%; margin-top: 6px"
+                    ></div>
+                  </div>
+                  <div style="background: var(--color-cream-soft)"></div>
+                </div>
+                <div
+                  style="
+                    border: 2px solid var(--color-ink);
+                    display: grid;
+                    grid-template-columns: 1.25fr 1fr;
+                    height: 76px;
+                  "
+                >
+                  <div style="padding: 8px">
+                    <div class="bar" style="height: 6px; width: 50%"></div>
+                    <div
+                      class="bar"
+                      style="height: 16px; width: 70%; margin-top: 6px"
+                    ></div>
+                  </div>
+                  <div style="background: var(--color-cream-soft)"></div>
+                </div>
+              </div>
+              <div
+                class="bar"
+                style="height: 90px; width: 100%; margin-top: 10px"
+              ></div>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <p class="col-label now">Loads as → /ploegen</p>
+          <div class="mini" style="height: 400px">
+            <div class="mini-inner">
+              <p class="r-kicker">De club</p>
+              <p class="r-h1" style="font-size: 22px">Ploegen.</p>
+              <div style="display: flex; flex-direction: column; gap: 8px">
+                <div
+                  style="
+                    border: 2px solid var(--color-ink);
+                    display: grid;
+                    grid-template-columns: 1.25fr 1fr;
+                    height: 76px;
+                  "
+                >
+                  <div style="padding: 8px">
+                    <p class="r-kicker">Senioren</p>
+                    <p class="r-h2" style="font-size: 13px">A-ploeg.</p>
+                  </div>
+                  <div style="background: var(--color-cream-soft)"></div>
+                </div>
+                <div
+                  style="
+                    border: 2px solid var(--color-ink);
+                    display: grid;
+                    grid-template-columns: 1.25fr 1fr;
+                    height: 76px;
+                  "
+                >
+                  <div style="padding: 8px">
+                    <p class="r-kicker">Senioren</p>
+                    <p class="r-h2" style="font-size: 13px">B-ploeg.</p>
+                  </div>
+                  <div style="background: var(--color-cream-soft)"></div>
+                </div>
+              </div>
+              <p class="r-h2" style="margin-top: 10px">Jeugd.</p>
+              <p class="r-body" style="font-size: 8px">
+                Bovenbouw — 4 · Middenbouw — 4 · Onderbouw — 7 · Reserven — 1
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col">
+          <p class="col-label">wedstrijden skeleton</p>
+          <div class="mini" style="height: 400px">
+            <div class="mini-inner">
+              <div class="bar" style="height: 7px; width: 50%"></div>
+              <div
+                class="bar"
+                style="height: 24px; width: 62%; margin: 6px 0 10px"
+              ></div>
+              <div class="bar" style="height: 150px; width: 100%"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="verdict">
+        Identical to B on <code>[slug]</code>, and it gives the other two routes
+        a rule instead of an exception.
+        <b>The test is not "does the page have this section" but "is the count
+        knowable before the fetch".</b>
+        <span class="cost">wrong on 0 of 18 · one rule, three files</span>
+      </p>
+      <p
+        class="verdict"
+        style="border-left-color: var(--color-ink); margin-top: 10px"
+      >
+        <b>Correction — 2026-08-14, after the rule was locked.</b> The
+        <code>/ploegen</code> panel above draws two flagship blocks on the claim
+        that two is structural. <b>It is not.</b>
+        <code>page.tsx:83,95</code> gates each one —
+        <code>{aTeam ? … : null}</code> and <code>{bTeam ? … : null}</code> — so
+        0, 1 or 2 can render, and the count comes from the same Sanity fetch the
+        skeleton covers. Under D's own test the flagships are
+        <b>not drawn</b>; the invariant on that route is the editorial header
+        alone (<code>Onze ploegen</code> and its tagline are hardcoded copy).
+        The rendering above is left in place rather than deleted so the mistake
+        stays legible.
+      </p>
+    </section>
+  </body>
+</html>

--- a/docs/research/gauntlet-loop.md
+++ b/docs/research/gauntlet-loop.md
@@ -1,0 +1,443 @@
+# The gauntlet loop — what it is, who owns it, and whether it belongs in this repo
+
+> **Provenance.** Produced 2026-08-17 by a research agent, against primary sources only. Every claim
+> below is traced to the source that owns it — the author's own site, his own repository, the
+> plugin's own manifest, or official Anthropic documentation. Secondary write-ups are cited **only**
+> where the primary source is unreachable, and are labelled as such. Fetch failures are stated rather
+> than guessed around, in [`README.md`](./README.md)'s house convention.
+>
+> **Why this file exists.** To decide whether the technique is worth adopting alongside
+> `scripts/ralph.sh` and the new `ralph-afk` skill. The short answer is at the top.
+
+## Verdict up front
+
+**"Gauntlet loop" is a real, named, single-author technique — about three weeks old, coined by Matt
+Shumer in late July 2026, with a primary source you can read in five minutes.** It is not vague, and
+it is not a hallucinated term. But it is also not a tool, a plugin, or a skill in any official
+registry: it is a _prompt shape_, and every implementation in the wild is a community repackaging.
+
+**It solves a different problem than Ralph or worktree fan-out.** Ralph and fan-out are _throughput_
+patterns — get more issues done. The gauntlet loop is a _quality-convergence_ pattern — drive **one**
+artifact toward **one** external reference until a blind judge prefers yours. They do not compete and
+one does not replace the other.
+
+**For this repo: do not adopt it.** It requires a fetchable external reference per unit of work, and
+a 127-issue queue of specced tickets has no such thing. It also aims at the wrong bottleneck. The one
+idea worth stealing is the **separate-critic blind A/B** — and the place to put it is the PR review
+gate, not the implementation loop. Details in [§7](#7-applicability-to-this-repo) and
+[§8](#8-the-adjacent-technique-actually-worth-taking).
+
+---
+
+## 1. Is it real, and who owns it?
+
+**Yes. Coined and named by Matt Shumer** (AI investor, former HyperWrite CEO), off the back of a
+viral project called _Claude of Duty_.
+
+### The primary sources, in order of authority
+
+| Source                                                                                                                   | What it owns                                                                                                                                          | Status                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [`github.com/mshumer/Claude-of-Duty`](https://github.com/mshumer/Claude-of-Duty)                                         | The run itself. Created **2026-07-25**, ~3,180 stars. Contains `prompt.md` — the entire originating prompt — plus an unusually honest results section | Read in full                                                                                                     |
+| [`github.com/mshumer/Claude-of-Duty/blob/main/prompt.md`](https://github.com/mshumer/Claude-of-Duty/blob/main/prompt.md) | **The canonical prompt text**, verbatim                                                                                                               | Read in full                                                                                                     |
+| [`somethingbig.ai/gauntlet-loop`](https://somethingbig.ai/gauntlet-loop)                                                 | Shumer's own write-up on **his own site** (footer: "© 2026 Something Big, LLC"). The canonical method description                                     | Read                                                                                                             |
+| [`x.com/mattshumer_/status/2081857631254372509`](https://x.com/mattshumer_/status/2081857631254372509)                   | Where he actually coins the name: _"driven by a technique I'm calling the Gauntlet Loop"_                                                             | **Could not read** — HTTP 402 via WebFetch, CAPTCHA via `xcancel.com`. Title text captured via search index only |
+
+### Two facts that matter about the provenance
+
+**The name came after the artifact.** `Claude-of-Duty`'s README never uses the words "gauntlet loop"
+— not once. The repo is just a Three.js FPS with a process note. Shumer named the technique
+retroactively, in the X post above, after the demo went viral. The technique is therefore _described_
+by its author, but it was never _specified_ by him: there is no reference implementation, no schema,
+no versioned definition.
+
+**There is no canonical implementation, and no official packaging.** Within days of the X post,
+GitHub filled with independent repackagings. None is authoritative, and none is Shumer's:
+
+| Repo                                                                             | Created      | Stars | Note                                                                                                                                       |
+| -------------------------------------------------------------------------------- | ------------ | ----- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`robonuggets/gauntlet-loop`](https://github.com/robonuggets/gauntlet-loop)      | 2026-08-05   | 373   | The most-adopted packaging. A single `SKILL.md`. Explicitly credits Shumer and links back to `Claude-of-Duty`                              |
+| [`duolahypercho/gauntlet-loop`](https://github.com/duolahypercho/gauntlet-loop)  | 2026-07-27   | 129   | Earliest packaging                                                                                                                         |
+| [`jolbol1/apex-gp`](https://github.com/jolbol1/apex-gp)                          | 2026-08-02   | 25    | Not a packaging — a _second independent run_ of the technique, with published cost data. See [§3](#3-what-the-technique-actually-produced) |
+| `NicholasSpisak`, `trilwu`, `PARAD111GM`, `MyriadSecurity`, `kamtS`, `ugulay`, … | Jul–Aug 2026 | 0–3   | A dozen more near-identical forks of the same idea                                                                                         |
+
+**`mshumer` has published no `gauntlet-loop` repo of his own.** His repository list shows
+`Claude-of-Duty` (2026-07-25) and nothing else on the subject.
+
+---
+
+## 2. What it actually does — mechanism, loop shape, termination
+
+### The entire original prompt
+
+This is `prompt.md` from `Claude-of-Duty`, verbatim and complete. The README's framing is that this
+is "the entire prompt that produced this repository" — roughly 55k lines across 11 subsystems.
+
+```text
+I want you to build a first-person shooter at the level of the most recent Call of Duty games. It
+should be utterly perfect, visually beautiful, with every single thing done at AAA quality—from
+textures to physics to anything you could think of.
+
+Fan out sub-agents and have sub-agents tackle each one individually so that the game is utterly
+perfect. You should /loop on each item and have a separate sub-agent check it visually to ensure it
+looks triple A. That separate sub-agent should be a really harsh critic, and if it doesn't look
+triple A, it should keep going.
+
+Don't stop until each sub-agent is utterly wowed with the quality when compared with the actual Call
+of Duty game. It should literally compare them side by side blind and say which one looks better. Do
+this in ThreeJS. /loop until it's utterly perfect. Fan out sub-agents and ultracode.
+```
+
+That is the whole technique. Everything else written about it is elaboration.
+
+### The loop shape
+
+```text
+             ┌──────────────────────────────────────────────┐
+             │  LEAD AGENT                                  │
+             │  goal + a named, fetchable external BAR      │
+             │  decomposes into independently judgeable     │
+             │  pieces — the agent decides the split,       │
+             │  not the human                               │
+             └───────────────────┬──────────────────────────┘
+                                 │  fan out, one pair per piece
+        ┌────────────────────────┼────────────────────────┐
+        ▼                        ▼                        ▼
+  ┌───────────┐            ┌───────────┐            ┌───────────┐
+  │ BUILDER   │            │ BUILDER   │            │ BUILDER   │
+  └─────┬─────┘            └─────┬─────┘            └─────┬─────┘
+        │ artifact               │                        │
+        ▼                        ▼                        ▼
+  ┌─────────────────────────────────────────────────────────────┐
+  │ CRITIC — a SEPARATE agent, FRESH context.                   │
+  │ Opens the real output. Fetches the real bar.                │
+  │ Blind A/B with labels stripped: "which is better?"          │
+  │ Binary, not a score. Names the single biggest gap.          │
+  └───────────────┬─────────────────────────┬───────────────────┘
+                  │ ours loses              │ ours wins
+                  │ → back to builder       │ → piece exits
+                  └──────── loop ───────────┘
+```
+
+Three load-bearing properties, per Shumer's own write-up at
+[`somethingbig.ai/gauntlet-loop`](https://somethingbig.ai/gauntlet-loop):
+
+1. **A real, fetchable bar.** _"You give a lead agent a goal and a real example of what great looks
+   like."_ Not a rubric, not "make it amazing" — a concrete artifact the critic can screenshot, run,
+   read, or open. This is the part that carries the whole technique.
+2. **Builder and critic must be separate agents with separate context.** Shumer's stated failure
+   mode: _"the builder and critic should be separate agents"_ — a builder remembers its own decisions
+   and rationalises them, producing "reasonable" work rather than better work.
+3. **Blind, binary comparison rather than scoring.** Labels stripped, pick A or B. Scores out of ten
+   drift upward every round.
+
+### Termination condition
+
+**There is no automatic exit.** Shumer states termination as three human-side conditions: stop
+_"when you like the result, when improvements become too small to matter, or when you have spent as
+much compute as you are willing to spend."_
+
+The prompt's nominal exit — "loop until the critic picks ours blind" — is a bar the run is expected
+to _fail_, and did (see [§3](#3-what-the-technique-actually-produced)). Every community packaging
+converges on the same rule: the exit is winning the comparison **or the operator stopping the run**,
+never a round count.
+
+### `ultracode` and `/loop` are real Claude Code features
+
+The prompt's last line is not folklore. Per the official docs at
+[`code.claude.com/docs/en/workflows`](https://code.claude.com/docs/en/workflows), `ultracode` is a
+keyword that opts a single prompt into a **dynamic workflow** — a JavaScript orchestration script
+Claude writes and a background runtime executes, spawning subagents at scale. Documented hard limits:
+**up to 16 concurrent agents** and **1,000 agents total per run**. `/loop` is a separate feature that
+reruns a prompt on an interval or lets the model pace itself.
+
+---
+
+## 3. What the technique actually produced
+
+This section exists because the primary source is far more honest than the coverage of it, and the
+numbers change the verdict.
+
+### From `Claude-of-Duty`'s own README
+
+Under the heading **"Honest assessment"**, the repo states plainly: _"The goal was to match a modern
+Call of Duty. **It does not.**"_
+
+| Round | Critic score /10      |
+| ----- | --------------------- |
+| 1     | 3.59                  |
+| 2     | 4.14                  |
+| 3     | **4.05** (regression) |
+| 4     | 5.05                  |
+
+And the line that matters most: _"In a blind A/B, **every critic in every round picked the real Call
+of Duty frame.**"_
+
+**The loop never met its own exit condition.** It ran until the operator stopped it. The technique's
+headline framing — "loop until it wins" — did not happen in the run that named the technique.
+
+### The process note — parallel fan-out _lost_
+
+This is the single most surprising primary finding, and it sits in the README of the project the
+technique is named after:
+
+> _"Sequential single-owner passes beat parallel fan-out decisively. Three rounds of six agents each
+> owning one directory moved the score +0.46 and left frame-ruining defects **higher** than they
+> started (60 → 47 → 66), because tonemapping, sky and indirect light are one coupled system and
+> isolated agents kept breaking each other's assumptions. One sequential pass with a single owner per
+> coupled concern moved it +1.00 and cut defects 66 → 26."_
+
+Read that carefully before generalising it — **the stated cause is coupling, not parallelism**. The
+subsystems fought because they shared one rendering pipeline. It is evidence against fanning agents
+out across a _coupled_ surface. It is not evidence against fanning them out across _independent_
+units of work. That distinction is what saves `ralph-afk` from this finding
+([§5](#5-versus-parallel-git-worktree-fan-out)).
+
+### Independent replication cost
+
+[`jolbol1/apex-gp`](https://github.com/jolbol1/apex-gp), an explicit second run of the technique
+(procedural F1 game, same builder/blind-critic shape), publishes its own numbers in its README:
+
+> _"It took **137 agents, 22.0M tokens and 19.3 hours** of agent wall-clock over 10 rounds, and
+> finished at **67.3/100** where 90 means a [player could not tell the difference]."_
+
+### Practitioner criticism
+
+Pieter Levels ([`@levelsio`](https://x.com/levelsio/status/2084997902632390981)) — _low confidence on
+exact wording, the post itself returned HTTP 402 and this is a search-index reproduction_:
+
+> _"Every time I do a Gauntlet Loop I end up with a total mess and chaos of unperformant code and too
+> many things happening and nothing works properly. And I burn $500. I have to clean everything up
+> manually and get back to what I had."_
+
+The consistent, independently-reported failure mode across secondary coverage: **when there is no
+real bar, the critic invents one and approves everything**, and there is no budget ceiling in the
+loop, so an unreachable bar burns tokens indefinitely.
+
+---
+
+## 4. Versus the Ralph loop
+
+Ralph is Geoffrey Huntley's technique ([`ghuntley.com/ralph`](https://ghuntley.com/ralph/)), reduced
+by its author to one line:
+
+```bash
+while :; do cat PROMPT.md | claude-code ; done
+```
+
+Anthropic ships it officially: **`ralph-loop` is in `anthropics/claude-plugins-official`** (confirmed
+by reading `.claude-plugin/marketplace.json` — 286 plugins, author "Anthropic", homepage
+[`anthropics/claude-plugins-public/tree/main/plugins/ralph-loop`](https://github.com/anthropics/claude-plugins-public/tree/main/plugins/ralph-loop)).
+The plugin implements the loop with a **Stop hook** that blocks session exit and re-feeds the same
+prompt, rather than an external bash loop.
+
+|                              | **Ralph loop**                                                                                                                                                             | **Gauntlet loop**                                                                                                                                     |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Author                       | Geoffrey Huntley                                                                                                                                                           | Matt Shumer                                                                                                                                           |
+| Primary source               | [ghuntley.com/ralph](https://ghuntley.com/ralph/)                                                                                                                          | [somethingbig.ai/gauntlet-loop](https://somethingbig.ai/gauntlet-loop) + [`prompt.md`](https://github.com/mshumer/Claude-of-Duty/blob/main/prompt.md) |
+| Official packaging           | **Yes** — `ralph-loop`, Anthropic official marketplace                                                                                                                     | **No** — see [§6](#6-confusions-ruled-in-and-out)                                                                                                     |
+| Loop axis                    | **Time.** Same prompt, again, forever                                                                                                                                      | **Quality.** Same artifact, judged against an external bar                                                                                            |
+| What carries state           | The **filesystem** — prior work persists as files and git history                                                                                                          | The **critic's verdict** — a gap statement fed back to the builder                                                                                    |
+| Who judges                   | Nothing, or the test suite / linter                                                                                                                                        | A **separate agent with fresh context**, blind A/B                                                                                                    |
+| Needs an external reference? | No                                                                                                                                                                         | **Yes — mandatory.** Without it the technique degenerates                                                                                             |
+| Termination                  | None inherent. Human stops it, or `--max-iterations` / a completion promise string                                                                                         | None inherent. Human stops it, or the blind A/B is won                                                                                                |
+| Parallelism                  | Optional. Huntley permits _"up to 500 parallel subagents for all operations but only 1 subagent for build/tests"_                                                          | Central — fan-out is in the prompt                                                                                                                    |
+| Anthropic's stated fit       | _"Well-defined tasks with clear success criteria… tasks with automatic verification (tests, linters)"_; **not** for _"tasks requiring human judgment or design decisions"_ | Taste-dominated work where a reference exists and tests cannot express the goal                                                                       |
+
+**They are complementary, not rival.** Ralph handles _"is it done?"_ when a machine can answer.
+Gauntlet handles _"is it good?"_ when only a comparison can answer. In Anthropic's own vocabulary
+from [Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents),
+the gauntlet loop is **evaluator-optimizer** (_"one LLM call generates a response while another
+provides evaluation and feedback in a loop"_) wrapped in **orchestrator-workers** (_"a central LLM
+dynamically breaks down tasks, delegates them to worker LLMs, and synthesizes their results"_). Both
+patterns predate the name by well over a year. The gauntlet loop's genuine contribution is the
+insistence that the evaluator's criterion be an **external, fetchable artifact** rather than a
+rubric.
+
+---
+
+## 5. Versus parallel git-worktree fan-out
+
+This is the shape `ralph-afk` is being built to: compute a wave of mutually-unblocked `ready` issues,
+spawn one background agent per issue, each in `../kcvv-issue-<N>` on `feat/issue-<N>`.
+
+|                              | **Worktree fan-out** (`ralph-afk`)                                                      | **Gauntlet loop**                                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Unit of parallelism          | **One issue** — a whole independent deliverable                                         | **One facet of one artifact** — hero, motion, type, colour                                                  |
+| Isolation mechanism          | **Filesystem.** Separate worktrees, separate branches. Agents physically cannot collide | **Context only.** All agents write into one tree                                                            |
+| Merge model                  | `N` separate PRs, each reviewed and merged independently                                | One artifact; convergence happens inside the run                                                            |
+| What guarantees independence | GitHub's native `blockedBy` GraphQL relationships, checked per issue                    | Nothing. The lead agent's judgement about what is separable                                                 |
+| Optimises for                | **Throughput** — issues closed per wall-clock hour                                      | **Quality ceiling** — one artifact versus one reference                                                     |
+| Correct failure mode         | An agent produces a bad PR; review catches it; blast radius is one branch               | Agents break each other's assumptions in shared files — **exactly the documented `Claude-of-Duty` failure** |
+
+**The `Claude-of-Duty` process note does not indict `ralph-afk`.** Its stated cause was that
+"tonemapping, sky and indirect light are one coupled system" — six agents editing one rendering
+pipeline. `ralph-afk` fans out across issues that are _decoupled by construction_, gated on
+`blockedBy`, and physically separated by worktrees. That is the configuration the note implicitly
+endorses: one owner per coupled concern.
+
+**What the note _does_ indict is any future temptation to fan several agents onto one issue.** If a
+wave ever puts two agents in the same worktree, or two issues touch the same coupled subsystem
+(`packages/sanity-schemas`, the type ramp, `render`-equivalent shared tokens), this is the primary
+evidence that it will regress. That risk is worth a line in `ralph-afk`'s hard rules.
+
+---
+
+## 6. Confusions ruled in and out
+
+Each of these was checked directly, not inferred.
+
+| Candidate                                                                         | Verdict                                                                           | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A `gauntlet` plugin in Anthropic's official marketplace**                       | **Ruled out.** Does not exist                                                     | Fetched `anthropics/claude-plugins-official/.claude-plugin/marketplace.json` — **286 plugins**, zero substring matches for `gaunt` anywhere in any entry. `ralph-loop` **is** there                                                                                                                                                                                                                                        |
+| **A `gauntlet` plugin in Anthropic's community marketplace**                      | **Ruled out.** Does not exist                                                     | Fetched `anthropics/claude-plugins-community/.claude-plugin/marketplace.json` — **2,281 plugins**, zero matches for `gaunt`. (`ralph` matches 4 unrelated plugins; `worktree` matches 17)                                                                                                                                                                                                                                  |
+| **A `gauntlet` skill in `anthropics/skills`**                                     | **Ruled out.** Does not exist                                                     | Full recursive tree listing, zero matches                                                                                                                                                                                                                                                                                                                                                                                  |
+| **A `gauntlet` npm package for agents**                                           | **Ruled out.** No such thing                                                      | `gauntlet-loop` → **404**. `gauntlet` → a **2014** package, _"Make your js applications dance on the client and the server"_, v0.0.2, unrelated. The `@chainlink/*-gauntlet-*` family and `@gauntlet-xyz/sdk` are blockchain/DeFi tooling from Gauntlet Networks, unrelated                                                                                                                                                |
+| **"Gauntlet" in AI evals/benchmarking**                                           | **Real, and genuinely unrelated.** A homonym                                      | MosaicML / Databricks' **[Mosaic Eval Gauntlet](https://github.com/mosaicml/llm-foundry/blob/main/scripts/eval/local_data/EVAL_GAUNTLET.md)** — a battery of ~35–39 public benchmarks across 6 competency categories, shipped in `llm-foundry`. It runs _a model_ through _many tests_. The gauntlet loop runs _one artifact_ through _one critic_, repeatedly. Same metaphor, opposite topology. **Do not conflate them** |
+| **"gantlet" (the other spelling)** in agent-harness or prompt-engineering writing | **Ruled out.** No usage found                                                     | Search returns only unrelated "agent harness engineering" / "loop engineering" literature. Nobody in this space uses the `gantlet` spelling                                                                                                                                                                                                                                                                                |
+| **A built-in Claude Code feature**                                                | **Ruled out** as a named feature — but its two dependencies **are** real features | `ultracode` and `/loop` are documented at [code.claude.com/docs/en/workflows](https://code.claude.com/docs/en/workflows). "Gauntlet loop" appears nowhere in Anthropic documentation                                                                                                                                                                                                                                       |
+
+---
+
+## 7. Applicability to this repo
+
+Concretely: one solo developer, `soniCaH/www.kcvvelewijt.be`, pnpm + Turborepo, Next.js on Vercel +
+Sanity Studio + a Cloudflare Workers BFF, TypeScript strict + Effect. ~127 open issues, ~30 `ready`.
+A sequential `scripts/ralph.sh` with a human PR-review gate, and a `ralph-afk` skill in progress. The
+real bottleneck is that **the human must review and merge every PR**, with CodeRabbitAI on each one.
+
+### Verdict: ignore it as a loop, steal exactly one idea, and put it somewhere else
+
+**Why not to adopt it:**
+
+1. **It aims at the wrong bottleneck.** The gauntlet loop makes _one artifact better_. It does not
+   make _more issues ship_, and it does not touch review throughput. Adding it slows the queue down —
+   more rounds, more tokens, more PRs waiting on the same one reviewer.
+2. **The bar requirement does not survive contact with a ticket queue.** Shumer's own rule is that
+   the reference must be **named, fetchable, and comparable**. That works for "beat Nike's running
+   campaign page." It does not work for "#2606 placeholder fixture" or "#2607 loading skeletons."
+   Roughly 30 `ready` issues would need 30 hand-picked external references. The documented
+   consequence of skipping that step is the technique's most common failure: **the critic invents a
+   standard and approves everything**, at full token cost.
+3. **This repo already has the bar in a better form.** `docs/design/` mockups, `DESIGN.md`, the
+   locked-primitive rules, `PRODUCT.md` Brand Commitments, and the VR baseline suite are all
+   _internal, versioned, fetchable_ references — and unlike a competitor's live page, they are the
+   references the project has actually committed to. A blind A/B against a competitor's site would
+   optimise toward someone else's design language, straight into the
+   "consistency ≠ flattening" and "no magazine chrome" rules.
+4. **The cost profile is wrong for a solo hobby project.** 22M tokens / 19.3h for one artifact
+   (`apex-gp`), or $500–900 burned with 95% discarded (levels.io). That budget buys a lot of
+   sequential Ralph turns.
+5. **The one run that named the technique never met its own exit condition,** and its own author
+   recorded that sequential single-owner passes beat parallel fan-out on the coupled surface.
+
+**The one idea worth stealing — the separate-critic blind A/B.** Not the loop; the _judge_. The
+transferable insight is Shumer's stated failure mode: a builder that grades its own work rationalises
+it, and a **score drifts upward every round while a binary blind comparison does not**. Where that
+applies here:
+
+- **Not applicable to `scripts/ralph.sh` — checked and ruled out.** An earlier draft of this section
+  claimed `run_code_review()` grades work in the implementer's own session. It does not.
+  `scripts/ralph.sh` makes four independent `claude --print` invocations
+  (lines 215, 242, 323, 381) with no `--resume` or `--continue` between them, so the reviewer already
+  starts from a fresh context and never sees the implementation reasoning. The builder-grades-itself
+  failure mode does not exist here. Left in as a negative finding so it is not "discovered" again.
+- **`ralph-afk`'s hard rules should forbid two agents in one worktree, and flag waves whose issues
+  touch a shared coupled surface** — the `Claude-of-Duty` process note is the citation for that rule.
+- **Where a design ticket genuinely does have a fetchable bar** — an approved mockup under
+  `docs/design/mockups/`, or a VR baseline — a blind A/B against _that_ is cheap and correctly aimed.
+  This is the gauntlet idea pointed at an internal reference, which is the only version that fits.
+
+**What not to do:** do not install any of the community `gauntlet-loop` skills. They are
+paste-a-prompt generators with no code, zero official provenance, and 0–373 stars of unreviewed
+third-party origin. If the pattern is ever wanted, the entire technique is three paragraphs — write
+them into a project skill and keep the authorship local.
+
+---
+
+## 8. The adjacent technique actually worth taking
+
+Found while searching, and aimed squarely at the stated bottleneck: **Claude Code dynamic workflows**
+— official, documented, and not a community pattern.
+[`code.claude.com/docs/en/workflows`](https://code.claude.com/docs/en/workflows).
+
+A dynamic workflow is a JavaScript orchestration script Claude writes and a background runtime
+executes. Its relevance here is specific: **intermediate results stay in script variables instead of
+landing in a context window**, the run is resumable, and — critically — the docs list _reviewing a
+changeset_ as a first-class example. This is Anthropic's own example prompt, verbatim:
+
+```text
+use a workflow to review every file changed in this PR for correctness issues, then merge the
+per-file findings into one ranked summary
+```
+
+Why this is the right shape for this repo's actual constraint:
+
+- **It attacks review, not implementation.** The bottleneck is one human reading `N` PRs. A per-file
+  reviewer fan-out that returns _one ranked, deduplicated summary_ compresses the reading, which is
+  the scarce resource. CodeRabbitAI already covers correctness; a workflow can be pointed at what
+  CodeRabbit does not know — `CLAUDE.md` conventions, the locked design primitives, peer-drift
+  against sibling files, the `blockedBy`/spec match.
+- **Adversarial verification is built in.** The docs describe workflows applying "a repeatable
+  quality pattern": _"it can have independent agents adversarially review each other's findings
+  before they're reported."_ That is the gauntlet loop's separate-critic idea, already implemented,
+  already official, without the token profile.
+- **It is savable and shareable.** Press `s` in `/workflows` and the script becomes a `/command` in
+  `.claude/workflows/`. In a monorepo, project workflows load from every `.claude/workflows/` between
+  cwd and the repo root — so a web-specific review workflow can live under `apps/web/`.
+- **The cost is bounded and visible.** Documented caps: **16 concurrent agents**, **1,000 agents per
+  run**, a `Large workflow` warning past 25 agents or 1.5M projected tokens, and a
+  `workflowSizeGuideline` setting (`small` = fewer than 5 agents). None of which the gauntlet loop
+  has.
+
+Two smaller notes worth recording, both from the same page:
+
+- **Stopping mid-fan-out is expensive.** On resume, _"cached results stop at the first agent that
+  didn't finish, and every agent that started after that one runs again, even if it completed."_
+  Many small agents preserve more progress than one long one.
+- **`ultracode` typed into a prompt does not trigger from `-p`.** Per the docs, the keyword is an
+  opt-in _"only in a prompt you type yourself"_ — it does **not** start a workflow from `claude -p`,
+  an SDK prompt not stamped as human, a scheduled task, or a PR comment. `scripts/ralph.sh` drives
+  `claude --print`, so the keyword would be inert there. A workflow must be requested in the prompt
+  body instead.
+
+---
+
+## Sources — what was read, and what could not be
+
+**Read in full (primary):**
+
+- [`github.com/mshumer/Claude-of-Duty`](https://github.com/mshumer/Claude-of-Duty) — README and
+  `prompt.md`, fetched raw. Repo metadata via GitHub API (created 2026-07-25, ~3,180 stars).
+- [`somethingbig.ai/gauntlet-loop`](https://somethingbig.ai/gauntlet-loop) — Matt Shumer's own site.
+- [`ghuntley.com/ralph`](https://ghuntley.com/ralph/) — Geoffrey Huntley's Ralph write-up.
+- [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) and
+  [`anthropics/claude-plugins-community`](https://github.com/anthropics/claude-plugins-community) —
+  both `marketplace.json` files parsed programmatically (286 and 2,281 plugins).
+- [`anthropics/claude-plugins-public/plugins/ralph-loop`](https://github.com/anthropics/claude-plugins-public/tree/main/plugins/ralph-loop) — plugin README and file tree.
+- [`code.claude.com/docs/en/workflows`](https://code.claude.com/docs/en/workflows) — official
+  dynamic-workflows / `ultracode` documentation.
+- [`anthropic.com/engineering/building-effective-agents`](https://www.anthropic.com/engineering/building-effective-agents) — evaluator-optimizer and orchestrator-workers definitions.
+- [`robonuggets/gauntlet-loop`](https://github.com/robonuggets/gauntlet-loop) `SKILL.md` — the
+  leading community packaging (third-party, cited as such).
+- [`jolbol1/apex-gp`](https://github.com/jolbol1/apex-gp) README — independent replication numbers.
+- npm registry: `gauntlet-loop` (404), `gauntlet` (2014, unrelated), full `gauntlet` search page.
+- `anthropics/skills` full recursive tree.
+
+**Could not be read — stated plainly:**
+
+- [`x.com/mattshumer_/status/2081857631254372509`](https://x.com/mattshumer_/status/2081857631254372509)
+  — **HTTP 402** via WebFetch; `xcancel.com` mirror served a CAPTCHA. This is the post where the term
+  is coined. Its title text (_"a technique I'm calling the Gauntlet Loop"_) was recovered from the
+  search index only. **The coinage attribution is therefore one step removed from the post itself** —
+  though it is corroborated by Shumer's own site and by `robonuggets`' attribution.
+- [`x.com/levelsio/status/2084997902632390981`](https://x.com/levelsio/status/2084997902632390981) —
+  same 402. The criticism quoted in [§3](#3-what-the-technique-actually-produced) is a
+  **search-index reproduction, low confidence on exact wording**; the substance (cost burned, work
+  discarded) is corroborated across several independent secondary write-ups.
+- The `$1,200` / `$1,700` per-project cost figures that circulate in secondary coverage were **not**
+  traced to any primary source and are **deliberately excluded** from this document.
+
+**Secondary sources consulted but not relied on for any claim:** Decrypt, daily.dev, digg,
+thepromptindex, stork.ai, ournationonline, we0.ai. Where they were the only route to a fact, the fact
+is labelled low-confidence above.


### PR DESCRIPTION
Housekeeping. Four things that had been sitting uncommitted in the main checkout, each of which the repo already has a convention for keeping.

## What is here

- **`docs/design/mockups/2508-motion-speeds/`, `2512-outcome-word/`, `2607-loading-skeletons/`** — three comparison passes that were built but never committed, so the comparisons they argue from lived on one disk only. Twenty-odd sibling mockup directories are already tracked; these follow that convention.
- **`apps/web/.impeccable/critique/`** — two critique reports from 2026-08-12. One critique file is already tracked, so this follows suit.
- **`docs/research/gauntlet-loop.md`** — a finished piece of research with its verdict up front: *do not adopt*. The technique needs a fetchable external reference per unit of work, which a queue of specced tickets does not have. Recorded so nobody researches it a second time.
- **`.claude/settings.json`** — disables the Vercel plugin.

## Notes

The two critique files were run through prettier; the mockup HTML was deliberately left alone, because the tracked mockups on `main` are not prettier-clean either and a wide `--write` over that directory rewrites hundreds of unrelated files.

No code changes, so no behaviour to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
