### PR TITLE
fix(config): --first must not report success after a failed blocker query

### DIFF
--- a/scripts/unblocked-issues.sh
+++ b/scripts/unblocked-issues.sh
@@ -76,7 +76,10 @@ for num in $CANDIDATES; do
 
   if [ "$open_blockers" = "0" ]; then
     echo "$num"
-    [ "$FIRST_ONLY" = true ] && exit 0
+    # break, not `exit 0` — fall through to the ANY_FAILED check below. A
+    # --first pick made after an earlier blocker query failed is not the first
+    # unblocked issue, only the first one we could confirm.
+    [ "$FIRST_ONLY" = true ] && break
   fi
 done
 


### PR DESCRIPTION
Found while the 2026-08-17 GitHub outage was making every `blockedBy` query flaky.

## The promise

`scripts/unblocked-issues.sh` says in its own header:

> Exits 1 if any blockedBy query failed, so a caller can never mistake an API failure for "nothing is blocked".

## The hole

The `--first` path never kept that promise. It hit `exit 0` on the first confirmed match, jumping straight past the `ANY_FAILED` check at the bottom of the file. So an issue whose blocker query returned a 503 was skipped in silence, and the caller was told everything was fine.

`scripts/ralph.sh` is the caller that pays for it. `pick_next_issue()` uses `--first`, and documents:

> A nonzero exit here means the blocker state is unknown, not that the queue is empty — the caller aborts rather than guessing.

During the outage that abort would never have fired. Ralph would have picked whichever issue happened to answer first, quietly skipping higher-priority ones whose blocker state was simply unknown.

## The fix

`break` instead of `exit 0`, so the loop falls through to the `ANY_FAILED` block that was already there. Three lines of comment explain why it must not go back.

## Verification

Stubbed `gh` with a deterministic failure on the first candidate:

| Case | Before | After |
| --- | --- | --- |
| First blocker query fails, second is clean | prints `2`, exits **0** | prints `2`, exits **1** |
| Healthy, `--first` | prints `1`, exits 0 | unchanged |
| Healthy, full list | prints `1 2 3`, exits 0 | unchanged |

No permanent test added: the repo has no shell test harness, and standing one up would be a larger diff than the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
