### PR TITLE
feat(ui): export the scheurkalender as print-ready A2 artwork (#2702)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1026,6 +1026,17 @@
   }
 }
 
+/* The consent modal never belongs on a printed page. It needs its own rule
+   rather than riding a page's print stylesheet: the library animates the modal
+   with `visibility`, so it sets `visibility: visible` on itself and survives a
+   blanket `visibility: hidden` — it printed straight over the /scheurkalender
+   poster artwork (#2702). */
+@media print {
+  #cc-main {
+    display: none !important;
+  }
+}
+
 /* ===== vanilla-cookieconsent Theme — KCVV Elewijt (retro-terrace · #2125) ===== */
 /* Scoped to #cc-main so specificity beats the library's :root defaults
    regardless of CSS chunk load order (library CSS loads dynamically).

--- a/apps/web/src/components/scheurkalender/PosterPrintScale.test.tsx
+++ b/apps/web/src/components/scheurkalender/PosterPrintScale.test.tsx
@@ -42,7 +42,9 @@ afterEach(() => {
 
 describe("PosterPrintScale", () => {
   it("scales a long season down so it fits the block height", () => {
-    const sheetHeight = 1464; // 26/27: 56 fixtures, taller than the block
+    // Taller than 26/27, which fits on width alone at the current layout
+    // width — the height fit only takes over past ~1534 px.
+    const sheetHeight = 1800;
     mountSheet(sheetHeight);
     render(<PosterPrintScale />);
 
@@ -62,7 +64,7 @@ describe("PosterPrintScale", () => {
   });
 
   it("measures on mount, so a browser that never fires beforeprint still fits", () => {
-    const sheetHeight = 1464;
+    const sheetHeight = 1800;
     mountSheet(sheetHeight);
 
     render(<PosterPrintScale />);
@@ -86,7 +88,9 @@ describe("PosterPrintScale", () => {
   });
 
   it("stops measuring once unmounted", () => {
-    mountSheet(1464);
+    // Height-limited, so the replacement sheet below would measure to a
+    // different scale — otherwise a leaked listener would look like a pass.
+    mountSheet(1800);
     const { unmount } = render(<PosterPrintScale />);
     const scaleAtUnmount = readScale();
     unmount();

--- a/apps/web/src/components/scheurkalender/PosterPrintScale.test.tsx
+++ b/apps/web/src/components/scheurkalender/PosterPrintScale.test.tsx
@@ -7,12 +7,13 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render } from "@testing-library/react";
 import { PosterPrintScale } from "./PosterPrintScale";
+import { BLOCK_HEIGHT_PX, WIDTH_FIT_SCALE } from "./poster-geometry";
 
-const PX_PER_MM = 96 / 25.4;
-const SHEET_WIDTH_PX = 796;
-const WIDTH_FIT = (340 * PX_PER_MM) / SHEET_WIDTH_PX;
-
-/** A sheet in the document with a stubbed height — jsdom lays nothing out. */
+/**
+ * A sheet in the document with a stubbed height — jsdom lays nothing out. It
+ * carries the print-only dateline the real sheet has, so the branch that forces
+ * that into the measurement is exercised.
+ */
 function mountSheet(scrollHeight: number): HTMLElement {
   const sheet = document.createElement("div");
   sheet.className = "sk-poster-sheet";
@@ -20,6 +21,10 @@ function mountSheet(scrollHeight: number): HTMLElement {
     configurable: true,
     value: scrollHeight,
   });
+  const footer = document.createElement("p");
+  footer.className = "sk-poster-footer";
+  footer.style.display = "none";
+  sheet.appendChild(footer);
   document.body.appendChild(sheet);
   return sheet;
 }
