### PR TITLE
fix(matches): the ics feed stops naming a pitch reservation as a match against itself (#2698)

### DIFF
--- a/apps/web/src/app/(main)/wedstrijd/[matchId]/utils.ts
+++ b/apps/web/src/app/(main)/wedstrijd/[matchId]/utils.ts
@@ -9,7 +9,7 @@ import type {
 import type { MatchHeroTeam } from "@/components/match/MatchHero";
 import type { LineupPlayer } from "@/components/match/MatchLineup";
 import { toMatchDisplayZone } from "@/lib/utils/dates";
-import { reservationView } from "@/lib/utils/match-display";
+import { reservationTitle } from "@/lib/utils/match-display";
 
 /**
  * Convert a match's home team into props suitable for the MatchHero component.
@@ -103,9 +103,10 @@ export { extractMatchTime } from "@/lib/utils/match-time";
  * Builds an SEO-friendly match title.
  *
  * A pitch-reservation placeholder (#2606) gets its own title rather than
- * "KCVV Elewijt vs KCVV Elewijt" — composed from `reservationView()`'s
- * subject, the same source `<MatchHero>`'s kicker reads, so the fallback
- * word and the competition subject can't drift between the two (#2688).
+ * "KCVV Elewijt vs KCVV Elewijt" — via the shared `reservationTitle()`
+ * (`lib/utils/match-display.ts`), the same helper `buildSummary()`
+ * (`lib/utils/ical.ts`, the ICS feed) calls, so the wording can't drift
+ * between the two surfaces (#2688/#2698).
  *
  * @returns `HomeTeam X - Y AwayTeam` if the match status is finished and both scores are present, otherwise `HomeTeam vs AwayTeam`
  */
@@ -114,7 +115,7 @@ export function formatMatchTitle(match: MatchDetail): string {
   const awayTeam = match.away_team.name;
 
   if (match.is_placeholder) {
-    return `${reservationView(match).subject} — ${homeTeam}`;
+    return reservationTitle(match);
   }
 
   // Only show score if match is finished AND both scores are defined

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -17,6 +17,21 @@ function makeMatch(overrides: Partial<Match> = {}): Match {
   } as Match;
 }
 
+/**
+ * A pitch-reservation placeholder (#2606): both sides are the same club, so
+ * `home_team`/`away_team` carry identical ids and names.
+ */
+function makePlaceholderMatch(overrides: Partial<Match> = {}): Match {
+  return makeMatch({
+    id: 54321,
+    home_team: { id: 5, name: "KCVV Elewijt", score: undefined },
+    away_team: { id: 5, name: "KCVV Elewijt", score: undefined },
+    is_placeholder: true,
+    competition: "Jeugdtornooi",
+    ...overrides,
+  } as Partial<Match>);
+}
+
 describe("generateIcal", () => {
   it("generates a valid iCal with a scheduled match", () => {
     const matches = [makeMatch()];
@@ -204,6 +219,39 @@ describe("generateIcal", () => {
     const idx1 = output.indexOf("kcvv-match-1@kcvvelewijt.be");
     const idx2 = output.indexOf("kcvv-match-2@kcvvelewijt.be");
     expect(idx1).toBeLessThan(idx2);
+  });
+});
+
+describe("a pitch-reservation placeholder", () => {
+  it("never renders a home===away SUMMARY", () => {
+    const output = generateIcal([makePlaceholderMatch()]);
+
+    expect(output).not.toContain("SUMMARY:KCVV Elewijt - KCVV Elewijt");
+  });
+
+  it("uses the reservation subject as the SUMMARY, mirroring formatMatchTitle", () => {
+    const output = generateIcal([
+      makePlaceholderMatch({ competition: "Jeugdtornooi" }),
+    ]);
+
+    expect(output).toContain("SUMMARY:Jeugdtornooi — KCVV Elewijt");
+  });
+
+  it("falls back to the reservation word when no competition is set", () => {
+    const output = generateIcal([
+      makePlaceholderMatch({ competition: undefined }),
+    ]);
+
+    expect(output).toContain("SUMMARY:Gereserveerd — KCVV Elewijt");
+  });
+
+  it("is treated as a home fixture for side filtering — it is the club's own booking, and both sides are literally the same club name", () => {
+    const match = makePlaceholderMatch();
+
+    expect(generateIcal([match], { side: "home" })).toContain("BEGIN:VEVENT");
+    expect(generateIcal([match], { side: "away" })).not.toContain(
+      "BEGIN:VEVENT",
+    );
   });
 });
 

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -29,7 +29,7 @@ function makePlaceholderMatch(overrides: Partial<Match> = {}): Match {
     is_placeholder: true,
     competition: "Jeugdtornooi",
     ...overrides,
-  } as Partial<Match>);
+  });
 }
 
 describe("generateIcal", () => {
@@ -252,6 +252,30 @@ describe("a pitch-reservation placeholder", () => {
     expect(generateIcal([match], { side: "away" })).not.toContain(
       "BEGIN:VEVENT",
     );
+  });
+
+  it("folds a cancelled status into the SUMMARY, the way every other reservation renderer does", () => {
+    const output = generateIcal([
+      makePlaceholderMatch({ status: "postponed" }),
+    ]);
+
+    expect(output).toContain(
+      "SUMMARY:Jeugdtornooi — KCVV Elewijt — Uitgesteld",
+    );
+  });
+
+  it("omits LOCATION when no venue is set — a reservation can be an external tournament, not necessarily at the home venue", () => {
+    const output = generateIcal([makePlaceholderMatch({ venue: undefined })]);
+
+    expect(output).not.toMatch(/^LOCATION:/m);
+  });
+
+  it("uses the given venue for LOCATION when one is set", () => {
+    const output = generateIcal([
+      makePlaceholderMatch({ venue: "Sportcomplex De Nekker" }),
+    ]);
+
+    expect(output).toContain("Sportcomplex De Nekker");
   });
 });
 

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -5,7 +5,7 @@ import type { Match } from "@kcvv/api-contract";
 // Doubles as the calendar's `TZID` — an iCal protocol value, not only a display
 // pin — so it is read from the one home rather than restated.
 import { CLUB_TIMEZONE as TIMEZONE, toMatchDisplayZone } from "./dates";
