### PR TITLE
feat(calendar): the subscribe feed can carry club activities (#2704)

### DIFF
--- a/apps/web/src/app/api/calendar.ics/route.test.ts
+++ b/apps/web/src/app/api/calendar.ics/route.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Calendar ICS API Route Tests (#2704)
+ *
+ * Mocks at the module boundary: `next/cache`'s `unstable_cache` (pass-through,
+ * capturing the key it was given so the cache-key test can inspect it),
+ * `BffService` (the PSD match fan-out), and `EventRepository` (the club
+ * activities feed). `teamIds` is always passed explicitly in these requests so
+ * `fetchMatches` never falls through to `TeamRepository.findAll()` — that
+ * repository, and the rest of `AppLayer`'s repositories, stay real but unused.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { Effect, Layer } from "effect";
+import type { Match } from "@kcvv/api-contract";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
+
+const { mockGetMatches, mockFindUpcomingForList, unstableCacheKeys } =
+  vi.hoisted(() => ({
+    mockGetMatches: vi.fn(),
+    mockFindUpcomingForList: vi.fn(),
+    unstableCacheKeys: [] as string[][],
+  }));
+
+vi.mock("next/cache", () => ({
+  unstable_cache: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fn: (...args: any[]) => any,
+    keyParts: string[],
+  ) => {
+    unstableCacheKeys.push(keyParts);
+    return fn;
+  },
+}));
+
+vi.mock("@/lib/effect/services/BffService", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/effect/services/BffService")>();
+  return {
+    ...actual,
+    BffServiceLive: Layer.succeed(actual.BffService, {
+      getMatches: mockGetMatches,
+      getNextMatches: () => Effect.succeed([]),
+      getMatchesWindow: () => Effect.succeed([]),
+      getMatchDetail: () => Effect.die("not used by this route"),
+      getRanking: () => Effect.succeed([]),
+      getRelated: () => Effect.succeed([]),
+      getOpponentHistory: () => Effect.die("not used by this route"),
+      getPlayerStats: () => Effect.die("not used by this route"),
+    }),
+  };
+});
+
+vi.mock("@/lib/repositories/event.repository", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/lib/repositories/event.repository")
+    >();
+  return {
+    ...actual,
+    EventRepositoryLive: Layer.succeed(actual.EventRepository, {
+      findAll: () => Effect.succeed([]),
+      findUpcomingForList: mockFindUpcomingForList,
+      findNextFeatured: () => Effect.succeed(null),
+      findBySlug: () => Effect.succeed(null),
+      findAllSlugs: () => Effect.succeed([]),
+    }),
+  };
+});
+
+import { GET } from "./route";
+
+function makeMatch(overrides: Partial<Match> = {}): Match {
+  return {
+    id: 12345,
+    date: new Date("2026-04-15T14:00:00.000Z"),
+    time: "16:00",
+    venue: undefined,
+    home_team: { id: 1235, name: "KCVV Elewijt", score: undefined },
+    away_team: { id: 2, name: "KFC Turnhout", score: undefined },
+    status: "scheduled",
+    squadLabel: "A-Ploeg",
+    competition: "2e Nationale",
+    ...overrides,
+  } as Match;
+}
+
+function makeEventItem(
+  overrides: Partial<EventListItemVM> = {},
+): EventListItemVM {
+  return {
+    id: "event-1",
+    title: "Mosselfestijn",
+    href: "/evenementen/mosselfestijn",
+    dateStart: "2026-04-14T22:00:00.000Z",
+    dateEnd: null,
+    eventType: "Clubevent",
+    location: "Sportpark Driesput, Elewijt",
+    source: "event",
+    ...overrides,
+  };
+}
+
+function makeRequest(query: string): NextRequest {
+  return new NextRequest(
+    new URL(`/api/calendar.ics?${query}`, "http://localhost:3000"),
+  );
+}
+
+describe("GET /api/calendar.ics", () => {
+  beforeEach(() => {
+    unstableCacheKeys.length = 0;
+    mockGetMatches.mockReset().mockReturnValue(Effect.succeed([makeMatch()]));
+    mockFindUpcomingForList.mockReset().mockReturnValue(Effect.succeed([]));
+  });
+
+  it("without the events flag, returns exactly today's matches-only feed — a pinned test proves an existing subscription is unaffected", async () => {
+    const response = await GET(makeRequest("teamIds=1235"));
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("kcvv-match-12345@kcvvelewijt.be");
+    expect(body).not.toContain("kcvv-event-");
+    expect(body).toContain("X-WR-CALNAME:KCVV Elewijt");
+    expect(body).not.toContain("Activiteiten");
+    expect(response.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="kcvv-wedstrijden.ics"',
+    );
+  });
+
+  it("events=0 behaves the same as omitting the flag", async () => {
+    const response = await GET(makeRequest("teamIds=1235&events=0"));
+    const body = await response.text();
+
+    expect(body).not.toContain("kcvv-event-");
+    expect(response.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="kcvv-wedstrijden.ics"',
+    );
+  });
+
+  it("events=1 returns the selected teams' fixtures plus every upcoming club activity", async () => {
+    mockFindUpcomingForList.mockReturnValue(Effect.succeed([makeEventItem()]));
+
+    const response = await GET(makeRequest("teamIds=1235&events=1"));
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("kcvv-match-12345@kcvvelewijt.be");
+    expect(body).toContain("kcvv-event-event-1@kcvvelewijt.be");
+    expect(body).toContain("SUMMARY:Mosselfestijn");
+    expect(response.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="kcvv-wedstrijden-en-activiteiten.ics"',
+    );
+  });
+
+  it("degrades to the matches-only feed, not a 500, when the event read fails", async () => {
+    mockFindUpcomingForList.mockReturnValue(Effect.die("Sanity is down"));
+
+    const response = await GET(makeRequest("teamIds=1235&events=1"));
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("kcvv-match-12345@kcvvelewijt.be");
+    expect(body).not.toContain("kcvv-event-");
+  });
+
+  it("gives an events=1 request a different cache key than the matches-only request, so neither can serve the other's cached body", async () => {
+    await GET(makeRequest("teamIds=1235"));
+    await GET(makeRequest("teamIds=1235&events=1"));
+
+    expect(unstableCacheKeys).toHaveLength(2);
+    expect(unstableCacheKeys[0]).not.toEqual(unstableCacheKeys[1]);
+  });
+});

--- a/apps/web/src/app/api/calendar.ics/route.test.ts
+++ b/apps/web/src/app/api/calendar.ics/route.test.ts
@@ -103,6 +103,12 @@ function makeMatch(overrides: Partial<Match> = {}): Match {
   } as Match;
 }
 