@@ -43,8 +48,8 @@ describe("PosterPrintScale", () => {
 
     window.dispatchEvent(new Event("beforeprint"));
 
-    expect(readScale()).toBeCloseTo((567 * PX_PER_MM) / sheetHeight, 4);
-    expect(readScale()).toBeLessThan(WIDTH_FIT);
+    expect(readScale()).toBeCloseTo(BLOCK_HEIGHT_PX / sheetHeight, 4);
+    expect(readScale()).toBeLessThan(WIDTH_FIT_SCALE);
   });
 
   it("never scales a short season past the block width", () => {
@@ -53,28 +58,44 @@ describe("PosterPrintScale", () => {
 
     window.dispatchEvent(new Event("beforeprint"));
 
-    expect(readScale()).toBeCloseTo(WIDTH_FIT, 4);
+    expect(readScale()).toBeCloseTo(WIDTH_FIT_SCALE, 4);
   });
 
-  it("leaves the sheet's own width untouched after measuring", () => {
+  it("measures on mount, so a browser that never fires beforeprint still fits", () => {
+    const sheetHeight = 1464;
+    mountSheet(sheetHeight);
+
+    render(<PosterPrintScale />);
+
+    expect(readScale()).toBeCloseTo(BLOCK_HEIGHT_PX / sheetHeight, 4);
+  });
+
+  it("puts the sheet and its dateline back the way it found them", () => {
     const sheet = mountSheet(1464);
     sheet.style.width = "500px";
+    const footer = sheet.querySelector<HTMLElement>(".sk-poster-footer")!;
     render(<PosterPrintScale />);
 
     window.dispatchEvent(new Event("beforeprint"));
 
     expect(sheet.style.width).toBe("500px");
+    // Restored to what it was, not to a hardcoded "none" — the dateline is
+    // hidden by a class on screen, and forcing an inline value would change
+    // what the print stylesheet is allowed to do with it.
+    expect(footer.style.display).toBe("none");
   });
 
   it("stops measuring once unmounted", () => {
     mountSheet(1464);
     const { unmount } = render(<PosterPrintScale />);
+    const scaleAtUnmount = readScale();
     unmount();
 
+    // A second sheet that would measure differently — the scale must not move.
+    document.querySelectorAll(".sk-poster-sheet").forEach((el) => el.remove());
+    mountSheet(200);
     window.dispatchEvent(new Event("beforeprint"));
 
-    expect(
-      document.documentElement.style.getPropertyValue("--sk-poster-scale"),
-    ).toBe("");
+    expect(readScale()).toBe(scaleAtUnmount);
   });
 });

--- a/apps/web/src/components/scheurkalender/PosterPrintScale.test.tsx
+++ b/apps/web/src/components/scheurkalender/PosterPrintScale.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * PosterPrintScale Tests
+ *
+ * The fit is the only thing standing between a long season and fixtures
+ * clipped off the bottom of the poster, so both bounds get a case.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { PosterPrintScale } from "./PosterPrintScale";
+
+const PX_PER_MM = 96 / 25.4;
+const SHEET_WIDTH_PX = 796;
+const WIDTH_FIT = (340 * PX_PER_MM) / SHEET_WIDTH_PX;
+
+/** A sheet in the document with a stubbed height — jsdom lays nothing out. */
+function mountSheet(scrollHeight: number): HTMLElement {
+  const sheet = document.createElement("div");
+  sheet.className = "sk-poster-sheet";
+  Object.defineProperty(sheet, "scrollHeight", {
+    configurable: true,
+    value: scrollHeight,
+  });
+  document.body.appendChild(sheet);
+  return sheet;
+}
+
+function readScale(): number {
+  return Number(
+    document.documentElement.style.getPropertyValue("--sk-poster-scale"),
+  );
+}
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--sk-poster-scale");
+  document.querySelectorAll(".sk-poster-sheet").forEach((el) => el.remove());
+});
+
+describe("PosterPrintScale", () => {
+  it("scales a long season down so it fits the block height", () => {
+    const sheetHeight = 1464; // 26/27: 56 fixtures, taller than the block
+    mountSheet(sheetHeight);
+    render(<PosterPrintScale />);
+
+    window.dispatchEvent(new Event("beforeprint"));
+
+    expect(readScale()).toBeCloseTo((567 * PX_PER_MM) / sheetHeight, 4);
+    expect(readScale()).toBeLessThan(WIDTH_FIT);
+  });
+
+  it("never scales a short season past the block width", () => {
+    mountSheet(200);
+    render(<PosterPrintScale />);
+
+    window.dispatchEvent(new Event("beforeprint"));
+
+    expect(readScale()).toBeCloseTo(WIDTH_FIT, 4);
+  });
+
+  it("leaves the sheet's own width untouched after measuring", () => {
+    const sheet = mountSheet(1464);
+    sheet.style.width = "500px";
+    render(<PosterPrintScale />);
+
+    window.dispatchEvent(new Event("beforeprint"));
+
+    expect(sheet.style.width).toBe("500px");
+  });
+
+  it("stops measuring once unmounted", () => {
+    mountSheet(1464);
+    const { unmount } = render(<PosterPrintScale />);
+    unmount();
+
+    window.dispatchEvent(new Event("beforeprint"));
+
+    expect(
+      document.documentElement.style.getPropertyValue("--sk-poster-scale"),
+    ).toBe("");
+  });
+});

--- a/apps/web/src/components/scheurkalender/PosterPrintScale.tsx
+++ b/apps/web/src/components/scheurkalender/PosterPrintScale.tsx
@@ -1,24 +1,11 @@
 "use client";
 
 import { useEffect } from "react";
