### PR TITLE
test(ui): the motion vocabulary is enforced, not just written down (#2658)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -45,10 +45,16 @@ const IN_BODY_ROUTE_IMPORT = `:matches(${TEST_CALLS}) ImportExpression > Literal
 // a one-line string. Class strings are assembled through `cn()` and template
 // literals as often as plain string literals, so every selector matches both
 // `Literal` and `TemplateElement`.
+// `duration-0` and `animate-none` are both legitimate "off" values — a
+// zero-length transition and Tailwind's static `animation: none` utility,
+// neither drawn from a theme scale — so both are excluded from their
+// respective bans below. Flagging them would tell an author the opposite of
+// what's true.
 const OFF_SCALE_DURATION_PATTERN =
-  "duration-(?!150(?:[^0-9]|$))(?!300(?:[^0-9]|$))(?!500(?:[^0-9]|$))[0-9]+";
+  "duration-(?!0(?:[^0-9]|$))(?!150(?:[^0-9]|$))(?!300(?:[^0-9]|$))(?!500(?:[^0-9]|$))[0-9]+";
 const ARBITRARY_MOTION_VALUE_PATTERN = "(?:duration|ease|animate)-\\[";
-const UNGUARDED_LOOP_PATTERN = "(?<!motion-safe:)(?<!motion-reduce:)animate-";
+const UNGUARDED_LOOP_PATTERN =
+  "(?<!motion-safe:)(?<!motion-reduce:)animate-(?!none\\b)";
 
 const matchesClassString = (pattern) =>
   `:matches(Literal[value=/${pattern}/], TemplateElement[value.raw=/${pattern}/])`;

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -32,6 +32,27 @@ const TEST_CALLS = TEST_CALL_FORMS.flatMap((form) =>
 // keeps exiting 0, and nothing is checked ever again.
 const IN_BODY_ROUTE_IMPORT = `:matches(${TEST_CALLS}) ImportExpression > Literal[value=/\\/(page|layout|route|robots|sitemap|opengraph-image)$/]`;
 
+// Motion Vocabulary bans — DESIGN.md → Motion (#2658). #2650's `@theme`
+// resets (`--ease-*: initial`, `--animate-*: initial`) already make most of
+// Tailwind's motion utilities compile to nothing, but four gaps survive a
+// namespace reset: `duration-<n>` is a bare-value utility that accepts any
+// number regardless of theme, bracket syntax (`duration-[…]`, `ease-[…]`,
+// `animate-[…]`) bypasses the theme entirely, and an `animate-` loop utility
+// with no `motion-safe:`/`motion-reduce:` guard ignores
+// `prefers-reduced-motion`. These three selectors close those gaps.
+//
+// Same newline trap as IN_BODY_ROUTE_IMPORT above: each pattern is built as
+// a one-line string. Class strings are assembled through `cn()` and template
+// literals as often as plain string literals, so every selector matches both
+// `Literal` and `TemplateElement`.
+const OFF_SCALE_DURATION_PATTERN =
+  "duration-(?!150(?:[^0-9]|$))(?!300(?:[^0-9]|$))(?!500(?:[^0-9]|$))[0-9]+";
+const ARBITRARY_MOTION_VALUE_PATTERN = "(?:duration|ease|animate)-\\[";
+const UNGUARDED_LOOP_PATTERN = "(?<!motion-safe:)(?<!motion-reduce:)animate-";
+
+const matchesClassString = (pattern) =>
+  `:matches(Literal[value=/${pattern}/], TemplateElement[value.raw=/${pattern}/])`;
+
 const eslintConfig = [
   ...nextCoreWebVitals,
   ...nextTypescript,
@@ -64,6 +85,36 @@ const eslintConfig = [
           argsIgnorePattern: "^_",
           varsIgnorePattern: "^_",
           caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    // Motion Vocabulary bans (DESIGN.md → Motion, #2658). Test/spec files
+    // are exempt — #2507 established the bare `animate-pulse` token as the
+    // correct thing to write in a test selector (e.g.
+    // `MatchLineup.test.tsx`, `MatchEvents.test.tsx`, both
+    // `[class*="animate-pulse"]`), so guarding it there would be wrong, not
+    // just unnecessary.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: matchesClassString(OFF_SCALE_DURATION_PATTERN),
+          message:
+            "Off-scale duration — the Three Speeds Rule allows only duration-150, duration-300 or duration-500 (apps/web/DESIGN.md → Motion). A duration outside those three is not a speed.",
+        },
+        {
+          selector: matchesClassString(ARBITRARY_MOTION_VALUE_PATTERN),
+          message:
+            "Arbitrary motion value — bracket syntax bypasses the `@theme` namespace reset entirely (apps/web/DESIGN.md → Motion, the Namespace Rule). Use a sanctioned duration/curve/loop token instead.",
+        },
+        {
+          selector: matchesClassString(UNGUARDED_LOOP_PATTERN),
+          message:
+            "Unguarded loop — an animate- utility needs a motion-safe: (or motion-reduce: to remove it) guard so prefers-reduced-motion can stop it (apps/web/DESIGN.md → Motion, the Reduced-Motion Rule).",
         },
       ],
     },

--- a/apps/web/src/app/globals-motion.test.ts
+++ b/apps/web/src/app/globals-motion.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Pins the `@theme` motion-namespace reset and the Motion Vocabulary's
+ * duration/curve scale in place (#2658, mirroring `apps/web/DESIGN.md` →
+ * Motion). `eslint.config.mjs`'s Motion Vocabulary bans catch a bad class
+ * string in `src/**\/*.tsx`; this file catches the other half — a deleted
+ * reset line or a stray raw-CSS duration/curve, which `@theme` does nothing
+ * to guard because they are hand-written rules, not utility classes.
+ *
+ * CSS comments are stripped before every count-based assertion below. The
+ * file documents its own history in prose next to the block it replaced
+ * (see the `--motion-fast`/`--motion-base`/`--motion-tape` removal note and
+ * the Namespace Rule comment above the reset) and that prose legitimately
+ * quotes the old `240ms cubic-bezier(0.2, 0.8, 0.2, 1)` values it replaced —
+ * counting comment text would make this test fail for a documentation
+ * convention the codebase otherwise encourages.
+ */
+const globalsCssRaw = readFileSync(join(__dirname, "globals.css"), "utf8");
+const globalsCss = globalsCssRaw.replace(/\/\*[\s\S]*?\*\//g, "");
+
+describe("globals.css — the Motion Vocabulary reset (DESIGN.md → Motion)", () => {
+  it.each([
+    ["--ease-*", "--ease-*: initial;"],
+    ["--animate-*", "--animate-*: initial;"],
+    ["--default-transition-duration", "--default-transition-duration: 150ms;"],
+    [
+      "--default-transition-timing-function",
+      "--default-transition-timing-function: var(--ease-out);",
+    ],
+  ])("resets %s", (_label, declaration) => {
+    expect(globalsCss).toContain(declaration);
+  });
+
+  it("declares exactly one cubic-bezier(...), the One Curve Rule's curve", () => {
+    const matches = [...globalsCss.matchAll(/cubic-bezier\([^)]*\)/g)].map(
+      (m) => m[0],
+    );
+    expect(matches).toEqual(["cubic-bezier(0, 0, 0.58, 1)"]);
+  });
+
+  it("uses only the three sanctioned travel durations (150ms/300ms/500ms)", () => {
+    // Every `ms`-suffixed duration in the file is a travel/on-demand
+    // duration — the three loops below all use bare-`s` periods, so this
+    // pattern never needs to special-case them.
+    const msValues = [...globalsCss.matchAll(/\b(\d+(?:\.\d+)?)ms\b/g)].map(
+      (m) => m[1],
+    );
+    expect(msValues.length).toBeGreaterThan(0);
+    for (const value of msValues) {
+      expect(["150", "300", "500"]).toContain(value);
+    }
+  });
+
+  // Loops are exempt, by name. Their periods are the Loop Rule's own
+  // per-loop choice (DESIGN.md → Motion → The Loop Rule), never the Three
+  // Speeds scale — an allow-list without this comment naming exactly which
+  // three loops it covers will read as a leftover and get "simplified"
+  // away by the next reader.
+  it.each([
+    ["the scarf — kcvv-scarf-scroll", "kcvv-scarf-scroll 1.5s"],
+    ["the dots — kcvv-spinner-dot-pulse", "kcvv-spinner-dot-pulse 1.2s"],
+    ["the dots' stagger delays", "animation-delay: 0.15s;"],
+    ["the dots' stagger delays", "animation-delay: 0.3s;"],
+    ["the skeleton pulse — kcvv-pulse", "kcvv-pulse 2s"],
+  ])("keeps the loop period for %s", (_label, snippet) => {
+    expect(globalsCss).toContain(snippet);
+  });
+
+  it("has no bare-`s` duration outside the three loops' own periods", () => {
+    // A travel duration always carries an explicit `ms` suffix in this file
+    // (asserted above); a bare-`s` value is therefore always a loop period.
+    // Pinning the full set closes the gap the `ms`-only check above can't
+    // see on its own — a new loop, or a travel rule mistakenly written in
+    // seconds, would otherwise slip through unnoticed.
+    const sValues = [...globalsCss.matchAll(/\b(\d+(?:\.\d+)?)s\b/g)].map(
+      (m) => m[1],
+    );
+    expect(sValues.sort()).toEqual(["0.15", "0.3", "1.2", "1.5", "2"]);
+  });
+});

--- a/apps/web/src/app/globals-motion.test.ts
+++ b/apps/web/src/app/globals-motion.test.ts
@@ -75,9 +75,22 @@ describe("globals.css — the Motion Vocabulary reset (DESIGN.md → Motion)", (
     // Pinning the full set closes the gap the `ms`-only check above can't
     // see on its own — a new loop, or a travel rule mistakenly written in
     // seconds, would otherwise slip through unnoticed.
+    //
+    // Compared as a Set, not a multiset: a second rule re-using an existing
+    // period (e.g. another element on the 2s pulse) must NOT fail this
+    // test — only a genuinely new, unsanctioned period should. `.sort()`
+    // below is a plain lexicographic string sort, which happens to match
+    // numeric order for this exact set — a future `10s` would sort before
+    // `2`, and that's expected, not a bug.
     const sValues = [...globalsCss.matchAll(/\b(\d+(?:\.\d+)?)s\b/g)].map(
       (m) => m[1],
     );
-    expect(sValues.sort()).toEqual(["0.15", "0.3", "1.2", "1.5", "2"]);
+    expect([...new Set(sValues)].sort()).toEqual([
+      "0.15",
+      "0.3",
+      "1.2",
+      "1.5",
+      "2",
+    ]);
   });
 });


