### PR TITLE
fix(matches): keep reserven fixtures off the scheurkalender

### DIFF
--- a/apps/web/src/app/(main)/scheurkalender/page.tsx
+++ b/apps/web/src/app/(main)/scheurkalender/page.tsx
@@ -15,6 +15,7 @@ import {
   BFF_FAN_OUT_CONCURRENCY,
 } from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
+import { selectSeniorTeams } from "@/components/home/FirstTeamsBlock/first-teams";
 import type { Match } from "@/lib/effect/schemas/match.schema";
 import { KCVV_CLUB_ID } from "@/lib/constants";
 import {
@@ -80,10 +81,12 @@ async function fetchScheurkalenderData(): Promise<ScheurkalenderData> {
       const bff = yield* BffService;
       const teamRepo = yield* TeamRepository;
 
-      // Senior A + B squads (age "A"); the one whose name ends " B" is the B-team.
-      const seniorTeams = (yield* teamRepo.findAll()).filter(
-        (team) => team.age === "A" && team.psdId !== null,
-      );
+      // Senior A + B squads; the one whose name ends " B" is the B-team.
+      // Uses the shared first-team filter rather than a local `age === "A"`
+      // test: Reserven carries the senior age code "A" too, so the local test
+      // put its league fixtures on the poster the moment its `showInNavigation`
+      // was turned on — labelled "A", since its name ends in neither suffix.
+      const seniorTeams = selectSeniorTeams(yield* teamRepo.findAll());
 
       // Full-season fixtures per team, in parallel. Catch broadly (the
       // CLAUDE.md "broader catch when necessary" exception): this ISR page is


### PR DESCRIPTION
## Problem

`/scheurkalender` — the private data source for the A2 season poster — started
listing Reserven fixtures.

The page selected its squads with a local test:

```ts
(yield* teamRepo.findAll()).filter((team) => team.age === "A" && team.psdId !== null)
```

Reserven's Sanity `age` is the senior code `"A"`, exactly like the two first
teams. So the moment its `showInNavigation` was turned on, `findAll()` returned
it and its league fixtures landed on the poster sheet — labelled **A**, because
`squadLabel()` only assigns "B" to a name ending in `" B"`.

Confirmed against production Sanity: `showInNavigation != false && defined(psdId)
&& !(age match "U*")` returns exactly `Eerste Elftallen A` (1), `Eerste Elftallen B`
(2) and `Reserven` (34).

## Fix

Use `selectSeniorTeams` — the shared first-team filter that already drops
Reserven by `psdId` for the homepage `<FirstTeamsBlock>` and the landing
`<MatchStrip>`. One definition of "first team" instead of three, so the next
visibility flip cannot reopen this on a third surface.

## Verification

- `pnpm --filter @kcvv/web check-all` green — 318 test files, 6868 tests, build OK.
- The `next build` log now fans out over psdIds **1 and 2 only**; the
  `[Scheurkalender] … (psdId: 34)` line is gone.
- No new test: `first-teams.test.ts` already asserts `selectSeniorTeams([RESERVEN])`
  is empty, and that is now the code path this page runs.

## Out of scope

Reserven remains visible on every other surface `showInNavigation` gates — nav,
`/kalender`, search, the ICS feed and the BFF's `getNextMatches` fan-out. That is
the flag working as intended; only the poster sheet was reported as wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The calendar now shows fixtures only for senior A and B squads.
  * Reserve and other non-senior team fixtures are excluded from the calendar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->