### PR TITLE
feat(api): competitiontype gains a tournament member (#2692)

### DIFF
--- a/apps/api/src/psd/transforms.test.ts
+++ b/apps/api/src/psd/transforms.test.ts
@@ -34,8 +34,12 @@ describe("resolveCompetitionType", () => {
     expect(resolveCompetitionType(obj("FRIENDLY"))).toBe("friendly");
   });
 
-  it("maps an unknown object type to 'other'", () => {
-    expect(resolveCompetitionType(obj("TOURNAMENT"))).toBe("other");
+  it("maps TOURNAMENT to 'tournament'", () => {
+    expect(resolveCompetitionType(obj("TOURNAMENT"))).toBe("tournament");
+  });
+
+  it("maps an object type with no member of its own to 'other'", () => {
+    expect(resolveCompetitionType(obj("INTERNATIONAL"))).toBe("other");
   });
 
   it("maps a plain-string (inlined match-detail label) to 'other'", () => {

--- a/apps/api/src/psd/transforms.ts
+++ b/apps/api/src/psd/transforms.ts
@@ -100,8 +100,9 @@ function resolveCompetitionLabel(
 }
 
 /**
- * Resolve a PSD competitionType field to the normalized league/cup/friendly
- * classification used by the UI gate (e.g. match-day standings).
+ * Resolve a PSD competitionType field to the normalized
+ * league/cup/friendly/tournament classification used by the UI gate (e.g.
+ * match-day standings).
  *
  * Only the **object** form carries a reliable `.type`. The match-detail
  * endpoint (`/games/{id}/info`) inlines a display *string* (e.g. "Croky Cup"),
@@ -111,7 +112,9 @@ function resolveCompetitionLabel(
  * match-team index, not from `/games/{id}/info` directly.
  *
  * PSD uses `type: "OFFICIAL"` (Dutch "Competitie") for league play; `"LEAGUE"`
- * is accepted as a forward-compat synonym.
+ * is accepted as a forward-compat synonym. `"TOURNAMENT"` resolves to
+ * `"tournament"`; any other code (e.g. `"INTERNATIONAL"`) has no member of
+ * its own and falls through to `"other"`.
  */
 export function resolveCompetitionType(
   ct: PsdCompetitionType | string | null | undefined,
@@ -125,6 +128,8 @@ export function resolveCompetitionType(
       return "cup";
     case "FRIENDLY":
       return "friendly";
+    case "TOURNAMENT":
+      return "tournament";
     default:
       return "other";
   }

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -103,6 +103,7 @@ The type of tournament a match belongs to. Stored on `Match.competition`.
 | `LEAGUE`          | Competitie        | Regular league play                                            |
 | `CUP`             | Beker             | Cup tournament (specific name from PSD `competitionType.name`) |
 | `FRIENDLY`        | Vriendschappelijk | Friendly match                                                 |
+| `TOURNAMENT`      | Tornooi           | Tournament fixture                                             |
 
 **Open:** PSD also returns `competitionType.name` (e.g. "Beker van Brabant"). This should be mapped to a Dutch display label. See PRD.
 
@@ -112,7 +113,7 @@ The specific division a team is placed in for a competition — `3de Afdeling Vo
 
 A reeks is named in **two vocabularies** and both are correct: the federation's (PSD `competition.name`, prefixed `Voetbal : <bond> -` plus a trailing space) and the club's (Sanity `divisionFull`). `3de Afdeling Voetb Vl A` and `3e Nationale VV A` are the same reeks. The club's name wins on anything a human reads; PSD's fills the gap where no editorial value is set (#2589).
 
-**Only PSD carries a reeks per competition.** A match carries none — the fixture feed knows only `OFFICIAL`/`CUP`/`FRIENDLY`. Sanity carries one per _team_, which cannot name two phases.
+**Only PSD carries a reeks per competition.** A match carries none — the fixture feed knows only `OFFICIAL`/`CUP`/`FRIENDLY`/`TOURNAMENT`. Sanity carries one per _team_, which cannot name two phases.
 
 ### Competition Phase
 

--- a/packages/api-contract/src/schemas/match.ts
+++ b/packages/api-contract/src/schemas/match.ts
@@ -43,15 +43,16 @@ export const MatchStatus = S.Literal(...MATCH_STATUS_VALUES);
 export type MatchStatus = S.Schema.Type<typeof MatchStatus>;
 
 /**
- * Normalized league/cup/friendly classification for a match.
+ * Normalized league/cup/friendly/tournament classification for a match.
  *
  * Surfaced so consumers can gate behaviour on the *structured* competition type
  * instead of string-matching the Dutch `competition` label (which is a division
  * name like "3de Nationale", not "Competitie"). Derived by the BFF from PSD's
  * `competitionType.type` (`OFFICIAL`/`LEAGUE` → `"league"`, `CUP` → `"cup"`,
- * `FRIENDLY` → `"friendly"`, anything else → `"other"`).
+ * `FRIENDLY` → `"friendly"`, `TOURNAMENT` → `"tournament"`, anything else →
+ * `"other"`).
  */
-export const CompetitionType = S.Literal("league", "cup", "friendly", "other");
+export const CompetitionType = S.Literal("league", "cup", "friendly", "tournament", "other");
 export type CompetitionType = S.Schema.Type<typeof CompetitionType>;
 
 /** Shared fields between Match and MatchDetail */


### PR DESCRIPTION
Closes #2692

## Changes

- `packages/api-contract/src/schemas/match.ts`: added `tournament` as a member of the `CompetitionType` literal union, and updated its doc comment to document the new PSD `TOURNAMENT` → `"tournament"` mapping.
- `apps/api/src/psd/transforms.ts`: `resolveCompetitionType()` gains a `TOURNAMENT` case that resolves to `"tournament"` instead of falling through to `"other"`.
- `apps/api/src/psd/transforms.test.ts`: updated the existing assertion that `TOURNAMENT` resolves to `"other"` (now asserts `"tournament"`), and added a new assertion that a code with no member of its own (`INTERNATIONAL`) still resolves to `"other"` — so that fallback path stays covered now that `TOURNAMENT` isn't the example for it anymore.

## Why land a union member ahead of any consumer

This is normally something this repo refuses (peer-drift/unused-code concerns), but it was a deliberate call at triage (see the issue's Agent Brief): the consumer that would react to `"tournament"` cannot be built first, because building it would require string-matching the Dutch `"Tornooi"` label — which this repo forbids. Landing the contract member is therefore the only lawful way to make the distinction expressible; the actual consumer (deciding how a tournament fixture renders) is explicitly deferred to #2693 and is out of scope here.

## Explicitly not touched

- No change to how a tournament fixture renders (agenda row, `MatchStripView`, `UpcomingMatches`, `/kalender`, `/ploegen/*/wedstrijden`) — that's #2693's decision.
- `mapCompetitionLabel()` (the Dutch display-label mapper) is unchanged — `TOURNAMENT` still yields `"Tornooi"` (or the tournament's own name when PSD sends one).
- No `placeholderKind` enum, no `remarks` reads, no further `isPlaceholder` adoption — all out of scope per the issue.
- Checked every `competitionType` reader in `apps/web`/`apps/api` (via grep + full `tsgo` type-check across all 7 workspace packages) for an exhaustive switch that would need the new member handled — found none; all existing gates only check `=== "league"` / `!== "league"`.
- `CLAUDE.md` was not updated — a new union member is not an architecture change (new package, renamed path, schema ownership), so this doesn't qualify.

## Testing

- `pnpm --filter @kcvv/web lint:fix` — clean, no changes.
- `pnpm --filter @kcvv/web check-all` — lint clean, type-check clean, 6885/6885 tests passed, `next build` compiled successfully (346/346 static pages generated; the `[sitemap]`/`[HomePage]` fetch errors in the log are expected — no local BFF running at `localhost:8787` in this worktree — and are handled gracefully per the existing ISR catchAll behavior).
- `pnpm --filter @kcvv/api test` — 475/475 tests passed (32 files).
- `pnpm --filter @kcvv/api type-check` — clean.
- `pnpm turbo build --filter=@kcvv/api-contract --force` rerun after every edit to `packages/api-contract/src/` before type-checking downstream, per the worktree bootstrap note.
- No visual-regression capture performed — this ticket renders nothing new.

## Deploy-window caveat (documentation only — no code change here)

This widens `CompetitionType`, a strict `S.Literal` that `apps/web`'s `BffService` decodes worker responses against (`HttpApiClient.make(PsdApi, ...)` in `apps/web/src/lib/effect/services/BffService.ts:88`). A web bundle compiled before this change cannot decode a response containing `"tournament"`. The Cloudflare worker and the Vercel web build deploy independently on merge to `main`, so there is a window where the worker has already started emitting `"tournament"` but the old web bundle is still live and fails to decode it. This is not hypothetical: a tournament fixture (the U9 row on 30 Aug named in #2692) is in production data today. Deciding the mitigation (deploy ordering, splitting this across two PRs/deploys, or loosening decode strictness) is a call bigger than this ticket — flagging it here so it isn't discovered at merge time.

**Decided: ship as one PR and accept the window.** The site is not yet public — the apex still serves Drupal — so the only readers during the gap are the team on the `.vercel.app` host. That makes a few minutes of degraded fixture decoding an acceptable cost, and it is the reason this is acceptable, not a judgement that the risk is zero.

Worth keeping in view: after go-live the same reasoning no longer holds. The next widening of a response literal will need real handling — deploy ordering, a two-PR split, or a tolerant decode. This PR is not the precedent for doing it this way once the site is public.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for classifying tournament competitions as **“tournament.”**
  - Tournament fixtures are now recognized alongside league, cup, and friendly match types.

- **Documentation**
  - Updated the competition glossary to include the tournament classification and its Dutch label, **“Tornooi.”**
  - Clarified that tournament fixtures may be associated with match series.

- **Bug Fixes**
  - Unrecognized competition types continue to be categorized as **“other”** for consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