### PR DESCRIPTION
Closes #2658

## Changes

- **`apps/web/eslint.config.mjs`** — one new flat-config block, `files: ["src/**/*.{ts,tsx}"]` with `ignores: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"]`, carrying one `no-restricted-syntax` array with three selectors (each `Literal`+`TemplateElement`, each on a single line — an esquery selector with a newline fails silently):
  - **Ban 1 — off-scale duration**: allow-lists `duration-150`/`duration-300`/`duration-500`; anything else (e.g. `duration-240`) is a violation.
  - **Ban 2 — arbitrary motion values**: `duration-[…]`, `ease-[…]`, `animate-[…]` bracket syntax.
  - **Ban 3 — unguarded loop**: `animate-` not preceded by `motion-safe:` or `motion-reduce:`.
  - Every message names the rule and points at `apps/web/DESIGN.md` → Motion.
- **`apps/web/src/app/globals-motion.test.ts`** (new) — mirrors `apps/web/src/lib/brand-token-mirrors.test.ts` (readFileSync + regex, no new dependency). Asserts: the four `@theme` resets are present; exactly one live `cubic-bezier(...)` remains, and it's `cubic-bezier(0, 0, 0.58, 1)`; every `ms`-suffixed duration in the file is 150/300/500; and the only bare-`s` values left are the three named loop periods.