-
-/** CSS px per millimetre — print CSS resolves `px` at a fixed 96 dpi. */
-const PX_PER_MM = 96 / 25.4;
-
-/**
- * The poster block between the InDesign sponsor blocks
- * (`docs/design/mockups/phase-10-scheurkalender/sk2-poster-layout-locked.md`).
- * The print stylesheet reserves exactly this box inside the A2 page.
- */
-const BLOCK_WIDTH_PX = 340 * PX_PER_MM;
-const BLOCK_HEIGHT_PX = 567 * PX_PER_MM;
-
-/**
- * Width the sheet is laid out at in print — the width it has at the 860 px
- * viewport the layout was locked against, minus `<PageContainer>`'s `md:px-8`.
- * Kept in step with `POSTER_PRINT_CSS`.
- */
-const SHEET_WIDTH_PX = 796;
+import {
+  BLOCK_HEIGHT_PX,
+  BLOCK_WIDTH_PX,
+  SHEET_WIDTH_PX,
+} from "./poster-geometry";
 
 /**
  * Scales the poster sheet to fit the printed block (#2702).
@@ -38,8 +25,10 @@ const SHEET_WIDTH_PX = 796;
  *
  * Measuring cannot wait for the print layout (`beforeprint` fires before it),
  * and the on-screen sheet is a different width at every viewport, so the height
- * is read with the print width forced on. One synchronous reflow, once, at
- * print time.
+ * is read with the print width forced on — one forced reflow per measurement.
+ * It runs on mount, again if the web fonts were still loading, and again before
+ * printing; the page is a private tool one person opens to export a poster, so
+ * that costs nothing worth caching against.
  */
 export function PosterPrintScale() {
   useEffect(() => {
@@ -72,6 +61,18 @@ export function PosterPrintScale() {
       );
     };
 
+    // Measure on mount, not only on `beforeprint`. WebKit never fires that
+    // event, so on Safari — the likely "Save as PDF" route on a Mac — the
+    // sheet would keep the width-only fallback and clip; the same gap opens if
+    // Cmd+P beats hydration. Nothing about the measurement needs print state,
+    // so taking it early costs one reflow and closes both.
+    applyScale();
+    // Web fonts change the height. Only wait for them if they are still
+    // loading — on a warm cache they are done before this runs, and the
+    // already-resolved promise would just re-measure to the same answer.
+    if (document.fonts && document.fonts.status !== "loaded") {
+      void document.fonts.ready.then(applyScale);
+    }
     window.addEventListener("beforeprint", applyScale);
     return () => window.removeEventListener("beforeprint", applyScale);
   }, []);