-import { reservationView } from "./match-display";
+import { reservationTitle, reservationView } from "./match-display";
 
 const HOME_VENUE_FALLBACK = "Sportpark Elewijt, Elewijt, België";
 
@@ -28,14 +28,25 @@ function isHomeMatch(match: Match): boolean {
 
 /**
  * A pitch-reservation placeholder (#2606) gets its own summary rather than
- * "KCVV Elewijt - KCVV Elewijt" — composed from `reservationView()`'s
- * subject, the same source `formatMatchTitle()`
- * (`/wedstrijd/[matchId]/utils.ts`) reads, so the wording can't drift between
- * the ICS feed and the match detail page's SEO title (#2698).
+ * "KCVV Elewijt - KCVV Elewijt" — via the shared `reservationTitle()`
+ * (`lib/utils/match-display.ts`), the same helper `formatMatchTitle()`
+ * (`/wedstrijd/[matchId]/utils.ts`, the match detail page's SEO title) calls,
+ * so the wording can't drift between the two surfaces (#2698).
+ *
+ * Also folds in `statusWording` (e.g. "Afgelast"), the way every other
+ * reservation renderer does (`<TeamAgendaRow>`, `<MatchStripView>`,
+ * `<MatchHero>`, `<CalendarWeek>`, `<UpcomingMatchesClient>`) — a cancelled
+ * reservation carries no opponent or score to otherwise hint that anything
+ * changed, and a subscriber's calendar app has no other way to show it.
+ * Scoped to the placeholder branch only: an ordinary match has the same gap
+ * today, but that is a separate, pre-existing concern (out of scope here).
  */
 function buildSummary(match: Match): string {
   if (match.is_placeholder) {
-    return `${reservationView(match).subject} — ${match.home_team.name}`;
+    const { statusWording } = reservationView(match);
+    return `${reservationTitle(match)}${
+      statusWording ? ` — ${statusWording.longForm}` : ""
+    }`;
   }
   if (
     match.status === "finished" &&
@@ -51,8 +62,14 @@ function buildSummary(match: Match): string {
  * No `is_placeholder` branch needed here (verified for #2698): this reads
  * only `competition`/`squadLabel`, never `home_team`/`away_team`, so it
  * cannot reproduce the "X - X" bug `buildSummary()` had. For a reservation
- * it already prints the same competition/squad wording `reservationView()`
- * derives the summary's subject from.
+ * with a `competition` set, the description is a verbatim repeat of the
+ * summary's subject (`DESCRIPTION:Jeugdtornooi`) rather than genuinely new
+ * information — acceptable for an ICS `DESCRIPTION` field, which has no
+ * neighbouring "subject" line of its own to duplicate the way an on-page
+ * slot would (the Writer Rule's metadata/OG carve-out applies the same way
+ * here). `squadLabel` never actually appears alongside it: the contract
+ * field (`packages/api-contract/src/schemas/match.ts`) has no writer on the
+ * `getMatches` path this route reads — worth its own issue, not chased here.
  */
 function buildDescription(match: Match): string {
   const parts: string[] = [];
@@ -61,8 +78,21 @@ function buildDescription(match: Match): string {
   return parts.join(" — ");
 }
 
+/**
+ * A pitch-reservation placeholder (#2606) is "the club has something that
+ * day, the details aren't settled" and — per the contract's own doc comment
+ * (`packages/api-contract/src/schemas/match.ts`) — the club uses the same
+ * device for external tournaments too. `isHomeMatch()` reading `true` for it
+ * is a filtering decision ("this belongs in the club's feed"), not a claim
+ * about where it happens — asserting the club's own street address for a
+ * reservation with no confirmed venue would tell a subscriber's calendar app
+ * to offer directions to a tournament that may be nowhere near it (#2698).
+ * So the home-venue fallback is skipped for a placeholder; only a `venue`
+ * PSD actually sent produces a `LOCATION` line.
+ */
 function buildLocation(match: Match): string | undefined {
   if (match.venue) return match.venue;
+  if (match.is_placeholder) return undefined;
   if (isHomeMatch(match)) return HOME_VENUE_FALLBACK;
   return undefined;
 }

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -5,6 +5,7 @@ import type { Match } from "@kcvv/api-contract";
 // Doubles as the calendar's `TZID` — an iCal protocol value, not only a display
 // pin — so it is read from the one home rather than restated.
 import { CLUB_TIMEZONE as TIMEZONE, toMatchDisplayZone } from "./dates";
+import { reservationView } from "./match-display";
 
 const HOME_VENUE_FALLBACK = "Sportpark Elewijt, Elewijt, België";
 
@@ -12,11 +13,30 @@ export interface IcalOptions {
   side?: "home" | "away" | "all";
 }
 
+/**
+ * A pitch-reservation placeholder (#2606) has `home_team.id === away_team.id`,
+ * so both sides carry the literal name "KCVV Elewijt" — `isHomeMatch` returns
+ * `true` for it without needing a special case. That is the intended reading:
+ * a reservation is the club's own booking with no designated away side, so
+ * `side=home` includes it and `side=away` excludes it (#2698). Verified
+ * against `ical.test.ts`'s "is treated as a home fixture" case rather than
+ * assumed.
+ */
 function isHomeMatch(match: Match): boolean {
   return match.home_team.name.toLowerCase().includes("elewijt");
 }
 
+/**
+ * A pitch-reservation placeholder (#2606) gets its own summary rather than
+ * "KCVV Elewijt - KCVV Elewijt" — composed from `reservationView()`'s
+ * subject, the same source `formatMatchTitle()`
+ * (`/wedstrijd/[matchId]/utils.ts`) reads, so the wording can't drift between
+ * the ICS feed and the match detail page's SEO title (#2698).
+ */
 function buildSummary(match: Match): string {
+  if (match.is_placeholder) {
+    return `${reservationView(match).subject} — ${match.home_team.name}`;
+  }
   if (
     match.status === "finished" &&
     match.home_team.score != null &&
@@ -27,6 +47,13 @@ function buildSummary(match: Match): string {
   return `${match.home_team.name} - ${match.away_team.name}`;
 }
 
+/**
+ * No `is_placeholder` branch needed here (verified for #2698): this reads
+ * only `competition`/`squadLabel`, never `home_team`/`away_team`, so it
+ * cannot reproduce the "X - X" bug `buildSummary()` had. For a reservation
+ * it already prints the same competition/squad wording `reservationView()`
+ * derives the summary's subject from.
+ */
 function buildDescription(match: Match): string {
   const parts: string[] = [];
   if (match.competition) parts.push(match.competition);

--- a/apps/web/src/lib/utils/match-display.ts
+++ b/apps/web/src/lib/utils/match-display.ts
@@ -254,6 +254,23 @@ export function reservationView(
   };
 }
 
+/** The fields `reservationTitle()` needs, on top of `reservationView()`'s own. */
+export interface ReservationTitleInput extends ReservationSubjectInput {
+  home_team: { name: string };
+}
+
+/**
+ * A pitch-reservation placeholder's title/summary: `reservationView()`'s
+ * subject plus the club's own name, the shape both `formatMatchTitle()`
+ * (`/wedstrijd/[matchId]/utils.ts`, the match detail page's SEO title) and
+ * `buildSummary()` (`lib/utils/ical.ts`, the ICS feed) need. Shared here
+ * rather than hand-spelled twice so the separator between the two halves
+ * can't diverge silently between the two surfaces (#2698).
+ */
+export function reservationTitle(match: ReservationTitleInput): string {
+  return `${reservationView(match).subject} — ${match.home_team.name}`;
+}
+
 /**
  * The accessible-name sentence for a reservation row — the one grammar three
  * renderers (`<MatchStripView>`, `<UpcomingMatchesClient>`, `<TeamAgendaRow>`)


### PR DESCRIPTION
Closes #2698

## Re-validated claims

Re-checked the issue's bullet list against the current repo before implementing:

- `buildSummary()` had no `is_placeholder` branch, confirmed — a pitch-reservation placeholder (`home_team.id === away_team.id`) rendered `"KCVV Elewijt - KCVV Elewijt"`.
- `buildDescription()` — verified it needs no parallel branch (see below).
- `isHomeMatch()`/`side` filtering — verified, and it turns out no code change is needed (see below); the issue only asked to verify and document, not to assume a fix was required.

## Changes

- **`buildSummary()`** (`apps/web/src/lib/utils/ical.ts`): added an `is_placeholder` branch that composes `${reservationView(match).subject} — ${match.home_team.name}`, mirroring `formatMatchTitle()` in `apps/web/src/app/(main)/wedstrijd/[matchId]/utils.ts` — the closest peer per #2688's convention — so the wording can't drift between the ICS feed and the match detail page's SEO title.
- **`buildDescription()`**: no code change. It only reads `competition`/`squadLabel`, never `home_team`/`away_team`, so it cannot reproduce the "X - X" bug. Documented inline with a comment explaining why.
- **`isHomeMatch()`**: no code change. For a placeholder, both `home_team` and `away_team` are literally "KCVV Elewijt" (per the Pitch-Reservation Placeholder definition in `docs/ubiquitous-language.md`), so `isHomeMatch()` already returns `true` — `side=home` includes the reservation, `side=away` excludes it. Decided this is the correct reading: a reservation is the club's own booking with no designated away side, so it belongs in the "home" feed. Documented the decision inline with a code comment, and pinned it with a test rather than leaving it implicit.

## Testing

- `pnpm --filter @kcvv/web lint:fix` — clean
- `pnpm --filter @kcvv/web check-all` — passes: lint clean, type-check clean, 319/319 test files (6889/6889 tests) passed, `next build` succeeds
- New tests in `apps/web/src/lib/utils/ical.test.ts` under "a pitch-reservation placeholder": SUMMARY is never `home===away`, SUMMARY uses the reservation subject (with and without a `competition` value), and side filtering treats a placeholder as a home fixture.
- No visual-regression capture — this ticket renders no pixels (a text-only ICS feed).