## Already satisfied on `main` — group C not needed

The ticket's group C ("three dead motion tokens `#2650` does not touch") is **already done**. `#2650` (merged as PR #2695) deleted `--motion-fast`/`--motion-base`/`--motion-tape` from `globals.css` and their rows from `SpacingAndIcons.mdx`, with an inline comment citing `#2650` explaining why. Verified via `git blame`/grep before starting — no changes made to either file in this PR.

## Re-measured counts vs. the ticket's claims

The ticket was written while `#2650` was still open; several counts and one behavioural claim are stale on `main` at the branch point:

- **`duration-300` / `duration-150`**: ticket claimed 48× / 11×. Actual: **47× / 9×** (both legal, no violations).
- **Off-scale/bracket durations in `src`**: `grep -rnoE 'duration-(\[[^]]+\]|[0-9]+)' apps/web/src --include='*.tsx' | grep -vE 'duration-(150|300|500)$'` and `grep -rn 'ease-\[\|animate-\[' apps/web/src` both return nothing — zero pre-existing violations for either new ban.
- **`NavTakeover.tsx:106`**: the ticket cites this as the example of `motion-reduce:` used correctly. That code no longer exists — `#2650`/PR #2695 deleted the dead `animate-in fade-in` and its now-inert `motion-reduce:animate-none` outright. No `motion-reduce:animate-` guard currently exists anywhere in `src`; every live `animate-` use is `motion-safe:animate-pulse`.
- **The Loop Rule names a third loop the ticket's own allow-list text omits — RESOLVED, ticket text was stale, DESIGN.md wins**: the ticket's B section only names `kcvv-scarf-scroll 1.5s` and `kcvv-spinner-dot-pulse 1.2s` (+ its `0.15s`/`0.3s` delays) as loop exemptions. `apps/web/DESIGN.md:333` → Motion → The Loop Rule (landed in `#2650`) names **three**: "the scarf runs `1.5s`, the dots `1.2s` ..., the pulse `2s`." `globals.css:609` declares `--animate-pulse: kcvv-pulse 2s ease-in-out infinite;` with its keyframes at `:612`. The ticket's own text predates `#2650` landing and never caught up; the shipped `DESIGN.md` is the authority here. Kept the third exemption (`kcvv-pulse 2s`) in `globals-motion.test.ts`, named with a comment, the same treatment the ticket asked for the other two — **do not "simplify" this back down to two.**
- **`components/share/`**: no `animate-`/`duration-`/`ease-` usage that would trip any ban was found there (two `duration-300` sites, both legal) — no eslint-disable needed, no note left for the sibling branch.

