### PR TITLE
refactor(teams): stop fetching the team fields that have no reader (#2687)

### DIFF
--- a/apps/web/src/components/layout/MatchStrip/MatchStripInContext.stories.tsx
+++ b/apps/web/src/components/layout/MatchStrip/MatchStripInContext.stories.tsx
@@ -29,7 +29,6 @@ const makeTeam = (over: Partial<TeamNavVM>): TeamNavVM => ({
   psdId: null,
   division: null,
   divisionFull: null,
-  tagline: null,
   teamImageUrl: null,
 });
 

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.stories.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.stories.tsx
@@ -15,7 +15,6 @@ const makeTeam = (over: Partial<TeamNavVM>): TeamNavVM => ({
   psdId: null,
   division: null,
   divisionFull: null,
-  tagline: null,
   teamImageUrl: null,
 });
 

--- a/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
+++ b/apps/web/src/components/layout/SiteHeader/SiteHeader.test.tsx
@@ -21,7 +21,6 @@ const makeTeam = (over: Partial<TeamNavVM>): TeamNavVM => ({
   psdId: null,
   division: null,
   divisionFull: null,
-  tagline: null,
   teamImageUrl: null,
 });
 

--- a/apps/web/src/lib/repositories/team.repository.test.ts
+++ b/apps/web/src/lib/repositories/team.repository.test.ts
@@ -40,11 +40,8 @@ function makeTeamRow(
     displayName: null,
     slug: "eerste-elftallen-a",
     age: "A",
-    gender: "male",
-    footbelId: 12345,
     division: "3de Afdeling",
     divisionFull: "3de Afdeling VFV A",
-    tagline: "Er is maar één plezante compagnie",
     teamImageUrl: "https://cdn.sanity.io/team.webp",
     ...overrides,
   };
@@ -74,7 +71,6 @@ describe("TeamRepository", () => {
         psdId: "100",
         division: "3de Afdeling",
         divisionFull: "3de Afdeling VFV A",
-        tagline: "Er is maar één plezante compagnie",
         teamImageUrl: "https://cdn.sanity.io/team.webp",
       });
     });
@@ -88,7 +84,6 @@ describe("TeamRepository", () => {
           psdId: null,
           division: null,
           divisionFull: null,
-          tagline: null,
           teamImageUrl: null,
         }),
       ]);
@@ -106,7 +101,6 @@ describe("TeamRepository", () => {
       expect(t.psdId).toBeNull();
       expect(t.division).toBeNull();
       expect(t.divisionFull).toBeNull();
-      expect(t.tagline).toBeNull();
       expect(t.teamImageUrl).toBeNull();
     });
   });

--- a/apps/web/src/lib/repositories/team.repository.ts
+++ b/apps/web/src/lib/repositories/team.repository.ts
@@ -16,8 +16,7 @@ import type { TeamStaffMember } from "../team-role-resolution";
 
 export const TEAMS_QUERY =
   defineQuery(`*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {
-  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,
-  tagline,
+  _id, psdId, name, displayName, "slug": slug.current, age, division, divisionFull,
   "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))
 }`);
 
@@ -93,7 +92,6 @@ export interface TeamNavVM {
   psdId: string | null;
   division: string | null;
   divisionFull: string | null;
-  tagline: string | null;
   teamImageUrl: string | null;
 }
 