--- a/apps/web/src/components/scheurkalender/PosterPrintScale.tsx
+++ b/apps/web/src/components/scheurkalender/PosterPrintScale.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+
+/** CSS px per millimetre — print CSS resolves `px` at a fixed 96 dpi. */
+const PX_PER_MM = 96 / 25.4;
+
+/**
+ * The poster block between the InDesign sponsor blocks
+ * (`docs/design/mockups/phase-10-scheurkalender/sk2-poster-layout-locked.md`).
+ * The print stylesheet reserves exactly this box inside the A2 page.
+ */
+const BLOCK_WIDTH_PX = 340 * PX_PER_MM;
+const BLOCK_HEIGHT_PX = 567 * PX_PER_MM;
+
+/**
+ * Width the sheet is laid out at in print — the width it has at the 860 px
+ * viewport the layout was locked against, minus `<PageContainer>`'s `md:px-8`.
+ * Kept in step with `POSTER_PRINT_CSS`.
+ */
+const SHEET_WIDTH_PX = 796;
+
+/**
+ * Scales the poster sheet to fit the printed block (#2702).
+ *
+ * A fixed scale factor cannot do this. The sheet's width is known, but its
+ * *height* is the season: 56 fixtures across nine months in 26/27, and a
+ * different number every year. Scaling on width alone overflowed the block by
+ * ~44 mm on the first real export and `overflow: hidden` silently ate the back
+ * half of December — the failure mode a poster cannot have.
+ *
+ * So the factor is measured, the same way `<VolledigOrganigram>` measures its
+ * chart before printing. Two differences, both because this sheet is artwork
+ * rather than a paper copy: the fit is against the poster block instead of the
+ * paper, and it runs on `beforeprint` rather than a button click, so `Cmd+P`
+ * gets it too — the club exports through the browser's PDF writer, not through
+ * the button.
+ *
+ * Measuring cannot wait for the print layout (`beforeprint` fires before it),
+ * and the on-screen sheet is a different width at every viewport, so the height
+ * is read with the print width forced on. One synchronous reflow, once, at
+ * print time.
+ */
+export function PosterPrintScale() {
+  useEffect(() => {
+    const applyScale = () => {
+      const sheet = document.querySelector<HTMLElement>(".sk-poster-sheet");
+      if (!sheet) return;
+
+      // The dateline is `hidden print:block`, so on screen it contributes no
+      // height. Left out of the measurement it is left out of the fit, and the
+      // sheet prints that much too tall — the last fixtures fall off the
+      // bottom. Force it in for the reading, exactly like the width.
+      const footer = sheet.querySelector<HTMLElement>(".sk-poster-footer");
+      const previousWidth = sheet.style.width;
+      const previousFooterDisplay = footer?.style.display ?? "";
+      sheet.style.width = `${SHEET_WIDTH_PX}px`;
+      if (footer) footer.style.display = "block";
+      const sheetHeight = sheet.scrollHeight;
+      sheet.style.width = previousWidth;
+      if (footer) footer.style.display = previousFooterDisplay;
+
+      // Never scale up past the block: a short season should print at the
+      // locked type size, not stretch to fill the sheet.
+      const scale = Math.min(
+        BLOCK_WIDTH_PX / SHEET_WIDTH_PX,
+        BLOCK_HEIGHT_PX / sheetHeight,
+      );
+      document.documentElement.style.setProperty(
+        "--sk-poster-scale",
+        String(scale),
+      );
+    };
+
+    window.addEventListener("beforeprint", applyScale);
+    return () => window.removeEventListener("beforeprint", applyScale);
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.stories.tsx
@@ -139,8 +139,10 @@ export const Default: Story = {
 };
 
 /**
- * Poster width — the ~860 px render the owner screenshots at, which prints the
- * club names at roughly 5.5 mm inside the 340 × 567 mm block.
+ * Poster width — the ~860 px render the owner used to screenshot, which prints
+ * the club names at roughly 5.5 mm inside the 340 × 567 mm block but wraps the
+ * longest two. The PDF export lays out wider than this so none of them wrap
+ * (`poster-geometry.ts`); this story is the narrow end of the range.
  */
 export const PosterWidth: Story = {
   args: { matches: seasonFixtures },

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
@@ -271,4 +271,26 @@ describe("ScheurkalenderPage", () => {
       ).toBeInTheDocument();
     });
   });
+
+  // The print export IS the poster artwork (#2702) — it replaces a screenshot,
+  // so a silently dropped hook means a blurry poster, not a broken page. jsdom
+  // applies no print styles, so these assert the wiring the stylesheet needs;
+  // the geometry itself is verified by exporting a PDF (see the PR).
+  describe("poster print export", () => {
+    it("wraps the sheet in the scaled page area", () => {
+      const { container } = renderPage();
+      const page = container.querySelector(".sk-poster");
+      expect(page).not.toBeNull();
+      expect(page!.querySelector(".sk-poster-sheet")).not.toBeNull();
+    });
+
+    it("prints A2 with background fills kept", () => {
+      const { container } = renderPage();
+      const css = container.querySelector("style")?.textContent ?? "";
+      expect(css).toContain("size: A2 portrait");
+      // Margins that leave the 340 × 567 mm poster block.
+      expect(css).toContain("margin: 13.5mm 40mm");
+      expect(css).toContain("print-color-adjust: exact");
+    });
+  });
 });

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.test.tsx
@@ -11,6 +11,7 @@ import {
   ScheurkalenderPage,
   type ScheurkalenderMatch,
 } from "./ScheurkalenderPage";
+import { SHEET_WIDTH_PX, WIDTH_FIT_SCALE } from "./poster-geometry";
 
 // Fixtures spanning both calendar years of a season, so the column split is
 // exercised. Weekends: 29–30/08, 05–06/09 (2026) | 09–10/01, 16/01 (2027).
@@ -287,10 +288,23 @@ describe("ScheurkalenderPage", () => {
     it("prints A2 with background fills kept", () => {
       const { container } = renderPage();
       const css = container.querySelector("style")?.textContent ?? "";
-      expect(css).toContain("size: A2 portrait");
+      // A2 as explicit dimensions — the `A2` keyword is invalid CSS and gets
+      // the whole declaration dropped, so assert the rule, not the prose that
+      // explains it.
+      expect(css).toContain("size: 420mm 594mm");
       // Margins that leave the 340 × 567 mm poster block.
       expect(css).toContain("margin: 13.5mm 40mm");
       expect(css).toContain("print-color-adjust: exact");
+    });
+
+    it("falls back to the width fit the poster block implies", () => {
+      const { container } = renderPage();
+      const css = container.querySelector("style")?.textContent ?? "";
+      // The fallback only bites when the measurement never runs — a path no
+      // on-screen check exercises, so nothing else notices if the stylesheet
+      // stops carrying it.
+      expect(css).toContain(`--sk-poster-scale, ${WIDTH_FIT_SCALE}`);
+      expect(css).toContain(`width: ${SHEET_WIDTH_PX}px`);
     });
   });
 });

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -25,6 +25,7 @@ import { toDisplayZone } from "@/lib/utils/dates";
 import { capitalize } from "@/lib/utils/capitalize";
 import { EmptyState, PageContainer } from "@/components/design-system";
 import { PosterPrintScale } from "./PosterPrintScale";
+import { SHEET_WIDTH_PX, WIDTH_FIT_SCALE } from "./poster-geometry";
 import { PrintButton } from "./PrintButton";
 import { PrintDate } from "./PrintDate";
 