## Testing

- `pnpm --filter @kcvv/web lint:fix` — exit 0, no changes, run in the foreground.
- `pnpm --filter @kcvv/web check-all` — exit 0 in the foreground: lint clean, type-check clean, **320 test files / 6898 tests passed**, build succeeded (346/346 static pages). The `fetch failed`/`ECONNREFUSED` lines during sitemap generation are the pre-existing BFF-unreachable-at-build degrade path (no local BFF running) — unrelated to this change.
- Each ban proven to fire, then reverted, via a temporary line in a real `src/**/*.tsx` file (`EditorialLink.tsx`), `pnpm --filter @kcvv/web lint` run in the foreground each time:
  - Ban 1: `className="transition-all duration-240"` → `error  Off-scale duration — the Three Speeds Rule allows only duration-150, duration-300 or duration-500 (apps/web/DESIGN.md → Motion)...`
  - Ban 2: `className="transition-all duration-[240ms]"` → `error  Arbitrary motion value — bracket syntax bypasses the \`@theme\` namespace reset entirely (apps/web/DESIGN.md → Motion, the Namespace Rule)...`
  - Ban 3: `className="animate-pulse"` → `error  Unguarded loop — an animate- utility needs a motion-safe: (or motion-reduce: to remove it) guard...`
  - Sanity check: `className="motion-safe:animate-pulse duration-300"` on the same file → lint exits 0 (no false positive on the guarded/legal form).
- No VR capture — this ticket lints and asserts; it renders nothing.

## Review findings applied (round 1)

The coordinator reviewed the branch directly against the code and returned two low-severity findings, both applied in a follow-up commit:

1. **`UNGUARDED_LOOP_PATTERN` flagged `animate-none`** — Tailwind's static "turn animation off" utility, not drawn from the `--animate-*` theme namespace, so it survives the `#2650` reset and is a legitimate way to stop motion. The ban's own message ("needs a motion-safe: guard") told an author the opposite of what was true. Fixed with a `(?!none\b)` exclusion. Same class of issue existed on `OFF_SCALE_DURATION_PATTERN` for `duration-0` (a legitimate zero-length "no transition" value, not an off-scale speed) — excluded the same way in the same commit, since `DESIGN.md` doesn't sanction or forbid it either way and treating it consistently with `animate-none` was the more defensible call.
2. **The bare-`s` loop-period assertion in `globals-motion.test.ts` compared a multiset, not a set** — a second CSS rule re-using an existing loop period (e.g. another element on the `2s` pulse) would have failed the test even though nothing about the Motion Vocabulary changed. Fixed by comparing the de-duplicated `Set`; added a one-line comment noting the `.sort()` is lexicographic-on-strings (works today, but a future `10s` would sort before `2` — that's expected).

Re-verified after the fix, all in the foreground: a real unguarded `animate-pulse` still fails lint with the same message; `animate-none duration-0` together now pass clean; `pnpm --filter @kcvv/web lint:fix` and `check-all` both exit 0 (320/320 test files, 6898/6898 tests, build succeeds).

Cleared by the reviewer without changes needed: no `no-restricted-syntax` rule-clobber between the new motion block and the existing route-import block (disjoint `files`/`ignores`); the off-scale regex's edge cases (`duration-300`/`150` pass, `duration-3000`/`240` caught, `duration-[240ms]` falls through to the bracket ban); `Literal`+`TemplateElement` coverage and the one-line-selector convention; group C already satisfied on `main`; `/simplify` found nothing to cut.