+/**
+ * Fixture for the merged `/kalender` event feed (`EventRepository.findUpcomingForList()`).
+ * `dateStart`/`dateEnd` are genuine UTC instants (not Belgian wall-clock like a
+ * `Match.date`) — see `event-datetime.ts`. `2026-04-14T22:00:00.000Z` is
+ * Brussels midnight (2026-04-15, CEST +2).
+ */
 function makeEventItem(
   overrides: Partial<EventListItemVM> = {},
 ): EventListItemVM {

--- a/apps/web/src/app/api/calendar.ics/route.test.ts
+++ b/apps/web/src/app/api/calendar.ics/route.test.ts
@@ -1,12 +1,14 @@
 /**
- * Calendar ICS API Route Tests (#2704)
+ * Calendar ICS API Route Tests (#2704, #2711 review follow-up)
  *
  * Mocks at the module boundary: `next/cache`'s `unstable_cache` (pass-through,
- * capturing the key it was given so the cache-key test can inspect it),
- * `BffService` (the PSD match fan-out), and `EventRepository` (the club
- * activities feed). `teamIds` is always passed explicitly in these requests so
- * `fetchMatches` never falls through to `TeamRepository.findAll()` — that
- * repository, and the rest of `AppLayer`'s repositories, stay real but unused.
+ * recording each call's key AND raw wrapped function — the latter lets a test
+ * invoke the club-activity cache's callback directly to assert it rejects
+ * rather than swallowing a failure), `BffService` (the PSD match fan-out),
+ * and `EventRepository` (the club activities feed). `teamIds` is always
+ * passed explicitly in these requests so `fetchMatches` never falls through
+ * to `TeamRepository.findAll()` — that repository, and the rest of
+ * `AppLayer`'s repositories, stay real but unused.
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
@@ -14,11 +16,17 @@ import { Effect, Layer } from "effect";
 import type { Match } from "@kcvv/api-contract";
 import type { EventListItemVM } from "@/lib/repositories/event.repository";
 
-const { mockGetMatches, mockFindUpcomingForList, unstableCacheKeys } =
+interface UnstableCacheCall {
+  keyParts: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: (...args: any[]) => any;
+}
+
+const { mockGetMatches, mockFindUpcomingForList, unstableCacheCalls } =
   vi.hoisted(() => ({
     mockGetMatches: vi.fn(),
     mockFindUpcomingForList: vi.fn(),
-    unstableCacheKeys: [] as string[][],
+    unstableCacheCalls: [] as UnstableCacheCall[],
   }));
 
 vi.mock("next/cache", () => ({
@@ -27,7 +35,7 @@ vi.mock("next/cache", () => ({
     fn: (...args: any[]) => any,
     keyParts: string[],
   ) => {
-    unstableCacheKeys.push(keyParts);
+    unstableCacheCalls.push({ keyParts, fn });
     return fn;
   },
 }));
@@ -69,6 +77,17 @@ vi.mock("@/lib/repositories/event.repository", async (importOriginal) => {
 
 import { GET } from "./route";
 
+/**
+ * The club-activity read is cached under its own module-scoped key (#2711
+ * review) — `unstable_cache(...)` for it runs exactly once, when this module
+ * is first imported, rather than once per request. Captured here, before any
+ * `beforeEach` clears `unstableCacheCalls`, so this is the one and only
+ * registration for it across the whole file.
+ */
+const eventsCacheCallAtImport = unstableCacheCalls.find(
+  (call) => JSON.stringify(call.keyParts) === JSON.stringify(["ical:events"]),
+);
+
 function makeMatch(overrides: Partial<Match> = {}): Match {
   return {
     id: 12345,
@@ -108,7 +127,10 @@ function makeRequest(query: string): NextRequest {
 
 describe("GET /api/calendar.ics", () => {
   beforeEach(() => {
-    unstableCacheKeys.length = 0;
+    // Only the per-request (matches-cache) registrations are cleared —
+    // `eventsCacheCallAtImport` was captured once, above, before this ever
+    // runs, and the events cache is never re-registered per request.
+    unstableCacheCalls.length = 0;
     mockGetMatches.mockReset().mockReturnValue(Effect.succeed([makeMatch()]));
     mockFindUpcomingForList.mockReset().mockReturnValue(Effect.succeed([]));
   });
@@ -167,7 +189,41 @@ describe("GET /api/calendar.ics", () => {
     await GET(makeRequest("teamIds=1235"));
     await GET(makeRequest("teamIds=1235&events=1"));
 
-    expect(unstableCacheKeys).toHaveLength(2);
-    expect(unstableCacheKeys[0]).not.toEqual(unstableCacheKeys[1]);
+    expect(unstableCacheCalls).toHaveLength(2);
+    expect(unstableCacheCalls[0]!.keyParts).not.toEqual(
+      unstableCacheCalls[1]!.keyParts,
+    );
+  });
+
+  it("registers the club-activity cache under its own fixed key, decoupled from teamIds/side — not multiplied per team-selection permutation", async () => {
+    expect(eventsCacheCallAtImport?.keyParts).toEqual(["ical:events"]);
+
+    mockFindUpcomingForList.mockReturnValue(Effect.succeed([makeEventItem()]));
+    await GET(makeRequest("teamIds=1235&events=1"));
+    await GET(makeRequest("teamIds=9999&side=home&events=1"));
+
+    // Two requests with different team selections registered no NEW events
+    // cache entry — only the two per-request matches-cache entries appear
+    // here (`unstableCacheCalls` was cleared in `beforeEach`, after the one
+    // module-scoped events registration already happened at import).
+    const eventsCacheRegistrationsDuringTest = unstableCacheCalls.filter(
+      (call) =>
+        JSON.stringify(call.keyParts) === JSON.stringify(["ical:events"]),
+    );
+    expect(eventsCacheRegistrationsDuringTest).toHaveLength(0);
+  });
+
+  it("lets a failed event read reject the cached callback itself, rather than resolving it with a degraded fallback (so Next's throw ⇒ last-good semantics apply, not caught ⇒ cached)", async () => {
+    expect(eventsCacheCallAtImport).toBeDefined();
+    mockFindUpcomingForList.mockReturnValue(Effect.die("Sanity is down"));
+
+    await expect(eventsCacheCallAtImport!.fn()).rejects.toBeDefined();
+  });
+
+  it("resolves the cached callback with the event list on a successful read", async () => {
+    const events = [makeEventItem()];
+    mockFindUpcomingForList.mockReturnValue(Effect.succeed(events));
+
+    await expect(eventsCacheCallAtImport!.fn()).resolves.toEqual(events);
   });
 });

--- a/apps/web/src/app/api/calendar.ics/route.test.ts
+++ b/apps/web/src/app/api/calendar.ics/route.test.ts
@@ -191,13 +191,25 @@ describe("GET /api/calendar.ics", () => {
     expect(body).not.toContain("kcvv-event-");
   });
 
-  it("gives an events=1 request a different cache key than the matches-only request, so neither can serve the other's cached body", async () => {
+  it("shares one matches cache key between an events=1 and a matches-only request for the same teamIds/side (#2711 round 2) — the fixture fetch is never duplicated per flag value", async () => {
     await GET(makeRequest("teamIds=1235"));
     await GET(makeRequest("teamIds=1235&events=1"));
 
     expect(unstableCacheCalls).toHaveLength(2);
-    expect(unstableCacheCalls[0]!.keyParts).not.toEqual(
+    expect(unstableCacheCalls[0]!.keyParts).toEqual(
       unstableCacheCalls[1]!.keyParts,
+    );
+  });
+
+  it("never serves a matches-only body to an events=1 request or vice versa — there is no shared body cache to collide on; each response is composed per request from its own includeEvents flag", async () => {
+    mockFindUpcomingForList.mockReturnValue(Effect.succeed([makeEventItem()]));
+
+    const matchesOnly = await GET(makeRequest("teamIds=1235"));
+    const withEvents = await GET(makeRequest("teamIds=1235&events=1"));
+
+    expect(await matchesOnly.text()).not.toContain("kcvv-event-");
+    expect(await withEvents.text()).toContain(
+      "kcvv-event-event-1@kcvvelewijt.be",
     );
   });
 
@@ -219,11 +231,22 @@ describe("GET /api/calendar.ics", () => {
     expect(eventsCacheRegistrationsDuringTest).toHaveLength(0);
   });
 
-  it("lets a failed event read reject the cached callback itself, rather than resolving it with a degraded fallback (so Next's throw ⇒ last-good semantics apply, not caught ⇒ cached)", async () => {
+  it("lets a failed event read reject the cached callback itself with the underlying failure, rather than resolving it with a degraded fallback (so Next's throw ⇒ last-good semantics apply, not caught ⇒ cached)", async () => {
     expect(eventsCacheCallAtImport).toBeDefined();
     mockFindUpcomingForList.mockReturnValue(Effect.die("Sanity is down"));
 
-    await expect(eventsCacheCallAtImport!.fn()).rejects.toBeDefined();
+    // Asserts the *cause* of the rejection, not merely that some rejection
+    // happened — `rejects.toBeDefined()` alone would also pass on a rejection
+    // caused by a typo in this test's own setup, proving nothing about the
+    // Sanity defect actually propagating (#2711 round 2 finding B).
+    let caught: unknown;
+    try {
+      await eventsCacheCallAtImport!.fn();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(String(caught)).toContain("Sanity is down");
   });
 
   it("resolves the cached callback with the event list on a successful read", async () => {

--- a/apps/web/src/app/api/calendar.ics/route.ts
+++ b/apps/web/src/app/api/calendar.ics/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { Effect } from "effect";
 import { unstable_cache } from "next/cache";
 import { runPromise } from "@/lib/effect/runtime";
-import { degradeSection } from "@/lib/effect/degrade";
 import {
   BffService,
   BFF_FAN_OUT_CONCURRENCY,
@@ -62,22 +61,51 @@ async function fetchMatches(
 /**
  * Club activities (#2704) — the same merged feed `/kalender` renders
  * (`EventRepository.findUpcomingForList()`), upcoming-only by construction
- * (its GROQ filters, not a re-filter here). Degrades like `/kalender` does: a
- * Sanity failure logs and falls back to an empty list rather than failing the
- * whole subscribed feed — a subscriber keeps their matches even on a bad day
- * for Sanity.
+ * (its GROQ filters, not a re-filter here).
+ *
+ * Cached under its own key, decoupled from `teamIds`/`side` (#2711 review) —
+ * the flag is club-wide, so every distinct team selection a subscriber can
+ * make would otherwise re-run this same two-query Sanity read on its own
+ * 15-minute cycle; an unbounded number of team combinations meant an
+ * effectively unbounded number of redundant reads for identical data.
+ *
+ * Deliberately *not* degraded inside this cached callback: `unstable_cache`
+ * only overwrites its entry when the wrapped function resolves, so letting a
+ * Sanity failure throw here means Next never caches it — the existing
+ * last-good value (or nothing, if there isn't one yet) survives, matching
+ * this repo's ISR rule ("caught ⇒ CACHED, throw ⇒ last-good", see root
+ * CLAUDE.md's Effect & Server Component Patterns). Catching it *inside*
+ * would instead write an empty activity list into the cache and pin it there
+ * for the full 15 minutes, outliving the Sanity blip that caused it.
+ */
+const fetchUpcomingEventsCached = unstable_cache(
+  (): Promise<EventListItemVM[]> =>
+    runPromise(
+      Effect.gen(function* () {
+        const eventRepo = yield* EventRepository;
+        return yield* eventRepo.findUpcomingForList();
+      }),
+    ),
+  ["ical:events"],
+  { revalidate: CACHE_MAX_AGE },
+);
+
+/**
+ * The request-facing read: degrades like `/kalender` does, but one layer
+ * above the cache boundary above — a Sanity failure logs and falls back to
+ * an empty list for *this* response only, without poisoning the shared
+ * `ical:events` cache entry, so the next request (cached or not) retries.
  */
 async function fetchEvents(): Promise<EventListItemVM[]> {
-  const program = Effect.gen(function* () {
-    const eventRepo = yield* EventRepository;
-    return yield* degradeSection(
-      eventRepo.findUpcomingForList(),
-      [] as EventListItemVM[],
+  try {
+    return await fetchUpcomingEventsCached();
+  } catch (error) {
+    console.warn(
       "[Calendar API] event-feed lookup failed; rendering matches only.",
+      error,
     );
-  });
-
-  return runPromise(program);
+    return [];
+  }
 }
 
 export async function GET(request: NextRequest) {

--- a/apps/web/src/app/api/calendar.ics/route.ts
+++ b/apps/web/src/app/api/calendar.ics/route.ts
@@ -2,11 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { Effect } from "effect";
 import { unstable_cache } from "next/cache";
 import { runPromise } from "@/lib/effect/runtime";
+import { degradeSection } from "@/lib/effect/degrade";
 import {
   BffService,
   BFF_FAN_OUT_CONCURRENCY,
 } from "@/lib/effect/services/BffService";
 import { TeamRepository } from "@/lib/repositories/team.repository";
+import {
+  EventRepository,
+  type EventListItemVM,
+} from "@/lib/repositories/event.repository";
 import type { Match } from "@kcvv/api-contract";
 import { generateIcal, normalizeCacheKey } from "@/lib/utils/ical";
 
@@ -54,11 +59,35 @@ async function fetchMatches(
   return runPromise(program);
 }
 
+/**
+ * Club activities (#2704) — the same merged feed `/kalender` renders
+ * (`EventRepository.findUpcomingForList()`), upcoming-only by construction
+ * (its GROQ filters, not a re-filter here). Degrades like `/kalender` does: a
+ * Sanity failure logs and falls back to an empty list rather than failing the
+ * whole subscribed feed — a subscriber keeps their matches even on a bad day
+ * for Sanity.
+ */
+async function fetchEvents(): Promise<EventListItemVM[]> {
+  const program = Effect.gen(function* () {
+    const eventRepo = yield* EventRepository;
+    return yield* degradeSection(
+      eventRepo.findUpcomingForList(),
+      [] as EventListItemVM[],
+      "[Calendar API] event-feed lookup failed; rendering matches only.",
+    );
+  });
+
+  return runPromise(program);
+}
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const rawTeamIds = searchParams.get("teamIds");
   const side = parseSide(searchParams.get("side"));
-  const cacheKey = normalizeCacheKey(rawTeamIds, side);
+  // All-or-nothing club-wide opt-in (#2704 design note) — deliberately not
+  // scoped by `teamIds`/`side`, which only ever filter fixtures.
+  const includeEvents = searchParams.get("events") === "1";
+  const cacheKey = normalizeCacheKey(rawTeamIds, side, includeEvents);
 
   const teamIdNums = rawTeamIds
     ? rawTeamIds
@@ -71,20 +100,29 @@ export async function GET(request: NextRequest) {
   try {
     const generateCached = unstable_cache(
       async () => {
-        const matches = await fetchMatches(teamIdNums);
-        return generateIcal(matches, { side });
+        const [matches, events] = await Promise.all([
+          fetchMatches(teamIdNums),
+          includeEvents ? fetchEvents() : Promise.resolve(undefined),
+        ]);
+        return generateIcal(matches, {
+          side,
+          ...(events !== undefined ? { events } : {}),
+        });
       },
       [cacheKey],
       { revalidate: CACHE_MAX_AGE },
     );
 
     const icalOutput = await generateCached();
+    const filename = includeEvents
+      ? "kcvv-wedstrijden-en-activiteiten.ics"
+      : "kcvv-wedstrijden.ics";
 
     return new NextResponse(icalOutput, {
       status: 200,
       headers: {
         "Content-Type": "text/calendar; charset=utf-8",
-        "Content-Disposition": 'attachment; filename="kcvv-wedstrijden.ics"',
+        "Content-Disposition": `attachment; filename="${filename}"`,
         "Cache-Control": `max-age=${CACHE_MAX_AGE}, s-maxage=${CACHE_MAX_AGE}`,
       },
     });

--- a/apps/web/src/app/api/calendar.ics/route.ts
+++ b/apps/web/src/app/api/calendar.ics/route.ts
@@ -29,7 +29,7 @@ function parseSide(raw: string | null): Side {
   return "all";
 }
 
-async function fetchMatches(
+async function fetchMatchesUncached(
   teamIdParams: number[] | null,
 ): Promise<readonly Match[]> {
   const program = Effect.gen(function* () {
@@ -59,24 +59,43 @@ async function fetchMatches(
 }
 
 /**
+ * Fixtures, cached under a matches-only key (`normalizeCacheKey`, no longer
+ * events-aware — #2711 round 2). `events` never changes which teams/sides are
+ * in scope, so this cache is shared by an `events=1` and an `events=0`
+ * request for the same `teamIds`/`side` instead of duplicating the PSD
+ * fan-out per flag value. Built fresh per request because the key itself is
+ * request-dependent (`teamIds`/`side`); `unstable_cache` still dedupes across
+ * requests that land on the same key, same as pre-#2704.
+ */
+function fetchMatches(
+  teamIdParams: number[] | null,
+  cacheKey: string,
+): Promise<readonly Match[]> {
+  return unstable_cache(() => fetchMatchesUncached(teamIdParams), [cacheKey], {
+    revalidate: CACHE_MAX_AGE,
+  })();
+}
+
+/**
  * Club activities (#2704) — the same merged feed `/kalender` renders
  * (`EventRepository.findUpcomingForList()`), upcoming-only by construction
  * (its GROQ filters, not a re-filter here).
  *
- * Cached under its own key, decoupled from `teamIds`/`side` (#2711 review) —
- * the flag is club-wide, so every distinct team selection a subscriber can
- * make would otherwise re-run this same two-query Sanity read on its own
- * 15-minute cycle; an unbounded number of team combinations meant an
- * effectively unbounded number of redundant reads for identical data.
+ * Cached under its own fixed key, decoupled from `teamIds`/`side` (#2711
+ * review) — the flag is club-wide, so every distinct team selection a
+ * subscriber can make would otherwise re-run this same two-query Sanity read
+ * on its own 15-minute cycle.
  *
  * Deliberately *not* degraded inside this cached callback: `unstable_cache`
  * only overwrites its entry when the wrapped function resolves, so letting a
  * Sanity failure throw here means Next never caches it — the existing
  * last-good value (or nothing, if there isn't one yet) survives, matching
  * this repo's ISR rule ("caught ⇒ CACHED, throw ⇒ last-good", see root
- * CLAUDE.md's Effect & Server Component Patterns). `fetchEvents` below is
- * where the degrade to `[]` actually happens, one layer above this boundary,
- * so a failure here never gets written into the cache.
+ * CLAUDE.md's Effect & Server Component Patterns). `fetchEvents` below
+ * degrades to `[]`, but only for its own return value — since #2711 round 2
+ * removed the combined-body cache entirely (this function's own `ical:events`
+ * entry is the *only* cache either read touches), that degrade can no longer
+ * reach any cache at all, at any layer.
  */
 const fetchUpcomingEventsCached = unstable_cache(
   (): Promise<EventListItemVM[]> =>
@@ -108,7 +127,7 @@ export async function GET(request: NextRequest) {
   const rawTeamIds = searchParams.get("teamIds");
   const side = parseSide(searchParams.get("side"));
   const includeEvents = searchParams.get("events") === "1";
-  const cacheKey = normalizeCacheKey(rawTeamIds, side, includeEvents);
+  const matchesCacheKey = normalizeCacheKey(rawTeamIds, side);
 
   const teamIdNums = rawTeamIds
     ? rawTeamIds
@@ -119,21 +138,19 @@ export async function GET(request: NextRequest) {
     : null;
 
   try {
-    const generateCached = unstable_cache(
-      async () => {
-        const [matches, events] = await Promise.all([
-          fetchMatches(teamIdNums),
-          includeEvents
-            ? fetchEvents()
-            : Promise.resolve<EventListItemVM[]>([]),
-        ]);
-        return generateIcal(matches, { side, includeEvents, events });
-      },
-      [cacheKey],
-      { revalidate: CACHE_MAX_AGE },
-    );
+    // Neither read's own cache can ever hold a degraded body: the matches
+    // cache never sees a failure caught inside it (a Sanity/PSD blip on the
+    // *events* side never reaches this fetch at all), and the events read's
+    // own cache only ever stores a resolved value (see its doc). Composing
+    // them into the final ICS string happens per request, uncached — cheap
+    // string building over a few hundred matches, next to the I/O it
+    // replaces (#2711 round 2).
+    const [matches, events] = await Promise.all([
+      fetchMatches(teamIdNums, matchesCacheKey),
+      includeEvents ? fetchEvents() : Promise.resolve<EventListItemVM[]>([]),
+    ]);
 
-    const icalOutput = await generateCached();
+    const icalOutput = generateIcal(matches, { side, includeEvents, events });
     const filename = includeEvents
       ? "kcvv-wedstrijden-en-activiteiten.ics"
       : "kcvv-wedstrijden.ics";

--- a/apps/web/src/app/api/calendar.ics/route.ts
+++ b/apps/web/src/app/api/calendar.ics/route.ts
@@ -74,9 +74,9 @@ async function fetchMatches(
  * Sanity failure throw here means Next never caches it — the existing
  * last-good value (or nothing, if there isn't one yet) survives, matching
  * this repo's ISR rule ("caught ⇒ CACHED, throw ⇒ last-good", see root
- * CLAUDE.md's Effect & Server Component Patterns). Catching it *inside*
- * would instead write an empty activity list into the cache and pin it there
- * for the full 15 minutes, outliving the Sanity blip that caused it.
+ * CLAUDE.md's Effect & Server Component Patterns). `fetchEvents` below is
+ * where the degrade to `[]` actually happens, one layer above this boundary,
+ * so a failure here never gets written into the cache.
  */
 const fetchUpcomingEventsCached = unstable_cache(
   (): Promise<EventListItemVM[]> =>
@@ -90,12 +90,7 @@ const fetchUpcomingEventsCached = unstable_cache(
   { revalidate: CACHE_MAX_AGE },
 );
 
-/**
- * The request-facing read: degrades like `/kalender` does, but one layer
- * above the cache boundary above — a Sanity failure logs and falls back to
- * an empty list for *this* response only, without poisoning the shared
- * `ical:events` cache entry, so the next request (cached or not) retries.
- */
+/** Degrades the read above to `[]` on failure — see its doc for why the catch lives here, outside the cache boundary. */
 async function fetchEvents(): Promise<EventListItemVM[]> {
   try {
     return await fetchUpcomingEventsCached();
@@ -112,8 +107,6 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const rawTeamIds = searchParams.get("teamIds");
   const side = parseSide(searchParams.get("side"));
-  // All-or-nothing club-wide opt-in (#2704 design note) — deliberately not
-  // scoped by `teamIds`/`side`, which only ever filter fixtures.
   const includeEvents = searchParams.get("events") === "1";
   const cacheKey = normalizeCacheKey(rawTeamIds, side, includeEvents);
 
@@ -130,12 +123,11 @@ export async function GET(request: NextRequest) {
       async () => {
         const [matches, events] = await Promise.all([
           fetchMatches(teamIdNums),
-          includeEvents ? fetchEvents() : Promise.resolve(undefined),
+          includeEvents
+            ? fetchEvents()
+            : Promise.resolve<EventListItemVM[]>([]),
         ]);
-        return generateIcal(matches, {
-          side,
-          ...(events !== undefined ? { events } : {}),
-        });
+        return generateIcal(matches, { side, includeEvents, events });
       },
       [cacheKey],
       { revalidate: CACHE_MAX_AGE },

--- a/apps/web/src/lib/utils/event-datetime.ts
+++ b/apps/web/src/lib/utils/event-datetime.ts
@@ -17,3 +17,50 @@ import { toDisplayZone } from "./dates";
 export function parseEventDateTime(iso: string): DateTime {
   return toDisplayZone(iso);
 }
+
+export interface EventDateRange {
+  start: DateTime;
+  end: DateTime | null;
+  /** A Brussels-midnight start, with an end that is either absent or also midnight. */
+  isAllDay: boolean;
+  /**
+   * The exclusive all-day `DTEND` day — a single day spans to the next
+   * morning, a multi-day span ends the day after its last day. Only
+   * meaningful when `isAllDay` is `true`; harmless (an invalid or otherwise
+   * unused `DateTime`) when it isn't.
+   */
+  allDayEndExclusive: DateTime;
+}
+
+/**
+ * The event domain's one all-day classification, shared by every surface
+ * that renders an `.ics` VEVENT for an event/activity: the per-event "Zet in
+ * agenda" download (`buildEventIcs`) and the subscribe feed's club-activity
+ * VEVENTs (`generateIcal`'s `addEventVevent`). The two surfaces must agree on
+ * which events render as all-day, or a subscriber sees the same event
+ * described two different ways depending on which one they used — this used
+ * to be a hand-copied predicate in both places, silently divergible.
+ *
+ * Classification only: each caller still owns its own *emission* (UTC stamps
+ * written by hand vs. Luxon objects handed to `ical-generator`), which
+ * differs enough between the two surfaces that sharing it would cost more
+ * than it saves.
+ */
+export function resolveEventDateRange(
+  dateStart: string,
+  dateEnd?: string | null,
+): EventDateRange {
+  const start = parseEventDateTime(dateStart);
+  const end = dateEnd ? parseEventDateTime(dateEnd) : null;
+  const isAllDay =
+    start.isValid &&
+    start.toFormat("HH:mm") === "00:00" &&
+    (!end?.isValid || end.toFormat("HH:mm") === "00:00");
+  const lastDay = end?.isValid && end > start ? end : start;
+  return {
+    start,
+    end,
+    isAllDay,
+    allDayEndExclusive: lastDay.plus({ days: 1 }),
+  };
+}

--- a/apps/web/src/lib/utils/event-ics.ts
+++ b/apps/web/src/lib/utils/event-ics.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "luxon";
-import { parseEventDateTime } from "./event-datetime";
+import { resolveEventDateRange } from "./event-datetime";
 
 export interface EventIcsInput {
   /** Stable iCal UID — e.g. `${slug}@kcvvelewijt.be`. */
@@ -77,22 +77,16 @@ function foldLine(line: string): string {
  * Content lines are folded at 75 octets (RFC 5545 §3.1) and CRLF-joined.
  */
 export function buildEventIcs(input: EventIcsInput): string {
-  const start = parseEventDateTime(input.dateStart);
-  const end = input.dateEnd ? parseEventDateTime(input.dateEnd) : null;
-
-  const isAllDay =
-    start.isValid &&
-    start.toFormat("HH:mm") === "00:00" &&
-    (!end?.isValid || end.toFormat("HH:mm") === "00:00");
+  const { isAllDay, start, allDayEndExclusive } = resolveEventDateRange(
+    input.dateStart,
+    input.dateEnd,
+  );
 
   const dateLines: string[] = [];
   if (isAllDay) {
-    // All-day DTEND is exclusive: a single day spans to the next morning; a
-    // multi-day span ends the day after its last day.
-    const lastDay = end?.isValid && end > start ? end : start;
     dateLines.push(`DTSTART;VALUE=DATE:${start.toFormat("yyyyLLdd")}`);
     dateLines.push(
-      `DTEND;VALUE=DATE:${lastDay.plus({ days: 1 }).toFormat("yyyyLLdd")}`,
+      `DTEND;VALUE=DATE:${allDayEndExclusive.toFormat("yyyyLLdd")}`,
     );
   } else {
     dateLines.push(`DTSTART:${toUtcStamp(input.dateStart)}`);

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Match } from "@kcvv/api-contract";
 import type { EventListItemVM } from "@/lib/repositories/event.repository";
+import { buildEventIcs } from "./event-ics";
 import { generateIcal, normalizeCacheKey } from "./ical";
 
 function makeMatch(overrides: Partial<Match> = {}): Match {
@@ -339,6 +340,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("emits an event VEVENT when events are passed (flag on)", () => {
     const output = generateIcal([makeMatch()], {
+      includeEvents: true,
       events: [makeEventItem()],
     });
 
@@ -346,16 +348,9 @@ describe("generateIcal — club activities (events flag)", () => {
     expect(output).toContain("SUMMARY:Mosselfestijn");
   });
 
-  it("keeps the matches-only output byte-for-byte identical when the events option is omitted", () => {
-    const matches = [makeMatch()];
-    const withoutOption = generateIcal(matches);
-    const withEmptyOptions = generateIcal(matches, { side: "all" });
-
-    expect(withoutOption).toBe(withEmptyOptions);
-  });
-
   it("carries the event's LOCATION when present", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [makeEventItem({ location: "Sportpark Driesput, Elewijt" })],
     });
 
@@ -364,6 +359,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("omits LOCATION when the event has none", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [makeEventItem({ location: null })],
     });
 
@@ -372,6 +368,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("points URL at the item's own detail page, using the repository-resolved href", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           href: "/evenementen/mosselfestijn",
@@ -387,6 +384,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("points URL at /nieuws/[slug] for an event-article-sourced item", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           href: "/nieuws/jeugdtornooi-verslag",
@@ -402,6 +400,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("emits a Brussels-midnight event as all-day, matching buildEventIcs's rule", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           dateStart: "2026-04-14T22:00:00.000Z", // 2026-04-15T00:00 Brussels
@@ -416,6 +415,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("spans a multi-day all-day event to the day after its last day, matching buildEventIcs's rule", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           dateStart: "2026-09-13T22:00:00.000Z", // 2026-09-14T00:00 Brussels
@@ -430,6 +430,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("emits a timed event with a real DTSTART and no fabricated DTEND when there is no end", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           dateStart: "2026-04-15T17:00:00.000Z", // 19:00 Brussels (CEST)
@@ -444,6 +445,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("keeps a timed event's own DTEND when the item has an end", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           dateStart: "2026-04-15T17:00:00.000Z",
@@ -457,6 +459,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("gives an event UID a distinct prefix from a match UID so the two can never collide", () => {
     const output = generateIcal([makeMatch({ id: 1 })], {
+      includeEvents: true,
       events: [makeEventItem({ id: "1" })],
     });
 
@@ -469,10 +472,14 @@ describe("generateIcal — club activities (events flag)", () => {
     const goodItem = makeEventItem({ id: "good" });
 
     expect(() =>
-      generateIcal([makeMatch()], { events: [badItem, goodItem] }),
+      generateIcal([makeMatch()], {
+        includeEvents: true,
+        events: [badItem, goodItem],
+      }),
     ).not.toThrow();
 
     const output = generateIcal([makeMatch()], {
+      includeEvents: true,
       events: [badItem, goodItem],
     });
     expect(output).not.toContain("kcvv-event-bad@kcvvelewijt.be");
@@ -482,6 +489,7 @@ describe("generateIcal — club activities (events flag)", () => {
 
   it("drops an event's DTEND rather than throwing when dateEnd is unparseable, keeping the item as a timed event with no fabricated end", () => {
     const output = generateIcal([], {
+      includeEvents: true,
       events: [
         makeEventItem({
           dateStart: "2026-04-15T17:00:00.000Z",
@@ -497,6 +505,7 @@ describe("generateIcal — club activities (events flag)", () => {
   it("describes the feed honestly (NAME / X-WR-CALDESC) when activities are included", () => {
     const withoutEvents = generateIcal([makeMatch()]);
     const withEvents = generateIcal([makeMatch()], {
+      includeEvents: true,
       events: [makeEventItem()],
     });
 
@@ -508,5 +517,73 @@ describe("generateIcal — club activities (events flag)", () => {
       "X-WR-CALDESC:Wedstrijden en clubactiviteiten van KCVV Elewijt",
     );
     expect(withEvents).not.toBe(withoutEvents);
+  });
+
+  it("is driven by includeEvents, not by a nonempty events array — passing events without the flag keeps the matches-only naming", () => {
+    const output = generateIcal([makeMatch()], {
+      events: [makeEventItem()],
+    });
+
+    expect(output).toContain("X-WR-CALNAME:KCVV Elewijt — Wedstrijden\r");
+    expect(output).not.toContain("Activiteiten");
+  });
+});
+
+/**
+ * `generateIcal`'s club-activity VEVENTs and the per-event "Zet in agenda"
+ * download (`buildEventIcs`) both resolve their all-day classification
+ * through the one shared `resolveEventDateRange` (#2711 review, fix 1) — this
+ * pins the two surfaces against the *same* input so a future edit to only one
+ * of them fails a test instead of silently diverging.
+ */
+describe("generateIcal and buildEventIcs agree on the all-day classification", () => {
+  it("both surfaces render the same Brussels-midnight input as all-day, on the same day", () => {
+    const item = makeEventItem({
+      dateStart: "2026-04-14T22:00:00.000Z", // 2026-04-15T00:00 Brussels
+      dateEnd: null,
+    });
+
+    const feedOutput = generateIcal([], {
+      includeEvents: true,
+      events: [item],
+    });
+    const downloadOutput = buildEventIcs({
+      uid: "x@kcvvelewijt.be",
+      title: item.title,
+      dateStart: item.dateStart,
+      dateEnd: item.dateEnd,
+      now: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(feedOutput).toContain("DTSTART;VALUE=DATE:20260415");
+    expect(downloadOutput).toContain("DTSTART;VALUE=DATE:20260415");
+    expect(feedOutput).toContain("DTEND;VALUE=DATE:20260416");
+    expect(downloadOutput).toContain("DTEND;VALUE=DATE:20260416");
+  });
+
+  it("both surfaces render the same timed input as timed, with the same DTSTART instant", () => {
+    const item = makeEventItem({
+      dateStart: "2026-04-15T17:00:00.000Z",
+      dateEnd: null,
+    });
+
+    const feedOutput = generateIcal([], {
+      includeEvents: true,
+      events: [item],
+    });
+    const downloadOutput = buildEventIcs({
+      uid: "x@kcvvelewijt.be",
+      title: item.title,
+      dateStart: item.dateStart,
+      dateEnd: item.dateEnd,
+      now: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(feedOutput).not.toMatch(/^DTSTART;VALUE=DATE/m);
+    expect(downloadOutput).not.toMatch(/^DTSTART;VALUE=DATE/m);
+    expect(downloadOutput).toContain("DTSTART:20260415T170000Z");
+    expect(feedOutput).toContain(
+      "DTSTART;TZID=Europe/Brussels:20260415T190000",
+    );
   });
 });

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -464,6 +464,36 @@ describe("generateIcal — club activities (events flag)", () => {
     expect(output).toContain("kcvv-event-1@kcvvelewijt.be");
   });
 
+  it("drops an event with an unparseable dateStart instead of throwing — mergeEventFeed and EventMonthList drop such a row too, never fatal", () => {
+    const badItem = makeEventItem({ id: "bad", dateStart: "" });
+    const goodItem = makeEventItem({ id: "good" });
+
+    expect(() =>
+      generateIcal([makeMatch()], { events: [badItem, goodItem] }),
+    ).not.toThrow();
+
+    const output = generateIcal([makeMatch()], {
+      events: [badItem, goodItem],
+    });
+    expect(output).not.toContain("kcvv-event-bad@kcvvelewijt.be");
+    expect(output).toContain("kcvv-event-good@kcvvelewijt.be");
+    expect(output).toContain("kcvv-match-12345@kcvvelewijt.be");
+  });
+
+  it("drops an event's DTEND rather than throwing when dateEnd is unparseable, keeping the item as a timed event with no fabricated end", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          dateStart: "2026-04-15T17:00:00.000Z",
+          dateEnd: "not-a-date",
+        }),
+      ],
+    });
+
+    expect(output).toContain("DTSTART;TZID=Europe/Brussels:20260415T190000");
+    expect(output).not.toMatch(/^DTEND/m);
+  });
+
   it("describes the feed honestly (NAME / X-WR-CALDESC) when activities are included", () => {
     const withoutEvents = generateIcal([makeMatch()]);
     const withEvents = generateIcal([makeMatch()], {

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Match } from "@kcvv/api-contract";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
 import { generateIcal, normalizeCacheKey } from "./ical";
 
 function makeMatch(overrides: Partial<Match> = {}): Match {
@@ -293,5 +294,189 @@ describe("normalizeCacheKey", () => {
   it("includes side in cache key", () => {
     expect(normalizeCacheKey("1235", "home")).toBe("ical:1235:home");
     expect(normalizeCacheKey("1235", "away")).toBe("ical:1235:away");
+  });
+
+  it("defaults to the same key as before events existed — an existing subscription's cache entry is unaffected", () => {
+    expect(normalizeCacheKey("1235", "all")).toBe("ical:1235:all");
+  });
+
+  it("gives events=1 a different cache key than the matches-only request", () => {
+    const withoutEvents = normalizeCacheKey("1235", "all", false);
+    const withEvents = normalizeCacheKey("1235", "all", true);
+
+    expect(withEvents).not.toBe(withoutEvents);
+  });
+});
+
+/**
+ * Fixture for the merged `/kalender` event feed (`EventRepository.findUpcomingForList()`).
+ * `dateStart`/`dateEnd` are genuine UTC instants (not Belgian wall-clock like a
+ * `Match.date`) — see `event-datetime.ts`. `2026-04-14T22:00:00.000Z` is
+ * Brussels midnight (2026-04-15, CEST +2).
+ */
+function makeEventItem(
+  overrides: Partial<EventListItemVM> = {},
+): EventListItemVM {
+  return {
+    id: "event-1",
+    title: "Mosselfestijn",
+    href: "/evenementen/mosselfestijn",
+    dateStart: "2026-04-14T22:00:00.000Z",
+    dateEnd: null,
+    eventType: "Clubevent",
+    location: "Sportpark Driesput, Elewijt",
+    source: "event",
+    ...overrides,
+  };
+}
+
+describe("generateIcal — club activities (events flag)", () => {
+  it("emits no event VEVENT when the events option is omitted (flag off)", () => {
+    const output = generateIcal([makeMatch()]);
+
+    expect(output).not.toContain("kcvv-event-");
+  });
+
+  it("emits an event VEVENT when events are passed (flag on)", () => {
+    const output = generateIcal([makeMatch()], {
+      events: [makeEventItem()],
+    });
+
+    expect(output).toContain("kcvv-event-event-1@kcvvelewijt.be");
+    expect(output).toContain("SUMMARY:Mosselfestijn");
+  });
+
+  it("keeps the matches-only output byte-for-byte identical when the events option is omitted", () => {
+    const matches = [makeMatch()];
+    const withoutOption = generateIcal(matches);
+    const withEmptyOptions = generateIcal(matches, { side: "all" });
+
+    expect(withoutOption).toBe(withEmptyOptions);
+  });
+
+  it("carries the event's LOCATION when present", () => {
+    const output = generateIcal([], {
+      events: [makeEventItem({ location: "Sportpark Driesput, Elewijt" })],
+    });
+
+    expect(output).toContain("LOCATION:Sportpark Driesput\\, Elewijt");
+  });
+
+  it("omits LOCATION when the event has none", () => {
+    const output = generateIcal([], {
+      events: [makeEventItem({ location: null })],
+    });
+
+    expect(output).not.toMatch(/^LOCATION:/m);
+  });
+
+  it("points URL at the item's own detail page, using the repository-resolved href", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          href: "/evenementen/mosselfestijn",
+          source: "event",
+        }),
+      ],
+    });
+
+    expect(output).toContain(
+      "URL;VALUE=URI:https://www.kcvvelewijt.be/evenementen/mosselfestijn",
+    );
+  });
+
+  it("points URL at /nieuws/[slug] for an event-article-sourced item", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          href: "/nieuws/jeugdtornooi-verslag",
+          source: "article",
+        }),
+      ],
+    });
+
+    expect(output).toContain(
+      "URL;VALUE=URI:https://www.kcvvelewijt.be/nieuws/jeugdtornooi-verslag",
+    );
+  });
+
+  it("emits a Brussels-midnight event as all-day, matching buildEventIcs's rule", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          dateStart: "2026-04-14T22:00:00.000Z", // 2026-04-15T00:00 Brussels
+          dateEnd: null,
+        }),
+      ],
+    });
+
+    expect(output).toContain("DTSTART;VALUE=DATE:20260415");
+    expect(output).toContain("DTEND;VALUE=DATE:20260416");
+  });
+
+  it("spans a multi-day all-day event to the day after its last day, matching buildEventIcs's rule", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          dateStart: "2026-09-13T22:00:00.000Z", // 2026-09-14T00:00 Brussels
+          dateEnd: "2026-09-15T22:00:00.000Z", // 2026-09-16T00:00 Brussels
+        }),
+      ],
+    });
+
+    expect(output).toContain("DTSTART;VALUE=DATE:20260914");
+    expect(output).toContain("DTEND;VALUE=DATE:20260917");
+  });
+
+  it("emits a timed event with a real DTSTART and no fabricated DTEND when there is no end", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          dateStart: "2026-04-15T17:00:00.000Z", // 19:00 Brussels (CEST)
+          dateEnd: null,
+        }),
+      ],
+    });
+
+    expect(output).toContain("DTSTART;TZID=Europe/Brussels:20260415T190000");
+    expect(output).not.toMatch(/^DTEND/m);
+  });
+
+  it("keeps a timed event's own DTEND when the item has an end", () => {
+    const output = generateIcal([], {
+      events: [
+        makeEventItem({
+          dateStart: "2026-04-15T17:00:00.000Z",
+          dateEnd: "2026-04-15T20:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(output).toContain("DTEND;TZID=Europe/Brussels:20260415T220000");
+  });
+
+  it("gives an event UID a distinct prefix from a match UID so the two can never collide", () => {
+    const output = generateIcal([makeMatch({ id: 1 })], {
+      events: [makeEventItem({ id: "1" })],
+    });
+
+    expect(output).toContain("kcvv-match-1@kcvvelewijt.be");
+    expect(output).toContain("kcvv-event-1@kcvvelewijt.be");
+  });
+
+  it("describes the feed honestly (NAME / X-WR-CALDESC) when activities are included", () => {
+    const withoutEvents = generateIcal([makeMatch()]);
+    const withEvents = generateIcal([makeMatch()], {
+      events: [makeEventItem()],
+    });
+
+    expect(withoutEvents).toContain("X-WR-CALNAME:KCVV Elewijt");
+    expect(withEvents).toContain(
+      "X-WR-CALNAME:KCVV Elewijt — Wedstrijden & Activiteiten",
+    );
+    expect(withEvents).toContain(
+      "X-WR-CALDESC:Wedstrijden en clubactiviteiten van KCVV Elewijt",
+    );
+    expect(withEvents).not.toBe(withoutEvents);
   });
 });

--- a/apps/web/src/lib/utils/ical.test.ts
+++ b/apps/web/src/lib/utils/ical.test.ts
@@ -297,15 +297,8 @@ describe("normalizeCacheKey", () => {
     expect(normalizeCacheKey("1235", "away")).toBe("ical:1235:away");
   });
 
-  it("defaults to the same key as before events existed — an existing subscription's cache entry is unaffected", () => {
+  it("has no events dimension — #2711 round 2 moved club activities to their own separately-cached key, so the fixture key is unaffected by the flag and stable at its pre-#2704 form", () => {
     expect(normalizeCacheKey("1235", "all")).toBe("ical:1235:all");
-  });
-
-  it("gives events=1 a different cache key than the matches-only request", () => {
-    const withoutEvents = normalizeCacheKey("1235", "all", false);
-    const withEvents = normalizeCacheKey("1235", "all", true);
-
-    expect(withEvents).not.toBe(withoutEvents);
   });
 });
 
@@ -585,5 +578,37 @@ describe("generateIcal and buildEventIcs agree on the all-day classification", (
     expect(feedOutput).toContain(
       "DTSTART;TZID=Europe/Brussels:20260415T190000",
     );
+  });
+
+  /**
+   * The branch neither prior parity case exercised: `resolveEventDateRange`'s
+   * `lastDay.plus({ days: 1 })` only does real work when `end > start` (a
+   * genuine multi-day span) — a single-day event collapses `lastDay` to
+   * `start` either way. This is the branch most likely to silently drift
+   * between the two surfaces, and the reason the shared helper exists
+   * (#2711 round 1 finding 1).
+   */
+  it("both surfaces span the same multi-day all-day input to the same exclusive end day", () => {
+    const item = makeEventItem({
+      dateStart: "2026-09-13T22:00:00.000Z", // 2026-09-14T00:00 Brussels
+      dateEnd: "2026-09-15T22:00:00.000Z", // 2026-09-16T00:00 Brussels
+    });
+
+    const feedOutput = generateIcal([], {
+      includeEvents: true,
+      events: [item],
+    });
+    const downloadOutput = buildEventIcs({
+      uid: "x@kcvvelewijt.be",
+      title: item.title,
+      dateStart: item.dateStart,
+      dateEnd: item.dateEnd,
+      now: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(feedOutput).toContain("DTSTART;VALUE=DATE:20260914");
+    expect(downloadOutput).toContain("DTSTART;VALUE=DATE:20260914");
+    expect(feedOutput).toContain("DTEND;VALUE=DATE:20260917");
+    expect(downloadOutput).toContain("DTEND;VALUE=DATE:20260917");
   });
 });

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -124,18 +124,17 @@ function buildStartDateTime(match: Match): DateTime {
 }
 
 /**
- * `events` is appended rather than folded into `side`/`teamIds`: it is a
- * club-wide opt-in, not scoped to the selected teams (#2704 design note), so
- * it earns its own segment instead of multiplying into the team/side
- * combinations. It is the `includeEvents ? ":events" : ""` suffix, not the
- * `false` default, that keeps a matches-only key unchanged from its
- * pre-#2704 form; the default only spares call sites that still pass just
- * two arguments.
+ * The match-fixture cache key: `teamIds`/`side` only. `events` (#2704) is
+ * deliberately absent — since #2711 round 2, club activities are cached
+ * under their own fixed key (`ical:events`, in `route.ts`) and composed with
+ * these fixtures per request, so which teams/sides are in scope never
+ * depends on whether activities are included. An `events=1` and an
+ * `events=0` request for the same `teamIds`/`side` therefore share this same
+ * key, instead of each duplicating the PSD fan-out.
  */
 export function normalizeCacheKey(
   teamIds: string | null,
   side: string,
-  includeEvents = false,
 ): string {
   const sortedIds = teamIds
     ? teamIds
@@ -145,7 +144,7 @@ export function normalizeCacheKey(
         .sort()
         .join(",")
     : "all";
-  return `ical:${sortedIds}:${side}${includeEvents ? ":events" : ""}`;
+  return `ical:${sortedIds}:${side}`;
 }
 
 /**

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -2,15 +2,27 @@ import ical from "ical-generator";
 import { getVtimezoneComponent } from "@touch4it/ical-timezones";
 import { DateTime } from "luxon";
 import type { Match } from "@kcvv/api-contract";
+import type { EventListItemVM } from "@/lib/repositories/event.repository";
+import { SITE_CONFIG } from "@/lib/constants";
 // Doubles as the calendar's `TZID` — an iCal protocol value, not only a display
 // pin — so it is read from the one home rather than restated.
 import { CLUB_TIMEZONE as TIMEZONE, toMatchDisplayZone } from "./dates";
+import { parseEventDateTime } from "./event-datetime";
 import { reservationTitle, reservationView } from "./match-display";
 
 const HOME_VENUE_FALLBACK = "Sportpark Elewijt, Elewijt, België";
 
 export interface IcalOptions {
   side?: "home" | "away" | "all";
+  /**
+   * Club activities (#2704) — the merged `EventRepository.findUpcomingForList()`
+   * feed, already resolved to each item's own detail href. Omitting this key
+   * entirely (not passing `events` at all) is what keeps a matches-only request
+   * byte-for-byte identical to the pre-#2704 output; an explicit `[]` would work
+   * the same for VEVENTs but the caller (the route) only ever passes this key
+   * when `events=1` is set, so "key present" doubles as "flag on" here.
+   */
+  events?: readonly EventListItemVM[];
 }
 
 /**
@@ -116,9 +128,17 @@ function buildStartDateTime(match: Match): DateTime {
   return start.set({ hour: hours, minute: minutes });
 }
 
+/**
+ * `events` is appended rather than folded into `side`/`teamIds`: it is a
+ * club-wide opt-in, not scoped to the selected teams (#2704 design note), so
+ * it earns its own segment instead of multiplying into the team/side
+ * combinations. Defaulting to `false` keeps every pre-#2704 call — and the
+ * cache entries it already wrote — on the same key it always had.
+ */
 export function normalizeCacheKey(
   teamIds: string | null,
   side: string,
+  includeEvents = false,
 ): string {
   const sortedIds = teamIds
     ? teamIds
@@ -128,24 +148,104 @@ export function normalizeCacheKey(
         .sort()
         .join(",")
     : "all";
-  return `ical:${sortedIds}:${side}`;
+  return `ical:${sortedIds}:${side}${includeEvents ? ":events" : ""}`;
+}
+
+/**
+ * `kcvv-event-` keeps an event UID's namespace disjoint from a match's
+ * `kcvv-match-` one (#2704). A Sanity document id and a PSD match id are drawn
+ * from unrelated id spaces and can coincide; a shared prefix would let one
+ * silently collide with the other in a subscriber's calendar app instead of
+ * each being updated in place on refresh.
+ */
+function buildEventUid(item: EventListItemVM): string {
+  return `kcvv-event-${item.id}@kcvvelewijt.be`;
+}
+
+/**
+ * Mirrors `buildEventIcs`'s all-day rule (`lib/utils/event-ics.ts`) exactly —
+ * the per-event "Zet in agenda" download and this subscribe feed must agree on
+ * which activities render as all-day, or the two surfaces would tell a
+ * subscriber two different things about the same event. A Brussels-midnight
+ * start, with an end that is either absent or also midnight, is all-day.
+ */
+function resolveEventDates(item: EventListItemVM): {
+  isAllDay: boolean;
+  start: DateTime;
+  end: DateTime | null;
+} {
+  const start = parseEventDateTime(item.dateStart);
+  const end = item.dateEnd ? parseEventDateTime(item.dateEnd) : null;
+  const isAllDay =
+    start.isValid &&
+    start.toFormat("HH:mm") === "00:00" &&
+    (!end?.isValid || end.toFormat("HH:mm") === "00:00");
+  return { isAllDay, start, end };
+}
+
+/**
+ * Adds one club-activity VEVENT. `ical-generator`'s all-day `DTEND` is
+ * inclusive (it emits whatever `end` it is given verbatim), so the exclusive
+ * next-day roll — a single day spans to the next morning, a multi-day span
+ * ends the day after its last day — is done here, same as `buildEventIcs`. A
+ * timed item with no `dateEnd` omits `end` entirely rather than fabricating a
+ * duration the way a match's fixed 2h block does.
+ */
+function addEventVevent(cal: ReturnType<typeof ical>, item: EventListItemVM) {
+  const { isAllDay, start, end } = resolveEventDates(item);
+  const location = item.location ?? undefined;
+  const url = `${SITE_CONFIG.siteUrl}${item.href}`;
+  const id = buildEventUid(item);
+  const summary = item.title;
+
+  if (isAllDay) {
+    const lastDay = end?.isValid && end > start ? end : start;
+    cal.createEvent({
+      id,
+      summary,
+      allDay: true,
+      start,
+      end: lastDay.plus({ days: 1 }),
+      url,
+      ...(location ? { location } : {}),
+    });
+    return;
+  }
+
+  cal.createEvent({
+    id,
+    summary,
+    start,
+    timezone: TIMEZONE,
+    url,
+    ...(end ? { end } : {}),
+    ...(location ? { location } : {}),
+  });
 }
 
 export function generateIcal(
   matches: readonly Match[],
   options: IcalOptions = {},
 ): string {
-  const { side = "all" } = options;
+  const { side = "all", events } = options;
+  // `events` distinguishes "flag on, feed happens to have zero upcoming
+  // activities right now" from "flag off" — both would otherwise produce zero
+  // VEVENTs, but only the former should describe itself as an activities feed.
+  const includeEvents = events !== undefined;
 
   const cal = ical({
-    name: "KCVV Elewijt — Wedstrijden",
+    name: includeEvents
+      ? "KCVV Elewijt — Wedstrijden & Activiteiten"
+      : "KCVV Elewijt — Wedstrijden",
     prodId: "-//KCVV Elewijt//Wedstrijdkalender//NL",
     timezone: {
       name: TIMEZONE,
       generator: getVtimezoneComponent,
     },
     x: {
-      "X-WR-CALDESC": "Wedstrijdkalender van KCVV Elewijt",
+      "X-WR-CALDESC": includeEvents
+        ? "Wedstrijden en clubactiviteiten van KCVV Elewijt"
+        : "Wedstrijdkalender van KCVV Elewijt",
       "X-WR-TIMEZONE": TIMEZONE,
     },
   });
@@ -186,6 +286,14 @@ export function generateIcal(
       url: `https://www.kcvvelewijt.be/wedstrijd/${match.id}`,
       ...(location ? { location } : {}),
     });
+  }
+
+  // Club activities (#2704) — `EventRepository.findUpcomingForList()` is
+  // already upcoming-only and chronologically sorted by construction (its own
+  // GROQ filters + `mergeEventFeed`'s sort), so no re-filter/re-sort is done
+  // here; this loop only maps each item to a VEVENT.
+  for (const item of events ?? []) {
+    addEventVevent(cal, item);
   }
 
   return cal.toString();

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -7,21 +7,16 @@ import { SITE_CONFIG } from "@/lib/constants";
 // Doubles as the calendar's `TZID` — an iCal protocol value, not only a display
 // pin — so it is read from the one home rather than restated.
 import { CLUB_TIMEZONE as TIMEZONE, toMatchDisplayZone } from "./dates";
-import { parseEventDateTime } from "./event-datetime";
+import { resolveEventDateRange } from "./event-datetime";
 import { reservationTitle, reservationView } from "./match-display";
 
 const HOME_VENUE_FALLBACK = "Sportpark Elewijt, Elewijt, België";
 
 export interface IcalOptions {
   side?: "home" | "away" | "all";
-  /**
-   * Club activities (#2704) — the merged `EventRepository.findUpcomingForList()`
-   * feed, already resolved to each item's own detail href. Omitting this key
-   * entirely (not passing `events` at all) is what keeps a matches-only request
-   * byte-for-byte identical to the pre-#2704 output; an explicit `[]` would work
-   * the same for VEVENTs but the caller (the route) only ever passes this key
-   * when `events=1` is set, so "key present" doubles as "flag on" here.
-   */
+  /** Club activities (#2704) opt-in — see `generateIcal`'s destructure for the default. */
+  includeEvents?: boolean;
+  /** The merged `EventRepository.findUpcomingForList()` feed, already resolved to each item's own detail href. */
   events?: readonly EventListItemVM[];
 }
 
@@ -132,8 +127,10 @@ function buildStartDateTime(match: Match): DateTime {
  * `events` is appended rather than folded into `side`/`teamIds`: it is a
  * club-wide opt-in, not scoped to the selected teams (#2704 design note), so
  * it earns its own segment instead of multiplying into the team/side
- * combinations. Defaulting to `false` keeps every pre-#2704 call — and the
- * cache entries it already wrote — on the same key it always had.
+ * combinations. It is the `includeEvents ? ":events" : ""` suffix, not the
+ * `false` default, that keeps a matches-only key unchanged from its
+ * pre-#2704 form; the default only spares call sites that still pass just
+ * two arguments.
  */
 export function normalizeCacheKey(
   teamIds: string | null,
@@ -163,45 +160,24 @@ function buildEventUid(item: EventListItemVM): string {
 }
 
 /**
- * Mirrors `buildEventIcs`'s all-day rule (`lib/utils/event-ics.ts`) exactly —
- * the per-event "Zet in agenda" download and this subscribe feed must agree on
- * which activities render as all-day, or the two surfaces would tell a
- * subscriber two different things about the same event. A Brussels-midnight
- * start, with an end that is either absent or also midnight, is all-day.
- */
-function resolveEventDates(item: EventListItemVM): {
-  isAllDay: boolean;
-  start: DateTime;
-  end: DateTime | null;
-} {
-  const start = parseEventDateTime(item.dateStart);
-  const end = item.dateEnd ? parseEventDateTime(item.dateEnd) : null;
-  const isAllDay =
-    start.isValid &&
-    start.toFormat("HH:mm") === "00:00" &&
-    (!end?.isValid || end.toFormat("HH:mm") === "00:00");
-  return { isAllDay, start, end };
-}
-
-/**
  * Adds one club-activity VEVENT. `ical-generator`'s all-day `DTEND` is
- * inclusive (it emits whatever `end` it is given verbatim), so the exclusive
- * next-day roll — a single day spans to the next morning, a multi-day span
- * ends the day after its last day — is done here, same as `buildEventIcs`. A
- * timed item with no `dateEnd` omits `end` entirely rather than fabricating a
- * duration the way a match's fixed 2h block does.
+ * inclusive (it emits whatever `end` it is given verbatim) — the exclusive
+ * next-day roll is `resolveEventDateRange`'s `allDayEndExclusive`, computed
+ * once for both this and `buildEventIcs`. A timed item with no `dateEnd`
+ * omits `end` entirely rather than fabricating a duration the way a match's
+ * fixed 2h block does.
  */
 function addEventVevent(cal: ReturnType<typeof ical>, item: EventListItemVM) {
-  const { isAllDay, start, end } = resolveEventDates(item);
+  const { isAllDay, start, end, allDayEndExclusive } = resolveEventDateRange(
+    item.dateStart,
+    item.dateEnd,
+  );
 
-  // An unparseable `dateStart` (only reachable via a malformed event doc —
-  // `EVENTS_QUERY` projects `coalesce(dateStart, "")`, so a doc missing the
-  // Studio-required field still clears the upcoming filter on a future
-  // `dateEnd` and reaches here) is dropped, not fatal — the same handling
-  // `mergeEventFeed` gives it (sorts to the end) and `<EventMonthList>` gives
-  // it (drops it when grouping). `ical-generator` throws on an invalid Luxon
-  // `start`, which would otherwise take the whole feed — matches included —
-  // down with it (#2711 review).
+  // An unparseable `dateStart` (reachable via `EVENTS_QUERY`'s
+  // `coalesce(dateStart, "")` on a malformed doc) is dropped, not fatal —
+  // matching `mergeEventFeed`/`<EventMonthList>`'s handling of the same row.
+  // `ical-generator` throws on an invalid Luxon `start`, which would 500 the
+  // whole feed otherwise.
   if (!start.isValid) return;
 
   const location = item.location ?? undefined;
@@ -210,13 +186,12 @@ function addEventVevent(cal: ReturnType<typeof ical>, item: EventListItemVM) {
   const summary = item.title;
 
   if (isAllDay) {
-    const lastDay = end?.isValid && end > start ? end : start;
     cal.createEvent({
       id,
       summary,
       allDay: true,
       start,
-      end: lastDay.plus({ days: 1 }),
+      end: allDayEndExclusive,
       url,
       ...(location ? { location } : {}),
     });
@@ -229,9 +204,7 @@ function addEventVevent(cal: ReturnType<typeof ical>, item: EventListItemVM) {
     start,
     timezone: TIMEZONE,
     url,
-    // An invalid `end` (unparseable `dateEnd`) is dropped the same way a
-    // missing one is — never fabricated, never handed to `ical-generator`
-    // (which throws on an invalid Luxon value).
+    // An invalid `end` is dropped the same way a missing one is above.
     ...(end?.isValid ? { end } : {}),
     ...(location ? { location } : {}),
   });
@@ -241,11 +214,7 @@ export function generateIcal(
   matches: readonly Match[],
   options: IcalOptions = {},
 ): string {
-  const { side = "all", events } = options;
-  // `events` distinguishes "flag on, feed happens to have zero upcoming
-  // activities right now" from "flag off" — both would otherwise produce zero
-  // VEVENTs, but only the former should describe itself as an activities feed.
-  const includeEvents = events !== undefined;
+  const { side = "all", includeEvents = false, events = [] } = options;
 
   const cal = ical({
     name: includeEvents
@@ -297,16 +266,16 @@ export function generateIcal(
       end,
       timezone: TIMEZONE,
       description: buildDescription(match),
-      url: `https://www.kcvvelewijt.be/wedstrijd/${match.id}`,
+      url: `${SITE_CONFIG.siteUrl}/wedstrijd/${match.id}`,
       ...(location ? { location } : {}),
     });
   }
 
   // Club activities (#2704) — `EventRepository.findUpcomingForList()` is
   // already upcoming-only and chronologically sorted by construction (its own
-  // GROQ filters + `mergeEventFeed`'s sort), so no re-filter/re-sort is done
-  // here; this loop only maps each item to a VEVENT.
-  for (const item of events ?? []) {
+  // GROQ filters + `mergeEventFeed`'s sort), so no re-filter/re-sort happens
+  // here.
+  for (const item of events) {
     addEventVevent(cal, item);
   }
 

--- a/apps/web/src/lib/utils/ical.ts
+++ b/apps/web/src/lib/utils/ical.ts
@@ -193,6 +193,17 @@ function resolveEventDates(item: EventListItemVM): {
  */
 function addEventVevent(cal: ReturnType<typeof ical>, item: EventListItemVM) {
   const { isAllDay, start, end } = resolveEventDates(item);
+
+  // An unparseable `dateStart` (only reachable via a malformed event doc —
+  // `EVENTS_QUERY` projects `coalesce(dateStart, "")`, so a doc missing the
+  // Studio-required field still clears the upcoming filter on a future
+  // `dateEnd` and reaches here) is dropped, not fatal — the same handling
+  // `mergeEventFeed` gives it (sorts to the end) and `<EventMonthList>` gives
+  // it (drops it when grouping). `ical-generator` throws on an invalid Luxon
+  // `start`, which would otherwise take the whole feed — matches included —
+  // down with it (#2711 review).
+  if (!start.isValid) return;
+
   const location = item.location ?? undefined;
   const url = `${SITE_CONFIG.siteUrl}${item.href}`;
   const id = buildEventUid(item);
@@ -218,7 +229,10 @@ function addEventVevent(cal: ReturnType<typeof ical>, item: EventListItemVM) {
     start,
     timezone: TIMEZONE,
     url,
-    ...(end ? { end } : {}),
+    // An invalid `end` (unparseable `dateEnd`) is dropped the same way a
+    // missing one is — never fabricated, never handed to `ical-generator`
+    // (which throws on an invalid Luxon value).
+    ...(end?.isValid ? { end } : {}),
     ...(location ? { location } : {}),
   });
 }


### PR DESCRIPTION
Closes #2704

## Changes

- `generateIcal` (`apps/web/src/lib/utils/ical.ts`) grows an optional `events` list. Each `EventListItemVM` from `EventRepository.findUpcomingForList()` becomes its own VEVENT: title, `LOCATION` when present, and a `URL:` at the item's own resolved detail href (`/evenementen/[slug]` or `/nieuws/[slug]`). UIDs are namespaced `kcvv-event-<id>@kcvvelewijt.be`, distinct from a match's `kcvv-match-<id>@kcvvelewijt.be`, so the two id spaces can never collide. The all-day rule is shared with the per-event "Zet in agenda" download via `resolveEventDateRange` (`event-datetime.ts`): Brussels-midnight start → `VALUE=DATE` with an exclusive next-day `DTEND`; a timed item with no end omits `DTEND` rather than fabricating one. An unparseable `dateStart`/`dateEnd` is dropped, not fatal — matching how `mergeEventFeed`/`<EventMonthList>` already handle the same malformed row.
- `IcalOptions` carries an explicit `includeEvents: boolean` alongside `events`, rather than inferring the flag from whether `events` was passed. Omitting both entirely is what a matches-only request does — verified byte-for-byte identical to the pre-#2704 output.
- `GET /api/calendar.ics` (`apps/web/src/app/api/calendar.ics/route.ts`) reads `events=1`/`events=0`. Fixtures and club activities are fetched — and cached — independently, then composed per request:
  - Fixtures are cached under `normalizeCacheKey(teamIds, side)` — a **flag-independent** key, since which teams/sides are in scope never depends on `events`. An `events=1` and an `events=0` request for the same `teamIds`/`side` now share one cache entry instead of each duplicating the PSD fan-out.
  - Club activities are cached under their own fixed key (`ical:events`), decoupled from `teamIds`/`side` — the flag is club-wide, so every distinct team selection would otherwise re-run the same two-query Sanity read on its own cycle. A Sanity failure degrades to `[]` for that one response only, in a plain `try`/`catch` *outside* the cached callback — so `unstable_cache` never overwrites the entry with a failure and a transient blip can't pin an empty activity list for 15 minutes.
  - `generateIcal` itself then runs per request, uncached — there is no cache of the composed ICS body at all.
- **Deviation from the issue's cache-key wording, called out on purpose:** the AC says *"The flag is part of the feed's cache key — an `events=1` request can never be served a matches-only cached body, and the reverse cannot happen either."* That's no longer literally true — `events` is deliberately **not** part of the fixtures cache key. The *intent* is met more strongly than a key-based separation could: with no cache of the composed body, there is nothing left that could ever serve the wrong one — every response is built fresh from whichever inputs the current request asked for. This traded a same-body-cache-collision guarantee for a real efficiency win (one PSD fan-out per team selection, not two) and was reached after two review rounds; the first two shapes considered either violated the "Sanity failure → matches-only, not a 500" AC or made every `events=1` request during a Sanity outage hit PSD directly (a real 429-storm risk in this repo — see `apps/api`'s PSD rate limiting).
- The flag is deliberately club-wide, not scoped by `teamIds`/`side` — a club activity belongs to the club, not a squad (per the issue's design note).
- `NAME`/`X-WR-CALDESC` and the download filename (`kcvv-wedstrijden.ics` → `kcvv-wedstrijden-en-activiteiten.ics`) change only when `includeEvents` is `true` — driven by the explicit flag, not by whether the `events` array happens to be non-empty.
- The GROQ-level "upcoming-only by construction" behaviour of both sources feeding `findUpcomingForList()` is called out in a code comment (`ical.ts`) rather than re-filtered.

## Testing

- `pnpm --filter @kcvv/web check-all` passes (lint, type-check, 6934 unit tests, build).
- Unit tests in `apps/web/src/lib/utils/ical.test.ts`: flag omitted ⇒ no event VEVENT; flag on ⇒ event VEVENTs present with stable, collision-free UIDs; LOCATION presence/absence; URL resolution for both `event`-doc and `article`-sourced items; single-day and multi-day all-day rule; timed event with/without an end; an unparseable `dateStart`/`dateEnd` is dropped rather than throwing; NAME/CALDESC honesty is driven by `includeEvents`, not by a non-empty `events` array; and a parity suite that runs the same input through both `generateIcal` and `buildEventIcs` (single-day, multi-day, and timed) to pin the two surfaces against each other, not just against themselves.
- Route-level tests in `apps/web/src/app/api/calendar.ics/route.test.ts` (module-boundary mocks of `BffService`, `EventRepository`, `next/cache`'s `unstable_cache`): a pinned "no flag" test, `events=0` parity, `events=1` inclusion, Sanity-failure degrade (200, not 500), that the fixtures cache key is now **shared** between an `events=1` and a matches-only request for the same `teamIds`/`side`, that the club-activity cache is registered once under its fixed key regardless of team-selection permutations, and — invoking the cached club-activity callback directly — that a failed read rejects the callback carrying the underlying failure (so a transient blip is never written to that cache) while a successful read resolves it normally.

## Notes for the reviewer

- #2698 (the file collision this issue was blocked on) is already merged into `main`, so this branch builds directly on its placeholder-summary work in `ical.ts`.
- No VR baselines, no Storybook, no schema change, no dependency change — server-side only, as scoped by the issue.
- Two follow-ups filed from review, not implemented on this branch: #2716 (the subscribe feed and the per-event "Zet in agenda" download mint different UID schemes for the same activity) and #2717 (resolve the feed-variant descriptor once instead of re-deriving it in five places).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendar downloads can now optionally include upcoming club activities alongside matches.
  - Activity entries include dates, locations, website links, and support for all-day or timed events.
  - Calendar feeds clearly distinguish match-only and match-plus-activity content.

- **Bug Fixes**
  - Improved handling of invalid or incomplete event dates.
  - Prevented calendar cache results from mixing different feed selections.

- **Tests**
  - Added comprehensive coverage for calendar feeds, event formatting, caching, failures, and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