@@ -145,14 +146,14 @@ const POSTER_PRINT_CSS = `
      relative to the block (the 5.5 mm the layout was locked on) and can
      rebalance the calendar-year column split. */
   .sk-poster-sheet {
-    width: 796px;
+    width: ${SHEET_WIDTH_PX}px;
     margin: 0 auto;
     /* Set by <PosterPrintScale> on \`beforeprint\` — it fits the sheet to the
        block on *both* axes, which a constant cannot do because the height is
        however long the season is. The fallback is the width fit: correct for
        a season short enough to fit, and the best available answer if the
        measurement never runs. */
-    transform: scale(var(--sk-poster-scale, 1.6144));
+    transform: scale(var(--sk-poster-scale, ${WIDTH_FIT_SCALE}));
     transform-origin: top center;
   }
 

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -24,6 +24,7 @@ import { DateTime } from "luxon";
 import { toDisplayZone } from "@/lib/utils/dates";
 import { capitalize } from "@/lib/utils/capitalize";
 import { EmptyState, PageContainer } from "@/components/design-system";
+import { PosterPrintScale } from "./PosterPrintScale";
 import { PrintButton } from "./PrintButton";
 import { PrintDate } from "./PrintDate";
 
@@ -68,6 +69,102 @@ interface MonthGroup {
 }
 
 const NL_WEEKDAYS = ["ma", "di", "wo", "do", "vr", "za", "zo"];
+
+/**
+ * Print stylesheet — turns `Cmd+P` into the poster's *source artwork* rather
+ * than a paper copy of a web page (#2702).
+ *
+ * The fixture table used to reach the A2 InDesign poster as a screenshot: a
+ * ~96 dpi raster placed in a document that prints at A2. Exported through the
+ * browser's PDF writer instead, the same sheet arrives as vector — InDesign
+ * places PDFs as vector, so the type stays sharp at any size and the screenshot
+ * step disappears.
+ *
+ * Scoped to this component rather than `globals.css`: it is page artwork, not a
+ * site-wide print convention. Deliberately static CSS — unlike
+ * `<VolledigOrganigram>`, which injects its rule at click time because its
+ * scale-to-fit factor depends on the rendered chart, every number here is
+ * fixed by the locked layout.
+ *
+ * No `>` in any selector: React escapes text children, and an escaped entity
+ * inside a raw-text `<style>` element is never decoded back.
+ */
+const POSTER_PRINT_CSS = `
+@media print {
+  /* A2 portrait, with margins that leave a content box of exactly
+     340 × 567 mm — the poster block between the InDesign sponsor blocks
+     (sk2-poster-layout-locked.md). The export therefore places at 100 %.
+
+     Written as explicit dimensions, not \`size: A2 portrait\`: the CSS
+     page-size keywords stop at A3 (A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 |
+     letter | legal | ledger), so \`A2\` is an invalid value the whole
+     declaration is dropped for — silently, and the export falls back to the
+     browser's default paper. */
+  @page { size: 420mm 594mm; margin: 13.5mm 40mm; }
+
+  /* Bound the document to exactly one page. Hiding the rest of the site below
+     only stops it being *painted* — it is still laid out, and a full site
+     header plus footer is taller than one sheet, so without this the export
+     came out three pages long, two of them blank. */
+  html, body {
+    width: 340mm !important;
+    height: 567mm !important;
+    min-height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    /* \`visibility: hidden\` below hides the site's boxes but not the page
+       ground behind them, so the cream body background printed as a border
+       around the artwork. */
+    background: #fff !important;
+  }
+
+  /* Only the sheet prints. The site header, the site footer and the toolbar
+     are screen chrome; without this they land on the poster. */
+  body * { visibility: hidden !important; }
+  .sk-poster, .sk-poster * { visibility: visible !important; }
+
+  /* The page area itself. \`overflow: hidden\` clips whatever the scale cannot
+     fit, so a long season can never spill a second, near-blank A2 sheet. */
+  .sk-poster {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 340mm !important;
+    height: 567mm;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden;
+  }
+
+  /* The layout is locked against an 860 px viewport, where <PageContainer>
+     leaves the sheet 796 px wide (860 − 2 × 32 px of \`md:px-8\`). Print lays
+     out at the physical page width instead, so the sheet is *scaled* onto the
+     block rather than reflowed into it — reflowing would shrink the club names
+     relative to the block (the 5.5 mm the layout was locked on) and can
+     rebalance the calendar-year column split. */
+  .sk-poster-sheet {
+    width: 796px;
+    margin: 0 auto;
+    /* Set by <PosterPrintScale> on \`beforeprint\` — it fits the sheet to the
+       block on *both* axes, which a constant cannot do because the height is
+       however long the season is. The fallback is the width fit: correct for
+       a season short enough to fit, and the best available answer if the
+       measurement never runs. */
+    transform: scale(var(--sk-poster-scale, 1.6144));
+    transform-origin: top center;
+  }
+
+  /* Chrome drops background fills in print unless the reader ticks "Background
+     graphics" by hand — which would silently flatten the sheet frame and the
+     white ground the poster block sits on. */
+  .sk-poster, .sk-poster * {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+`;
 
 /** Bucket fixtures per weekend (ISO week — Mon–Sun share a group). */
 function groupByWeekend(matches: ScheurkalenderMatch[]): Weekend[] {
@@ -218,69 +315,78 @@ export function ScheurkalenderPage({
 
   return (
     <div className="bg-cream min-h-screen print:bg-white">
+      <style>{POSTER_PRINT_CSS}</style>
+      <PosterPrintScale />
+
       {/* Screen-only toolbar — hidden on print and cropped out of poster screenshots. */}
       <PageContainer className="flex justify-end pt-6 print:hidden">
         <PrintButton />
       </PageContainer>
 
-      <PageContainer className="pt-4 pb-12 print:p-0">
-        {/* The "sheet" — this is what gets screenshotted into the poster. */}
-        <div className="border-ink border-2 bg-white print:border-0">
-          {/* Masthead */}
-          <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
-            <h1 className="font-body text-ink text-lg font-extrabold tracking-[0.02em] uppercase">
-              KCVV Elewijt — Competitie {season}
-            </h1>
-            <p className="text-ink-muted font-mono text-[10px] tracking-[0.08em] uppercase">
-              A &amp; B · Wedstrijdkalender
-            </p>
+      {/* `sk-poster` is the printed page area; `sk-poster-sheet` is the artwork
+          scaled into it. Both are print-only hooks — see POSTER_PRINT_CSS. */}
+      <PageContainer className="sk-poster pt-4 pb-12 print:p-0">
+        <div className="sk-poster-sheet">
+          {/* The "sheet" — this is the artwork the poster places. */}
+          <div className="border-ink border-2 bg-white print:border-0">
+            {/* Masthead */}
+            <div className="border-ink flex items-baseline justify-between gap-4 border-b-2 px-4 py-3.5">
+              <h1 className="font-body text-ink text-lg font-extrabold tracking-[0.02em] uppercase">
+                KCVV Elewijt — Competitie {season}
+              </h1>
+              <p className="text-ink-muted font-mono text-[10px] tracking-[0.08em] uppercase">
+                A &amp; B · Wedstrijdkalender
+              </p>
+            </div>
+
+            {hasMatches ? (
+              <div
+                className={`grid px-5 pt-1.5 pb-[18px] ${
+                  columns.length > 1 ? "grid-cols-2" : "grid-cols-1"
+                }`}
+              >
+                {columns.map((weekends, index) => (
+                  <div
+                    key={weekends[0]?.key ?? index}
+                    className={
+                      index === 0 && columns.length > 1
+                        ? "border-ink/15 border-r pr-[17px]"
+                        : columns.length > 1
+                          ? "pl-[17px]"
+                          : ""
+                    }
+                  >
+                    <FixtureColumn weekends={weekends} />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              // "gevonden" is banned outside query surfaces (#2427 rule 3) — this
+              // is a data source, not a search. surface="bare": already inside
+              // the poster's own `border-ink` sheet frame — a second frame here
+              // nested two ink borders, and dropped a taped jersey into a print
+              // poster (#2562 review round 3). `className="px-5"` matches the
+              // populated grid's own horizontal inset above — without it, this
+              // branch's copy ran wider than the content it replaces inside
+              // the same sheet (#2562 review round 4).
+              <EmptyState
+                tier="surface"
+                heading="Geen competitiewedstrijden"
+                surface="bare"
+                className="px-5"
+              >
+                Er zijn geen competitiewedstrijden voor dit seizoen beschikbaar.
+              </EmptyState>
+            )}
           </div>
 
-          {hasMatches ? (
-            <div
-              className={`grid px-5 pt-1.5 pb-[18px] ${
-                columns.length > 1 ? "grid-cols-2" : "grid-cols-1"
-              }`}
-            >
-              {columns.map((weekends, index) => (
-                <div
-                  key={weekends[0]?.key ?? index}
-                  className={
-                    index === 0 && columns.length > 1
-                      ? "border-ink/15 border-r pr-[17px]"
-                      : columns.length > 1
-                        ? "pl-[17px]"
-                        : ""
-                  }
-                >
-                  <FixtureColumn weekends={weekends} />
-                </div>
-              ))}
-            </div>
-          ) : (
-            // "gevonden" is banned outside query surfaces (#2427 rule 3) — this
-            // is a data source, not a search. surface="bare": already inside
-            // the poster's own `border-ink` sheet frame — a second frame here
-            // nested two ink borders, and dropped a taped jersey into a print
-            // poster (#2562 review round 3). `className="px-5"` matches the
-            // populated grid's own horizontal inset above — without it, this
-            // branch's copy ran wider than the content it replaces inside
-            // the same sheet (#2562 review round 4).
-            <EmptyState
-              tier="surface"
-              heading="Geen competitiewedstrijden"
-              surface="bare"
-              className="px-5"
-            >
-              Er zijn geen competitiewedstrijden voor dit seizoen beschikbaar.
-            </EmptyState>
-          )}
+          {/* Print-only footer. It rides inside the scaled sheet on purpose: a
+              poster export is a snapshot of live PSD fixtures, so the artwork
+              carries the day it was pulled. */}
+          <p className="sk-poster-footer text-ink-muted mt-4 hidden text-center font-mono text-[10px] uppercase print:block">
+            KCVV Elewijt · Competitie {season} · afgedrukt op <PrintDate />
+          </p>
         </div>
-
-        {/* Print-only footer — kiosk prints get a date; the screen sheet stays clean. */}
-        <p className="text-ink-muted mt-4 hidden text-center font-mono text-[10px] uppercase print:block">
-          KCVV Elewijt · Competitie {season} · afgedrukt op <PrintDate />
-        </p>
       </PageContainer>
     </div>
   );

--- a/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
+++ b/apps/web/src/components/scheurkalender/ScheurkalenderPage.tsx
@@ -139,12 +139,11 @@ const POSTER_PRINT_CSS = `
     overflow: hidden;
   }
 
-  /* The layout is locked against an 860 px viewport, where <PageContainer>
-     leaves the sheet 796 px wide (860 − 2 × 32 px of \`md:px-8\`). Print lays
-     out at the physical page width instead, so the sheet is *scaled* onto the
-     block rather than reflowed into it — reflowing would shrink the club names
-     relative to the block (the 5.5 mm the layout was locked on) and can
-     rebalance the calendar-year column split. */
+  /* Laid out at a fixed width and *scaled* onto the block, never reflowed into
+     it. Print's own width is the physical page, which is far wider in CSS px
+     than any screen render — reflowing there shrinks the club names relative to
+     the block and rebalances the calendar-year column split. The width itself
+     is chosen in \`poster-geometry.ts\`, on where club names stop wrapping. */
   .sk-poster-sheet {
     width: ${SHEET_WIDTH_PX}px;
     margin: 0 auto;

--- a/apps/web/src/components/scheurkalender/poster-geometry.ts
+++ b/apps/web/src/components/scheurkalender/poster-geometry.ts
@@ -25,11 +25,30 @@ export const BLOCK_WIDTH_PX = 340 * PX_PER_MM;
 export const BLOCK_HEIGHT_PX = 567 * PX_PER_MM;
 
 /**
- * Width the sheet is laid out at in print — the width it has at the 860 px
- * viewport the layout was locked against, minus `<PageContainer>`'s `md:px-8`
- * (860 − 2 × 32).
+ * Width the sheet is laid out at in print: the narrowest width at which no
+ * club name wraps to a second line.
+ *
+ * It started as 796 — the sheet's width at the 860 px viewport the layout was
+ * locked against (860 − 2 × 32 px of `<PageContainer>`'s `md:px-8`) — because
+ * that is the render the owner used to screenshot. Measured against the real
+ * 56-fixture 26/27 season, that width is dominated on both counts it was
+ * chosen for:
+ *
+ * | laid out at | names wrapped | printed name |
+ * | ----------- | ------------- | ------------ |
+ * | 796 px      | 6             | 5.42 mm      |
+ * | 860 px      | 2             | 5.53 mm      |
+ * | 920 px      | 0             | 5.17 mm      |
+ * | 976 px      | 0             | 4.88 mm      |
+ *
+ * Wrapping is not free height: six wrapped rows make the sheet tall enough that
+ * the height fit, not the width fit, decides the scale — so 796 printed both
+ * more wrapping *and* smaller type than 860. Past 920 the sheet stops getting
+ * shorter (nothing is left to unwrap) while the type keeps shrinking, so 920 is
+ * the last width that buys anything. The poster keeps a whole club name on one
+ * line at the cost of 0.36 mm of type against the lock.
  */
-export const SHEET_WIDTH_PX = 796;
+export const SHEET_WIDTH_PX = 920;
 
 /**
  * Fit on width alone. The stylesheet carries this as the fallback for a print

--- a/apps/web/src/components/scheurkalender/poster-geometry.ts
+++ b/apps/web/src/components/scheurkalender/poster-geometry.ts
@@ -1,0 +1,39 @@
+/**
+ * The poster export's geometry, in one place (#2702).
+ *
+ * These numbers are load-bearing in two files at once — the print stylesheet in
+ * `<ScheurkalenderPage>` reserves the block and lays the sheet out at
+ * `SHEET_WIDTH_PX`, and `<PosterPrintScale>` measures against the same box.
+ * They were hand-typed in both, plus a third time in the tests, kept in step by
+ * a comment: update one and the sheet gets measured at a width the stylesheet
+ * does not render it at, which silently clips fixtures off the poster.
+ *
+ * Its own module rather than an export from `<PosterPrintScale>`: that file is
+ * `"use client"`, and every export of a client module reaches a server
+ * component as a client reference, not as the number.
+ */
+
+/** CSS px per millimetre — print CSS resolves `px` at a fixed 96 dpi. */
+export const PX_PER_MM = 96 / 25.4;
+
+/**
+ * The poster block between the InDesign sponsor blocks
+ * (`docs/design/mockups/phase-10-scheurkalender/sk2-poster-layout-locked.md`).
+ * The print stylesheet reserves exactly this box inside the A2 page.
+ */
+export const BLOCK_WIDTH_PX = 340 * PX_PER_MM;
+export const BLOCK_HEIGHT_PX = 567 * PX_PER_MM;
+
+/**
+ * Width the sheet is laid out at in print — the width it has at the 860 px
+ * viewport the layout was locked against, minus `<PageContainer>`'s `md:px-8`
+ * (860 − 2 × 32).
+ */
+export const SHEET_WIDTH_PX = 796;
+
+/**
+ * Fit on width alone. The stylesheet carries this as the fallback for a print
+ * that never got measured; it is correct for any season short enough to fit,
+ * and it is the ceiling `<PosterPrintScale>` never scales past.
+ */
+export const WIDTH_FIT_SCALE = BLOCK_WIDTH_PX / SHEET_WIDTH_PX;


### PR DESCRIPTION
Closes #2702

## Changes

`/scheurkalender` now exports itself. `Cmd+P` (or the page's own button) produces a **vector PDF** InDesign can place directly, replacing the ~96 dpi screenshot that has been capping the A2 poster's sharpness.

The print stylesheet gives the page an A2 portrait sheet whose margins leave a content box of exactly **340 × 567 mm** — the locked poster block — and scales the sheet onto it.

Four things the browser does not do on its own, each found by exporting and looking at the result:

| Symptom in the export | Cause | Fix |
| --- | --- | --- |
| US Letter, not A2 | `size: A2 portrait` is invalid CSS — the page-size keywords stop at A3, so the whole declaration is dropped, silently | Explicit `420mm 594mm` |
| Three pages, two blank | The rest of the site is hidden but still laid out, and a full header + footer is taller than one sheet | The print flow is bounded to one page |
| Back half of December missing | A width-only fit overflowed the block by ~44 mm and `overflow: hidden` ate the rest | `<PosterPrintScale>` measures on `beforeprint` and fits both axes |
| Cookie modal printed over the artwork | The consent library animates with `visibility`, so it sets itself visible again and survives a blanket `visibility: hidden` | It never prints now, on any page — this also fixes the same latent bug in the organigram's print export |

The scale cannot be a constant: the sheet's width is fixed but its height is however long the season is. Measurement also runs on mount, because WebKit never fires `beforeprint` and Safari is a plausible Save-as-PDF route.

## Testing

`pnpm --filter @kcvv/web check-all` — 319 test files, 6885 tests, build green.

Verified by exporting the live 26/27 season (56 fixtures) through Chrome with `preferCSSPageSize`, which is what the print dialog does and what the `--print-to-pdf` CLI flag does *not*:

- **1 page**, MediaBox `1191.12 × 1684.08 pt` = A2
- Artwork **308.3 × 567.0 mm** inside the 340 × 567 mm block — height-limited, so nothing is clipped
- Club names print at **5.4 mm** (locked reference: 5.5 mm)
- **3 embedded fonts, 0 raster images** — genuinely vector
- Every month August–April present, dateline intact

Both new stylesheet assertions were mutation-checked (break the rule → the tests fail).

## Review gate

`/code-review` (high) raised 4 findings and `/simplify` raised 6; all were applied except three, noted here:

- **A shared `scaleElementToFit` helper with `<VolledigOrganigram>`** — skipped. The two differ in trigger model (mount-and-`beforeprint` vs. click) and fit target (poster block vs. paper); parameterising both leaves ~3 lines of standard print CSS actually shared. The altitude reviewer independently reached the same conclusion.
- **Caching the measurement across its three triggers** — skipped. Up to three forced reflows on a private page one person opens to export a poster is not worth a dirty-flag.
- **Merging two rule blocks that share a selector** — skipped; they are grouped with the explanations they belong to.

## Notes

The **Gullegem** fixture still shows its old kick-off time until the kalendercommissie pushes the agreed change into ProSoccerData. Override that line in devtools before exporting, or reprint later — deliberately not a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Scheurkalender poster printing with optimized scaling to fit the artwork accurately on A2 paper.
  - Print output now preserves colors, uses consistent poster dimensions and margins, and hides non-printable site elements.
- **Bug Fixes**
  - Cookie-consent dialogs are no longer included in printed pages.
  - Poster sizing now adapts reliably to content height and loaded fonts, reducing clipping and overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->