@@ -158,7 +156,6 @@ export function toTeamNavVM(row: TEAMS_QUERY_RESULT[number]): TeamNavVM {
     psdId: row.psdId,
     division: row.division,
     divisionFull: row.divisionFull,
-    tagline: row.tagline,
     teamImageUrl: row.teamImageUrl,
   };
 }

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -2623,7 +2623,7 @@ export type STAFF_MEMBERS_PSDID_QUERY_RESULT = Array<{
 
 // Source: ../web/src/lib/repositories/team.repository.ts
 // Variable: TEAMS_QUERY
-// Query: *[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,  tagline,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))}
+// Query: *[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {  _id, psdId, name, displayName, "slug": slug.current, age, division, divisionFull,  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))}
 export type TEAMS_QUERY_RESULT = Array<{
   _id: string;
   psdId: string | null;
@@ -2631,11 +2631,8 @@ export type TEAMS_QUERY_RESULT = Array<{
   displayName: string | null;
   slug: string | null;
   age: string | null;
-  gender: string | null;
-  footbelId: number | null;
   division: string | null;
   divisionFull: string | null;
-  tagline: string | null;
   teamImageUrl: string | null;
 }>;
 
@@ -2803,7 +2800,7 @@ declare module "@sanity/client" {
     '*[_type == "organigramNode" && active == true && roleCode in $roleCodes]{\n  title,\n  roleCode,\n  "members": members[@->archived != true && defined(@->email)]->{\n    "name": coalesce(firstName, "") + " " + coalesce(lastName, ""),\n    email\n  }\n}[count(members) > 0] | order(title asc)': KEY_CONTACTS_QUERY_RESULT;
     '*[_type == "staffMember" && psdId == $psdId && archived != true][0] {\n  _id, psdId, firstName, lastName, email, phone, bio,\n  "photoUrl": photo.asset->url + "?w=600&q=80&fm=webp&fit=max",\n  "organigramPositions": *[_type == "organigramNode" && ^._id in members[]._ref && active == true] | order(title asc, _id asc) { _id, title, roleCode, department },\n  // Reverse lookup: find responsibilities where this staff member is referenced through organigramNode members.\n  // primaryContact branch: ^.^ = staffMember (parent of responsibility filter, parent of organigramNode filter).\n  // steps branch: ^.^.^ = staffMember (extra caret level because steps[] adds a scope).\n  "responsibilityPaths": *[_type == "responsibility" && active == true && defined(slug.current) && slug.current != "" && (primaryContact.organigramNode._ref in *[_type == "organigramNode" && ^.^._id in members[]._ref]._id || count(steps[defined(contact.organigramNode._ref) && contact.organigramNode._ref in *[_type == "organigramNode" && ^.^.^._id in members[]._ref]._id]) > 0)] | order(title asc, _id asc) { title, "slug": slug.current, category, icon }\n}': STAFF_MEMBER_BY_PSD_ID_QUERY_RESULT;
     '*[_type == "staffMember" && archived != true && defined(psdId) && psdId != ""] | order(lastName asc) {\n  _id, psdId\n}': STAFF_MEMBERS_PSDID_QUERY_RESULT;
-    '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))\n}': TEAMS_QUERY_RESULT;
+    '*[_type == "team" && archived != true && showInNavigation != false] | order(name asc) {\n  _id, psdId, name, displayName, "slug": slug.current, age, division, divisionFull,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5))\n}': TEAMS_QUERY_RESULT;
     '*[_type == "team" && slug.current == $slug][0] {\n  _id, psdId, name, displayName, "slug": slug.current, age, gender, footbelId, division, divisionFull,\n  tagline, body[]{ ..., "fileUrl": file.asset->url }, contactInfo,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),\n  trainingSchedule,\n  players[]-> {\n    _id, psdId, firstName, lastName, jerseyNumber, keeper, positionPsd, position,\n    "psdImageUrl": psdImage.asset->url + "?w=400&q=80&fm=webp&fit=max",\n    "transparentImageUrl": transparentImage.asset->url + "?w=600&q=80&fm=webp&fit=max"\n  },\n  staff[] { role, "member": member-> { _id, psdId, archived, firstName, lastName, functionTitle, "photoUrl": photo.asset->url + "?w=200&q=80&fm=webp&fit=max", "hasBio": count(bio) > 0 } }\n}': TEAM_BY_SLUG_QUERY_RESULT;
     '*[_type == "team" && archived != true && defined(age) && age match "U*"] | order(name asc) {\n  _id, name, "slug": slug.current, age,\n  staff[defined(member) && !member->archived] { role, "member": member-> { _id, firstName, lastName, email, phone } }\n}': YOUTH_TEAMS_CONTACT_QUERY_RESULT;
     '*[_type == "team" && archived != true && showInNavigation != false && defined(age)] | order(name asc) {\n  _id, psdId, name, displayName, "slug": slug.current, age,\n  division, divisionFull, tagline,\n  "teamImageUrl": teamImage.asset->url + "?w=1200&h=800&q=80&fm=webp&fit=crop&crop=focalpoint&fp-x=" + string(coalesce(teamImage.hotspot.x, 0.5)) + "&fp-y=" + string(coalesce(teamImage.hotspot.y, 0.5)),\n  staff[] { role, "member": member-> { firstName, lastName, functionTitle } }\n}': TEAMS_LANDING_QUERY_RESULT;


### PR DESCRIPTION
Closes #2687

## Audit result

| Field | Reader | Action |
| --- | --- | --- |
| `gender` | None. Fetched in `TEAMS_QUERY`'s GROQ projection but never mapped by `toTeamNavVM` — `TeamNavVM` has no `gender` field. The only `.gender` hits in `apps/web/src` are `MembershipForm` (club-membership gender, a different domain) and generated `@kcvv/api-contract` PSD player schemas (unrelated to `team.gender`). | Dropped from `TEAMS_QUERY`. |
| `footbelId` | None on this path. Fetched in `TEAMS_QUERY`'s GROQ projection but never mapped by `toTeamNavVM` — `TeamNavVM` has no `footbelId` field. (`TEAM_BY_SLUG_QUERY` — a separate query, out of scope — does map `footbelId` onto `TeamDetailVM`, itself also unread by any component; left untouched per the issue's "don't widen into other queries" instruction.) | Dropped from `TEAMS_QUERY`. |
| `tagline` | None on this path. Fetched in `TEAMS_QUERY` and mapped onto `TeamNavVM.tagline`, but no consumer of `TeamNavVM` (`SiteHeader.tsx`, `menuItems.ts`, `MatchStrip*`, root `layout.tsx`, the landing page's `firstTeamVMs`) ever reads `.tagline` — only `displayName`, `slug`, `age`, `psdId`, `division`/`divisionFull` are used. `team.tagline` **does** have a real reader elsewhere — `TeamDetailVM.tagline` on `TeamHero` via `TEAM_BY_SLUG_QUERY` (apps/web/src/app/(main)/ploegen/[slug]/page.tsx:73,228; fixed to not duplicate `division` in #2630) — that query/VM is untouched. | Dropped from `TEAMS_QUERY` and `TeamNavVM`. |

## Changes

- `TEAMS_QUERY` (`apps/web/src/lib/repositories/team.repository.ts`) no longer projects `gender`, `footbelId`, or `tagline`.
- `TeamNavVM` no longer carries `tagline` (it never carried `gender`/`footbelId`).
- `toTeamNavVM` no longer maps `tagline`.
- Regenerated Sanity typegen (`apps/web/src/lib/sanity/sanity.types.ts`) for the trimmed `TEAMS_QUERY_RESULT`.
- Updated `TeamNavVM` fixtures that carried the now-removed field: `team.repository.test.ts`, `SiteHeader.stories.tsx`, `SiteHeader.test.tsx`, `MatchStripInContext.stories.tsx`.
- `TEAM_BY_SLUG_QUERY` and `TEAMS_LANDING_QUERY` (and their view models) are untouched — out of scope per the issue, and their `tagline`/`footbelId` fields have real (or at least separately-scoped) readers.

## Testing

- `pnpm --filter @kcvv/web lint:fix` — clean
- `pnpm --filter @kcvv/web check-all` — passes (lint, type-check, 6806/6806 tests, build)